### PR TITLE
Fix comment location

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-delta-lake-databricks/delta.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-delta-lake-databricks/delta.properties
@@ -1,8 +1,8 @@
 connector.name=delta_lake
 hive.metastore=glue
 hive.metastore.glue.region=${ENV:AWS_REGION}
-# We need to give access to bucket owner (the AWS account integrated with Databricks), otherwise files won't be readable from Databricks
 fs.hadoop.enabled=true
+# We need to give access to bucket owner (the AWS account integrated with Databricks), otherwise files won't be readable from Databricks
 hive.s3.upload-acl-type=BUCKET_OWNER_FULL_CONTROL
 delta.enable-non-concurrent-writes=true
 delta.hive-catalog-name=hive

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-delta-lake-databricks/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-delta-lake-databricks/hive.properties
@@ -1,8 +1,8 @@
 connector.name=hive
 hive.metastore=glue
 hive.metastore.glue.region=${ENV:AWS_REGION}
-# We need to give access to bucket owner (the AWS account integrated with Databricks), otherwise files won't be readable from Databricks
 fs.hadoop.enabled=true
+# We need to give access to bucket owner (the AWS account integrated with Databricks), otherwise files won't be readable from Databricks
 hive.s3.upload-acl-type=BUCKET_OWNER_FULL_CONTROL
 hive.non-managed-table-writes-enabled=true
 # Required by some product tests


### PR DESCRIPTION
Comment become separate from the line it is about when `fs.hadoop.enabled=true` was added.
