### PR TITLE
Make Opensearch deployment type configurable

### DIFF
--- a/docs/src/main/sphinx/connector/opensearch.md
+++ b/docs/src/main/sphinx/connector/opensearch.md
@@ -112,6 +112,8 @@ following options must be configured:
     the configured IAM user must be able to assume this role.
 * - `opensearch.aws.external-id`
   - Optional external ID to pass while assuming an AWS IAM role.
+* - `opensearch.aws.deployment-type`
+  - AWS OpenSearch deployment type. Possible values are `PROVISIONED` & `SERVERLESS`. This option is required.
 :::
 
 To enable password authentication, the `opensearch.security` option must be set

--- a/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/AwsSecurityConfig.java
+++ b/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/AwsSecurityConfig.java
@@ -22,11 +22,18 @@ import java.util.Optional;
 
 public class AwsSecurityConfig
 {
+    public enum DeploymentType
+    {
+        PROVISIONED,
+        SERVERLESS,
+    }
+
     private String accessKey;
     private String secretKey;
     private String region;
     private String iamRole;
     private String externalId;
+    private DeploymentType deploymentType;
 
     @NotNull
     public Optional<String> getAccessKey()
@@ -92,6 +99,19 @@ public class AwsSecurityConfig
     public AwsSecurityConfig setExternalId(String externalId)
     {
         this.externalId = externalId;
+        return this;
+    }
+
+    @NotNull
+    public DeploymentType getDeploymentType()
+    {
+        return deploymentType;
+    }
+
+    @Config("opensearch.aws.deployment-type")
+    public AwsSecurityConfig setDeploymentType(DeploymentType deploymentType)
+    {
+        this.deploymentType = deploymentType;
         return this;
     }
 }

--- a/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/client/OpenSearchClient.java
+++ b/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/client/OpenSearchClient.java
@@ -237,6 +237,7 @@ public class OpenSearchClient
 
             awsSecurityConfig.ifPresent(securityConfig -> clientBuilder.addInterceptorLast(new AwsRequestSigner(
                     securityConfig.getRegion(),
+                    securityConfig.getDeploymentType(),
                     getAwsCredentialsProvider(securityConfig))));
 
             return clientBuilder;

--- a/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/TestAwsSecurityConfig.java
+++ b/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/TestAwsSecurityConfig.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.trino.plugin.opensearch.AwsSecurityConfig.DeploymentType.SERVERLESS;
 
 public class TestAwsSecurityConfig
 {
@@ -32,7 +33,8 @@ public class TestAwsSecurityConfig
                 .setSecretKey(null)
                 .setRegion(null)
                 .setIamRole(null)
-                .setExternalId(null));
+                .setExternalId(null)
+                .setDeploymentType(null));
     }
 
     @Test
@@ -44,6 +46,7 @@ public class TestAwsSecurityConfig
                 .put("opensearch.aws.region", "region")
                 .put("opensearch.aws.iam-role", "iamRole")
                 .put("opensearch.aws.external-id", "externalId")
+                .put("opensearch.aws.deployment-type", "SERVERLESS")
                 .buildOrThrow();
 
         AwsSecurityConfig expected = new AwsSecurityConfig()
@@ -51,7 +54,8 @@ public class TestAwsSecurityConfig
                 .setSecretKey("secret")
                 .setRegion("region")
                 .setIamRole("iamRole")
-                .setExternalId("externalId");
+                .setExternalId("externalId")
+                .setDeploymentType(SERVERLESS);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

AWS4Signer takes [different service name based on the deployment type](https://repost.aws/questions/QU5Uh7PmQERR6ysMQgrHv9AA/is-opensearch-serverless-meant-to-authenticate-like-opensearch-service)([Opensearch serverless](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless.html) vs [Opensearch provisioned](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/what-is.html)). Make Opensearch deployment type configurable to populate correct service name while using AWS auth.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
Make opensearch deployment type configurable while using AWS auth
```
