### PR TITLE
Support for extended boolean literal for LazySimpleSerde

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/encodings/text/BooleanEncoding.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/encodings/text/BooleanEncoding.java
@@ -29,12 +29,14 @@ public class BooleanEncoding
     private static final Slice FALSE = Slices.utf8Slice("false");
 
     private final Type type;
+    private final boolean isExtendedBooleanLiteral;
     private final Slice nullSequence;
 
-    public BooleanEncoding(Type type, Slice nullSequence)
+    public BooleanEncoding(Type type, Slice nullSequence, boolean isExtendedBooleanLiteral)
     {
         this.type = type;
         this.nullSequence = nullSequence;
+        this.isExtendedBooleanLiteral = isExtendedBooleanLiteral;
     }
 
     @Override
@@ -102,24 +104,39 @@ public class BooleanEncoding
     }
 
     @SuppressWarnings("PointlessArithmeticExpression")
-    private static boolean isFalse(Slice slice, int start, int length)
+    private boolean isFalse(Slice slice, int start, int length)
     {
-        return (length == 5) &&
-                (toUpperCase(slice.getByte(start + 0)) == 'F') &&
-                (toUpperCase(slice.getByte(start + 1)) == 'A') &&
-                (toUpperCase(slice.getByte(start + 2)) == 'L') &&
-                (toUpperCase(slice.getByte(start + 3)) == 'S') &&
-                (toUpperCase(slice.getByte(start + 4)) == 'E');
+        if (length == 5) {
+            return (toUpperCase(slice.getByte(start + 0)) == 'F') &&
+                    (toUpperCase(slice.getByte(start + 1)) == 'A') &&
+                    (toUpperCase(slice.getByte(start + 2)) == 'L') &&
+                    (toUpperCase(slice.getByte(start + 3)) == 'S') &&
+                    (toUpperCase(slice.getByte(start + 4)) == 'E');
+        }
+
+        if (length == 1 && isExtendedBooleanLiteral) {
+            byte byteValue = slice.getByte(start);
+            return toUpperCase(byteValue) == 'F' ||
+                    byteValue == '0';
+        }
+        return false;
     }
 
     @SuppressWarnings("PointlessArithmeticExpression")
-    private static boolean isTrue(Slice slice, int start, int length)
+    private boolean isTrue(Slice slice, int start, int length)
     {
-        return (length == 4) &&
-                (toUpperCase(slice.getByte(start + 0)) == 'T') &&
-                (toUpperCase(slice.getByte(start + 1)) == 'R') &&
-                (toUpperCase(slice.getByte(start + 2)) == 'U') &&
-                (toUpperCase(slice.getByte(start + 3)) == 'E');
+        if (length == 4) {
+            return (toUpperCase(slice.getByte(start + 0)) == 'T') &&
+                    (toUpperCase(slice.getByte(start + 1)) == 'R') &&
+                    (toUpperCase(slice.getByte(start + 2)) == 'U') &&
+                    (toUpperCase(slice.getByte(start + 3)) == 'E');
+        }
+        if (length == 1 && isExtendedBooleanLiteral) {
+            byte byteValue = slice.getByte(start);
+            return toUpperCase(byteValue) == 'T' ||
+                    byteValue == '1';
+        }
+        return false;
     }
 
     private static byte toUpperCase(byte b)

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/encodings/text/TextColumnEncodingFactory.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/encodings/text/TextColumnEncodingFactory.java
@@ -88,7 +88,7 @@ public class TextColumnEncodingFactory
     private TextColumnEncoding getEncoding(Type type, int depth)
     {
         if (BOOLEAN.equals(type)) {
-            return new BooleanEncoding(type, textEncodingOptions.getNullSequence());
+            return new BooleanEncoding(type, textEncodingOptions.getNullSequence(), textEncodingOptions.isExtendedBooleanLiteral());
         }
         if (TINYINT.equals(type) || SMALLINT.equals(type) || INTEGER.equals(type) || BIGINT.equals(type)) {
             return new LongEncoding(type, textEncodingOptions.getNullSequence());

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/encodings/text/TextEncodingOptions.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/encodings/text/TextEncodingOptions.java
@@ -36,6 +36,7 @@ public class TextEncodingOptions
     private static final String LAST_COLUMN_TAKES_REST_KEY = "serialization.last.column.takes.rest";
 
     private static final String FIELD_DELIMITER_KEY = "field.delim";
+    private static final String EXTENDED_BOOLEAN_LITERAL = "extended_boolean_literal";
     private static final String COLLECTION_DELIMITER_KEY = "collection.delim";
     private static final String MAP_KEY_DELIMITER_KEY = "mapkey.delim";
     private static final String ESCAPE_CHAR_KEY = "escape.delim";
@@ -126,6 +127,7 @@ public class TextEncodingOptions
     private final Slice separators;
     private final Byte escapeByte;
     private final boolean lastColumnTakesRest;
+    private final boolean extendedBooleanLiteral;
     private final List<String> timestampFormats;
 
     private TextEncodingOptions(
@@ -134,7 +136,8 @@ public class TextEncodingOptions
             Slice separators,
             Byte escapeByte,
             boolean lastColumnTakesRest,
-            List<String> timestampFormats)
+            List<String> timestampFormats,
+            boolean extendedBooleanLiteral)
     {
         this.nullSequence = nullSequence;
         this.nestingLevels = nestingLevels;
@@ -142,6 +145,7 @@ public class TextEncodingOptions
         this.escapeByte = escapeByte;
         this.lastColumnTakesRest = lastColumnTakesRest;
         this.timestampFormats = timestampFormats;
+        this.extendedBooleanLiteral = extendedBooleanLiteral;
     }
 
     public Slice getNullSequence()
@@ -169,6 +173,11 @@ public class TextEncodingOptions
         return lastColumnTakesRest;
     }
 
+    public boolean isExtendedBooleanLiteral()
+    {
+        return extendedBooleanLiteral;
+    }
+
     public List<String> getTimestampFormats()
     {
         return timestampFormats;
@@ -192,6 +201,9 @@ public class TextEncodingOptions
         }
         if (lastColumnTakesRest) {
             schema.put(LAST_COLUMN_TAKES_REST_KEY, "true");
+        }
+        if (extendedBooleanLiteral) {
+            schema.put(EXTENDED_BOOLEAN_LITERAL, "true");
         }
         if (escapeByte != null) {
             schema.put(ESCAPE_CHAR_KEY, String.valueOf(escapeByte));
@@ -242,6 +254,11 @@ public class TextEncodingOptions
             builder.lastColumnTakesRest();
         }
 
+        String extendedBooleanLiteral = serdeProperties.get(EXTENDED_BOOLEAN_LITERAL);
+        if ("true".equalsIgnoreCase(extendedBooleanLiteral)) {
+            builder.extendedBooleanLiteral();
+        }
+
         // escaped
         String escapeProperty = serdeProperties.get(ESCAPE_CHAR_KEY);
         if (escapeProperty != null) {
@@ -287,6 +304,7 @@ public class TextEncodingOptions
         private byte mapKeyDelimiter = DEFAULT_SEPARATORS[2];
         private Byte escapeByte;
         private boolean lastColumnTakesRest;
+        private boolean extendedBooleanLiteral;
         private List<String> timestampFormats = ImmutableList.of();
 
         public Builder() {}
@@ -301,6 +319,7 @@ public class TextEncodingOptions
             escapeByte = textEncodingOptions.getEscapeByte();
             lastColumnTakesRest = textEncodingOptions.isLastColumnTakesRest();
             timestampFormats = textEncodingOptions.getTimestampFormats();
+            extendedBooleanLiteral = textEncodingOptions.isExtendedBooleanLiteral();
         }
 
         public Builder nullSequence(Slice nullSequence)
@@ -355,6 +374,12 @@ public class TextEncodingOptions
             return this;
         }
 
+        public Builder extendedBooleanLiteral()
+        {
+            this.extendedBooleanLiteral = true;
+            return this;
+        }
+
         public Builder timestampFormats(String... timestampFormats)
         {
             return timestampFormats(ImmutableList.copyOf(timestampFormats));
@@ -369,7 +394,7 @@ public class TextEncodingOptions
         public TextEncodingOptions build()
         {
             Slice separators = nestingLevels.getSeparators(fieldDelimiter, collectionDelimiter, mapKeyDelimiter);
-            return new TextEncodingOptions(nullSequence, nestingLevels, separators, escapeByte, lastColumnTakesRest, timestampFormats);
+            return new TextEncodingOptions(nullSequence, nestingLevels, separators, escapeByte, lastColumnTakesRest, timestampFormats, extendedBooleanLiteral);
         }
     }
 }

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/simple/TestSimpleFormat.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/simple/TestSimpleFormat.java
@@ -546,6 +546,42 @@ public class TestSimpleFormat
     }
 
     @Test
+    public void testExtendedBooleanLiterals()
+            throws Exception
+    {
+        TextEncodingOptions textEncodingOptions = TextEncodingOptions.builder()
+                .extendedBooleanLiteral()
+                .build();
+
+        assertValue(BOOLEAN, "\\N", null, textEncodingOptions);
+        assertValue(BOOLEAN, "NOPE", null, textEncodingOptions);
+
+        // empty value is not allowed
+        assertValue(BOOLEAN, "", null, textEncodingOptions);
+
+        assertValue(BOOLEAN, "true", true, textEncodingOptions);
+        assertValue(BOOLEAN, "TRUE", true, textEncodingOptions);
+        assertValue(BOOLEAN, "tRuE", true, textEncodingOptions);
+
+        assertValue(BOOLEAN, "false", false, textEncodingOptions);
+        assertValue(BOOLEAN, "FALSE", false, textEncodingOptions);
+        assertValue(BOOLEAN, "fAlSe", false, textEncodingOptions);
+
+        assertValueTrino(BOOLEAN, "t", true, textEncodingOptions, true);
+        assertValueTrino(BOOLEAN, "T", true, textEncodingOptions, true);
+        assertValueTrino(BOOLEAN, "1", true, textEncodingOptions, true);
+        assertValueTrino(BOOLEAN, "f", false, textEncodingOptions, true);
+        assertValueTrino(BOOLEAN, "F", false, textEncodingOptions, true);
+        assertValueTrino(BOOLEAN, "0", false, textEncodingOptions, true);
+
+        assertValue(BOOLEAN, "unknown", null);
+        assertValue(BOOLEAN, "null", null);
+        assertValue(BOOLEAN, "-1", null);
+        assertValue(BOOLEAN, "1.23", null);
+        assertValue(BOOLEAN, "1.23e45", null);
+    }
+
+    @Test
     public void testBigint()
             throws Exception
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Hive [supports](https://issues.apache.org/jira/browse/HIVE-3635) `hive.lazysimple.extended_boolean_literal` for `LazySimpleSerde`.
```
LazySimpleSerde uses this property to determine if it treats 'T', 't', 'F', 'f', '1', and '0' as extended, legal boolean literal, in addition to 'TRUE' and 'FALSE'. The default is false, which means only 'TRUE' and 'FALSE' are treated as legal boolean literal.
```

Adding the same here.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
