### PR TITLE
Hive `sync_partition_metadata`: Alter partition when the synced path differs only in case

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/SyncPartitionMetadataProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/SyncPartitionMetadataProcedure.java
@@ -216,11 +216,11 @@ public class SyncPartitionMetadataProcedure
             ConnectorSession session,
             Table table)
     {
-        if (syncMode == SyncMode.ADD || syncMode == SyncMode.FULL) {
-            addPartitions(metastore, session, table, partitionsToAdd);
-        }
         if (syncMode == SyncMode.DROP || syncMode == SyncMode.FULL) {
             dropPartitions(metastore, session, table, partitionsToDrop);
+        }
+        if (syncMode == SyncMode.ADD || syncMode == SyncMode.FULL) {
+            addPartitions(metastore, session, table, partitionsToAdd);
         }
         metastore.commit();
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Change the order of the operations in `sync_partition_metadata` operation. This change allows ALTER handling in `SemiTransactionalMetastore` when syncing a partition path case change.

e.g. `part=val` gets changed to `PART=val`

Note in the example above that the partition name and not the value has changed in case.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Relevant code snippet in reviewing this PR for highlighting that the order of operations (`DROP` first and `ADD` second) in `sync_partition_metadata`) is effective:

https://github.com/trinodb/trino/blob/06d208dea861229494ec6e793b9bce19d6ef97f3/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java#L887-L889


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
