### PR TITLE
Use text blocks in WindowAssertions

### DIFF
--- a/core/trino-main/src/test/java/io/trino/operator/window/WindowAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/window/WindowAssertions.java
@@ -22,77 +22,86 @@ import static java.lang.String.format;
 
 public final class WindowAssertions
 {
-    private static final String VALUES = "" +
-            "SELECT *\n" +
-            "FROM (\n" +
-            "  VALUES\n" +
-            "    ( 1, 'O', '1996-01-02'),\n" +
-            "    ( 2, 'O', '1996-12-01'),\n" +
-            "    ( 3, 'F', '1993-10-14'),\n" +
-            "    ( 4, 'O', '1995-10-11'),\n" +
-            "    ( 5, 'F', '1994-07-30'),\n" +
-            "    ( 6, 'F', '1992-02-21'),\n" +
-            "    ( 7, 'O', '1996-01-10'),\n" +
-            "    (32, 'O', '1995-07-16'),\n" +
-            "    (33, 'F', '1993-10-27'),\n" +
-            "    (34, 'O', '1998-07-21')\n" +
-            ") AS orders (orderkey, orderstatus, orderdate)";
+    private static final String VALUES = """
+            SELECT *
+            FROM (
+              VALUES
+                ( 1, 'O', '1996-01-02'),
+                ( 2, 'O', '1996-12-01'),
+                ( 3, 'F', '1993-10-14'),
+                ( 4, 'O', '1995-10-11'),
+                ( 5, 'F', '1994-07-30'),
+                ( 6, 'F', '1992-02-21'),
+                ( 7, 'O', '1996-01-10'),
+                (32, 'O', '1995-07-16'),
+                (33, 'F', '1993-10-27'),
+                (34, 'O', '1998-07-21')
+            ) AS orders (orderkey, orderstatus, orderdate)
+            """;
 
-    private static final String VALUES_WITH_NULLS = "" +
-            "SELECT *\n" +
-            "FROM (\n" +
-            "  VALUES\n" +
-            "    ( 1,                   CAST(NULL AS VARCHAR), CAST(NULL AS VARCHAR)),\n" +
-            "    ( 3,                   'F',                   '1993-10-14'),\n" +
-            "    ( 5,                   'F',                   CAST(NULL AS VARCHAR)),\n" +
-            "    ( 7,                   CAST(NULL AS VARCHAR), '1996-01-10'),\n" +
-            "    (34,                   'O',                   '1998-07-21'),\n" +
-            "    ( 6,                   'F',                   '1992-02-21'),\n" +
-            "    (CAST(NULL AS BIGINT), 'F',                   '1993-10-27'),\n" +
-            "    (CAST(NULL AS BIGINT), 'O',                   '1996-12-01'),\n" +
-            "    (CAST(NULL AS BIGINT), CAST(NULL AS VARCHAR), CAST(NULL AS VARCHAR)),\n" +
-            "    (CAST(NULL AS BIGINT), CAST(NULL AS VARCHAR), '1995-07-16')\n" +
-            ") AS orders (orderkey, orderstatus, orderdate)";
+    private static final String VALUES_WITH_NULLS = """
+            SELECT *
+            FROM (
+              VALUES
+                ( 1,                   CAST(NULL AS VARCHAR), CAST(NULL AS VARCHAR)),
+                ( 3,                   'F',                   '1993-10-14'),
+                ( 5,                   'F',                   CAST(NULL AS VARCHAR)),
+                ( 7,                   CAST(NULL AS VARCHAR), '1996-01-10'),
+                (34,                   'O',                   '1998-07-21'),
+                ( 6,                   'F',                   '1992-02-21'),
+                (CAST(NULL AS BIGINT), 'F',                   '1993-10-27'),
+                (CAST(NULL AS BIGINT), 'O',                   '1996-12-01'),
+                (CAST(NULL AS BIGINT), CAST(NULL AS VARCHAR), CAST(NULL AS VARCHAR)),
+                (CAST(NULL AS BIGINT), CAST(NULL AS VARCHAR), '1995-07-16')
+            ) AS orders (orderkey, orderstatus, orderdate)
+            """;
 
-    private static final String VALUES_WITH_NAN = "" +
-            "SELECT *\n" +
-            "FROM (\n" +
-            "  VALUES\n" +
-            "    ( 1, 'O', '1996-01-02'),\n" +
-            "    ( 2, 'O', '1996-12-01'),\n" +
-            "    ( 3, 'F', '1993-10-14'),\n" +
-            "    ( 4, 'O', '1995-10-11'),\n" +
-            "    ( nan(), 'F', '1994-07-30'),\n" +
-            "    ( 6, 'F', '1992-02-21'),\n" +
-            "    ( 7, 'O', '1996-01-10'),\n" +
-            "    (32, 'O', '1995-07-16'),\n" +
-            "    (33, 'F', '1993-10-27'),\n" +
-            "    (34, 'O', '1998-07-21')\n" +
-            ") AS orders (orderkey, orderstatus, orderdate)";
+    private static final String VALUES_WITH_NAN = """
+            SELECT *
+            FROM (
+              VALUES
+                ( 1, 'O', '1996-01-02'),
+                ( 2, 'O', '1996-12-01'),
+                ( 3, 'F', '1993-10-14'),
+                ( 4, 'O', '1995-10-11'),
+                ( nan(), 'F', '1994-07-30'),
+                ( 6, 'F', '1992-02-21'),
+                ( 7, 'O', '1996-01-10'),
+                (32, 'O', '1995-07-16'),
+                (33, 'F', '1993-10-27'),
+                (34, 'O', '1998-07-21')
+            ) AS orders (orderkey, orderstatus, orderdate)
+            """;
 
-    private static final String VALUES_WITH_INFINITY = "" +
-            "SELECT *\n" +
-            "FROM (\n" +
-            "  VALUES\n" +
-            "    ( 1, 'O', '1996-01-02'),\n" +
-            "    ( 2, 'O', '1996-12-01'),\n" +
-            "    ( 3, 'F', '1993-10-14'),\n" +
-            "    ( 4, 'O', '1995-10-11'),\n" +
-            "    ( infinity(), 'F', '1994-07-30'),\n" +
-            "    ( 6, 'F', '1992-02-21'),\n" +
-            "    ( 7, 'O', '1996-01-10'),\n" +
-            "    (32, 'O', '1995-07-16'),\n" +
-            "    (33, 'F', '1993-10-27'),\n" +
-            "    (34, 'O', '1998-07-21')\n" +
-            ") AS orders (orderkey, orderstatus, orderdate)";
+    private static final String VALUES_WITH_INFINITY = """
+            SELECT *
+            FROM (
+              VALUES
+                ( 1, 'O', '1996-01-02'),
+                ( 2, 'O', '1996-12-01'),
+                ( 3, 'F', '1993-10-14'),
+                ( 4, 'O', '1995-10-11'),
+                ( infinity(), 'F', '1994-07-30'),
+                ( 6, 'F', '1992-02-21'),
+                ( 7, 'O', '1996-01-10'),
+                (32, 'O', '1995-07-16'),
+                (33, 'F', '1993-10-27'),
+                (34, 'O', '1998-07-21')
+            ) AS orders (orderkey, orderstatus, orderdate)
+            """;
 
     private WindowAssertions() {}
 
     public static void assertWindowQuery(@Language("SQL") String sql, MaterializedResult expected, QueryRunner queryRunner)
     {
-        @Language("SQL") String query = format("" +
-                "SELECT orderkey, orderstatus,\n%s\n" +
-                "FROM (%s) x", sql, VALUES);
+        @Language("SQL") String query = format(
+                """
+                SELECT orderkey, orderstatus,
+                %s
+                FROM (%s) x
+                """,
+                sql,
+                VALUES);
 
         MaterializedResult actual = queryRunner.execute(query);
         assertEqualsIgnoreOrder(actual.getMaterializedRows(), expected.getMaterializedRows());
@@ -106,18 +115,28 @@ public final class WindowAssertions
 
     public static MaterializedResult executeWindowQueryWithNulls(@Language("SQL") String sql, QueryRunner queryRunner)
     {
-        @Language("SQL") String query = format("" +
-                "SELECT orderkey, orderstatus,\n%s\n" +
-                "FROM (%s) x", sql, VALUES_WITH_NULLS);
+        @Language("SQL") String query = format(
+                """
+                SELECT orderkey, orderstatus,
+                %s
+                FROM (%s) x
+                """,
+                sql,
+                VALUES_WITH_NULLS);
 
         return queryRunner.execute(query);
     }
 
     public static void assertWindowQueryWithNan(@Language("SQL") String sql, MaterializedResult expected, QueryRunner queryRunner)
     {
-        @Language("SQL") String query = format("" +
-                "SELECT orderkey, orderstatus,\n%s\n" +
-                "FROM (%s) x", sql, VALUES_WITH_NAN);
+        @Language("SQL") String query = format(
+                """
+                SELECT orderkey, orderstatus,
+                %s
+                FROM (%s) x
+                """,
+                sql,
+                VALUES_WITH_NAN);
 
         MaterializedResult actual = queryRunner.execute(query);
         assertEqualsIgnoreOrder(actual.getMaterializedRows(), expected.getMaterializedRows());
@@ -125,9 +144,14 @@ public final class WindowAssertions
 
     public static void assertWindowQueryWithInfinity(@Language("SQL") String sql, MaterializedResult expected, QueryRunner queryRunner)
     {
-        @Language("SQL") String query = format("" +
-                "SELECT orderkey, orderstatus,\n%s\n" +
-                "FROM (%s) x", sql, VALUES_WITH_INFINITY);
+        @Language("SQL") String query = format(
+                """
+                SELECT orderkey, orderstatus,
+                %s
+                FROM (%s) x
+                """,
+                sql,
+                VALUES_WITH_INFINITY);
 
         MaterializedResult actual = queryRunner.execute(query);
         assertEqualsIgnoreOrder(actual.getMaterializedRows(), expected.getMaterializedRows());


### PR DESCRIPTION
## Description
Cleanup test code in `WindowAssertions` to use text blocks instead of concatenation for multiline SQL strings.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
