### PR TITLE
Fix failure when listing tables in Elasticsearch and OpenSearch

### DIFF
--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/ElasticsearchClient.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/ElasticsearchClient.java
@@ -389,9 +389,17 @@ public class ElasticsearchClient
                     int docsCount = root.get(i).get("docs.count").asInt();
                     int deletedDocsCount = root.get(i).get("docs.deleted").asInt();
                     if (docsCount == 0 && deletedDocsCount == 0) {
-                        // without documents, the index won't have any dynamic mappings, but maybe there are some explicit ones
-                        if (getIndexMetadata(index).getSchema().getFields().isEmpty()) {
-                            continue;
+                        try {
+                            // without documents, the index won't have any dynamic mappings, but maybe there are some explicit ones
+                            if (getIndexMetadata(index).getSchema().getFields().isEmpty()) {
+                                continue;
+                            }
+                        }
+                        catch (TrinoException e) {
+                            if (e.getErrorCode().equals(ELASTICSEARCH_INVALID_METADATA.toErrorCode())) {
+                                continue;
+                            }
+                            throw e;
                         }
                     }
                     result.add(index);

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
@@ -880,6 +880,8 @@ public abstract class BaseElasticsearchConnectorTest
 
         createIndex(indexName, mapping);
 
+        assertQueryReturnsEmptyResult("SHOW TABLES LIKE '" + indexName + "'");
+
         index(indexName, ImmutableMap.of("array_raw_field", "test"));
 
         assertThatThrownBy(() -> computeActual("SELECT array_raw_field FROM " + indexName))

--- a/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/client/OpenSearchClient.java
+++ b/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/client/OpenSearchClient.java
@@ -389,9 +389,17 @@ public class OpenSearchClient
                     int docsCount = root.get(i).get("docs.count").asInt();
                     int deletedDocsCount = root.get(i).get("docs.deleted").asInt();
                     if (docsCount == 0 && deletedDocsCount == 0) {
-                        // without documents, the index won't have any dynamic mappings, but maybe there are some explicit ones
-                        if (getIndexMetadata(index).getSchema().getFields().isEmpty()) {
-                            continue;
+                        try {
+                            // without documents, the index won't have any dynamic mappings, but maybe there are some explicit ones
+                            if (getIndexMetadata(index).getSchema().getFields().isEmpty()) {
+                                continue;
+                            }
+                        }
+                        catch (TrinoException e) {
+                            if (e.getErrorCode().equals(OPENSEARCH_INVALID_METADATA.toErrorCode())) {
+                                continue;
+                            }
+                            throw e;
                         }
                     }
                     result.add(index);

--- a/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
+++ b/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
@@ -886,6 +886,8 @@ public abstract class BaseOpenSearchConnectorTest
 
         createIndex(indexName, mapping);
 
+        assertQueryReturnsEmptyResult("SHOW TABLES LIKE '" + indexName + "'");
+
         index(indexName, ImmutableMap.of("array_raw_field", "test"));
 
         assertThatThrownBy(() -> computeActual("SELECT array_raw_field FROM " + indexName))


### PR DESCRIPTION
## Description

Fixes https://github.com/trinodb/trino/issues/21020

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Elasticsearch, OpenSearch
* Fix failure when listing tables having invalid fields on indexes. ({issue}`issuenumber`)
```
