### PR TITLE
Add client option to disable following redirects

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
@@ -273,6 +273,9 @@ public class ClientOptions
     @Option(names = "--disable-auto-suggestion", description = "Disable auto suggestion")
     public boolean disableAutoSuggestion;
 
+    @Option(names = "--disable-follow-redirects", description = "Disable following redirects from server")
+    public boolean disableFollowRedirects;
+
     public enum OutputFormat
     {
         AUTO,
@@ -401,6 +404,7 @@ public class ClientOptions
         if (!sessionProperties.isEmpty()) {
             builder.setSessionProperties(toProperties(sessionProperties));
         }
+        builder.setDisableFollowRedirects(disableFollowRedirects);
         builder.setExternalAuthentication(externalAuthentication);
         builder.setExternalRedirectStrategies(externalAuthenticationRedirectHandler);
         source.ifPresent(builder::setSource);

--- a/client/trino-cli/src/test/java/io/trino/cli/TestClientOptions.java
+++ b/client/trino-cli/src/test/java/io/trino/cli/TestClientOptions.java
@@ -269,6 +269,18 @@ public class TestClientOptions
     }
 
     @Test
+    public void testFollowRedirects()
+    {
+        Console console = createConsole("--disable-follow-redirects");
+        ClientOptions options = console.clientOptions;
+        assertThat(options.disableFollowRedirects).isTrue();
+
+        console = createConsole("--disable-follow-redirects=false");
+        options = console.clientOptions;
+        assertThat(options.disableFollowRedirects).isFalse();
+    }
+
+    @Test
     public void testThreePartPropertyName()
     {
         assertThatThrownBy(() -> new ClientSessionProperty("foo.bar.baz=value"))

--- a/client/trino-cli/src/test/java/io/trino/cli/TestClientRedirect.java
+++ b/client/trino-cli/src/test/java/io/trino/cli/TestClientRedirect.java
@@ -1,0 +1,320 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.cli;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.json.JsonCodec;
+import io.trino.client.ClientException;
+import io.trino.client.ClientSession;
+import io.trino.client.ClientTypeSignature;
+import io.trino.client.Column;
+import io.trino.client.QueryResults;
+import io.trino.client.StatementStats;
+import io.trino.client.uri.PropertyName;
+import io.trino.client.uri.TrinoUri;
+import okhttp3.Credentials;
+import okhttp3.logging.HttpLoggingInterceptor;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.sql.SQLException;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.Properties;
+
+import static com.google.common.io.ByteStreams.nullOutputStream;
+import static com.google.common.net.HttpHeaders.AUTHORIZATION;
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static com.google.common.net.HttpHeaders.LOCATION;
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static io.trino.cli.ClientOptions.OutputFormat.CSV;
+import static io.trino.cli.TerminalUtils.getTerminal;
+import static io.trino.cli.TestQueryRunner.createClientSession;
+import static io.trino.client.ClientStandardTypes.BIGINT;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
+
+@TestInstance(PER_METHOD)
+public class TestClientRedirect
+{
+    private static final JsonCodec<QueryResults> QUERY_RESULTS_CODEC = jsonCodec(QueryResults.class);
+    private static final String DUMMY_ACCESS_TOKEN = Base64.getEncoder().encodeToString("jwt-signing-key".getBytes(US_ASCII));
+    private static final String DUMMY_USER = "DUMMY_USER";
+    private static final String DUMMY_PASSWORD = "DUMMY_PASSWORD";
+    private static final String DUMMY_BASIC_AUTH_TOKEN = Credentials.basic(DUMMY_USER, DUMMY_PASSWORD);
+    private static final String REDIRECT_EXCEPTION = "Client redirection was detected, but 'disableFollowRedirects' flag is set to true";
+    private MockWebServer proxyServer;
+    private MockWebServer server;
+
+    @BeforeEach
+    public void setup()
+            throws IOException
+    {
+        proxyServer = new MockWebServer();
+        proxyServer.start();
+        server = new MockWebServer();
+        server.start();
+    }
+
+    @AfterEach
+    public void teardown()
+            throws IOException
+    {
+        proxyServer.close();
+        proxyServer = null;
+        server.close();
+        server = null;
+    }
+
+    @Test
+    public void testDisableClientRedirectsDefaultWithAccessToken()
+            throws Exception
+    {
+        assertRedirectIsFollowedWithAuthorizationHeader(Optional.empty(), false);
+    }
+
+    @Test
+    public void testClientRedirectEnabledWithAccessToken()
+            throws Exception
+    {
+        assertRedirectIsFollowedWithAuthorizationHeader(Optional.of(false), false);
+    }
+
+    @Test
+    public void testClientRedirectDisabledWithAccessToken()
+    {
+        assertRedirectIsNotFollowed(false);
+    }
+
+    @Test
+    public void testDisableClientRedirectsDefaultWithBasicAuth()
+            throws Exception
+    {
+        assertRedirectIsFollowedWithAuthorizationHeader(Optional.empty(), true);
+    }
+
+    @Test
+    public void testClientRedirectEnabledWithBasicAuth()
+            throws Exception
+    {
+        assertRedirectIsFollowedWithAuthorizationHeader(Optional.of(false), true);
+    }
+
+    @Test
+    public void testClientRedirectDisabledWithBasicAuth()
+    {
+        assertRedirectIsNotFollowed(true);
+    }
+
+    @Test
+    public void testClientRedirectDisabledExternalAuth()
+            throws Exception
+    {
+        proxyServer.enqueue(new MockResponse()
+                .setResponseCode(307)
+                .addHeader(LOCATION, server.url("redirect1/v1/statement")));
+        server.enqueue(new MockResponse()
+                .addHeader(CONTENT_TYPE, "application/json")
+                .setBody(createResults(server)));
+
+        try {
+            QueryRunner queryRunner = createQueryRunner(createTrinoUri(proxyServer, Optional.of(true), Optional.empty(),
+                    Optional.empty(), Optional.of(true)), createClientSession(proxyServer));
+
+            try (Query query = queryRunner.startQuery("SELECT 1")) {
+                query.renderOutput(getTerminal(), nullPrintStream(), nullPrintStream(), CSV, Optional.of(""), false);
+            }
+        }
+        catch (Exception e) {
+            assertThat(e).isInstanceOf(ClientException.class);
+            assertThat(e.getMessage()).isEqualTo(REDIRECT_EXCEPTION);
+        }
+    }
+
+    @Test
+    public void testClientRedirectsMultipleHop()
+            throws Exception
+    {
+        MockWebServer server2 = new MockWebServer();
+        server2.start();
+
+        proxyServer.enqueue(new MockResponse()
+                .setResponseCode(307)
+                .addHeader(LOCATION, server2.url("redirect1/v1/statement"))
+                .addHeader(AUTHORIZATION, DUMMY_ACCESS_TOKEN));
+        server2.enqueue(new MockResponse()
+                .setResponseCode(307)
+                .addHeader(LOCATION, server.url("redirect2/v1/statement")));
+        server.enqueue(new MockResponse()
+                .addHeader(CONTENT_TYPE, "application/json")
+                .setBody(createResults(server)));
+
+        QueryRunner queryRunner = createQueryRunner(createTrinoUri(proxyServer, Optional.empty(),
+                Optional.empty(), Optional.of(true), Optional.empty()), createClientSession(proxyServer));
+
+        try (Query query = queryRunner.startQuery("SELECT 1")) {
+            query.renderOutput(getTerminal(), nullPrintStream(), nullPrintStream(), CSV, Optional.of(""), false);
+        }
+
+        //verify the redirect request has the same Authorization header
+        RecordedRequest redirectedRequest = server.takeRequest();
+        assertThat(redirectedRequest.getHeader(AUTHORIZATION)).isEqualTo("Bearer " + DUMMY_ACCESS_TOKEN);
+
+        server2.close();
+    }
+
+    private void assertRedirectIsFollowedWithAuthorizationHeader(Optional<Boolean> disableFollowRedirects, boolean isBasicAuth)
+            throws Exception
+    {
+        proxyServer.enqueue(new MockResponse()
+                .setResponseCode(307)
+                .addHeader(LOCATION, server.url("redirect/v1/statement"))
+                .addHeader(AUTHORIZATION, isBasicAuth ? DUMMY_BASIC_AUTH_TOKEN : DUMMY_ACCESS_TOKEN));
+        server.enqueue(new MockResponse()
+                .addHeader(CONTENT_TYPE, "application/json")
+                .setBody(createResults(server)));
+
+        QueryRunner queryRunner;
+        if (isBasicAuth) {
+            queryRunner = createQueryRunner(createTrinoUri(proxyServer, disableFollowRedirects, Optional.of(true),
+                    Optional.empty(), Optional.empty()), createClientSession(proxyServer));
+        }
+        else {
+            queryRunner = createQueryRunner(createTrinoUri(proxyServer, disableFollowRedirects, Optional.empty(),
+                    Optional.of(true), Optional.empty()), createClientSession(proxyServer));
+        }
+
+        try (Query query = queryRunner.startQuery("SELECT 1")) {
+            query.renderOutput(getTerminal(), nullPrintStream(), nullPrintStream(), CSV, Optional.of(""), false);
+        }
+
+        //verify the redirect request has the same Authorization header
+        RecordedRequest redirectedRequest = server.takeRequest();
+        if (isBasicAuth) {
+            assertThat(redirectedRequest.getHeader(AUTHORIZATION)).isEqualTo(DUMMY_BASIC_AUTH_TOKEN);
+        }
+        else {
+            assertThat(redirectedRequest.getHeader(AUTHORIZATION)).isEqualTo("Bearer " + DUMMY_ACCESS_TOKEN);
+        }
+    }
+
+    private void assertRedirectIsNotFollowed(boolean isBasicAuth)
+    {
+        proxyServer.enqueue(new MockResponse()
+                .setResponseCode(307)
+                .addHeader(LOCATION, server.url("redirect/v1/statement"))
+                .addHeader(AUTHORIZATION, isBasicAuth ? DUMMY_BASIC_AUTH_TOKEN : DUMMY_ACCESS_TOKEN));
+        server.enqueue(new MockResponse()
+                .addHeader(CONTENT_TYPE, "application/json")
+                .setBody(createResults(server)));
+        try {
+            QueryRunner queryRunner;
+            if (isBasicAuth) {
+                queryRunner = createQueryRunner(createTrinoUri(proxyServer, Optional.of(true), Optional.of(true),
+                        Optional.empty(), Optional.empty()), createClientSession(proxyServer));
+            }
+            else {
+                queryRunner = createQueryRunner(createTrinoUri(proxyServer, Optional.of(true),
+                        Optional.empty(), Optional.of(true), Optional.empty()), createClientSession(proxyServer));
+            }
+
+            try (Query query = queryRunner.startQuery("SELECT 1")) {
+                query.renderOutput(getTerminal(), nullPrintStream(), nullPrintStream(), CSV, Optional.of(""), false);
+            }
+        }
+        catch (Exception e) {
+            assertThat(e).isInstanceOf(ClientException.class);
+            assertThat(e.getMessage()).isEqualTo(REDIRECT_EXCEPTION);
+        }
+    }
+
+    private static TrinoUri createTrinoUriExternalAuth(MockWebServer server, Optional<Boolean> disableFollowRedirects)
+            throws SQLException
+    {
+        Properties properties = new Properties();
+        if (disableFollowRedirects.isPresent()) {
+            properties.setProperty(PropertyName.DISABLE_FOLLOW_REDIRECTS.toString(), Boolean.toString(disableFollowRedirects.get()));
+        }
+        properties.setProperty(PropertyName.SSL.toString(), Boolean.toString(true));
+        properties.setProperty(PropertyName.EXTERNAL_AUTHENTICATION.toString(), Boolean.toString(true));
+        return TrinoUri.create(server.url("/").uri(), properties);
+    }
+
+    private static TrinoUri createTrinoUri(MockWebServer server, Optional<Boolean> disableFollowRedirects,
+                                    Optional<Boolean> isBasicAuth, Optional<Boolean> isAccessToken,
+                                    Optional<Boolean> isExternalAuth)
+            throws SQLException
+    {
+        Properties properties = new Properties();
+        if (disableFollowRedirects.isPresent()) {
+            properties.setProperty(PropertyName.DISABLE_FOLLOW_REDIRECTS.toString(), Boolean.toString(disableFollowRedirects.get()));
+        }
+        if (isBasicAuth.isPresent()) {
+            properties.setProperty(PropertyName.USER.toString(), DUMMY_USER);
+            properties.setProperty(PropertyName.PASSWORD.toString(), DUMMY_PASSWORD);
+        }
+        else if (isAccessToken.isPresent()) {
+            properties.setProperty(PropertyName.ACCESS_TOKEN.toString(), DUMMY_ACCESS_TOKEN);
+        }
+        else if (isExternalAuth.isPresent()) {
+            properties.setProperty(PropertyName.EXTERNAL_AUTHENTICATION.toString(), Boolean.toString(true));
+        }
+        properties.setProperty(PropertyName.SSL.toString(), Boolean.toString(true));
+        return TrinoUri.create(server.url("/").uri(), properties);
+    }
+
+    private static String createResults(MockWebServer server)
+    {
+        QueryResults queryResults = new QueryResults(
+                "20240327_104103_00010_pu6b8",
+                server.url("/query.html?20240327_104103_00010_pu6b8").uri(),
+                null,
+                null,
+                ImmutableList.of(new Column("_col0", BIGINT, new ClientTypeSignature(BIGINT))),
+                ImmutableList.of(ImmutableList.of(1)),
+                StatementStats.builder()
+                        .setState("FINISHED")
+                        .setProgressPercentage(OptionalDouble.empty())
+                        .setRunningPercentage(OptionalDouble.empty())
+                        .build(),
+                null,
+                ImmutableList.of(),
+                null,
+                null);
+        return QUERY_RESULTS_CODEC.toJson(queryResults);
+    }
+
+    private static QueryRunner createQueryRunner(TrinoUri uri, ClientSession clientSession)
+    {
+        return new QueryRunner(
+                uri,
+                clientSession,
+                false,
+                HttpLoggingInterceptor.Level.NONE);
+    }
+
+    private static PrintStream nullPrintStream()
+    {
+        return new PrintStream(nullOutputStream());
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/uri/ConnectionProperties.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/ConnectionProperties.java
@@ -100,6 +100,7 @@ final class ConnectionProperties
     public static final ConnectionProperty<String, String> HOSTNAME_IN_CERTIFICATE = new HostnameInCertificate();
     public static final ConnectionProperty<String, ZoneId> TIMEZONE = new TimeZone();
     public static final ConnectionProperty<String, Boolean> EXPLICIT_PREPARE = new ExplicitPrepare();
+    public static final ConnectionProperty<String, Boolean> DISABLE_FOLLOW_REDIRECTS = new DisableFollowRedirects();
 
     private static final Set<ConnectionProperty<?, ?>> ALL_PROPERTIES = ImmutableSet.<ConnectionProperty<?, ?>>builder()
             .add(USER)
@@ -146,6 +147,7 @@ final class ConnectionProperties
             .add(HOSTNAME_IN_CERTIFICATE)
             .add(TIMEZONE)
             .add(EXPLICIT_PREPARE)
+            .add(DISABLE_FOLLOW_REDIRECTS)
             .build();
 
     private static final Map<String, ConnectionProperty<?, ?>> KEY_LOOKUP = unmodifiableMap(ALL_PROPERTIES.stream()
@@ -725,6 +727,15 @@ final class ConnectionProperties
         public ExplicitPrepare()
         {
             super(PropertyName.EXPLICIT_PREPARE, NOT_REQUIRED, ALLOWED, BOOLEAN_CONVERTER);
+        }
+    }
+
+    private static class DisableFollowRedirects
+            extends AbstractConnectionProperty<String, Boolean>
+    {
+        public DisableFollowRedirects()
+        {
+            super(PropertyName.DISABLE_FOLLOW_REDIRECTS, NOT_REQUIRED, ALLOWED, BOOLEAN_CONVERTER);
         }
     }
 

--- a/client/trino-client/src/main/java/io/trino/client/uri/PropertyName.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/PropertyName.java
@@ -62,6 +62,7 @@ public enum PropertyName
     SESSION_PROPERTIES("sessionProperties"),
     SOURCE("source"),
     EXPLICIT_PREPARE("explicitPrepare"),
+    DISABLE_FOLLOW_REDIRECTS("disableFollowRedirects"),
     DNS_RESOLVER("dnsResolver"),
     DNS_RESOLVER_CONTEXT("dnsResolverContext"),
     HOSTNAME_IN_CERTIFICATE("hostnameInCertificate"),

--- a/client/trino-client/src/test/java/io/trino/client/auth/external/TestExternalAuthenticator.java
+++ b/client/trino-client/src/test/java/io/trino/client/auth/external/TestExternalAuthenticator.java
@@ -141,7 +141,7 @@ public class TestExternalAuthenticator
     {
         MockTokenPoller tokenPoller = new MockTokenPoller()
                 .withResult(URI.create("http://token.uri"), successful(new Token("valid-token")));
-        ExternalAuthenticator authenticator = new ExternalAuthenticator(uri -> {}, tokenPoller, KnownToken.local(), Duration.ofSeconds(1));
+        ExternalAuthenticator authenticator = new ExternalAuthenticator(uri -> {}, tokenPoller, KnownToken.local(), Duration.ofSeconds(1), true);
 
         Request authenticated = authenticator.authenticate(null, getUnauthorizedResponse("Bearer x_token_server=\"http://token.uri\""));
 
@@ -155,7 +155,7 @@ public class TestExternalAuthenticator
         MockTokenPoller tokenPoller = new MockTokenPoller()
                 .withResult(URI.create("http://token.uri"), successful(new Token("first-token")))
                 .withResult(URI.create("http://token.uri"), successful(new Token("second-token")));
-        ExternalAuthenticator authenticator = new ExternalAuthenticator(uri -> {}, tokenPoller, KnownToken.local(), Duration.ofSeconds(1));
+        ExternalAuthenticator authenticator = new ExternalAuthenticator(uri -> {}, tokenPoller, KnownToken.local(), Duration.ofSeconds(1), true);
 
         Request request = authenticator.authenticate(null, getUnauthorizedResponse("Bearer x_token_server=\"http://token.uri\""));
         Request reAuthenticated = authenticator.authenticate(null, getUnauthorizedResponse("Bearer x_token_server=\"http://token.uri\"", request));
@@ -177,7 +177,7 @@ public class TestExternalAuthenticator
 
         List<Future<Request>> requests = times(
                 4,
-                () -> new ExternalAuthenticator(redirectHandler, tokenPoller, KnownToken.local(), Duration.ofSeconds(1))
+                () -> new ExternalAuthenticator(redirectHandler, tokenPoller, KnownToken.local(), Duration.ofSeconds(1), true)
                         .authenticate(null, getUnauthorizedResponse("Bearer x_token_server=\"http://token.uri\", x_redirect_server=\"http://redirect.uri\"")))
                 .map(executor::submit)
                 .collect(toImmutableList());
@@ -202,7 +202,7 @@ public class TestExternalAuthenticator
 
         List<Future<Request>> requests = times(
                 2,
-                () -> new ExternalAuthenticator(redirectHandler, tokenPoller, KnownToken.memoryCached(), Duration.ofSeconds(1))
+                () -> new ExternalAuthenticator(redirectHandler, tokenPoller, KnownToken.memoryCached(), Duration.ofSeconds(1), true)
                         .authenticate(null, getUnauthorizedResponse("Bearer x_token_server=\"http://token.uri\", x_redirect_server=\"http://redirect.uri\"")))
                 .map(executor::submit)
                 .collect(toImmutableList());
@@ -226,12 +226,12 @@ public class TestExternalAuthenticator
         MockRedirectHandler redirectHandler = new MockRedirectHandler()
                 .sleepOnRedirect(Duration.ofMillis(500));
 
-        ExternalAuthenticator authenticator = new ExternalAuthenticator(redirectHandler, tokenPoller, KnownToken.memoryCached(), Duration.ofSeconds(1));
+        ExternalAuthenticator authenticator = new ExternalAuthenticator(redirectHandler, tokenPoller, KnownToken.memoryCached(), Duration.ofSeconds(1), true);
         Request firstRequest = authenticator.authenticate(null, getUnauthorizedResponse("Bearer x_token_server=\"http://token.uri\", x_redirect_server=\"http://redirect.uri\""));
 
         List<Future<Request>> requests = times(
                 4,
-                () -> new ExternalAuthenticator(redirectHandler, tokenPoller, KnownToken.memoryCached(), Duration.ofSeconds(1))
+                () -> new ExternalAuthenticator(redirectHandler, tokenPoller, KnownToken.memoryCached(), Duration.ofSeconds(1), true)
                         .authenticate(null, getUnauthorizedResponse("Bearer x_token_server=\"http://token.uri\", x_redirect_server=\"http://redirect.uri\"", firstRequest)))
                 .map(executor::submit)
                 .collect(toImmutableList());
@@ -253,7 +253,7 @@ public class TestExternalAuthenticator
 
         List<Future<Request>> requests = times(
                 2,
-                () -> new ExternalAuthenticator(redirectHandler, onPoll(TokenPollResult::pending), KnownToken.memoryCached(), Duration.ofMillis(1))
+                () -> new ExternalAuthenticator(redirectHandler, onPoll(TokenPollResult::pending), KnownToken.memoryCached(), Duration.ofMillis(1), true)
                         .authenticate(null, getUnauthorizedResponse("Bearer x_token_server=\"http://token.uri\", x_redirect_server=\"http://redirect.uri\"")))
                 .map(executor::submit)
                 .collect(toImmutableList());
@@ -274,13 +274,13 @@ public class TestExternalAuthenticator
         MockRedirectHandler redirectHandler = new MockRedirectHandler()
                 .sleepOnRedirect(Duration.ofMinutes(1));
 
-        ExternalAuthenticator authenticator = new ExternalAuthenticator(redirectHandler, onPoll(TokenPollResult::pending), KnownToken.memoryCached(), Duration.ofMillis(1));
+        ExternalAuthenticator authenticator = new ExternalAuthenticator(redirectHandler, onPoll(TokenPollResult::pending), KnownToken.memoryCached(), Duration.ofMillis(1), true);
         Future<Request> interruptedAuthentication = interruptableThreadPool.submit(
                 () -> authenticator.authenticate(null, getUnauthorizedResponse("Bearer x_token_server=\"http://token.uri\", x_redirect_server=\"http://redirect.uri\"")));
         Thread.sleep(100); //It's here to make sure that authentication will start before the other threads.
         List<Future<Request>> requests = times(
                 2,
-                () -> new ExternalAuthenticator(redirectHandler, onPoll(TokenPollResult::pending), KnownToken.memoryCached(), Duration.ofMillis(1))
+                () -> new ExternalAuthenticator(redirectHandler, onPoll(TokenPollResult::pending), KnownToken.memoryCached(), Duration.ofMillis(1), true)
                         .authenticate(null, getUnauthorizedResponse("Bearer x_token_server=\"http://token.uri\", x_redirect_server=\"http://redirect.uri\"")))
                 .map(executor::submit)
                 .collect(toImmutableList());

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriverUri.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriverUri.java
@@ -23,6 +23,7 @@ import java.util.Properties;
 
 import static io.trino.client.uri.PropertyName.CLIENT_TAGS;
 import static io.trino.client.uri.PropertyName.DISABLE_COMPRESSION;
+import static io.trino.client.uri.PropertyName.DISABLE_FOLLOW_REDIRECTS;
 import static io.trino.client.uri.PropertyName.EXTRA_CREDENTIALS;
 import static io.trino.client.uri.PropertyName.HTTP_PROXY;
 import static io.trino.client.uri.PropertyName.SOCKS_PROXY;
@@ -353,6 +354,21 @@ public class TestTrinoDriverUri
 
         Properties properties = parameters.getProperties();
         assertThat(properties.getProperty(SSL_USE_SYSTEM_TRUST_STORE.toString())).isEqualTo("true");
+    }
+
+    @Test
+    public void testUriWithFollowRedirects()
+            throws SQLException
+    {
+        TrinoDriverUri parameters = createDriverUri("jdbc:trino://localhost:8080?disableFollowRedirects=true");
+        Properties properties = parameters.getProperties();
+        assertThat(properties.getProperty(DISABLE_FOLLOW_REDIRECTS.toString())).isEqualTo("true");
+
+        parameters = createDriverUri("jdbc:trino://localhost:8080?disableFollowRedirects=false");
+        properties = parameters.getProperties();
+        assertThat(properties.getProperty(DISABLE_FOLLOW_REDIRECTS.toString())).isEqualTo("false");
+
+        assertInvalid("jdbc:trino://localhost:8080?disableFollowRedirects=INVALIDVALUE", "Connection property disableFollowRedirects value is invalid: INVALIDVALUE");
     }
 
     @Test

--- a/docs/src/main/sphinx/client/cli.md
+++ b/docs/src/main/sphinx/client/cli.md
@@ -148,6 +148,8 @@ mode:
     processing statistics.
 * - `--disable-auto-suggestion`
   - Disables autocomplete suggestions.
+* - `--disable-follow-redirects`
+  - Set to `true` to turn off client redirects. Defaults to `false`.
 * - `--disable-compression`
   - Disables compression of query results.
 * - `--editing-mode`

--- a/docs/src/main/sphinx/client/jdbc.md
+++ b/docs/src/main/sphinx/client/jdbc.md
@@ -248,4 +248,6 @@ may not be specified using both methods.
     `PREPARE <statement>` followed by `EXECUTE <statement>`. This reduces
     network overhead and uses smaller HTTP headers and requires Trino 431 or
     greater.
+* - `disableFollowRedirects`
+  - Set to `true` to turn off client redirects. Defaults to `false`. 
 :::

--- a/testing/trino-testing/src/test/java/io/trino/testing/TestTestingTrinoClient.java
+++ b/testing/trino-testing/src/test/java/io/trino/testing/TestTestingTrinoClient.java
@@ -94,7 +94,7 @@ public class TestTestingTrinoClient
     public void testAuthenticationWithForwarding()
     {
         OkHttpClient httpClient = new OkHttpClient.Builder()
-                .addInterceptor(OkHttpUtil.basicAuth(TEST_USER, PASSWORD))
+                .addNetworkInterceptor(OkHttpUtil.basicAuth(TEST_USER, PASSWORD, true))
                 .addInterceptor(httpsForwarded())
                 .build();
 
@@ -108,7 +108,7 @@ public class TestTestingTrinoClient
     public void testAuthenticationWithoutForwarding()
     {
         OkHttpClient httpClient = new OkHttpClient.Builder()
-                .addInterceptor(OkHttpUtil.basicAuth(TEST_USER, PASSWORD))
+                .addNetworkInterceptor(OkHttpUtil.basicAuth(TEST_USER, PASSWORD, true))
                 .build();
 
         try (TestingTrinoClient client = new TestingTrinoClient(server, session, httpClient)) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

During 412 release as part of OkHttp version upgrade, explicit client retry logic was removed in the event of a 307/308 redirect. This will cause 401: 'Unauthorized' error when trino client is talking to a Trino Cluster that is deployed behind a load balancer(For example AWS ALB) with a redirect mode(e.g. 307/308) routing policy.

Reference: https://github.com/trinodb/trino/commit/4be14018af945684bb28a53e4dcedfe744529bb0

Okhttp by default does follow redirects. However it drops Authorization headers if the redirect is across hosts. 

Reference: https://github.com/square/okhttp/blob/okhttp_4.10.x/okhttp/src/main/kotlin/okhttp3/internal/http/RetryAndFollowUpInterceptor.kt#L323-L328

Solution:
This PR introduces a flag `--disable-follow-redirects` to give an option to clients to follow a redirect or not. By default the flag is set to `false` which means redirects are going to be followed. 



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Fixes https://github.com/trinodb/trino/issues/21026

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

