### PR TITLE
Avoid populating _schema if the collection is empty in MongoDB connector

### DIFF
--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
@@ -878,7 +878,7 @@ public class MongoSession
     {
         MongoDatabase db = client.getDatabase(schemaName);
         Document doc = db.getCollection(tableName).find().first();
-        if (doc == null) {
+        if (doc == null || doc.isEmpty()) {
             // no records at the collection
             return ImmutableList.of();
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This PR is to fix the [issue][1]. Whenever a empty collection was created an entry was populated in default collection `_schema`.  Further upon populating the collection with documents the fields in `_schema` remained empty. So a workaround there is a check introduced to avoid populating `_schema` if collection is empty.

Fixes #20972

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
