### PR TITLE
Delete also blobs ending in slash when deleting directory contents

### DIFF
--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/AbstractTestTrinoFileSystem.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/AbstractTestTrinoFileSystem.java
@@ -1310,7 +1310,7 @@ public abstract class AbstractTestTrinoFileSystem
         }
     }
 
-    private Location createBlob(Closer closer, String path)
+    protected Location createBlob(Closer closer, String path)
     {
         Location location = createLocation(path);
         closer.register(new TempBlob(location)).createOrOverwrite(TEST_BLOB_CONTENT_PREFIX + location.toString());


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

AWS S3 allows creating "folder" blobs with the media type "application/x-directory". These blobs should be deleted as well along with the normal blobs when deleting the contents of a directory in order to ensure that the directory corresponding to a table is actually fully deleted.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Use solution inspired from https://github.com/trinodb/trino/pull/13974

Fixes https://github.com/trinodb/trino/issues/21111

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# S3 File System
* Delete also blobs ending in slash when deleting directory contents. ({issue}`issuenumber`)
```
