### PR TITLE
Add support for `avg` aggregation pushdown on `bigint` type in Snowflake

### DIFF
--- a/plugin/trino-snowflake/src/main/java/io/trino/plugin/snowflake/ImplementAvgBigint.java
+++ b/plugin/trino-snowflake/src/main/java/io/trino/plugin/snowflake/ImplementAvgBigint.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.snowflake;
+
+import io.trino.plugin.jdbc.aggregation.BaseImplementAvgBigint;
+
+public class ImplementAvgBigint
+        extends BaseImplementAvgBigint
+{
+    @Override
+    protected String getRewriteFormatExpression()
+    {
+        return "avg((%s * 1.0))";
+    }
+}

--- a/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestSnowflakeConnectorTest.java
+++ b/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestSnowflakeConnectorTest.java
@@ -66,14 +66,20 @@ public class TestSnowflakeConnectorTest
     protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
     {
         return switch (connectorBehavior) {
+            case SUPPORTS_AGGREGATION_PUSHDOWN -> true;
             case SUPPORTS_ADD_COLUMN_WITH_COMMENT,
-                    SUPPORTS_AGGREGATION_PUSHDOWN,
+                    SUPPORTS_AGGREGATION_PUSHDOWN_CORRELATION,
+                    SUPPORTS_AGGREGATION_PUSHDOWN_COUNT_DISTINCT,
+                    SUPPORTS_AGGREGATION_PUSHDOWN_COVARIANCE,
+                    SUPPORTS_AGGREGATION_PUSHDOWN_REGRESSION,
+                    SUPPORTS_AGGREGATION_PUSHDOWN_STDDEV,
+                    SUPPORTS_AGGREGATION_PUSHDOWN_VARIANCE,
                     SUPPORTS_ARRAY,
                     SUPPORTS_COMMENT_ON_COLUMN,
                     SUPPORTS_COMMENT_ON_TABLE,
                     SUPPORTS_CREATE_TABLE_WITH_COLUMN_COMMENT,
                     SUPPORTS_CREATE_TABLE_WITH_TABLE_COMMENT,
-                    SUPPORTS_LIMIT_PUSHDOWN,
+                    SUPPORTS_PREDICATE_PUSHDOWN,
                     SUPPORTS_ROW_TYPE,
                     SUPPORTS_SET_COLUMN_TYPE,
                     SUPPORTS_TOPN_PUSHDOWN -> false;
@@ -206,13 +212,6 @@ public class TestSnowflakeConnectorTest
     @Test
     @Override
     public void testCountDistinctWithStringTypes()
-    {
-        abort("TODO");
-    }
-
-    @Test
-    @Override
-    public void testAggregationPushdown()
     {
         abort("TODO");
     }


### PR DESCRIPTION
## Release notes

(X) Release notes are required, with the following suggested text:

```markdown
# Snowflake
* Add support for `avg` aggregation pushdown on `bigint` type. 
```