### PR TITLE
Unify Iceberg registration behaviour for table location

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/RegisterTableProcedure.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/RegisterTableProcedure.java
@@ -195,6 +195,8 @@ public class RegisterTableProcedure
     {
         // Normalize e.g. s3a to s3, so that table can be registed using s3:// location
         // even if internally it uses s3a:// paths.
-        return tableLocation.replaceFirst("^s3[an]://", "s3://");
+        String normalizedSchema = tableLocation.replaceFirst("^s3[an]://", "s3://");
+        // Remove trailing slashes so that test_dir is equal to test_dir/
+        return stripTrailingSlash(normalizedSchema);
     }
 }


### PR DESCRIPTION
## Description

Register procedure should accept locations which differ with trailing slash
Fixes https://github.com/trinodb/trino/issues/19143

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

