### PR TITLE
Simplify IS (NOT) NULL on not-null columns

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
@@ -575,7 +575,7 @@ public class TestLogicalPlanner
     @Test
     public void testLeftConvertedToInnerInequalityJoinNoEquiJoinConjuncts()
     {
-        assertPlan("SELECT 1 FROM orders o LEFT JOIN lineitem l ON o.orderkey < l.orderkey WHERE l.orderkey IS NOT NULL",
+        assertPlan("SELECT 1 FROM orders o LEFT JOIN lineitem l ON o.orderkey < l.orderkey WHERE l.orderkey != 123",
                 anyTree(
                         filter(
                                 new Comparison(LESS_THAN, new Reference(BIGINT, "O_ORDERKEY"), new Reference(BIGINT, "L_ORDERKEY")),
@@ -587,7 +587,7 @@ public class TestLogicalPlanner
                                         .right(
                                                 any(
                                                         filter(
-                                                                not(getPlanTester().getPlannerContext().getMetadata(), new IsNull(new Reference(BIGINT, "L_ORDERKEY"))),
+                                                                new Comparison(NOT_EQUAL, new Reference(BIGINT, "L_ORDERKEY"), new Constant(BIGINT, 123L)),
                                                                 tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey")))))))));
     }
 
@@ -1681,18 +1681,15 @@ public class TestLogicalPlanner
                                                                 .left(
                                                                         assignUniqueId(
                                                                                 "unique",
-                                                                                filter(
-                                                                                        not(getPlanTester().getPlannerContext().getMetadata(), new IsNull(new Reference(BIGINT, "region_regionkey"))),
+                                                                                any(
                                                                                         tableScan("region", ImmutableMap.of(
                                                                                                 "region_regionkey", "regionkey",
                                                                                                 "region_name", "name")))))
                                                                 .right(
                                                                         any(
-                                                                                filter(
-                                                                                        not(getPlanTester().getPlannerContext().getMetadata(), new IsNull(new Reference(BIGINT, "nation_regionkey"))),
-                                                                                        tableScan("nation", ImmutableMap.of(
+                                                                                tableScan("nation", ImmutableMap.of(
                                                                                                 "nation_name", "name",
-                                                                                                "nation_regionkey", "regionkey"))))))))))));
+                                                                                                "nation_regionkey", "regionkey")))))))))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestPredicatePushdown.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestPredicatePushdown.java
@@ -23,7 +23,6 @@ import io.trino.sql.ir.Call;
 import io.trino.sql.ir.Cast;
 import io.trino.sql.ir.Comparison;
 import io.trino.sql.ir.Constant;
-import io.trino.sql.ir.IsNull;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.planner.plan.ExchangeNode;
 import org.junit.jupiter.api.Test;
@@ -35,7 +34,6 @@ import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static io.trino.sql.ir.Comparison.Operator.EQUAL;
-import static io.trino.sql.ir.IrExpressions.not;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
@@ -124,7 +122,7 @@ public class TestPredicatePushdown
                 "SELECT customer.name, orders.orderdate " +
                         "FROM orders " +
                         "LEFT JOIN customer ON orders.custkey = customer.custkey " +
-                        "WHERE customer.name IS NOT NULL",
+                        "WHERE customer.name = 'test'",
                 disableJoinReordering,
                 anyTree(
                         join(INNER, builder -> builder
@@ -135,7 +133,7 @@ public class TestPredicatePushdown
                                 .right(
                                         anyTree(
                                                 filter(
-                                                        not(getPlanTester().getPlannerContext().getMetadata(), new IsNull(new Reference(VARCHAR, "c_name"))),
+                                                        new Comparison(EQUAL, new Reference(createVarcharType(25), "c_name"), new Constant(createVarcharType(25), Slices.utf8Slice("test"))),
                                                         tableScan("customer", ImmutableMap.of("c_custkey", "custkey", "c_name", "name"))))))));
 
         // nested joins
@@ -144,7 +142,7 @@ public class TestPredicatePushdown
                         "FROM lineitem " +
                         "LEFT JOIN orders ON lineitem.orderkey = orders.orderkey " +
                         "LEFT JOIN customer ON orders.custkey = customer.custkey " +
-                        "WHERE customer.name IS NOT NULL",
+                        "WHERE customer.name = 'test'",
                 disableJoinReordering,
                 anyTree(
                         join(INNER, builder -> builder
@@ -162,7 +160,7 @@ public class TestPredicatePushdown
                                 .right(
                                         anyTree(
                                                 filter(
-                                                        not(getPlanTester().getPlannerContext().getMetadata(), new IsNull(new Reference(VARCHAR, "c_name"))),
+                                                        new Comparison(EQUAL, new Reference(createVarcharType(25), "c_name"), new Constant(createVarcharType(25), Slices.utf8Slice("test"))),
                                                         tableScan("customer", ImmutableMap.of("c_custkey", "custkey", "c_name", "name"))))))));
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestPredicatePushdownWithoutDynamicFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestPredicatePushdownWithoutDynamicFilter.java
@@ -23,7 +23,6 @@ import io.trino.sql.ir.Call;
 import io.trino.sql.ir.Cast;
 import io.trino.sql.ir.Comparison;
 import io.trino.sql.ir.Constant;
-import io.trino.sql.ir.IsNull;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.planner.plan.ExchangeNode;
 import org.junit.jupiter.api.Test;
@@ -35,7 +34,6 @@ import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static io.trino.sql.ir.Comparison.Operator.EQUAL;
-import static io.trino.sql.ir.IrExpressions.not;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
@@ -123,7 +121,7 @@ public class TestPredicatePushdownWithoutDynamicFilter
                 "SELECT customer.name, orders.orderdate " +
                         "FROM orders " +
                         "LEFT JOIN customer ON orders.custkey = customer.custkey " +
-                        "WHERE customer.name IS NOT NULL",
+                        "WHERE customer.name = 'test'",
                 disableJoinReordering,
                 anyTree(
                         join(INNER, builder -> builder
@@ -133,7 +131,7 @@ public class TestPredicatePushdownWithoutDynamicFilter
                                 .right(
                                         anyTree(
                                                 filter(
-                                                        not(getPlanTester().getPlannerContext().getMetadata(), new IsNull(new Reference(VARCHAR, "c_name"))),
+                                                        new Comparison(EQUAL, new Reference(createVarcharType(25), "c_name"), new Constant(createVarcharType(25), Slices.utf8Slice("test"))),
                                                         tableScan("customer", ImmutableMap.of("c_custkey", "custkey", "c_name", "name"))))))));
 
         // nested joins
@@ -142,7 +140,7 @@ public class TestPredicatePushdownWithoutDynamicFilter
                         "FROM lineitem " +
                         "LEFT JOIN orders ON lineitem.orderkey = orders.orderkey " +
                         "LEFT JOIN customer ON orders.custkey = customer.custkey " +
-                        "WHERE customer.name IS NOT NULL",
+                        "WHERE customer.name = 'test'",
                 disableJoinReordering,
                 anyTree(
                         join(INNER, builder -> builder
@@ -159,7 +157,7 @@ public class TestPredicatePushdownWithoutDynamicFilter
                                 .right(
                                         anyTree(
                                                 filter(
-                                                        not(getPlanTester().getPlannerContext().getMetadata(), new IsNull(new Reference(VARCHAR, "c_name"))),
+                                                        new Comparison(EQUAL, new Reference(createVarcharType(25), "c_name"), new Constant(createVarcharType(25), Slices.utf8Slice("test"))),
                                                         tableScan("customer", ImmutableMap.of("c_custkey", "custkey", "c_name", "name"))))))));
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ColumnMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ColumnMetadata.java
@@ -67,6 +67,9 @@ public class ColumnMetadata
         return type;
     }
 
+    /**
+     * This method should return false only when not null constraint is guaranteed by the underlying data source.
+     */
     public boolean isNullable()
     {
         return nullable;


### PR DESCRIPTION
## Description

Simplify the following expressions: 
* not_null_column IS NOT NULL → remove the condition as redundant expressions
* not_null_column IS NULL → always return false 

Constant cases are handled in [EvaluateIsNull](https://github.com/trinodb/trino/blob/master/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/EvaluateIsNull.java) IR rule. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
