### PR TITLE
Add writer and scale writer stats

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/OperatorContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OperatorContext.java
@@ -92,7 +92,6 @@ public class OperatorContext
 
     private final AtomicLong writerInputDataSize = new AtomicLong();
     private final AtomicLong physicalWrittenDataSize = new AtomicLong();
-
     private final AtomicReference<SettableFuture<Void>> memoryFuture;
     private final AtomicReference<SettableFuture<Void>> revocableMemoryFuture;
     private final AtomicReference<BlockedMonitor> blockedMonitor = new AtomicReference<>();

--- a/core/trino-main/src/main/java/io/trino/operator/TableWriterOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableWriterOperator.java
@@ -235,6 +235,7 @@ public class TableWriterOperator
             finishFuture = pageSink.finish();
             blockedOnFinish = toListenableFuture(finishFuture);
             updateWrittenBytes();
+            operatorContext.setLatestMetrics(pageSink.getMetrics());
         }
         this.blocked = asVoid(allAsList(currentlyBlocked, blockedOnAggregation, blockedOnFinish));
     }

--- a/core/trino-main/src/main/java/io/trino/operator/TaskStats.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TaskStats.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.operator.output.SkewedPartitionRebalancer.ScaleWriterStats;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -87,6 +88,10 @@ public class TaskStats
     private final DataSize physicalWrittenDataSize;
     private final Optional<Integer> maxWriterCount;
 
+    // scale writers metrics
+    private final Optional<ScaleWriterStats> scaleWriterRemoteExchangeStats;
+    private final Optional<ScaleWriterStats> scaleWriterLocalExchangeStats;
+
     private final int fullGcCount;
     private final Duration fullGcTime;
 
@@ -135,6 +140,8 @@ public class TaskStats
                 new Duration(0, MILLISECONDS),
                 DataSize.ofBytes(0),
                 DataSize.ofBytes(0),
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty(),
                 0,
                 new Duration(0, MILLISECONDS),
@@ -196,6 +203,10 @@ public class TaskStats
             @JsonProperty("writerInputDataSize") DataSize writerInputDataSize,
             @JsonProperty("physicalWrittenDataSize") DataSize physicalWrittenDataSize,
             @JsonProperty("writerCount") Optional<Integer> writerCount,
+
+            // scale writer stats
+            @JsonProperty("scaleWriterRemoteExchangeStats") Optional<ScaleWriterStats> scaleWriterRemoteExchangeStats,
+            @JsonProperty("scaleWriterLocalExchangeStats") Optional<ScaleWriterStats> scaleWriterLocalExchangeStats,
 
             @JsonProperty("fullGcCount") int fullGcCount,
             @JsonProperty("fullGcTime") Duration fullGcTime,
@@ -272,6 +283,9 @@ public class TaskStats
         this.writerInputDataSize = requireNonNull(writerInputDataSize, "writerInputDataSize is null");
         this.physicalWrittenDataSize = requireNonNull(physicalWrittenDataSize, "physicalWrittenDataSize is null");
         this.maxWriterCount = requireNonNull(writerCount, "writerCount is null");
+
+        this.scaleWriterRemoteExchangeStats = requireNonNull(scaleWriterRemoteExchangeStats, "scaleWriterRemoteExchangeStats is null");
+        this.scaleWriterLocalExchangeStats = requireNonNull(scaleWriterLocalExchangeStats, "scaleWriterLocalExchangeStats is null");
 
         checkArgument(fullGcCount >= 0, "fullGcCount is negative");
         this.fullGcCount = fullGcCount;
@@ -514,6 +528,18 @@ public class TaskStats
     }
 
     @JsonProperty
+    public Optional<ScaleWriterStats> getScaleWriterRemoteExchangeStats()
+    {
+        return scaleWriterRemoteExchangeStats;
+    }
+
+    @JsonProperty
+    public Optional<ScaleWriterStats> getScaleWriterLocalExchangeStats()
+    {
+        return scaleWriterLocalExchangeStats;
+    }
+
+    @JsonProperty
     public List<PipelineStats> getPipelines()
     {
         return pipelines;
@@ -600,6 +626,8 @@ public class TaskStats
                 writerInputDataSize,
                 physicalWrittenDataSize,
                 maxWriterCount,
+                scaleWriterRemoteExchangeStats,
+                scaleWriterLocalExchangeStats,
                 fullGcCount,
                 fullGcTime,
                 ImmutableList.of());
@@ -650,6 +678,8 @@ public class TaskStats
                 writerInputDataSize,
                 physicalWrittenDataSize,
                 maxWriterCount,
+                scaleWriterRemoteExchangeStats,
+                scaleWriterLocalExchangeStats,
                 fullGcCount,
                 fullGcTime,
                 summarizePipelineStats(pipelines));

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchange.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchange.java
@@ -53,6 +53,7 @@ import static io.trino.SystemSessionProperties.getQueryMaxMemoryPerNode;
 import static io.trino.SystemSessionProperties.getSkewedPartitionMinDataProcessedRebalanceThreshold;
 import static io.trino.operator.InterpretedHashGenerator.createChannelsHashGenerator;
 import static io.trino.operator.exchange.LocalExchangeSink.finishedLocalExchangeSink;
+import static io.trino.operator.output.SkewedPartitionRebalancer.ScaleWriterStats;
 import static io.trino.sql.planner.PartitioningHandle.isScaledWriterHashDistribution;
 import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_ARBITRARY_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_BROADCAST_DISTRIBUTION;
@@ -98,7 +99,8 @@ public class LocalExchange
             DataSize maxBufferedBytes,
             TypeOperators typeOperators,
             DataSize writerScalingMinDataProcessed,
-            Supplier<Long> totalMemoryUsed)
+            Supplier<Long> totalMemoryUsed,
+            Consumer<ScaleWriterStats> scaleWriterStatsConsumer)
     {
         int bufferCount = computeBufferCount(partitioning, defaultConcurrency, partitionChannels);
 
@@ -145,7 +147,8 @@ public class LocalExchange
                     bufferCount,
                     1,
                     writerScalingMinDataProcessed.toBytes(),
-                    getSkewedPartitionMinDataProcessedRebalanceThreshold(session).toBytes());
+                    getSkewedPartitionMinDataProcessedRebalanceThreshold(session).toBytes(),
+                    scaleWriterStatsConsumer);
             LocalExchangeMemoryManager memoryManager = new LocalExchangeMemoryManager(maxBufferedBytes.toBytes());
             sources = IntStream.range(0, bufferCount)
                     .mapToObj(i -> new LocalExchangeSource(memoryManager, source -> checkAllSourcesFinished()))

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -595,7 +595,8 @@ public class LocalExecutionPlanner
                     taskCount,
                     taskBucketCount,
                     getWriterScalingMinDataProcessed(taskContext.getSession()).toBytes(),
-                    getSkewedPartitionMinDataProcessedRebalanceThreshold(taskContext.getSession()).toBytes()));
+                    getSkewedPartitionMinDataProcessedRebalanceThreshold(taskContext.getSession()).toBytes(),
+                    taskContext::setScaleWriterRemoteExchangeStats));
         }
         else {
             partitionFunction = nodePartitioningManager.getPartitionFunction(taskContext.getSession(), partitioningScheme, partitionChannelTypes);
@@ -3614,7 +3615,8 @@ public class LocalExecutionPlanner
                     maxLocalExchangeBufferSize,
                     typeOperators,
                     getWriterScalingMinDataProcessed(session),
-                    () -> context.getTaskContext().getQueryMemoryReservation().toBytes());
+                    () -> context.getTaskContext().getQueryMemoryReservation().toBytes(),
+                    context.getTaskContext()::setScaleWriterLocalExchangeStats);
 
             List<Symbol> expectedLayout = getOnlyElement(node.getInputs());
             Function<Page, Page> pagePreprocessor = enforceLoadedLayoutProcessor(expectedLayout, source.getLayout());
@@ -3691,7 +3693,8 @@ public class LocalExecutionPlanner
                     maxLocalExchangeBufferSize,
                     typeOperators,
                     getWriterScalingMinDataProcessed(session),
-                    () -> context.getTaskContext().getQueryMemoryReservation().toBytes());
+                    () -> context.getTaskContext().getQueryMemoryReservation().toBytes(),
+                    context.getTaskContext()::setScaleWriterLocalExchangeStats);
             for (int i = 0; i < node.getSources().size(); i++) {
                 DriverFactoryParameters driverFactoryParameters = driverFactoryParametersList.get(i);
                 PhysicalOperation source = driverFactoryParameters.getSource();

--- a/core/trino-main/src/test/java/io/trino/execution/TestStageStateMachine.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestStageStateMachine.java
@@ -316,6 +316,8 @@ public class TestStageStateMachine
                 DataSize.ofBytes(baseValue),
                 DataSize.ofBytes(baseValue),
                 Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
                 baseValue,
                 new Duration(baseValue, MILLISECONDS),
                 pipelineContexts.stream().map(PipelineContext::getPipelineStats).collect(toImmutableList()));

--- a/core/trino-main/src/test/java/io/trino/memory/TestLeastWastedEffortTaskLowMemoryKiller.java
+++ b/core/trino-main/src/test/java/io/trino/memory/TestLeastWastedEffortTaskLowMemoryKiller.java
@@ -327,6 +327,8 @@ public class TestLeastWastedEffortTaskLowMemoryKiller
                         DataSize.ofBytes(0),
                         DataSize.ofBytes(0),
                         Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
                         0,
                         new Duration(0, MILLISECONDS),
                         ImmutableList.of()),

--- a/core/trino-main/src/test/java/io/trino/memory/TestTotalReservationOnBlockedNodesTaskLowMemoryKiller.java
+++ b/core/trino-main/src/test/java/io/trino/memory/TestTotalReservationOnBlockedNodesTaskLowMemoryKiller.java
@@ -302,6 +302,8 @@ public class TestTotalReservationOnBlockedNodesTaskLowMemoryKiller
                         DataSize.ofBytes(0),
                         DataSize.ofBytes(0),
                         Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
                         0,
                         new Duration(0, MILLISECONDS),
                         ImmutableList.of()),

--- a/core/trino-main/src/test/java/io/trino/operator/TestTaskStats.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestTaskStats.java
@@ -84,6 +84,9 @@ public class TestTaskStats
             DataSize.ofBytes(25),
             Optional.of(2),
 
+            Optional.empty(),
+            Optional.empty(),
+
             26,
             new Duration(27, NANOSECONDS),
 

--- a/core/trino-main/src/test/java/io/trino/operator/exchange/TestLocalExchange.java
+++ b/core/trino-main/src/test/java/io/trino/operator/exchange/TestLocalExchange.java
@@ -61,6 +61,7 @@ import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.SystemSessionProperties.QUERY_MAX_MEMORY_PER_NODE;
 import static io.trino.SystemSessionProperties.SKEWED_PARTITION_MIN_DATA_PROCESSED_REBALANCE_THRESHOLD;
 import static io.trino.operator.InterpretedHashGenerator.createChannelsHashGenerator;
+import static io.trino.operator.output.SkewedPartitionRebalancer.ScaleWriterStats;
 import static io.trino.spi.connector.ConnectorBucketNodeMap.createBucketNodeMap;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
@@ -89,6 +90,7 @@ public class TestLocalExchange
     private static final Session SESSION = testSessionBuilder().build();
     private static final DataSize WRITER_SCALING_MIN_DATA_PROCESSED = DataSize.of(32, MEGABYTE);
     private static final Supplier<Long> TOTAL_MEMORY_USED = () -> 0L;
+    private static final Consumer<ScaleWriterStats> SCALE_WRITER_STATS_CONSUMER = scaleWriterStats -> {};
 
     private final ConcurrentMap<CatalogHandle, ConnectorNodePartitioningProvider> partitionManagers = new ConcurrentHashMap<>();
     private NodePartitioningManager nodePartitioningManager;
@@ -125,7 +127,8 @@ public class TestLocalExchange
                 DataSize.ofBytes(retainedSizeOfPages(99)),
                 TYPE_OPERATORS,
                 WRITER_SCALING_MIN_DATA_PROCESSED,
-                TOTAL_MEMORY_USED);
+                TOTAL_MEMORY_USED,
+                SCALE_WRITER_STATS_CONSUMER);
 
         run(localExchange, exchange -> {
             assertThat(exchange.getBufferCount()).isEqualTo(1);
@@ -199,7 +202,8 @@ public class TestLocalExchange
                 LOCAL_EXCHANGE_MAX_BUFFERED_BYTES,
                 TYPE_OPERATORS,
                 WRITER_SCALING_MIN_DATA_PROCESSED,
-                TOTAL_MEMORY_USED);
+                TOTAL_MEMORY_USED,
+                SCALE_WRITER_STATS_CONSUMER);
 
         run(localExchange, exchange -> {
             assertThat(exchange.getBufferCount()).isEqualTo(2);
@@ -249,7 +253,8 @@ public class TestLocalExchange
                 DataSize.ofBytes(retainedSizeOfPages(4)),
                 TYPE_OPERATORS,
                 DataSize.ofBytes(sizeOfPages(2)),
-                TOTAL_MEMORY_USED);
+                TOTAL_MEMORY_USED,
+                SCALE_WRITER_STATS_CONSUMER);
 
         run(localExchange, exchange -> {
             assertThat(exchange.getBufferCount()).isEqualTo(3);
@@ -309,7 +314,8 @@ public class TestLocalExchange
                 DataSize.ofBytes(retainedSizeOfPages(4)),
                 TYPE_OPERATORS,
                 DataSize.ofBytes(sizeOfPages(10)),
-                TOTAL_MEMORY_USED);
+                TOTAL_MEMORY_USED,
+                SCALE_WRITER_STATS_CONSUMER);
 
         run(localExchange, exchange -> {
             assertThat(exchange.getBufferCount()).isEqualTo(3);
@@ -360,7 +366,8 @@ public class TestLocalExchange
                 DataSize.ofBytes(retainedSizeOfPages(2)),
                 TYPE_OPERATORS,
                 DataSize.of(10, KILOBYTE),
-                TOTAL_MEMORY_USED);
+                TOTAL_MEMORY_USED,
+                SCALE_WRITER_STATS_CONSUMER);
 
         run(localExchange, exchange -> {
             assertThat(exchange.getBufferCount()).isEqualTo(4);
@@ -469,7 +476,8 @@ public class TestLocalExchange
                 DataSize.ofBytes(retainedSizeOfPages(4)),
                 TYPE_OPERATORS,
                 DataSize.ofBytes(sizeOfPages(2)),
-                totalMemoryUsed::get);
+                totalMemoryUsed::get,
+                SCALE_WRITER_STATS_CONSUMER);
 
         run(localExchange, exchange -> {
             assertThat(exchange.getBufferCount()).isEqualTo(3);
@@ -513,7 +521,8 @@ public class TestLocalExchange
                 DataSize.ofBytes(retainedSizeOfPages(20)),
                 TYPE_OPERATORS,
                 DataSize.ofBytes(sizeOfPages(2)),
-                TOTAL_MEMORY_USED);
+                TOTAL_MEMORY_USED,
+                SCALE_WRITER_STATS_CONSUMER);
 
         run(localExchange, exchange -> {
             assertThat(exchange.getBufferCount()).isEqualTo(3);
@@ -566,7 +575,8 @@ public class TestLocalExchange
                 DataSize.ofBytes(retainedSizeOfPages(2)),
                 TYPE_OPERATORS,
                 DataSize.of(10, KILOBYTE),
-                TOTAL_MEMORY_USED);
+                TOTAL_MEMORY_USED,
+                SCALE_WRITER_STATS_CONSUMER);
 
         run(localExchange, exchange -> {
             assertThat(exchange.getBufferCount()).isEqualTo(4);
@@ -662,7 +672,8 @@ public class TestLocalExchange
                 DataSize.ofBytes(retainedSizeOfPages(2)),
                 TYPE_OPERATORS,
                 DataSize.of(50, MEGABYTE),
-                TOTAL_MEMORY_USED);
+                TOTAL_MEMORY_USED,
+                SCALE_WRITER_STATS_CONSUMER);
 
         run(localExchange, exchange -> {
             assertThat(exchange.getBufferCount()).isEqualTo(4);
@@ -732,7 +743,8 @@ public class TestLocalExchange
                 DataSize.of(50, MEGABYTE),
                 TYPE_OPERATORS,
                 DataSize.of(10, KILOBYTE),
-                TOTAL_MEMORY_USED);
+                TOTAL_MEMORY_USED,
+                SCALE_WRITER_STATS_CONSUMER);
 
         run(localExchange, exchange -> {
             assertThat(exchange.getBufferCount()).isEqualTo(4);
@@ -804,7 +816,8 @@ public class TestLocalExchange
                 DataSize.ofBytes(retainedSizeOfPages(2)),
                 TYPE_OPERATORS,
                 DataSize.of(10, KILOBYTE),
-                totalMemoryUsed::get);
+                totalMemoryUsed::get,
+                SCALE_WRITER_STATS_CONSUMER);
 
         run(localExchange, exchange -> {
             assertThat(exchange.getBufferCount()).isEqualTo(4);
@@ -891,7 +904,8 @@ public class TestLocalExchange
                 DataSize.ofBytes(retainedSizeOfPages(2)),
                 TYPE_OPERATORS,
                 DataSize.of(10, KILOBYTE),
-                totalMemoryUsed::get);
+                totalMemoryUsed::get,
+                SCALE_WRITER_STATS_CONSUMER);
 
         run(localExchange, exchange -> {
             assertThat(exchange.getBufferCount()).isEqualTo(4);
@@ -984,7 +998,8 @@ public class TestLocalExchange
                 DataSize.ofBytes(retainedSizeOfPages(2)),
                 TYPE_OPERATORS,
                 DataSize.of(50, KILOBYTE),
-                TOTAL_MEMORY_USED);
+                TOTAL_MEMORY_USED,
+                SCALE_WRITER_STATS_CONSUMER);
 
         run(localExchange, exchange -> {
             assertThat(exchange.getBufferCount()).isEqualTo(2);
@@ -1032,7 +1047,8 @@ public class TestLocalExchange
                 DataSize.ofBytes(retainedSizeOfPages(1)),
                 TYPE_OPERATORS,
                 WRITER_SCALING_MIN_DATA_PROCESSED,
-                TOTAL_MEMORY_USED);
+                TOTAL_MEMORY_USED,
+                SCALE_WRITER_STATS_CONSUMER);
 
         run(localExchange, exchange -> {
             assertThat(exchange.getBufferCount()).isEqualTo(2);
@@ -1100,7 +1116,8 @@ public class TestLocalExchange
                 LOCAL_EXCHANGE_MAX_BUFFERED_BYTES,
                 TYPE_OPERATORS,
                 WRITER_SCALING_MIN_DATA_PROCESSED,
-                TOTAL_MEMORY_USED);
+                TOTAL_MEMORY_USED,
+                SCALE_WRITER_STATS_CONSUMER);
 
         run(localExchange, exchange -> {
             assertThat(exchange.getBufferCount()).isEqualTo(2);
@@ -1197,7 +1214,8 @@ public class TestLocalExchange
                 LOCAL_EXCHANGE_MAX_BUFFERED_BYTES,
                 TYPE_OPERATORS,
                 WRITER_SCALING_MIN_DATA_PROCESSED,
-                TOTAL_MEMORY_USED);
+                TOTAL_MEMORY_USED,
+                SCALE_WRITER_STATS_CONSUMER);
 
         run(localExchange, exchange -> {
             assertThat(exchange.getBufferCount()).isEqualTo(2);
@@ -1249,7 +1267,8 @@ public class TestLocalExchange
                 LOCAL_EXCHANGE_MAX_BUFFERED_BYTES,
                 TYPE_OPERATORS,
                 WRITER_SCALING_MIN_DATA_PROCESSED,
-                TOTAL_MEMORY_USED);
+                TOTAL_MEMORY_USED,
+                SCALE_WRITER_STATS_CONSUMER);
 
         run(localExchange, exchange -> {
             assertThat(exchange.getBufferCount()).isEqualTo(2);
@@ -1297,7 +1316,8 @@ public class TestLocalExchange
                 DataSize.ofBytes(2),
                 TYPE_OPERATORS,
                 WRITER_SCALING_MIN_DATA_PROCESSED,
-                TOTAL_MEMORY_USED);
+                TOTAL_MEMORY_USED,
+                SCALE_WRITER_STATS_CONSUMER);
 
         run(localExchange, exchange -> {
             assertThat(exchange.getBufferCount()).isEqualTo(2);

--- a/core/trino-main/src/test/java/io/trino/operator/join/JoinTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/JoinTestUtils.java
@@ -153,7 +153,8 @@ public final class JoinTestUtils
                 DataSize.of(32, DataSize.Unit.MEGABYTE),
                 TYPE_OPERATORS,
                 DataSize.of(32, DataSize.Unit.MEGABYTE),
-                () -> 0L);
+                () -> 0L,
+                scaleWriterStats -> {});
 
         // collect input data into the partitioned exchange
         DriverContext collectDriverContext = taskContext.addPipelineContext(0, true, true, false).addDriverContext();

--- a/core/trino-main/src/test/java/io/trino/operator/join/unspilled/JoinTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/unspilled/JoinTestUtils.java
@@ -149,7 +149,8 @@ public final class JoinTestUtils
                 DataSize.of(32, DataSize.Unit.MEGABYTE),
                 TYPE_OPERATORS,
                 DataSize.of(32, DataSize.Unit.MEGABYTE),
-                () -> 0L);
+                () -> 0L,
+                scaleWriterStats -> {});
 
         // collect input data into the partitioned exchange
         DriverContext collectDriverContext = taskContext.addPipelineContext(0, true, true, false).addDriverContext();

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorPageSink.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorPageSink.java
@@ -15,6 +15,7 @@ package io.trino.spi.connector;
 
 import io.airlift.slice.Slice;
 import io.trino.spi.Page;
+import io.trino.spi.metrics.Metrics;
 
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
@@ -79,4 +80,15 @@ public interface ConnectorPageSink
     CompletableFuture<Collection<Slice>> finish();
 
     void abort();
+
+    /**
+     * Returns the connector's metrics, mapping a metric ID to its latest value.
+     * Each call must return an immutable snapshot of available metrics.
+     * Same ID metrics are merged across all tasks and exposed via OperatorStats.
+     * This method can be called after the page source is closed.
+     */
+    default Metrics getMetrics()
+    {
+        return Metrics.EMPTY;
+    }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorPageSink.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorPageSink.java
@@ -18,6 +18,7 @@ import io.airlift.slice.Slice;
 import io.trino.spi.Page;
 import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.ConnectorPageSink;
+import io.trino.spi.metrics.Metrics;
 
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
@@ -90,6 +91,14 @@ public class ClassLoaderSafeConnectorPageSink
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             delegate.abort();
+        }
+    }
+
+    @Override
+    public Metrics getMetrics()
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getMetrics();
         }
     }
 }

--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -93,6 +93,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>stats</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
         </dependency>
 
@@ -313,12 +318,6 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>node</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>stats</artifactId>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Added the following stats to TaskStats:
1. writtenFileSizes (Distribution)
2. numberOfIdleWritersClosed
3. partitionsAssigned to task distribution for scale writers
4. totalScalingCount
5. scaled partition percentage

Note: Scale writers stats are added for both remote and local exchange.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
