### PR TITLE
Require all methods implemented for ForwardingFileIo

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/fileio/ForwardingFileIo.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/fileio/ForwardingFileIo.java
@@ -81,6 +81,18 @@ public class ForwardingFileIo
     }
 
     @Override
+    public void deleteFile(InputFile file)
+    {
+        SupportsBulkOperations.super.deleteFile(file);
+    }
+
+    @Override
+    public void deleteFile(OutputFile file)
+    {
+        SupportsBulkOperations.super.deleteFile(file);
+    }
+
+    @Override
     public void deleteFiles(Iterable<String> pathsToDelete)
             throws BulkDeletionFailureException
     {
@@ -116,4 +128,7 @@ public class ForwardingFileIo
     {
         throw new UnsupportedOperationException("ForwardingFileIO does not support initialization by properties");
     }
+
+    @Override
+    public void close() {}
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/fileio/TestForwardingFileIo.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/fileio/TestForwardingFileIo.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.fileio;
+
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.SupportsBulkOperations;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.spi.testing.InterfaceTestUtils.assertAllMethodsOverridden;
+
+public class TestForwardingFileIo
+{
+    @Test
+    public void testEverythingImplemented()
+    {
+        assertAllMethodsOverridden(FileIO.class, ForwardingFileIo.class);
+        assertAllMethodsOverridden(SupportsBulkOperations.class, ForwardingFileIo.class);
+    }
+}


### PR DESCRIPTION
During one of Iceberg update PRs a regression was introduced because `ForwardingFileIo` did not implement some optional method of the `FileIO` interface, resulting with suboptimal performance. Require that all methods are implemented and use default interface methods consciously.
