### PR TITLE
Retain authorization header during cross host client redirects

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/uri/TrinoUri.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/TrinoUri.java
@@ -664,7 +664,7 @@ public class TrinoUri
                 if (!useSecureConnection) {
                     throw new SQLException("TLS/SSL required for authentication using an access token");
                 }
-                builder.addInterceptor(tokenAuth(accessToken.get()));
+                builder.addNetworkInterceptor(tokenAuth(accessToken.get()));
             }
 
             if (externalAuthentication.orElse(false)) {
@@ -692,7 +692,7 @@ public class TrinoUri
                         redirectHandler, poller, knownTokenCache.create(), timeout);
 
                 builder.authenticator(authenticator);
-                builder.addInterceptor(authenticator);
+                builder.addNetworkInterceptor(authenticator);
             }
 
             Optional<String> resolverContext = DNS_RESOLVER_CONTEXT.getValue(properties);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Another approach to the solution present in #21027

Fix #21026 


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

OkHttp module changed the way it handles Authorization headers during HTTP redirects. Trino engine uses OkHttp's interceptors to inject the Authorization header. There are [two types of interceptors](https://square.github.io/okhttp/features/interceptors/) in OkHttp module. Currently, Trino uses Application interceptor and Authorization header gets cleared during redirects. Instead, if we use Network interceptor, the Authorization header token will be retained as it happens after OkHttp module clears the headers during redirects. 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:


