### PR TITLE
Preseve fileStatisticsDomain across getNextBatch calls

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
@@ -135,6 +135,7 @@ public class IcebergSplitSource
     private long targetSplitSize;
     private CloseableIterator<FileScanTask> fileScanIterator;
     private Iterator<FileScanTask> fileTasksIterator = emptyIterator();
+    private TupleDomain<IcebergColumnHandle> fileStatisticsDomain;
 
     private final boolean recordScannedFiles;
     private final ImmutableSet.Builder<DataFileWithDeleteFiles> scannedFiles = ImmutableSet.builder();
@@ -245,7 +246,6 @@ public class IcebergSplitSource
         }
 
         List<ConnectorSplit> splits = new ArrayList<>(maxSize);
-        TupleDomain<IcebergColumnHandle> fileStatisticsDomain = null;
         while (splits.size() < maxSize && (fileTasksIterator.hasNext() || fileScanIterator.hasNext())) {
             if (!fileTasksIterator.hasNext()) {
                 if (limit.isPresent() && limit.getAsLong() <= outputRowsLowerBound) {


### PR DESCRIPTION
getNextBatch will return when enough splits are generated, therefore fileStatisticsDomain needs to be preserved across getNextBatch calls.

Caused by https://github.com/trinodb/trino/pull/20918 (since version 440).

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Fix NPE errors when enumerating splits. ({issue}`issuenumber`)
```
