### PR TITLE
Update airlift to 243 and airbase to 153

### DIFF
--- a/client/trino-jdbc/pom.xml
+++ b/client/trino-jdbc/pom.xml
@@ -415,6 +415,10 @@
                                     <shadedPattern>${shadeBase}.jakarta.annotation</shadedPattern>
                                 </relocation>
                                 <relocation>
+                                    <pattern>net.bytebuddy</pattern>
+                                    <shadedPattern>${shadeBase}.net.bytebuddy</shadedPattern>
+                                </relocation>
+                                <relocation>
                                     <pattern>org.joda.time</pattern>
                                     <shadedPattern>${shadeBase}.joda.time</shadedPattern>
                                 </relocation>
@@ -457,6 +461,7 @@
                                         <exclude>org/intellij/**</exclude>
                                         <exclude>com/google/errorprone/**</exclude>
                                         <exclude>META-INF/maven/**</exclude>
+                                        <exclude>META-INF/licenses/**</exclude>
                                         <exclude>META-INF/services/com.fasterxml.**</exclude>
                                         <exclude>META-INF/proguard/**</exclude>
                                         <exclude>LICENSE</exclude>

--- a/lib/trino-cache/src/test/java/io/trino/cache/MoreFutures.java
+++ b/lib/trino-cache/src/test/java/io/trino/cache/MoreFutures.java
@@ -16,7 +16,8 @@ package io.trino.cache;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-import static com.google.common.base.Throwables.propagateIfPossible;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.util.Objects.requireNonNull;
 
 final class MoreFutures
@@ -49,7 +50,8 @@ final class MoreFutures
         }
         catch (ExecutionException e) {
             Throwable cause = e.getCause() == null ? e : e.getCause();
-            propagateIfPossible(cause, exceptionType);
+            throwIfInstanceOf(cause, exceptionType);
+            throwIfUnchecked(cause);
             throw new RuntimeException(cause);
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>152</version>
+        <version>153</version>
     </parent>
 
     <groupId>io.trino</groupId>
@@ -179,7 +179,7 @@
         <!-- keep dependency properties sorted -->
         <dep.accumulo-hadoop.version>2.7.7-1</dep.accumulo-hadoop.version>
         <dep.accumulo.version>3.0.0</dep.accumulo.version>
-        <dep.airlift.version>242</dep.airlift.version>
+        <dep.airlift.version>243</dep.airlift.version>
         <dep.alluxio.version>311</dep.alluxio.version>
         <dep.antlr.version>4.13.1</dep.antlr.version>
         <dep.avro.version>1.11.3</dep.avro.version>

--- a/testing/trino-product-tests/pom.xml
+++ b/testing/trino-product-tests/pom.xml
@@ -291,24 +291,6 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.1.1</version>
-            <!--
-            It is required by SchemaRegistryClient. The actual dependencies
-            are excluded from SchemaRegistryClient as it conflicts with Trino's dependency
-            -->
-            <scope>runtime</scope>
-        </dependency>
-
-        <!-- TODO: move it to airlift -->
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-xml</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
             <scope>runtime</scope>


### PR DESCRIPTION
Fixes Jackson long string serialization issue (thx @losipiuk) and makes maven project infrastructure compatible with JDK 22/23.

The changes around Throwables are the result of the deprecations in Guava.