### PR TITLE
Constant-fold Values nodes

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/ir/IrExpressions.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/IrExpressions.java
@@ -14,8 +14,13 @@
 package io.trino.sql.ir;
 
 import com.google.common.collect.ImmutableList;
+import io.trino.spi.type.RowType;
 
+import java.util.Arrays;
 import java.util.Optional;
+
+import static io.trino.spi.block.RowValueBuilder.buildRowValue;
+import static io.trino.spi.type.TypeUtils.writeNativeValue;
 
 public class IrExpressions
 {
@@ -29,5 +34,15 @@ public class IrExpressions
     public static Expression ifExpression(Expression condition, Expression trueCase, Expression falseCase)
     {
         return new SearchedCaseExpression(ImmutableList.of(new WhenClause(condition, trueCase)), Optional.of(falseCase));
+    }
+
+    public static Constant row(Constant... values)
+    {
+        RowType type = RowType.anonymous(Arrays.stream(values).map(Constant::getType).toList());
+        return new Constant(type, buildRowValue(type, fields -> {
+            for (int i = 0; i < values.length; ++i) {
+                writeNativeValue(values[i].getType(), fields.get(i), values[i].getValue());
+            }
+        }));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -47,6 +47,7 @@ import io.trino.sql.planner.iterative.rule.DetermineJoinDistributionType;
 import io.trino.sql.planner.iterative.rule.DetermineSemiJoinDistributionType;
 import io.trino.sql.planner.iterative.rule.DetermineTableScanNodePartitioning;
 import io.trino.sql.planner.iterative.rule.EliminateCrossJoins;
+import io.trino.sql.planner.iterative.rule.EvaluateConstantValues;
 import io.trino.sql.planner.iterative.rule.EvaluateEmptyIntersect;
 import io.trino.sql.planner.iterative.rule.EvaluateZeroSample;
 import io.trino.sql.planner.iterative.rule.ExtractDereferencesFromFilterAboveScan;
@@ -376,6 +377,7 @@ public class PlanOptimizers
                 .addAll(new RemoveRedundantDateTrunc(plannerContext, typeAnalyzer).rules())
                 .addAll(new ArraySortAfterArrayDistinct(plannerContext).rules())
                 .add(new RemoveTrivialFilters())
+                .add(new EvaluateConstantValues(plannerContext, typeAnalyzer))
                 .build();
         IterativeOptimizer simplifyOptimizer = new IterativeOptimizer(
                 plannerContext,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/EvaluateConstantValues.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/EvaluateConstantValues.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.spi.type.Type;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.NodeRef;
+import io.trino.sql.planner.IrExpressionInterpreter;
+import io.trino.sql.planner.IrTypeAnalyzer;
+import io.trino.sql.planner.NoOpSymbolResolver;
+import io.trino.sql.planner.SymbolsExtractor;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.plan.ValuesNode;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.trino.sql.planner.plan.Patterns.values;
+import static java.util.Objects.requireNonNull;
+
+public class EvaluateConstantValues
+        implements Rule<ValuesNode>
+{
+    private static final Pattern<ValuesNode> PATTERN = values();
+
+    private final PlannerContext plannerContext;
+    private final IrTypeAnalyzer typeAnalyzer;
+
+    public EvaluateConstantValues(PlannerContext plannerContext, IrTypeAnalyzer typeAnalyzer)
+    {
+        this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
+        this.typeAnalyzer = requireNonNull(typeAnalyzer, "typeAnalyzer is null");
+    }
+
+    @Override
+    public Pattern<ValuesNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(ValuesNode values, Captures captures, Context context)
+    {
+        if (values.getRows().isEmpty()) {
+            return Result.empty();
+        }
+
+        List<Expression> rows = values.getRows().get();
+
+        ImmutableList.Builder<Expression> result = ImmutableList.builder();
+        for (Expression row : rows) {
+            Map<NodeRef<Expression>, Type> types = typeAnalyzer.getTypes(context.getSymbolAllocator().getTypes(), row);
+            IrExpressionInterpreter interpreter = new IrExpressionInterpreter(row, plannerContext, context.getSession(), types);
+
+            if (!SymbolsExtractor.extractAll(row).isEmpty()) {
+                Object optimized = interpreter.optimize(NoOpSymbolResolver.INSTANCE);
+                result.add(switch (optimized) {
+                    case Expression e -> e;
+                    default -> new Constant(types.get(NodeRef.of(row)), optimized);
+                });
+            }
+            else {
+                Object optimized = interpreter.evaluate(NoOpSymbolResolver.INSTANCE);
+                result.add(new Constant(types.get(NodeRef.of(row)), optimized));
+            }
+        }
+
+        List<Expression> newRows = result.build();
+
+        if (rows.equals(newRows)) {
+            return Result.empty();
+        }
+
+        return Result.ofPlanNode(new ValuesNode(values.getId(), values.getOutputSymbols(), newRows));
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/BenchmarkPlanner.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/BenchmarkPlanner.java
@@ -36,13 +36,11 @@ import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
-import org.openjdk.jmh.runner.options.WarmupMode;
 
 import java.io.IOException;
 import java.net.URL;
@@ -72,7 +70,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Warmup(iterations = 5)
 @Fork(1)
-@Measurement(iterations = 20)
+@Measurement(iterations = 5)
 @BenchmarkMode(Mode.AverageTime)
 public class BenchmarkPlanner
 {
@@ -82,9 +80,9 @@ public class BenchmarkPlanner
     @State(Scope.Benchmark)
     public static class BenchmarkData
     {
-        @Param({"OPTIMIZED", "CREATED"})
+//        @Param({"OPTIMIZED", "CREATED"})
         private Stage stage = OPTIMIZED;
-        @Param
+//        @Param
         private Queries queries = TPCH;
 
         private PlanTester planTester;
@@ -220,6 +218,6 @@ public class BenchmarkPlanner
             data.tearDown();
         }
 
-        benchmark(BenchmarkPlanner.class, WarmupMode.BULK).run();
+        benchmark(BenchmarkPlanner.class).run();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestCanonicalize.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestCanonicalize.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.spi.connector.SortOrder;
 import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.IrExpressions;
 import io.trino.sql.planner.assertions.BasePlanTest;
 import io.trino.sql.planner.assertions.ExpectedValueProvider;
 import io.trino.sql.planner.iterative.IterativeOptimizer;
@@ -49,7 +50,7 @@ public class TestCanonicalize
                         ") t\n" +
                         "CROSS JOIN (VALUES 2)",
                 anyTree(
-                        values(ImmutableList.of("field", "expr"), ImmutableList.of(ImmutableList.of(new Constant(INTEGER, 2L), new Constant(BIGINT, 1L))))));
+                        values(ImmutableList.of("field", "expr"), ImmutableList.of(IrExpressions.row(new Constant(INTEGER, 2L), new Constant(BIGINT, 1L))))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDereferencePushDown.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDereferencePushDown.java
@@ -37,6 +37,7 @@ import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static io.trino.sql.ir.ArithmeticBinaryExpression.Operator.MULTIPLY;
 import static io.trino.sql.ir.ComparisonExpression.Operator.EQUAL;
+import static io.trino.sql.ir.IrExpressions.row;
 import static io.trino.sql.ir.LogicalExpression.Operator.OR;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.any;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
@@ -73,7 +74,7 @@ public class TestDereferencePushDown
                                 join(INNER, builder -> builder
                                         .left(values("a_msg"))
                                         .right(
-                                                values(ImmutableList.of("b_msg_y"), ImmutableList.of(ImmutableList.of(new Constant(DOUBLE, 2e0)), ImmutableList.of(new Constant(DOUBLE, 4e0)))))))));
+                                                values(ImmutableList.of("b_msg_y"), ImmutableList.of(row(new Constant(DOUBLE, 2e0)), row(new Constant(DOUBLE, 4e0)))))))));
     }
 
     @Test
@@ -91,7 +92,7 @@ public class TestDereferencePushDown
                                         new ComparisonExpression(EQUAL, new SymbolReference("a_y"), new SymbolReference("b_y")),
                                         values(
                                                 ImmutableList.of("b_x", "b_y", "a_y"),
-                                                ImmutableList.of(ImmutableList.of(
+                                                ImmutableList.of(row(
                                                         new Constant(BIGINT, 1L),
                                                         new Constant(DOUBLE, 2e0),
                                                         new Constant(DOUBLE, 2e0))))))));
@@ -112,13 +113,13 @@ public class TestDereferencePushDown
                                 .left(
                                         project(filter(
                                                 new ComparisonExpression(EQUAL, new SymbolReference("a_y"), new Constant(DOUBLE, 2.0)),
-                                                values(ImmutableList.of("a_y"), ImmutableList.of(ImmutableList.of(new Constant(DOUBLE, 2e0)))))))
+                                                values(ImmutableList.of("a_y"), ImmutableList.of(row(new Constant(DOUBLE, 2e0)))))))
                                 .right(
                                         project(filter(
                                                 new ComparisonExpression(EQUAL, new SymbolReference("b_y"), new Constant(DOUBLE, 2.0)),
                                                 values(
                                                         ImmutableList.of("b_y", "b_x"),
-                                                        ImmutableList.of(ImmutableList.of(new Constant(DOUBLE, 2.0), new Constant(BIGINT, 1L))))))))));
+                                                        ImmutableList.of(row(new Constant(DOUBLE, 2.0), new Constant(BIGINT, 1L))))))))));
     }
 
     @Test
@@ -138,7 +139,7 @@ public class TestDereferencePushDown
                                                 new FunctionCall(IS_FINITE, ImmutableList.of(new SymbolReference("b_y"))))),
                                         values(
                                                 ImmutableList.of("b_x", "b_y", "a_y", "a_x"),
-                                                ImmutableList.of(ImmutableList.of(
+                                                ImmutableList.of(row(
                                                         new Constant(BIGINT, 1L),
                                                         new Constant(DOUBLE, 2.0),
                                                         new Constant(DOUBLE, 2.0),
@@ -154,7 +155,7 @@ public class TestDereferencePushDown
                 anyTree(
                         values(
                                 ImmutableList.of("x", "y"),
-                                ImmutableList.of(ImmutableList.of(new Constant(DOUBLE, 2.0), new Constant(BIGINT, 1L))))));
+                                ImmutableList.of(row(new Constant(DOUBLE, 2.0), new Constant(BIGINT, 1L))))));
 
         assertPlanWithSession(
                 "WITH t(msg1, msg2, msg3, msg4, msg5) AS (VALUES " +
@@ -240,7 +241,7 @@ public class TestDereferencePushDown
                                                 new ComparisonExpression(EQUAL, new SymbolReference("a_y"), new SymbolReference("b_y")),
                                                 values(
                                                         ImmutableList.of("b_x", "b_y", "a_y"),
-                                                        ImmutableList.of(ImmutableList.of(
+                                                        ImmutableList.of(row(
                                                                 new Constant(BIGINT, 1L),
                                                                 new Constant(DOUBLE, 2e0),
                                                                 new Constant(DOUBLE, 2e0)))))))));
@@ -262,13 +263,13 @@ public class TestDereferencePushDown
                                 .left(
                                         project(filter(
                                                 new ComparisonExpression(EQUAL, new SymbolReference("a_y"), new Constant(DOUBLE, 2.0)),
-                                                values(ImmutableList.of("a_y"), ImmutableList.of(ImmutableList.of(new Constant(DOUBLE, 2e0)))))))
+                                                values(ImmutableList.of("a_y"), ImmutableList.of(row(new Constant(DOUBLE, 2e0)))))))
                                 .right(
                                         project(filter(
                                                 new ComparisonExpression(EQUAL, new SymbolReference("b_y"), new Constant(DOUBLE, 2.0)),
                                                 values(
                                                         ImmutableList.of("b_y", "b_x"),
-                                                        ImmutableList.of(ImmutableList.of(new Constant(DOUBLE, 2.0), new Constant(BIGINT, 1L))))))))));
+                                                        ImmutableList.of(row(new Constant(DOUBLE, 2.0), new Constant(BIGINT, 1L))))))))));
     }
 
     @Test
@@ -292,6 +293,6 @@ public class TestDereferencePushDown
                                                         project(
                                                                 filter(
                                                                         new ComparisonExpression(EQUAL, new SymbolReference("b_y"), new Constant(DOUBLE, 2.0)),
-                                                                        values(ImmutableList.of("b_y"), ImmutableList.of(ImmutableList.of(new Constant(DOUBLE, 2e0))))))))))));
+                                                                        values(ImmutableList.of("b_y"), ImmutableList.of(row(new Constant(DOUBLE, 2e0))))))))))));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestHaving.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestHaving.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static io.trino.spi.type.VarcharType.createVarcharType;
+import static io.trino.sql.ir.IrExpressions.row;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.output;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
 
@@ -32,6 +33,6 @@ public class TestHaving
     {
         assertPlan(
                 "SELECT 'a' FROM (VALUES 1, 1, 2) t(a) HAVING true",
-                output(values(List.of("a_symbol"), List.of(List.of(new Constant(createVarcharType(1), Slices.utf8Slice("a")))))));
+                output(values(List.of("a_symbol"), List.of(row(new Constant(createVarcharType(1), Slices.utf8Slice("a")))))));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLocalExecutionPlanner.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLocalExecutionPlanner.java
@@ -55,17 +55,6 @@ public class TestLocalExecutionPlanner
     }
 
     @Test
-    public void testProjectionCompilerFailure()
-    {
-        String inner = "(" + Joiner.on(" + ").join(nCopies(100, "rand()")) + ")";
-        String outer = "x + x + " + Joiner.on(" + ").join(nCopies(100, inner));
-
-        assertTrinoExceptionThrownBy(() -> runner.execute("SELECT " + outer + " FROM (VALUES rand()) t(x)"))
-                .hasErrorCode(COMPILER_ERROR)
-                .hasMessage("Query exceeded maximum columns. Please reduce the number of columns referenced and re-run the query.");
-    }
-
-    @Test
     public void testFilterCompilerFailure()
     {
         // Filter Query

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestMaterializedViews.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestMaterializedViews.java
@@ -67,6 +67,7 @@ import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.sql.ir.ArithmeticBinaryExpression.Operator.ADD;
 import static io.trino.sql.ir.ComparisonExpression.Operator.LESS_THAN;
+import static io.trino.sql.ir.IrExpressions.row;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.exchange;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
@@ -341,7 +342,7 @@ public class TestMaterializedViews
         // No-op REFRESH
         assertPlan("REFRESH MATERIALIZED VIEW materialized_view_with_casts",
                 output(
-                        values(List.of("rows"), List.of(List.of(new Constant(BIGINT, 0L))))));
+                        values(List.of("rows"), List.of(row(new Constant(BIGINT, 0L))))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestTableFunctionInvocation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestTableFunctionInvocation.java
@@ -30,6 +30,7 @@ import io.trino.spi.function.table.Descriptor;
 import io.trino.spi.function.table.Descriptor.Field;
 import io.trino.sql.ir.Cast;
 import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Row;
 import io.trino.sql.ir.SymbolReference;
 import io.trino.sql.planner.assertions.BasePlanTest;
 import io.trino.sql.planner.assertions.RowNumberSymbolMatcher;
@@ -46,6 +47,7 @@ import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.sql.ir.BooleanLiteral.TRUE_LITERAL;
+import static io.trino.sql.ir.IrExpressions.row;
 import static io.trino.sql.planner.LogicalPlanner.Stage.CREATED;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
@@ -131,7 +133,7 @@ public class TestTableFunctionInvocation
                                 .addCopartitioning(ImmutableList.of("INPUT_1", "INPUT_3"))
                                 .properOutputs(ImmutableList.of("OUTPUT")),
                         anyTree(project(ImmutableMap.of("c1", expression(new Constant(createVarcharType(1), Slices.utf8Slice("a")))), values(1))),
-                        anyTree(values(ImmutableList.of("c2"), ImmutableList.of(ImmutableList.of(new Constant(INTEGER, 1L))))),
+                        anyTree(values(ImmutableList.of("c2"), ImmutableList.of(new Row(ImmutableList.of(new Constant(INTEGER, 1L)))))),
                         anyTree(project(ImmutableMap.of("c3", expression(new Constant(createVarcharType(1), Slices.utf8Slice("b")))), values(1))))));
     }
 
@@ -161,8 +163,8 @@ public class TestTableFunctionInvocation
                                 .addCopartitioning(ImmutableList.of("INPUT1", "INPUT2"))
                                 .properOutputs(ImmutableList.of("COLUMN")),
                         project(ImmutableMap.of("c1_coerced", expression(new Cast(new SymbolReference("c1"), INTEGER))),
-                                anyTree(values(ImmutableList.of("c1"), ImmutableList.of(ImmutableList.of(new Constant(SMALLINT, 1L)))))),
-                        anyTree(values(ImmutableList.of("c2"), ImmutableList.of(ImmutableList.of(new Constant(INTEGER, 2L))))))));
+                                anyTree(values(ImmutableList.of("c1"), ImmutableList.of(new Row(ImmutableList.of(new Constant(SMALLINT, 1L))))))),
+                        anyTree(values(ImmutableList.of("c2"), ImmutableList.of(new Row(ImmutableList.of(new Constant(INTEGER, 2L)))))))));
     }
 
     @Test
@@ -214,7 +216,7 @@ public class TestTableFunctionInvocation
                                         .passThroughSymbols(ImmutableList.of(ImmutableList.of("a", "b")))
                                         .requiredSymbols(ImmutableList.of(ImmutableList.of("a")))
                                         .specification(specification(ImmutableList.of(), ImmutableList.of(), ImmutableMap.of())),
-                                values(ImmutableList.of("a", "b"), ImmutableList.of(ImmutableList.of(new Constant(INTEGER, 1L), TRUE_LITERAL))))));
+                                values(ImmutableList.of("a", "b"), ImmutableList.of(row(new Constant(INTEGER, 1L), TRUE_LITERAL))))));
 
         // no table function outputs are referenced. All pass-through symbols are pruned from the TableFunctionProcessorNode. The unused symbol "b" is pruned from the source values node.
         assertPlan("SELECT 'constant' c FROM TABLE(mock.system.pass_through_function(input => TABLE(SELECT 1, true) t(a, b)))",
@@ -229,7 +231,7 @@ public class TestTableFunctionInvocation
                                                 .passThroughSymbols(ImmutableList.of(ImmutableList.of()))
                                                 .requiredSymbols(ImmutableList.of(ImmutableList.of("a")))
                                                 .specification(specification(ImmutableList.of(), ImmutableList.of(), ImmutableMap.of())),
-                                        values(ImmutableList.of("a"), ImmutableList.of(ImmutableList.of(new Constant(INTEGER, 1L))))))));
+                                        values(ImmutableList.of("a"), ImmutableList.of(row(new Constant(INTEGER, 1L))))))));
     }
 
     @Test
@@ -284,7 +286,7 @@ public class TestTableFunctionInvocation
                                         project(
                                                 rowNumber(
                                                         builder -> builder.partitionBy(ImmutableList.of()),
-                                                        values(ImmutableList.of("c"), ImmutableList.of(ImmutableList.of(new Constant(INTEGER, 2L)))))
+                                                        values(ImmutableList.of("c"), ImmutableList.of(row(new Constant(INTEGER, 2L)))))
                                                         .withAlias("input_2_row_number", new RowNumberSymbolMatcher()))))));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestWindowFrameRange.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestWindowFrameRange.java
@@ -25,6 +25,7 @@ import io.trino.sql.ir.Cast;
 import io.trino.sql.ir.ComparisonExpression;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.FunctionCall;
+import io.trino.sql.ir.Row;
 import io.trino.sql.ir.SymbolReference;
 import io.trino.sql.planner.assertions.BasePlanTest;
 import io.trino.sql.planner.assertions.PlanMatchPattern;
@@ -111,8 +112,8 @@ public class TestWindowFrameRange
                                                                         values(
                                                                                 ImmutableList.of("key", "x"),
                                                                                 ImmutableList.of(
-                                                                                        ImmutableList.of(new Constant(INTEGER, 1L), new Constant(createDecimalType(2, 1), Decimals.valueOfShort(new BigDecimal("1.1")))),
-                                                                                        ImmutableList.of(new Constant(INTEGER, 2L), new Constant(createDecimalType(2, 1), Decimals.valueOfShort(new BigDecimal("2.2")))))))))))));
+                                                                                        new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(createDecimalType(2, 1), Decimals.valueOfShort(new BigDecimal("1.1"))))),
+                                                                                        new Row(ImmutableList.of(new Constant(INTEGER, 2L), new Constant(createDecimalType(2, 1), Decimals.valueOfShort(new BigDecimal("2.2"))))))))))))));
 
         assertPlan(sql, CREATED, pattern);
     }
@@ -159,8 +160,8 @@ public class TestWindowFrameRange
                                                                         values(
                                                                                 ImmutableList.of("key", "x"),
                                                                                 ImmutableList.of(
-                                                                                        ImmutableList.of(new Constant(createDecimalType(2, 1), Decimals.valueOfShort(new BigDecimal("1.1"))), new Constant(INTEGER, 1L)),
-                                                                                        ImmutableList.of(new Constant(createDecimalType(2, 1), Decimals.valueOfShort(new BigDecimal("2.2"))), new Constant(INTEGER, 2L)))))))))));
+                                                                                        new Row(ImmutableList.of(new Constant(createDecimalType(2, 1), Decimals.valueOfShort(new BigDecimal("1.1"))), new Constant(INTEGER, 1L))),
+                                                                                        new Row(ImmutableList.of(new Constant(createDecimalType(2, 1), Decimals.valueOfShort(new BigDecimal("2.2"))), new Constant(INTEGER, 2L))))))))))));
 
         assertPlan(sql, CREATED, pattern);
     }
@@ -210,8 +211,8 @@ public class TestWindowFrameRange
                                                                         values(
                                                                                 ImmutableList.of("key", "x", "y"),
                                                                                 ImmutableList.of(
-                                                                                        ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 1L), new Constant(INTEGER, 1L)),
-                                                                                        ImmutableList.of(new Constant(INTEGER, 2L), new Constant(INTEGER, 2L), new Constant(INTEGER, 2L)))))))))));
+                                                                                        new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 1L), new Constant(INTEGER, 1L))),
+                                                                                        new Row(ImmutableList.of(new Constant(INTEGER, 2L), new Constant(INTEGER, 2L), new Constant(INTEGER, 2L))))))))))));
 
         assertPlan(sql, CREATED, pattern);
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
@@ -758,14 +758,12 @@ public final class PlanMatchPattern
         return node(ValuesNode.class).with(new ValuesMatcher(aliasToIndex, expectedOutputSymbolCount, expectedRows));
     }
 
-    private static PlanMatchPattern values(List<String> aliases, Optional<List<List<Expression>>> expectedRows)
+    private static PlanMatchPattern values(List<String> aliases, Optional<List<Expression>> expectedRows)
     {
         return values(
                 aliasToIndex(aliases),
                 Optional.of(aliases.size()),
-                expectedRows.map(list -> list.stream()
-                        .map(Row::new)
-                        .collect(toImmutableList())));
+                expectedRows);
     }
 
     public static Map<String, Integer> aliasToIndex(List<String> aliases)
@@ -785,10 +783,10 @@ public final class PlanMatchPattern
 
     public static PlanMatchPattern values(int rowCount)
     {
-        return values(ImmutableList.of(), nCopies(rowCount, ImmutableList.of()));
+        return values(ImmutableList.of(), nCopies(rowCount, new Row(ImmutableList.of())));
     }
 
-    public static PlanMatchPattern values(List<String> aliases, List<List<Expression>> expectedRows)
+    public static PlanMatchPattern values(List<String> aliases, List<Expression> expectedRows)
     {
         return values(aliases, Optional.of(expectedRows));
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestExpressionRewriteRuleSet.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestExpressionRewriteRuleSet.java
@@ -125,7 +125,7 @@ public class TestExpressionRewriteRuleSet
                         ImmutableList.<Symbol>of(p.symbol("a")),
                         ImmutableList.of(ImmutableList.of(new Constant(INTEGER, 1L)))))
                 .matches(
-                        values(ImmutableList.of("a"), ImmutableList.of(ImmutableList.of(new Constant(INTEGER, 0L)))));
+                        values(ImmutableList.of("a"), ImmutableList.of(new Row(ImmutableList.of(new Constant(INTEGER, 0L))))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestMergeProjectWithValues.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestMergeProjectWithValues.java
@@ -126,8 +126,8 @@ public class TestMergeProjectWithValues
                 .matches(values(
                         ImmutableList.of("a", "b"),
                         ImmutableList.of(
-                                ImmutableList.of(new Constant(createCharType(1), Slices.utf8Slice("x")), TRUE_LITERAL),
-                                ImmutableList.of(new Constant(createCharType(1), Slices.utf8Slice("x")), TRUE_LITERAL))));
+                                new Row(ImmutableList.of(new Constant(createCharType(1), Slices.utf8Slice("x")), TRUE_LITERAL)),
+                                new Row(ImmutableList.of(new Constant(createCharType(1), Slices.utf8Slice("x")), TRUE_LITERAL)))));
 
         // ValuesNode has no rows
         tester().assertThat(new MergeProjectWithValues())
@@ -156,7 +156,7 @@ public class TestMergeProjectWithValues
                 .matches(
                         values(
                                 ImmutableList.of("rand"),
-                                ImmutableList.of(ImmutableList.of(randomFunction))));
+                                ImmutableList.of(new Row(ImmutableList.of(randomFunction)))));
 
         // ValuesNode has multiple rows
         tester().assertThat(new MergeProjectWithValues())
@@ -172,9 +172,9 @@ public class TestMergeProjectWithValues
                         values(
                                 ImmutableList.of("output"),
                                 ImmutableList.of(
-                                        ImmutableList.of(new Constant(UnknownType.UNKNOWN, null)),
-                                        ImmutableList.of(randomFunction),
-                                        ImmutableList.of(new ArithmeticNegation(randomFunction)))));
+                                        new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null))),
+                                        new Row(ImmutableList.of(randomFunction)),
+                                        new Row(ImmutableList.of(new ArithmeticNegation(randomFunction))))));
 
         // ValuesNode has multiple non-deterministic outputs
         tester().assertThat(new MergeProjectWithValues())
@@ -192,9 +192,9 @@ public class TestMergeProjectWithValues
                         values(
                                 ImmutableList.of("x", "y"),
                                 ImmutableList.of(
-                                        ImmutableList.of(new ArithmeticNegation(new Constant(DOUBLE, 1e0)), randomFunction),
-                                        ImmutableList.of(new ArithmeticNegation(randomFunction), new Constant(UnknownType.UNKNOWN, null)),
-                                        ImmutableList.of(new ArithmeticNegation(new ArithmeticNegation(randomFunction)), new Constant(UnknownType.UNKNOWN, null)))));
+                                        new Row(ImmutableList.of(new ArithmeticNegation(new Constant(DOUBLE, 1e0)), randomFunction)),
+                                        new Row(ImmutableList.of(new ArithmeticNegation(randomFunction), new Constant(UnknownType.UNKNOWN, null))),
+                                        new Row(ImmutableList.of(new ArithmeticNegation(new ArithmeticNegation(randomFunction)), new Constant(UnknownType.UNKNOWN, null))))));
     }
 
     @Test
@@ -233,7 +233,7 @@ public class TestMergeProjectWithValues
                         p.valuesOfExpressions(
                                 ImmutableList.of(p.symbol("a")),
                                 ImmutableList.of(new Row(ImmutableList.of(new Constant(INTEGER, 1L)))))))
-                .matches(values(ImmutableList.of("x"), ImmutableList.of(ImmutableList.of(new ArithmeticBinaryExpression(ADD_INTEGER, ADD, new Constant(INTEGER, 1L), new SymbolReference("corr"))))));
+                .matches(values(ImmutableList.of("x"), ImmutableList.of(new Row(ImmutableList.of(new ArithmeticBinaryExpression(ADD_INTEGER, ADD, new Constant(INTEGER, 1L), new SymbolReference("corr")))))));
 
         // correlation symbol in values (note: the resulting plan is not yet supported in execution)
         tester().assertThat(new MergeProjectWithValues())
@@ -242,7 +242,7 @@ public class TestMergeProjectWithValues
                         p.valuesOfExpressions(
                                 ImmutableList.of(p.symbol("a")),
                                 ImmutableList.of(new Row(ImmutableList.of(new SymbolReference("corr")))))))
-                .matches(values(ImmutableList.of("x"), ImmutableList.of(ImmutableList.of(new SymbolReference("corr")))));
+                .matches(values(ImmutableList.of("x"), ImmutableList.of(new Row(ImmutableList.of(new SymbolReference("corr"))))));
 
         // correlation symbol is not present in the resulting expression
         tester().assertThat(new MergeProjectWithValues())
@@ -251,7 +251,7 @@ public class TestMergeProjectWithValues
                         p.valuesOfExpressions(
                                 ImmutableList.of(p.symbol("a")),
                                 ImmutableList.of(new Row(ImmutableList.of(new SymbolReference("corr")))))))
-                .matches(values(ImmutableList.of("x"), ImmutableList.of(ImmutableList.of(new Constant(INTEGER, 1L)))));
+                .matches(values(ImmutableList.of("x"), ImmutableList.of(new Row(ImmutableList.of(new Constant(INTEGER, 1L))))));
     }
 
     @Test
@@ -265,7 +265,7 @@ public class TestMergeProjectWithValues
                         p.valuesOfExpressions(
                                 ImmutableList.of(p.symbol("a")),
                                 ImmutableList.of(new Row(ImmutableList.of(new Constant(INTEGER, 1L)))))))
-                .matches(values(ImmutableList.of("x"), ImmutableList.of(ImmutableList.of(failFunction))));
+                .matches(values(ImmutableList.of("x"), ImmutableList.of(new Row(ImmutableList.of(failFunction)))));
     }
 
     @Test
@@ -296,9 +296,9 @@ public class TestMergeProjectWithValues
                 .matches(values(
                         ImmutableList.of("a", "d", "e", "f"),
                         ImmutableList.of(
-                                ImmutableList.of(new Constant(createCharType(1), Slices.utf8Slice("x")), TRUE_LITERAL, new IsNullPredicate(new Constant(createCharType(1), Slices.utf8Slice("x"))), new Constant(INTEGER, 1L)),
-                                ImmutableList.of(new Constant(createCharType(1), Slices.utf8Slice("y")), FALSE_LITERAL, new IsNullPredicate(new Constant(createCharType(1), Slices.utf8Slice("y"))), new Constant(INTEGER, 1L)),
-                                ImmutableList.of(new Constant(createCharType(1), Slices.utf8Slice("z")), TRUE_LITERAL, new IsNullPredicate(new Constant(createCharType(1), Slices.utf8Slice("z"))), new Constant(INTEGER, 1L)))));
+                                new Row(ImmutableList.of(new Constant(createCharType(1), Slices.utf8Slice("x")), TRUE_LITERAL, new IsNullPredicate(new Constant(createCharType(1), Slices.utf8Slice("x"))), new Constant(INTEGER, 1L))),
+                                new Row(ImmutableList.of(new Constant(createCharType(1), Slices.utf8Slice("y")), FALSE_LITERAL, new IsNullPredicate(new Constant(createCharType(1), Slices.utf8Slice("y"))), new Constant(INTEGER, 1L))),
+                                new Row(ImmutableList.of(new Constant(createCharType(1), Slices.utf8Slice("z")), TRUE_LITERAL, new IsNullPredicate(new Constant(createCharType(1), Slices.utf8Slice("z"))), new Constant(INTEGER, 1L))))));
 
         // ValuesNode has no rows
         tester().assertThat(new MergeProjectWithValues())

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneValuesColumns.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneValuesColumns.java
@@ -54,8 +54,8 @@ public class TestPruneValuesColumns
                                 values(
                                         ImmutableList.of("x"),
                                         ImmutableList.of(
-                                                ImmutableList.of(new Constant(INTEGER, 2L)),
-                                                ImmutableList.of(new Constant(INTEGER, 4L))))));
+                                                new Row(ImmutableList.of(new Constant(INTEGER, 2L))),
+                                                new Row(ImmutableList.of(new Constant(INTEGER, 4L)))))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveEmptyExceptBranches.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveEmptyExceptBranches.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Row;
 import io.trino.sql.ir.SymbolReference;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
@@ -84,8 +85,8 @@ public class TestRemoveEmptyExceptBranches
                 })
                 .matches(
                         except(
-                                values(List.of("input1"), List.of(List.of(new Constant(UnknownType.UNKNOWN, null)))),
-                                values(List.of("input3"), List.of(List.of(new Constant(UnknownType.UNKNOWN, null)), List.of(new Constant(UnknownType.UNKNOWN, null))))));
+                                values(List.of("input1"), List.of(new Row(List.of(new Constant(UnknownType.UNKNOWN, null))))),
+                                values(List.of("input3"), List.of(new Row(List.of(new Constant(UnknownType.UNKNOWN, null))), new Row(List.of(new Constant(UnknownType.UNKNOWN, null)))))));
     }
 
     @Test
@@ -110,7 +111,7 @@ public class TestRemoveEmptyExceptBranches
                 .matches(
                         project(
                                 ImmutableMap.of("output", expression(new SymbolReference("input1"))),
-                                values(ImmutableList.of("input1"), ImmutableList.of(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null))))));
+                                values(ImmutableList.of("input1"), ImmutableList.of(new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null)))))));
     }
 
     @Test
@@ -140,7 +141,7 @@ public class TestRemoveEmptyExceptBranches
                                 Step.SINGLE,
                                 project(
                                         ImmutableMap.of("output", expression(new SymbolReference("input1"))),
-                                        values(ImmutableList.of("input1"), ImmutableList.of(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null)))))));
+                                        values(ImmutableList.of("input1"), ImmutableList.of(new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null))))))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveEmptyUnionBranches.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveEmptyUnionBranches.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Row;
 import io.trino.sql.ir.SymbolReference;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
@@ -80,8 +81,8 @@ public class TestRemoveEmptyUnionBranches
                 })
                 .matches(
                         union(
-                                values(List.of("input1"), List.of(List.of(new Constant(UnknownType.UNKNOWN, null)))),
-                                values(List.of("input3"), List.of(List.of(new Constant(UnknownType.UNKNOWN, null)), List.of(new Constant(UnknownType.UNKNOWN, null))))));
+                                values(List.of("input1"), List.of(new Row(List.of(new Constant(UnknownType.UNKNOWN, null))))),
+                                values(List.of("input3"), List.of(new Row(List.of(new Constant(UnknownType.UNKNOWN, null))), new Row(List.of(new Constant(UnknownType.UNKNOWN, null)))))));
     }
 
     @Test
@@ -105,7 +106,7 @@ public class TestRemoveEmptyUnionBranches
                 .matches(
                         project(
                                 ImmutableMap.of("output", expression(new SymbolReference("input1"))),
-                                values(ImmutableList.of("input1"), ImmutableList.of(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null))))));
+                                values(ImmutableList.of("input1"), ImmutableList.of(new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null)))))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveRedundantOffset.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveRedundantOffset.java
@@ -15,6 +15,7 @@ package io.trino.sql.planner.iterative.rule;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Row;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import org.junit.jupiter.api.Test;
 
@@ -55,8 +56,8 @@ public class TestRemoveRedundantOffset
                         values(
                                 ImmutableList.of("a"),
                                 ImmutableList.of(
-                                        ImmutableList.of(new Constant(INTEGER, 1L)),
-                                        ImmutableList.of(new Constant(INTEGER, 2L)))));
+                                        new Row(ImmutableList.of(new Constant(INTEGER, 1L))),
+                                        new Row(ImmutableList.of(new Constant(INTEGER, 2L))))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestReplaceRedundantJoinWithProject.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestReplaceRedundantJoinWithProject.java
@@ -16,6 +16,7 @@ package io.trino.sql.planner.iterative.rule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Row;
 import io.trino.sql.ir.SymbolReference;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.type.UnknownType;
@@ -92,7 +93,7 @@ public class TestReplaceRedundantJoinWithProject
                                 ImmutableMap.of(
                                         "a", expression(new SymbolReference("a")),
                                         "b", expression(new Constant(BIGINT, null))),
-                                values(ImmutableList.of("a"), nCopies(10, ImmutableList.of(new Constant(UnknownType.UNKNOWN, null))))));
+                                values(ImmutableList.of("a"), nCopies(10, new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null)))))));
     }
 
     @Test
@@ -109,7 +110,7 @@ public class TestReplaceRedundantJoinWithProject
                                 ImmutableMap.of(
                                         "a", expression(new Constant(BIGINT, null)),
                                         "b", expression(new SymbolReference("b"))),
-                                values(ImmutableList.of("b"), nCopies(10, ImmutableList.of(new Constant(UnknownType.UNKNOWN, null))))));
+                                values(ImmutableList.of("b"), nCopies(10, new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null)))))));
     }
 
     @Test
@@ -126,7 +127,7 @@ public class TestReplaceRedundantJoinWithProject
                                 ImmutableMap.of(
                                         "a", expression(new SymbolReference("a")),
                                         "b", expression(new Constant(BIGINT, null))),
-                                values(ImmutableList.of("a"), nCopies(10, ImmutableList.of(new Constant(UnknownType.UNKNOWN, null))))));
+                                values(ImmutableList.of("a"), nCopies(10, new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null)))))));
 
         tester().assertThat(new ReplaceRedundantJoinWithProject())
                 .on(p ->
@@ -139,6 +140,6 @@ public class TestReplaceRedundantJoinWithProject
                                 ImmutableMap.of(
                                         "a", expression(new Constant(BIGINT, null)),
                                         "b", expression(new SymbolReference("b"))),
-                                values(ImmutableList.of("b"), nCopies(10, ImmutableList.of(new Constant(UnknownType.UNKNOWN, null))))));
+                                values(ImmutableList.of("b"), nCopies(10, new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null)))))));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestReplaceRedundantJoinWithSource.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestReplaceRedundantJoinWithSource.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.sql.ir.ComparisonExpression;
 import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Row;
 import io.trino.sql.ir.SymbolReference;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.assertions.PlanMatchPattern;
@@ -122,7 +123,7 @@ public class TestReplaceRedundantJoinWithSource
                                 p.values(10, p.symbol("a")),
                                 p.values(1)))
                 .matches(
-                        values(ImmutableList.of("a"), nCopies(10, ImmutableList.of(new Constant(UnknownType.UNKNOWN, null)))));
+                        values(ImmutableList.of("a"), nCopies(10, new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null))))));
 
         tester().assertThat(new ReplaceRedundantJoinWithSource())
                 .on(p ->
@@ -131,7 +132,7 @@ public class TestReplaceRedundantJoinWithSource
                                 p.values(1),
                                 p.values(10, p.symbol("b"))))
                 .matches(
-                        values(ImmutableList.of("b"), nCopies(10, ImmutableList.of(new Constant(UnknownType.UNKNOWN, null)))));
+                        values(ImmutableList.of("b"), nCopies(10, new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null))))));
     }
 
     @Test
@@ -147,7 +148,7 @@ public class TestReplaceRedundantJoinWithSource
                 .matches(
                         filter(
                                 new ComparisonExpression(GREATER_THAN, new SymbolReference("a"), new Constant(INTEGER, 0L)),
-                                values(ImmutableList.of("a"), nCopies(10, ImmutableList.of(new Constant(UnknownType.UNKNOWN, null))))));
+                                values(ImmutableList.of("a"), nCopies(10, new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null)))))));
 
         tester().assertThat(new ReplaceRedundantJoinWithSource())
                 .on(p ->
@@ -159,7 +160,7 @@ public class TestReplaceRedundantJoinWithSource
                 .matches(
                         filter(
                                 new ComparisonExpression(GREATER_THAN, new SymbolReference("b"), new Constant(INTEGER, 0L)),
-                                values(ImmutableList.of("b"), nCopies(10, ImmutableList.of(new Constant(UnknownType.UNKNOWN, null))))));
+                                values(ImmutableList.of("b"), nCopies(10, new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null)))))));
     }
 
     @Test
@@ -172,7 +173,7 @@ public class TestReplaceRedundantJoinWithSource
                                 p.values(10, p.symbol("a")),
                                 p.values(1)))
                 .matches(
-                        values(ImmutableList.of("a"), nCopies(10, ImmutableList.of(new Constant(UnknownType.UNKNOWN, null)))));
+                        values(ImmutableList.of("a"), nCopies(10, new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null))))));
 
         // in case of outer join, filter does not affect the result
         tester().assertThat(new ReplaceRedundantJoinWithSource())
@@ -183,7 +184,7 @@ public class TestReplaceRedundantJoinWithSource
                                 p.values(1),
                                 new ComparisonExpression(GREATER_THAN, new SymbolReference("a"), new Constant(INTEGER, 0L))))
                 .matches(
-                        values(ImmutableList.of("a"), nCopies(10, ImmutableList.of(new Constant(UnknownType.UNKNOWN, null)))));
+                        values(ImmutableList.of("a"), nCopies(10, new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null))))));
     }
 
     @Test
@@ -196,7 +197,7 @@ public class TestReplaceRedundantJoinWithSource
                                 p.values(1),
                                 p.values(10, p.symbol("b"))))
                 .matches(
-                        values(ImmutableList.of("b"), nCopies(10, ImmutableList.of(new Constant(UnknownType.UNKNOWN, null)))));
+                        values(ImmutableList.of("b"), nCopies(10, new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null))))));
 
         // in case of outer join, filter does not affect the result
         tester().assertThat(new ReplaceRedundantJoinWithSource())
@@ -207,7 +208,7 @@ public class TestReplaceRedundantJoinWithSource
                                 p.values(10, p.symbol("b")),
                                 new ComparisonExpression(GREATER_THAN, new SymbolReference("b"), new Constant(INTEGER, 0L))))
                 .matches(
-                        values(ImmutableList.of("b"), nCopies(10, ImmutableList.of(new Constant(UnknownType.UNKNOWN, null)))));
+                        values(ImmutableList.of("b"), nCopies(10, new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null))))));
     }
 
     @Test
@@ -220,7 +221,7 @@ public class TestReplaceRedundantJoinWithSource
                                 p.values(10, p.symbol("a")),
                                 p.values(1)))
                 .matches(
-                        values(ImmutableList.of("a"), nCopies(10, ImmutableList.of(new Constant(UnknownType.UNKNOWN, null)))));
+                        values(ImmutableList.of("a"), nCopies(10, new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null))))));
 
         tester().assertThat(new ReplaceRedundantJoinWithSource())
                 .on(p ->
@@ -229,7 +230,7 @@ public class TestReplaceRedundantJoinWithSource
                                 p.values(1),
                                 p.values(10, p.symbol("b"))))
                 .matches(
-                        values(ImmutableList.of("b"), nCopies(10, ImmutableList.of(new Constant(UnknownType.UNKNOWN, null)))));
+                        values(ImmutableList.of("b"), nCopies(10, new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null))))));
 
         // in case of outer join, filter does not affect the result
         tester().assertThat(new ReplaceRedundantJoinWithSource())
@@ -240,7 +241,7 @@ public class TestReplaceRedundantJoinWithSource
                                 p.values(10, p.symbol("b")),
                                 new ComparisonExpression(GREATER_THAN, new SymbolReference("b"), new Constant(INTEGER, 0L))))
                 .matches(
-                        values(ImmutableList.of("b"), nCopies(10, ImmutableList.of(new Constant(UnknownType.UNKNOWN, null)))));
+                        values(ImmutableList.of("b"), nCopies(10, new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null))))));
 
         // Right source is scalar with no outputs. Left source cannot be determined to be at least scalar.
         // In such case, FULL join cannot be replaced with left source. The result would be incorrect
@@ -288,7 +289,7 @@ public class TestReplaceRedundantJoinWithSource
                 .matches(
                         project(
                                 ImmutableMap.of("a", PlanMatchPattern.expression(new SymbolReference("a"))),
-                                values(ImmutableList.of("a", "b"), nCopies(10, ImmutableList.of(new Constant(UnknownType.UNKNOWN, null), new Constant(UnknownType.UNKNOWN, null))))));
+                                values(ImmutableList.of("a", "b"), nCopies(10, new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null), new Constant(UnknownType.UNKNOWN, null)))))));
 
         tester().assertThat(new ReplaceRedundantJoinWithSource())
                 .on(p -> {
@@ -308,6 +309,6 @@ public class TestReplaceRedundantJoinWithSource
                                 ImmutableMap.of("a", PlanMatchPattern.expression(new SymbolReference("a"))),
                                 filter(
                                         new ComparisonExpression(GREATER_THAN, new SymbolReference("a"), new SymbolReference("b")),
-                                        values(ImmutableList.of("a", "b"), nCopies(10, ImmutableList.of(new Constant(UnknownType.UNKNOWN, null), new Constant(UnknownType.UNKNOWN, null)))))));
+                                        values(ImmutableList.of("a", "b"), nCopies(10, new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null), new Constant(UnknownType.UNKNOWN, null))))))));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedSingleRowSubqueryToProject.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedSingleRowSubqueryToProject.java
@@ -110,9 +110,9 @@ public class TestTransformCorrelatedSingleRowSubqueryToProject
                         project(
                                 ImmutableMap.of("a", PlanMatchPattern.expression(new SymbolReference("a"))),
                                 values(ImmutableList.of("a"), ImmutableList.of(
-                                        ImmutableList.of(new Constant(UnknownType.UNKNOWN, null)),
-                                        ImmutableList.of(new Constant(UnknownType.UNKNOWN, null)),
-                                        ImmutableList.of(new Constant(UnknownType.UNKNOWN, null))))));
+                                        new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null))),
+                                        new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null))),
+                                        new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null)))))));
 
         tester().assertThat(new TransformCorrelatedSingleRowSubqueryToProject())
                 .on(p -> {
@@ -131,9 +131,9 @@ public class TestTransformCorrelatedSingleRowSubqueryToProject
                                         "b", PlanMatchPattern.expression(new SymbolReference("b")),
                                         "c", PlanMatchPattern.expression(new Constant(INTEGER, 1L))),
                                 values(ImmutableList.of("a", "b"), ImmutableList.of(
-                                        ImmutableList.of(new Constant(UnknownType.UNKNOWN, null), new Constant(UnknownType.UNKNOWN, null)),
-                                        ImmutableList.of(new Constant(UnknownType.UNKNOWN, null), new Constant(UnknownType.UNKNOWN, null)),
-                                        ImmutableList.of(new Constant(UnknownType.UNKNOWN, null), new Constant(UnknownType.UNKNOWN, null))))));
+                                        new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null), new Constant(UnknownType.UNKNOWN, null))),
+                                        new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null), new Constant(UnknownType.UNKNOWN, null))),
+                                        new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null), new Constant(UnknownType.UNKNOWN, null)))))));
     }
 
     @Test
@@ -154,9 +154,9 @@ public class TestTransformCorrelatedSingleRowSubqueryToProject
                                         "a", PlanMatchPattern.expression(new SymbolReference("a")),
                                         "b", PlanMatchPattern.expression(new Constant(UnknownType.UNKNOWN, null))),
                                 values(ImmutableList.of("a"), ImmutableList.of(
-                                        ImmutableList.of(new Constant(UnknownType.UNKNOWN, null)),
-                                        ImmutableList.of(new Constant(UnknownType.UNKNOWN, null)),
-                                        ImmutableList.of(new Constant(UnknownType.UNKNOWN, null))))));
+                                        new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null))),
+                                        new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null))),
+                                        new Row(ImmutableList.of(new Constant(UnknownType.UNKNOWN, null)))))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestAddExchangesPlans.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestAddExchangesPlans.java
@@ -67,6 +67,7 @@ import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.sql.ir.ArithmeticBinaryExpression.Operator.MODULUS;
 import static io.trino.sql.ir.ComparisonExpression.Operator.GREATER_THAN;
 import static io.trino.sql.ir.ComparisonExpression.Operator.LESS_THAN;
+import static io.trino.sql.ir.IrExpressions.row;
 import static io.trino.sql.planner.OptimizerConfig.JoinDistributionType.PARTITIONED;
 import static io.trino.sql.planner.OptimizerConfig.JoinReorderingStrategy.ELIMINATE_CROSS_JOINS;
 import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_ARBITRARY_DISTRIBUTION;
@@ -151,7 +152,7 @@ public class TestAddExchangesPlans
                                         anyTree(
                                                 exchange(REMOTE, REPARTITION,
                                                         anyTree(
-                                                                values(ImmutableList.of("expr"), ImmutableList.of(ImmutableList.of(new Constant(BIGINT, 1L)))))))))));
+                                                                values(ImmutableList.of("expr"), ImmutableList.of(row(new Constant(BIGINT, 1L)))))))))));
     }
 
     @Test
@@ -191,7 +192,7 @@ public class TestAddExchangesPlans
                                                         anyTree(
                                                                 tableScan("nation", ImmutableMap.of("nationkey", "nationkey")))),
                                                 exchange(REMOTE, REPARTITION,
-                                                        values(ImmutableList.of("expr"), ImmutableList.of(ImmutableList.of(new Constant(BIGINT, 1L)))))))
+                                                        values(ImmutableList.of("expr"), ImmutableList.of(row(new Constant(BIGINT, 1L)))))))
                                 .right(
                                         anyTree(
                                                 exchange(REMOTE, REPARTITION,
@@ -275,11 +276,11 @@ public class TestAddExchangesPlans
                                         exchange(REMOTE, REPARTITION, ImmutableList.of(), ImmutableSet.of("partition1", "partition2"),
                                                 values(
                                                         ImmutableList.of("field", "partition2", "partition1"),
-                                                        ImmutableList.of(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L), new Constant(INTEGER, 1L))))),
+                                                        ImmutableList.of(row(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L), new Constant(INTEGER, 1L))))),
                                         exchange(REMOTE, REPARTITION, ImmutableList.of(), ImmutableSet.of("partition3"),
                                                 values(
                                                         ImmutableList.of("partition3", "partition4", "field_0"),
-                                                        ImmutableList.of(ImmutableList.of(new Constant(INTEGER, 3L), new Constant(INTEGER, 4L), new Constant(INTEGER, 1L)))))))));
+                                                        ImmutableList.of(row(new Constant(INTEGER, 3L), new Constant(INTEGER, 4L), new Constant(INTEGER, 1L)))))))));
 
         assertDistributedPlan(
                 query,
@@ -293,11 +294,11 @@ public class TestAddExchangesPlans
                                         exchange(REMOTE, REPARTITION, ImmutableList.of(), ImmutableSet.of("partition1"),
                                                 values(
                                                         ImmutableList.of("field", "partition2", "partition1"),
-                                                        ImmutableList.of(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L), new Constant(INTEGER, 1L))))),
+                                                        ImmutableList.of(row(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L), new Constant(INTEGER, 1L))))),
                                         exchange(REMOTE, REPARTITION, ImmutableList.of(), ImmutableSet.of("partition3"),
                                                 values(
                                                         ImmutableList.of("partition3", "partition4", "field_0"),
-                                                        ImmutableList.of(ImmutableList.of(new Constant(INTEGER, 3L), new Constant(INTEGER, 4L), new Constant(INTEGER, 1L)))))))));
+                                                        ImmutableList.of(row(new Constant(INTEGER, 3L), new Constant(INTEGER, 4L), new Constant(INTEGER, 1L)))))))));
     }
 
     @Test
@@ -480,7 +481,7 @@ public class TestAddExchangesPlans
         assertPlan(
                 "SELECT 10, a FROM (VALUES 1) t(a)",
                 anyTree(
-                        values(ImmutableList.of("a", "expr"), ImmutableList.of(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 10L))))));
+                        values(ImmutableList.of("a", "expr"), ImmutableList.of(row(new Constant(INTEGER, 1L), new Constant(INTEGER, 10L))))));
 
         assertPlan(
                 "SELECT 1 UNION ALL SELECT 1",
@@ -488,8 +489,8 @@ public class TestAddExchangesPlans
                         exchange(
                                 LOCAL,
                                 REPARTITION,
-                                values(ImmutableList.of("expr"), ImmutableList.of(ImmutableList.of(new Constant(INTEGER, 1L)))),
-                                values(ImmutableList.of("expr_0"), ImmutableList.of(ImmutableList.of(new Constant(INTEGER, 1L)))))));
+                                values(ImmutableList.of("expr"), ImmutableList.of(row(new Constant(INTEGER, 1L)))),
+                                values(ImmutableList.of("expr_0"), ImmutableList.of(row(new Constant(INTEGER, 1L)))))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestPartialTopNWithPresortedInput.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestPartialTopNWithPresortedInput.java
@@ -45,6 +45,7 @@ import static io.trino.spi.connector.SortOrder.ASC_NULLS_LAST;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.sql.ir.ComparisonExpression.Operator.EQUAL;
+import static io.trino.sql.ir.IrExpressions.row;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.exchange;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
@@ -189,8 +190,8 @@ public class TestPartialTopNWithPresortedInput
                                                         values(
                                                                 ImmutableList.of("id"),
                                                                 ImmutableList.of(
-                                                                        ImmutableList.of(new Constant(INTEGER, 1L)),
-                                                                        ImmutableList.of(new Constant(INTEGER, 1L))))))))));
+                                                                        row(new Constant(INTEGER, 1L)),
+                                                                        row(new Constant(INTEGER, 1L))))))))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
@@ -115,7 +115,7 @@ public class TestJsonRepresentation
                                 "Values",
                                 ImmutableMap.of(),
                                 ImmutableList.of(typedSymbol("field", INTEGER)),
-                                ImmutableList.of("(integer '1')", "(integer '2')"),
+                                ImmutableList.of("row(integer) '[1]'", "row(integer) '[2]'"),
                                 ImmutableList.of(new PlanNodeStatsAndCostSummary(2, 10, 0, 0, 0)),
                                 ImmutableList.of())))));
 

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestExpressions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestExpressions.java
@@ -52,16 +52,8 @@ public class TestExpressions
     @Test
     public void testInShortCircuit()
     {
-        // Because of the failing in-list item 5 / 0, the in-predicate cannot be simplified.
-        // Also, because of the non-deterministic expression `rand()` referenced twice in
-        // the in-predicate (`x + x`), the in-predicate cannot be inlined into Values.
-        // It is instead processed with the use of generated code which applies the short-circuit
-        // logic and finds a match without evaluating the failing item.
-        // According to in-predicate semantics, this query should fail, as all the in-list items
-        // should be successfully evaluated before a check for the match is performed.
-        // However, the execution of in-predicate is optimized for efficiency at the cost of
-        // correctness in this edge case.
-        assertThat(assertions.query("SELECT IF(3 IN (2, 4, 3, 5 / 0), 1e0, x + x) FROM (VALUES rand()) t(x)")).matches("VALUES 1e0");
+        assertThat(assertions.query("SELECT IF(3 IN (2, 4, 3, 5 / 0), 1e0, x + x) FROM (VALUES rand()) t(x)"))
+                .failure().hasMessage("Division by zero");
 
         // the in-predicate is inlined into Values and evaluated by the ExpressionInterpreter: eager evaluation, failure.
         assertThat(assertions.query("SELECT 3 IN (2, 4, 3, 5 / 0)"))

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestMetadataQueryOptimization.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestMetadataQueryOptimization.java
@@ -21,6 +21,7 @@ import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
 import io.trino.spi.security.PrincipalType;
 import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Row;
 import io.trino.sql.planner.assertions.BasePushdownPlanTest;
 import io.trino.testing.PlanTester;
 import org.junit.jupiter.api.AfterAll;
@@ -101,15 +102,15 @@ public class TestMetadataQueryOptimization
                 anyTree(values(
                         ImmutableList.of("b", "c"),
                         ImmutableList.of(
-                                ImmutableList.of(new Constant(INTEGER, 6L), new Constant(INTEGER, 7L)),
-                                ImmutableList.of(new Constant(INTEGER, 9L), new Constant(INTEGER, 10L))))));
+                                new Row(ImmutableList.of(new Constant(INTEGER, 6L), new Constant(INTEGER, 7L))),
+                                new Row(ImmutableList.of(new Constant(INTEGER, 9L), new Constant(INTEGER, 10L)))))));
 
         assertPlan(
                 format("SELECT DISTINCT b, c FROM %s WHERE b > 7", testTable),
                 session,
                 anyTree(values(
                         ImmutableList.of("b", "c"),
-                        ImmutableList.of(ImmutableList.of(new Constant(INTEGER, 9L), new Constant(INTEGER, 10L))))));
+                        ImmutableList.of(new Row(ImmutableList.of(new Constant(INTEGER, 9L), new Constant(INTEGER, 10L)))))));
 
         assertPlan(
                 format("SELECT DISTINCT b, c FROM %s WHERE b > 7 AND c < 8", testTable),


### PR DESCRIPTION
Uncorrelated expressions in Values nodes are now constant-folded. This opens up opportunities for downstream optimizations due to values being known at planning time.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Section
* TBD
```
