### PR TITLE
Exclude unused dependencies from Launcher

### DIFF
--- a/testing/trino-product-tests-launcher/pom.xml
+++ b/testing/trino-product-tests-launcher/pom.xml
@@ -310,6 +310,7 @@
                             <skip>false</skip>
                             <includeArtifactIds>kafka-protobuf-provider,kafka-protobuf-types</includeArtifactIds>
                             <outputDirectory>${project.build.directory}</outputDirectory>
+                            <stripVersion>true</stripVersion>
                         </configuration>
                     </execution>
                     <execution>

--- a/testing/trino-product-tests-launcher/pom.xml
+++ b/testing/trino-product-tests-launcher/pom.xml
@@ -153,59 +153,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.databricks</groupId>
-            <artifactId>databricks-jdbc</artifactId>
-            <version>2.6.36</version>
-            <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-protobuf-provider</artifactId>
-            <!-- This is under Confluent Community License and we use it under runtime scope only for tests -->
-            <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-protobuf-types</artifactId>
-            <!-- This is under Confluent Community License and we use it under runtime scope only for tests -->
-            <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.hive</groupId>
-            <artifactId>hive-jdbc</artifactId>
-            <version>3.1.3</version>
-            <classifier>standalone</classifier>
-            <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>junit-extensions</artifactId>
             <scope>test</scope>
@@ -242,24 +189,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.basepom.maven</groupId>
-                <artifactId>duplicate-finder-maven-plugin</artifactId>
-                <configuration>
-                    <ignoredDependencies>
-                        <dependency>
-                            <groupId>com.databricks</groupId>
-                            <artifactId>databricks-jdbc</artifactId>
-                        </dependency>
-
-                        <dependency>
-                            <groupId>org.apache.hive</groupId>
-                            <artifactId>hive-jdbc</artifactId>
-                        </dependency>
-                    </ignoredDependencies>
-                </configuration>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
@@ -301,43 +230,46 @@
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>copy-kafka</id>
+                        <id>copy</id>
                         <goals>
-                            <goal>copy-dependencies</goal>
+                            <goal>copy</goal>
                         </goals>
                         <phase>package</phase>
                         <configuration>
                             <skip>false</skip>
-                            <includeArtifactIds>kafka-protobuf-provider,kafka-protobuf-types</includeArtifactIds>
-                            <outputDirectory>${project.build.directory}</outputDirectory>
-                            <stripVersion>true</stripVersion>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>copy-databricks</id>
-                        <goals>
-                            <goal>copy-dependencies</goal>
-                        </goals>
-                        <phase>package</phase>
-                        <configuration>
-                            <skip>false</skip>
-                            <includeArtifactIds>databricks-jdbc</includeArtifactIds>
-                            <outputDirectory>${project.build.directory}</outputDirectory>
-                            <stripVersion>true</stripVersion>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>copy-hive</id>
-                        <goals>
-                            <goal>copy-dependencies</goal>
-                        </goals>
-                        <phase>package</phase>
-                        <configuration>
-                            <skip>false</skip>
-                            <includeArtifactIds>hive-jdbc</includeArtifactIds>
-                            <outputDirectory>${project.build.directory}</outputDirectory>
-                            <stripVersion>true</stripVersion>
-                            <stripClassifier>true</stripClassifier>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>io.confluent</groupId>
+                                    <artifactId>kafka-protobuf-provider</artifactId>
+                                    <type>jar</type>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                    <destFileName>kafka-protobuf-provider.jar</destFileName>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>io.confluent</groupId>
+                                    <artifactId>kafka-protobuf-types</artifactId>
+                                    <type>jar</type>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                    <destFileName>kafka-protobuf-types.jar</destFileName>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.hive</groupId>
+                                    <artifactId>hive-jdbc</artifactId>
+                                    <classifier>standalone</classifier>
+                                    <version>3.1.3</version>
+                                    <type>jar</type>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                    <destFileName>hive-jdbc.jar</destFileName>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.databricks</groupId>
+                                    <artifactId>databricks-jdbc</artifactId>
+                                    <version>2.6.36</version>
+                                    <type>jar</type>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                    <destFileName>databricks-jdbc.jar</destFileName>
+                                </artifactItem>
+                            </artifactItems>
                         </configuration>
                     </execution>
                 </executions>

--- a/testing/trino-product-tests-launcher/pom.xml
+++ b/testing/trino-product-tests-launcher/pom.xml
@@ -212,12 +212,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.trino</groupId>
-            <artifactId>trino-jdbc</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodeConfluentKafka.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodeConfluentKafka.java
@@ -26,7 +26,6 @@ import io.trino.tests.product.launcher.env.common.TestsEnvironment;
 
 import java.io.File;
 
-import static io.trino.testing.TestingProperties.getConfluentVersion;
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.configureTempto;
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.isTrinoContainer;
 import static io.trino.tests.product.launcher.env.common.Standard.CONTAINER_TRINO_ETC;
@@ -44,8 +43,8 @@ import static org.testcontainers.utility.MountableFile.forHostPath;
 public final class EnvMultinodeConfluentKafka
         extends EnvironmentProvider
 {
-    private static final File KAFKA_PROTOBUF_PROVIDER = new File("testing/trino-product-tests-launcher/target/kafka-protobuf-provider-" + getConfluentVersion() + ".jar");
-    private static final File KAFKA_PROTOBUF_TYPES = new File("testing/trino-product-tests-launcher/target/kafka-protobuf-types-" + getConfluentVersion() + ".jar");
+    private static final File KAFKA_PROTOBUF_PROVIDER = new File("testing/trino-product-tests-launcher/target/kafka-protobuf-provider.jar");
+    private static final File KAFKA_PROTOBUF_TYPES = new File("testing/trino-product-tests-launcher/target/kafka-protobuf-types.jar");
 
     private final ResourceProvider configDir;
 

--- a/testing/trino-testing-services/src/main/java/io/trino/testing/TestingProperties.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testing/TestingProperties.java
@@ -52,11 +52,6 @@ public class TestingProperties
         return getProjectProperty("docker.images.version");
     }
 
-    public static String getConfluentVersion()
-    {
-        return getProjectProperty("confluent.version");
-    }
-
     private static String getProjectProperty(String name)
     {
         return requireNonNull(properties.get().getProperty(name), name + " is null");

--- a/testing/trino-testing-services/src/main/resources/trino-testing.properties
+++ b/testing/trino-testing-services/src/main/resources/trino-testing.properties
@@ -1,3 +1,2 @@
 project.version=${project.version}
 docker.images.version=${dep.docker.images.version}
-confluent.version=${dep.confluent.version}


### PR DESCRIPTION
Product Tests Launcher uses mounts various jars (JDBC drivers,
libraries) in the docker container it starts. These files are loaded at
runtime from Launcher's `target/` directory. Remove these jars from
Launcher classpath. This shrinks the launcher executable jar from 155 MB
to 63 MB.

