### PR TITLE
Isolate testSelectInformationSchemaColumns for SQL Server

### DIFF
--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConnectorTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConnectorTest.java
@@ -278,4 +278,12 @@ public class TestSqlServerConnectorTest
                 .add("close]bracket")
                 .build();
     }
+
+    @Test
+    @Override
+    public void testSelectInformationSchemaColumns()
+    {
+        // Isolate this test to avoid problem described in https://github.com/trinodb/trino/issues/10846
+        executeExclusively(super::testSelectInformationSchemaColumns);
+    }
 }


### PR DESCRIPTION
Workaround product problem which leads to test flakiness. Having unfixed product problem is bad, but having unfixed product problem *and* flaky tests isn't better.

Relates to https://github.com/trinodb/trino/issues/10846
Fixes https://github.com/trinodb/trino/issues/16286
Fixes https://github.com/trinodb/trino/issues/8556
