### PR TITLE
Implement fs.cache.skip-paths

### DIFF
--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioFileSystemCache.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioFileSystemCache.java
@@ -45,7 +45,7 @@ public class AlluxioFileSystemCache
     private final CacheManager cacheManager;
     private final AlluxioConfiguration config;
     private final AlluxioCacheStats statistics;
-    private final List<String> denylist;
+    private final List<String> skipPaths;
     private final HashFunction hashFunction = Hashing.murmur3_128();
 
     @Inject
@@ -55,7 +55,7 @@ public class AlluxioFileSystemCache
         this.tracer = requireNonNull(tracer, "tracer is null");
         this.config = AlluxioConfigurationFactory.create(requireNonNull(config, "config is null"));
         this.pageSize = config.getCachePageSize();
-        this.denylist = config.getDenylist();
+        this.skipPaths = config.getSkipPaths();
         this.cacheManager = CacheManager.Factory.create(this.config);
         this.statistics = requireNonNull(statistics, "statistics is null");
     }
@@ -106,7 +106,7 @@ public class AlluxioFileSystemCache
 
     private boolean uncacheable(TrinoInputFile file)
     {
-        return denylist.stream()
-                .anyMatch(deny -> file.location().path().contains(deny));
+        return skipPaths.stream()
+                .anyMatch(pattern -> file.location().path().matches(pattern));
     }
 }

--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioFileSystemCacheConfig.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioFileSystemCacheConfig.java
@@ -41,7 +41,7 @@ public class AlluxioFileSystemCacheConfig
     static final String CACHE_MAX_PERCENTAGES = "fs.cache.max-disk-usage-percentages";
 
     private List<String> cacheDirectories;
-    private List<String> denylist = ImmutableList.of();
+    private List<String> skipPaths = ImmutableList.of();
     private List<DataSize> maxCacheSizes = ImmutableList.of();
     private Optional<Duration> cacheTTL = Optional.of(Duration.valueOf("7d"));
     private List<Integer> maxCacheDiskUsagePercentages = ImmutableList.of();
@@ -95,16 +95,16 @@ public class AlluxioFileSystemCacheConfig
     }
 
     @NotNull
-    public List<String> getDenylist()
+    public List<String> getSkipPaths()
     {
-        return denylist;
+        return skipPaths;
     }
 
-    @Config("fs.cache.denylist")
-    @ConfigDescription("Comma-separated list of file name patterns that will not be cached")
-    public AlluxioFileSystemCacheConfig setDenylist(String denylistParam)
+    @Config("fs.cache.skip-paths")
+    @ConfigDescription("Comma-separated list of path patterns that will not be cached")
+    public AlluxioFileSystemCacheConfig setSkipPaths(String skipPathsParam)
     {
-        this.denylist = denylistParam == null ? ImmutableList.of() : SPLITTER.splitToList(denylistParam);
+        this.skipPaths = skipPathsParam == null ? ImmutableList.of() : SPLITTER.splitToList(skipPathsParam);
         return this;
     }
 

--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioFileSystemCacheConfig.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioFileSystemCacheConfig.java
@@ -41,6 +41,7 @@ public class AlluxioFileSystemCacheConfig
     static final String CACHE_MAX_PERCENTAGES = "fs.cache.max-disk-usage-percentages";
 
     private List<String> cacheDirectories;
+    private List<String> denylist = ImmutableList.of();
     private List<DataSize> maxCacheSizes = ImmutableList.of();
     private Optional<Duration> cacheTTL = Optional.of(Duration.valueOf("7d"));
     private List<Integer> maxCacheDiskUsagePercentages = ImmutableList.of();
@@ -90,6 +91,20 @@ public class AlluxioFileSystemCacheConfig
     public AlluxioFileSystemCacheConfig disableTTL()
     {
         this.cacheTTL = Optional.empty();
+        return this;
+    }
+
+    @NotNull
+    public List<String> getDenylist()
+    {
+        return denylist;
+    }
+
+    @Config("fs.cache.denylist")
+    @ConfigDescription("Comma-separated list of file name patterns that will not be cached")
+    public AlluxioFileSystemCacheConfig setDenylist(String denylistParam)
+    {
+        this.denylist = denylistParam == null ? ImmutableList.of() : SPLITTER.splitToList(denylistParam);
         return this;
     }
 

--- a/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestAlluxioFileSystemCacheConfig.java
+++ b/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestAlluxioFileSystemCacheConfig.java
@@ -68,7 +68,7 @@ class TestAlluxioFileSystemCacheConfig
                 .setMaxCacheSizes(null)
                 .setMaxCacheDiskUsagePercentages(null)
                 .setCacheTTL(Duration.valueOf("7d"))
-                .setDenylist(""));
+                .setSkipPaths(""));
     }
 
     @Test
@@ -83,7 +83,7 @@ class TestAlluxioFileSystemCacheConfig
                 .put("fs.cache.max-sizes", "1GB")
                 .put("fs.cache.max-disk-usage-percentages", "50")
                 .put("fs.cache.ttl", "1d")
-                .put("fs.cache.denylist", "foo_table")
+                .put("fs.cache.skip-paths", "foo_table")
                 .buildOrThrow();
 
         AlluxioFileSystemCacheConfig expected = new AlluxioFileSystemCacheConfig()
@@ -92,7 +92,7 @@ class TestAlluxioFileSystemCacheConfig
                 .setMaxCacheSizes("1GB")
                 .setMaxCacheDiskUsagePercentages("50")
                 .setCacheTTL(Duration.valueOf("1d"))
-                .setDenylist("foo_table");
+                .setSkipPaths("foo_table");
 
         assertFullMapping(properties, expected);
     }

--- a/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestAlluxioFileSystemCacheConfig.java
+++ b/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestAlluxioFileSystemCacheConfig.java
@@ -67,7 +67,8 @@ class TestAlluxioFileSystemCacheConfig
                 .setCachePageSize(DataSize.valueOf("1MB"))
                 .setMaxCacheSizes(null)
                 .setMaxCacheDiskUsagePercentages(null)
-                .setCacheTTL(Duration.valueOf("7d")));
+                .setCacheTTL(Duration.valueOf("7d"))
+                .setDenylist(""));
     }
 
     @Test
@@ -82,6 +83,7 @@ class TestAlluxioFileSystemCacheConfig
                 .put("fs.cache.max-sizes", "1GB")
                 .put("fs.cache.max-disk-usage-percentages", "50")
                 .put("fs.cache.ttl", "1d")
+                .put("fs.cache.denylist", "foo_table")
                 .buildOrThrow();
 
         AlluxioFileSystemCacheConfig expected = new AlluxioFileSystemCacheConfig()
@@ -89,7 +91,8 @@ class TestAlluxioFileSystemCacheConfig
                 .setCachePageSize(DataSize.valueOf("7MB"))
                 .setMaxCacheSizes("1GB")
                 .setMaxCacheDiskUsagePercentages("50")
-                .setCacheTTL(Duration.valueOf("1d"));
+                .setCacheTTL(Duration.valueOf("1d"))
+                .setDenylist("foo_table");
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description

Add a new configuration option `fs.cache.skip-paths` to allow for fine-grained control of filesystem cache.

## Additional context and related issues

The filesystem cache implemented in #18719 is all-or-nothing once enabled on a connector. This PR brings in a new configuration option, `fs.cache.skip-paths`, that will prevent any file matching it to cached.

`fs.cache.skip-paths` accepts a comma-separated list of patterns. Any file path matching one of these patterns will be accessed directly from underlying storage, and never cached.

In practice, this can be used to prevent caching a very large, not-so-often used table that would otherwise trash the cache.

Usage:
```
# Do not cache this very large table
fs.cache.skip-paths=.*very_large_file.*
```

```
# Do not cache either of these files
fs.cache.skip-paths=.*file_foo.*,.*table_bar.*
```

```
# Do not cache JSON files
fs.cache.skip-paths=.*\.json
```

```
# Do not cache Delta metadata files
fs.cache.skip-paths=.*/_delta_log/.*
```

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Add filesystem cache skip-paths option `fs.cache.skip-paths` ({issue}`issuenumber`)
```
