### PR TITLE
Remove isEffectivelyLiteral

### DIFF
--- a/core/trino-main/src/main/java/io/trino/cost/ScalarStatsCalculator.java
+++ b/core/trino-main/src/main/java/io/trino/cost/ScalarStatsCalculator.java
@@ -42,7 +42,6 @@ import java.util.Map;
 import java.util.OptionalDouble;
 
 import static io.trino.spi.statistics.StatsUtil.toStatsRepresentation;
-import static io.trino.sql.ir.IrUtils.isEffectivelyLiteral;
 import static io.trino.util.MoreMath.max;
 import static io.trino.util.MoreMath.min;
 import static java.lang.Double.NaN;
@@ -126,7 +125,7 @@ public class ScalarStatsCalculator
                 return nullStatsEstimate();
             }
 
-            if (value instanceof Expression && !isEffectivelyLiteral(plannerContext, session, (Expression) value)) {
+            if (value instanceof Expression) {
                 // value is not a constant
                 return SymbolStatsEstimate.unknown();
             }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/IrExpressionInterpreter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/IrExpressionInterpreter.java
@@ -102,7 +102,6 @@ import static io.trino.spi.type.TypeUtils.writeNativeValue;
 import static io.trino.sql.DynamicFilters.isDynamicFilter;
 import static io.trino.sql.gen.VarArgsToMapAdapterGenerator.generateVarArgsToMapAdapter;
 import static io.trino.sql.ir.ArithmeticUnaryExpression.Sign.MINUS;
-import static io.trino.sql.ir.IrUtils.isEffectivelyLiteral;
 import static io.trino.sql.planner.DeterminismEvaluator.isDeterministic;
 import static io.trino.util.Failures.checkCondition;
 import static java.lang.Math.toIntExact;
@@ -116,7 +115,6 @@ public class IrExpressionInterpreter
     private final Expression expression;
     private final PlannerContext plannerContext;
     private final Metadata metadata;
-    private final Session session;
     private final ConnectorSession connectorSession;
     private final Map<NodeRef<Expression>, Type> expressionTypes;
     private final InterpretedFunctionInvoker functionInvoker;
@@ -129,7 +127,6 @@ public class IrExpressionInterpreter
         this.expression = requireNonNull(expression, "expression is null");
         this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
         this.metadata = plannerContext.getMetadata();
-        this.session = requireNonNull(session, "session is null");
         this.connectorSession = session.toConnectorSession();
         this.expressionTypes = ImmutableMap.copyOf(requireNonNull(expressionTypes, "expressionTypes is null"));
         verify(expressionTypes.containsKey(NodeRef.of(expression)));
@@ -378,7 +375,7 @@ public class IrExpressionInterpreter
                             newOperands.add(nestedOperand);
                         }
                         // This operand can be evaluated to a non-null value. Remaining operands can be skipped.
-                        if (isEffectivelyLiteral(plannerContext, session, nestedOperand)) {
+                        if (nestedOperand instanceof Constant constant && constant.getValue() != null) {
                             return newOperands;
                         }
                     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PartialTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PartialTranslator.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.type.Type;
-import io.trino.sql.PlannerContext;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.IrVisitor;
 import io.trino.sql.ir.LambdaExpression;
@@ -41,8 +40,7 @@ public final class PartialTranslator
             Expression inputExpression,
             Session session,
             IrTypeAnalyzer typeAnalyzer,
-            TypeProvider typeProvider,
-            PlannerContext plannerContext)
+            TypeProvider typeProvider)
     {
         requireNonNull(inputExpression, "inputExpression is null");
         requireNonNull(session, "session is null");
@@ -50,7 +48,7 @@ public final class PartialTranslator
         requireNonNull(typeProvider, "typeProvider is null");
 
         Map<NodeRef<Expression>, ConnectorExpression> partialTranslations = new HashMap<>();
-        new Visitor(session, typeAnalyzer.getTypes(typeProvider, inputExpression), partialTranslations, plannerContext).process(inputExpression);
+        new Visitor(session, typeAnalyzer.getTypes(typeProvider, inputExpression), partialTranslations).process(inputExpression);
         return ImmutableMap.copyOf(partialTranslations);
     }
 
@@ -60,11 +58,11 @@ public final class PartialTranslator
         private final Map<NodeRef<Expression>, ConnectorExpression> translatedSubExpressions;
         private final ConnectorExpressionTranslator.SqlToConnectorExpressionTranslator translator;
 
-        Visitor(Session session, Map<NodeRef<Expression>, Type> types, Map<NodeRef<Expression>, ConnectorExpression> translatedSubExpressions, PlannerContext plannerContext)
+        Visitor(Session session, Map<NodeRef<Expression>, Type> types, Map<NodeRef<Expression>, ConnectorExpression> translatedSubExpressions)
         {
             requireNonNull(types, "types is null");
             this.translatedSubExpressions = requireNonNull(translatedSubExpressions, "translatedSubExpressions is null");
-            this.translator = new ConnectorExpressionTranslator.SqlToConnectorExpressionTranslator(session, types, plannerContext);
+            this.translator = new ConnectorExpressionTranslator.SqlToConnectorExpressionTranslator(session, types);
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/CanonicalizeExpressions.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/CanonicalizeExpressions.java
@@ -13,7 +13,6 @@
  */
 package io.trino.sql.planner.iterative.rule;
 
-import io.trino.sql.PlannerContext;
 import io.trino.sql.planner.IrTypeAnalyzer;
 
 import static io.trino.sql.planner.iterative.rule.CanonicalizeExpressionRewriter.rewrite;
@@ -21,8 +20,8 @@ import static io.trino.sql.planner.iterative.rule.CanonicalizeExpressionRewriter
 public class CanonicalizeExpressions
         extends ExpressionRewriteRuleSet
 {
-    public CanonicalizeExpressions(PlannerContext plannerContext, IrTypeAnalyzer typeAnalyzer)
+    public CanonicalizeExpressions(IrTypeAnalyzer typeAnalyzer)
     {
-        super((expression, context) -> rewrite(expression, context.getSession(), plannerContext, typeAnalyzer, context.getSymbolAllocator().getTypes()));
+        super((expression, context) -> rewrite(expression, typeAnalyzer, context.getSymbolAllocator().getTypes()));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/EliminateCrossJoins.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/EliminateCrossJoins.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
-import io.trino.sql.PlannerContext;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.planner.IrTypeAnalyzer;
 import io.trino.sql.planner.OptimizerConfig.JoinReorderingStrategy;
@@ -56,12 +55,10 @@ public class EliminateCrossJoins
         implements Rule<JoinNode>
 {
     private static final Pattern<JoinNode> PATTERN = join();
-    private final PlannerContext plannerContext;
     private final IrTypeAnalyzer typeAnalyzer;
 
-    public EliminateCrossJoins(PlannerContext plannerContext, IrTypeAnalyzer typeAnalyzer)
+    public EliminateCrossJoins(IrTypeAnalyzer typeAnalyzer)
     {
-        this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
         this.typeAnalyzer = requireNonNull(typeAnalyzer, "typeAnalyzer is null");
     }
 
@@ -82,7 +79,7 @@ public class EliminateCrossJoins
     @Override
     public Result apply(JoinNode node, Captures captures, Context context)
     {
-        JoinGraph joinGraph = JoinGraph.buildFrom(plannerContext, node, context.getLookup(), context.getIdAllocator(), context.getSession(), typeAnalyzer, context.getSymbolAllocator().getTypes());
+        JoinGraph joinGraph = JoinGraph.buildFrom(node, context.getLookup(), context.getIdAllocator(), context.getSession(), typeAnalyzer, context.getSymbolAllocator().getTypes());
         if (joinGraph.size() < 3 || !joinGraph.isContainsCrossJoin()) {
             return Result.empty();
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushJoinIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushJoinIntoTableScan.java
@@ -114,7 +114,6 @@ public class PushJoinIntoTableScan
                 context.getSession(),
                 effectiveFilter,
                 context.getSymbolAllocator().getTypes(),
-                plannerContext,
                 typeAnalyzer);
 
         if (!translation.remainingExpression().equals(BooleanLiteral.TRUE_LITERAL)) {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushMergeWriterUpdateIntoConnector.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushMergeWriterUpdateIntoConnector.java
@@ -23,7 +23,6 @@ import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
-import io.trino.sql.PlannerContext;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.Row;
@@ -72,15 +71,13 @@ public class PushMergeWriterUpdateIntoConnector
                                     project().capturedAs(PROJECT_NODE_CAPTURE).with(source().matching(
                                             tableScan().capturedAs(TABLE_SCAN)))))))));
 
-    public PushMergeWriterUpdateIntoConnector(PlannerContext plannerContext, IrTypeAnalyzer typeAnalyzer, Metadata metadata)
+    public PushMergeWriterUpdateIntoConnector(IrTypeAnalyzer typeAnalyzer, Metadata metadata)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.typeAnalyzer = requireNonNull(typeAnalyzer, "typeAnalyzer is null");
-        this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
     }
 
     private final Metadata metadata;
-    private final PlannerContext plannerContext;
     private final IrTypeAnalyzer typeAnalyzer;
 
     @Override
@@ -136,7 +133,6 @@ public class PushMergeWriterUpdateIntoConnector
                         context.getSession(),
                         field,
                         context.getSymbolAllocator().getTypes(),
-                        plannerContext,
                         typeAnalyzer);
 
                 // we don't support any expressions in update statements yet, only constants

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPredicateIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPredicateIntoTableScan.java
@@ -184,7 +184,6 @@ public class PushPredicateIntoTableScan
                 session,
                 decomposedPredicate.getRemainingExpression(),
                 symbolAllocator.getTypes(),
-                plannerContext,
                 typeAnalyzer);
         Map<String, ColumnHandle> connectorExpressionAssignments = node.getAssignments()
                 .entrySet().stream()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushProjectionIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushProjectionIntoTableScan.java
@@ -111,8 +111,8 @@ public class PushProjectionIntoTableScan
                                 expression.getValue(),
                                 session,
                                 typeAnalyzer,
-                                context.getSymbolAllocator().getTypes(),
-                                plannerContext).entrySet().stream())
+                                context.getSymbolAllocator().getTypes()
+                        ).entrySet().stream())
                 // Filter out constant expressions. Constant expressions should not be pushed to the connector.
                 .filter(entry -> !(entry.getValue() instanceof io.trino.spi.expression.Constant))
                 // Avoid duplicates

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushProjectionThroughJoin.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushProjectionThroughJoin.java
@@ -15,8 +15,6 @@ package io.trino.sql.planner.iterative.rule;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
-import io.trino.Session;
-import io.trino.sql.PlannerContext;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.planner.IrTypeAnalyzer;
 import io.trino.sql.planner.PlanNodeIdAllocator;
@@ -48,11 +46,9 @@ import static io.trino.sql.planner.plan.JoinType.INNER;
 public final class PushProjectionThroughJoin
 {
     public static Optional<PlanNode> pushProjectionThroughJoin(
-            PlannerContext plannerContext,
             ProjectNode projectNode,
             Lookup lookup,
             PlanNodeIdAllocator planNodeIdAllocator,
-            Session session,
             IrTypeAnalyzer typeAnalyzer,
             TypeProvider types)
     {
@@ -116,17 +112,13 @@ public final class PushProjectionThroughJoin
                 joinNode.getId(),
                 joinNode.getType(),
                 inlineProjections(
-                        plannerContext,
                         new ProjectNode(planNodeIdAllocator.getNextId(), leftChild, leftAssignments),
                         lookup,
-                        session,
                         typeAnalyzer,
                         types),
                 inlineProjections(
-                        plannerContext,
                         new ProjectNode(planNodeIdAllocator.getNextId(), rightChild, rightAssignments),
                         lookup,
-                        session,
                         typeAnalyzer,
                         types),
                 joinNode.getCriteria(),
@@ -143,10 +135,8 @@ public final class PushProjectionThroughJoin
     }
 
     private static PlanNode inlineProjections(
-            PlannerContext plannerContext,
             ProjectNode parentProjection,
             Lookup lookup,
-            Session session,
             IrTypeAnalyzer typeAnalyzer,
             TypeProvider types)
     {
@@ -155,8 +145,8 @@ public final class PushProjectionThroughJoin
             return parentProjection;
         }
 
-        return InlineProjections.inlineProjections(plannerContext, parentProjection, childProjection, session, typeAnalyzer, types)
-                .map(node -> inlineProjections(plannerContext, node, lookup, session, typeAnalyzer, types))
+        return InlineProjections.inlineProjections(parentProjection, childProjection, typeAnalyzer, types)
+                .map(node -> inlineProjections(node, lookup, typeAnalyzer, types))
                 .orElse(parentProjection);
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveRedundantDateTrunc.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveRedundantDateTrunc.java
@@ -19,6 +19,7 @@ import io.trino.spi.function.CatalogSchemaFunctionName;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 import io.trino.sql.PlannerContext;
+import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.ExpressionTreeRewriter;
 import io.trino.sql.ir.FunctionCall;
@@ -34,7 +35,6 @@ import java.util.Map;
 
 import static io.trino.metadata.GlobalFunctionCatalog.builtinFunctionName;
 import static io.trino.spi.type.DateType.DATE;
-import static io.trino.sql.ir.IrUtils.isEffectivelyLiteral;
 import static java.util.Objects.requireNonNull;
 
 public class RemoveRedundantDateTrunc
@@ -80,7 +80,7 @@ public class RemoveRedundantDateTrunc
                 Map<NodeRef<Expression>, Type> expressionTypes = typeAnalyzer.getTypes(types, node);
                 Expression unitExpression = node.getArguments().get(0);
                 Expression argument = node.getArguments().get(1);
-                if (expressionTypes.get(NodeRef.of(argument)) == DATE && expressionTypes.get(NodeRef.of(unitExpression)) instanceof VarcharType && isEffectivelyLiteral(plannerContext, session, unitExpression)) {
+                if (expressionTypes.get(NodeRef.of(argument)) == DATE && expressionTypes.get(NodeRef.of(unitExpression)) instanceof VarcharType && unitExpression instanceof Constant) {
                     Slice unitValue = (Slice) new IrExpressionInterpreter(unitExpression, plannerContext, session, expressionTypes)
                             .optimize(NoOpSymbolResolver.INSTANCE);
                     if (unitValue != null && "day".equals(unitValue.toStringUtf8().toLowerCase(Locale.ENGLISH))) {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapDateTruncInComparison.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapDateTruncInComparison.java
@@ -65,7 +65,6 @@ import static io.trino.sql.ir.ComparisonExpression.Operator.GREATER_THAN;
 import static io.trino.sql.ir.ComparisonExpression.Operator.GREATER_THAN_OR_EQUAL;
 import static io.trino.sql.ir.ComparisonExpression.Operator.LESS_THAN;
 import static io.trino.sql.ir.ComparisonExpression.Operator.LESS_THAN_OR_EQUAL;
-import static io.trino.sql.ir.IrUtils.isEffectivelyLiteral;
 import static io.trino.sql.ir.IrUtils.or;
 import static io.trino.sql.planner.iterative.rule.UnwrapCastInComparison.falseIfNotNull;
 import static io.trino.sql.planner.iterative.rule.UnwrapCastInComparison.trueIfNotNull;
@@ -158,7 +157,7 @@ public class UnwrapDateTruncInComparison
 
             Map<NodeRef<Expression>, Type> expressionTypes = typeAnalyzer.getTypes(types, expression);
             Expression unitExpression = call.getArguments().get(0);
-            if (!(expressionTypes.get(NodeRef.of(unitExpression)) instanceof VarcharType) || !isEffectivelyLiteral(plannerContext, session, unitExpression)) {
+            if (!(expressionTypes.get(NodeRef.of(unitExpression)) instanceof VarcharType) || !(unitExpression instanceof Constant)) {
                 return expression;
             }
             Slice unitName = (Slice) new IrExpressionInterpreter(unitExpression, plannerContext, session, expressionTypes)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddLocalExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddLocalExchanges.java
@@ -22,6 +22,7 @@ import io.trino.spi.connector.GroupingProperty;
 import io.trino.spi.connector.LocalProperty;
 import io.trino.spi.connector.WriterScalingOptions;
 import io.trino.sql.PlannerContext;
+import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.SymbolReference;
 import io.trino.sql.planner.IrTypeAnalyzer;
 import io.trino.sql.planner.Partitioning;
@@ -84,7 +85,6 @@ import static io.trino.SystemSessionProperties.getTaskMinWriterCount;
 import static io.trino.SystemSessionProperties.isDistributedSortEnabled;
 import static io.trino.SystemSessionProperties.isSpillEnabled;
 import static io.trino.SystemSessionProperties.isTaskScaleWritersEnabled;
-import static io.trino.sql.ir.IrUtils.isEffectivelyLiteral;
 import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_ARBITRARY_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.SCALED_WRITER_HASH_DISTRIBUTION;
@@ -190,7 +190,7 @@ public class AddLocalExchanges
         {
             // Special handling for trivial projections. Applies to identity and renaming projections, and constants
             // It might be extended to handle other low-cost projections.
-            if (node.getAssignments().getExpressions().stream().allMatch(expression -> expression instanceof SymbolReference || isEffectivelyLiteral(plannerContext, session, expression))) {
+            if (node.getAssignments().getExpressions().stream().allMatch(expression -> expression instanceof SymbolReference || expression instanceof Constant constant && constant.getValue() != null)) {
                 if (parentPreferences.isSingleStreamPreferred()) {
                     // Do not enforce gathering exchange below project:
                     // - if project's source is single stream, no exchanges will be added around project,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
@@ -99,7 +99,6 @@ import static io.trino.sql.ir.ComparisonExpression.Operator.LESS_THAN_OR_EQUAL;
 import static io.trino.sql.ir.IrUtils.combineConjuncts;
 import static io.trino.sql.ir.IrUtils.extractConjuncts;
 import static io.trino.sql.ir.IrUtils.filterDeterministicConjuncts;
-import static io.trino.sql.ir.IrUtils.isEffectivelyLiteral;
 import static io.trino.sql.planner.DeterminismEvaluator.isDeterministic;
 import static io.trino.sql.planner.ExpressionSymbolInliner.inlineSymbols;
 import static io.trino.sql.planner.SymbolsExtractor.extractUnique;
@@ -284,7 +283,7 @@ public class PredicatePushDown
 
             List<Expression> inlinedDeterministicConjuncts = inlineConjuncts.get(true).stream()
                     .map(entry -> inlineSymbols(node.getAssignments().getMap(), entry))
-                    .map(conjunct -> canonicalizeExpression(conjunct, typeAnalyzer, types, plannerContext, session)) // normalize expressions to a form that unwrapCasts understands
+                    .map(conjunct -> canonicalizeExpression(conjunct, typeAnalyzer, types)) // normalize expressions to a form that unwrapCasts understands
                     .map(conjunct -> unwrapCasts(session, plannerContext, typeAnalyzer, types, conjunct))
                     .collect(Collectors.toList());
 
@@ -315,7 +314,7 @@ public class PredicatePushDown
 
             return dependencies.entrySet().stream()
                     .allMatch(entry -> entry.getValue() == 1
-                            || isEffectivelyLiteral(plannerContext, session, node.getAssignments().get(entry.getKey()))
+                            || node.getAssignments().get(entry.getKey()) instanceof Constant
                             || node.getAssignments().get(entry.getKey()) instanceof SymbolReference);
         }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestPartialTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestPartialTranslator.java
@@ -89,17 +89,17 @@ public class TestPartialTranslator
 
     private void assertPartialTranslation(Expression expression, List<Expression> subexpressions)
     {
-        Map<NodeRef<Expression>, ConnectorExpression> translation = extractPartialTranslations(expression, TEST_SESSION, TYPE_ANALYZER, TYPE_PROVIDER, PLANNER_CONTEXT);
+        Map<NodeRef<Expression>, ConnectorExpression> translation = extractPartialTranslations(expression, TEST_SESSION, TYPE_ANALYZER, TYPE_PROVIDER);
         assertThat(subexpressions.size()).isEqualTo(translation.size());
         for (Expression subexpression : subexpressions) {
-            assertThat(translation).containsEntry(NodeRef.of(subexpression), translate(TEST_SESSION, subexpression, TYPE_PROVIDER, PLANNER_CONTEXT, TYPE_ANALYZER).get());
+            assertThat(translation).containsEntry(NodeRef.of(subexpression), translate(TEST_SESSION, subexpression, TYPE_PROVIDER, TYPE_ANALYZER).get());
         }
     }
 
     private void assertFullTranslation(Expression expression)
     {
-        Map<NodeRef<Expression>, ConnectorExpression> translation = extractPartialTranslations(expression, TEST_SESSION, TYPE_ANALYZER, TYPE_PROVIDER, PLANNER_CONTEXT);
+        Map<NodeRef<Expression>, ConnectorExpression> translation = extractPartialTranslations(expression, TEST_SESSION, TYPE_ANALYZER, TYPE_PROVIDER);
         assertThat(getOnlyElement(translation.keySet())).isEqualTo(NodeRef.of(expression));
-        assertThat(getOnlyElement(translation.values())).isEqualTo(translate(TEST_SESSION, expression, TYPE_PROVIDER, PLANNER_CONTEXT, TYPE_ANALYZER).get());
+        assertThat(getOnlyElement(translation.values())).isEqualTo(translate(TEST_SESSION, expression, TYPE_PROVIDER, TYPE_ANALYZER).get());
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestCanonicalizeExpressions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestCanonicalizeExpressions.java
@@ -25,7 +25,7 @@ public class TestCanonicalizeExpressions
     @Test
     public void testDoesNotFireForExpressionsInCanonicalForm()
     {
-        CanonicalizeExpressions canonicalizeExpressions = new CanonicalizeExpressions(tester().getPlannerContext(), tester().getTypeAnalyzer());
+        CanonicalizeExpressions canonicalizeExpressions = new CanonicalizeExpressions(tester().getTypeAnalyzer());
         tester().assertThat(canonicalizeExpressions.filterExpressionRewrite())
                 .on(p -> p.filter(FALSE_LITERAL, p.values()))
                 .doesNotFire();
@@ -34,7 +34,7 @@ public class TestCanonicalizeExpressions
     @Test
     public void testDoesNotFireForUnfilteredJoin()
     {
-        CanonicalizeExpressions canonicalizeExpressions = new CanonicalizeExpressions(tester().getPlannerContext(), tester().getTypeAnalyzer());
+        CanonicalizeExpressions canonicalizeExpressions = new CanonicalizeExpressions(tester().getTypeAnalyzer());
         tester().assertThat(canonicalizeExpressions.joinExpressionRewrite())
                 .on(p -> p.join(INNER, p.values(), p.values()))
                 .doesNotFire();
@@ -43,7 +43,7 @@ public class TestCanonicalizeExpressions
     @Test
     public void testDoesNotFireForCanonicalExpressions()
     {
-        CanonicalizeExpressions canonicalizeExpressions = new CanonicalizeExpressions(tester().getPlannerContext(), tester().getTypeAnalyzer());
+        CanonicalizeExpressions canonicalizeExpressions = new CanonicalizeExpressions(tester().getTypeAnalyzer());
         tester().assertThat(canonicalizeExpressions.joinExpressionRewrite())
                 .on(p -> p.join(INNER, p.values(), p.values(), FALSE_LITERAL))
                 .doesNotFire();

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestEliminateCrossJoins.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestEliminateCrossJoins.java
@@ -67,7 +67,7 @@ public class TestEliminateCrossJoins
     @Test
     public void testEliminateCrossJoin()
     {
-        tester().assertThat(new EliminateCrossJoins(tester().getPlannerContext(), tester().getTypeAnalyzer()))
+        tester().assertThat(new EliminateCrossJoins(tester().getTypeAnalyzer()))
                 .setSystemProperty(JOIN_REORDERING_STRATEGY, "ELIMINATE_CROSS_JOINS")
                 .on(crossJoinAndJoin(INNER))
                 .matches(
@@ -84,7 +84,7 @@ public class TestEliminateCrossJoins
     @Test
     public void testRetainOutgoingGroupReferences()
     {
-        tester().assertThat(new EliminateCrossJoins(tester().getPlannerContext(), tester().getTypeAnalyzer()))
+        tester().assertThat(new EliminateCrossJoins(tester().getTypeAnalyzer()))
                 .setSystemProperty(JOIN_REORDERING_STRATEGY, "ELIMINATE_CROSS_JOINS")
                 .on(crossJoinAndJoin(INNER))
                 .matches(
@@ -98,7 +98,7 @@ public class TestEliminateCrossJoins
     @Test
     public void testDoNotReorderOuterJoin()
     {
-        tester().assertThat(new EliminateCrossJoins(tester().getPlannerContext(), tester().getTypeAnalyzer()))
+        tester().assertThat(new EliminateCrossJoins(tester().getTypeAnalyzer()))
                 .setSystemProperty(JOIN_REORDERING_STRATEGY, "ELIMINATE_CROSS_JOINS")
                 .on(crossJoinAndJoin(JoinType.LEFT))
                 .doesNotFire();
@@ -125,7 +125,7 @@ public class TestEliminateCrossJoins
                         "a", "c",
                         "b", "c");
 
-        JoinGraph joinGraph = JoinGraph.buildFrom(tester().getPlannerContext(), plan, noLookup(), new PlanNodeIdAllocator(), session, new IrTypeAnalyzer(tester().getPlannerContext()), TypeProvider.empty());
+        JoinGraph joinGraph = JoinGraph.buildFrom(plan, noLookup(), new PlanNodeIdAllocator(), session, new IrTypeAnalyzer(tester().getPlannerContext()), TypeProvider.empty());
 
         assertThat(getJoinOrder(joinGraph)).isEqualTo(ImmutableList.of(0, 2, 1));
     }
@@ -155,7 +155,7 @@ public class TestEliminateCrossJoins
 
         PlanNode plan = joinNode(leftPlan, rightPlan);
 
-        JoinGraph joinGraph = JoinGraph.buildFrom(tester().getPlannerContext(), plan, noLookup(), new PlanNodeIdAllocator(), session, new IrTypeAnalyzer(tester().getPlannerContext()), TypeProvider.empty());
+        JoinGraph joinGraph = JoinGraph.buildFrom(plan, noLookup(), new PlanNodeIdAllocator(), session, new IrTypeAnalyzer(tester().getPlannerContext()), TypeProvider.empty());
 
         assertThat(getJoinOrder(joinGraph)).isEqualTo(ImmutableList.of(0, 2, 1, 3, 5, 4));
     }
@@ -175,7 +175,7 @@ public class TestEliminateCrossJoins
                         "b1", "c1",
                         "b2", "c2");
 
-        JoinGraph joinGraph = JoinGraph.buildFrom(tester().getPlannerContext(), plan, noLookup(), new PlanNodeIdAllocator(), session, new IrTypeAnalyzer(tester().getPlannerContext()), TypeProvider.empty());
+        JoinGraph joinGraph = JoinGraph.buildFrom(plan, noLookup(), new PlanNodeIdAllocator(), session, new IrTypeAnalyzer(tester().getPlannerContext()), TypeProvider.empty());
 
         assertThat(getJoinOrder(joinGraph)).isEqualTo(ImmutableList.of(0, 2, 1));
     }
@@ -194,7 +194,7 @@ public class TestEliminateCrossJoins
                         values("c"),
                         "b", "c");
 
-        JoinGraph joinGraph = JoinGraph.buildFrom(tester().getPlannerContext(), plan, noLookup(), new PlanNodeIdAllocator(), session, new IrTypeAnalyzer(tester().getPlannerContext()), TypeProvider.empty());
+        JoinGraph joinGraph = JoinGraph.buildFrom(plan, noLookup(), new PlanNodeIdAllocator(), session, new IrTypeAnalyzer(tester().getPlannerContext()), TypeProvider.empty());
 
         assertThat(getJoinOrder(joinGraph)).isEqualTo(ImmutableList.of(0, 1, 2));
     }
@@ -212,7 +212,7 @@ public class TestEliminateCrossJoins
                         values("c"),
                         "b", "c");
 
-        JoinGraph joinGraph = JoinGraph.buildFrom(tester().getPlannerContext(), plan, noLookup(), new PlanNodeIdAllocator(), session, new IrTypeAnalyzer(tester().getPlannerContext()), TypeProvider.empty());
+        JoinGraph joinGraph = JoinGraph.buildFrom(plan, noLookup(), new PlanNodeIdAllocator(), session, new IrTypeAnalyzer(tester().getPlannerContext()), TypeProvider.empty());
 
         assertThat(getJoinOrder(joinGraph)).isEqualTo(ImmutableList.of(0, 1, 2));
     }
@@ -220,7 +220,7 @@ public class TestEliminateCrossJoins
     @Test
     public void testEliminateCrossJoinWithNonIdentityProjections()
     {
-        tester().assertThat(new EliminateCrossJoins(tester().getPlannerContext(), tester().getTypeAnalyzer()))
+        tester().assertThat(new EliminateCrossJoins(tester().getTypeAnalyzer()))
                 .setSystemProperty(JOIN_REORDERING_STRATEGY, "ELIMINATE_CROSS_JOINS")
                 .on(p -> {
                     Symbol a1 = p.symbol("a1");
@@ -299,7 +299,7 @@ public class TestEliminateCrossJoins
                         "a2", "c",
                         "b", "c");
 
-        assertThat(JoinGraph.buildFrom(tester().getPlannerContext(), plan, noLookup(), new PlanNodeIdAllocator(), session, new IrTypeAnalyzer(tester().getPlannerContext()), TypeProvider.empty()).size()).isEqualTo(2);
+        assertThat(JoinGraph.buildFrom(plan, noLookup(), new PlanNodeIdAllocator(), session, new IrTypeAnalyzer(tester().getPlannerContext()), TypeProvider.empty()).size()).isEqualTo(2);
     }
 
     private Function<PlanBuilder, PlanNode> crossJoinAndJoin(JoinType secondJoinType)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestInlineProjections.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestInlineProjections.java
@@ -48,7 +48,7 @@ public class TestInlineProjections
     @Test
     public void test()
     {
-        tester().assertThat(new InlineProjections(tester().getPlannerContext(), tester().getTypeAnalyzer()))
+        tester().assertThat(new InlineProjections(tester().getTypeAnalyzer()))
                 .on(p ->
                         p.project(
                                 Assignments.builder()
@@ -98,7 +98,7 @@ public class TestInlineProjections
     @Test
     public void testInlineEffectivelyLiteral()
     {
-        tester().assertThat(new InlineProjections(tester().getPlannerContext(), tester().getTypeAnalyzer()))
+        tester().assertThat(new InlineProjections(tester().getTypeAnalyzer()))
                 .on(p ->
                         p.project(
                                 Assignments.builder()
@@ -121,7 +121,7 @@ public class TestInlineProjections
     @Test
     public void testEliminatesIdentityProjection()
     {
-        tester().assertThat(new InlineProjections(tester().getPlannerContext(), tester().getTypeAnalyzer()))
+        tester().assertThat(new InlineProjections(tester().getTypeAnalyzer()))
                 .on(p ->
                         p.project(
                                 Assignments.builder()
@@ -141,7 +141,7 @@ public class TestInlineProjections
     public void testIdentityProjections()
     {
         // projection renaming symbol
-        tester().assertThat(new InlineProjections(tester().getPlannerContext(), tester().getTypeAnalyzer()))
+        tester().assertThat(new InlineProjections(tester().getTypeAnalyzer()))
                 .on(p ->
                         p.project(
                                 Assignments.of(p.symbol("output"), new SymbolReference("value")),
@@ -151,7 +151,7 @@ public class TestInlineProjections
                 .doesNotFire();
 
         // identity projection
-        tester().assertThat(new InlineProjections(tester().getPlannerContext(), tester().getTypeAnalyzer()))
+        tester().assertThat(new InlineProjections(tester().getTypeAnalyzer()))
                 .on(p ->
                         p.project(
                                 Assignments.identity(p.symbol("x")),
@@ -167,7 +167,7 @@ public class TestInlineProjections
     @Test
     public void testSubqueryProjections()
     {
-        tester().assertThat(new InlineProjections(tester().getPlannerContext(), tester().getTypeAnalyzer()))
+        tester().assertThat(new InlineProjections(tester().getTypeAnalyzer()))
                 .on(p ->
                         p.project(
                                 Assignments.identity(p.symbol("fromOuterScope"), p.symbol("value")),
@@ -180,7 +180,7 @@ public class TestInlineProjections
                                 // ImmutableMap.of("fromOuterScope", PlanMatchPattern.expression("fromOuterScope"), "value", PlanMatchPattern.expression("value")),
                                 values(ImmutableMap.of("value", 0))));
 
-        tester().assertThat(new InlineProjections(tester().getPlannerContext(), tester().getTypeAnalyzer()))
+        tester().assertThat(new InlineProjections(tester().getTypeAnalyzer()))
                 .on(p ->
                         p.project(
                                 Assignments.identity(p.symbol("fromOuterScope"), p.symbol("value_1")),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestJoinNodeFlattener.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestJoinNodeFlattener.java
@@ -109,7 +109,7 @@ public class TestJoinNodeFlattener
                 ImmutableList.of(a1),
                 ImmutableList.of(b1),
                 Optional.empty());
-        assertThatThrownBy(() -> toMultiJoinNode(queryRunner.getPlannerContext(), outerJoin, noLookup(), planNodeIdAllocator, DEFAULT_JOIN_LIMIT, false, testSessionBuilder().build(), new IrTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes()))
+        assertThatThrownBy(() -> toMultiJoinNode(outerJoin, noLookup(), planNodeIdAllocator, DEFAULT_JOIN_LIMIT, false, testSessionBuilder().build(), new IrTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes()))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageMatching("join type must be.*");
     }
@@ -144,7 +144,7 @@ public class TestJoinNodeFlattener
                 .setSources(leftJoin, valuesC).setFilter(createEqualsExpression(a1, c1))
                 .setOutputSymbols(a1, b1, c1)
                 .build();
-        assertThat(toMultiJoinNode(queryRunner.getPlannerContext(), joinNode, noLookup(), planNodeIdAllocator, DEFAULT_JOIN_LIMIT, false, testSessionBuilder().build(), new IrTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes())).isEqualTo(expected);
+        assertThat(toMultiJoinNode(joinNode, noLookup(), planNodeIdAllocator, DEFAULT_JOIN_LIMIT, false, testSessionBuilder().build(), new IrTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes())).isEqualTo(expected);
     }
 
     @Test
@@ -170,7 +170,7 @@ public class TestJoinNodeFlattener
                                 equiJoinClause(a, b))),
                 valuesC,
                 equiJoinClause(d, c));
-        MultiJoinNode actual = toMultiJoinNode(queryRunner.getPlannerContext(), joinNode, noLookup(), planNodeIdAllocator, DEFAULT_JOIN_LIMIT, true, testSessionBuilder().build(), new IrTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes());
+        MultiJoinNode actual = toMultiJoinNode(joinNode, noLookup(), planNodeIdAllocator, DEFAULT_JOIN_LIMIT, true, testSessionBuilder().build(), new IrTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes());
         assertThat(actual.getOutputSymbols()).isEqualTo(ImmutableList.of(d, c));
         assertThat(actual.getFilter()).isEqualTo(and(createEqualsExpression(a, b), createEqualsExpression(d, c)));
         assertThat(actual.isPushedProjectionThroughJoin()).isTrue();
@@ -216,7 +216,7 @@ public class TestJoinNodeFlattener
                                 equiJoinClause(a, b))),
                 valuesC,
                 equiJoinClause(d, c));
-        MultiJoinNode actual = toMultiJoinNode(queryRunner.getPlannerContext(), joinNode, noLookup(), planNodeIdAllocator, DEFAULT_JOIN_LIMIT, true, testSessionBuilder().build(), new IrTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes());
+        MultiJoinNode actual = toMultiJoinNode(joinNode, noLookup(), planNodeIdAllocator, DEFAULT_JOIN_LIMIT, true, testSessionBuilder().build(), new IrTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes());
         assertThat(actual.getOutputSymbols()).isEqualTo(ImmutableList.of(d, c));
         assertThat(actual.getFilter()).isEqualTo(createEqualsExpression(d, c));
         assertThat(actual.isPushedProjectionThroughJoin()).isFalse();
@@ -267,7 +267,7 @@ public class TestJoinNodeFlattener
                 .setFilter(and(createEqualsExpression(b1, c1), createEqualsExpression(a1, b1)))
                 .setOutputSymbols(a1, b1)
                 .build();
-        assertThat(toMultiJoinNode(queryRunner.getPlannerContext(), joinNode, noLookup(), planNodeIdAllocator, DEFAULT_JOIN_LIMIT, false, testSessionBuilder().build(), new IrTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes())).isEqualTo(expected);
+        assertThat(toMultiJoinNode(joinNode, noLookup(), planNodeIdAllocator, DEFAULT_JOIN_LIMIT, false, testSessionBuilder().build(), new IrTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes())).isEqualTo(expected);
     }
 
     @Test
@@ -311,7 +311,7 @@ public class TestJoinNodeFlattener
                 and(new ComparisonExpression(EQUAL, b1.toSymbolReference(), c1.toSymbolReference()), new ComparisonExpression(EQUAL, a1.toSymbolReference(), b1.toSymbolReference()), bcFilter, abcFilter),
                 ImmutableList.of(a1, b1, b2, c1, c2),
                 false);
-        assertThat(toMultiJoinNode(queryRunner.getPlannerContext(), joinNode, noLookup(), planNodeIdAllocator, DEFAULT_JOIN_LIMIT, false, testSessionBuilder().build(), new IrTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes())).isEqualTo(expected);
+        assertThat(toMultiJoinNode(joinNode, noLookup(), planNodeIdAllocator, DEFAULT_JOIN_LIMIT, false, testSessionBuilder().build(), new IrTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes())).isEqualTo(expected);
     }
 
     @Test
@@ -367,7 +367,7 @@ public class TestJoinNodeFlattener
                 .setFilter(and(createEqualsExpression(a1, b1), createEqualsExpression(a1, c1), createEqualsExpression(d1, e1), createEqualsExpression(d2, e2), createEqualsExpression(b1, e1)))
                 .setOutputSymbols(a1, b1, c1, d1, d2, e1, e2)
                 .build();
-        assertThat(toMultiJoinNode(queryRunner.getPlannerContext(), joinNode, noLookup(), planNodeIdAllocator, 5, false, testSessionBuilder().build(), new IrTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes())).isEqualTo(expected);
+        assertThat(toMultiJoinNode(joinNode, noLookup(), planNodeIdAllocator, 5, false, testSessionBuilder().build(), new IrTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes())).isEqualTo(expected);
     }
 
     @Test
@@ -425,7 +425,7 @@ public class TestJoinNodeFlattener
                 .setFilter(and(createEqualsExpression(a1, c1), createEqualsExpression(b1, e1)))
                 .setOutputSymbols(a1, b1, c1, d1, d2, e1, e2)
                 .build();
-        assertThat(toMultiJoinNode(queryRunner.getPlannerContext(), joinNode, noLookup(), planNodeIdAllocator, 2, false, testSessionBuilder().build(), new IrTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes())).isEqualTo(expected);
+        assertThat(toMultiJoinNode(joinNode, noLookup(), planNodeIdAllocator, 2, false, testSessionBuilder().build(), new IrTypeAnalyzer(queryRunner.getPlannerContext()), p.getTypes())).isEqualTo(expected);
     }
 
     private ComparisonExpression createEqualsExpression(Symbol left, Symbol right)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushMergeWriterUpdateIntoConnector.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushMergeWriterUpdateIntoConnector.java
@@ -23,7 +23,6 @@ import io.trino.metadata.TableHandle;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TestingColumnHandle;
-import io.trino.sql.PlannerContext;
 import io.trino.sql.ir.ArithmeticBinaryExpression;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
@@ -173,10 +172,8 @@ public class TestPushMergeWriterUpdateIntoConnector
 
     private static PushMergeWriterUpdateIntoConnector createRule(RuleTester tester)
     {
-        PlannerContext plannerContext = tester.getPlannerContext();
         IrTypeAnalyzer typeAnalyzer = tester.getTypeAnalyzer();
         return new PushMergeWriterUpdateIntoConnector(
-                plannerContext,
                 typeAnalyzer,
                 new AbstractMockMetadata()
                 {

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushProjectionThroughJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushProjectionThroughJoin.java
@@ -89,7 +89,7 @@ public class TestPushProjectionThroughJoin
                         new JoinNode.EquiJoinClause(a1, b1)));
 
         Session session = testSessionBuilder().build();
-        Optional<PlanNode> rewritten = pushProjectionThroughJoin(PLANNER_CONTEXT, planNode, noLookup(), idAllocator, session, new IrTypeAnalyzer(PLANNER_CONTEXT), p.getTypes());
+        Optional<PlanNode> rewritten = pushProjectionThroughJoin(planNode, noLookup(), idAllocator, new IrTypeAnalyzer(PLANNER_CONTEXT), p.getTypes());
         assertThat(rewritten.isPresent()).isTrue();
         assertPlan(
                 session,
@@ -130,7 +130,7 @@ public class TestPushProjectionThroughJoin
                         INNER,
                         p.values(a),
                         p.values(b)));
-        Optional<PlanNode> rewritten = pushProjectionThroughJoin(PLANNER_CONTEXT, planNode, noLookup(), new PlanNodeIdAllocator(), testSessionBuilder().build(), new IrTypeAnalyzer(PLANNER_CONTEXT), p.getTypes());
+        Optional<PlanNode> rewritten = pushProjectionThroughJoin(planNode, noLookup(), new PlanNodeIdAllocator(), new IrTypeAnalyzer(PLANNER_CONTEXT), p.getTypes());
         assertThat(rewritten).isEmpty();
     }
 
@@ -149,7 +149,7 @@ public class TestPushProjectionThroughJoin
                         LEFT,
                         p.values(a),
                         p.values(b)));
-        Optional<PlanNode> rewritten = pushProjectionThroughJoin(PLANNER_CONTEXT, planNode, noLookup(), new PlanNodeIdAllocator(), testSessionBuilder().build(), new IrTypeAnalyzer(PLANNER_CONTEXT), p.getTypes());
+        Optional<PlanNode> rewritten = pushProjectionThroughJoin(planNode, noLookup(), new PlanNodeIdAllocator(), new IrTypeAnalyzer(PLANNER_CONTEXT), p.getTypes());
         assertThat(rewritten).isEmpty();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestReorderJoins.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestReorderJoins.java
@@ -670,6 +670,6 @@ public class TestReorderJoins
 
     private RuleBuilder assertReorderJoins()
     {
-        return tester.assertThat(new ReorderJoins(PLANNER_CONTEXT, new CostComparator(1, 1, 1), new IrTypeAnalyzer(PLANNER_CONTEXT)));
+        return tester.assertThat(new ReorderJoins(new CostComparator(1, 1, 1), new IrTypeAnalyzer(PLANNER_CONTEXT)));
     }
 }

--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteClient.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteClient.java
@@ -219,7 +219,6 @@ public class TestIgniteClient
                         expression,
                         TypeProvider.viewOf(symbolTypes.entrySet().stream()
                                 .collect(toImmutableMap(entry -> new Symbol(entry.getKey()), Map.Entry::getValue))),
-                        PLANNER_CONTEXT,
                         new IrTypeAnalyzer(PLANNER_CONTEXT))
                 .orElseThrow();
     }

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlClient.java
@@ -36,10 +36,8 @@ import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.expression.Variable;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.VarcharType;
 import io.trino.sql.ir.ArithmeticBinaryExpression;
 import io.trino.sql.ir.ArithmeticUnaryExpression;
-import io.trino.sql.ir.Cast;
 import io.trino.sql.ir.ComparisonExpression;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
@@ -433,8 +431,8 @@ public class TestPostgreSqlClient
                                 new InPredicate(
                                         new SymbolReference("c_varchar"),
                                         List.of(
-                                                new Cast(new Constant(VarcharType.VARCHAR, utf8Slice("value1")), VARCHAR_COLUMN.getColumnType()),
-                                                new Cast(new Constant(VarcharType.VARCHAR, utf8Slice("value2")), VARCHAR_COLUMN.getColumnType()),
+                                                new Constant(VARCHAR_COLUMN.getColumnType(), utf8Slice("value1")),
+                                                new Constant(VARCHAR_COLUMN.getColumnType(), utf8Slice("value2")),
                                                 new SymbolReference("c_varchar2"))),
                                 Map.of("c_varchar", VARCHAR_COLUMN.getColumnType(), "c_varchar2", VARCHAR_COLUMN2.getColumnType())),
                         Map.of(VARCHAR_COLUMN.getColumnName(), VARCHAR_COLUMN, VARCHAR_COLUMN2.getColumnName(), VARCHAR_COLUMN2))
@@ -452,7 +450,6 @@ public class TestPostgreSqlClient
                         expression,
                         TypeProvider.viewOf(symbolTypes.entrySet().stream()
                                 .collect(toImmutableMap(entry -> new Symbol(entry.getKey()), Entry::getValue))),
-                        PLANNER_CONTEXT,
                         new IrTypeAnalyzer(PLANNER_CONTEXT))
                 .orElseThrow();
     }


### PR DESCRIPTION
No longer needed now that the IR supports arbitrary typed constants.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
