### PR TITLE
Use separate directory for raptor data

### DIFF
--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/RaptorQueryRunner.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/RaptorQueryRunner.java
@@ -31,7 +31,9 @@ import io.trino.testing.QueryRunner;
 import io.trino.tpch.TpchTable;
 import org.intellij.lang.annotations.Language;
 
-import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -64,15 +66,14 @@ public final class RaptorQueryRunner
         queryRunner.createCatalog("tpch", "tpch");
 
         queryRunner.installPlugin(new RaptorPlugin());
-        File baseDir = queryRunner.getCoordinator().getBaseDataDir().toFile();
         Map<String, String> raptorProperties = ImmutableMap.<String, String>builder()
                 .putAll(extraRaptorProperties)
                 .put("metadata.db.type", "h2")
-                .put("metadata.db.filename", new File(baseDir, "db").getAbsolutePath())
-                .put("storage.data-directory", new File(baseDir, "data").getAbsolutePath())
+                .put("metadata.db.filename", createTempDirectory("raptor-db").toString())
+                .put("storage.data-directory", createTempDirectory("raptor-data").toString())
                 .put("storage.max-shard-rows", "2000")
                 .put("backup.provider", "file")
-                .put("backup.directory", new File(baseDir, "backup").getAbsolutePath())
+                .put("backup.directory", createTempDirectory("raptor-backup").toString())
                 .buildOrThrow();
 
         queryRunner.createCatalog("raptor", "raptor_legacy", raptorProperties);
@@ -161,6 +162,14 @@ public final class RaptorQueryRunner
                 .setSchema(schema)
                 .setSystemProperty("enable_intermediate_aggregations", "true")
                 .build();
+    }
+
+    public static Path createTempDirectory(String name)
+            throws IOException
+    {
+        Path tempDirectory = Files.createTempDirectory(name);
+        tempDirectory.toFile().deleteOnExit();
+        return tempDirectory.toAbsolutePath();
     }
 
     public static void main(String[] args)

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/TestRaptorMySqlConnectorTest.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/TestRaptorMySqlConnectorTest.java
@@ -18,18 +18,15 @@ import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.TestInstance;
 import org.testcontainers.containers.MySQLContainer;
 
-import java.io.File;
 import java.util.Map;
 
 import static io.trino.plugin.raptor.legacy.RaptorQueryRunner.copyTables;
 import static io.trino.plugin.raptor.legacy.RaptorQueryRunner.createSession;
+import static io.trino.plugin.raptor.legacy.RaptorQueryRunner.createTempDirectory;
 import static java.lang.String.format;
-import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
-@TestInstance(PER_CLASS)
 public class TestRaptorMySqlConnectorTest
         extends BaseRaptorConnectorTest
 {
@@ -68,15 +65,14 @@ public class TestRaptorMySqlConnectorTest
         queryRunner.createCatalog("tpch", "tpch");
 
         queryRunner.installPlugin(new RaptorPlugin());
-        File baseDir = queryRunner.getCoordinator().getBaseDataDir().toFile();
         Map<String, String> raptorProperties = ImmutableMap.<String, String>builder()
                 .put("metadata.db.type", "mysql")
                 .put("metadata.db.url", mysqlUrl)
                 .put("storage.compaction-enabled", "false")
-                .put("storage.data-directory", new File(baseDir, "data").getAbsolutePath())
+                .put("storage.data-directory", createTempDirectory("raptor-db").toString())
                 .put("storage.max-shard-rows", "2000")
                 .put("backup.provider", "file")
-                .put("backup.directory", new File(baseDir, "backup").getAbsolutePath())
+                .put("backup.directory", createTempDirectory("raptor-db").toString())
                 .buildOrThrow();
 
         queryRunner.createCatalog("raptor", "raptor_legacy", raptorProperties);


### PR DESCRIPTION
There is a race condition between shard cleaner and query runner cleanup when baseDir is used

Fixes https://github.com/trinodb/trino/issues/12385

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
