### PR TITLE
Isolate testSelectInformationSchemaColumns for Ignite

### DIFF
--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteConnectorTest.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteConnectorTest.java
@@ -478,4 +478,12 @@ public class TestIgniteConnectorTest
     {
         return "Date must be between 1970-01-01 and 9999-12-31 in Ignite: " + date;
     }
+
+    @Test
+    @Override
+    public void testSelectInformationSchemaColumns()
+    {
+        // Isolate this test to avoid problem described in https://github.com/trinodb/trino/issues/16671
+        executeExclusively(super::testSelectInformationSchemaColumns);
+    }
 }


### PR DESCRIPTION
## Description

This test failed in https://github.com/trinodb/trino/actions/runs/8286235466/job/22675808796
testAddAndDropColumnName also failed in the above job, but I assume isolating testSelectInformationSchemaColumns is sufficient. 