### PR TITLE
Synchronize listing tables in file metastore

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -521,7 +521,7 @@ public class FileHiveMetastore
     }
 
     @Override
-    public List<TableInfo> getTables(String databaseName)
+    public synchronized List<TableInfo> getTables(String databaseName)
     {
         return listAllTables(databaseName);
     }


### PR DESCRIPTION
This is to prevent listing tables failures when tables dropped concurrently. This also fixes IDE warning about synchronization not matching `@GuardedBy` annotations.

Fixes https://github.com/trinodb/trino/issues/21121