### PR TITLE
Block task execution on catalog loading flag

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/WorkerDynamicCatalogManager.java
+++ b/core/trino-main/src/main/java/io/trino/connector/WorkerDynamicCatalogManager.java
@@ -61,7 +61,7 @@ public class WorkerDynamicCatalogManager
     private final Lock catalogLoadingLock = catalogsLock.readLock();
     private final Lock catalogRemovingLock = catalogsLock.writeLock();
     private final ConcurrentMap<CatalogHandle, CatalogConnector> catalogs = new ConcurrentHashMap<>();
-    private final ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
+    private final ExecutorService executor = Executors.newCachedThreadPool();
 
     @GuardedBy("catalogsUpdateLock")
     private boolean stopped;

--- a/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
@@ -108,6 +108,7 @@ public class SqlTask
     private final AtomicReference<Span> taskSpan = new AtomicReference<>(Span.getInvalid());
     private final AtomicReference<String> traceToken = new AtomicReference<>();
     private final AtomicReference<Set<CatalogHandle>> catalogs = new AtomicReference<>();
+    private final AtomicBoolean catalogsLoaded = new AtomicBoolean(false);
 
     public static SqlTask createSqlTask(
             TaskId taskId,
@@ -289,6 +290,16 @@ public class SqlTask
     {
         requireNonNull(catalogs, "catalogs is null");
         return this.catalogs.compareAndSet(null, requireNonNull(catalogs, "catalogs is null"));
+    }
+
+    public boolean catalogsLoaded()
+    {
+        return catalogsLoaded.get();
+    }
+
+    public boolean setCatalogsLoaded()
+    {
+        return catalogsLoaded.compareAndSet(false, true);
     }
 
     public VersionedDynamicFilterDomains acknowledgeAndGetNewDynamicFilterDomains(long callersDynamicFiltersVersion)

--- a/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
@@ -536,7 +536,8 @@ public class SqlTaskManager
                     Set<CatalogHandle> catalogHandles = activeCatalogs.stream()
                             .map(CatalogProperties::catalogHandle)
                             .collect(toImmutableSet());
-                    if (sqlTask.setCatalogs(catalogHandles) || !sqlTask.catalogsLoaded()) {
+                    sqlTask.setCatalogs(catalogHandles);
+                    if (!sqlTask.catalogsLoaded()) {
                         ReentrantReadWriteLock.ReadLock catalogInitLock = catalogsLock.readLock();
                         catalogInitLock.lock();
                         try {

--- a/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
@@ -536,11 +536,12 @@ public class SqlTaskManager
                     Set<CatalogHandle> catalogHandles = activeCatalogs.stream()
                             .map(CatalogProperties::catalogHandle)
                             .collect(toImmutableSet());
-                    if (sqlTask.setCatalogs(catalogHandles)) {
+                    if (sqlTask.setCatalogs(catalogHandles) || !sqlTask.catalogsLoaded()) {
                         ReentrantReadWriteLock.ReadLock catalogInitLock = catalogsLock.readLock();
                         catalogInitLock.lock();
                         try {
                             connectorServicesProvider.ensureCatalogsLoaded(session, activeCatalogs);
+                            sqlTask.setCatalogsLoaded();
                         }
                         finally {
                             catalogInitLock.unlock();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Block task updating on all catalogs being loaded. Currently the second request to task update will always update the task before waiting for the catalogs to be loaded. This will block all threads trying to update the task on waiting for catalogs to load. 

fixes https://github.com/trinodb/trino/issues/20326

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
