### PR TITLE
Specify Locale for DecimalFormat

### DIFF
--- a/core/trino-main/src/main/java/io/trino/type/DoubleOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/DoubleOperators.java
@@ -26,6 +26,7 @@ import io.trino.spi.function.SqlType;
 import io.trino.spi.type.StandardTypes;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 
 import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.slice.Slices.utf8Slice;
@@ -45,6 +46,7 @@ import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.math.RoundingMode.FLOOR;
 import static java.math.RoundingMode.HALF_UP;
+import static java.util.Locale.ENGLISH;
 
 public final class DoubleOperators
 {
@@ -55,7 +57,7 @@ public final class DoubleOperators
     private static final double MIN_BYTE_AS_DOUBLE = -0x1p7;
     private static final double MAX_BYTE_PLUS_ONE_AS_DOUBLE = 0x1p7;
 
-    private static final ThreadLocal<DecimalFormat> FORMAT = ThreadLocal.withInitial(() -> new DecimalFormat("0.0###################E0"));
+    private static final ThreadLocal<DecimalFormat> FORMAT = ThreadLocal.withInitial(() -> new DecimalFormat("0.0###################E0", new DecimalFormatSymbols(ENGLISH)));
 
     private DoubleOperators()
     {

--- a/core/trino-main/src/main/java/io/trino/type/RealOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/RealOperators.java
@@ -26,6 +26,7 @@ import io.trino.spi.function.SqlType;
 import io.trino.spi.type.StandardTypes;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
@@ -43,6 +44,7 @@ import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.math.RoundingMode.FLOOR;
+import static java.util.Locale.ENGLISH;
 
 public final class RealOperators
 {
@@ -51,7 +53,7 @@ public final class RealOperators
     private static final float MIN_BYTE_AS_FLOAT = -0x1p7f;
     private static final float MAX_BYTE_PLUS_ONE_AS_FLOAT = 0x1p7f;
 
-    private static final ThreadLocal<DecimalFormat> FORMAT = ThreadLocal.withInitial(() -> new DecimalFormat("0.0#####E0"));
+    private static final ThreadLocal<DecimalFormat> FORMAT = ThreadLocal.withInitial(() -> new DecimalFormat("0.0#####E0", new DecimalFormatSymbols(ENGLISH)));
 
     private RealOperators()
     {


### PR DESCRIPTION
Before this change, when casting real or double to varchar, we used DecimalFormat without specified Locale. It defaulted to user's locale, causing inconsistent formatting and test failures. For example, with locale `AU`, the `E` in scientific notation is lowercase.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Ensure consistent formatting when casting from double or real to varchar. ({issue}`issuenumber`)
```
