### PR TITLE
Support creating view with properties in parser

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -104,7 +104,8 @@ statement
         (WITH properties)? AS rootQuery                                #createMaterializedView
     | CREATE (OR REPLACE)? VIEW qualifiedName
         (COMMENT string)?
-        (SECURITY (DEFINER | INVOKER))? AS rootQuery                   #createView
+        (SECURITY (DEFINER | INVOKER))?
+        (WITH properties)? AS rootQuery                                #createView
     | REFRESH MATERIALIZED VIEW qualifiedName                          #refreshMaterializedView
     | DROP MATERIALIZED VIEW (IF EXISTS)? qualifiedName                #dropMaterializedView
     | ALTER MATERIALIZED VIEW (IF EXISTS)? from=qualifiedName

--- a/core/trino-main/src/main/java/io/trino/execution/CreateViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateViewTask.java
@@ -37,6 +37,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.execution.ParameterExtractor.bindParameters;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.TABLE_ALREADY_EXISTS;
 import static io.trino.sql.SqlFormatterUtil.getFormattedSql;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
@@ -73,6 +74,9 @@ public class CreateViewTask
             List<Expression> parameters,
             WarningCollector warningCollector)
     {
+        if (!statement.getProperties().isEmpty()) {
+            throw semanticException(NOT_SUPPORTED, statement, "Creating views with properties is not supported");
+        }
         Session session = stateMachine.getSession();
         QualifiedObjectName name = createQualifiedObjectName(session, statement, statement.getName());
 

--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
@@ -652,7 +652,8 @@ public final class ShowQueriesRewrite
                         query,
                         false,
                         viewDefinition.get().getComment(),
-                        Optional.of(security)))
+                        Optional.of(security),
+                        ImmutableList.of()))
                         .trim();
                 return singleValueQuery("Create View", sql);
             }

--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateViewTask.java
@@ -142,7 +142,8 @@ public class TestCreateViewTask
                 query,
                 replace,
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                ImmutableList.of());
         return new CreateViewTask(metadata, new AllowAllAccessControl(), parser, analyzerFactory).execute(statement, queryStateMachine, ImmutableList.of(), WarningCollector.NOOP);
     }
 }

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -1163,6 +1163,8 @@ public final class SqlFormatter
                     .append(" SECURITY ")
                     .append(security.name()));
 
+            builder.append(formatPropertiesMultiLine(node.getProperties()));
+
             builder.append(" AS\n");
 
             process(node.getQuery(), indent);

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -896,13 +896,19 @@ class AstBuilder
             security = Optional.of(CreateView.Security.INVOKER);
         }
 
+        List<Property> properties = ImmutableList.of();
+        if (context.properties() != null) {
+            properties = visit(context.properties().propertyAssignments().property(), Property.class);
+        }
+
         return new CreateView(
                 getLocation(context),
                 getQualifiedName(context.qualifiedName()),
                 (Query) visit(context.rootQuery()),
                 context.REPLACE() != null,
                 comment,
-                security);
+                security,
+                properties);
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/CreateView.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/CreateView.java
@@ -35,18 +35,19 @@ public class CreateView
     private final boolean replace;
     private final Optional<String> comment;
     private final Optional<Security> security;
+    private final List<Property> properties;
 
-    public CreateView(QualifiedName name, Query query, boolean replace, Optional<String> comment, Optional<Security> security)
+    public CreateView(QualifiedName name, Query query, boolean replace, Optional<String> comment, Optional<Security> security, List<Property> properties)
     {
-        this(Optional.empty(), name, query, replace, comment, security);
+        this(Optional.empty(), name, query, replace, comment, security, properties);
     }
 
-    public CreateView(NodeLocation location, QualifiedName name, Query query, boolean replace, Optional<String> comment, Optional<Security> security)
+    public CreateView(NodeLocation location, QualifiedName name, Query query, boolean replace, Optional<String> comment, Optional<Security> security, List<Property> properties)
     {
-        this(Optional.of(location), name, query, replace, comment, security);
+        this(Optional.of(location), name, query, replace, comment, security, properties);
     }
 
-    private CreateView(Optional<NodeLocation> location, QualifiedName name, Query query, boolean replace, Optional<String> comment, Optional<Security> security)
+    private CreateView(Optional<NodeLocation> location, QualifiedName name, Query query, boolean replace, Optional<String> comment, Optional<Security> security, List<Property> properties)
     {
         super(location);
         this.name = requireNonNull(name, "name is null");
@@ -54,6 +55,7 @@ public class CreateView
         this.replace = replace;
         this.comment = requireNonNull(comment, "comment is null");
         this.security = requireNonNull(security, "security is null");
+        this.properties = ImmutableList.copyOf(requireNonNull(properties, "properties is null"));
     }
 
     public QualifiedName getName()
@@ -81,6 +83,11 @@ public class CreateView
         return security;
     }
 
+    public List<Property> getProperties()
+    {
+        return properties;
+    }
+
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context)
     {
@@ -90,13 +97,16 @@ public class CreateView
     @Override
     public List<Node> getChildren()
     {
-        return ImmutableList.of(query);
+        return ImmutableList.<Node>builder()
+                .add(query)
+                .addAll(properties)
+                .build();
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, query, replace, security);
+        return Objects.hash(name, query, replace, security, properties);
     }
 
     @Override
@@ -113,7 +123,8 @@ public class CreateView
                 && Objects.equals(query, o.query)
                 && Objects.equals(replace, o.replace)
                 && Objects.equals(comment, o.comment)
-                && Objects.equals(security, o.security);
+                && Objects.equals(security, o.security)
+                && Objects.equals(properties, o.properties);
     }
 
     @Override
@@ -125,6 +136,7 @@ public class CreateView
                 .add("replace", replace)
                 .add("comment", comment)
                 .add("security", security)
+                .add("properties", properties)
                 .toString();
     }
 }

--- a/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
@@ -28,6 +28,7 @@ import io.trino.sql.tree.GenericDataType;
 import io.trino.sql.tree.Identifier;
 import io.trino.sql.tree.LongLiteral;
 import io.trino.sql.tree.NodeLocation;
+import io.trino.sql.tree.Property;
 import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.Query;
 import io.trino.sql.tree.ShowCatalogs;
@@ -46,6 +47,7 @@ import static io.trino.sql.QueryUtil.selectList;
 import static io.trino.sql.QueryUtil.simpleQuery;
 import static io.trino.sql.QueryUtil.table;
 import static io.trino.sql.SqlFormatter.formatSql;
+import static io.trino.sql.tree.CreateView.Security.DEFINER;
 import static io.trino.sql.tree.SaveMode.FAIL;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -318,7 +320,8 @@ public class TestSqlFormatter
                         simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))),
                         false,
                         Optional.empty(),
-                        Optional.empty())))
+                        Optional.empty(),
+                        ImmutableList.of())))
                 .isEqualTo("CREATE VIEW test AS\n" +
                         "SELECT *\n" +
                         "FROM\n" +
@@ -330,11 +333,55 @@ public class TestSqlFormatter
                         simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))),
                         false,
                         Optional.of("攻殻機動隊"),
-                        Optional.empty())))
+                        Optional.empty(),
+                        ImmutableList.of())))
                 .isEqualTo("CREATE VIEW test COMMENT '攻殻機動隊' AS\n" +
                         "SELECT *\n" +
                         "FROM\n" +
                         "  t\n");
+
+        // CREATE VIEW WITH PROPERTIES
+        assertThat(formatSql(
+                new CreateView(
+                        new NodeLocation(1, 1),
+                        QualifiedName.of("test"),
+                        simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))),
+                        false,
+                        Optional.empty(),
+                        Optional.empty(),
+                        ImmutableList.of(
+                                new Property(new Identifier("property_1"), new StringLiteral("property_value")),
+                                new Property(new Identifier("property_2"), new StringLiteral("another_value"))))))
+                .isEqualTo("""
+                        CREATE VIEW test
+                        WITH (
+                           property_1 = 'property_value',
+                           property_2 = 'another_value'
+                        ) AS
+                        SELECT *
+                        FROM
+                          t
+                        """);
+
+        // CREATE VIEW WITH ALL PARAMETERS
+        assertThat(formatSql(
+                new CreateView(
+                        new NodeLocation(1, 1),
+                        QualifiedName.of("test"),
+                        simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))),
+                        false,
+                        Optional.of("攻殻機動隊"),
+                        Optional.of(DEFINER),
+                        ImmutableList.of(new Property(new Identifier("property"), new StringLiteral("property_value"))))))
+                .isEqualTo("""
+                        CREATE VIEW test COMMENT '攻殻機動隊' SECURITY DEFINER
+                        WITH (
+                           property = 'property_value'
+                        ) AS
+                        SELECT *
+                        FROM
+                          t
+                        """);
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -3331,21 +3331,34 @@ public class TestSqlParser
     {
         Query query = simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t")));
 
-        assertStatement("CREATE VIEW a AS SELECT * FROM t", new CreateView(QualifiedName.of("a"), query, false, Optional.empty(), Optional.empty()));
-        assertStatement("CREATE OR REPLACE VIEW a AS SELECT * FROM t", new CreateView(QualifiedName.of("a"), query, true, Optional.empty(), Optional.empty()));
+        assertStatement("CREATE VIEW a AS SELECT * FROM t", new CreateView(QualifiedName.of("a"), query, false, Optional.empty(), Optional.empty(), ImmutableList.of()));
+        assertStatement("CREATE OR REPLACE VIEW a AS SELECT * FROM t", new CreateView(QualifiedName.of("a"), query, true, Optional.empty(), Optional.empty(), ImmutableList.of()));
 
-        assertStatement("CREATE VIEW a SECURITY DEFINER AS SELECT * FROM t", new CreateView(QualifiedName.of("a"), query, false, Optional.empty(), Optional.of(CreateView.Security.DEFINER)));
-        assertStatement("CREATE VIEW a SECURITY INVOKER AS SELECT * FROM t", new CreateView(QualifiedName.of("a"), query, false, Optional.empty(), Optional.of(CreateView.Security.INVOKER)));
+        assertStatement("CREATE VIEW a SECURITY DEFINER AS SELECT * FROM t", new CreateView(QualifiedName.of("a"), query, false, Optional.empty(), Optional.of(CreateView.Security.DEFINER), ImmutableList.of()));
+        assertStatement("CREATE VIEW a SECURITY INVOKER AS SELECT * FROM t", new CreateView(QualifiedName.of("a"), query, false, Optional.empty(), Optional.of(CreateView.Security.INVOKER), ImmutableList.of()));
 
-        assertStatement("CREATE VIEW a COMMENT 'comment' SECURITY DEFINER AS SELECT * FROM t", new CreateView(QualifiedName.of("a"), query, false, Optional.of("comment"), Optional.of(CreateView.Security.DEFINER)));
-        assertStatement("CREATE VIEW a COMMENT '' SECURITY INVOKER AS SELECT * FROM t", new CreateView(QualifiedName.of("a"), query, false, Optional.of(""), Optional.of(CreateView.Security.INVOKER)));
+        assertStatement("CREATE VIEW a COMMENT 'comment' SECURITY DEFINER AS SELECT * FROM t", new CreateView(QualifiedName.of("a"), query, false, Optional.of("comment"), Optional.of(CreateView.Security.DEFINER), ImmutableList.of()));
+        assertStatement("CREATE VIEW a COMMENT '' SECURITY INVOKER AS SELECT * FROM t", new CreateView(QualifiedName.of("a"), query, false, Optional.of(""), Optional.of(CreateView.Security.INVOKER), ImmutableList.of()));
 
-        assertStatement("CREATE VIEW a COMMENT 'comment' AS SELECT * FROM t", new CreateView(QualifiedName.of("a"), query, false, Optional.of("comment"), Optional.empty()));
-        assertStatement("CREATE VIEW a COMMENT '' AS SELECT * FROM t", new CreateView(QualifiedName.of("a"), query, false, Optional.of(""), Optional.empty()));
+        assertStatement("CREATE VIEW a COMMENT 'comment' AS SELECT * FROM t", new CreateView(QualifiedName.of("a"), query, false, Optional.of("comment"), Optional.empty(), ImmutableList.of()));
+        assertStatement("CREATE VIEW a COMMENT '' AS SELECT * FROM t", new CreateView(QualifiedName.of("a"), query, false, Optional.of(""), Optional.empty(), ImmutableList.of()));
 
-        assertStatement("CREATE VIEW bar.foo AS SELECT * FROM t", new CreateView(QualifiedName.of("bar", "foo"), query, false, Optional.empty(), Optional.empty()));
-        assertStatement("CREATE VIEW \"awesome view\" AS SELECT * FROM t", new CreateView(QualifiedName.of("awesome view"), query, false, Optional.empty(), Optional.empty()));
-        assertStatement("CREATE VIEW \"awesome schema\".\"awesome view\" AS SELECT * FROM t", new CreateView(QualifiedName.of("awesome schema", "awesome view"), query, false, Optional.empty(), Optional.empty()));
+        assertStatement(
+                "CREATE VIEW a WITH (property_1 = 'value_1', property_2 = 2) AS SELECT * FROM t",
+                new CreateView(
+                        QualifiedName.of("a"),
+                        query,
+                        false,
+                        Optional.empty(),
+                        Optional.empty(),
+                        ImmutableList.of(
+                                new Property(new Identifier("property_1"), new StringLiteral("value_1")),
+                                new Property(new Identifier("property_2"), new LongLiteral("2")))));
+
+
+        assertStatement("CREATE VIEW bar.foo AS SELECT * FROM t", new CreateView(QualifiedName.of("bar", "foo"), query, false, Optional.empty(), Optional.empty(), ImmutableList.of()));
+        assertStatement("CREATE VIEW \"awesome view\" AS SELECT * FROM t", new CreateView(QualifiedName.of("awesome view"), query, false, Optional.empty(), Optional.empty(), ImmutableList.of()));
+        assertStatement("CREATE VIEW \"awesome schema\".\"awesome view\" AS SELECT * FROM t", new CreateView(QualifiedName.of("awesome schema", "awesome view"), query, false, Optional.empty(), Optional.empty(), ImmutableList.of()));
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Parser set of changes for supporting creating view properties. 

The proposed syntax would be like this

```
CREATE VIEW view_name WITH (property_key = 'property_value') AS SELECT ...
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
