### PR TITLE
Clean up IR Subscript

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/ir/DefaultTraversalVisitor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/DefaultTraversalVisitor.java
@@ -53,7 +53,7 @@ public abstract class DefaultTraversalVisitor<C>
     }
 
     @Override
-    protected Void visitSubscript(Subscript node, C context)
+    protected Void visitFieldReference(FieldReference node, C context)
     {
         process(node.base(), context);
         process(node.index(), context);

--- a/core/trino-main/src/main/java/io/trino/sql/ir/DefaultTraversalVisitor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/DefaultTraversalVisitor.java
@@ -56,7 +56,6 @@ public abstract class DefaultTraversalVisitor<C>
     protected Void visitFieldReference(FieldReference node, C context)
     {
         process(node.base(), context);
-        process(node.index(), context);
 
         return null;
     }

--- a/core/trino-main/src/main/java/io/trino/sql/ir/Expression.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/Expression.java
@@ -42,13 +42,13 @@ import java.util.List;
         @JsonSubTypes.Type(value = Row.class, name = "row"),
         @JsonSubTypes.Type(value = Case.class, name = "case"),
         @JsonSubTypes.Type(value = Switch.class, name = "switch"),
-        @JsonSubTypes.Type(value = Subscript.class, name = "subscript"),
+        @JsonSubTypes.Type(value = FieldReference.class, name = "field"),
         @JsonSubTypes.Type(value = Reference.class, name = "reference"),
 })
 public sealed interface Expression
         permits Arithmetic, Between, Bind, Call, Case, Cast, Coalesce,
-        Comparison, Constant, In, IsNull, Lambda, Logical, Negation,
-        Not, NullIf, Reference, Row, Subscript, Switch
+        Comparison, Constant, FieldReference, In, IsNull, Lambda, Logical,
+        Negation, Not, NullIf, Reference, Row, Switch
 {
     Type type();
 

--- a/core/trino-main/src/main/java/io/trino/sql/ir/ExpressionFormatter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/ExpressionFormatter.java
@@ -64,7 +64,7 @@ public final class ExpressionFormatter
         @Override
         protected String visitFieldReference(FieldReference node, Void context)
         {
-            return formatExpression(node.base()) + "[" + formatExpression(node.index()) + "]";
+            return formatExpression(node.base()) + "." + node.field();
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/ir/ExpressionFormatter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/ExpressionFormatter.java
@@ -62,7 +62,7 @@ public final class ExpressionFormatter
         }
 
         @Override
-        protected String visitSubscript(Subscript node, Void context)
+        protected String visitFieldReference(FieldReference node, Void context)
         {
             return formatExpression(node.base()) + "[" + formatExpression(node.index()) + "]";
         }

--- a/core/trino-main/src/main/java/io/trino/sql/ir/ExpressionRewriter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/ExpressionRewriter.java
@@ -105,7 +105,7 @@ public class ExpressionRewriter<C>
         return rewriteExpression(node, context, treeRewriter);
     }
 
-    public Expression rewriteSubscript(Subscript node, C context, ExpressionTreeRewriter<C> treeRewriter)
+    public Expression rewriteSubscript(FieldReference node, C context, ExpressionTreeRewriter<C> treeRewriter)
     {
         return rewriteExpression(node, context, treeRewriter);
     }

--- a/core/trino-main/src/main/java/io/trino/sql/ir/ExpressionTreeRewriter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/ExpressionTreeRewriter.java
@@ -136,7 +136,7 @@ public final class ExpressionTreeRewriter<C>
         }
 
         @Override
-        protected Expression visitSubscript(Subscript node, Context<C> context)
+        protected Expression visitFieldReference(FieldReference node, Context<C> context)
         {
             if (!context.isDefaultRewrite()) {
                 Expression result = rewriter.rewriteSubscript(node, context.get(), ExpressionTreeRewriter.this);
@@ -149,7 +149,7 @@ public final class ExpressionTreeRewriter<C>
             Expression index = rewrite(node.index(), context.get());
 
             if (base != node.base() || index != node.index()) {
-                return new Subscript(base, index);
+                return new FieldReference(base, index);
             }
 
             return node;

--- a/core/trino-main/src/main/java/io/trino/sql/ir/ExpressionTreeRewriter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/ExpressionTreeRewriter.java
@@ -146,10 +146,9 @@ public final class ExpressionTreeRewriter<C>
             }
 
             Expression base = rewrite(node.base(), context.get());
-            Expression index = rewrite(node.index(), context.get());
 
-            if (base != node.base() || index != node.index()) {
-                return new FieldReference(base, index);
+            if (base != node.base()) {
+                return new FieldReference(base, node.field());
             }
 
             return node;

--- a/core/trino-main/src/main/java/io/trino/sql/ir/FieldReference.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/FieldReference.java
@@ -21,11 +21,9 @@ import io.trino.spi.type.Type;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static io.trino.spi.type.IntegerType.INTEGER;
-import static io.trino.sql.ir.IrUtils.validateType;
 
 @JsonSerialize
-public record FieldReference(Expression base, Expression index)
+public record FieldReference(Expression base, int field)
         implements Expression
 {
     public FieldReference
@@ -34,15 +32,12 @@ public record FieldReference(Expression base, Expression index)
             throw new IllegalArgumentException("Expected 'row' type but found '%s' for expression: %s".formatted(base.type(), base));
         }
 
-        validateType(INTEGER, index);
-        int field = (int) (long) ((Constant) index).value() - 1;
         checkArgument(field < rowType.getFields().size(), "Expected 'row' type to have at least %s fields, but has: %s", field + 1, rowType.getFields().size());
     }
 
     @Override
     public Type type()
     {
-        int field = (int) (long) ((Constant) index).value() - 1;
         return ((RowType) base.type()).getFields().get(field).getType();
     }
 
@@ -55,6 +50,6 @@ public record FieldReference(Expression base, Expression index)
     @Override
     public List<? extends Expression> children()
     {
-        return ImmutableList.of(base, index);
+        return ImmutableList.of(base);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/ir/FieldReference.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/FieldReference.java
@@ -25,10 +25,10 @@ import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.sql.ir.IrUtils.validateType;
 
 @JsonSerialize
-public record Subscript(Expression base, Expression index)
+public record FieldReference(Expression base, Expression index)
         implements Expression
 {
-    public Subscript
+    public FieldReference
     {
         if (!(base.type() instanceof RowType rowType)) {
             throw new IllegalArgumentException("Expected 'row' type but found '%s' for expression: %s".formatted(base.type(), base));
@@ -49,7 +49,7 @@ public record Subscript(Expression base, Expression index)
     @Override
     public <R, C> R accept(IrVisitor<R, C> visitor, C context)
     {
-        return visitor.visitSubscript(this, context);
+        return visitor.visitFieldReference(this, context);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/sql/ir/IrVisitor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/IrVisitor.java
@@ -102,7 +102,7 @@ public abstract class IrVisitor<R, C>
         return visitExpression(node, context);
     }
 
-    protected R visitSubscript(Subscript node, C context)
+    protected R visitFieldReference(FieldReference node, C context)
     {
         return visitExpression(node, context);
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/ConnectorExpressionTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ConnectorExpressionTranslator.java
@@ -94,7 +94,6 @@ import static io.trino.spi.expression.StandardFunctions.NULLIF_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.OR_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.SUBTRACT_FUNCTION_NAME;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
-import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.sql.DynamicFilters.isDynamicFilterFunction;
@@ -208,7 +207,7 @@ public final class ConnectorExpressionTranslator
 
             if (expression instanceof FieldDereference dereference) {
                 return translate(dereference.getTarget())
-                        .map(base -> new FieldReference(base, new Constant(INTEGER, (long) (dereference.getField() + 1))));
+                        .map(base -> new FieldReference(base, dereference.getField()));
             }
 
             if (expression instanceof io.trino.spi.expression.Call call) {
@@ -804,7 +803,7 @@ public final class ConnectorExpressionTranslator
                 return Optional.empty();
             }
 
-            return Optional.of(new FieldDereference(((Expression) node).type(), translatedBase.get(), (int) ((long) ((Constant) node.index()).value() - 1)));
+            return Optional.of(new FieldDereference(((Expression) node).type(), translatedBase.get(), node.field()));
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/ConnectorExpressionTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ConnectorExpressionTranslator.java
@@ -43,6 +43,7 @@ import io.trino.sql.ir.Cast;
 import io.trino.sql.ir.Comparison;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.In;
 import io.trino.sql.ir.IrVisitor;
 import io.trino.sql.ir.IsNull;
@@ -51,7 +52,6 @@ import io.trino.sql.ir.Negation;
 import io.trino.sql.ir.Not;
 import io.trino.sql.ir.NullIf;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.tree.QualifiedName;
 import io.trino.type.JoniRegexp;
 import io.trino.type.JsonPathType;
@@ -208,7 +208,7 @@ public final class ConnectorExpressionTranslator
 
             if (expression instanceof FieldDereference dereference) {
                 return translate(dereference.getTarget())
-                        .map(base -> new Subscript(base, new Constant(INTEGER, (long) (dereference.getField() + 1))));
+                        .map(base -> new FieldReference(base, new Constant(INTEGER, (long) (dereference.getField() + 1))));
             }
 
             if (expression instanceof io.trino.spi.expression.Call call) {
@@ -793,7 +793,7 @@ public final class ConnectorExpressionTranslator
         }
 
         @Override
-        protected Optional<ConnectorExpression> visitSubscript(Subscript node, Void context)
+        protected Optional<ConnectorExpression> visitFieldReference(FieldReference node, Void context)
         {
             if (!(node.base().type() instanceof RowType)) {
                 return Optional.empty();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/IrExpressionInterpreter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/IrExpressionInterpreter.java
@@ -43,6 +43,7 @@ import io.trino.sql.ir.Comparison;
 import io.trino.sql.ir.Comparison.Operator;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.In;
 import io.trino.sql.ir.IrVisitor;
 import io.trino.sql.ir.IsNull;
@@ -53,7 +54,6 @@ import io.trino.sql.ir.Not;
 import io.trino.sql.ir.NullIf;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.ir.Row;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.ir.Switch;
 import io.trino.sql.ir.WhenClause;
 import io.trino.type.FunctionType;
@@ -883,7 +883,7 @@ public class IrExpressionInterpreter
         }
 
         @Override
-        protected Object visitSubscript(Subscript node, Object context)
+        protected Object visitFieldReference(FieldReference node, Object context)
         {
             Object base = processWithExceptionHandling(node.base(), context);
             if (base == null) {
@@ -898,7 +898,7 @@ public class IrExpressionInterpreter
             }
 
             if (hasUnresolvedValue(base, index)) {
-                return new Subscript(toExpression(base, node.base().type()), toExpression(index, node.index().type()));
+                return new FieldReference(toExpression(base, node.base().type()), toExpression(index, node.index().type()));
             }
 
             // Subscript on Row hasn't got a dedicated operator. It is interpreted by hand.

--- a/core/trino-main/src/main/java/io/trino/sql/planner/IrExpressionInterpreter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/IrExpressionInterpreter.java
@@ -18,7 +18,6 @@ import com.google.common.primitives.Primitives;
 import io.trino.Session;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.ResolvedFunction;
-import io.trino.operator.scalar.ArraySubscriptOperator;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.SqlRow;
 import io.trino.spi.connector.ConnectorSession;
@@ -82,7 +81,6 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.metadata.GlobalFunctionCatalog.builtinFunctionName;
-import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.block.RowValueBuilder.buildRowValue;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
@@ -95,7 +93,6 @@ import static io.trino.spi.type.TypeUtils.writeNativeValue;
 import static io.trino.sql.DynamicFilters.isDynamicFilter;
 import static io.trino.sql.gen.VarArgsToMapAdapterGenerator.generateVarArgsToMapAdapter;
 import static io.trino.sql.planner.DeterminismEvaluator.isDeterministic;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
@@ -889,30 +886,14 @@ public class IrExpressionInterpreter
             if (base == null) {
                 return null;
             }
-            Object index = processWithExceptionHandling(node.index(), context);
-            if (index == null) {
-                return null;
-            }
-            if ((index instanceof Long) && isArray(node.base().type())) {
-                ArraySubscriptOperator.checkArrayIndex((Long) index);
+
+            if (hasUnresolvedValue(base)) {
+                return new FieldReference(toExpression(base, node.base().type()), node.field());
             }
 
-            if (hasUnresolvedValue(base, index)) {
-                return new FieldReference(toExpression(base, node.base().type()), toExpression(index, node.index().type()));
-            }
-
-            // Subscript on Row hasn't got a dedicated operator. It is interpreted by hand.
-            if (base instanceof SqlRow row) {
-                int fieldIndex = toIntExact((long) index - 1);
-                if (fieldIndex < 0 || fieldIndex >= row.getFieldCount()) {
-                    throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "ROW index out of bounds: " + (fieldIndex + 1));
-                }
-                Type returnType = node.base().type().getTypeParameters().get(fieldIndex);
-                return readNativeValue(returnType, row.getRawFieldBlock(fieldIndex), row.getRawIndex());
-            }
-
-            // Subscript on Array or Map is interpreted using operator.
-            return invokeOperator(OperatorType.SUBSCRIPT, types(node.base(), node.index()), ImmutableList.of(base, index));
+            SqlRow row = (SqlRow) base;
+            Type returnType = node.base().type().getTypeParameters().get(node.field());
+            return readNativeValue(returnType, row.getRawFieldBlock(node.field()), row.getRawIndex());
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/NullabilityAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/NullabilityAnalyzer.java
@@ -19,9 +19,9 @@ import io.trino.sql.ir.Cast;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.DefaultTraversalVisitor;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.In;
 import io.trino.sql.ir.NullIf;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.ir.Switch;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -97,7 +97,7 @@ public final class NullabilityAnalyzer
         }
 
         @Override
-        protected Void visitSubscript(Subscript node, AtomicBoolean result)
+        protected Void visitFieldReference(FieldReference node, AtomicBoolean result)
         {
             result.set(true);
             return null;

--- a/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
@@ -888,7 +888,7 @@ class QueryPlanner
                 subPlanProject,
                 Assignments.builder()
                         .putIdentities(subPlanProject.getOutputSymbols())
-                        .put(caseNumberSymbol, new FieldReference(mergeRowSymbol.toSymbolReference(), new Constant(INTEGER, (long) mergeAnalysis.getMergeRowType().getFields().size())))
+                        .put(caseNumberSymbol, new FieldReference(mergeRowSymbol.toSymbolReference(), mergeAnalysis.getMergeRowType().getFields().size() - 1))
                         .build());
 
         // Mark distinct combinations of the unique_id value and the case_number

--- a/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
@@ -48,11 +48,11 @@ import io.trino.sql.ir.Coalesce;
 import io.trino.sql.ir.Comparison;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.IsNull;
 import io.trino.sql.ir.Logical;
 import io.trino.sql.ir.Not;
 import io.trino.sql.ir.Row;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.ir.WhenClause;
 import io.trino.sql.planner.RelationPlanner.PatternRecognitionComponents;
 import io.trino.sql.planner.plan.AggregationNode;
@@ -81,7 +81,6 @@ import io.trino.sql.planner.plan.WindowFrameType;
 import io.trino.sql.planner.plan.WindowNode;
 import io.trino.sql.tree.Delete;
 import io.trino.sql.tree.FetchFirst;
-import io.trino.sql.tree.FieldReference;
 import io.trino.sql.tree.FrameBound;
 import io.trino.sql.tree.FunctionCall.NullTreatment;
 import io.trino.sql.tree.Join;
@@ -513,7 +512,7 @@ class QueryPlanner
             builder = filter(builder, node.getWhere().get(), node);
         }
 
-        FieldReference reference = analysis.getRowIdField(table);
+        io.trino.sql.tree.FieldReference reference = analysis.getRowIdField(table);
         Symbol rowIdSymbol = builder.translate(reference);
         List<Symbol> outputs = ImmutableList.of(
                 symbolAllocator.newSymbol("partialrows", BIGINT),
@@ -655,7 +654,7 @@ class QueryPlanner
             }
         }
 
-        FieldReference rowIdReference = analysis.getRowIdField(mergeAnalysis.getTargetTable());
+        io.trino.sql.tree.FieldReference rowIdReference = analysis.getRowIdField(mergeAnalysis.getTargetTable());
         assignments.putIdentity(relationPlan.getFieldMappings().get(rowIdReference.getFieldIndex()));
 
         // Add the "present" field
@@ -770,7 +769,7 @@ class QueryPlanner
 
         PlanBuilder subPlan = newPlanBuilder(joinPlan, analysis, lambdaDeclarationToSymbolMap, session, plannerContext);
 
-        FieldReference rowIdReference = analysis.getRowIdField(mergeAnalysis.getTargetTable());
+        io.trino.sql.tree.FieldReference rowIdReference = analysis.getRowIdField(mergeAnalysis.getTargetTable());
         Symbol rowIdSymbol = planWithPresentColumn.getFieldMappings().get(rowIdReference.getFieldIndex());
 
         // Build the SearchedCaseExpression that creates the project merge_row
@@ -889,7 +888,7 @@ class QueryPlanner
                 subPlanProject,
                 Assignments.builder()
                         .putIdentities(subPlanProject.getOutputSymbols())
-                        .put(caseNumberSymbol, new Subscript(mergeRowSymbol.toSymbolReference(), new Constant(INTEGER, (long) mergeAnalysis.getMergeRowType().getFields().size())))
+                        .put(caseNumberSymbol, new FieldReference(mergeRowSymbol.toSymbolReference(), new Constant(INTEGER, (long) mergeAnalysis.getMergeRowType().getFields().size())))
                         .build());
 
         // Mark distinct combinations of the unique_id value and the case_number

--- a/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
@@ -137,7 +137,6 @@ import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.StandardErrorCode.TOO_MANY_ARGUMENTS;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DoubleType.DOUBLE;
-import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.TimeWithTimeZoneType.createTimeWithTimeZoneType;
 import static io.trino.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
 import static io.trino.spi.type.TinyintType.TINYINT;
@@ -157,6 +156,7 @@ import static io.trino.type.LikePatternType.LIKE_PATTERN;
 import static io.trino.util.DateTimeUtils.parseDayTimeInterval;
 import static io.trino.util.DateTimeUtils.parseYearMonthInterval;
 import static io.trino.util.Failures.checkCondition;
+import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -669,9 +669,7 @@ public class TranslationMap
 
         checkState(index >= 0, "could not find field name: %s", fieldName);
 
-        return new FieldReference(
-                translateExpression(expression.getBase()),
-                new Constant(INTEGER, (long) (index + 1)));
+        return new FieldReference(translateExpression(expression.getBase()), index);
     }
 
     private io.trino.sql.ir.Expression translate(Array expression)
@@ -957,7 +955,7 @@ public class TranslationMap
             io.trino.sql.ir.Expression rewrittenBase = translateExpression(node.getBase());
             LongLiteral index = (LongLiteral) node.getIndex();
             return new FieldReference(
-                    rewrittenBase, new Constant(INTEGER, index.getParsedValue()));
+                    rewrittenBase, toIntExact(index.getParsedValue() - 1));
         }
 
         ResolvedFunction operator = plannerContext.getMetadata()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ExtractDereferencesFromFilterAboveScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ExtractDereferencesFromFilterAboveScan.java
@@ -19,8 +19,8 @@ import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.plan.Assignments;
 import io.trino.sql.planner.plan.FilterNode;
@@ -78,7 +78,7 @@ public class ExtractDereferencesFromFilterAboveScan
     @Override
     public Result apply(FilterNode node, Captures captures, Context context)
     {
-        Set<Subscript> dereferences = extractRowSubscripts(ImmutableList.of(node.getPredicate()), true);
+        Set<FieldReference> dereferences = extractRowSubscripts(ImmutableList.of(node.getPredicate()), true);
         if (dereferences.isEmpty()) {
             return Result.empty();
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/InlineProjections.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/InlineProjections.java
@@ -22,8 +22,8 @@ import io.trino.matching.Pattern;
 import io.trino.spi.type.RowType;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.SymbolsExtractor;
 import io.trino.sql.planner.iterative.Rule;
@@ -180,8 +180,8 @@ public class InlineProjections
                     // skip dereferences, otherwise, inlining can cause conflicts with PushdownDereferences
                     Expression assignment = child.getAssignments().get(entry.getKey());
 
-                    if (assignment instanceof Subscript) {
-                        if (((Subscript) assignment).base().type() instanceof RowType) {
+                    if (assignment instanceof FieldReference) {
+                        if (((FieldReference) assignment).base().type() instanceof RowType) {
                             return false;
                         }
                     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferenceThroughFilter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferenceThroughFilter.java
@@ -19,8 +19,8 @@ import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.plan.Assignments;
 import io.trino.sql.planner.plan.FilterNode;
@@ -80,7 +80,7 @@ public class PushDownDereferenceThroughFilter
                 .build();
 
         // Extract dereferences from project node assignments for pushdown
-        Set<Subscript> dereferences = extractRowSubscripts(expressions, false);
+        Set<FieldReference> dereferences = extractRowSubscripts(expressions, false);
 
         if (dereferences.isEmpty()) {
             return Result.empty();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferenceThroughJoin.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferenceThroughJoin.java
@@ -20,8 +20,8 @@ import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.Rule;
@@ -92,7 +92,7 @@ public class PushDownDereferenceThroughJoin
         ImmutableList.Builder<Expression> expressionsBuilder = ImmutableList.builder();
         expressionsBuilder.addAll(projectNode.getAssignments().getExpressions());
         joinNode.getFilter().ifPresent(expressionsBuilder::add);
-        Set<Subscript> dereferences = extractRowSubscripts(expressionsBuilder.build(), false);
+        Set<FieldReference> dereferences = extractRowSubscripts(expressionsBuilder.build(), false);
 
         // Exclude criteria symbols
         ImmutableSet.Builder<Symbol> criteriaSymbolsBuilder = ImmutableSet.builder();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferenceThroughProject.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferenceThroughProject.java
@@ -18,8 +18,8 @@ import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.plan.Assignments;
 import io.trino.sql.planner.plan.ProjectNode;
@@ -66,7 +66,7 @@ public class PushDownDereferenceThroughProject
         ProjectNode child = captures.get(CHILD);
 
         // Extract dereferences from project node assignments for pushdown
-        Set<Subscript> dereferences = extractRowSubscripts(node.getAssignments().getExpressions(), false);
+        Set<FieldReference> dereferences = extractRowSubscripts(node.getAssignments().getExpressions(), false);
 
         // Exclude dereferences on symbols being synthesized within child
         dereferences = dereferences.stream()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferenceThroughSemiJoin.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferenceThroughSemiJoin.java
@@ -19,8 +19,8 @@ import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.plan.Assignments;
 import io.trino.sql.planner.plan.PlanNode;
@@ -78,7 +78,7 @@ public class PushDownDereferenceThroughSemiJoin
         SemiJoinNode semiJoinNode = captures.get(CHILD);
 
         // Extract dereferences from project node assignments for pushdown
-        Set<Subscript> dereferences = extractRowSubscripts(projectNode.getAssignments().getExpressions(), false);
+        Set<FieldReference> dereferences = extractRowSubscripts(projectNode.getAssignments().getExpressions(), false);
 
         // All dereferences can be assumed on the symbols coming from source, since filteringSource output is not propagated,
         // and semiJoinOutput is of type boolean. We exclude pushdown of dereferences on sourceJoinSymbol.

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferenceThroughUnnest.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferenceThroughUnnest.java
@@ -19,8 +19,8 @@ import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.plan.Assignments;
@@ -79,7 +79,7 @@ public class PushDownDereferenceThroughUnnest
         expressionsBuilder.addAll(projectNode.getAssignments().getExpressions());
 
         // Extract dereferences for pushdown
-        Set<Subscript> dereferences = extractRowSubscripts(expressionsBuilder.build(), false);
+        Set<FieldReference> dereferences = extractRowSubscripts(expressionsBuilder.build(), false);
 
         // Only retain dereferences on replicate symbols
         dereferences = dereferences.stream()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferencesThroughAssignUniqueId.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferencesThroughAssignUniqueId.java
@@ -19,8 +19,8 @@ import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.plan.AssignUniqueId;
 import io.trino.sql.planner.plan.Assignments;
@@ -70,7 +70,7 @@ public class PushDownDereferencesThroughAssignUniqueId
         AssignUniqueId assignUniqueId = captures.get(CHILD);
 
         // Extract dereferences from project node assignments for pushdown
-        Set<Subscript> dereferences = extractRowSubscripts(projectNode.getAssignments().getExpressions(), false);
+        Set<FieldReference> dereferences = extractRowSubscripts(projectNode.getAssignments().getExpressions(), false);
 
         // We do not need to filter dereferences on idColumn symbol since it is supposed to be of BIGINT type.
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferencesThroughLimit.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferencesThroughLimit.java
@@ -20,8 +20,8 @@ import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.OrderingScheme;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.Rule;
@@ -75,7 +75,7 @@ public class PushDownDereferencesThroughLimit
         LimitNode limitNode = captures.get(CHILD);
 
         // Extract dereferences from project node assignments for pushdown
-        Set<Subscript> dereferences = extractRowSubscripts(projectNode.getAssignments().getExpressions(), false);
+        Set<FieldReference> dereferences = extractRowSubscripts(projectNode.getAssignments().getExpressions(), false);
 
         // Exclude dereferences on symbols being used in tiesResolvingScheme and requiresPreSortedInputs
         Set<Symbol> excludedSymbols = ImmutableSet.<Symbol>builder()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferencesThroughMarkDistinct.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferencesThroughMarkDistinct.java
@@ -19,8 +19,8 @@ import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.plan.Assignments;
 import io.trino.sql.planner.plan.MarkDistinctNode;
@@ -75,7 +75,7 @@ public class PushDownDereferencesThroughMarkDistinct
         MarkDistinctNode markDistinctNode = captures.get(CHILD);
 
         // Extract dereferences from project node assignments for pushdown
-        Set<Subscript> dereferences = extractRowSubscripts(projectNode.getAssignments().getExpressions(), false);
+        Set<FieldReference> dereferences = extractRowSubscripts(projectNode.getAssignments().getExpressions(), false);
 
         // Exclude dereferences on distinct symbols being used in markDistinctNode. We do not need to filter
         // dereferences on markerSymbol since it is supposed to be of boolean type.

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferencesThroughRowNumber.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferencesThroughRowNumber.java
@@ -19,8 +19,8 @@ import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.plan.Assignments;
 import io.trino.sql.planner.plan.ProjectNode;
@@ -75,7 +75,7 @@ public class PushDownDereferencesThroughRowNumber
         RowNumberNode rowNumberNode = captures.get(CHILD);
 
         // Extract dereferences from project node assignments for pushdown
-        Set<Subscript> dereferences = extractRowSubscripts(projectNode.getAssignments().getExpressions(), false);
+        Set<FieldReference> dereferences = extractRowSubscripts(projectNode.getAssignments().getExpressions(), false);
 
         // Exclude dereferences on symbols being used in partitionBy
         dereferences = dereferences.stream()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferencesThroughSort.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferencesThroughSort.java
@@ -19,8 +19,8 @@ import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.plan.Assignments;
 import io.trino.sql.planner.plan.ProjectNode;
@@ -75,7 +75,7 @@ public class PushDownDereferencesThroughSort
         SortNode sortNode = captures.get(CHILD);
 
         // Extract dereferences from project node assignments for pushdown
-        Set<Subscript> dereferences = extractRowSubscripts(projectNode.getAssignments().getExpressions(), false);
+        Set<FieldReference> dereferences = extractRowSubscripts(projectNode.getAssignments().getExpressions(), false);
 
         // Exclude dereferences on symbols used in ordering scheme to avoid replication of data
         dereferences = dereferences.stream()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferencesThroughTopN.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferencesThroughTopN.java
@@ -19,8 +19,8 @@ import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.plan.Assignments;
 import io.trino.sql.planner.plan.ProjectNode;
@@ -75,7 +75,7 @@ public class PushDownDereferencesThroughTopN
         TopNNode topNNode = captures.get(CHILD);
 
         // Extract dereferences from project node assignments for pushdown
-        Set<Subscript> dereferences = extractRowSubscripts(projectNode.getAssignments().getExpressions(), false);
+        Set<FieldReference> dereferences = extractRowSubscripts(projectNode.getAssignments().getExpressions(), false);
 
         // Exclude dereferences on symbols being used in orderBy
         dereferences = dereferences.stream()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferencesThroughTopNRanking.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferencesThroughTopNRanking.java
@@ -19,8 +19,8 @@ import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.OrderingScheme;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.Rule;
@@ -78,7 +78,7 @@ public class PushDownDereferencesThroughTopNRanking
         TopNRankingNode topNRankingNode = captures.get(CHILD);
 
         // Extract dereferences from project node assignments for pushdown
-        Set<Subscript> dereferences = extractRowSubscripts(projectNode.getAssignments().getExpressions(), false);
+        Set<FieldReference> dereferences = extractRowSubscripts(projectNode.getAssignments().getExpressions(), false);
 
         // Exclude dereferences on symbols being used in partitionBy and orderBy
         DataOrganizationSpecification specification = topNRankingNode.getSpecification();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferencesThroughWindow.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferencesThroughWindow.java
@@ -19,8 +19,8 @@ import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.OrderingScheme;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.Rule;
@@ -79,7 +79,7 @@ public class PushDownDereferencesThroughWindow
         WindowNode windowNode = captures.get(CHILD);
 
         // Extract dereferences for pushdown
-        Set<Subscript> dereferences = extractRowSubscripts(
+        Set<FieldReference> dereferences = extractRowSubscripts(
                 ImmutableList.<Expression>builder()
                         .addAll(projectNode.getAssignments().getExpressions())
                         // also include dereference projections used in window functions

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapRowSubscript.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapRowSubscript.java
@@ -19,8 +19,8 @@ import io.trino.sql.ir.Cast;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.ExpressionTreeRewriter;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Row;
-import io.trino.sql.ir.Subscript;
 import io.trino.type.UnknownType;
 
 import java.util.ArrayDeque;
@@ -48,7 +48,7 @@ public class UnwrapRowSubscript
             extends io.trino.sql.ir.ExpressionRewriter<Void>
     {
         @Override
-        public Expression rewriteSubscript(Subscript node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+        public Expression rewriteSubscript(FieldReference node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
         {
             Expression base = treeRewriter.rewrite(node.base(), context);
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapRowSubscript.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapRowSubscript.java
@@ -16,7 +16,6 @@ package io.trino.sql.planner.iterative.rule;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.sql.ir.Cast;
-import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.ExpressionTreeRewriter;
 import io.trino.sql.ir.FieldReference;
@@ -58,8 +57,7 @@ public class UnwrapRowSubscript
                     break;
                 }
 
-                int index = (int) (long) ((Constant) node.index()).value();
-                Type type = rowType.getFields().get(index - 1).getType();
+                Type type = rowType.getFields().get(node.field()).getType();
                 if (!(type instanceof UnknownType)) {
                     coercions.push(new Coercion(type, cast.safe()));
                 }
@@ -68,8 +66,7 @@ public class UnwrapRowSubscript
             }
 
             if (base instanceof Row row) {
-                int index = (int) (long) ((Constant) node.index()).value();
-                Expression result = row.items().get(index - 1);
+                Expression result = row.items().get(node.field());
 
                 while (!coercions.isEmpty()) {
                     Coercion coercion = coercions.pop();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapSingleColumnRowInApply.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapSingleColumnRowInApply.java
@@ -20,7 +20,7 @@ import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
-import io.trino.sql.ir.Subscript;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.plan.ApplyNode;
@@ -148,8 +148,8 @@ public class UnwrapSingleColumnRowInApply
                 Symbol valueSymbol = context.getSymbolAllocator().newSymbol("input", elementType);
                 Symbol listSymbol = context.getSymbolAllocator().newSymbol("subquery", elementType);
 
-                Assignment inputAssignment = new Assignment(valueSymbol, new Subscript(value, new Constant(INTEGER, 1L)));
-                Assignment nestedPlanAssignment = new Assignment(listSymbol, new Subscript(list, new Constant(INTEGER, 1L)));
+                Assignment inputAssignment = new Assignment(valueSymbol, new FieldReference(value, new Constant(INTEGER, 1L)));
+                Assignment nestedPlanAssignment = new Assignment(listSymbol, new FieldReference(list, new Constant(INTEGER, 1L)));
                 ApplyNode.SetExpression comparison = function.apply(valueSymbol, listSymbol);
 
                 return Optional.of(new Unwrapping(comparison, inputAssignment, nestedPlanAssignment));

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapSingleColumnRowInApply.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapSingleColumnRowInApply.java
@@ -18,7 +18,6 @@ import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
-import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.FieldReference;
 import io.trino.sql.planner.Symbol;
@@ -32,7 +31,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
 
-import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.sql.planner.plan.Patterns.applyNode;
 import static java.util.Objects.requireNonNull;
 
@@ -148,8 +146,8 @@ public class UnwrapSingleColumnRowInApply
                 Symbol valueSymbol = context.getSymbolAllocator().newSymbol("input", elementType);
                 Symbol listSymbol = context.getSymbolAllocator().newSymbol("subquery", elementType);
 
-                Assignment inputAssignment = new Assignment(valueSymbol, new FieldReference(value, new Constant(INTEGER, 1L)));
-                Assignment nestedPlanAssignment = new Assignment(listSymbol, new FieldReference(list, new Constant(INTEGER, 1L)));
+                Assignment inputAssignment = new Assignment(valueSymbol, new FieldReference(value, 0));
+                Assignment nestedPlanAssignment = new Assignment(listSymbol, new FieldReference(list, 0));
                 ApplyNode.SetExpression comparison = function.apply(valueSymbol, listSymbol);
 
                 return Optional.of(new Unwrapping(comparison, inputAssignment, nestedPlanAssignment));

--- a/core/trino-main/src/main/java/io/trino/sql/relational/SqlToRowExpressionTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/relational/SqlToRowExpressionTranslator.java
@@ -32,6 +32,7 @@ import io.trino.sql.ir.Comparison;
 import io.trino.sql.ir.Comparison.Operator;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.In;
 import io.trino.sql.ir.IrVisitor;
 import io.trino.sql.ir.IsNull;
@@ -42,7 +43,6 @@ import io.trino.sql.ir.Not;
 import io.trino.sql.ir.NullIf;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.ir.Row;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.ir.Switch;
 import io.trino.sql.ir.WhenClause;
 import io.trino.sql.planner.Symbol;
@@ -489,7 +489,7 @@ public final class SqlToRowExpressionTranslator
         }
 
         @Override
-        protected RowExpression visitSubscript(Subscript node, Void context)
+        protected RowExpression visitFieldReference(FieldReference node, Void context)
         {
             RowExpression base = process(node.base(), context);
             RowExpression index = process(node.index(), context);

--- a/core/trino-main/src/main/java/io/trino/sql/relational/SqlToRowExpressionTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/relational/SqlToRowExpressionTranslator.java
@@ -18,7 +18,6 @@ import io.trino.Session;
 import io.trino.metadata.FunctionManager;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.ResolvedFunction;
-import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
 import io.trino.sql.ir.Arithmetic;
@@ -60,7 +59,6 @@ import static io.trino.spi.function.OperatorType.HASH_CODE;
 import static io.trino.spi.function.OperatorType.INDETERMINATE;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.function.OperatorType.NEGATION;
-import static io.trino.spi.function.OperatorType.SUBSCRIPT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
@@ -492,17 +490,7 @@ public final class SqlToRowExpressionTranslator
         protected RowExpression visitFieldReference(FieldReference node, Void context)
         {
             RowExpression base = process(node.base(), context);
-            RowExpression index = process(node.index(), context);
-
-            if (node.base().type() instanceof RowType) {
-                long value = (Long) ((ConstantExpression) index).getValue();
-                return new SpecialForm(DEREFERENCE, ((Expression) node).type(), base, constant(value - 1, INTEGER));
-            }
-
-            return call(
-                    metadata.resolveOperator(SUBSCRIPT, ImmutableList.of(base.getType(), index.getType())),
-                    base,
-                    index);
+            return new SpecialForm(DEREFERENCE, node.type(), base, constant((long) node.field(), INTEGER));
         }
 
         @Override

--- a/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
@@ -859,7 +859,7 @@ public class TestExpressionInterpreter
     public void testRowSubscript()
     {
         assertOptimizedEquals(
-                new FieldReference(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(VARCHAR, Slices.utf8Slice("a")), TRUE)), new Constant(INTEGER, 3L)),
+                new FieldReference(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(VARCHAR, Slices.utf8Slice("a")), TRUE)), 2),
                 TRUE);
         assertOptimizedEquals(
                 new FieldReference(
@@ -872,24 +872,24 @@ public class TestExpressionInterpreter
                                                         new Constant(INTEGER, 2L),
                                                         new Constant(VARCHAR, Slices.utf8Slice("b")),
                                                         new Row(ImmutableList.of(new Constant(INTEGER, 3L), new Constant(VARCHAR, Slices.utf8Slice("c")))))))),
-                                        new Constant(INTEGER, 3L)),
-                                new Constant(INTEGER, 3L)),
-                        new Constant(INTEGER, 2L)),
+                                        2),
+                                2),
+                        1),
                 new Constant(VARCHAR, Slices.utf8Slice("c")));
 
         assertOptimizedEquals(
-                new FieldReference(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(UNKNOWN, null))), new Constant(INTEGER, 2L)),
+                new FieldReference(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(UNKNOWN, null))), 1),
                 new Constant(UNKNOWN, null));
         assertOptimizedEquals(
-                new FieldReference(new Row(ImmutableList.of(new Arithmetic(DIVIDE_INTEGER, DIVIDE, new Constant(INTEGER, 0L), new Constant(INTEGER, 0L)), new Constant(INTEGER, 1L))), new Constant(INTEGER, 1L)),
-                new FieldReference(new Row(ImmutableList.of(new Arithmetic(DIVIDE_INTEGER, DIVIDE, new Constant(INTEGER, 0L), new Constant(INTEGER, 0L)), new Constant(INTEGER, 1L))), new Constant(INTEGER, 1L)));
+                new FieldReference(new Row(ImmutableList.of(new Arithmetic(DIVIDE_INTEGER, DIVIDE, new Constant(INTEGER, 0L), new Constant(INTEGER, 0L)), new Constant(INTEGER, 1L))), 0),
+                new FieldReference(new Row(ImmutableList.of(new Arithmetic(DIVIDE_INTEGER, DIVIDE, new Constant(INTEGER, 0L), new Constant(INTEGER, 0L)), new Constant(INTEGER, 1L))), 0));
         assertOptimizedEquals(
-                new FieldReference(new Row(ImmutableList.of(new Arithmetic(DIVIDE_INTEGER, DIVIDE, new Constant(INTEGER, 0L), new Constant(INTEGER, 0L)), new Constant(INTEGER, 1L))), new Constant(INTEGER, 2L)),
-                new FieldReference(new Row(ImmutableList.of(new Arithmetic(DIVIDE_INTEGER, DIVIDE, new Constant(INTEGER, 0L), new Constant(INTEGER, 0L)), new Constant(INTEGER, 1L))), new Constant(INTEGER, 2L)));
+                new FieldReference(new Row(ImmutableList.of(new Arithmetic(DIVIDE_INTEGER, DIVIDE, new Constant(INTEGER, 0L), new Constant(INTEGER, 0L)), new Constant(INTEGER, 1L))), 1),
+                new FieldReference(new Row(ImmutableList.of(new Arithmetic(DIVIDE_INTEGER, DIVIDE, new Constant(INTEGER, 0L), new Constant(INTEGER, 0L)), new Constant(INTEGER, 1L))), 1));
 
-        assertTrinoExceptionThrownBy(() -> evaluate(new FieldReference(new Row(ImmutableList.of(new Arithmetic(DIVIDE_INTEGER, DIVIDE, new Constant(INTEGER, 0L), new Constant(INTEGER, 0L)), new Constant(INTEGER, 1L))), new Constant(INTEGER, 2L))))
+        assertTrinoExceptionThrownBy(() -> evaluate(new FieldReference(new Row(ImmutableList.of(new Arithmetic(DIVIDE_INTEGER, DIVIDE, new Constant(INTEGER, 0L), new Constant(INTEGER, 0L)), new Constant(INTEGER, 1L))), 1)))
                 .hasErrorCode(DIVISION_BY_ZERO);
-        assertTrinoExceptionThrownBy(() -> evaluate(new FieldReference(new Row(ImmutableList.of(new Arithmetic(DIVIDE_INTEGER, DIVIDE, new Constant(INTEGER, 0L), new Constant(INTEGER, 0L)), new Constant(INTEGER, 1L))), new Constant(INTEGER, 2L))))
+        assertTrinoExceptionThrownBy(() -> evaluate(new FieldReference(new Row(ImmutableList.of(new Arithmetic(DIVIDE_INTEGER, DIVIDE, new Constant(INTEGER, 0L), new Constant(INTEGER, 0L)), new Constant(INTEGER, 1L))), 1)))
                 .hasErrorCode(DIVISION_BY_ZERO);
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
@@ -28,6 +28,7 @@ import io.trino.sql.ir.Coalesce;
 import io.trino.sql.ir.Comparison;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.In;
 import io.trino.sql.ir.IsNull;
 import io.trino.sql.ir.Logical;
@@ -36,7 +37,6 @@ import io.trino.sql.ir.Not;
 import io.trino.sql.ir.NullIf;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.ir.Row;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.ir.Switch;
 import io.trino.sql.ir.WhenClause;
 import io.trino.sql.planner.IrExpressionInterpreter;
@@ -859,12 +859,12 @@ public class TestExpressionInterpreter
     public void testRowSubscript()
     {
         assertOptimizedEquals(
-                new Subscript(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(VARCHAR, Slices.utf8Slice("a")), TRUE)), new Constant(INTEGER, 3L)),
+                new FieldReference(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(VARCHAR, Slices.utf8Slice("a")), TRUE)), new Constant(INTEGER, 3L)),
                 TRUE);
         assertOptimizedEquals(
-                new Subscript(
-                        new Subscript(
-                                new Subscript(
+                new FieldReference(
+                        new FieldReference(
+                                new FieldReference(
                                         new Row(ImmutableList.of(
                                                 new Constant(INTEGER, 1L),
                                                 new Constant(VARCHAR, Slices.utf8Slice("a")),
@@ -878,18 +878,18 @@ public class TestExpressionInterpreter
                 new Constant(VARCHAR, Slices.utf8Slice("c")));
 
         assertOptimizedEquals(
-                new Subscript(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(UNKNOWN, null))), new Constant(INTEGER, 2L)),
+                new FieldReference(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(UNKNOWN, null))), new Constant(INTEGER, 2L)),
                 new Constant(UNKNOWN, null));
         assertOptimizedEquals(
-                new Subscript(new Row(ImmutableList.of(new Arithmetic(DIVIDE_INTEGER, DIVIDE, new Constant(INTEGER, 0L), new Constant(INTEGER, 0L)), new Constant(INTEGER, 1L))), new Constant(INTEGER, 1L)),
-                new Subscript(new Row(ImmutableList.of(new Arithmetic(DIVIDE_INTEGER, DIVIDE, new Constant(INTEGER, 0L), new Constant(INTEGER, 0L)), new Constant(INTEGER, 1L))), new Constant(INTEGER, 1L)));
+                new FieldReference(new Row(ImmutableList.of(new Arithmetic(DIVIDE_INTEGER, DIVIDE, new Constant(INTEGER, 0L), new Constant(INTEGER, 0L)), new Constant(INTEGER, 1L))), new Constant(INTEGER, 1L)),
+                new FieldReference(new Row(ImmutableList.of(new Arithmetic(DIVIDE_INTEGER, DIVIDE, new Constant(INTEGER, 0L), new Constant(INTEGER, 0L)), new Constant(INTEGER, 1L))), new Constant(INTEGER, 1L)));
         assertOptimizedEquals(
-                new Subscript(new Row(ImmutableList.of(new Arithmetic(DIVIDE_INTEGER, DIVIDE, new Constant(INTEGER, 0L), new Constant(INTEGER, 0L)), new Constant(INTEGER, 1L))), new Constant(INTEGER, 2L)),
-                new Subscript(new Row(ImmutableList.of(new Arithmetic(DIVIDE_INTEGER, DIVIDE, new Constant(INTEGER, 0L), new Constant(INTEGER, 0L)), new Constant(INTEGER, 1L))), new Constant(INTEGER, 2L)));
+                new FieldReference(new Row(ImmutableList.of(new Arithmetic(DIVIDE_INTEGER, DIVIDE, new Constant(INTEGER, 0L), new Constant(INTEGER, 0L)), new Constant(INTEGER, 1L))), new Constant(INTEGER, 2L)),
+                new FieldReference(new Row(ImmutableList.of(new Arithmetic(DIVIDE_INTEGER, DIVIDE, new Constant(INTEGER, 0L), new Constant(INTEGER, 0L)), new Constant(INTEGER, 1L))), new Constant(INTEGER, 2L)));
 
-        assertTrinoExceptionThrownBy(() -> evaluate(new Subscript(new Row(ImmutableList.of(new Arithmetic(DIVIDE_INTEGER, DIVIDE, new Constant(INTEGER, 0L), new Constant(INTEGER, 0L)), new Constant(INTEGER, 1L))), new Constant(INTEGER, 2L))))
+        assertTrinoExceptionThrownBy(() -> evaluate(new FieldReference(new Row(ImmutableList.of(new Arithmetic(DIVIDE_INTEGER, DIVIDE, new Constant(INTEGER, 0L), new Constant(INTEGER, 0L)), new Constant(INTEGER, 1L))), new Constant(INTEGER, 2L))))
                 .hasErrorCode(DIVISION_BY_ZERO);
-        assertTrinoExceptionThrownBy(() -> evaluate(new Subscript(new Row(ImmutableList.of(new Arithmetic(DIVIDE_INTEGER, DIVIDE, new Constant(INTEGER, 0L), new Constant(INTEGER, 0L)), new Constant(INTEGER, 1L))), new Constant(INTEGER, 2L))))
+        assertTrinoExceptionThrownBy(() -> evaluate(new FieldReference(new Row(ImmutableList.of(new Arithmetic(DIVIDE_INTEGER, DIVIDE, new Constant(INTEGER, 0L), new Constant(INTEGER, 0L)), new Constant(INTEGER, 1L))), new Constant(INTEGER, 2L))))
                 .hasErrorCode(DIVISION_BY_ZERO);
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestConnectorExpressionTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestConnectorExpressionTranslator.java
@@ -38,6 +38,7 @@ import io.trino.sql.ir.Cast;
 import io.trino.sql.ir.Comparison;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.In;
 import io.trino.sql.ir.IsNull;
 import io.trino.sql.ir.Logical;
@@ -45,7 +46,6 @@ import io.trino.sql.ir.Negation;
 import io.trino.sql.ir.Not;
 import io.trino.sql.ir.NullIf;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.testing.TestingSession;
 import io.trino.transaction.TestingTransactionManager;
 import io.trino.transaction.TransactionManager;
@@ -144,7 +144,7 @@ public class TestConnectorExpressionTranslator
     public void testTranslateRowSubscript()
     {
         assertTranslationRoundTrips(
-                new Subscript(
+                new FieldReference(
                         new Reference(ROW_TYPE, "row_symbol_1"),
                         new Constant(INTEGER, 1L)),
                 new FieldDereference(

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestConnectorExpressionTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestConnectorExpressionTranslator.java
@@ -146,7 +146,7 @@ public class TestConnectorExpressionTranslator
         assertTranslationRoundTrips(
                 new FieldReference(
                         new Reference(ROW_TYPE, "row_symbol_1"),
-                        new Constant(INTEGER, 1L)),
+                        0),
                 new FieldDereference(
                         INTEGER,
                         new Variable("row_symbol_1", ROW_TYPE),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDereferencePushDown.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDereferencePushDown.java
@@ -34,7 +34,6 @@ import static io.trino.SystemSessionProperties.FILTERING_SEMI_JOIN_TO_INNER;
 import static io.trino.SystemSessionProperties.MERGE_PROJECT_WITH_VALUES;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DoubleType.DOUBLE;
-import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static io.trino.sql.ir.Arithmetic.Operator.MULTIPLY;
 import static io.trino.sql.ir.Comparison.Operator.EQUAL;
@@ -68,7 +67,7 @@ public class TestDereferencePushDown
                 output(ImmutableList.of("a_msg_x", "a_msg", "b_msg_y"),
                         strictProject(
                                 ImmutableMap.of(
-                                        "a_msg_x", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, DOUBLE), "a_msg"), new Constant(INTEGER, 1L))),
+                                        "a_msg_x", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, DOUBLE), "a_msg"), 0)),
                                         "a_msg", expression(new Reference(RowType.anonymousRow(BIGINT, DOUBLE), "a_msg")),
                                         "b_msg_y", expression(new Reference(DOUBLE, "b_msg_y"))),
                                 join(INNER, builder -> builder
@@ -191,8 +190,8 @@ public class TestDereferencePushDown
                                         "msg1", expression(new Reference(RowType.anonymousRow(BIGINT, DOUBLE), "msg1")), // not pushed down because used in partition by
                                         "msg2", expression(new Reference(RowType.anonymousRow(BIGINT, DOUBLE), "msg2")), // not pushed down because used in order by
                                         "msg3", expression(new Reference(RowType.anonymousRow(BIGINT, DOUBLE), "msg3")), // not pushed down because used in window function
-                                        "msg4_x", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, DOUBLE), "msg4"), new Constant(INTEGER, 1L))), // pushed down because msg4.x used in window function
-                                        "msg5_x", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, DOUBLE), "msg5"), new Constant(INTEGER, 1L)))), // pushed down because window node does not refer it
+                                        "msg4_x", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, DOUBLE), "msg4"), 0)), // pushed down because msg4.x used in window function
+                                        "msg5_x", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, DOUBLE), "msg5"), 0))), // pushed down because window node does not refer it
                                 values("msg1", "msg2", "msg3", "msg4", "msg5"))));
     }
 
@@ -210,7 +209,7 @@ public class TestDereferencePushDown
                 anyTree(
                         semiJoin("a_x", "b_z", "semi_join_symbol",
                                 project(
-                                        ImmutableMap.of("a_y", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, DOUBLE, BIGINT), "msg"), new Constant(INTEGER, 2L)))),
+                                        ImmutableMap.of("a_y", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, DOUBLE, BIGINT), "msg"), 1))),
                                         values(ImmutableList.of("msg", "a_x"), ImmutableList.of())),
                                 values(ImmutableList.of("b_z"), ImmutableList.of()))));
     }
@@ -223,7 +222,7 @@ public class TestDereferencePushDown
                 anyTree(
                         strictProject(ImmutableMap.of("x_into_3", expression(new Arithmetic(MULTIPLY_BIGINT, MULTIPLY, new Reference(BIGINT, "msg_x"), new Constant(BIGINT, 3L)))),
                                 limit(1,
-                                        strictProject(ImmutableMap.of("msg_x", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, DOUBLE), "msg"), new Constant(INTEGER, 1L)))),
+                                        strictProject(ImmutableMap.of("msg_x", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, DOUBLE), "msg"), 0))),
                                                 values("msg"))))));
 
         // dereference pushdown + constant folding

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDereferencePushDown.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDereferencePushDown.java
@@ -24,9 +24,9 @@ import io.trino.sql.ir.Arithmetic;
 import io.trino.sql.ir.Call;
 import io.trino.sql.ir.Comparison;
 import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Logical;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.assertions.BasePlanTest;
 import org.junit.jupiter.api.Test;
 
@@ -68,7 +68,7 @@ public class TestDereferencePushDown
                 output(ImmutableList.of("a_msg_x", "a_msg", "b_msg_y"),
                         strictProject(
                                 ImmutableMap.of(
-                                        "a_msg_x", expression(new Subscript(new Reference(RowType.anonymousRow(BIGINT, DOUBLE), "a_msg"), new Constant(INTEGER, 1L))),
+                                        "a_msg_x", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, DOUBLE), "a_msg"), new Constant(INTEGER, 1L))),
                                         "a_msg", expression(new Reference(RowType.anonymousRow(BIGINT, DOUBLE), "a_msg")),
                                         "b_msg_y", expression(new Reference(DOUBLE, "b_msg_y"))),
                                 join(INNER, builder -> builder
@@ -191,8 +191,8 @@ public class TestDereferencePushDown
                                         "msg1", expression(new Reference(RowType.anonymousRow(BIGINT, DOUBLE), "msg1")), // not pushed down because used in partition by
                                         "msg2", expression(new Reference(RowType.anonymousRow(BIGINT, DOUBLE), "msg2")), // not pushed down because used in order by
                                         "msg3", expression(new Reference(RowType.anonymousRow(BIGINT, DOUBLE), "msg3")), // not pushed down because used in window function
-                                        "msg4_x", expression(new Subscript(new Reference(RowType.anonymousRow(BIGINT, DOUBLE), "msg4"), new Constant(INTEGER, 1L))), // pushed down because msg4.x used in window function
-                                        "msg5_x", expression(new Subscript(new Reference(RowType.anonymousRow(BIGINT, DOUBLE), "msg5"), new Constant(INTEGER, 1L)))), // pushed down because window node does not refer it
+                                        "msg4_x", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, DOUBLE), "msg4"), new Constant(INTEGER, 1L))), // pushed down because msg4.x used in window function
+                                        "msg5_x", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, DOUBLE), "msg5"), new Constant(INTEGER, 1L)))), // pushed down because window node does not refer it
                                 values("msg1", "msg2", "msg3", "msg4", "msg5"))));
     }
 
@@ -210,7 +210,7 @@ public class TestDereferencePushDown
                 anyTree(
                         semiJoin("a_x", "b_z", "semi_join_symbol",
                                 project(
-                                        ImmutableMap.of("a_y", expression(new Subscript(new Reference(RowType.anonymousRow(BIGINT, DOUBLE, BIGINT), "msg"), new Constant(INTEGER, 2L)))),
+                                        ImmutableMap.of("a_y", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, DOUBLE, BIGINT), "msg"), new Constant(INTEGER, 2L)))),
                                         values(ImmutableList.of("msg", "a_x"), ImmutableList.of())),
                                 values(ImmutableList.of("b_z"), ImmutableList.of()))));
     }
@@ -223,7 +223,7 @@ public class TestDereferencePushDown
                 anyTree(
                         strictProject(ImmutableMap.of("x_into_3", expression(new Arithmetic(MULTIPLY_BIGINT, MULTIPLY, new Reference(BIGINT, "msg_x"), new Constant(BIGINT, 3L)))),
                                 limit(1,
-                                        strictProject(ImmutableMap.of("msg_x", expression(new Subscript(new Reference(RowType.anonymousRow(BIGINT, DOUBLE), "msg"), new Constant(INTEGER, 1L)))),
+                                        strictProject(ImmutableMap.of("msg_x", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, DOUBLE), "msg"), new Constant(INTEGER, 1L)))),
                                                 values("msg"))))));
 
         // dereference pushdown + constant folding

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
@@ -299,8 +299,8 @@ public class TestLogicalPlanner
                 any(
                         project(
                                 ImmutableMap.of(
-                                        "output_1", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "row"), new Constant(INTEGER, 1L))),
-                                        "output_2", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "row"), new Constant(INTEGER, 2L)))),
+                                        "output_1", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "row"), 0)),
+                                        "output_2", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "row"), 1))),
                                 project(
                                         ImmutableMap.of("row", expression(new Row(ImmutableList.of(new Reference(BIGINT, "min"), new Reference(BIGINT, "max"))))),
                                         aggregation(
@@ -328,8 +328,8 @@ public class TestLogicalPlanner
                 any(
                         project(
                                 ImmutableMap.of(
-                                        "output_1", expression(new FieldReference(new Reference(RowType.anonymousRow(DOUBLE, DOUBLE), "row"), new Constant(INTEGER, 1L))),
-                                        "output_2", expression(new FieldReference(new Reference(RowType.anonymousRow(DOUBLE, DOUBLE), "row"), new Constant(INTEGER, 2L)))),
+                                        "output_1", expression(new FieldReference(new Reference(RowType.anonymousRow(DOUBLE, DOUBLE), "row"), 0)),
+                                        "output_2", expression(new FieldReference(new Reference(RowType.anonymousRow(DOUBLE, DOUBLE), "row"), 1))),
                                 project(
                                         ImmutableMap.of("row", expression(new Row(ImmutableList.of(new Reference(DOUBLE, "rand"), new Reference(DOUBLE, "rand"))))),
                                         values(
@@ -340,8 +340,8 @@ public class TestLogicalPlanner
                 any(
                         project(
                                 ImmutableMap.of(
-                                        "output_1", expression(new FieldReference(new Reference(RowType.anonymousRow(DOUBLE, DOUBLE), "r"), new Constant(INTEGER, 1L))),
-                                        "output_2", expression(new FieldReference(new Reference(RowType.anonymousRow(DOUBLE, DOUBLE), "r"), new Constant(INTEGER, 2L)))),
+                                        "output_1", expression(new FieldReference(new Reference(RowType.anonymousRow(DOUBLE, DOUBLE), "r"), 0)),
+                                        "output_2", expression(new FieldReference(new Reference(RowType.anonymousRow(DOUBLE, DOUBLE), "r"), 1))),
                                 values(
                                         ImmutableList.of("r"),
                                         ImmutableList.of(ImmutableList.of(new Row(ImmutableList.of(randomFunction, randomFunction))))))));
@@ -353,8 +353,8 @@ public class TestLogicalPlanner
                                 any(
                                         project(
                                                 ImmutableMap.of(
-                                                        "output_1", expression(new FieldReference(new Reference(RowType.anonymousRow(DOUBLE, DOUBLE), "row"), new Constant(INTEGER, 1L))),
-                                                        "output_2", expression(new FieldReference(new Reference(RowType.anonymousRow(DOUBLE, DOUBLE), "row"), new Constant(INTEGER, 2L)))),
+                                                        "output_1", expression(new FieldReference(new Reference(RowType.anonymousRow(DOUBLE, DOUBLE), "row"), 0)),
+                                                        "output_2", expression(new FieldReference(new Reference(RowType.anonymousRow(DOUBLE, DOUBLE), "row"), 1))),
                                                 values(
                                                         ImmutableList.of("row"),
                                                         ImmutableList.of(

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
@@ -36,13 +36,13 @@ import io.trino.sql.ir.Cast;
 import io.trino.sql.ir.Coalesce;
 import io.trino.sql.ir.Comparison;
 import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.In;
 import io.trino.sql.ir.IsNull;
 import io.trino.sql.ir.Logical;
 import io.trino.sql.ir.Not;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.ir.Row;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.ir.Switch;
 import io.trino.sql.ir.WhenClause;
 import io.trino.sql.planner.OptimizerConfig.JoinDistributionType;
@@ -299,8 +299,8 @@ public class TestLogicalPlanner
                 any(
                         project(
                                 ImmutableMap.of(
-                                        "output_1", expression(new Subscript(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "row"), new Constant(INTEGER, 1L))),
-                                        "output_2", expression(new Subscript(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "row"), new Constant(INTEGER, 2L)))),
+                                        "output_1", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "row"), new Constant(INTEGER, 1L))),
+                                        "output_2", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "row"), new Constant(INTEGER, 2L)))),
                                 project(
                                         ImmutableMap.of("row", expression(new Row(ImmutableList.of(new Reference(BIGINT, "min"), new Reference(BIGINT, "max"))))),
                                         aggregation(
@@ -328,8 +328,8 @@ public class TestLogicalPlanner
                 any(
                         project(
                                 ImmutableMap.of(
-                                        "output_1", expression(new Subscript(new Reference(RowType.anonymousRow(DOUBLE, DOUBLE), "row"), new Constant(INTEGER, 1L))),
-                                        "output_2", expression(new Subscript(new Reference(RowType.anonymousRow(DOUBLE, DOUBLE), "row"), new Constant(INTEGER, 2L)))),
+                                        "output_1", expression(new FieldReference(new Reference(RowType.anonymousRow(DOUBLE, DOUBLE), "row"), new Constant(INTEGER, 1L))),
+                                        "output_2", expression(new FieldReference(new Reference(RowType.anonymousRow(DOUBLE, DOUBLE), "row"), new Constant(INTEGER, 2L)))),
                                 project(
                                         ImmutableMap.of("row", expression(new Row(ImmutableList.of(new Reference(DOUBLE, "rand"), new Reference(DOUBLE, "rand"))))),
                                         values(
@@ -340,8 +340,8 @@ public class TestLogicalPlanner
                 any(
                         project(
                                 ImmutableMap.of(
-                                        "output_1", expression(new Subscript(new Reference(RowType.anonymousRow(DOUBLE, DOUBLE), "r"), new Constant(INTEGER, 1L))),
-                                        "output_2", expression(new Subscript(new Reference(RowType.anonymousRow(DOUBLE, DOUBLE), "r"), new Constant(INTEGER, 2L)))),
+                                        "output_1", expression(new FieldReference(new Reference(RowType.anonymousRow(DOUBLE, DOUBLE), "r"), new Constant(INTEGER, 1L))),
+                                        "output_2", expression(new FieldReference(new Reference(RowType.anonymousRow(DOUBLE, DOUBLE), "r"), new Constant(INTEGER, 2L)))),
                                 values(
                                         ImmutableList.of("r"),
                                         ImmutableList.of(ImmutableList.of(new Row(ImmutableList.of(randomFunction, randomFunction))))))));
@@ -353,8 +353,8 @@ public class TestLogicalPlanner
                                 any(
                                         project(
                                                 ImmutableMap.of(
-                                                        "output_1", expression(new Subscript(new Reference(RowType.anonymousRow(DOUBLE, DOUBLE), "row"), new Constant(INTEGER, 1L))),
-                                                        "output_2", expression(new Subscript(new Reference(RowType.anonymousRow(DOUBLE, DOUBLE), "row"), new Constant(INTEGER, 2L)))),
+                                                        "output_1", expression(new FieldReference(new Reference(RowType.anonymousRow(DOUBLE, DOUBLE), "row"), new Constant(INTEGER, 1L))),
+                                                        "output_2", expression(new FieldReference(new Reference(RowType.anonymousRow(DOUBLE, DOUBLE), "row"), new Constant(INTEGER, 2L)))),
                                                 values(
                                                         ImmutableList.of("row"),
                                                         ImmutableList.of(

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestPartialTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestPartialTranslator.java
@@ -58,8 +58,8 @@ public class TestPartialTranslator
     public void testPartialTranslator()
     {
         Expression rowSymbolReference = new Reference(RowType.anonymousRow(INTEGER, INTEGER), "row_symbol_1");
-        Expression dereferenceExpression1 = new FieldReference(rowSymbolReference, new Constant(INTEGER, 1L));
-        Expression dereferenceExpression2 = new FieldReference(rowSymbolReference, new Constant(INTEGER, 2L));
+        Expression dereferenceExpression1 = new FieldReference(rowSymbolReference, 0);
+        Expression dereferenceExpression2 = new FieldReference(rowSymbolReference, 1);
         Expression stringLiteral = new Constant(VARCHAR, Slices.utf8Slice("abcd"));
         Expression symbolReference1 = new Reference(INTEGER, "double_symbol_1");
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestPartialTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestPartialTranslator.java
@@ -26,9 +26,9 @@ import io.trino.sql.ir.Call;
 import io.trino.sql.ir.Cast;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.NodeRef;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.transaction.TransactionId;
 import org.junit.jupiter.api.Test;
 
@@ -58,8 +58,8 @@ public class TestPartialTranslator
     public void testPartialTranslator()
     {
         Expression rowSymbolReference = new Reference(RowType.anonymousRow(INTEGER, INTEGER), "row_symbol_1");
-        Expression dereferenceExpression1 = new Subscript(rowSymbolReference, new Constant(INTEGER, 1L));
-        Expression dereferenceExpression2 = new Subscript(rowSymbolReference, new Constant(INTEGER, 2L));
+        Expression dereferenceExpression1 = new FieldReference(rowSymbolReference, new Constant(INTEGER, 1L));
+        Expression dereferenceExpression2 = new FieldReference(rowSymbolReference, new Constant(INTEGER, 2L));
         Expression stringLiteral = new Constant(VARCHAR, Slices.utf8Slice("abcd"));
         Expression symbolReference1 = new Reference(INTEGER, "double_symbol_1");
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/ExpressionVerifier.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/ExpressionVerifier.java
@@ -22,6 +22,7 @@ import io.trino.sql.ir.Coalesce;
 import io.trino.sql.ir.Comparison;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.In;
 import io.trino.sql.ir.IrVisitor;
 import io.trino.sql.ir.IsNull;
@@ -31,7 +32,6 @@ import io.trino.sql.ir.Negation;
 import io.trino.sql.ir.Not;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.ir.Row;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.ir.Switch;
 import io.trino.sql.ir.WhenClause;
 
@@ -325,9 +325,9 @@ public final class ExpressionVerifier
     }
 
     @Override
-    protected Boolean visitSubscript(Subscript actual, Expression expectedExpression)
+    protected Boolean visitFieldReference(FieldReference actual, Expression expectedExpression)
     {
-        if (!(expectedExpression instanceof Subscript expected)) {
+        if (!(expectedExpression instanceof FieldReference expected)) {
             return false;
         }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/ExpressionVerifier.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/ExpressionVerifier.java
@@ -331,7 +331,7 @@ public final class ExpressionVerifier
             return false;
         }
 
-        return process(actual.base(), expected.base()) && process(actual.index(), expected.index());
+        return process(actual.base(), expected.base()) && actual.field() == expected.field();
     }
 
     private <T extends Expression> boolean process(List<T> actuals, List<T> expecteds)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestInlineProjections.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestInlineProjections.java
@@ -22,8 +22,8 @@ import io.trino.spi.type.Decimals;
 import io.trino.spi.type.RowType;
 import io.trino.sql.ir.Arithmetic;
 import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.assertions.ExpressionMatcher;
 import io.trino.sql.planner.assertions.PlanMatchPattern;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
@@ -75,7 +75,7 @@ public class TestInlineProjections
                                                 .put(p.symbol("complex"), new Arithmetic(MULTIPLY_INTEGER, MULTIPLY, new Reference(INTEGER, "x"), new Constant(INTEGER, 2L)))
                                                 .put(p.symbol("literal"), new Constant(INTEGER, 1L))
                                                 .put(p.symbol("complex_2"), new Arithmetic(SUBTRACT_INTEGER, SUBTRACT, new Reference(INTEGER, "x"), new Constant(INTEGER, 1L)))
-                                                .put(p.symbol("z"), new Subscript(new Reference(MSG_TYPE, "msg"), new Constant(INTEGER, 1L)))
+                                                .put(p.symbol("z"), new FieldReference(new Reference(MSG_TYPE, "msg"), new Constant(INTEGER, 1L)))
                                                 .put(p.symbol("v"), new Reference(INTEGER, "x"))
                                                 .build(),
                                         p.values(p.symbol("x", INTEGER), p.symbol("msg", MSG_TYPE)))))
@@ -95,7 +95,7 @@ public class TestInlineProjections
                                         ImmutableMap.of(
                                                 "x", PlanMatchPattern.expression(new Reference(INTEGER, "x")),
                                                 "y", PlanMatchPattern.expression(new Arithmetic(MULTIPLY_INTEGER, MULTIPLY, new Reference(INTEGER, "x"), new Constant(INTEGER, 2L))),
-                                                "z", PlanMatchPattern.expression(new Subscript(new Reference(MSG_TYPE, "msg"), new Constant(INTEGER, 1L)))),
+                                                "z", PlanMatchPattern.expression(new FieldReference(new Reference(MSG_TYPE, "msg"), new Constant(INTEGER, 1L)))),
                                         values(ImmutableMap.of("x", 0, "msg", 1)))));
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestInlineProjections.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestInlineProjections.java
@@ -75,7 +75,7 @@ public class TestInlineProjections
                                                 .put(p.symbol("complex"), new Arithmetic(MULTIPLY_INTEGER, MULTIPLY, new Reference(INTEGER, "x"), new Constant(INTEGER, 2L)))
                                                 .put(p.symbol("literal"), new Constant(INTEGER, 1L))
                                                 .put(p.symbol("complex_2"), new Arithmetic(SUBTRACT_INTEGER, SUBTRACT, new Reference(INTEGER, "x"), new Constant(INTEGER, 1L)))
-                                                .put(p.symbol("z"), new FieldReference(new Reference(MSG_TYPE, "msg"), new Constant(INTEGER, 1L)))
+                                                .put(p.symbol("z"), new FieldReference(new Reference(MSG_TYPE, "msg"), 0))
                                                 .put(p.symbol("v"), new Reference(INTEGER, "x"))
                                                 .build(),
                                         p.values(p.symbol("x", INTEGER), p.symbol("msg", MSG_TYPE)))))
@@ -95,7 +95,7 @@ public class TestInlineProjections
                                         ImmutableMap.of(
                                                 "x", PlanMatchPattern.expression(new Reference(INTEGER, "x")),
                                                 "y", PlanMatchPattern.expression(new Arithmetic(MULTIPLY_INTEGER, MULTIPLY, new Reference(INTEGER, "x"), new Constant(INTEGER, 2L))),
-                                                "z", PlanMatchPattern.expression(new FieldReference(new Reference(MSG_TYPE, "msg"), new Constant(INTEGER, 1L)))),
+                                                "z", PlanMatchPattern.expression(new FieldReference(new Reference(MSG_TYPE, "msg"), 0))),
                                         values(ImmutableMap.of("x", 0, "msg", 1)))));
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushCastIntoRow.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushCastIntoRow.java
@@ -65,8 +65,8 @@ public class TestPushCastIntoRow
 
         // expression nested in another unrelated expression
         test(
-                new FieldReference(new Cast(new Row(ImmutableList.of(new Constant(INTEGER, 1L))), anonymousRow(BIGINT)), new Constant(INTEGER, 1L)),
-                new FieldReference(new Row(ImmutableList.of(new Cast(new Constant(INTEGER, 1L), BIGINT))), new Constant(INTEGER, 1L)));
+                new FieldReference(new Cast(new Row(ImmutableList.of(new Constant(INTEGER, 1L))), anonymousRow(BIGINT)), 0),
+                new FieldReference(new Row(ImmutableList.of(new Cast(new Constant(INTEGER, 1L), BIGINT))), 0));
 
         // don't insert CAST(x AS unknown)
         test(

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushCastIntoRow.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushCastIntoRow.java
@@ -18,8 +18,8 @@ import io.airlift.slice.Slices;
 import io.trino.sql.ir.Cast;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Row;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.assertions.PlanMatchPattern;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.plan.Assignments;
@@ -65,8 +65,8 @@ public class TestPushCastIntoRow
 
         // expression nested in another unrelated expression
         test(
-                new Subscript(new Cast(new Row(ImmutableList.of(new Constant(INTEGER, 1L))), anonymousRow(BIGINT)), new Constant(INTEGER, 1L)),
-                new Subscript(new Row(ImmutableList.of(new Cast(new Constant(INTEGER, 1L), BIGINT))), new Constant(INTEGER, 1L)));
+                new FieldReference(new Cast(new Row(ImmutableList.of(new Constant(INTEGER, 1L))), anonymousRow(BIGINT)), new Constant(INTEGER, 1L)),
+                new FieldReference(new Row(ImmutableList.of(new Cast(new Constant(INTEGER, 1L), BIGINT))), new Constant(INTEGER, 1L)));
 
         // don't insert CAST(x AS unknown)
         test(

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushDownDereferencesRules.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushDownDereferencesRules.java
@@ -30,12 +30,12 @@ import io.trino.sql.ir.Call;
 import io.trino.sql.ir.Cast;
 import io.trino.sql.ir.Comparison;
 import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.IsNull;
 import io.trino.sql.ir.Logical;
 import io.trino.sql.ir.Not;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.ir.Row;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.OrderingScheme;
 import io.trino.sql.planner.assertions.ExpressionMatcher;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
@@ -115,8 +115,8 @@ public class TestPushDownDereferencesRules
                 .on(p ->
                         p.project(
                                 Assignments.of(
-                                        p.symbol("expr_1"), new Subscript(new Cast(new Row(ImmutableList.of(new Reference(ROW_TYPE, "a"), new Reference(BIGINT, "b"))), rowType(field("f1", rowType(field("x", BIGINT), field("y", BIGINT))), field("f2", BIGINT))), new Constant(INTEGER, 1L)),
-                                        p.symbol("expr_2"), new Subscript(new Subscript(new Cast(new Row(ImmutableList.of(new Reference(ROW_TYPE, "a"), new Reference(BIGINT, "b"))), rowType(field("f1", rowType(field("x", BIGINT), field("y", BIGINT))), field("f2", BIGINT))), new Constant(INTEGER, 1L)), new Constant(INTEGER, 2L))),
+                                        p.symbol("expr_1"), new FieldReference(new Cast(new Row(ImmutableList.of(new Reference(ROW_TYPE, "a"), new Reference(BIGINT, "b"))), rowType(field("f1", rowType(field("x", BIGINT), field("y", BIGINT))), field("f2", BIGINT))), new Constant(INTEGER, 1L)),
+                                        p.symbol("expr_2"), new FieldReference(new FieldReference(new Cast(new Row(ImmutableList.of(new Reference(ROW_TYPE, "a"), new Reference(BIGINT, "b"))), rowType(field("f1", rowType(field("x", BIGINT), field("y", BIGINT))), field("f2", BIGINT))), new Constant(INTEGER, 1L)), new Constant(INTEGER, 2L))),
                                 p.project(
                                         Assignments.of(
                                                 p.symbol("a", ROW_TYPE), new Reference(ROW_TYPE, "a"),
@@ -130,7 +130,7 @@ public class TestPushDownDereferencesRules
                         p.project(
                                 Assignments.of(
                                         p.symbol("expr", ROW_TYPE), new Reference(ROW_TYPE, "a"),
-                                        p.symbol("a_x"), new Subscript(new Reference(ROW_TYPE, "a"), new Constant(INTEGER, 1L))),
+                                        p.symbol("a_x"), new FieldReference(new Reference(ROW_TYPE, "a"), new Constant(INTEGER, 1L))),
                                 p.project(
                                         Assignments.of(p.symbol("a", ROW_TYPE), new Reference(ROW_TYPE, "a")),
                                         p.values(p.symbol("a", ROW_TYPE)))))
@@ -143,7 +143,7 @@ public class TestPushDownDereferencesRules
         tester().assertThat(new PushDownDereferenceThroughProject())
                 .on(p ->
                         p.project(
-                                Assignments.of(p.symbol("x"), new Subscript(new Reference(ROW_TYPE, "msg"), new Constant(INTEGER, 1L))),
+                                Assignments.of(p.symbol("x"), new FieldReference(new Reference(ROW_TYPE, "msg"), new Constant(INTEGER, 1L))),
                                 p.project(
                                         Assignments.of(
                                                 p.symbol("y"), new Reference(BIGINT, "y"),
@@ -154,7 +154,7 @@ public class TestPushDownDereferencesRules
                                 ImmutableMap.of("x", expression(new Reference(BIGINT, "msg_x"))),
                                 strictProject(
                                         ImmutableMap.of(
-                                                "msg_x", expression(new Subscript(new Reference(ROW_TYPE, "msg"), new Constant(INTEGER, 1L))),
+                                                "msg_x", expression(new FieldReference(new Reference(ROW_TYPE, "msg"), new Constant(INTEGER, 1L))),
                                                 "y", expression(new Reference(BIGINT, "y")),
                                                 "msg", expression(new Reference(BIGINT, "msg"))),
                                         values("msg", "y"))));
@@ -167,8 +167,8 @@ public class TestPushDownDereferencesRules
                 .on(p ->
                         p.project(
                                 Assignments.builder()
-                                        .put(p.symbol("left_x"), new Subscript(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L)))
-                                        .put(p.symbol("right_y"), new Subscript(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 2L)))
+                                        .put(p.symbol("left_x"), new FieldReference(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L)))
+                                        .put(p.symbol("right_y"), new FieldReference(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 2L)))
                                         .put(p.symbol("z"), new Reference(BIGINT, "z"))
                                         .build(),
                                 p.join(INNER,
@@ -185,14 +185,14 @@ public class TestPushDownDereferencesRules
                                         .left(
                                                 strictProject(
                                                         ImmutableMap.of(
-                                                                "x", expression(new Subscript(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L))),
+                                                                "x", expression(new FieldReference(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L))),
                                                                 "msg1", expression(new Reference(ROW_TYPE, "msg1")),
                                                                 "unreferenced_symbol", expression(new Reference(BIGINT, "unreferenced_symbol"))),
                                                         values("msg1", "unreferenced_symbol")))
                                         .right(
                                                 strictProject(
                                                         ImmutableMap.<String, ExpressionMatcher>builder()
-                                                                .put("y", expression(new Subscript(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 2L))))
+                                                                .put("y", expression(new FieldReference(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 2L))))
                                                                 .put("z", expression(new Reference(BIGINT, "z")))
                                                                 .put("msg2", expression(new Reference(ROW_TYPE, "msg2")))
                                                                 .buildOrThrow(),
@@ -203,23 +203,23 @@ public class TestPushDownDereferencesRules
                 .on(p ->
                         p.project(
                                 Assignments.of(
-                                        p.symbol("expr"), new Subscript(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L)),
+                                        p.symbol("expr"), new FieldReference(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L)),
                                         p.symbol("expr_2"), new Reference(ROW_TYPE, "msg2")),
                                 p.join(INNER,
                                         p.values(p.symbol("msg1", ROW_TYPE)),
                                         p.values(p.symbol("msg2", ROW_TYPE)),
-                                        new Comparison(GREATER_THAN, new Arithmetic(ADD_BIGINT, ADD, new Subscript(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L)), new Subscript(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 2L))), new Constant(BIGINT, 10L)))))
+                                        new Comparison(GREATER_THAN, new Arithmetic(ADD_BIGINT, ADD, new FieldReference(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L)), new FieldReference(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 2L))), new Constant(BIGINT, 10L)))))
                 .matches(
                         project(
                                 ImmutableMap.of(
                                         "expr", expression(new Reference(BIGINT, "msg1_x")),
                                         "expr_2", expression(new Reference(ROW_TYPE, "msg2"))),
                                 join(INNER, builder -> builder
-                                        .filter(new Comparison(GREATER_THAN, new Arithmetic(ADD_BIGINT, ADD, new Reference(BIGINT, "msg1_x"), new Subscript(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 2L))), new Constant(BIGINT, 10L)))
+                                        .filter(new Comparison(GREATER_THAN, new Arithmetic(ADD_BIGINT, ADD, new Reference(BIGINT, "msg1_x"), new FieldReference(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 2L))), new Constant(BIGINT, 10L)))
                                         .left(
                                                 strictProject(
                                                         ImmutableMap.of(
-                                                                "msg1_x", expression(new Subscript(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L))),
+                                                                "msg1_x", expression(new FieldReference(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L))),
                                                                 "msg1", expression(new Reference(ROW_TYPE, "msg1"))),
                                                         values("msg1")))
                                         .right(values("msg2")))));
@@ -232,8 +232,8 @@ public class TestPushDownDereferencesRules
                 .on(p ->
                         p.project(
                                 Assignments.builder()
-                                        .put(p.symbol("msg1_x"), new Subscript(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L)))
-                                        .put(p.symbol("msg2_x"), new Subscript(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 1L)))
+                                        .put(p.symbol("msg1_x"), new FieldReference(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L)))
+                                        .put(p.symbol("msg2_x"), new FieldReference(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 1L)))
                                         .build(),
                                 p.semiJoin(
                                         p.symbol("msg2", ROW_TYPE),
@@ -247,7 +247,7 @@ public class TestPushDownDereferencesRules
                         strictProject(
                                 ImmutableMap.<String, ExpressionMatcher>builder()
                                         .put("msg1_x", expression(new Reference(BIGINT, "expr")))
-                                        .put("msg2_x", expression(new Subscript(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 1L))))   // Not pushed down because msg2 is sourceJoinSymbol
+                                        .put("msg2_x", expression(new FieldReference(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 1L))))   // Not pushed down because msg2 is sourceJoinSymbol
                                         .buildOrThrow(),
                                 semiJoin(
                                         "msg2",
@@ -255,7 +255,7 @@ public class TestPushDownDereferencesRules
                                         "match",
                                         strictProject(
                                                 ImmutableMap.of(
-                                                        "expr", expression(new Subscript(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L))),
+                                                        "expr", expression(new FieldReference(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L))),
                                                         "msg1", expression(new Reference(ROW_TYPE, "msg1")),
                                                         "msg2", expression(new Reference(ROW_TYPE, "msg2"))),
                                                 values("msg1", "msg2")),
@@ -269,7 +269,7 @@ public class TestPushDownDereferencesRules
         tester().assertThat(new PushDownDereferenceThroughUnnest())
                 .on(p ->
                         p.project(
-                                Assignments.of(p.symbol("x"), new Subscript(new Reference(ROW_TYPE, "msg"), new Constant(INTEGER, 1L))),
+                                Assignments.of(p.symbol("x"), new FieldReference(new Reference(ROW_TYPE, "msg"), new Constant(INTEGER, 1L))),
                                 p.unnest(
                                         ImmutableList.of(p.symbol("msg", ROW_TYPE)),
                                         ImmutableList.of(new UnnestNode.Mapping(p.symbol("arr", arrayType), ImmutableList.of(p.symbol("field")))),
@@ -282,7 +282,7 @@ public class TestPushDownDereferencesRules
                                 unnest(
                                         strictProject(
                                                 ImmutableMap.of(
-                                                        "msg_x", expression(new Subscript(new Reference(ROW_TYPE, "msg"), new Constant(INTEGER, 1L))),
+                                                        "msg_x", expression(new FieldReference(new Reference(ROW_TYPE, "msg"), new Constant(INTEGER, 1L))),
                                                         "msg", expression(new Reference(ROW_TYPE, "msg")),
                                                         "arr", expression(new Reference(arrayType, "arr"))),
                                                 values("msg", "arr")))));
@@ -296,7 +296,7 @@ public class TestPushDownDereferencesRules
                 .on(p ->
                         p.project(
                                 Assignments.of(
-                                        p.symbol("deref_replicate", BIGINT), new Subscript(new Reference(rowType, "replicate"), new Constant(INTEGER, 2L)),
+                                        p.symbol("deref_replicate", BIGINT), new FieldReference(new Reference(rowType, "replicate"), new Constant(INTEGER, 2L)),
                                         p.symbol("deref_unnest", BIGINT), new Call(subscript, ImmutableList.of(new Reference(nestedColumnType, "unnested_row"), new Constant(BIGINT, 2L)))),
                                 p.unnest(
                                         ImmutableList.of(p.symbol("replicate", rowType)),
@@ -315,7 +315,7 @@ public class TestPushDownDereferencesRules
                                         ImmutableList.of(unnestMapping("nested", ImmutableList.of("unnested_bigint", "unnested_row"))),
                                         strictProject(
                                                 ImmutableMap.of(
-                                                        "symbol", expression(new Subscript(new Reference(rowType, "replicate"), new Constant(INTEGER, 2L))),
+                                                        "symbol", expression(new FieldReference(new Reference(rowType, "replicate"), new Constant(INTEGER, 2L))),
                                                         "replicate", expression(new Reference(rowType, "replicate")),
                                                         "nested", expression(new Reference(nestedColumnType, "nested"))),
                                                 values("replicate", "nested")))));
@@ -334,9 +334,9 @@ public class TestPushDownDereferencesRules
                 .on(p ->
                         p.filter(
                                 new Logical(AND, ImmutableList.of(
-                                        new Comparison(NOT_EQUAL, new Subscript(new Subscript(new Reference(nestedRowType, "a"), new Constant(INTEGER, 1L)), new Constant(INTEGER, 1L)), new Constant(BIGINT, 5L)),
-                                        new Comparison(EQUAL, new Subscript(new Reference(ROW_TYPE, "b"), new Constant(INTEGER, 2L)), new Constant(BIGINT, 2L)),
-                                        new Not(new IsNull(new Cast(new Subscript(new Reference(nestedRowType, "a"), new Constant(INTEGER, 1L)), JSON))))),
+                                        new Comparison(NOT_EQUAL, new FieldReference(new FieldReference(new Reference(nestedRowType, "a"), new Constant(INTEGER, 1L)), new Constant(INTEGER, 1L)), new Constant(BIGINT, 5L)),
+                                        new Comparison(EQUAL, new FieldReference(new Reference(ROW_TYPE, "b"), new Constant(INTEGER, 2L)), new Constant(BIGINT, 2L)),
+                                        new Not(new IsNull(new Cast(new FieldReference(new Reference(nestedRowType, "a"), new Constant(INTEGER, 1L)), JSON))))),
                                 p.tableScan(
                                         testTable,
                                         ImmutableList.of(p.symbol("a", nestedRowType), p.symbol("b", ROW_TYPE)),
@@ -348,9 +348,9 @@ public class TestPushDownDereferencesRules
                                 new Logical(AND, ImmutableList.of(new Comparison(NOT_EQUAL, new Reference(BIGINT, "expr"), new Constant(BIGINT, 5L)), new Comparison(EQUAL, new Reference(BIGINT, "expr_0"), new Constant(BIGINT, 2L)), new Not(new IsNull(new Cast(new Reference(ROW_TYPE, "expr_1"), JSON))))),
                                 strictProject(
                                         ImmutableMap.of(
-                                                "expr", expression(new Subscript(new Subscript(new Reference(nestedRowType, "a"), new Constant(INTEGER, 1L)), new Constant(INTEGER, 1L))),
-                                                "expr_0", expression(new Subscript(new Reference(ROW_TYPE, "b"), new Constant(INTEGER, 2L))),
-                                                "expr_1", expression(new Subscript(new Reference(nestedRowType, "a"), new Constant(INTEGER, 1L))),
+                                                "expr", expression(new FieldReference(new FieldReference(new Reference(nestedRowType, "a"), new Constant(INTEGER, 1L)), new Constant(INTEGER, 1L))),
+                                                "expr_0", expression(new FieldReference(new Reference(ROW_TYPE, "b"), new Constant(INTEGER, 2L))),
+                                                "expr_1", expression(new FieldReference(new Reference(nestedRowType, "a"), new Constant(INTEGER, 1L))),
                                                 "a", expression(new Reference(nestedRowType, "a")),
                                                 "b", expression(new Reference(ROW_TYPE, "b"))),
                                         tableScan(
@@ -368,21 +368,21 @@ public class TestPushDownDereferencesRules
                 .on(p ->
                         p.project(
                                 Assignments.of(
-                                        p.symbol("expr", BIGINT), new Subscript(new Reference(ROW_TYPE, "msg"), new Constant(INTEGER, 1L)),
-                                        p.symbol("expr_2", BIGINT), new Subscript(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 1L))),
+                                        p.symbol("expr", BIGINT), new FieldReference(new Reference(ROW_TYPE, "msg"), new Constant(INTEGER, 1L)),
+                                        p.symbol("expr_2", BIGINT), new FieldReference(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 1L))),
                                 p.filter(
-                                        new Logical(AND, ImmutableList.of(new Comparison(NOT_EQUAL, new Subscript(new Reference(ROW_TYPE, "msg"), new Constant(INTEGER, 1L)), new Constant(BIGINT, 3L)), new Not(new IsNull(new Reference(ROW_TYPE, "msg2"))))),
+                                        new Logical(AND, ImmutableList.of(new Comparison(NOT_EQUAL, new FieldReference(new Reference(ROW_TYPE, "msg"), new Constant(INTEGER, 1L)), new Constant(BIGINT, 3L)), new Not(new IsNull(new Reference(ROW_TYPE, "msg2"))))),
                                         p.values(p.symbol("msg", ROW_TYPE), p.symbol("msg2", ROW_TYPE)))))
                 .matches(
                         strictProject(
                                 ImmutableMap.of(
                                         "expr", expression(new Reference(BIGINT, "msg_x")),
-                                        "expr_2", expression(new Subscript(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 1L)))), // not pushed down since predicate contains msg2 reference
+                                        "expr_2", expression(new FieldReference(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 1L)))), // not pushed down since predicate contains msg2 reference
                                 filter(
                                         new Logical(AND, ImmutableList.of(new Comparison(NOT_EQUAL, new Reference(BIGINT, "msg_x"), new Constant(BIGINT, 3L)), new Not(new IsNull(new Reference(ROW_TYPE, "msg2"))))),
                                         strictProject(
                                                 ImmutableMap.of(
-                                                        "msg_x", expression(new Subscript(new Reference(ROW_TYPE, "msg"), new Constant(INTEGER, 1L))),
+                                                        "msg_x", expression(new FieldReference(new Reference(ROW_TYPE, "msg"), new Constant(INTEGER, 1L))),
                                                         "msg", expression(new Reference(ROW_TYPE, "msg")),
                                                         "msg2", expression(new Reference(ROW_TYPE, "msg2"))),
                                                 values("msg", "msg2")))));
@@ -395,8 +395,8 @@ public class TestPushDownDereferencesRules
                 .on(p ->
                         p.project(
                                 Assignments.builder()
-                                        .put(p.symbol("msg1_x"), new Subscript(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L)))
-                                        .put(p.symbol("msg2_y"), new Subscript(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 2L)))
+                                        .put(p.symbol("msg1_x"), new FieldReference(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L)))
+                                        .put(p.symbol("msg2_y"), new FieldReference(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 2L)))
                                         .put(p.symbol("z"), new Reference(BIGINT, "z"))
                                         .build(),
                                 p.limit(10,
@@ -406,7 +406,7 @@ public class TestPushDownDereferencesRules
                         strictProject(
                                 ImmutableMap.<String, ExpressionMatcher>builder()
                                         .put("msg1_x", expression(new Reference(BIGINT, "x")))
-                                        .put("msg2_y", expression(new Subscript(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 2L))))
+                                        .put("msg2_y", expression(new FieldReference(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 2L))))
                                         .put("z", expression(new Reference(BIGINT, "z")))
                                         .buildOrThrow(),
                                 limit(
@@ -414,7 +414,7 @@ public class TestPushDownDereferencesRules
                                         ImmutableList.of(sort("msg2", ASCENDING, FIRST)),
                                         strictProject(
                                                 ImmutableMap.<String, ExpressionMatcher>builder()
-                                                        .put("x", expression(new Subscript(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L))))
+                                                        .put("x", expression(new FieldReference(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L))))
                                                         .put("z", expression(new Reference(BIGINT, "z")))
                                                         .put("msg1", expression(new Reference(ROW_TYPE, "msg1")))
                                                         .put("msg2", expression(new Reference(ROW_TYPE, "msg2")))
@@ -428,8 +428,8 @@ public class TestPushDownDereferencesRules
         tester().assertThat(new PushDownDereferencesThroughLimit())
                 .on(p -> p.project(
                         Assignments.builder()
-                                .put(p.symbol("msg1_x"), new Subscript(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L)))
-                                .put(p.symbol("msg2_y"), new Subscript(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 2L)))
+                                .put(p.symbol("msg1_x"), new FieldReference(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L)))
+                                .put(p.symbol("msg2_y"), new FieldReference(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 2L)))
                                 .put(p.symbol("z"), new Reference(BIGINT, "z"))
                                 .build(),
                         p.limit(
@@ -441,7 +441,7 @@ public class TestPushDownDereferencesRules
                         strictProject(
                                 ImmutableMap.<String, ExpressionMatcher>builder()
                                         .put("msg1_x", expression(new Reference(BIGINT, "x")))
-                                        .put("msg2_y", expression(new Subscript(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 2L))))
+                                        .put("msg2_y", expression(new FieldReference(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 2L))))
                                         .put("z", expression(new Reference(BIGINT, "z")))
                                         .buildOrThrow(),
                                 limit(
@@ -451,7 +451,7 @@ public class TestPushDownDereferencesRules
                                         ImmutableList.of("msg2"),
                                         strictProject(
                                                 ImmutableMap.<String, ExpressionMatcher>builder()
-                                                        .put("x", expression(new Subscript(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L))))
+                                                        .put("x", expression(new FieldReference(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L))))
                                                         .put("z", expression(new Reference(BIGINT, "z")))
                                                         .put("msg1", expression(new Reference(ROW_TYPE, "msg1")))
                                                         .put("msg2", expression(new Reference(ROW_TYPE, "msg2")))
@@ -467,8 +467,8 @@ public class TestPushDownDereferencesRules
                 .on(p ->
                         p.project(
                                 Assignments.builder()
-                                        .put(p.symbol("msg_x"), new Subscript(new Reference(ROW_TYPE, "msg"), new Constant(INTEGER, 1L)))
-                                        .put(p.symbol("msg_y"), new Subscript(new Reference(ROW_TYPE, "msg"), new Constant(INTEGER, 2L)))
+                                        .put(p.symbol("msg_x"), new FieldReference(new Reference(ROW_TYPE, "msg"), new Constant(INTEGER, 1L)))
+                                        .put(p.symbol("msg_y"), new FieldReference(new Reference(ROW_TYPE, "msg"), new Constant(INTEGER, 2L)))
                                         .put(p.symbol("z"), new Reference(BIGINT, "z"))
                                         .build(),
                                 p.sort(
@@ -480,7 +480,7 @@ public class TestPushDownDereferencesRules
                 .on(p ->
                         p.project(
                                 Assignments.builder()
-                                        .put(p.symbol("msg_x"), new Subscript(new Reference(ROW_TYPE, "msg"), new Constant(INTEGER, 1L)))
+                                        .put(p.symbol("msg_x"), new FieldReference(new Reference(ROW_TYPE, "msg"), new Constant(INTEGER, 1L)))
                                         .put(p.symbol("z"), new Reference(BIGINT, "z"))
                                         .build(),
                                 p.sort(
@@ -495,7 +495,7 @@ public class TestPushDownDereferencesRules
                                 sort(ImmutableList.of(sort("z", ASCENDING, FIRST)),
                                         strictProject(
                                                 ImmutableMap.<String, ExpressionMatcher>builder()
-                                                        .put("x", expression(new Subscript(new Reference(ROW_TYPE, "msg"), new Constant(INTEGER, 1L))))
+                                                        .put("x", expression(new FieldReference(new Reference(ROW_TYPE, "msg"), new Constant(INTEGER, 1L))))
                                                         .put("z", expression(new Reference(BIGINT, "z")))
                                                         .put("msg", expression(new Reference(ROW_TYPE, "msg")))
                                                         .buildOrThrow(),
@@ -509,8 +509,8 @@ public class TestPushDownDereferencesRules
                 .on(p ->
                         p.project(
                                 Assignments.builder()
-                                        .put(p.symbol("msg1_x"), new Subscript(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L)))
-                                        .put(p.symbol("msg2_x"), new Subscript(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 1L)))
+                                        .put(p.symbol("msg1_x"), new FieldReference(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L)))
+                                        .put(p.symbol("msg2_x"), new FieldReference(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 1L)))
                                         .build(),
                                 p.rowNumber(
                                         ImmutableList.of(p.symbol("msg1", ROW_TYPE)),
@@ -520,7 +520,7 @@ public class TestPushDownDereferencesRules
                 .matches(
                         strictProject(
                                 ImmutableMap.<String, ExpressionMatcher>builder()
-                                        .put("msg1_x", expression(new Subscript(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L))))
+                                        .put("msg1_x", expression(new FieldReference(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L))))
                                         .put("msg2_x", expression(new Reference(BIGINT, "expr")))
                                         .buildOrThrow(),
                                 rowNumber(
@@ -528,7 +528,7 @@ public class TestPushDownDereferencesRules
                                                 .partitionBy(ImmutableList.of("msg1")),
                                         strictProject(
                                                 ImmutableMap.<String, ExpressionMatcher>builder()
-                                                        .put("expr", expression(new Subscript(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 1L))))
+                                                        .put("expr", expression(new FieldReference(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 1L))))
                                                         .put("msg1", expression(new Reference(ROW_TYPE, "msg1")))
                                                         .put("msg2", expression(new Reference(ROW_TYPE, "msg2")))
                                                         .buildOrThrow(),
@@ -542,9 +542,9 @@ public class TestPushDownDereferencesRules
                 .on(p ->
                         p.project(
                                 Assignments.builder()
-                                        .put(p.symbol("msg1_x"), new Subscript(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L)))
-                                        .put(p.symbol("msg2_x"), new Subscript(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 1L)))
-                                        .put(p.symbol("msg3_x"), new Subscript(new Reference(ROW_TYPE, "msg3"), new Constant(INTEGER, 1L)))
+                                        .put(p.symbol("msg1_x"), new FieldReference(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L)))
+                                        .put(p.symbol("msg2_x"), new FieldReference(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 1L)))
+                                        .put(p.symbol("msg3_x"), new FieldReference(new Reference(ROW_TYPE, "msg3"), new Constant(INTEGER, 1L)))
                                         .build(),
                                 p.topNRanking(
                                         new DataOrganizationSpecification(
@@ -560,15 +560,15 @@ public class TestPushDownDereferencesRules
                 .matches(
                         strictProject(
                                 ImmutableMap.<String, ExpressionMatcher>builder()
-                                        .put("msg1_x", expression(new Subscript(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L))))
-                                        .put("msg2_x", expression(new Subscript(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 1L))))
+                                        .put("msg1_x", expression(new FieldReference(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L))))
+                                        .put("msg2_x", expression(new FieldReference(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 1L))))
                                         .put("msg3_x", expression(new Reference(BIGINT, "expr")))
                                         .buildOrThrow(),
                                 topNRanking(
                                         pattern -> pattern.specification(singletonList("msg1"), singletonList("msg2"), ImmutableMap.of("msg2", ASC_NULLS_FIRST)),
                                         strictProject(
                                                 ImmutableMap.<String, ExpressionMatcher>builder()
-                                                        .put("expr", expression(new Subscript(new Reference(ROW_TYPE, "msg3"), new Constant(INTEGER, 1L))))
+                                                        .put("expr", expression(new FieldReference(new Reference(ROW_TYPE, "msg3"), new Constant(INTEGER, 1L))))
                                                         .put("msg1", expression(new Reference(ROW_TYPE, "msg1")))
                                                         .put("msg2", expression(new Reference(ROW_TYPE, "msg2")))
                                                         .put("msg3", expression(new Reference(ROW_TYPE, "msg3")))
@@ -583,21 +583,21 @@ public class TestPushDownDereferencesRules
                 .on(p ->
                         p.project(
                                 Assignments.builder()
-                                        .put(p.symbol("msg1_x"), new Subscript(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L)))
-                                        .put(p.symbol("msg2_x"), new Subscript(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 1L)))
+                                        .put(p.symbol("msg1_x"), new FieldReference(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L)))
+                                        .put(p.symbol("msg2_x"), new FieldReference(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 1L)))
                                         .build(),
                                 p.topN(5, ImmutableList.of(p.symbol("msg1", ROW_TYPE)),
                                         p.values(p.symbol("msg1", ROW_TYPE), p.symbol("msg2", ROW_TYPE)))))
                 .matches(
                         strictProject(
                                 ImmutableMap.<String, ExpressionMatcher>builder()
-                                        .put("msg1_x", expression(new Subscript(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L))))
+                                        .put("msg1_x", expression(new FieldReference(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L))))
                                         .put("msg2_x", expression(new Reference(BIGINT, "expr")))
                                         .buildOrThrow(),
                                 topN(5, ImmutableList.of(sort("msg1", ASCENDING, FIRST)),
                                         strictProject(
                                                 ImmutableMap.<String, ExpressionMatcher>builder()
-                                                        .put("expr", expression(new Subscript(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 1L))))
+                                                        .put("expr", expression(new FieldReference(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 1L))))
                                                         .put("msg1", expression(new Reference(ROW_TYPE, "msg1")))
                                                         .put("msg2", expression(new Reference(ROW_TYPE, "msg2")))
                                                         .buildOrThrow(),
@@ -611,11 +611,11 @@ public class TestPushDownDereferencesRules
                 .on(p ->
                         p.project(
                                 Assignments.builder()
-                                        .put(p.symbol("msg1_x"), new Subscript(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L)))
-                                        .put(p.symbol("msg2_x"), new Subscript(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 1L)))
-                                        .put(p.symbol("msg3_x"), new Subscript(new Reference(ROW_TYPE, "msg3"), new Constant(INTEGER, 1L)))
-                                        .put(p.symbol("msg4_x"), new Subscript(new Reference(ROW_TYPE, "msg4"), new Constant(INTEGER, 1L)))
-                                        .put(p.symbol("msg5_x"), new Subscript(new Reference(ROW_TYPE, "msg5"), new Constant(INTEGER, 1L)))
+                                        .put(p.symbol("msg1_x"), new FieldReference(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L)))
+                                        .put(p.symbol("msg2_x"), new FieldReference(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 1L)))
+                                        .put(p.symbol("msg3_x"), new FieldReference(new Reference(ROW_TYPE, "msg3"), new Constant(INTEGER, 1L)))
+                                        .put(p.symbol("msg4_x"), new FieldReference(new Reference(ROW_TYPE, "msg4"), new Constant(INTEGER, 1L)))
+                                        .put(p.symbol("msg5_x"), new FieldReference(new Reference(ROW_TYPE, "msg5"), new Constant(INTEGER, 1L)))
                                         .build(),
                                 p.window(
                                         new DataOrganizationSpecification(
@@ -647,9 +647,9 @@ public class TestPushDownDereferencesRules
                 .matches(
                         strictProject(
                                 ImmutableMap.<String, ExpressionMatcher>builder()
-                                        .put("msg1_x", expression(new Subscript(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L)))) // not pushed down because used in partitionBy
-                                        .put("msg2_x", expression(new Subscript(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 1L)))) // not pushed down because used in orderBy
-                                        .put("msg3_x", expression(new Subscript(new Reference(ROW_TYPE, "msg3"), new Constant(INTEGER, 1L)))) // not pushed down because the whole column is used in windowNode function
+                                        .put("msg1_x", expression(new FieldReference(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L)))) // not pushed down because used in partitionBy
+                                        .put("msg2_x", expression(new FieldReference(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 1L)))) // not pushed down because used in orderBy
+                                        .put("msg3_x", expression(new FieldReference(new Reference(ROW_TYPE, "msg3"), new Constant(INTEGER, 1L)))) // not pushed down because the whole column is used in windowNode function
                                         .put("msg4_x", expression(new Reference(BIGINT, "expr"))) // pushed down because msg4[1] is being used in the function
                                         .put("msg5_x", expression(new Reference(BIGINT, "expr2"))) // pushed down because not referenced in windowNode
                                         .buildOrThrow(),
@@ -664,8 +664,8 @@ public class TestPushDownDereferencesRules
                                                         .put("msg3", expression(new Reference(ROW_TYPE, "msg3")))
                                                         .put("msg4", expression(new Reference(ROW_TYPE, "msg4")))
                                                         .put("msg5", expression(new Reference(ROW_TYPE, "msg5")))
-                                                        .put("expr", expression(new Subscript(new Reference(ROW_TYPE, "msg4"), new Constant(INTEGER, 1L))))
-                                                        .put("expr2", expression(new Subscript(new Reference(ROW_TYPE, "msg5"), new Constant(INTEGER, 1L))))
+                                                        .put("expr", expression(new FieldReference(new Reference(ROW_TYPE, "msg4"), new Constant(INTEGER, 1L))))
+                                                        .put("expr2", expression(new FieldReference(new Reference(ROW_TYPE, "msg5"), new Constant(INTEGER, 1L))))
                                                         .buildOrThrow(),
                                                 values("msg1", "msg2", "msg3", "msg4", "msg5")))));
     }
@@ -677,7 +677,7 @@ public class TestPushDownDereferencesRules
                 .on(p ->
                         p.project(
                                 Assignments.builder()
-                                        .put(p.symbol("expr"), new Subscript(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L)))
+                                        .put(p.symbol("expr"), new FieldReference(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L)))
                                         .build(),
                                 p.assignUniqueId(
                                         p.symbol("unique"),
@@ -690,7 +690,7 @@ public class TestPushDownDereferencesRules
                                         strictProject(
                                                 ImmutableMap.<String, ExpressionMatcher>builder()
                                                         .put("msg1", expression(new Reference(ROW_TYPE, "msg1")))
-                                                        .put("msg1_x", expression(new Subscript(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L))))
+                                                        .put("msg1_x", expression(new FieldReference(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L))))
                                                         .buildOrThrow(),
                                                 values("msg1")))));
     }
@@ -702,8 +702,8 @@ public class TestPushDownDereferencesRules
                 .on(p ->
                         p.project(
                                 Assignments.builder()
-                                        .put(p.symbol("msg1_x"), new Subscript(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L)))
-                                        .put(p.symbol("msg2_x"), new Subscript(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 1L)))
+                                        .put(p.symbol("msg1_x"), new FieldReference(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L)))
+                                        .put(p.symbol("msg2_x"), new FieldReference(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 1L)))
                                         .build(),
                                 p.markDistinct(
                                         p.symbol("is_distinct", BOOLEAN),
@@ -713,7 +713,7 @@ public class TestPushDownDereferencesRules
                         strictProject(
                                 ImmutableMap.of(
                                         "msg1_x", expression(new Reference(BIGINT, "expr")), // pushed down
-                                        "msg2_x", expression(new Subscript(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 1L)))),   // not pushed down because used in markDistinct
+                                        "msg2_x", expression(new FieldReference(new Reference(ROW_TYPE, "msg2"), new Constant(INTEGER, 1L)))),   // not pushed down because used in markDistinct
                                 markDistinct(
                                         "is_distinct",
                                         singletonList("msg2"),
@@ -721,7 +721,7 @@ public class TestPushDownDereferencesRules
                                                 ImmutableMap.<String, ExpressionMatcher>builder()
                                                         .put("msg1", expression(new Reference(ROW_TYPE, "msg1")))
                                                         .put("msg2", expression(new Reference(ROW_TYPE, "msg2")))
-                                                        .put("expr", expression(new Subscript(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L))))
+                                                        .put("expr", expression(new FieldReference(new Reference(ROW_TYPE, "msg1"), new Constant(INTEGER, 1L))))
                                                         .buildOrThrow(),
                                                 values("msg1", "msg2")))));
     }
@@ -734,7 +734,7 @@ public class TestPushDownDereferencesRules
                 .on(p ->
                         p.project(
                                 Assignments.of(
-                                        p.symbol("expr_1"), new Subscript(new Reference(complexType, "a"), new Constant(INTEGER, 1L)),
+                                        p.symbol("expr_1"), new FieldReference(new Reference(complexType, "a"), new Constant(INTEGER, 1L)),
                                         p.symbol("expr_2"), new Arithmetic(
                                                 ADD_BIGINT,
                                                 ADD,
@@ -744,19 +744,19 @@ public class TestPushDownDereferencesRules
                                                         new Arithmetic(
                                                                 ADD_BIGINT,
                                                                 ADD,
-                                                                new Subscript(
-                                                                        new Subscript(
+                                                                new FieldReference(
+                                                                        new FieldReference(
                                                                                 new Reference(complexType, "a"),
                                                                                 new Constant(INTEGER, 1L)),
                                                                         new Constant(INTEGER, 1L)),
                                                                 new Constant(BIGINT, 2L)),
-                                                        new Subscript(
-                                                                new Subscript(
+                                                        new FieldReference(
+                                                                new FieldReference(
                                                                         new Reference(complexType, "b"),
                                                                         new Constant(INTEGER, 1L)),
                                                                 new Constant(INTEGER, 1L))),
-                                                new Subscript(
-                                                        new Subscript(
+                                                new FieldReference(
+                                                        new FieldReference(
                                                                 new Reference(complexType, "b"),
                                                                 new Constant(INTEGER, 1L)),
                                                         new Constant(INTEGER, 2L)))),
@@ -767,14 +767,14 @@ public class TestPushDownDereferencesRules
                         strictProject(
                                 ImmutableMap.of(
                                         "expr_1", expression(new Reference(complexType.getFields().get(0).getType(), "a_f1")),
-                                        "expr_2", expression(new Arithmetic(ADD_BIGINT, ADD, new Arithmetic(ADD_BIGINT, ADD, new Arithmetic(ADD_BIGINT, ADD, new Subscript(new Reference(complexType.getFields().get(0).getType(), "a_f1"), new Constant(INTEGER, 1L)), new Constant(BIGINT, 2L)), new Reference(BIGINT, "b_f1_f1")), new Reference(BIGINT, "b_f1_f2")))),
+                                        "expr_2", expression(new Arithmetic(ADD_BIGINT, ADD, new Arithmetic(ADD_BIGINT, ADD, new Arithmetic(ADD_BIGINT, ADD, new FieldReference(new Reference(complexType.getFields().get(0).getType(), "a_f1"), new Constant(INTEGER, 1L)), new Constant(BIGINT, 2L)), new Reference(BIGINT, "b_f1_f1")), new Reference(BIGINT, "b_f1_f2")))),
                                 strictProject(
                                         ImmutableMap.of(
                                                 "a", expression(new Reference(complexType, "a")),
                                                 "b", expression(new Reference(complexType, "b")),
-                                                "a_f1", expression(new Subscript(new Reference(complexType, "a"), new Constant(INTEGER, 1L))),
-                                                "b_f1_f1", expression(new Subscript(new Subscript(new Reference(complexType, "b"), new Constant(INTEGER, 1L)), new Constant(INTEGER, 1L))),
-                                                "b_f1_f2", expression(new Subscript(new Subscript(new Reference(complexType, "b"), new Constant(INTEGER, 1L)), new Constant(INTEGER, 2L)))),
+                                                "a_f1", expression(new FieldReference(new Reference(complexType, "a"), new Constant(INTEGER, 1L))),
+                                                "b_f1_f1", expression(new FieldReference(new FieldReference(new Reference(complexType, "b"), new Constant(INTEGER, 1L)), new Constant(INTEGER, 1L))),
+                                                "b_f1_f2", expression(new FieldReference(new FieldReference(new Reference(complexType, "b"), new Constant(INTEGER, 1L)), new Constant(INTEGER, 2L)))),
                                         values("a", "b"))));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushLimitThroughProject.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushLimitThroughProject.java
@@ -21,8 +21,8 @@ import io.trino.spi.function.OperatorType;
 import io.trino.spi.type.RowType;
 import io.trino.sql.ir.Arithmetic;
 import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.plan.Assignments;
@@ -159,8 +159,8 @@ public class TestPushLimitThroughProject
                     return p.limit(1,
                             p.project(
                                     Assignments.of(
-                                            p.symbol("b"), new Subscript(a.toSymbolReference(), new Constant(INTEGER, 1L)),
-                                            p.symbol("c"), new Subscript(a.toSymbolReference(), new Constant(INTEGER, 2L))),
+                                            p.symbol("b"), new FieldReference(a.toSymbolReference(), new Constant(INTEGER, 1L)),
+                                            p.symbol("c"), new FieldReference(a.toSymbolReference(), new Constant(INTEGER, 2L))),
                                     p.values(a)));
                 })
                 .doesNotFire();
@@ -222,13 +222,13 @@ public class TestPushLimitThroughProject
                     return p.limit(1,
                             p.project(
                                     Assignments.of(
-                                            p.symbol("b"), new Subscript(a.toSymbolReference(), new Constant(INTEGER, 1L)),
+                                            p.symbol("b"), new FieldReference(a.toSymbolReference(), new Constant(INTEGER, 1L)),
                                             p.symbol("c", rowType), a.toSymbolReference()),
                                     p.values(a)));
                 })
                 .matches(
                         project(
-                                ImmutableMap.of("b", io.trino.sql.planner.assertions.PlanMatchPattern.expression(new Subscript(new Reference(rowType, "a"), new Constant(INTEGER, 1L))), "c", expression(new Reference(rowType, "a"))),
+                                ImmutableMap.of("b", io.trino.sql.planner.assertions.PlanMatchPattern.expression(new FieldReference(new Reference(rowType, "a"), new Constant(INTEGER, 1L))), "c", expression(new Reference(rowType, "a"))),
                                 limit(1,
                                         values("a"))));
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushLimitThroughProject.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushLimitThroughProject.java
@@ -20,7 +20,6 @@ import io.trino.metadata.TestingFunctionResolution;
 import io.trino.spi.function.OperatorType;
 import io.trino.spi.type.RowType;
 import io.trino.sql.ir.Arithmetic;
-import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.planner.Symbol;
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.Test;
 import java.util.Optional;
 
 import static io.trino.spi.type.BigintType.BIGINT;
-import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.sql.ir.Arithmetic.Operator.ADD;
 import static io.trino.sql.ir.Booleans.TRUE;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
@@ -159,8 +157,8 @@ public class TestPushLimitThroughProject
                     return p.limit(1,
                             p.project(
                                     Assignments.of(
-                                            p.symbol("b"), new FieldReference(a.toSymbolReference(), new Constant(INTEGER, 1L)),
-                                            p.symbol("c"), new FieldReference(a.toSymbolReference(), new Constant(INTEGER, 2L))),
+                                            p.symbol("b"), new FieldReference(a.toSymbolReference(), 0),
+                                            p.symbol("c"), new FieldReference(a.toSymbolReference(), 1)),
                                     p.values(a)));
                 })
                 .doesNotFire();
@@ -222,13 +220,13 @@ public class TestPushLimitThroughProject
                     return p.limit(1,
                             p.project(
                                     Assignments.of(
-                                            p.symbol("b"), new FieldReference(a.toSymbolReference(), new Constant(INTEGER, 1L)),
+                                            p.symbol("b"), new FieldReference(a.toSymbolReference(), 0),
                                             p.symbol("c", rowType), a.toSymbolReference()),
                                     p.values(a)));
                 })
                 .matches(
                         project(
-                                ImmutableMap.of("b", io.trino.sql.planner.assertions.PlanMatchPattern.expression(new FieldReference(new Reference(rowType, "a"), new Constant(INTEGER, 1L))), "c", expression(new Reference(rowType, "a"))),
+                                ImmutableMap.of("b", io.trino.sql.planner.assertions.PlanMatchPattern.expression(new FieldReference(new Reference(rowType, "a"), 0)), "c", expression(new Reference(rowType, "a"))),
                                 limit(1,
                                         values("a"))));
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushProjectionIntoTableScan.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushProjectionIntoTableScan.java
@@ -101,7 +101,7 @@ public class TestPushProjectionIntoTableScan
                     .on(p -> {
                         Symbol symbol = p.symbol(columnName, columnType);
                         return p.project(
-                                Assignments.of(p.symbol("symbol_dereference", BIGINT), new FieldReference(symbol.toSymbolReference(), new Constant(INTEGER, 1L))),
+                                Assignments.of(p.symbol("symbol_dereference", BIGINT), new FieldReference(symbol.toSymbolReference(), 0)),
                                 p.tableScan(
                                         ruleTester.getCurrentCatalogTableHandle(TEST_SCHEMA, TEST_TABLE),
                                         ImmutableList.of(symbol),
@@ -136,7 +136,7 @@ public class TestPushProjectionIntoTableScan
             // Prepare project node assignments
             Assignments inputProjections = Assignments.builder()
                     .put(identity, baseColumn.toSymbolReference())
-                    .put(dereference, new FieldReference(baseColumn.toSymbolReference(), new Constant(INTEGER, 1L)))
+                    .put(dereference, new FieldReference(baseColumn.toSymbolReference(), 0))
                     .put(constant, new Constant(INTEGER, 5L))
                     .build();
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushProjectionIntoTableScan.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushProjectionIntoTableScan.java
@@ -42,8 +42,8 @@ import io.trino.spi.type.Type;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.rule.test.RuleTester;
 import io.trino.sql.planner.plan.Assignments;
@@ -101,7 +101,7 @@ public class TestPushProjectionIntoTableScan
                     .on(p -> {
                         Symbol symbol = p.symbol(columnName, columnType);
                         return p.project(
-                                Assignments.of(p.symbol("symbol_dereference", BIGINT), new Subscript(symbol.toSymbolReference(), new Constant(INTEGER, 1L))),
+                                Assignments.of(p.symbol("symbol_dereference", BIGINT), new FieldReference(symbol.toSymbolReference(), new Constant(INTEGER, 1L))),
                                 p.tableScan(
                                         ruleTester.getCurrentCatalogTableHandle(TEST_SCHEMA, TEST_TABLE),
                                         ImmutableList.of(symbol),
@@ -136,7 +136,7 @@ public class TestPushProjectionIntoTableScan
             // Prepare project node assignments
             Assignments inputProjections = Assignments.builder()
                     .put(identity, baseColumn.toSymbolReference())
-                    .put(dereference, new Subscript(baseColumn.toSymbolReference(), new Constant(INTEGER, 1L)))
+                    .put(dereference, new FieldReference(baseColumn.toSymbolReference(), new Constant(INTEGER, 1L)))
                     .put(constant, new Constant(INTEGER, 5L))
                     .build();
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushProjectionThroughUnion.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushProjectionThroughUnion.java
@@ -96,7 +96,7 @@ public class TestPushProjectionThroughUnion
                     return p.project(
                             Assignments.of(
                                     cTimes3, new Arithmetic(MULTIPLY_BIGINT, MULTIPLY, c.toSymbolReference(), new Constant(BIGINT, 3L)),
-                                    dX, new FieldReference(new Reference(ROW_TYPE, "d"), new Constant(INTEGER, 1L))),
+                                    dX, new FieldReference(new Reference(ROW_TYPE, "d"), 0)),
                             p.union(
                                     ImmutableListMultimap.<Symbol, Symbol>builder()
                                             .put(c, a)
@@ -111,10 +111,10 @@ public class TestPushProjectionThroughUnion
                 .matches(
                         union(
                                 project(
-                                        ImmutableMap.of("a_times_3", expression(new Arithmetic(MULTIPLY_BIGINT, MULTIPLY, new Reference(BIGINT, "a"), new Constant(BIGINT, 3L))), "z_x", expression(new FieldReference(new Reference(ROW_TYPE, "z"), new Constant(INTEGER, 1L)))),
+                                        ImmutableMap.of("a_times_3", expression(new Arithmetic(MULTIPLY_BIGINT, MULTIPLY, new Reference(BIGINT, "a"), new Constant(BIGINT, 3L))), "z_x", expression(new FieldReference(new Reference(ROW_TYPE, "z"), 0))),
                                         values(ImmutableList.of("a", "z"))),
                                 project(
-                                        ImmutableMap.of("b_times_3", expression(new Arithmetic(MULTIPLY_BIGINT, MULTIPLY, new Reference(BIGINT, "b"), new Constant(BIGINT, 3L))), "w_x", expression(new FieldReference(new Reference(ROW_TYPE, "w"), new Constant(INTEGER, 1L)))),
+                                        ImmutableMap.of("b_times_3", expression(new Arithmetic(MULTIPLY_BIGINT, MULTIPLY, new Reference(BIGINT, "b"), new Constant(BIGINT, 3L))), "w_x", expression(new FieldReference(new Reference(ROW_TYPE, "w"), 0))),
                                         values(ImmutableList.of("b", "w"))))
                                 .withNumberOfOutputColumns(2)
                                 .withAlias("a_times_3")

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushProjectionThroughUnion.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushProjectionThroughUnion.java
@@ -22,8 +22,8 @@ import io.trino.spi.function.OperatorType;
 import io.trino.spi.type.RowType;
 import io.trino.sql.ir.Arithmetic;
 import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.plan.Assignments;
@@ -96,7 +96,7 @@ public class TestPushProjectionThroughUnion
                     return p.project(
                             Assignments.of(
                                     cTimes3, new Arithmetic(MULTIPLY_BIGINT, MULTIPLY, c.toSymbolReference(), new Constant(BIGINT, 3L)),
-                                    dX, new Subscript(new Reference(ROW_TYPE, "d"), new Constant(INTEGER, 1L))),
+                                    dX, new FieldReference(new Reference(ROW_TYPE, "d"), new Constant(INTEGER, 1L))),
                             p.union(
                                     ImmutableListMultimap.<Symbol, Symbol>builder()
                                             .put(c, a)
@@ -111,10 +111,10 @@ public class TestPushProjectionThroughUnion
                 .matches(
                         union(
                                 project(
-                                        ImmutableMap.of("a_times_3", expression(new Arithmetic(MULTIPLY_BIGINT, MULTIPLY, new Reference(BIGINT, "a"), new Constant(BIGINT, 3L))), "z_x", expression(new Subscript(new Reference(ROW_TYPE, "z"), new Constant(INTEGER, 1L)))),
+                                        ImmutableMap.of("a_times_3", expression(new Arithmetic(MULTIPLY_BIGINT, MULTIPLY, new Reference(BIGINT, "a"), new Constant(BIGINT, 3L))), "z_x", expression(new FieldReference(new Reference(ROW_TYPE, "z"), new Constant(INTEGER, 1L)))),
                                         values(ImmutableList.of("a", "z"))),
                                 project(
-                                        ImmutableMap.of("b_times_3", expression(new Arithmetic(MULTIPLY_BIGINT, MULTIPLY, new Reference(BIGINT, "b"), new Constant(BIGINT, 3L))), "w_x", expression(new Subscript(new Reference(ROW_TYPE, "w"), new Constant(INTEGER, 1L)))),
+                                        ImmutableMap.of("b_times_3", expression(new Arithmetic(MULTIPLY_BIGINT, MULTIPLY, new Reference(BIGINT, "b"), new Constant(BIGINT, 3L))), "w_x", expression(new FieldReference(new Reference(ROW_TYPE, "w"), new Constant(INTEGER, 1L)))),
                                         values(ImmutableList.of("b", "w"))))
                                 .withNumberOfOutputColumns(2)
                                 .withAlias("a_times_3")

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushTopNThroughProject.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushTopNThroughProject.java
@@ -21,7 +21,6 @@ import io.trino.spi.function.OperatorType;
 import io.trino.spi.type.RowType;
 import io.trino.sql.ir.Arithmetic;
 import io.trino.sql.ir.Booleans;
-import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.planner.Symbol;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.Test;
 import java.util.Optional;
 
 import static io.trino.spi.type.BigintType.BIGINT;
-import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.sql.ir.Arithmetic.Operator.ADD;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
@@ -161,8 +159,8 @@ public class TestPushTopNThroughProject
                             ImmutableList.of(p.symbol("c")),
                             p.project(
                                     Assignments.builder()
-                                            .put(p.symbol("b"), new FieldReference(a.toSymbolReference(), new Constant(INTEGER, 1L)))
-                                            .put(p.symbol("c"), new FieldReference(a.toSymbolReference(), new Constant(INTEGER, 2L)))
+                                            .put(p.symbol("b"), new FieldReference(a.toSymbolReference(), 0))
+                                            .put(p.symbol("c"), new FieldReference(a.toSymbolReference(), 1))
                                             .build(),
                                     p.values(a)));
                 }).doesNotFire();
@@ -180,7 +178,7 @@ public class TestPushTopNThroughProject
                             ImmutableList.of(d),
                             p.project(
                                     Assignments.builder()
-                                            .put(p.symbol("b"), new FieldReference(a.toSymbolReference(), new Constant(INTEGER, 1L)))
+                                            .put(p.symbol("b"), new FieldReference(a.toSymbolReference(), 0))
                                             .put(p.symbol("c", rowType), a.toSymbolReference())
                                             .putIdentity(d)
                                             .build(),
@@ -188,7 +186,7 @@ public class TestPushTopNThroughProject
                 })
                 .matches(
                         project(
-                                ImmutableMap.of("b", expression(new FieldReference(new Reference(rowType, "a"), new Constant(INTEGER, 1L))), "c", expression(new Reference(BIGINT, "a")), "d", expression(new Reference(BIGINT, "d"))),
+                                ImmutableMap.of("b", expression(new FieldReference(new Reference(rowType, "a"), 0)), "c", expression(new Reference(BIGINT, "a")), "d", expression(new Reference(BIGINT, "d"))),
                                 topN(
                                         1,
                                         ImmutableList.of(sort("d", ASCENDING, FIRST)),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushTopNThroughProject.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushTopNThroughProject.java
@@ -22,8 +22,8 @@ import io.trino.spi.type.RowType;
 import io.trino.sql.ir.Arithmetic;
 import io.trino.sql.ir.Booleans;
 import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.plan.Assignments;
@@ -161,8 +161,8 @@ public class TestPushTopNThroughProject
                             ImmutableList.of(p.symbol("c")),
                             p.project(
                                     Assignments.builder()
-                                            .put(p.symbol("b"), new Subscript(a.toSymbolReference(), new Constant(INTEGER, 1L)))
-                                            .put(p.symbol("c"), new Subscript(a.toSymbolReference(), new Constant(INTEGER, 2L)))
+                                            .put(p.symbol("b"), new FieldReference(a.toSymbolReference(), new Constant(INTEGER, 1L)))
+                                            .put(p.symbol("c"), new FieldReference(a.toSymbolReference(), new Constant(INTEGER, 2L)))
                                             .build(),
                                     p.values(a)));
                 }).doesNotFire();
@@ -180,7 +180,7 @@ public class TestPushTopNThroughProject
                             ImmutableList.of(d),
                             p.project(
                                     Assignments.builder()
-                                            .put(p.symbol("b"), new Subscript(a.toSymbolReference(), new Constant(INTEGER, 1L)))
+                                            .put(p.symbol("b"), new FieldReference(a.toSymbolReference(), new Constant(INTEGER, 1L)))
                                             .put(p.symbol("c", rowType), a.toSymbolReference())
                                             .putIdentity(d)
                                             .build(),
@@ -188,7 +188,7 @@ public class TestPushTopNThroughProject
                 })
                 .matches(
                         project(
-                                ImmutableMap.of("b", expression(new Subscript(new Reference(rowType, "a"), new Constant(INTEGER, 1L))), "c", expression(new Reference(BIGINT, "a")), "d", expression(new Reference(BIGINT, "d"))),
+                                ImmutableMap.of("b", expression(new FieldReference(new Reference(rowType, "a"), new Constant(INTEGER, 1L))), "c", expression(new Reference(BIGINT, "a")), "d", expression(new Reference(BIGINT, "d"))),
                                 topN(
                                         1,
                                         ImmutableList.of(sort("d", ASCENDING, FIRST)),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestUnwrapRowSubscript.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestUnwrapRowSubscript.java
@@ -41,20 +41,20 @@ public class TestUnwrapRowSubscript
     @Test
     public void testSimpleSubscript()
     {
-        test(new FieldReference(new Row(ImmutableList.of(new Constant(INTEGER, 1L))), new Constant(INTEGER, 1L)), new Constant(INTEGER, 1L));
-        test(new FieldReference(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), new Constant(INTEGER, 1L)), new Constant(INTEGER, 1L));
-        test(new FieldReference(new FieldReference(new Row(ImmutableList.of(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), new Constant(INTEGER, 3L))), new Constant(INTEGER, 1L)), new Constant(INTEGER, 2L)), new Constant(INTEGER, 2L));
+        test(new FieldReference(new Row(ImmutableList.of(new Constant(INTEGER, 1L))), 0), new Constant(INTEGER, 1L));
+        test(new FieldReference(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), 0), new Constant(INTEGER, 1L));
+        test(new FieldReference(new FieldReference(new Row(ImmutableList.of(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), new Constant(INTEGER, 3L))), 0), 1), new Constant(INTEGER, 2L));
     }
 
     @Test
     public void testWithCast()
     {
         test(
-                new FieldReference(new Cast(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), rowType(field("a", BIGINT), field("b", BIGINT))), new Constant(INTEGER, 1L)),
+                new FieldReference(new Cast(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), rowType(field("a", BIGINT), field("b", BIGINT))), 0),
                 new Cast(new Constant(INTEGER, 1L), BIGINT));
 
         test(
-                new FieldReference(new Cast(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), anonymousRow(BIGINT, BIGINT)), new Constant(INTEGER, 1L)),
+                new FieldReference(new Cast(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), anonymousRow(BIGINT, BIGINT)), 0),
                 new Cast(new Constant(INTEGER, 1L), BIGINT));
 
         test(
@@ -63,9 +63,9 @@ public class TestUnwrapRowSubscript
                                 new Cast(
                                         new Row(ImmutableList.of(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), new Constant(INTEGER, 3L))),
                                         anonymousRow(anonymousRow(SMALLINT, SMALLINT), BIGINT)),
-                                new Constant(INTEGER, 1L)),
+                                0),
                                 rowType(field("x", BIGINT), field("y", BIGINT))),
-                        new Constant(INTEGER, 2L)),
+                        1),
                 new Cast(new Cast(new Constant(INTEGER, 2L), SMALLINT), BIGINT));
     }
 
@@ -73,15 +73,15 @@ public class TestUnwrapRowSubscript
     public void testWithTryCast()
     {
         test(
-                new FieldReference(new Cast(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), rowType(field("a", BIGINT), field("b", BIGINT)), true), new Constant(INTEGER, 1L)),
+                new FieldReference(new Cast(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), rowType(field("a", BIGINT), field("b", BIGINT)), true), 0),
                 new Cast(new Constant(INTEGER, 1L), BIGINT, true));
 
         test(
-                new FieldReference(new Cast(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), anonymousRow(BIGINT, BIGINT), true), new Constant(INTEGER, 1L)),
+                new FieldReference(new Cast(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), anonymousRow(BIGINT, BIGINT), true), 0),
                 new Cast(new Constant(INTEGER, 1L), BIGINT, true));
 
         test(
-                new FieldReference(new Cast(new FieldReference(new Cast(new Row(ImmutableList.of(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), new Constant(INTEGER, 3L))), anonymousRow(anonymousRow(SMALLINT, SMALLINT), BIGINT), true), new Constant(INTEGER, 1L)), rowType(field("x", BIGINT), field("y", BIGINT)), true), new Constant(INTEGER, 2L)),
+                new FieldReference(new Cast(new FieldReference(new Cast(new Row(ImmutableList.of(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), new Constant(INTEGER, 3L))), anonymousRow(anonymousRow(SMALLINT, SMALLINT), BIGINT), true), 0), rowType(field("x", BIGINT), field("y", BIGINT)), true), 1),
                 new Cast(new Cast(new Constant(INTEGER, 2L), SMALLINT, true), BIGINT, true));
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestUnwrapRowSubscript.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestUnwrapRowSubscript.java
@@ -17,8 +17,8 @@ import com.google.common.collect.ImmutableList;
 import io.trino.sql.ir.Cast;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Row;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.assertions.PlanMatchPattern;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.plan.Assignments;
@@ -41,25 +41,25 @@ public class TestUnwrapRowSubscript
     @Test
     public void testSimpleSubscript()
     {
-        test(new Subscript(new Row(ImmutableList.of(new Constant(INTEGER, 1L))), new Constant(INTEGER, 1L)), new Constant(INTEGER, 1L));
-        test(new Subscript(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), new Constant(INTEGER, 1L)), new Constant(INTEGER, 1L));
-        test(new Subscript(new Subscript(new Row(ImmutableList.of(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), new Constant(INTEGER, 3L))), new Constant(INTEGER, 1L)), new Constant(INTEGER, 2L)), new Constant(INTEGER, 2L));
+        test(new FieldReference(new Row(ImmutableList.of(new Constant(INTEGER, 1L))), new Constant(INTEGER, 1L)), new Constant(INTEGER, 1L));
+        test(new FieldReference(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), new Constant(INTEGER, 1L)), new Constant(INTEGER, 1L));
+        test(new FieldReference(new FieldReference(new Row(ImmutableList.of(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), new Constant(INTEGER, 3L))), new Constant(INTEGER, 1L)), new Constant(INTEGER, 2L)), new Constant(INTEGER, 2L));
     }
 
     @Test
     public void testWithCast()
     {
         test(
-                new Subscript(new Cast(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), rowType(field("a", BIGINT), field("b", BIGINT))), new Constant(INTEGER, 1L)),
+                new FieldReference(new Cast(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), rowType(field("a", BIGINT), field("b", BIGINT))), new Constant(INTEGER, 1L)),
                 new Cast(new Constant(INTEGER, 1L), BIGINT));
 
         test(
-                new Subscript(new Cast(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), anonymousRow(BIGINT, BIGINT)), new Constant(INTEGER, 1L)),
+                new FieldReference(new Cast(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), anonymousRow(BIGINT, BIGINT)), new Constant(INTEGER, 1L)),
                 new Cast(new Constant(INTEGER, 1L), BIGINT));
 
         test(
-                new Subscript(
-                        new Cast(new Subscript(
+                new FieldReference(
+                        new Cast(new FieldReference(
                                 new Cast(
                                         new Row(ImmutableList.of(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), new Constant(INTEGER, 3L))),
                                         anonymousRow(anonymousRow(SMALLINT, SMALLINT), BIGINT)),
@@ -73,15 +73,15 @@ public class TestUnwrapRowSubscript
     public void testWithTryCast()
     {
         test(
-                new Subscript(new Cast(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), rowType(field("a", BIGINT), field("b", BIGINT)), true), new Constant(INTEGER, 1L)),
+                new FieldReference(new Cast(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), rowType(field("a", BIGINT), field("b", BIGINT)), true), new Constant(INTEGER, 1L)),
                 new Cast(new Constant(INTEGER, 1L), BIGINT, true));
 
         test(
-                new Subscript(new Cast(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), anonymousRow(BIGINT, BIGINT), true), new Constant(INTEGER, 1L)),
+                new FieldReference(new Cast(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), anonymousRow(BIGINT, BIGINT), true), new Constant(INTEGER, 1L)),
                 new Cast(new Constant(INTEGER, 1L), BIGINT, true));
 
         test(
-                new Subscript(new Cast(new Subscript(new Cast(new Row(ImmutableList.of(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), new Constant(INTEGER, 3L))), anonymousRow(anonymousRow(SMALLINT, SMALLINT), BIGINT), true), new Constant(INTEGER, 1L)), rowType(field("x", BIGINT), field("y", BIGINT)), true), new Constant(INTEGER, 2L)),
+                new FieldReference(new Cast(new FieldReference(new Cast(new Row(ImmutableList.of(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(INTEGER, 2L))), new Constant(INTEGER, 3L))), anonymousRow(anonymousRow(SMALLINT, SMALLINT), BIGINT), true), new Constant(INTEGER, 1L)), rowType(field("x", BIGINT), field("y", BIGINT)), true), new Constant(INTEGER, 2L)),
                 new Cast(new Cast(new Constant(INTEGER, 2L), SMALLINT, true), BIGINT, true));
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestUnwrapSingleColumnRowInApply.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestUnwrapSingleColumnRowInApply.java
@@ -15,7 +15,6 @@ package io.trino.sql.planner.iterative.rule;
 
 import com.google.common.collect.ImmutableMap;
 import io.trino.spi.type.RowType;
-import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.planner.Symbol;
@@ -83,13 +82,13 @@ public class TestUnwrapSingleColumnRowInApply
                                                 .buildOrThrow(),
                                         project(
                                                 ImmutableMap.<String, ExpressionMatcher>builder()
-                                                        .put("unwrappedValue", expression(new FieldReference(new Reference(RowType.anonymousRow(INTEGER), "rowValue"), new Constant(INTEGER, 1L))))
+                                                        .put("unwrappedValue", expression(new FieldReference(new Reference(RowType.anonymousRow(INTEGER), "rowValue"), 0)))
                                                         .put("nonRowValue", expression(new Reference(INTEGER, "nonRowValue")))
                                                         .buildOrThrow(),
                                                 values("rowValue", "nonRowValue")),
                                         project(
                                                 ImmutableMap.<String, ExpressionMatcher>builder()
-                                                        .put("unwrappedElement", expression(new FieldReference(new Reference(RowType.anonymousRow(INTEGER), "rowElement"), new Constant(INTEGER, 1L))))
+                                                        .put("unwrappedElement", expression(new FieldReference(new Reference(RowType.anonymousRow(INTEGER), "rowElement"), 0)))
                                                         .put("nonRowElement", expression(new Reference(INTEGER, "nonRowElement")))
                                                         .buildOrThrow(),
                                                 values("rowElement", "nonRowElement")))));
@@ -121,13 +120,13 @@ public class TestUnwrapSingleColumnRowInApply
                                                 .buildOrThrow(),
                                         project(
                                                 ImmutableMap.<String, ExpressionMatcher>builder()
-                                                        .put("unwrappedValue", expression(new FieldReference(new Reference(RowType.anonymousRow(INTEGER), "rowValue"), new Constant(INTEGER, 1L))))
+                                                        .put("unwrappedValue", expression(new FieldReference(new Reference(RowType.anonymousRow(INTEGER), "rowValue"), 0)))
                                                         .put("nonRowValue", expression(new Reference(INTEGER, "nonRowValue")))
                                                         .buildOrThrow(),
                                                 values("rowValue", "nonRowValue")),
                                         project(
                                                 ImmutableMap.<String, ExpressionMatcher>builder()
-                                                        .put("unwrappedElement", expression(new FieldReference(new Reference(RowType.anonymousRow(INTEGER), "rowElement"), new Constant(INTEGER, 1L))))
+                                                        .put("unwrappedElement", expression(new FieldReference(new Reference(RowType.anonymousRow(INTEGER), "rowElement"), 0)))
                                                         .put("nonRowElement", expression(new Reference(INTEGER, "nonRowElement")))
                                                         .buildOrThrow(),
                                                 values("rowElement", "nonRowElement")))));

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestUnwrapSingleColumnRowInApply.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestUnwrapSingleColumnRowInApply.java
@@ -16,8 +16,8 @@ package io.trino.sql.planner.iterative.rule;
 import com.google.common.collect.ImmutableMap;
 import io.trino.spi.type.RowType;
 import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.assertions.ExpressionMatcher;
 import io.trino.sql.planner.assertions.SetExpressionMatcher;
@@ -83,13 +83,13 @@ public class TestUnwrapSingleColumnRowInApply
                                                 .buildOrThrow(),
                                         project(
                                                 ImmutableMap.<String, ExpressionMatcher>builder()
-                                                        .put("unwrappedValue", expression(new Subscript(new Reference(RowType.anonymousRow(INTEGER), "rowValue"), new Constant(INTEGER, 1L))))
+                                                        .put("unwrappedValue", expression(new FieldReference(new Reference(RowType.anonymousRow(INTEGER), "rowValue"), new Constant(INTEGER, 1L))))
                                                         .put("nonRowValue", expression(new Reference(INTEGER, "nonRowValue")))
                                                         .buildOrThrow(),
                                                 values("rowValue", "nonRowValue")),
                                         project(
                                                 ImmutableMap.<String, ExpressionMatcher>builder()
-                                                        .put("unwrappedElement", expression(new Subscript(new Reference(RowType.anonymousRow(INTEGER), "rowElement"), new Constant(INTEGER, 1L))))
+                                                        .put("unwrappedElement", expression(new FieldReference(new Reference(RowType.anonymousRow(INTEGER), "rowElement"), new Constant(INTEGER, 1L))))
                                                         .put("nonRowElement", expression(new Reference(INTEGER, "nonRowElement")))
                                                         .buildOrThrow(),
                                                 values("rowElement", "nonRowElement")))));
@@ -121,13 +121,13 @@ public class TestUnwrapSingleColumnRowInApply
                                                 .buildOrThrow(),
                                         project(
                                                 ImmutableMap.<String, ExpressionMatcher>builder()
-                                                        .put("unwrappedValue", expression(new Subscript(new Reference(RowType.anonymousRow(INTEGER), "rowValue"), new Constant(INTEGER, 1L))))
+                                                        .put("unwrappedValue", expression(new FieldReference(new Reference(RowType.anonymousRow(INTEGER), "rowValue"), new Constant(INTEGER, 1L))))
                                                         .put("nonRowValue", expression(new Reference(INTEGER, "nonRowValue")))
                                                         .buildOrThrow(),
                                                 values("rowValue", "nonRowValue")),
                                         project(
                                                 ImmutableMap.<String, ExpressionMatcher>builder()
-                                                        .put("unwrappedElement", expression(new Subscript(new Reference(RowType.anonymousRow(INTEGER), "rowElement"), new Constant(INTEGER, 1L))))
+                                                        .put("unwrappedElement", expression(new FieldReference(new Reference(RowType.anonymousRow(INTEGER), "rowElement"), new Constant(INTEGER, 1L))))
                                                         .put("nonRowElement", expression(new Reference(INTEGER, "nonRowElement")))
                                                         .buildOrThrow(),
                                                 values("rowElement", "nonRowElement")))));

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestPartialTopNWithPresortedInput.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestPartialTopNWithPresortedInput.java
@@ -29,8 +29,8 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.RowType;
 import io.trino.sql.ir.Comparison;
 import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.assertions.BasePlanTest;
 import io.trino.sql.planner.assertions.PlanMatchPattern;
 import io.trino.testing.PlanTester;
@@ -208,9 +208,9 @@ public class TestPartialTopNWithPresortedInput
                         topN(1, ImmutableList.of(sort("k", ASCENDING, LAST)), FINAL,
                                 anyTree(
                                         limit(1, ImmutableList.of(), true, ImmutableList.of("k"),
-                                                project(ImmutableMap.of("k", expression(new Subscript(new Reference(RowType.from(ImmutableList.of(RowType.field("k", INTEGER))), "nested"), new Constant(INTEGER, 1L)))),
+                                                project(ImmutableMap.of("k", expression(new FieldReference(new Reference(RowType.from(ImmutableList.of(RowType.field("k", INTEGER))), "nested"), new Constant(INTEGER, 1L)))),
                                                         filter(
-                                                                new Comparison(EQUAL, new Subscript(new Reference(RowType.from(ImmutableList.of(RowType.field("k", INTEGER))), "nested"), new Constant(INTEGER, 1L)), new Constant(INTEGER, 1L)),
+                                                                new Comparison(EQUAL, new FieldReference(new Reference(RowType.from(ImmutableList.of(RowType.field("k", INTEGER))), "nested"), new Constant(INTEGER, 1L)), new Constant(INTEGER, 1L)),
                                                                 tableScan("with_nested_field", ImmutableMap.of("nested", "nested")))))))));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestPartialTopNWithPresortedInput.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestPartialTopNWithPresortedInput.java
@@ -208,9 +208,9 @@ public class TestPartialTopNWithPresortedInput
                         topN(1, ImmutableList.of(sort("k", ASCENDING, LAST)), FINAL,
                                 anyTree(
                                         limit(1, ImmutableList.of(), true, ImmutableList.of("k"),
-                                                project(ImmutableMap.of("k", expression(new FieldReference(new Reference(RowType.from(ImmutableList.of(RowType.field("k", INTEGER))), "nested"), new Constant(INTEGER, 1L)))),
+                                                project(ImmutableMap.of("k", expression(new FieldReference(new Reference(RowType.from(ImmutableList.of(RowType.field("k", INTEGER))), "nested"), 0))),
                                                         filter(
-                                                                new Comparison(EQUAL, new FieldReference(new Reference(RowType.from(ImmutableList.of(RowType.field("k", INTEGER))), "nested"), new Constant(INTEGER, 1L)), new Constant(INTEGER, 1L)),
+                                                                new Comparison(EQUAL, new FieldReference(new Reference(RowType.from(ImmutableList.of(RowType.field("k", INTEGER))), "nested"), 0), new Constant(INTEGER, 1L)),
                                                                 tableScan("with_nested_field", ImmutableMap.of("nested", "nested")))))))));
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -2161,7 +2161,7 @@ public class TestDeltaLakeConnectorTest
                 sessionWithoutPushdown,
                 "EXPLAIN SELECT root.f2 FROM " + tableName,
                 "ScanProject\\[table = (.*)]",
-                "expr := root\\[integer '2']",
+                "expr := root.1",
                 "root := root:row\\(f1 bigint, f2 bigint\\):REGULAR");
 
         assertUpdate("DROP TABLE " + tableName);
@@ -2178,7 +2178,7 @@ public class TestDeltaLakeConnectorTest
         assertExplain(
                 "EXPLAIN SELECT id, _row.child, _array[1].child, _map[1] FROM " + tableName,
                 "ScanProject\\[table = (.*)]",
-                "expr(.*) := system\\.builtin\\.\\$operator\\$subscript\\(_array_.*, bigint '1'\\)\\[integer '1']",
+                "expr(.*) := system\\.builtin\\.\\$operator\\$subscript\\(_array_.*, bigint '1'\\).0",
                 "id(.*) := id:bigint:REGULAR",
                 // _array:array\\(row\\(child bigint\\)\\) is a symbol name, not a dereference expression.
                 "_array(.*) := _array:array\\(row\\(child bigint\\)\\):REGULAR",

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeProjectionPushdownPlans.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeProjectionPushdownPlans.java
@@ -148,7 +148,7 @@ public class TestDeltaLakeProjectionPushdownPlans
                 session,
                 any(
                         project(
-                                ImmutableMap.of("expr", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), new Constant(INTEGER, 1L))), "expr_2", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), new Constant(INTEGER, 2L)))),
+                                ImmutableMap.of("expr", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), 0)), "expr_2", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), 1))),
                                 tableScan(testTable, ImmutableMap.of("col0", "col0")))));
     }
 
@@ -226,9 +226,9 @@ public class TestDeltaLakeProjectionPushdownPlans
                 anyTree(
                         project(
                                 ImmutableMap.of(
-                                        "expr_0_x", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0"), new Constant(INTEGER, 1L))),
+                                        "expr_0_x", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0"), 0)),
                                         "expr_0", expression(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0")),
-                                        "expr_0_y", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0"), new Constant(INTEGER, 2L)))),
+                                        "expr_0_y", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0"), 1))),
                                 join(INNER, builder -> {
                                     PlanMatchPattern source = tableScan(
                                             table -> {

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeProjectionPushdownPlans.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeProjectionPushdownPlans.java
@@ -34,9 +34,9 @@ import io.trino.sql.ir.Arithmetic;
 import io.trino.sql.ir.Cast;
 import io.trino.sql.ir.Comparison;
 import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Logical;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.assertions.BasePushdownPlanTest;
 import io.trino.sql.planner.assertions.PlanMatchPattern;
 import io.trino.testing.PlanTester;
@@ -148,7 +148,7 @@ public class TestDeltaLakeProjectionPushdownPlans
                 session,
                 any(
                         project(
-                                ImmutableMap.of("expr", expression(new Subscript(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), new Constant(INTEGER, 1L))), "expr_2", expression(new Subscript(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), new Constant(INTEGER, 2L)))),
+                                ImmutableMap.of("expr", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), new Constant(INTEGER, 1L))), "expr_2", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), new Constant(INTEGER, 2L)))),
                                 tableScan(testTable, ImmutableMap.of("col0", "col0")))));
     }
 
@@ -226,9 +226,9 @@ public class TestDeltaLakeProjectionPushdownPlans
                 anyTree(
                         project(
                                 ImmutableMap.of(
-                                        "expr_0_x", expression(new Subscript(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0"), new Constant(INTEGER, 1L))),
+                                        "expr_0_x", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0"), new Constant(INTEGER, 1L))),
                                         "expr_0", expression(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0")),
-                                        "expr_0_y", expression(new Subscript(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0"), new Constant(INTEGER, 2L)))),
+                                        "expr_0_y", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0"), new Constant(INTEGER, 2L)))),
                                 join(INNER, builder -> {
                                     PlanMatchPattern source = tableScan(
                                             table -> {

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
@@ -40,9 +40,9 @@ import io.trino.sql.ir.Arithmetic;
 import io.trino.sql.ir.Comparison;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Negation;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.rule.PruneTableScanColumns;
 import io.trino.sql.planner.iterative.rule.PushPredicateIntoTableScan;
@@ -195,7 +195,7 @@ public class TestConnectorPushdownRulesWithHive
                 .on(p ->
                         p.project(
                                 Assignments.of(
-                                        p.symbol("expr_deref", BIGINT), new Subscript(p.symbol("struct_of_int", baseType).toSymbolReference(), new Constant(INTEGER, 1L))),
+                                        p.symbol("expr_deref", BIGINT), new FieldReference(p.symbol("struct_of_int", baseType).toSymbolReference(), new Constant(INTEGER, 1L))),
                                 p.tableScan(
                                         table,
                                         ImmutableList.of(p.symbol("struct_of_int", baseType)),
@@ -336,12 +336,12 @@ public class TestConnectorPushdownRulesWithHive
         // Test Dereference pushdown
         tester().assertThat(pushProjectionIntoTableScan)
                 .on(p -> {
-                    Subscript subscript = new Subscript(p.symbol("struct_of_bigint", ROW_TYPE).toSymbolReference(), new Constant(INTEGER, 1L));
-                    Expression sum = new Arithmetic(ADD_BIGINT, ADD, subscript, new Constant(BIGINT, 2L));
+                    FieldReference fieldReference = new FieldReference(p.symbol("struct_of_bigint", ROW_TYPE).toSymbolReference(), new Constant(INTEGER, 1L));
+                    Expression sum = new Arithmetic(ADD_BIGINT, ADD, fieldReference, new Constant(BIGINT, 2L));
                     return p.project(
                             Assignments.of(
                                     // The subscript expression instance is part of both the assignments
-                                    p.symbol("expr_deref", BIGINT), subscript,
+                                    p.symbol("expr_deref", BIGINT), fieldReference,
                                     p.symbol("expr_deref_2", BIGINT), sum),
                             p.tableScan(
                                     table,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
@@ -195,7 +195,7 @@ public class TestConnectorPushdownRulesWithHive
                 .on(p ->
                         p.project(
                                 Assignments.of(
-                                        p.symbol("expr_deref", BIGINT), new FieldReference(p.symbol("struct_of_int", baseType).toSymbolReference(), new Constant(INTEGER, 1L))),
+                                        p.symbol("expr_deref", BIGINT), new FieldReference(p.symbol("struct_of_int", baseType).toSymbolReference(), 0)),
                                 p.tableScan(
                                         table,
                                         ImmutableList.of(p.symbol("struct_of_int", baseType)),
@@ -336,7 +336,7 @@ public class TestConnectorPushdownRulesWithHive
         // Test Dereference pushdown
         tester().assertThat(pushProjectionIntoTableScan)
                 .on(p -> {
-                    FieldReference fieldReference = new FieldReference(p.symbol("struct_of_bigint", ROW_TYPE).toSymbolReference(), new Constant(INTEGER, 1L));
+                    FieldReference fieldReference = new FieldReference(p.symbol("struct_of_bigint", ROW_TYPE).toSymbolReference(), 0);
                     Expression sum = new Arithmetic(ADD_BIGINT, ADD, fieldReference, new Constant(BIGINT, 2L));
                     return p.project(
                             Assignments.of(

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestHiveProjectionPushdownIntoTableScan.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestHiveProjectionPushdownIntoTableScan.java
@@ -37,9 +37,9 @@ import io.trino.sql.ir.Arithmetic;
 import io.trino.sql.ir.Cast;
 import io.trino.sql.ir.Comparison;
 import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Logical;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.assertions.BasePushdownPlanTest;
 import io.trino.testing.PlanTester;
 import org.junit.jupiter.api.AfterAll;
@@ -134,8 +134,8 @@ public class TestHiveProjectionPushdownIntoTableScan
                 any(
                         project(
                                 ImmutableMap.of(
-                                        "expr", expression(new Subscript(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), new Constant(INTEGER, 1L))),
-                                        "expr_2", expression(new Subscript(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), new Constant(INTEGER, 2L)))),
+                                        "expr", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), new Constant(INTEGER, 1L))),
+                                        "expr_2", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), new Constant(INTEGER, 2L)))),
                                 tableScan(testTable, ImmutableMap.of("col0", "col0")))));
     }
 
@@ -214,9 +214,9 @@ public class TestHiveProjectionPushdownIntoTableScan
                 anyTree(
                         project(
                                 ImmutableMap.of(
-                                        "expr_0_x", expression(new Subscript(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0"), new Constant(INTEGER, 1L))),
+                                        "expr_0_x", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0"), new Constant(INTEGER, 1L))),
                                         "expr_0", expression(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0")),
-                                        "expr_0_y", expression(new Subscript(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0"), new Constant(INTEGER, 2L)))),
+                                        "expr_0_y", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0"), new Constant(INTEGER, 2L)))),
                                 join(INNER, builder -> builder
                                         .equiCriteria("t_expr_1", "s_expr_1")
                                         .left(

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestHiveProjectionPushdownIntoTableScan.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestHiveProjectionPushdownIntoTableScan.java
@@ -134,8 +134,8 @@ public class TestHiveProjectionPushdownIntoTableScan
                 any(
                         project(
                                 ImmutableMap.of(
-                                        "expr", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), new Constant(INTEGER, 1L))),
-                                        "expr_2", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), new Constant(INTEGER, 2L)))),
+                                        "expr", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), 0)),
+                                        "expr_2", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), 1))),
                                 tableScan(testTable, ImmutableMap.of("col0", "col0")))));
     }
 
@@ -214,9 +214,9 @@ public class TestHiveProjectionPushdownIntoTableScan
                 anyTree(
                         project(
                                 ImmutableMap.of(
-                                        "expr_0_x", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0"), new Constant(INTEGER, 1L))),
+                                        "expr_0_x", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0"), 0)),
                                         "expr_0", expression(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0")),
-                                        "expr_0_y", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0"), new Constant(INTEGER, 2L)))),
+                                        "expr_0_y", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0"), 1))),
                                 join(INNER, builder -> builder
                                         .equiCriteria("t_expr_1", "s_expr_1")
                                         .left(

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergProjectionPushdownPlans.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergProjectionPushdownPlans.java
@@ -140,7 +140,7 @@ public class TestIcebergProjectionPushdownPlans
                 session,
                 any(
                         project(
-                                ImmutableMap.of("expr", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), new Constant(INTEGER, 1L))), "expr_2", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), new Constant(INTEGER, 2L)))),
+                                ImmutableMap.of("expr", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), 0)), "expr_2", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), 1))),
                                 tableScan(testTable, ImmutableMap.of("col0", "col0")))));
     }
 
@@ -226,9 +226,9 @@ public class TestIcebergProjectionPushdownPlans
                 anyTree(
                         project(
                                 ImmutableMap.of(
-                                        "expr_0_x", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0"), new Constant(INTEGER, 1L))),
+                                        "expr_0_x", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0"), 0)),
                                         "expr_0", expression(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0")),
-                                        "expr_0_y", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0"), new Constant(INTEGER, 2L)))),
+                                        "expr_0_y", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0"), 1))),
                                 join(INNER, builder -> builder
                                         .equiCriteria("s_expr_1", "t_expr_1")
                                         .left(

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergProjectionPushdownPlans.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergProjectionPushdownPlans.java
@@ -34,9 +34,9 @@ import io.trino.sql.ir.Arithmetic;
 import io.trino.sql.ir.Cast;
 import io.trino.sql.ir.Comparison;
 import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Logical;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.assertions.BasePushdownPlanTest;
 import io.trino.testing.PlanTester;
 import org.junit.jupiter.api.AfterAll;
@@ -140,7 +140,7 @@ public class TestIcebergProjectionPushdownPlans
                 session,
                 any(
                         project(
-                                ImmutableMap.of("expr", expression(new Subscript(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), new Constant(INTEGER, 1L))), "expr_2", expression(new Subscript(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), new Constant(INTEGER, 2L)))),
+                                ImmutableMap.of("expr", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), new Constant(INTEGER, 1L))), "expr_2", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), new Constant(INTEGER, 2L)))),
                                 tableScan(testTable, ImmutableMap.of("col0", "col0")))));
     }
 
@@ -226,9 +226,9 @@ public class TestIcebergProjectionPushdownPlans
                 anyTree(
                         project(
                                 ImmutableMap.of(
-                                        "expr_0_x", expression(new Subscript(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0"), new Constant(INTEGER, 1L))),
+                                        "expr_0_x", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0"), new Constant(INTEGER, 1L))),
                                         "expr_0", expression(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0")),
-                                        "expr_0_y", expression(new Subscript(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0"), new Constant(INTEGER, 2L)))),
+                                        "expr_0_y", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "expr_0"), new Constant(INTEGER, 2L)))),
                                 join(INNER, builder -> builder
                                         .equiCriteria("s_expr_1", "t_expr_1")
                                         .left(

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/optimizer/TestConnectorPushdownRulesWithIceberg.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/optimizer/TestConnectorPushdownRulesWithIceberg.java
@@ -43,9 +43,9 @@ import io.trino.sql.ir.Arithmetic;
 import io.trino.sql.ir.Comparison;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Negation;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.rule.PruneTableScanColumns;
 import io.trino.sql.planner.iterative.rule.PushPredicateIntoTableScan;
@@ -220,7 +220,7 @@ public class TestConnectorPushdownRulesWithIceberg
                 .on(p ->
                         p.project(
                                 Assignments.of(
-                                        p.symbol("expr_deref", BIGINT), new Subscript(p.symbol("struct_of_int", baseType).toSymbolReference(), new Constant(INTEGER, 1L))),
+                                        p.symbol("expr_deref", BIGINT), new FieldReference(p.symbol("struct_of_int", baseType).toSymbolReference(), new Constant(INTEGER, 1L))),
                                 p.tableScan(
                                         table,
                                         ImmutableList.of(p.symbol("struct_of_int", baseType)),
@@ -414,12 +414,12 @@ public class TestConnectorPushdownRulesWithIceberg
         // Test Dereference pushdown
         tester().assertThat(pushProjectionIntoTableScan)
                 .on(p -> {
-                    Subscript subscript = new Subscript(p.symbol("struct_of_bigint", ROW_TYPE).toSymbolReference(), new Constant(INTEGER, 1L));
-                    Expression sum = new Arithmetic(ADD_BIGINT, ADD, subscript, new Constant(BIGINT, 2L));
+                    FieldReference fieldReference = new FieldReference(p.symbol("struct_of_bigint", ROW_TYPE).toSymbolReference(), new Constant(INTEGER, 1L));
+                    Expression sum = new Arithmetic(ADD_BIGINT, ADD, fieldReference, new Constant(BIGINT, 2L));
                     return p.project(
                             Assignments.of(
                                     // The subscript expression instance is part of both the assignments
-                                    p.symbol("expr_deref", BIGINT), subscript,
+                                    p.symbol("expr_deref", BIGINT), fieldReference,
                                     p.symbol("expr_deref_2", BIGINT), sum),
                             p.tableScan(
                                     table,

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/optimizer/TestConnectorPushdownRulesWithIceberg.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/optimizer/TestConnectorPushdownRulesWithIceberg.java
@@ -220,7 +220,7 @@ public class TestConnectorPushdownRulesWithIceberg
                 .on(p ->
                         p.project(
                                 Assignments.of(
-                                        p.symbol("expr_deref", BIGINT), new FieldReference(p.symbol("struct_of_int", baseType).toSymbolReference(), new Constant(INTEGER, 1L))),
+                                        p.symbol("expr_deref", BIGINT), new FieldReference(p.symbol("struct_of_int", baseType).toSymbolReference(), 0)),
                                 p.tableScan(
                                         table,
                                         ImmutableList.of(p.symbol("struct_of_int", baseType)),
@@ -414,7 +414,7 @@ public class TestConnectorPushdownRulesWithIceberg
         // Test Dereference pushdown
         tester().assertThat(pushProjectionIntoTableScan)
                 .on(p -> {
-                    FieldReference fieldReference = new FieldReference(p.symbol("struct_of_bigint", ROW_TYPE).toSymbolReference(), new Constant(INTEGER, 1L));
+                    FieldReference fieldReference = new FieldReference(p.symbol("struct_of_bigint", ROW_TYPE).toSymbolReference(), 0);
                     Expression sum = new Arithmetic(ADD_BIGINT, ADD, fieldReference, new Constant(BIGINT, 2L));
                     return p.project(
                             Assignments.of(

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoProjectionPushdownPlans.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoProjectionPushdownPlans.java
@@ -32,8 +32,8 @@ import io.trino.spi.type.Type;
 import io.trino.sql.ir.Arithmetic;
 import io.trino.sql.ir.Comparison;
 import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.Subscript;
 import io.trino.sql.planner.assertions.BasePushdownPlanTest;
 import io.trino.sql.planner.assertions.PlanMatchPattern;
 import io.trino.testing.PlanTester;
@@ -133,7 +133,7 @@ public class TestMongoProjectionPushdownPlans
                 session,
                 any(
                         project(
-                                ImmutableMap.of("expr_1", expression(new Subscript(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), new Constant(INTEGER, 1L))), "expr_2", expression(new Subscript(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), new Constant(INTEGER, 2L)))),
+                                ImmutableMap.of("expr_1", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), new Constant(INTEGER, 1L))), "expr_2", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), new Constant(INTEGER, 2L)))),
                                 tableScan(tableName, ImmutableMap.of("col0", "col0")))));
     }
 
@@ -205,9 +205,9 @@ public class TestMongoProjectionPushdownPlans
                 anyTree(
                         project(
                                 ImmutableMap.of(
-                                        "expr_0_x", expression(new Subscript(new Reference(RowType.anonymousRow(INTEGER), "expr_0"), new Constant(INTEGER, 1L))),
+                                        "expr_0_x", expression(new FieldReference(new Reference(RowType.anonymousRow(INTEGER), "expr_0"), new Constant(INTEGER, 1L))),
                                         "expr_0", expression(new Reference(RowType.anonymousRow(INTEGER), "expr_0")),
-                                        "expr_0_y", expression(new Subscript(new Reference(RowType.anonymousRow(INTEGER, INTEGER), "expr_0"), new Constant(INTEGER, 2L)))),
+                                        "expr_0_y", expression(new FieldReference(new Reference(RowType.anonymousRow(INTEGER, INTEGER), "expr_0"), new Constant(INTEGER, 2L)))),
                                 PlanMatchPattern.join(INNER, builder -> builder
                                         .equiCriteria("t_expr_1", "s_expr_1")
                                         .left(

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoProjectionPushdownPlans.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoProjectionPushdownPlans.java
@@ -133,7 +133,7 @@ public class TestMongoProjectionPushdownPlans
                 session,
                 any(
                         project(
-                                ImmutableMap.of("expr_1", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), new Constant(INTEGER, 1L))), "expr_2", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), new Constant(INTEGER, 2L)))),
+                                ImmutableMap.of("expr_1", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), 0)), "expr_2", expression(new FieldReference(new Reference(RowType.anonymousRow(BIGINT, BIGINT), "col0"), 1))),
                                 tableScan(tableName, ImmutableMap.of("col0", "col0")))));
     }
 
@@ -205,9 +205,9 @@ public class TestMongoProjectionPushdownPlans
                 anyTree(
                         project(
                                 ImmutableMap.of(
-                                        "expr_0_x", expression(new FieldReference(new Reference(RowType.anonymousRow(INTEGER), "expr_0"), new Constant(INTEGER, 1L))),
+                                        "expr_0_x", expression(new FieldReference(new Reference(RowType.anonymousRow(INTEGER), "expr_0"), 0)),
                                         "expr_0", expression(new Reference(RowType.anonymousRow(INTEGER), "expr_0")),
-                                        "expr_0_y", expression(new FieldReference(new Reference(RowType.anonymousRow(INTEGER, INTEGER), "expr_0"), new Constant(INTEGER, 2L)))),
+                                        "expr_0_y", expression(new FieldReference(new Reference(RowType.anonymousRow(INTEGER, INTEGER), "expr_0"), 1))),
                                 PlanMatchPattern.join(INNER, builder -> builder
                                         .equiCriteria("t_expr_1", "s_expr_1")
                                         .left(


### PR DESCRIPTION
Rename to FieldReference and make the field an integer instead of an IR expression.

This node is only relevant for expression of Row type, and the field is known at construction time.
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
