### PR TITLE
Add RemoteLogTracingEvent to allow tracing the event happen or not

### DIFF
--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/RemoteLogTracingEvent.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/RemoteLogTracingEvent.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+import static java.util.Objects.requireNonNull;
+
+public class RemoteLogTracingEvent
+        implements Consumer<RemoteDatabaseEvent>
+{
+    private final Predicate<RemoteDatabaseEvent> condition;
+    private final AtomicBoolean happened;
+
+    public RemoteLogTracingEvent(Predicate<RemoteDatabaseEvent> condition)
+    {
+        this.condition = requireNonNull(condition, "condition is null");
+        this.happened = new AtomicBoolean();
+    }
+
+    public boolean hasHappened()
+    {
+        return happened.get();
+    }
+
+    @Override
+    public void accept(RemoteDatabaseEvent remoteDatabaseEvent)
+    {
+        if (hasHappened()) {
+            return;
+        }
+
+        if (condition.test(remoteDatabaseEvent)) {
+            happened.compareAndSet(false, true);
+        }
+    }
+}

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -21,7 +21,7 @@ import io.trino.Session;
 import io.trino.plugin.jdbc.BaseJdbcConnectorTest;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcTableHandle;
-import io.trino.plugin.jdbc.RemoteDatabaseEvent;
+import io.trino.plugin.jdbc.RemoteLogTracingEvent;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.JoinCondition;
 import io.trino.spi.predicate.Range;
@@ -1061,9 +1061,15 @@ public class TestPostgreSqlConnectorTest
     }
 
     @Override
-    protected List<RemoteDatabaseEvent> getRemoteDatabaseEvents()
+    protected void startTracingDatabaseEvent(RemoteLogTracingEvent event)
     {
-        return postgreSqlServer.getRemoteDatabaseEvents();
+        postgreSqlServer.startTracingDatabaseEvent(event);
+    }
+
+    @Override
+    protected void stopTracingDatabaseEvent(RemoteLogTracingEvent event)
+    {
+        postgreSqlServer.stopTracingDatabaseEvent(event);
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Add RemoteTracingEvent to support check a database event(in log) happened or not without grab all logs from container at a time.
Update Postgresql testCancellation test to use RemoteTracingEvent.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

https://trinodb.slack.com/archives/CP1MUNEUX/p1710496005499909


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
