### PR TITLE
Add glacier skipping logic

### DIFF
--- a/docs/src/main/sphinx/object-storage/legacy-s3.md
+++ b/docs/src/main/sphinx/object-storage/legacy-s3.md
@@ -111,6 +111,9 @@ Trino uses its own S3 filesystem for the URI prefixes
 * - `hive.s3.sts.region`
   - Optional override for the sts region given that IAM role based
     authentication via sts is used.
+* - `hive.s3.storage-class-filter`
+  - Filter based on storage class of S3 object, defaults to `READ_ALL`.
+  
 :::
 
 (hive-s3-credentials)=

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/FileEntry.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/FileEntry.java
@@ -14,10 +14,12 @@
 package io.trino.filesystem;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -26,7 +28,7 @@ import static java.lang.Math.max;
 import static java.util.Comparator.comparing;
 import static java.util.Objects.requireNonNull;
 
-public record FileEntry(Location location, long length, Instant lastModified, Optional<List<Block>> blocks)
+public record FileEntry(Location location, long length, Instant lastModified, Optional<List<Block>> blocks, Set<String> tags)
 {
     public FileEntry
     {
@@ -34,6 +36,12 @@ public record FileEntry(Location location, long length, Instant lastModified, Op
         requireNonNull(location, "location is null");
         requireNonNull(blocks, "blocks is null");
         blocks = blocks.map(locations -> validatedBlocks(locations, length));
+        tags = ImmutableSet.copyOf(requireNonNull(tags, "tags is null"));
+    }
+
+    public FileEntry(Location location, long length, Instant lastModified, Optional<List<Block>> blocks)
+    {
+        this(location, length, lastModified, blocks, ImmutableSet.of());
     }
 
     public record Block(List<String> hosts, long offset, long length)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
@@ -176,6 +176,8 @@ public class HiveConfig
 
     private boolean partitionProjectionEnabled;
 
+    private S3StorageClassFilter s3StorageClassFilter = S3StorageClassFilter.READ_ALL;
+
     public boolean isSingleStatementWritesOnly()
     {
         return singleStatementWritesOnly;
@@ -1250,6 +1252,19 @@ public class HiveConfig
     public HiveConfig setPartitionProjectionEnabled(boolean enabledAthenaPartitionProjection)
     {
         this.partitionProjectionEnabled = enabledAthenaPartitionProjection;
+        return this;
+    }
+
+    public S3StorageClassFilter getS3StorageClassFilter()
+    {
+        return s3StorageClassFilter;
+    }
+
+    @Config("hive.s3.storage-class-filter")
+    @ConfigDescription("Filter based on storage class of S3 object")
+    public HiveConfig setS3StorageClassFilter(S3StorageClassFilter s3StorageClassFilter)
+    {
+        this.s3StorageClassFilter = s3StorageClassFilter;
         return this;
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/S3StorageClassFilter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/S3StorageClassFilter.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import io.trino.filesystem.FileEntry;
+
+import java.util.function.Predicate;
+
+import static com.google.common.base.Predicates.alwaysTrue;
+
+public enum S3StorageClassFilter {
+    READ_ALL,
+    READ_NON_GLACIER,
+    READ_NON_GLACIER_AND_RESTORED;
+
+    private static final String S3_GLACIER_TAG = "s3:glacier";
+    private static final String S3_GLACIER_AND_RESTORED_TAG = "s3:glacierRestored";
+
+    /**
+     * Checks if the S3 object is not an object with a storage class of glacier/deep_archive
+     *
+     * @return boolean that helps identify if FileEntry object contains tags for glacier object
+     */
+    private static boolean isNotGlacierObject(FileEntry fileEntry)
+    {
+        return !fileEntry.tags().contains(S3_GLACIER_TAG);
+    }
+
+    /**
+     * Only restored objects will have the restoreExpiryDate set.
+     * Ignore not-restored objects and in-progress restores.
+     *
+     * @return boolean that helps identify if FileEntry object contains tags for glacier or glacierRestored object
+     */
+    private static boolean isCompletedRestoredObject(FileEntry fileEntry)
+    {
+        return isNotGlacierObject(fileEntry) || fileEntry.tags().contains(S3_GLACIER_AND_RESTORED_TAG);
+    }
+
+    public Predicate<FileEntry> toFileEntryPredicate()
+    {
+        return switch (this) {
+            case READ_ALL -> alwaysTrue();
+            case READ_NON_GLACIER -> S3StorageClassFilter::isNotGlacierObject;
+            case READ_NON_GLACIER_AND_RESTORED -> S3StorageClassFilter::isCompletedRestoredObject;
+        };
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestBackgroundHiveSplitLoader.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestBackgroundHiveSplitLoader.java
@@ -75,6 +75,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.google.common.base.Predicates.alwaysTrue;
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.io.Resources.getResource;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
@@ -348,7 +349,7 @@ public class TestBackgroundHiveSplitLoader
     public void testCachedDirectoryLister()
             throws Exception
     {
-        CachingDirectoryLister cachingDirectoryLister = new CachingDirectoryLister(new Duration(5, TimeUnit.MINUTES), DataSize.of(100, KILOBYTE), List.of("test_dbname.test_table"));
+        CachingDirectoryLister cachingDirectoryLister = new CachingDirectoryLister(new Duration(5, TimeUnit.MINUTES), DataSize.of(100, KILOBYTE), List.of("test_dbname.test_table"), alwaysTrue());
         assertThat(cachingDirectoryLister.getRequestCount()).isEqualTo(0);
 
         int totalCount = 100;
@@ -775,7 +776,7 @@ public class TestBackgroundHiveSplitLoader
     public void testBuildManifestFileIterator()
             throws IOException
     {
-        CachingDirectoryLister directoryLister = new CachingDirectoryLister(new Duration(0, TimeUnit.MINUTES), DataSize.ofBytes(0), List.of());
+        CachingDirectoryLister directoryLister = new CachingDirectoryLister(new Duration(0, TimeUnit.MINUTES), DataSize.ofBytes(0), List.of(), alwaysTrue());
         Map<String, String> schema = ImmutableMap.<String, String>builder()
                 .put(FILE_INPUT_FORMAT, SYMLINK_TEXT_INPUT_FORMAT_CLASS)
                 .put(SERIALIZATION_LIB, AVRO.getSerde())
@@ -816,7 +817,7 @@ public class TestBackgroundHiveSplitLoader
     public void testBuildManifestFileIteratorNestedDirectory()
             throws IOException
     {
-        CachingDirectoryLister directoryLister = new CachingDirectoryLister(new Duration(5, TimeUnit.MINUTES), DataSize.of(100, KILOBYTE), List.of());
+        CachingDirectoryLister directoryLister = new CachingDirectoryLister(new Duration(5, TimeUnit.MINUTES), DataSize.of(100, KILOBYTE), List.of(), alwaysTrue());
         Map<String, String> schema = ImmutableMap.<String, String>builder()
                 .put(FILE_INPUT_FORMAT, SYMLINK_TEXT_INPUT_FORMAT_CLASS)
                 .put(SERIALIZATION_LIB, AVRO.getSerde())
@@ -858,7 +859,7 @@ public class TestBackgroundHiveSplitLoader
     public void testBuildManifestFileIteratorWithCacheInvalidation()
             throws IOException
     {
-        CachingDirectoryLister directoryLister = new CachingDirectoryLister(new Duration(5, TimeUnit.MINUTES), DataSize.of(1, MEGABYTE), List.of("*"));
+        CachingDirectoryLister directoryLister = new CachingDirectoryLister(new Duration(5, TimeUnit.MINUTES), DataSize.of(1, MEGABYTE), List.of("*"), alwaysTrue());
         Map<String, String> schema = ImmutableMap.<String, String>builder()
                 .put(FILE_INPUT_FORMAT, SYMLINK_TEXT_INPUT_FORMAT_CLASS)
                 .put(SERIALIZATION_LIB, AVRO.getSerde())
@@ -912,7 +913,7 @@ public class TestBackgroundHiveSplitLoader
     public void testMaxPartitions()
             throws Exception
     {
-        CachingDirectoryLister directoryLister = new CachingDirectoryLister(new Duration(0, TimeUnit.MINUTES), DataSize.ofBytes(0), List.of());
+        CachingDirectoryLister directoryLister = new CachingDirectoryLister(new Duration(0, TimeUnit.MINUTES), DataSize.ofBytes(0), List.of(), alwaysTrue());
         // zero partitions
         {
             BackgroundHiveSplitLoader backgroundHiveSplitLoader = backgroundHiveSplitLoader(

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
@@ -116,7 +116,8 @@ public class TestHiveConfig
                 .setDeltaLakeCatalogName(null)
                 .setHudiCatalogName(null)
                 .setAutoPurge(false)
-                .setPartitionProjectionEnabled(false));
+                .setPartitionProjectionEnabled(false)
+                .setS3StorageClassFilter(S3StorageClassFilter.READ_ALL));
     }
 
     @Test
@@ -201,6 +202,7 @@ public class TestHiveConfig
                 .put("hive.hudi-catalog-name", "hudi")
                 .put("hive.auto-purge", "true")
                 .put(CONFIGURATION_HIVE_PARTITION_PROJECTION_ENABLED, "true")
+                .put("hive.s3.storage-class-filter", "READ_NON_GLACIER_AND_RESTORED")
                 .buildOrThrow();
 
         HiveConfig expected = new HiveConfig()
@@ -281,7 +283,8 @@ public class TestHiveConfig
                 .setDeltaLakeCatalogName("delta")
                 .setHudiCatalogName("hudi")
                 .setAutoPurge(true)
-                .setPartitionProjectionEnabled(true);
+                .setPartitionProjectionEnabled(true)
+                .setS3StorageClassFilter(S3StorageClassFilter.READ_NON_GLACIER_AND_RESTORED);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This PR supersedes this one --> https://github.com/trinodb/trino/pull/18237

TrinoS3FileSystem contains logic/configuration for skipping Glacier objects found in S3.

This PR adds the missing functionality/configuration from TrinoS3FileSystem and also adds the capability to configure the filesystem to read restored Glacier objects.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Recently, S3 added the ```RestoreStatus``` to the result of ```ListObjectsV2``` - see https://aws.amazon.com/about-aws/whats-new/2023/06/amazon-s3-restore-status-s3-glacier-objects-list-api/ for more details.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Add support for reading S3 objects restored from glacier storage ({issue}`21164`)
```
