### PR TITLE
Add pushdown docs for Snowflake

### DIFF
--- a/docs/src/main/sphinx/connector/snowflake.md
+++ b/docs/src/main/sphinx/connector/snowflake.md
@@ -92,3 +92,27 @@ statements, the connector supports the following features:
 - {doc}`/sql/alter-table`
 - {doc}`/sql/create-schema`
 - {doc}`/sql/drop-schema`
+
+## Performance
+
+The connector includes a number of performance improvements, detailed in the
+following sections.
+
+(snowflake-pushdown)=
+### Pushdown
+
+The connector supports pushdown for a number of operations:
+
+- [](limit-pushdown)
+- [](topn-pushdown)
+
+{ref}`Aggregate pushdown <aggregation-pushdown>` for the following functions:
+
+- {func}`avg`
+- {func}`count`
+- {func}`max`
+- {func}`min`
+- {func}`sum`
+
+```{include} pushdown-correctness-behavior.fragment
+```


### PR DESCRIPTION
## Description

Currently I just copied the section from PostgreSQL connector to start a discussion what is actually implemented. Only one I know of is avg for bigint since that was implemented in the linked PR. Are there others already there that are just not yet documented @dprophet @yuuteng  @ebyhr 

Another PR merged and added topn, and one activated limit testing. So I added those. Anyone if join pushdown is supported? 

## Additional context and related issues

* #21148
* #21219 
* #21202 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
