### PR TITLE
Add explicit exception messages in base JDBC 

### DIFF
--- a/lib/trino-hdfs/src/main/java/io/trino/hdfs/s3/TrinoS3FileSystem.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/hdfs/s3/TrinoS3FileSystem.java
@@ -150,7 +150,6 @@ import static com.amazonaws.services.s3.Headers.SERVER_SIDE_ENCRYPTION;
 import static com.amazonaws.services.s3.Headers.UNENCRYPTED_CONTENT_LENGTH;
 import static com.amazonaws.services.s3.model.StorageClass.DeepArchive;
 import static com.amazonaws.services.s3.model.StorageClass.Glacier;
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkPositionIndexes;
 import static com.google.common.base.Preconditions.checkState;
@@ -167,6 +166,7 @@ import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.hdfs.s3.AwsCurrentRegionHolder.getCurrentRegionFromEC2Metadata;
 import static io.trino.hdfs.s3.RetryDriver.retry;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static io.trino.plugin.base.util.Exceptions.messageOrToString;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
@@ -2071,7 +2071,7 @@ public class TrinoS3FileSystem
     {
         String errorCode = s3Exception.getErrorCode();
         if (NO_SUCH_KEY_ERROR_CODE.equals(errorCode) || NO_SUCH_BUCKET_ERROR_CODE.equals(errorCode)) {
-            FileNotFoundException fileNotFoundException = new FileNotFoundException(format("%s (Bucket: %s, Key: %s)", firstNonNull(s3Exception.getMessage(), s3Exception), bucket, key));
+            FileNotFoundException fileNotFoundException = new FileNotFoundException(format("%s (Bucket: %s, Key: %s)", messageOrToString(s3Exception), bucket, key));
             fileNotFoundException.initCause(s3Exception);
             throw fileNotFoundException;
         }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/mapping/CachingIdentifierMapping.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/mapping/CachingIdentifierMapping.java
@@ -31,10 +31,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static io.trino.cache.SafeCaches.buildNonEvictableCacheWithWeakInvalidateAll;
+import static io.trino.plugin.base.util.Exceptions.messageOrToString;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -109,7 +109,7 @@ public final class CachingIdentifierMapping
             throw e;
         }
         catch (RuntimeException e) {
-            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to find remote schema name: " + firstNonNull(e.getMessage(), e), e);
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to find remote schema name: " + messageOrToString(e), e);
         }
 
         return identifierMapping.toRemoteSchemaName(remoteIdentifiers, identity, schemaName);
@@ -141,7 +141,7 @@ public final class CachingIdentifierMapping
             throw e;
         }
         catch (RuntimeException e) {
-            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to find remote table name: " + firstNonNull(e.getMessage(), e), e);
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to find remote table name: " + messageOrToString(e), e);
         }
 
         return identifierMapping.toRemoteTableName(remoteIdentifiers, identity, remoteSchema, tableName);

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/util/Exceptions.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/util/Exceptions.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.util;
+
+public final class Exceptions
+{
+    private Exceptions() {}
+
+    /**
+     * Returns {@link Throwable#getMessage()} is non-null and non-empty,
+     * otherwise returns {@link Throwable#toString()}.
+     */
+    public static String messageOrToString(Throwable e)
+    {
+        String message = e.getMessage();
+        if (message != null && !message.isBlank()) {
+            return message.strip();
+        }
+        return e.toString();
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -69,7 +69,6 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.emptyToNull;
@@ -79,6 +78,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.plugin.base.TemporaryTables.generateTemporaryTableName;
+import static io.trino.plugin.base.util.Exceptions.messageOrToString;
 import static io.trino.plugin.jdbc.CaseSensitivity.CASE_INSENSITIVE;
 import static io.trino.plugin.jdbc.CaseSensitivity.CASE_SENSITIVE;
 import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
@@ -150,7 +150,7 @@ public abstract class BaseJdbcClient
                     .collect(toImmutableSet());
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Failed to list schemas: " + e);
         }
     }
 
@@ -255,7 +255,7 @@ public abstract class BaseJdbcClient
                     ImmutableList.of());
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, "Failed to get table handle for prepared query. " + firstNonNull(e.getMessage(), e), e);
+            throw new TrinoException(JDBC_ERROR, "Failed to get table handle for prepared query. " + messageOrToString(e), e);
         }
     }
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -168,7 +168,7 @@ public abstract class BaseJdbcClient
             return schemaNames.build();
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Failed to list schemas: " + messageOrToString(e), e);
         }
     }
 
@@ -201,7 +201,7 @@ public abstract class BaseJdbcClient
             }
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Failed to list tables: " + messageOrToString(e), e);
         }
     }
 
@@ -228,7 +228,7 @@ public abstract class BaseJdbcClient
             }
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Failed to get table: " + messageOrToString(e), e);
         }
     }
 
@@ -348,7 +348,7 @@ public abstract class BaseJdbcClient
             return ImmutableList.copyOf(columns);
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Failed to get columns for table %s: %s".formatted(schemaTableName, messageOrToString(e)), e);
         }
     }
 
@@ -388,7 +388,7 @@ public abstract class BaseJdbcClient
                     .collect(toImmutableList());
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Failed to get column mappings for %s: %s".formatted(typeHandles, messageOrToString(e)), e);
         }
     }
 
@@ -468,7 +468,7 @@ public abstract class BaseJdbcClient
             return prepareQuery(session, connection, table, groupingSets, columns, columnExpressions, Optional.empty());
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Failed to prepare query: " + messageOrToString(e), e);
         }
     }
 
@@ -546,7 +546,7 @@ public abstract class BaseJdbcClient
                     joinConditions));
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Failed to prepare join query: " + messageOrToString(e), e);
         }
     }
 
@@ -581,7 +581,7 @@ public abstract class BaseJdbcClient
                     rightAssignments));
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Failed to prepare join query: " + messageOrToString(e), e);
         }
     }
 
@@ -613,7 +613,7 @@ public abstract class BaseJdbcClient
             createTable(session, tableMetadata, tableMetadata.getTable().getTableName());
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Failed to create table: " + messageOrToString(e), e);
         }
     }
 
@@ -634,7 +634,7 @@ public abstract class BaseJdbcClient
             }
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Failed to create table: " + messageOrToString(e), e);
         }
     }
 
@@ -775,7 +775,7 @@ public abstract class BaseJdbcClient
                     columns);
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Insert failed: " + messageOrToString(e), e);
         }
     }
 
@@ -848,7 +848,7 @@ public abstract class BaseJdbcClient
             execute(session, connection, sql);
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Insert failed to create staging table: " + messageOrToString(e), e);
         }
     }
 
@@ -890,7 +890,7 @@ public abstract class BaseJdbcClient
             renameTable(session, connection, catalogName, remoteSchemaName, remoteTableName, newRemoteSchemaName, newRemoteTableName);
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Rename failed: " + messageOrToString(e), e);
         }
     }
 
@@ -995,14 +995,14 @@ public abstract class BaseJdbcClient
             execute(session, connection, insertSql);
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Insert failed: " + messageOrToString(e), e);
         }
         finally {
             try {
                 closer.close();
             }
             catch (IOException e) {
-                throw new TrinoException(JDBC_ERROR, e);
+                throw new TrinoException(JDBC_ERROR, "Insert failed: " + messageOrToString(e), e);
             }
         }
     }
@@ -1030,7 +1030,7 @@ public abstract class BaseJdbcClient
             addColumn(session, connection, table, column);
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Failed to add column: " + messageOrToString(e), e);
         }
     }
 
@@ -1058,7 +1058,7 @@ public abstract class BaseJdbcClient
             renameColumn(session, connection, handle.asPlainTable().getRemoteTableName(), jdbcColumn.getColumnName(), newRemoteColumnName);
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Renaming column failed: " + messageOrToString(e), e);
         }
     }
 
@@ -1086,7 +1086,7 @@ public abstract class BaseJdbcClient
             execute(session, connection, sql);
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Dropping column failed: " + messageOrToString(e), e);
         }
     }
 
@@ -1104,7 +1104,7 @@ public abstract class BaseJdbcClient
             execute(session, connection, sql);
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Setting column type failed: " + messageOrToString(e), e);
         }
     }
 
@@ -1121,7 +1121,7 @@ public abstract class BaseJdbcClient
             execute(session, connection, sql);
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Dropping NOT NULL constraint failed: " + messageOrToString(e), e);
         }
     }
 
@@ -1235,7 +1235,7 @@ public abstract class BaseJdbcClient
             createSchema(session, connection, schemaName);
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Schema creation failed: " + messageOrToString(e), e);
         }
     }
 
@@ -1255,7 +1255,7 @@ public abstract class BaseJdbcClient
             dropSchema(session, connection, schemaName, cascade);
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Dropping schema failed: " + messageOrToString(e), e);
         }
     }
 
@@ -1282,7 +1282,7 @@ public abstract class BaseJdbcClient
             renameSchema(session, connection, remoteSchemaName, newRemoteSchemaName);
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Renaming schema failed: " + messageOrToString(e), e);
         }
     }
 
@@ -1298,6 +1298,7 @@ public abstract class BaseJdbcClient
             execute(session, connection, query);
         }
         catch (SQLException e) {
+            // TODO provide meaningful error message, perhaps by letting the caller of this method handle the exception
             throw new TrinoException(JDBC_ERROR, e);
         }
     }
@@ -1431,7 +1432,7 @@ public abstract class BaseJdbcClient
             }
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Delete failed: " + messageOrToString(e), e);
         }
     }
 
@@ -1458,7 +1459,7 @@ public abstract class BaseJdbcClient
             }
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Update failed: " + messageOrToString(e), e);
         }
     }
 
@@ -1492,7 +1493,7 @@ public abstract class BaseJdbcClient
             return OptionalInt.of(maxColumnNameLength);
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Failed to get max column name length: " + messageOrToString(e), e);
         }
     }
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPageSink.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPageSink.java
@@ -64,7 +64,7 @@ public class JdbcPageSink
             connection = jdbcClient.getConnection(session, handle);
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Connection failed: " + messageOrToString(e), e);
         }
 
         try {
@@ -77,7 +77,7 @@ public class JdbcPageSink
         }
         catch (SQLException e) {
             closeAllSuppress(e, connection);
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Configuring connection failed: " + messageOrToString(e), e);
         }
 
         this.pageSinkId = pageSinkId;
@@ -121,7 +121,7 @@ public class JdbcPageSink
         }
         catch (SQLException e) {
             closeAllSuppress(e, connection);
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Failed to prepare statement: " + messageOrToString(e), e);
         }
 
         // Making batch size configurable allows performance tuning for insert/write-heavy workloads over multiple connections.
@@ -158,7 +158,7 @@ public class JdbcPageSink
             }
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Insert failed: " + messageOrToString(e), e);
         }
         return NOT_BLOCKED;
     }
@@ -206,7 +206,7 @@ public class JdbcPageSink
             }
         }
         catch (SQLNonTransientException e) {
-            throw new TrinoException(JDBC_NON_TRANSIENT_ERROR, e);
+            throw new TrinoException(JDBC_NON_TRANSIENT_ERROR, "Insert failed: " + messageOrToString(e), e);
         }
         catch (SQLException e) {
             // Convert chained SQLExceptions to suppressed exceptions, so they are visible in the stack trace
@@ -217,7 +217,7 @@ public class JdbcPageSink
                 }
                 nextException = nextException.getNextException();
             }
-            throw new TrinoException(JDBC_ERROR, "Failed to insert data: " + messageOrToString(e), e);
+            throw new TrinoException(JDBC_ERROR, "Insert failed: " + messageOrToString(e), e);
         }
         // pass the successful page sink id
         Slice value = Slices.allocate(Long.BYTES);
@@ -238,7 +238,7 @@ public class JdbcPageSink
             }
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Failed to close connection: " + messageOrToString(e), e);
         }
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPageSink.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPageSink.java
@@ -33,10 +33,10 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.base.util.Closables.closeAllSuppress;
+import static io.trino.plugin.base.util.Exceptions.messageOrToString;
 import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_NON_TRANSIENT_ERROR;
 import static io.trino.plugin.jdbc.JdbcWriteSessionProperties.getWriteBatchSize;
@@ -217,7 +217,7 @@ public class JdbcPageSink
                 }
                 nextException = nextException.getNextException();
             }
-            throw new TrinoException(JDBC_ERROR, "Failed to insert data: " + firstNonNull(e.getMessage(), e), e);
+            throw new TrinoException(JDBC_ERROR, "Failed to insert data: " + messageOrToString(e), e);
         }
         // pass the successful page sink id
         Slice value = Slices.allocate(Long.BYTES);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRemoteIdentifiers.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRemoteIdentifiers.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.trino.plugin.base.util.Exceptions.messageOrToString;
 import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static java.util.Objects.requireNonNull;
 
@@ -61,7 +62,7 @@ public class JdbcRemoteIdentifiers
             return tableNames.build();
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Failed to list tables: " + messageOrToString(e), e);
         }
     }
 
@@ -97,7 +98,7 @@ public class JdbcRemoteIdentifiers
                 return storesUpperCaseIdentifiers;
             }
             catch (SQLException e) {
-                throw new TrinoException(JDBC_ERROR, e);
+                throw new TrinoException(JDBC_ERROR, "Failed to inspect database metadata: " + messageOrToString(e), e);
             }
         }
     }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ReusableConnectionFactory.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ReusableConnectionFactory.java
@@ -29,6 +29,7 @@ import java.time.Duration;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.cache.RemovalCause.EXPLICIT;
+import static io.trino.plugin.base.util.Exceptions.messageOrToString;
 import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static java.util.Objects.requireNonNull;
 
@@ -112,7 +113,7 @@ public final class ReusableConnectionFactory
                 connection.close();
             }
             catch (SQLException e) {
-                throw new TrinoException(JDBC_ERROR, e);
+                throw new TrinoException(JDBC_ERROR, "Failed to close connection: " + messageOrToString(e), e);
             }
         }
     }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcConnectorTest.java
@@ -261,7 +261,7 @@ public class TestJdbcConnectorTest
     @Override
     protected String errorMessageForInsertIntoNotNullColumn(String columnName)
     {
-        return format("NULL not allowed for column \"%s\"(?s).*", columnName.toUpperCase(ENGLISH));
+        return format("Insert failed: NULL not allowed for column \"%s\"(?s).*", columnName.toUpperCase(ENGLISH));
     }
 
     @Override
@@ -306,7 +306,7 @@ public class TestJdbcConnectorTest
     @Override
     protected void verifySchemaNameLengthFailurePermissible(Throwable e)
     {
-        assertThat(e).hasMessageMatching("(?s)(.*The name that starts with .* is too long\\..*)");
+        assertThat(e).hasMessageMatching("Schema creation failed: (?s)(.*The name that starts with .* is too long\\..*)");
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcFlushMetadataCacheProcedure.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcFlushMetadataCacheProcedure.java
@@ -123,7 +123,7 @@ public class TestJdbcFlushMetadataCacheProcedure
 
         // Should fail as Trino has old lowercase identifier mapping to uppercase cached
         assertThatThrownBy(() -> getQueryRunner().execute(query))
-                .hasMessageMatching("(?s)Table \"CACHED_NAME\" not found.*");
+                .hasMessageMatching("Failed to prepare query: Table \"CACHED_NAME\" not found(?s:.*)");
 
         // Should succeed after flushing Trino cache
         getQueryRunner().execute(getSession(), "CALL system.flush_metadata_cache()");

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingH2JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingH2JdbcClient.java
@@ -46,7 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
+import static io.trino.plugin.base.util.Exceptions.messageOrToString;
 import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static io.trino.plugin.jdbc.StandardColumnMappings.bigintColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.bigintWriteFunction;
@@ -275,7 +275,7 @@ class TestingH2JdbcClient
             return procedureHandle;
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, "Failed to get table handle for procedure query. " + firstNonNull(e.getMessage(), e), e);
+            throw new TrinoException(JDBC_ERROR, "Failed to get table handle for procedure query. " + messageOrToString(e), e);
         }
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/expression/SparkExpressionParser.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/expression/SparkExpressionParser.java
@@ -25,7 +25,7 @@ import org.antlr.v4.runtime.atn.PredictionMode;
 
 import java.util.function.Function;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
+import static io.trino.plugin.base.util.Exceptions.messageOrToString;
 
 public final class SparkExpressionParser
 {
@@ -53,7 +53,7 @@ public final class SparkExpressionParser
             return (SparkExpression) invokeParser(expression, SparkExpressionBaseParser::standaloneExpression);
         }
         catch (Exception e) {
-            throw new ParsingException("Cannot parse Spark expression [%s]: %s".formatted(expression, firstNonNull(e.getMessage(), e)), e);
+            throw new ParsingException("Cannot parse Spark expression [%s]: %s".formatted(expression, messageOrToString(e)), e);
         }
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -187,7 +187,6 @@ import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.base.Verify.verifyNotNull;
@@ -200,6 +199,7 @@ import static com.google.common.collect.Sets.difference;
 import static io.trino.plugin.base.filter.UtcConstraintExtractor.extractTupleDomain;
 import static io.trino.plugin.base.projection.ApplyProjectionUtil.extractSupportedProjectedColumns;
 import static io.trino.plugin.base.projection.ApplyProjectionUtil.replaceWithNewVariables;
+import static io.trino.plugin.base.util.Exceptions.messageOrToString;
 import static io.trino.plugin.base.util.Procedures.checkProcedureArgument;
 import static io.trino.plugin.iceberg.ExpressionConverter.isConvertableToIcebergExpression;
 import static io.trino.plugin.iceberg.ExpressionConverter.toIcebergExpression;
@@ -1898,7 +1898,7 @@ public class IcebergMetadata
                     .commit();
         }
         catch (RuntimeException e) {
-            throw new TrinoException(ICEBERG_COMMIT_ERROR, "Failed to add column: " + firstNonNull(e.getMessage(), e), e);
+            throw new TrinoException(ICEBERG_COMMIT_ERROR, "Failed to add column: " + messageOrToString(e), e);
         }
     }
 
@@ -1926,7 +1926,7 @@ public class IcebergMetadata
                     .commit();
         }
         catch (RuntimeException e) {
-            throw new TrinoException(ICEBERG_COMMIT_ERROR, "Failed to add field: " + firstNonNull(e.getMessage(), e), e);
+            throw new TrinoException(ICEBERG_COMMIT_ERROR, "Failed to add field: " + messageOrToString(e), e);
         }
     }
 
@@ -1971,7 +1971,7 @@ public class IcebergMetadata
                     .commit();
         }
         catch (RuntimeException e) {
-            throw new TrinoException(ICEBERG_COMMIT_ERROR, "Failed to drop column: " + firstNonNull(e.getMessage(), e), e);
+            throw new TrinoException(ICEBERG_COMMIT_ERROR, "Failed to drop column: " + messageOrToString(e), e);
         }
     }
 
@@ -1986,7 +1986,7 @@ public class IcebergMetadata
                     .commit();
         }
         catch (RuntimeException e) {
-            throw new TrinoException(ICEBERG_COMMIT_ERROR, "Failed to rename column: " + firstNonNull(e.getMessage(), e), e);
+            throw new TrinoException(ICEBERG_COMMIT_ERROR, "Failed to rename column: " + messageOrToString(e), e);
         }
     }
 
@@ -2007,7 +2007,7 @@ public class IcebergMetadata
                     .commit();
         }
         catch (RuntimeException e) {
-            throw new TrinoException(ICEBERG_COMMIT_ERROR, "Failed to rename field: " + firstNonNull(e.getMessage(), e), e);
+            throw new TrinoException(ICEBERG_COMMIT_ERROR, "Failed to rename field: " + messageOrToString(e), e);
         }
     }
 
@@ -2028,7 +2028,7 @@ public class IcebergMetadata
             schemaUpdate.commit();
         }
         catch (RuntimeException e) {
-            throw new TrinoException(ICEBERG_COMMIT_ERROR, "Failed to set column type: " + firstNonNull(e.getMessage(), e), e);
+            throw new TrinoException(ICEBERG_COMMIT_ERROR, "Failed to set column type: " + messageOrToString(e), e);
         }
     }
 
@@ -2112,7 +2112,7 @@ public class IcebergMetadata
                     .commit();
         }
         catch (RuntimeException e) {
-            throw new TrinoException(ICEBERG_COMMIT_ERROR, "Failed to set field type: " + firstNonNull(e.getMessage(), e), e);
+            throw new TrinoException(ICEBERG_COMMIT_ERROR, "Failed to set field type: " + messageOrToString(e), e);
         }
     }
 
@@ -2131,7 +2131,7 @@ public class IcebergMetadata
                     .commit();
         }
         catch (RuntimeException e) {
-            throw new TrinoException(ICEBERG_COMMIT_ERROR, "Failed to drop a not null constraint: " + firstNonNull(e.getMessage(), e), e);
+            throw new TrinoException(ICEBERG_COMMIT_ERROR, "Failed to drop a not null constraint: " + messageOrToString(e), e);
         }
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -103,7 +103,6 @@ import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.throwIfInstanceOf;
@@ -114,6 +113,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Streams.stream;
 import static io.trino.cache.CacheUtils.uncheckedCacheGet;
 import static io.trino.filesystem.Locations.appendPath;
+import static io.trino.plugin.base.util.Exceptions.messageOrToString;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_DATABASE_LOCATION_ERROR;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
 import static io.trino.plugin.hive.HiveMetadata.STORAGE_TABLE;
@@ -1476,7 +1476,7 @@ public class TrinoGlueCatalog
         }
         catch (UncheckedExecutionException e) {
             throwIfInstanceOf(e.getCause(), TrinoException.class);
-            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Get table request failed: " + firstNonNull(e.getMessage(), e), e.getCause());
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Get table request failed: " + messageOrToString(e), e.getCause());
         }
     }
 

--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteConnectorTest.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteConnectorTest.java
@@ -454,7 +454,7 @@ public class TestIgniteConnectorTest
     @Override
     protected String errorMessageForInsertIntoNotNullColumn(String columnName)
     {
-        return format("Failed to insert data: Null value is not allowed for column '%s'", columnName.toUpperCase(Locale.ENGLISH));
+        return format("Insert failed: Null value is not allowed for column '%s'", columnName.toUpperCase(Locale.ENGLISH));
     }
 
     @Test

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/BaseMariaDbConnectorTest.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/BaseMariaDbConnectorTest.java
@@ -318,19 +318,19 @@ public abstract class BaseMariaDbConnectorTest
     @Override
     protected String errorMessageForCreateTableAsSelectNegativeDate(String date)
     {
-        return format("Failed to insert data: \\(conn=.*\\) Incorrect date value: '%s'.*", date);
+        return format("Insert failed: \\(conn=.*\\) Incorrect date value: '%s'.*", date);
     }
 
     @Override
     protected String errorMessageForInsertNegativeDate(String date)
     {
-        return format("Failed to insert data: \\(conn=.*\\) Incorrect date value: '%s'.*", date);
+        return format("Insert failed: \\(conn=.*\\) Incorrect date value: '%s'.*", date);
     }
 
     @Override
     protected String errorMessageForInsertIntoNotNullColumn(String columnName)
     {
-        return format("Failed to insert data: \\(conn=.*\\) Field '%s' doesn't have a default value", columnName);
+        return format("Insert failed: \\(conn=.*\\) Field '%s' doesn't have a default value", columnName);
     }
 
     @Override

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbTypeMapping.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbTypeMapping.java
@@ -285,11 +285,11 @@ public class TestMariaDbTypeMapping
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 0),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Rounding necessary");
+                    "Failed to read value: Rounding necessary");
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 0),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Decimal overflow");
+                    "Failed to read value: Decimal overflow");
             assertQuery(
                     sessionWithDecimalMappingStrict(CONVERT_TO_VARCHAR),
                     format("SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'tpch' AND table_schema||'.'||table_name = '%s'", testTable.getName()),
@@ -316,7 +316,7 @@ public class TestMariaDbTypeMapping
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 0),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Rounding necessary");
+                    "Failed to read value: Rounding necessary");
             assertQuery(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 0),
                     "SELECT d_col FROM " + testTable.getName(),
@@ -328,7 +328,7 @@ public class TestMariaDbTypeMapping
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 8),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Rounding necessary");
+                    "Failed to read value: Rounding necessary");
             assertQuery(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 8),
                     "SELECT d_col FROM " + testTable.getName(),
@@ -340,7 +340,7 @@ public class TestMariaDbTypeMapping
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 20),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Decimal overflow");
+                    "Failed to read value: Decimal overflow");
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 9),
                     "SELECT d_col FROM " + testTable.getName(),
@@ -377,7 +377,7 @@ public class TestMariaDbTypeMapping
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 0),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Rounding necessary");
+                    "Failed to read value: Rounding necessary");
             assertQuery(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 0),
                     "SELECT d_col FROM " + testTable.getName(),
@@ -393,7 +393,7 @@ public class TestMariaDbTypeMapping
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 3),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Rounding necessary");
+                    "Failed to read value: Rounding necessary");
             assertQuery(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 8),
                     format("SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'tpch' AND table_schema||'.'||table_name = '%s'", testTable.getName()),
@@ -631,8 +631,8 @@ public class TestMariaDbTypeMapping
     public void testUnsupportedDate()
     {
         try (TestTable table = new TestTable(getQueryRunner()::execute, "test_negative_date", "(dt DATE)")) {
-            assertQueryFails(format("INSERT INTO %s VALUES (DATE '-0001-01-01')", table.getName()), ".*Failed to insert data.*");
-            assertQueryFails(format("INSERT INTO %s VALUES (DATE '10000-01-01')", table.getName()), ".*Failed to insert data.*");
+            assertQueryFails(format("INSERT INTO %s VALUES (DATE '-0001-01-01')", table.getName()), ".*Insert failed.*");
+            assertQueryFails(format("INSERT INTO %s VALUES (DATE '10000-01-01')", table.getName()), ".*Insert failed.*");
         }
     }
 
@@ -781,8 +781,8 @@ public class TestMariaDbTypeMapping
     public void testIncorrectTimestamp()
     {
         try (TestTable table = new TestTable(getQueryRunner()::execute, "test_incorrect_timestamp", "(dt TIMESTAMP)")) {
-            assertQueryFails(format("INSERT INTO %s VALUES (TIMESTAMP '1970-01-01 00:00:00.000')", table.getName()), ".*Failed to insert data.*");
-            assertQueryFails(format("INSERT INTO %s VALUES (TIMESTAMP '2038-01-19 03:14:08.000')", table.getName()), ".*Failed to insert data.*");
+            assertQueryFails(format("INSERT INTO %s VALUES (TIMESTAMP '1970-01-01 00:00:00.000')", table.getName()), ".*Insert failed.*");
+            assertQueryFails(format("INSERT INTO %s VALUES (TIMESTAMP '2038-01-19 03:14:08.000')", table.getName()), ".*Insert failed.*");
         }
     }
 
@@ -882,7 +882,7 @@ public class TestMariaDbTypeMapping
         // MariaDB supports any valid TIMESTAMP literal of type YYYY-MM-DD hh:mm:ss.S(up to 6 digits), fails otherwise
         try (TestTable table = new TestTable(server::execute, "test_incorrect_datetime", "(dt DATETIME)")) {
             assertQueryFails(format("INSERT INTO %s VALUES (TIMESTAMP '999-01-01 00:00:00.000')", table.getName()), ".*not a valid TIMESTAMP literal.*");
-            assertQueryFails(format("INSERT INTO %s VALUES (TIMESTAMP '10000-01-19 03:14:08.000')", table.getName()), ".*Failed to insert data.*");
+            assertQueryFails(format("INSERT INTO %s VALUES (TIMESTAMP '10000-01-19 03:14:08.000')", table.getName()), ".*Insert failed.*");
         }
     }
 

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
@@ -116,7 +116,6 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.emptyToNull;
@@ -129,6 +128,7 @@ import static com.mysql.cj.exceptions.MysqlErrorNumbers.ER_UNKNOWN_TABLE;
 import static com.mysql.cj.exceptions.MysqlErrorNumbers.SQL_STATE_ER_TABLE_EXISTS_ERROR;
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.base.util.Exceptions.messageOrToString;
 import static io.trino.plugin.base.util.JsonTypeUtil.jsonParse;
 import static io.trino.plugin.jdbc.CaseSensitivity.CASE_INSENSITIVE;
 import static io.trino.plugin.jdbc.CaseSensitivity.CASE_SENSITIVE;
@@ -328,7 +328,7 @@ public class MySqlClient
             if (e.getErrorCode() == ER_NO_SUCH_TABLE) {
                 throw new TableNotFoundException(tableHandle.asPlainTable().getSchemaTableName());
             }
-            throw new TrinoException(JDBC_ERROR, "Failed to get case sensitivity for columns. " + firstNonNull(e.getMessage(), e), e);
+            throw new TrinoException(JDBC_ERROR, "Failed to get case sensitivity for columns. " + messageOrToString(e), e);
         }
     }
 

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlConnectorTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlConnectorTest.java
@@ -233,19 +233,19 @@ public abstract class BaseMySqlConnectorTest
     @Override
     protected String errorMessageForCreateTableAsSelectNegativeDate(String date)
     {
-        return format("Failed to insert data: Data truncation: Incorrect datetime value: '%s'", date);
+        return format("Insert failed: Data truncation: Incorrect datetime value: '%s'", date);
     }
 
     @Override
     protected String errorMessageForInsertNegativeDate(String date)
     {
-        return format("Failed to insert data: Data truncation: Incorrect datetime value: '%s'", date);
+        return format("Insert failed: Data truncation: Incorrect datetime value: '%s'", date);
     }
 
     @Override
     protected String errorMessageForInsertIntoNotNullColumn(String columnName)
     {
-        return format("Failed to insert data: Field '%s' doesn't have a default value", columnName);
+        return format("Insert failed: Field '%s' doesn't have a default value", columnName);
     }
 
     @Test
@@ -562,7 +562,7 @@ public abstract class BaseMySqlConnectorTest
     @Override
     protected void verifySchemaNameLengthFailurePermissible(Throwable e)
     {
-        assertThat(e).hasMessageMatching("Identifier name .* is too long");
+        assertThat(e).hasMessageMatching("Schema creation failed: Identifier name .* is too long");
     }
 
     @Override

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlLegacyConnectorTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlLegacyConnectorTest.java
@@ -49,7 +49,7 @@ public class TestMySqlLegacyConnectorTest
     public void testCreateTableAsSelectWithUnicode()
     {
         assertThatThrownBy(super::testCreateTableAsSelectWithUnicode)
-                .hasStackTraceContaining("Failed to insert data: Incorrect string value: '\\xE2\\x98\\x83'");
+                .hasStackTraceContaining("Insert failed: Incorrect string value: '\\xE2\\x98\\x83'");
     }
 
     @Test

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTimeMappingsWithServerTimeZone.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTimeMappingsWithServerTimeZone.java
@@ -615,10 +615,10 @@ public class TestMySqlTimeMappingsWithServerTimeZone
             // Verify Trino writes
             assertQueryFails(
                     "INSERT INTO " + table.getName() + " VALUES (TIMESTAMP '1970-01-01 00:00:00 UTC')", // min - 1
-                    "Failed to insert data: Data truncation: Incorrect datetime value: '1969-12-31 16:00:00' for column 'data' at row 1");
+                    "Insert failed: Data truncation: Incorrect datetime value: '1969-12-31 16:00:00' for column 'data' at row 1");
             assertQueryFails(
                     "INSERT INTO " + table.getName() + " VALUES (TIMESTAMP '2038-01-19 03:14:08 UTC')", // max + 1
-                    "Failed to insert data: Data truncation: Incorrect datetime value: '2038-01-18 21:14:08' for column 'data' at row 1");
+                    "Insert failed: Data truncation: Incorrect datetime value: '2038-01-18 21:14:08' for column 'data' at row 1");
         }
     }
 

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTypeMapping.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTypeMapping.java
@@ -365,11 +365,11 @@ public class TestMySqlTypeMapping
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 0),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Rounding necessary");
+                    "Failed to read value: Rounding necessary");
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 0),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Decimal overflow");
+                    "Failed to read value: Decimal overflow");
             assertQuery(
                     sessionWithDecimalMappingStrict(CONVERT_TO_VARCHAR),
                     format("SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'tpch' AND table_schema||'.'||table_name = '%s'", testTable.getName()),
@@ -396,7 +396,7 @@ public class TestMySqlTypeMapping
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 0),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Rounding necessary");
+                    "Failed to read value: Rounding necessary");
             assertQuery(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 0),
                     "SELECT d_col FROM " + testTable.getName(),
@@ -408,7 +408,7 @@ public class TestMySqlTypeMapping
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 8),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Rounding necessary");
+                    "Failed to read value: Rounding necessary");
             assertQuery(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 8),
                     "SELECT d_col FROM " + testTable.getName(),
@@ -420,7 +420,7 @@ public class TestMySqlTypeMapping
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 20),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Decimal overflow");
+                    "Failed to read value: Decimal overflow");
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 9),
                     "SELECT d_col FROM " + testTable.getName(),
@@ -457,7 +457,7 @@ public class TestMySqlTypeMapping
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 0),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Rounding necessary");
+                    "Failed to read value: Rounding necessary");
             assertQuery(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 0),
                     "SELECT d_col FROM " + testTable.getName(),
@@ -473,7 +473,7 @@ public class TestMySqlTypeMapping
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 3),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Rounding necessary");
+                    "Failed to read value: Rounding necessary");
             assertQuery(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 8),
                     format("SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'tpch' AND table_schema||'.'||table_name = '%s'", testTable.getName()),
@@ -1111,10 +1111,10 @@ public class TestMySqlTypeMapping
             // Verify Trino writes
             assertQueryFails(
                     "INSERT INTO " + table.getName() + " VALUES (TIMESTAMP '1970-01-01 00:00:00 UTC')", // min - 1
-                    "Failed to insert data: Data truncation: Incorrect datetime value: '1969-12-31 16:00:00' for column 'data' at row 1");
+                    "Insert failed: Data truncation: Incorrect datetime value: '1969-12-31 16:00:00' for column 'data' at row 1");
             assertQueryFails(
                     "INSERT INTO " + table.getName() + " VALUES (TIMESTAMP '2038-01-19 03:14:08 UTC')", // max + 1
-                    "Failed to insert data: Data truncation: Incorrect datetime value: '2038-01-18 21:14:08' for column 'data' at row 1");
+                    "Insert failed: Data truncation: Incorrect datetime value: '2038-01-18 21:14:08' for column 'data' at row 1");
         }
     }
 

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/AbstractTestOracleTypeMapping.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/AbstractTestOracleTypeMapping.java
@@ -704,14 +704,14 @@ public abstract class AbstractTestOracleTypeMapping
         try (TestTable table = new TestTable(getQueryRunner()::execute, "test_unsupported_dt", "(ts date)")) {
             assertQueryFails(
                     format("INSERT INTO %s VALUES (DATE '-4713-12-31')", table.getName()),
-                    "\\QFailed to insert data: ORA-01841: (full) year must be between -4713 and +9999, and not be 0\n");
+                    "\\QInsert failed: ORA-01841: (full) year must be between -4713 and +9999, and not be 0\n");
             assertQueryFails(
                     format("INSERT INTO %s VALUES (DATE '0000-01-01')", table.getName()),
-                    "\\QFailed to insert data: ORA-01841: (full) year must be between -4713 and +9999, and not be 0\n");
+                    "\\QInsert failed: ORA-01841: (full) year must be between -4713 and +9999, and not be 0\n");
             // The error message sounds invalid date format in the connector, but it's no problem as the max year is 9999 in Oracle
             assertQueryFails(
                     format("INSERT INTO %s VALUES (DATE '10000-01-01')", table.getName()),
-                    "\\QFailed to insert data: ORA-01861: literal does not match format string\n");
+                    "\\QInsert failed: ORA-01861: literal does not match format string\n");
         }
     }
 
@@ -960,13 +960,13 @@ public abstract class AbstractTestOracleTypeMapping
         try (TestTable table = new TestTable(getQueryRunner()::execute, "test_unsupported_ts", "(ts timestamp)")) {
             assertQueryFails(
                     format("INSERT INTO %s VALUES (TIMESTAMP '-4713-12-31 00:00:00.000')", table.getName()),
-                    "\\QFailed to insert data: ORA-01841: (full) year must be between -4713 and +9999, and not be 0\n");
+                    "\\QInsert failed: ORA-01841: (full) year must be between -4713 and +9999, and not be 0\n");
             assertQueryFails(
                     format("INSERT INTO %s VALUES (TIMESTAMP '0000-01-01 00:00:00.000')", table.getName()),
-                    "\\QFailed to insert data: ORA-01841: (full) year must be between -4713 and +9999, and not be 0\n");
+                    "\\QInsert failed: ORA-01841: (full) year must be between -4713 and +9999, and not be 0\n");
             assertQueryFails(
                     format("INSERT INTO %s VALUES (TIMESTAMP '10000-01-01 00:00:00.000')", table.getName()),
-                    "\\QFailed to insert data: ORA-01862: the numeric value does not match the length of the format item\n");
+                    "\\QInsert failed: ORA-01862: the numeric value does not match the length of the format item\n");
         }
     }
 

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorTest.java
@@ -451,7 +451,7 @@ public abstract class BaseOracleConnectorTest
     @Override
     protected void verifySchemaNameLengthFailurePermissible(Throwable e)
     {
-        assertThat(e).hasMessage("ORA-00972: identifier is too long\n");
+        assertThat(e).hasMessage("Schema creation failed: ORA-00972: identifier is too long\n");
     }
 
     @Override

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -261,7 +261,7 @@ public class TestPostgreSqlConnectorTest
     @Override
     protected void verifyAddNotNullColumnToNonEmptyTableFailurePermissible(Throwable e)
     {
-        assertThat(e).hasMessageMatching("ERROR: column \".*\" contains null values");
+        assertThat(e).hasMessageMatching("Failed to add column: ERROR: column \".*\" contains null values");
     }
 
     @Test
@@ -955,7 +955,7 @@ public class TestPostgreSqlConnectorTest
     @Override
     protected String errorMessageForInsertIntoNotNullColumn(String columnName)
     {
-        return format("(?s).*null value in column \"%s\" violates not-null constraint.*", columnName);
+        return format("Insert failed: (?s).*null value in column \"%s\" violates not-null constraint.*", columnName);
     }
 
     @Test
@@ -1091,7 +1091,7 @@ public class TestPostgreSqlConnectorTest
     @Override
     protected void verifySchemaNameLengthFailurePermissible(Throwable e)
     {
-        assertThat(e).hasMessage("Schema name must be shorter than or equal to '63' characters but got '64'");
+        assertThat(e).hasMessage("Schema creation failed: Schema name must be shorter than or equal to '63' characters but got '64'");
     }
 
     @Override
@@ -1121,7 +1121,7 @@ public class TestPostgreSqlConnectorTest
     @Override
     protected void verifySetColumnTypeFailurePermissible(Throwable e)
     {
-        assertThat(e).hasMessageMatching("(?s)ERROR: .*(cannot be cast automatically to type|out of range).*");
+        assertThat(e).hasMessageMatching("Failed to add column: (?s)ERROR: .*(cannot be cast automatically to type|out of range).*");
     }
 
     @Override

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -557,11 +557,11 @@ public class TestPostgreSqlTypeMapping
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 0),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Rounding necessary");
+                    "Failed to read value: Rounding necessary");
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 0),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Decimal overflow");
+                    "Failed to read value: Decimal overflow");
             assertQuery(
                     sessionWithDecimalMappingStrict(CONVERT_TO_VARCHAR),
                     format("SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'tpch' AND table_name = '%s'", testTable.getName()),
@@ -590,7 +590,7 @@ public class TestPostgreSqlTypeMapping
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 0),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Rounding necessary");
+                    "Failed to read value: Rounding necessary");
             assertQuery(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 0),
                     "SELECT d_col FROM " + testTable.getName(),
@@ -602,7 +602,7 @@ public class TestPostgreSqlTypeMapping
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 8),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Rounding necessary");
+                    "Failed to read value: Rounding necessary");
             assertQuery(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 8),
                     "SELECT d_col FROM " + testTable.getName(),
@@ -614,7 +614,7 @@ public class TestPostgreSqlTypeMapping
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 20),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Decimal overflow");
+                    "Failed to read value: Decimal overflow");
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 9),
                     "SELECT d_col FROM " + testTable.getName(),
@@ -653,7 +653,7 @@ public class TestPostgreSqlTypeMapping
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 0),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Rounding necessary");
+                    "Failed to read value: Rounding necessary");
             assertQuery(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 0),
                     "SELECT d_col FROM " + testTable.getName(),
@@ -669,7 +669,7 @@ public class TestPostgreSqlTypeMapping
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 3),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Rounding necessary");
+                    "Failed to read value: Rounding necessary");
             assertQuery(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 8),
                     format("SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'tpch' AND table_name = '%s'", testTable.getName()),
@@ -706,7 +706,7 @@ public class TestPostgreSqlTypeMapping
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 0),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Rounding necessary");
+                    "Failed to read value: Rounding necessary");
             assertQuery(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 0),
                     "SELECT d_col FROM " + testTable.getName(),
@@ -714,7 +714,7 @@ public class TestPostgreSqlTypeMapping
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 1),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Rounding necessary");
+                    "Failed to read value: Rounding necessary");
             assertQuery(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 1),
                     format("SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'tpch' AND table_name = '%s'", testTable.getName()),
@@ -726,7 +726,7 @@ public class TestPostgreSqlTypeMapping
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 2),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Rounding necessary");
+                    "Failed to read value: Rounding necessary");
             assertQuery(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 2),
                     "SELECT d_col FROM " + testTable.getName(),
@@ -758,11 +758,11 @@ public class TestPostgreSqlTypeMapping
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 0),
                     "SELECT * FROM " + testTable.getName(),
-                    "Rounding necessary");
+                    "Failed to read value: Rounding necessary");
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 0),
                     "SELECT * FROM " + testTable.getName(),
-                    "Decimal overflow");
+                    "Failed to read value: Decimal overflow");
             assertQuery(
                     sessionWithDecimalMappingStrict(CONVERT_TO_VARCHAR),
                     format("SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'tpch' AND table_name = '%s'", testTable.getName()),

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConnectorTest.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConnectorTest.java
@@ -634,7 +634,7 @@ public class TestRedshiftConnectorTest
     @Override
     protected void verifySchemaNameLengthFailurePermissible(Throwable e)
     {
-        assertThat(e).hasMessage("Schema name must be shorter than or equal to '127' characters but got '128'");
+        assertThat(e).hasMessage("Schema creation failed: Schema name must be shorter than or equal to '127' characters but got '128'");
     }
 
     @Override

--- a/plugin/trino-singlestore/src/main/java/io/trino/plugin/singlestore/SingleStoreClient.java
+++ b/plugin/trino-singlestore/src/main/java/io/trino/plugin/singlestore/SingleStoreClient.java
@@ -708,7 +708,7 @@ public class SingleStoreClient
                 return rounded;
             }
             catch (DateTimeParseException e) {
-                throw new IllegalStateException(format("Supported Trino TIME type range is between 00:00:00 and 23:59:59.999999 but got %s", timeString), e);
+                throw new TrinoException(JDBC_ERROR, format("Supported Trino TIME type range is between 00:00:00 and 23:59:59.999999 but got %s", timeString), e);
             }
         };
     }

--- a/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/TestSingleStoreConnectorTest.java
+++ b/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/TestSingleStoreConnectorTest.java
@@ -244,7 +244,7 @@ public class TestSingleStoreConnectorTest
     @Override
     protected String errorMessageForInsertIntoNotNullColumn(String columnName)
     {
-        return format(".* Field '%s' doesn't have a default value", columnName);
+        return format("Insert failed: .* Field '%s' doesn't have a default value", columnName);
     }
 
     @Test
@@ -411,7 +411,7 @@ public class TestSingleStoreConnectorTest
     protected void verifySchemaNameLengthFailurePermissible(Throwable e)
     {
         // The error message says 60 char, but the actual limitation is 62
-        assertThat(e).hasMessageContaining("Distributed MemSQL requires the length of the database name to be at most 60 characters");
+        assertThat(e).hasMessageContaining("Schema creation failed: Distributed MemSQL requires the length of the database name to be at most 60 characters");
     }
 
     @Override

--- a/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/TestSingleStoreTypeMapping.java
+++ b/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/TestSingleStoreTypeMapping.java
@@ -348,11 +348,11 @@ public class TestSingleStoreTypeMapping
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 0),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Rounding necessary");
+                    "Failed to read value: Rounding necessary");
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 0),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Decimal overflow");
+                    "Failed to read value: Decimal overflow");
             assertQuery(
                     sessionWithDecimalMappingStrict(CONVERT_TO_VARCHAR),
                     format("SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'tpch' AND table_schema||'.'||table_name = '%s'", testTable.getName()),
@@ -379,7 +379,7 @@ public class TestSingleStoreTypeMapping
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 0),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Rounding necessary");
+                    "Failed to read value: Rounding necessary");
             assertQuery(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 0),
                     "SELECT d_col FROM " + testTable.getName(),
@@ -391,7 +391,7 @@ public class TestSingleStoreTypeMapping
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 8),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Rounding necessary");
+                    "Failed to read value: Rounding necessary");
             assertQuery(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 8),
                     "SELECT d_col FROM " + testTable.getName(),
@@ -403,7 +403,7 @@ public class TestSingleStoreTypeMapping
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 20),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Decimal overflow");
+                    "Failed to read value: Decimal overflow");
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 9),
                     "SELECT d_col FROM " + testTable.getName(),
@@ -440,7 +440,7 @@ public class TestSingleStoreTypeMapping
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 0),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Rounding necessary");
+                    "Failed to read value: Rounding necessary");
             assertQuery(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 0),
                     "SELECT d_col FROM " + testTable.getName(),
@@ -456,7 +456,7 @@ public class TestSingleStoreTypeMapping
             assertQueryFails(
                     sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 3),
                     "SELECT d_col FROM " + testTable.getName(),
-                    "Rounding necessary");
+                    "Failed to read value: Rounding necessary");
             assertQuery(
                     sessionWithDecimalMappingAllowOverflow(HALF_UP, 8),
                     format("SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'tpch' AND table_schema||'.'||table_name = '%s'", testTable.getName()),

--- a/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestSnowflakeConnectorTest.java
+++ b/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestSnowflakeConnectorTest.java
@@ -118,7 +118,7 @@ public class TestSnowflakeConnectorTest
         if (typeName.equals("real")) {
             return Optional.empty();
         }
-        // Error: Failed to insert data: SQL compilation error: error line 1 at position 130
+        // Error: Insert failed: SQL compilation error: error line 1 at position 130
         if (typeName.equals("time")
                 || typeName.equals("time(6)")
                 || typeName.equals("timestamp(6)")) {

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
@@ -123,13 +123,13 @@ import java.util.OptionalInt;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.collect.MoreCollectors.toOptional;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.slice.Slices.wrappedBuffer;
+import static io.trino.plugin.base.util.Exceptions.messageOrToString;
 import static io.trino.plugin.jdbc.CaseSensitivity.CASE_INSENSITIVE;
 import static io.trino.plugin.jdbc.CaseSensitivity.CASE_SENSITIVE;
 import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
@@ -525,7 +525,7 @@ public class SqlServerClient
                 // https://learn.microsoft.com/sql/relational-databases/errors-events/mssqlserver-208-database-engine-error
                 throw new TableNotFoundException(tableHandle.asPlainTable().getSchemaTableName());
             }
-            throw new TrinoException(JDBC_ERROR, "Failed to get case sensitivity for columns. " + firstNonNull(e.getMessage(), e), e);
+            throw new TrinoException(JDBC_ERROR, "Failed to get case sensitivity for columns. " + messageOrToString(e), e);
         }
     }
 
@@ -744,7 +744,7 @@ public class SqlServerClient
             }
         }
         catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, "Failed to get table handle for procedure query. " + firstNonNull(e.getMessage(), e), e);
+            throw new TrinoException(JDBC_ERROR, "Failed to get table handle for procedure query. " + messageOrToString(e), e);
         }
     }
 

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
@@ -572,13 +572,13 @@ public abstract class BaseSqlServerConnectorTest
     @Override
     protected String errorMessageForCreateTableAsSelectNegativeDate(String date)
     {
-        return "Failed to insert data: Conversion failed when converting date and/or time from character string.";
+        return "Insert failed: Conversion failed when converting date and/or time from character string.";
     }
 
     @Override
     protected String errorMessageForInsertNegativeDate(String date)
     {
-        return "Failed to insert data: Conversion failed when converting date and/or time from character string.";
+        return "Insert failed: Conversion failed when converting date and/or time from character string.";
     }
 
     @Override
@@ -596,7 +596,7 @@ public abstract class BaseSqlServerConnectorTest
     @Override
     protected void verifySchemaNameLengthFailurePermissible(Throwable e)
     {
-        assertThat(e).hasMessageMatching("The identifier that starts with '.*' is too long. Maximum length is 128.");
+        assertThat(e).hasMessageMatching("Schema creation failed: The identifier that starts with '.*' is too long. Maximum length is 128.");
     }
 
     @Override

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerTypeMapping.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerTypeMapping.java
@@ -507,7 +507,7 @@ public abstract class BaseSqlServerTypeMapping
         assertUpdate(format("CREATE TABLE %s (test_date date)", tableName));
         try {
             assertQueryFails(format("INSERT INTO %s VALUES (date %s)", tableName, unsupportedDate),
-                    "Failed to insert data: Conversion failed when converting date and/or time from character string.");
+                    "Insert failed: Conversion failed when converting date and/or time from character string.");
         }
         finally {
             assertUpdate("DROP TABLE " + tableName);


### PR DESCRIPTION
Rethrowing with JDBC driver provided exception's message may lead to
poor user experience, if the JDBC driver provided message is not
informative (or is empty). Always provide explicit message.

The places to update were identified by searching for

    new TrinoException\(\w+\, e\)