### PR TITLE
Log number of live query runner instances

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
@@ -218,7 +218,7 @@ public class DistributedQueryRunner
         this.trinoClient = closer.register(testingTrinoClientFactory.create(coordinator, defaultSession));
 
         ensureNodesGloballyVisible();
-        log.debug("Created DistributedQueryRunner in %s (unclosed instances = %s)", nanosSince(start), unclosedInstances.incrementAndGet());
+        log.info("Created DistributedQueryRunner in %s (unclosed instances = %s)", nanosSince(start), unclosedInstances.incrementAndGet());
     }
 
     private TestingTrinoServer createServer(


### PR DESCRIPTION
On CI we observe that sometimes tests create much higher than expected number of query runner instances and then often fail (too many resources taken or too many tests running in parallel). Logging this number helps attribute CI failure to this cause.

For https://github.com/trinodb/trino/issues/21053