### PR TITLE
Mongo contains function pushdown

### DIFF
--- a/plugin/trino-mongodb/pom.xml
+++ b/plugin/trino-mongodb/pom.xml
@@ -60,6 +60,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-matching</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-plugin-toolkit</artifactId>
         </dependency>
 
@@ -131,6 +136,19 @@
             <groupId>io.airlift</groupId>
             <artifactId>log-manager</artifactId>
             <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.vaadin.external.google</groupId>
+            <artifactId>android-json</artifactId>
+            <version>0.0.20131108.vaadin1</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -208,6 +226,12 @@
         </dependency>
 
         <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
@@ -229,6 +253,20 @@
             <!-- Needed while junit 4 is in classpath -->
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/plugin/trino-mongodb/pom.xml
+++ b/plugin/trino-mongodb/pom.xml
@@ -145,13 +145,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.vaadin.external.google</groupId>
-            <artifactId>android-json</artifactId>
-            <version>0.0.20131108.vaadin1</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>junit-extensions</artifactId>
             <scope>test</scope>
@@ -253,13 +246,6 @@
             <!-- Needed while junit 4 is in classpath -->
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.skyscreamer</groupId>
-            <artifactId>jsonassert</artifactId>
-            <version>1.5.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/plugin/trino-mongodb/pom.xml
+++ b/plugin/trino-mongodb/pom.xml
@@ -257,13 +257,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>5.11.0</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.skyscreamer</groupId>
             <artifactId>jsonassert</artifactId>
             <version>1.5.1</version>

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientConfig.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientConfig.java
@@ -45,6 +45,7 @@ public class MongoClientConfig
     private String requiredReplicaSetName;
     private String implicitRowFieldPrefix = "_pos";
     private boolean projectionPushDownEnabled = true;
+    private boolean complexExpressionPushdownEnabled = true;
     private boolean allowLocalScheduling;
 
     @NotNull
@@ -250,6 +251,18 @@ public class MongoClientConfig
     public MongoClientConfig setProjectionPushdownEnabled(boolean projectionPushDownEnabled)
     {
         this.projectionPushDownEnabled = projectionPushDownEnabled;
+        return this;
+    }
+
+    public boolean isComplexExpressionPushdownEnabled()
+    {
+        return complexExpressionPushdownEnabled;
+    }
+
+    @Config("mongodb.complex-expression-pushdown-enabled")
+    public MongoClientConfig setComplexExpressionPushdownEnabled(boolean complexExpressionPushdownEnabled)
+    {
+        this.complexExpressionPushdownEnabled = complexExpressionPushdownEnabled;
         return this;
     }
 

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
@@ -21,6 +21,7 @@ import com.google.common.io.Closer;
 import com.mongodb.client.MongoCollection;
 import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
+import io.trino.plugin.base.expression.ConnectorExpressions;
 import io.trino.plugin.base.projection.ApplyProjectionUtil;
 import io.trino.plugin.mongodb.MongoIndex.MongodbIndexKey;
 import io.trino.plugin.mongodb.ptf.Query.QueryFunctionHandle;
@@ -68,6 +69,7 @@ import io.trino.spi.type.VarcharType;
 import org.bson.Document;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -91,6 +93,7 @@ import static com.mongodb.client.model.Aggregates.project;
 import static com.mongodb.client.model.Filters.ne;
 import static com.mongodb.client.model.Projections.exclude;
 import static io.trino.plugin.base.TemporaryTables.generateTemporaryTableName;
+import static io.trino.plugin.base.expression.ConnectorExpressions.and;
 import static io.trino.plugin.base.projection.ApplyProjectionUtil.ProjectedColumnRepresentation;
 import static io.trino.plugin.base.projection.ApplyProjectionUtil.extractSupportedProjectedColumns;
 import static io.trino.plugin.base.projection.ApplyProjectionUtil.replaceWithNewVariables;
@@ -99,6 +102,7 @@ import static io.trino.plugin.mongodb.MongoSession.DATABASE_NAME;
 import static io.trino.plugin.mongodb.MongoSession.ID;
 import static io.trino.plugin.mongodb.MongoSessionProperties.isProjectionPushdownEnabled;
 import static io.trino.plugin.mongodb.TypeUtils.isPushdownSupportedType;
+import static io.trino.plugin.mongodb.ptf.Query.parseFilter;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -624,19 +628,40 @@ public class MongoMetadata
             remainingFilter = TupleDomain.withColumnDomains(unsupported);
         }
 
-        if (oldDomain.equals(newDomain)) {
+        ConnectorExpression oldExpression = constraint.getExpression();
+        List<ConnectorExpression> expressions = ConnectorExpressions.extractConjuncts(constraint.getExpression());
+        List<ConnectorExpression> notHandledExpressions = new ArrayList<>();
+        List<Document> supportedExpressions = new ArrayList<>();
+        for (ConnectorExpression expression : expressions) {
+            Optional<Document> predicate = mongoSession.convertExpression(session, expression, constraint.getAssignments());
+            if (predicate.isPresent()) {
+                supportedExpressions.add(predicate.get());
+            }
+            else {
+                notHandledExpressions.add(expression);
+            }
+        }
+
+        ConnectorExpression newExpression = and(notHandledExpressions);
+        if (oldDomain.equals(newDomain) && oldExpression.equals(newExpression)) {
             return Optional.empty();
         }
+
+        handle.getFilter().ifPresent(json -> supportedExpressions.add(parseFilter(json)));
+        Optional<Document> newFilterDocument =
+                supportedExpressions.isEmpty() ? Optional.empty() :
+                        Optional.ofNullable(supportedExpressions.size() == 1 ? supportedExpressions.getFirst() :
+                                new Document("$and", supportedExpressions));
 
         handle = new MongoTableHandle(
                 handle.getSchemaTableName(),
                 handle.getRemoteTableName(),
-                handle.getFilter(),
+                newFilterDocument.flatMap(document -> document.toJson().describeConstable()),
                 newDomain,
                 handle.getProjectedColumns(),
                 handle.getLimit());
 
-        return Optional.of(new ConstraintApplicationResult<>(handle, remainingFilter, constraint.getExpression(), false));
+        return Optional.of(new ConstraintApplicationResult<>(handle, remainingFilter, and(notHandledExpressions), false));
     }
 
     @Override

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSessionProperties.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSessionProperties.java
@@ -28,6 +28,8 @@ public final class MongoSessionProperties
 {
     private static final String PROJECTION_PUSHDOWN_ENABLED = "projection_pushdown_enabled";
 
+    public static final String COMPLEX_EXPRESSION_PUSHDOWN = "complex_expression_pushdown";
+
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
@@ -39,6 +41,11 @@ public final class MongoSessionProperties
                         "Read only required fields from a row type",
                         mongoConfig.isProjectionPushdownEnabled(),
                         false))
+                .add(booleanProperty(
+                        COMPLEX_EXPRESSION_PUSHDOWN,
+                        "Allow complex expression pushdown",
+                        mongoConfig.isComplexExpressionPushdownEnabled(),
+                        true))
                 .build();
     }
 
@@ -51,5 +58,10 @@ public final class MongoSessionProperties
     public static boolean isProjectionPushdownEnabled(ConnectorSession session)
     {
         return session.getProperty(PROJECTION_PUSHDOWN_ENABLED, Boolean.class);
+    }
+
+    public static boolean isComplexExpressionPushdown(ConnectorSession session)
+    {
+        return session.getProperty(COMPLEX_EXPRESSION_PUSHDOWN, Boolean.class);
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/TypeUtils.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/TypeUtils.java
@@ -53,6 +53,7 @@ import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MICROSECOND;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
 import static io.trino.spi.type.Timestamps.roundDiv;
 import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.floorDiv;
 import static java.lang.Math.floorMod;
@@ -89,6 +90,14 @@ public final class TypeUtils
                 || type instanceof DecimalType
                 || type instanceof ObjectIdType
                 || PUSHDOWN_SUPPORTED_PRIMITIVE_TYPES.contains(type);
+    }
+
+    public static boolean isPushdownSupportedArrayElementType(Type type)
+    {
+        if (type == TIME_MILLIS || type == VARBINARY) {
+            return false;
+        }
+        return isPushdownSupportedType(type);
     }
 
     public static Optional<Object> translateValue(Object trinoNativeValue, Type type)

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/TypeUtils.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/TypeUtils.java
@@ -14,15 +14,31 @@
 package io.trino.plugin.mongodb;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.primitives.Primitives;
+import com.google.common.primitives.Shorts;
+import com.google.common.primitives.SignedBytes;
+import io.airlift.slice.Slice;
 import io.trino.spi.type.CharType;
 import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Decimals;
+import io.trino.spi.type.Int128;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
+import org.bson.types.Decimal128;
+import org.bson.types.ObjectId;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Optional;
 import java.util.Set;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.Chars.padSpaces;
+import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
@@ -32,7 +48,17 @@ import static io.trino.spi.type.StandardTypes.JSON;
 import static io.trino.spi.type.TimeType.TIME_MILLIS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
+import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MICROSECOND;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
+import static io.trino.spi.type.Timestamps.roundDiv;
 import static io.trino.spi.type.TinyintType.TINYINT;
+import static java.lang.Float.intBitsToFloat;
+import static java.lang.Math.floorDiv;
+import static java.lang.Math.floorMod;
+import static java.lang.Math.toIntExact;
+import static java.time.ZoneOffset.UTC;
+import static java.util.Objects.requireNonNull;
 
 public final class TypeUtils
 {
@@ -63,5 +89,86 @@ public final class TypeUtils
                 || type instanceof DecimalType
                 || type instanceof ObjectIdType
                 || PUSHDOWN_SUPPORTED_PRIMITIVE_TYPES.contains(type);
+    }
+
+    public static Optional<Object> translateValue(Object trinoNativeValue, Type type)
+    {
+        requireNonNull(trinoNativeValue, "trinoNativeValue is null");
+        requireNonNull(type, "type is null");
+        checkArgument(Primitives.wrap(type.getJavaType()).isInstance(trinoNativeValue), "%s (%s) is not a valid representation for %s", trinoNativeValue, trinoNativeValue.getClass(), type);
+
+        if (type == BOOLEAN) {
+            return Optional.of(trinoNativeValue);
+        }
+
+        if (type == TINYINT) {
+            return Optional.of((long) SignedBytes.checkedCast(((Long) trinoNativeValue)));
+        }
+
+        if (type == SMALLINT) {
+            return Optional.of((long) Shorts.checkedCast(((Long) trinoNativeValue)));
+        }
+
+        if (type == INTEGER) {
+            return Optional.of((long) toIntExact(((Long) trinoNativeValue)));
+        }
+
+        if (type == BIGINT) {
+            return Optional.of(trinoNativeValue);
+        }
+
+        if (type == REAL) {
+            return Optional.of(intBitsToFloat(toIntExact((long) trinoNativeValue)));
+        }
+
+        if (type == DOUBLE) {
+            return Optional.of(trinoNativeValue);
+        }
+
+        if (type instanceof DecimalType decimalType) {
+            if (decimalType.isShort()) {
+                return Optional.of(Decimal128.parse(Decimals.toString((long) trinoNativeValue, decimalType.getScale())));
+            }
+            return Optional.of(Decimal128.parse(Decimals.toString((Int128) trinoNativeValue, decimalType.getScale())));
+        }
+
+        if (type instanceof ObjectIdType) {
+            return Optional.of(new ObjectId(((Slice) trinoNativeValue).getBytes()));
+        }
+
+        if (type instanceof CharType charType) {
+            Slice slice = padSpaces(((Slice) trinoNativeValue), charType);
+            return Optional.of(slice.toStringUtf8());
+        }
+
+        if (type instanceof VarcharType) {
+            return Optional.of(((Slice) trinoNativeValue).toStringUtf8());
+        }
+
+        if (type == DATE) {
+            long days = (long) trinoNativeValue;
+            return Optional.of(LocalDate.ofEpochDay(days));
+        }
+
+        if (type == TIME_MILLIS) {
+            long picos = (long) trinoNativeValue;
+            return Optional.of(LocalTime.ofNanoOfDay(roundDiv(picos, PICOSECONDS_PER_NANOSECOND)));
+        }
+
+        if (type == TIMESTAMP_MILLIS) {
+            long epochMicros = (long) trinoNativeValue;
+            long epochSecond = floorDiv(epochMicros, MICROSECONDS_PER_SECOND);
+            int nanoFraction = floorMod(epochMicros, MICROSECONDS_PER_SECOND) * NANOSECONDS_PER_MICROSECOND;
+            Instant instant = Instant.ofEpochSecond(epochSecond, nanoFraction);
+            return Optional.of(LocalDateTime.ofInstant(instant, UTC));
+        }
+
+        if (type == TIMESTAMP_TZ_MILLIS) {
+            long millisUtc = unpackMillisUtc((long) trinoNativeValue);
+            Instant instant = Instant.ofEpochMilli(millisUtc);
+            return Optional.of(LocalDateTime.ofInstant(instant, UTC));
+        }
+
+        return Optional.empty();
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/ContainsRewriteRule.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/ContainsRewriteRule.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.matching.Property;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.plugin.mongodb.MongoColumnHandle;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.expression.Variable;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.Type;
+import org.bson.Document;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.plugin.mongodb.TypeUtils.isPushdownSupportedArrayElementType;
+import static io.trino.plugin.mongodb.TypeUtils.translateValue;
+
+public class ContainsRewriteRule
+        implements ConnectorExpressionRule<Call, Document>
+{
+    private final Pattern<Call> expressionPattern;
+
+    public ContainsRewriteRule()
+    {
+        Pattern<Call> p = Pattern.typeOf(Call.class);
+        Property<Call, ?, FunctionName> functionName = Property.property("functionName", Call::getFunctionName);
+        this.expressionPattern = p.with(functionName.equalTo(new FunctionName("contains")));
+    }
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return this.expressionPattern;
+    }
+
+    @Override
+    public Optional<Document> rewrite(Call expression, Captures captures, RewriteContext<Document> context)
+    {
+        List<ConnectorExpression> arguments = expression.getArguments();
+
+        if (arguments.size() != 2 || !(arguments.get(0) instanceof Variable) || !(arguments.get(1) instanceof Constant)) {
+            return Optional.empty();
+        }
+
+        Variable arrVariable = (Variable) arguments.get(0);
+        Constant constValue = (Constant) arguments.get(1);
+
+        String columnName = arrVariable.getName();
+
+        if (!context.getAssignments().containsKey(columnName)) {
+            return Optional.empty();
+        }
+
+        MongoColumnHandle columnHandle = (MongoColumnHandle) context.getAssignment(columnName);
+        Type elementType = ((ArrayType) columnHandle.getType()).getElementType();
+        if (!isPushdownSupportedArrayElementType(elementType)) {
+            return Optional.empty();
+        }
+
+        Optional<Object> mongoValue = translateValue(constValue.getValue(), elementType);
+
+        return mongoValue.map(o -> new Document(columnHandle.getQualifiedName(), mapValueForJson(o)));
+    }
+
+    private Object mapValueForJson(Object value)
+    {
+        /*
+         * LocalDate and LocalDateTime in org.bson.Document causes an error when using Document.toJson().
+         * So convert it to Date object.
+         */
+        if (value instanceof LocalDate ld) {
+            return Date.from(ld.atStartOfDay().toInstant(ZoneOffset.UTC));
+        }
+        if (value instanceof LocalDateTime ldt) {
+            return Date.from(ldt.toInstant(ZoneOffset.UTC));
+        }
+
+        return value;
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/MongoConnectorExpressionRewriterBuilder.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/MongoConnectorExpressionRewriterBuilder.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.plugin.base.expression.ConnectorExpressionRewriter;
+import org.bson.Document;
+
+import java.util.Set;
+
+public class MongoConnectorExpressionRewriterBuilder
+{
+    private MongoConnectorExpressionRewriterBuilder() {}
+
+    public static ConnectorExpressionRewriter<Document> build()
+    {
+        return new ConnectorExpressionRewriter<Document>(Set.of(
+                new ContainsRewriteRule(),
+                new NotRewriteRule(),
+                new OrRewriteRule()));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/NotRewriteRule.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/NotRewriteRule.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.matching.Property;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.FunctionName;
+import org.bson.Document;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class NotRewriteRule
+        implements ConnectorExpressionRule<Call, Document>
+{
+    private final Pattern<Call> expressionPattern;
+
+    public NotRewriteRule()
+    {
+        Pattern<Call> p = Pattern.typeOf(Call.class);
+        Property<Call, ?, FunctionName> functionName = Property.property("functionName", Call::getFunctionName);
+        this.expressionPattern = p.with(functionName.equalTo(new FunctionName("$not")));
+    }
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return this.expressionPattern;
+    }
+
+    @Override
+    public Optional<Document> rewrite(Call expression, Captures captures, RewriteContext<Document> context)
+    {
+        List<Document> childrenPredicates = new ArrayList<>();
+
+        for (ConnectorExpression exp : expression.getArguments()) {
+            Optional<Document> predicate = context.defaultRewrite(exp);
+            if (predicate.isPresent()) {
+                childrenPredicates.add(predicate.get());
+            }
+            else {
+                return Optional.empty();
+            }
+        }
+
+        return Optional.of(new Document("$nor", childrenPredicates));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/NotRewriteRule.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/NotRewriteRule.java
@@ -15,33 +15,32 @@ package io.trino.plugin.mongodb.expression;
 
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
-import io.trino.matching.Property;
 import io.trino.plugin.base.expression.ConnectorExpressionRule;
 import io.trino.spi.expression.Call;
 import io.trino.spi.expression.ConnectorExpression;
-import io.trino.spi.expression.FunctionName;
 import org.bson.Document;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.spi.expression.StandardFunctions.NOT_FUNCTION_NAME;
+
 public class NotRewriteRule
         implements ConnectorExpressionRule<Call, Document>
 {
-    private final Pattern<Call> expressionPattern;
+    private static final Pattern<Call> PATTERN = call().with(functionName().equalTo(NOT_FUNCTION_NAME));
 
     public NotRewriteRule()
     {
-        Pattern<Call> p = Pattern.typeOf(Call.class);
-        Property<Call, ?, FunctionName> functionName = Property.property("functionName", Call::getFunctionName);
-        this.expressionPattern = p.with(functionName.equalTo(new FunctionName("$not")));
     }
 
     @Override
     public Pattern<Call> getPattern()
     {
-        return this.expressionPattern;
+        return PATTERN;
     }
 
     @Override

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/OrRewriteRule.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/OrRewriteRule.java
@@ -15,33 +15,32 @@ package io.trino.plugin.mongodb.expression;
 
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
-import io.trino.matching.Property;
 import io.trino.plugin.base.expression.ConnectorExpressionRule;
 import io.trino.spi.expression.Call;
 import io.trino.spi.expression.ConnectorExpression;
-import io.trino.spi.expression.FunctionName;
 import org.bson.Document;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.spi.expression.StandardFunctions.OR_FUNCTION_NAME;
+
 public class OrRewriteRule
         implements ConnectorExpressionRule<Call, Document>
 {
-    private final Pattern<Call> expressionPattern;
+    private static final Pattern<Call> PATTERN = call().with(functionName().equalTo(OR_FUNCTION_NAME));
 
     public OrRewriteRule()
     {
-        Pattern<Call> p = Pattern.typeOf(Call.class);
-        Property<Call, ?, FunctionName> functionName = Property.property("functionName", Call::getFunctionName);
-        this.expressionPattern = p.with(functionName.equalTo(new FunctionName("$or")));
     }
 
     @Override
     public Pattern<Call> getPattern()
     {
-        return (Pattern<Call>) this.expressionPattern;
+        return PATTERN;
     }
 
     @Override

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/OrRewriteRule.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/OrRewriteRule.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.matching.Property;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.FunctionName;
+import org.bson.Document;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class OrRewriteRule
+        implements ConnectorExpressionRule<Call, Document>
+{
+    private final Pattern<Call> expressionPattern;
+
+    public OrRewriteRule()
+    {
+        Pattern<Call> p = Pattern.typeOf(Call.class);
+        Property<Call, ?, FunctionName> functionName = Property.property("functionName", Call::getFunctionName);
+        this.expressionPattern = p.with(functionName.equalTo(new FunctionName("$or")));
+    }
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return (Pattern<Call>) this.expressionPattern;
+    }
+
+    @Override
+    public Optional<Document> rewrite(Call expression, Captures captures, RewriteContext<Document> context)
+    {
+        List<Document> childrenPredicates = new ArrayList<>();
+
+        for (ConnectorExpression exp : expression.getArguments()) {
+            Optional<Document> predicate = context.defaultRewrite(exp);
+            if (predicate.isPresent()) {
+                childrenPredicates.add(predicate.get());
+            }
+            else {
+                return Optional.empty();
+            }
+        }
+
+        return Optional.of(new Document("$or", childrenPredicates));
+    }
+}

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoClientConfig.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoClientConfig.java
@@ -44,6 +44,7 @@ public class TestMongoClientConfig
                 .setRequiredReplicaSetName(null)
                 .setImplicitRowFieldPrefix("_pos")
                 .setProjectionPushdownEnabled(true)
+                .setComplexExpressionPushdownEnabled(true)
                 .setAllowLocalScheduling(false));
     }
 
@@ -68,6 +69,7 @@ public class TestMongoClientConfig
                 .put("mongodb.required-replica-set", "replica_set")
                 .put("mongodb.implicit-row-field-prefix", "_prefix")
                 .put("mongodb.projection-pushdown-enabled", "false")
+                .put("mongodb.complex-expression-pushdown-enabled", "false")
                 .put("mongodb.allow-local-scheduling", "true")
                 .buildOrThrow();
 
@@ -88,6 +90,7 @@ public class TestMongoClientConfig
                 .setRequiredReplicaSetName("replica_set")
                 .setImplicitRowFieldPrefix("_prefix")
                 .setProjectionPushdownEnabled(false)
+                .setComplexExpressionPushdownEnabled(false)
                 .setAllowLocalScheduling(true);
 
         assertFullMapping(properties, expected);

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoComplexTypePredicatePushDown.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoComplexTypePredicatePushDown.java
@@ -17,8 +17,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.testing.BaseComplexTypesPredicatePushDownTest;
 import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
 
 import static io.trino.plugin.mongodb.MongoQueryRunner.createMongoQueryRunner;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestMongoComplexTypePredicatePushDown
         extends BaseComplexTypesPredicatePushDownTest
@@ -29,5 +32,82 @@ public class TestMongoComplexTypePredicatePushDown
     {
         MongoServer server = closeAfterClass(new MongoServer());
         return createMongoQueryRunner(server, ImmutableMap.of(), ImmutableList.of());
+    }
+
+    @Test
+    public void testArrayContainsPushdown()
+    {
+        String tableName = "test_array_contains_pushdown_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " (colArray ARRAY(BIGINT))");
+        assertUpdate("INSERT INTO " + tableName + " SELECT * FROM unnest(transform(SEQUENCE(1, 10000), x -> ROW(ARRAY[100, 200])))", 10000);
+
+        assertNoDataRead("SELECT * FROM " + tableName + " WHERE contains(colArray, -1)");
+
+        assertNoDataRead("SELECT * FROM " + tableName + " WHERE NOT contains(colArray, 100)");
+
+        assertNoDataRead("SELECT * FROM " + tableName + " WHERE contains(colArray, 100) AND contains(colArray, -1)");
+
+        assertNoDataRead("SELECT * FROM " + tableName + " WHERE NOT contains(colArray, 100) OR NOT contains(colArray, 200)");
+
+        assertQueryStats(
+                getSession(),
+                "SELECT * FROM " + tableName + " WHERE contains(colArray, 100)",
+                queryStats -> assertThat(queryStats.getProcessedInputDataSize().toBytes()).isGreaterThan(0),
+                results -> assertThat(results.getRowCount()).isEqualTo(10000));
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testArrayContainsPushdownDatatype()
+    {
+        String tableName = "test_array_contains_pushdown_datatype" + randomNameSuffix();
+        String createSql = """
+                CREATE TABLE %s (\
+                  boolArray ARRAY(BOOLEAN),\
+                  intArray ARRAY(BIGINT),\
+                  doubleArray ARRAY(DOUBLE),\
+                  decimalArray ARRAY(DECIMAL(10,3)),\
+                  tsArray ARRAY(TIMESTAMP(3)),\
+                  varcharArray ARRAY(VARCHAR),\
+                  varbinArray ARRAY(VARBINARY),\
+                  oidArray ARRAY(ObjectId))
+                """.formatted(tableName);
+        assertUpdate(createSql);
+        String insertSql = """
+                INSERT INTO %s SELECT * FROM unnest(transform(SEQUENCE(1, 10), x -> ROW(\
+                ARRAY[true, true],
+                ARRAY[100, 200],
+                ARRAY[10.3, 20.3],
+                ARRAY[10.3, 20.3],
+                ARRAY[TIMESTAMP '2024-03-19 15:28:23'],
+                ARRAY['hello', 'world'],
+                ARRAY[X'0D0A'],
+                ARRAY[ObjectId('55b151633864d6438c61a9ce')]
+                )))
+                """.formatted(tableName);
+        assertUpdate(insertSql, 10);
+
+        testFilterCount(tableName, "contains(boolArray, true)", 10);
+        testFilterCount(tableName,"contains(intArray, 100)", 10);
+        testFilterCount(tableName, "contains(doubleArray, 10.3)", 10);
+        testFilterCount(tableName, "contains(decimalArray, 10.3)", 10);
+        testFilterCount(tableName, "contains(tsArray, TIMESTAMP '2024-03-19 15:28:23')", 10);
+        testFilterCount(tableName, "contains(varcharArray, 'hello')", 10);
+        // testFilterCount(tableName, "contains(varbinArray, X'0D0A')", 10);
+        testFilterCount(tableName, "contains(oidArray, ObjectId('55b151633864d6438c61a9ce'))", 10);
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    private void testFilterCount(String tableName, String predicate, int expectCount)
+    {
+        assertQueryStats(
+                getSession(),
+                "SELECT * FROM %s WHERE %s".formatted(tableName, predicate),
+                queryStats -> assertThat(queryStats.getProcessedInputDataSize().toBytes()).isGreaterThan(0),
+                results -> assertThat(results.getRowCount()).isEqualTo(expectCount));
+
+        assertNoDataRead("SELECT * FROM %s WHERE not %s".formatted(tableName, predicate));
     }
 }

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoComplexTypePredicatePushDown.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoComplexTypePredicatePushDown.java
@@ -108,6 +108,8 @@ public class TestMongoComplexTypePredicatePushDown
                 queryStats -> assertThat(queryStats.getProcessedInputDataSize().toBytes()).isGreaterThan(0),
                 results -> assertThat(results.getRowCount()).isEqualTo(expectCount));
 
-        assertNoDataRead("SELECT * FROM %s WHERE not %s".formatted(tableName, predicate));
+        assertThat(query("SELECT * FROM %s WHERE not %s".formatted(tableName, predicate)))
+                .returnsEmptyResult()
+                .isFullyPushedDown();
     }
 }

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoExpressionRewrite.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoExpressionRewrite.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb;
+
+import io.trino.plugin.base.expression.ConnectorExpressionRewriter;
+import io.trino.plugin.mongodb.expression.MongoConnectorExpressionRewriterBuilder;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.expression.Variable;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.BigintType;
+import io.trino.spi.type.BooleanType;
+import org.bson.Document;
+import org.json.JSONException;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.Assert.assertTrue;
+
+public class TestMongoExpressionRewrite
+{
+    private final ConnectorExpressionRewriter<Document> connectorExpressionRewriter;
+
+    public TestMongoExpressionRewrite()
+    {
+        this.connectorExpressionRewriter = MongoConnectorExpressionRewriterBuilder.build();
+    }
+
+    @Test
+    public void testContainsFunctionRewrite()
+            throws JSONException
+    {
+        ConnectorExpression expression = buildContainsExpression("col", 1L);
+
+        Optional<Document> predicate = this.connectorExpressionRewriter.rewrite(
+                Mockito.mock(ConnectorSession.class),
+                expression,
+                Map.of("col", new MongoColumnHandle("col", List.of(), new ArrayType(BigintType.BIGINT), false, false, Optional.empty())));
+
+        assertTrue(predicate.isPresent());
+        JSONAssert.assertEquals("{\"col\": 1}", predicate.get().toJson(), false);
+    }
+
+    private static Call buildContainsExpression(String variableName, Long value)
+    {
+        return new Call(
+                BooleanType.BOOLEAN,
+                new FunctionName("contains"),
+                List.of(
+                        new Variable(variableName, new ArrayType(BigintType.BIGINT)),
+                        new Constant(value, BigintType.BIGINT)));
+    }
+
+    @Test
+    public void testNotContainsRewrite()
+            throws JSONException
+    {
+        ConnectorExpression expression = buildContainsExpression("col", 1L);
+        ConnectorExpression notExpression = new Call(
+                BooleanType.BOOLEAN,
+                new FunctionName("$not"),
+                List.of(expression));
+        Optional<Document> predicate = this.connectorExpressionRewriter.rewrite(
+                Mockito.mock(ConnectorSession.class),
+                notExpression,
+                Map.of("col", new MongoColumnHandle("col", List.of(), new ArrayType(BigintType.BIGINT), false, false, Optional.empty())));
+
+        assertTrue(predicate.isPresent());
+        JSONAssert.assertEquals("{\"$nor\": [{\"col\": 1}]}", predicate.get().toJson(), false);
+    }
+
+    @Test
+    public void testOrContainsRewrite()
+            throws JSONException
+    {
+        ConnectorExpression expression1 = buildContainsExpression("col", 1L);
+        ConnectorExpression expression2 = buildContainsExpression("col", 2L);
+        ConnectorExpression expression3 = buildContainsExpression("col", 3L);
+        ConnectorExpression notExpression = new Call(
+                BooleanType.BOOLEAN,
+                new FunctionName("$or"),
+                List.of(expression1, expression2, expression3));
+        Optional<Document> predicate = this.connectorExpressionRewriter.rewrite(
+                Mockito.mock(ConnectorSession.class),
+                notExpression,
+                Map.of("col", new MongoColumnHandle("col", List.of(), new ArrayType(BigintType.BIGINT), false, false, Optional.empty())));
+
+        assertTrue(predicate.isPresent());
+        JSONAssert.assertEquals("{\"$or\": [{\"col\": 1},{\"col\": 2},{\"col\": 3}]}", predicate.get().toJson(), false);
+    }
+}

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoExpressionRewrite.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoExpressionRewrite.java
@@ -15,7 +15,6 @@ package io.trino.plugin.mongodb;
 
 import io.trino.plugin.base.expression.ConnectorExpressionRewriter;
 import io.trino.plugin.mongodb.expression.MongoConnectorExpressionRewriterBuilder;
-import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.expression.Call;
 import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.expression.Constant;
@@ -24,10 +23,10 @@ import io.trino.spi.expression.Variable;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.BigintType;
 import io.trino.spi.type.BooleanType;
+import io.trino.testing.TestingConnectorSession;
 import org.bson.Document;
 import org.json.JSONException;
 import org.junit.Test;
-import org.mockito.Mockito;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.List;
@@ -52,7 +51,7 @@ public class TestMongoExpressionRewrite
         ConnectorExpression expression = buildContainsExpression("col", 1L);
 
         Optional<Document> predicate = this.connectorExpressionRewriter.rewrite(
-                Mockito.mock(ConnectorSession.class),
+                TestingConnectorSession.builder().build(),
                 expression,
                 Map.of("col", new MongoColumnHandle("col", List.of(), new ArrayType(BigintType.BIGINT), false, false, Optional.empty())));
 
@@ -80,7 +79,7 @@ public class TestMongoExpressionRewrite
                 new FunctionName("$not"),
                 List.of(expression));
         Optional<Document> predicate = this.connectorExpressionRewriter.rewrite(
-                Mockito.mock(ConnectorSession.class),
+                TestingConnectorSession.builder().build(),
                 notExpression,
                 Map.of("col", new MongoColumnHandle("col", List.of(), new ArrayType(BigintType.BIGINT), false, false, Optional.empty())));
 
@@ -100,7 +99,7 @@ public class TestMongoExpressionRewrite
                 new FunctionName("$or"),
                 List.of(expression1, expression2, expression3));
         Optional<Document> predicate = this.connectorExpressionRewriter.rewrite(
-                Mockito.mock(ConnectorSession.class),
+                TestingConnectorSession.builder().build(),
                 notExpression,
                 Map.of("col", new MongoColumnHandle("col", List.of(), new ArrayType(BigintType.BIGINT), false, false, Optional.empty())));
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Add "contains" function pushdown for mongo connector.

Tested the following formals:

    WHERE contains(colArray, -1)
    WHERE NOT contains(colArray, 100)
    WHERE NOT contains(colArray, 100) OR NOT contains(colArray, 200)

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Fixes #21043 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
