### PR TITLE
Run server with en_US locale

### DIFF
--- a/core/docker/default/etc/jvm.config
+++ b/core/docker/default/etc/jvm.config
@@ -17,3 +17,7 @@
 -XX:GCLockerRetryAllocationCount=32
 # Allow loading dynamic agent used by JOL
 -XX:+EnableDynamicAgentLoading
+# Trino server behavior does generally not depend on locale settings.
+# Use en_US as this is what Trino is tested with.
+-Duser.language=en
+-Duser.region=US

--- a/core/trino-server-rpm/src/main/resources/dist/config/jvm.config
+++ b/core/trino-server-rpm/src/main/resources/dist/config/jvm.config
@@ -16,3 +16,7 @@
 -XX:GCLockerRetryAllocationCount=32
 # Allow loading dynamic agent used by JOL
 -XX:+EnableDynamicAgentLoading
+# Trino server behavior does generally not depend on locale settings.
+# Use en_US as this is what Trino is tested with.
+-Duser.language=en
+-Duser.region=US

--- a/docs/src/main/sphinx/installation/deployment.md
+++ b/docs/src/main/sphinx/installation/deployment.md
@@ -147,6 +147,10 @@ The following provides a good starting point for creating `etc/jvm.config`:
 -XX:GCLockerRetryAllocationCount=32
 # Allow loading dynamic agent used by JOL
 -XX:+EnableDynamicAgentLoading
+# Trino server behavior does generally not depend on locale settings.
+# Use en_US as this is what Trino is tested with.
+-Duser.language=en
+-Duser.region=US
 ```
 
 You must adjust the value for the memory used by Trino, specified with `-Xmx`

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-all/jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-all/jvm.config
@@ -17,3 +17,7 @@
 -XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
 # Allow loading dynamic agent used by JOL
 -XX:+EnableDynamicAgentLoading
+# Trino server behavior does generally not depend on locale settings.
+# Use en_US as this is what Trino is tested with.
+-Duser.language=en
+-Duser.region=US

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/presto/etc/jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/presto/etc/jvm.config
@@ -16,3 +16,7 @@
 -XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
 # Allow loading dynamic agent used by JOL
 -XX:+EnableDynamicAgentLoading
+# Trino server behavior does generally not depend on locale settings.
+# Use en_US as this is what Trino is tested with.
+-Duser.language=en
+-Duser.region=US


### PR DESCRIPTION
Trino server behavior does generally not depend on locale settings.  Use en_US as this is what Trino is tested with.


Follows https://github.com/trinodb/trino/pull/21136 and https://github.com/trinodb/trino/pull/21140 .
