### PR TITLE
Avoid SELECT * in base JDBC query builder

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
@@ -36,6 +36,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -128,7 +129,9 @@ public class DefaultQueryBuilder
         String query = format(
                 // The subquery aliases (`l` and `r`) are needed by some databases, but are not needed for expressions
                 // The joinConditions and output columns are aliased to use unique names.
-                "SELECT * FROM (SELECT %s FROM (%s) l) l %s (SELECT %s FROM (%s) r) r ON %s",
+                "SELECT %s, %s FROM (SELECT %s FROM (%s) l) l %s (SELECT %s FROM (%s) r) r ON %s",
+                formatProjectionAliases(client, leftProjections.values()),
+                formatProjectionAliases(client, rightProjections.values()),
                 formatProjections(client, leftProjections),
                 leftSource.getQuery(),
                 formatJoinType(joinType),
@@ -337,6 +340,13 @@ public class DefaultQueryBuilder
     {
         return projections.entrySet().stream()
                 .map(entry -> format("%s AS %s", client.quoted(entry.getKey().getColumnName()), client.quoted(entry.getValue())))
+                .collect(joining(", "));
+    }
+
+    protected String formatProjectionAliases(JdbcClient client, Collection<String> aliases)
+    {
+        return aliases.stream()
+                .map(s -> format("%s", client.quoted(s)))
                 .collect(joining(", "));
     }
 

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcQueryBuilder.java
@@ -523,7 +523,7 @@ public class TestDefaultJdbcQueryBuilder
                 List.of(new ParameterizedExpression("\"lcol7\" = \"rcol8\"", List.of())));
         try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(jdbcClient, SESSION, connection, preparedQuery, Optional.empty())) {
             assertThat(preparedQuery.getQuery()).isEqualTo("""
-                    SELECT * FROM \
+                    SELECT "name1", "lcol7", "name2", "rcol8" FROM \
                     (SELECT "col_2" AS "name1", "col_7" AS "lcol7" FROM (SELECT * FROM "test_table") l) l \
                     INNER JOIN \
                     (SELECT "col_3" AS "name2", "col_8" AS "rcol8" FROM (SELECT * FROM "test_table") r) r \


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

SELECT * can have special behavior in some databases and generally should be avoided. This restores to previous behavior, before 91a29a7d8d2ddb1d1e7ba9bb529160d06f4542b5 (#19996).


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
