### PR TITLE
Run server with en_US locale

### DIFF
--- a/core/docker/default/etc/jvm.config
+++ b/core/docker/default/etc/jvm.config
@@ -17,3 +17,7 @@
 -XX:GCLockerRetryAllocationCount=32
 # Allow loading dynamic agent used by JOL
 -XX:+EnableDynamicAgentLoading
+# Trino server behavior does generally not depend on locale settings.
+# Use en_US as this is what Trino is tested with.
+-Duser.language=en
+-Duser.region=US

--- a/core/trino-main/src/main/java/io/trino/server/TrinoSystemRequirements.java
+++ b/core/trino-main/src/main/java/io/trino/server/TrinoSystemRequirements.java
@@ -39,6 +39,7 @@ final class TrinoSystemRequirements
 {
     private static final int MIN_FILE_DESCRIPTORS = 4096;
     private static final int RECOMMENDED_FILE_DESCRIPTORS = 8192;
+    private static final Locale EN_US = Locale.of("en", "US");
 
     private TrinoSystemRequirements() {}
 
@@ -52,6 +53,7 @@ final class TrinoSystemRequirements
         verifyFileDescriptor();
         verifySlice();
         verifyUtf8();
+        verifyLocale();
     }
 
     private static void verify64BitJvm()
@@ -159,6 +161,14 @@ final class TrinoSystemRequirements
         Charset defaultCharset = Charset.defaultCharset();
         if (!defaultCharset.equals(StandardCharsets.UTF_8)) {
             failRequirement("Trino requires that the default charset is UTF-8 (found %s). This can be set with the JVM command line option -Dfile.encoding=UTF-8", defaultCharset.name());
+        }
+    }
+
+    private static void verifyLocale()
+    {
+        Locale defaultLocale = Locale.getDefault();
+        if (!defaultLocale.equals(EN_US)) {
+            failRequirement("Trino requires that the default locale is ENGLISH (found %s). This can be set with the JVM command line option -Duser.language=en -Duser.region=US", defaultLocale);
         }
     }
 

--- a/core/trino-server-rpm/src/main/resources/dist/config/jvm.config
+++ b/core/trino-server-rpm/src/main/resources/dist/config/jvm.config
@@ -16,3 +16,7 @@
 -XX:GCLockerRetryAllocationCount=32
 # Allow loading dynamic agent used by JOL
 -XX:+EnableDynamicAgentLoading
+# Trino server behavior does generally not depend on locale settings.
+# Use en_US as this is what Trino is tested with.
+-Duser.language=en
+-Duser.region=US

--- a/docs/src/main/sphinx/installation/deployment.md
+++ b/docs/src/main/sphinx/installation/deployment.md
@@ -147,6 +147,10 @@ The following provides a good starting point for creating `etc/jvm.config`:
 -XX:GCLockerRetryAllocationCount=32
 # Allow loading dynamic agent used by JOL
 -XX:+EnableDynamicAgentLoading
+# Trino server behavior does generally not depend on locale settings.
+# Use en_US as this is what Trino is tested with.
+-Duser.language=en
+-Duser.region=US
 ```
 
 You must adjust the value for the memory used by Trino, specified with `-Xmx`

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-all/jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-all/jvm.config
@@ -17,3 +17,7 @@
 -XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
 # Allow loading dynamic agent used by JOL
 -XX:+EnableDynamicAgentLoading
+# Trino server behavior does generally not depend on locale settings.
+# Use en_US as this is what Trino is tested with.
+-Duser.language=en
+-Duser.region=US

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/presto/etc/jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/presto/etc/jvm.config
@@ -16,3 +16,7 @@
 -XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
 # Allow loading dynamic agent used by JOL
 -XX:+EnableDynamicAgentLoading
+# Trino server behavior does generally not depend on locale settings.
+# Use en_US as this is what Trino is tested with.
+-Duser.language=en
+-Duser.region=US


### PR DESCRIPTION
Trino server behavior does generally not depend on locale settings.  Use
en_US as this is what Trino is tested with.