### PR TITLE
Support topN for Snowflake connector

### DIFF
--- a/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestSnowflakeConnectorTest.java
+++ b/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestSnowflakeConnectorTest.java
@@ -81,8 +81,7 @@ public class TestSnowflakeConnectorTest
                     SUPPORTS_CREATE_TABLE_WITH_TABLE_COMMENT,
                     SUPPORTS_PREDICATE_PUSHDOWN,
                     SUPPORTS_ROW_TYPE,
-                    SUPPORTS_SET_COLUMN_TYPE,
-                    SUPPORTS_TOPN_PUSHDOWN -> false;
+                    SUPPORTS_SET_COLUMN_TYPE -> false;
             default -> super.hasBehavior(connectorBehavior);
         };
     }


### PR DESCRIPTION
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Snowflake
* Add support for top-N pushdown. ({issue}`21219`)
```
