### PR TITLE
Update docker-images version to 92

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
         <dep.aws-sdk.version>1.12.674</dep.aws-sdk.version>
         <dep.cassandra.version>4.17.0</dep.cassandra.version>
         <dep.confluent.version>7.5.1</dep.confluent.version>
-        <dep.docker.images.version>91</dep.docker.images.version>
+        <dep.docker.images.version>92</dep.docker.images.version>
         <dep.drift.version>1.21</dep.drift.version>
         <dep.errorprone.version>2.25.0</dep.errorprone.version>
         <dep.flyway.version>10.9.0</dep.flyway.version>


### PR DESCRIPTION
## Description

Relates to:
* https://github.com/trinodb/docker-images/pull/190
