### PR TITLE
Fix usage of split length instead of file length in parquet

### DIFF
--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/TracingInputFile.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/TracingInputFile.java
@@ -33,7 +33,7 @@ final class TracingInputFile
 {
     private final Tracer tracer;
     private final TrinoInputFile delegate;
-    private final Optional<Long> length;
+    private Optional<Long> length;
 
     public TracingInputFile(Tracer tracer, TrinoInputFile delegate, Optional<Long> length)
     {
@@ -76,7 +76,9 @@ final class TracingInputFile
         Span span = tracer.spanBuilder("InputFile.length")
                 .setAttribute(FileSystemAttributes.FILE_LOCATION, toString())
                 .startSpan();
-        return withTracing(span, delegate::length);
+        long fileLength = withTracing(span, delegate::length);
+        length = Optional.of(fileLength);
+        return fileLength;
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
@@ -452,7 +452,7 @@ public class TestDeltaLakeFileOperations
                         .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000004.json", "OutputFile.createOrOverwrite"))
                         .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000004.json", "InputFile.newStream"))
                         .addCopies(new FileOperation(DATA, "key=domain1/", "InputFile.newInput"), 2)
-                        .addCopies(new FileOperation(DATA, "key=domain1/", "InputFile.length"), 2)
+                        .add(new FileOperation(DATA, "key=domain1/", "InputFile.length"))
                         .add(new FileOperation(DATA, "key=domain1/", "OutputFile.create"))
                         .build());
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
@@ -215,7 +215,7 @@ public class ParquetPageSourceFactory
         ParquetDataSource dataSource = null;
         try {
             AggregatedMemoryContext memoryContext = newSimpleAggregatedMemoryContext();
-            dataSource = createDataSource(inputFile, length, estimatedFileSize, options, memoryContext, stats);
+            dataSource = createDataSource(inputFile, estimatedFileSize, options, memoryContext, stats);
 
             ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, parquetWriteValidation);
             FileMetaData fileMetaData = parquetMetadata.getFileMetaData();
@@ -303,7 +303,6 @@ public class ParquetPageSourceFactory
 
     public static ParquetDataSource createDataSource(
             TrinoInputFile inputFile,
-            long length,
             OptionalLong estimatedFileSize,
             ParquetReaderOptions options,
             AggregatedMemoryContext memoryContext,
@@ -311,7 +310,7 @@ public class ParquetPageSourceFactory
             throws IOException
     {
         if (estimatedFileSize.isEmpty() || estimatedFileSize.getAsLong() > options.getSmallFileThreshold().toBytes()) {
-            return new TrinoParquetDataSource(inputFile, length, options, stats);
+            return new TrinoParquetDataSource(inputFile, options, stats);
         }
         return new MemoryParquetDataSource(inputFile, memoryContext, stats);
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/TrinoParquetDataSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/TrinoParquetDataSource.java
@@ -34,13 +34,7 @@ public class TrinoParquetDataSource
     public TrinoParquetDataSource(TrinoInputFile file, ParquetReaderOptions options, FileFormatDataSourceStats stats)
             throws IOException
     {
-        this(file, file.length(), options, stats);
-    }
-
-    public TrinoParquetDataSource(TrinoInputFile file, long length, ParquetReaderOptions options, FileFormatDataSourceStats stats)
-            throws IOException
-    {
-        super(new ParquetDataSourceId(file.location().toString()), length, options);
+        super(new ParquetDataSourceId(file.location().toString()), file.length(), options);
         this.stats = requireNonNull(stats, "stats is null");
         this.input = file.newInput();
     }

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiPageSourceProvider.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiPageSourceProvider.java
@@ -195,7 +195,7 @@ public class HudiPageSourceProvider
         long length = hudiSplit.getLength();
         try {
             AggregatedMemoryContext memoryContext = newSimpleAggregatedMemoryContext();
-            dataSource = createDataSource(inputFile, inputFile.length(), OptionalLong.of(hudiSplit.getFileSize()), options, memoryContext, dataSourceStats);
+            dataSource = createDataSource(inputFile, OptionalLong.of(hudiSplit.getFileSize()), options, memoryContext, dataSourceStats);
             ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
             FileMetaData fileMetaData = parquetMetadata.getFileMetaData();
             MessageType fileSchema = fileMetaData.getSchema();

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -995,7 +995,7 @@ public class IcebergPageSourceProvider
 
         ParquetDataSource dataSource = null;
         try {
-            dataSource = createDataSource(inputFile, fileSize, OptionalLong.of(fileSize), options, memoryContext, fileFormatDataSourceStats);
+            dataSource = createDataSource(inputFile, OptionalLong.of(fileSize), options, memoryContext, fileFormatDataSourceStats);
             ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
             FileMetaData fileMetaData = parquetMetadata.getFileMetaData();
             MessageType fileSchema = fileMetaData.getSchema();


### PR DESCRIPTION
## Description
TrinoInputFile implementations already cache length, updated TracingInputFile to reflect that and fixed the usage of `length` introduced by https://github.com/trinodb/trino/pull/21070


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
