### PR TITLE
Fix incorrect partition pushdown when no partitionSpec exists in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -406,9 +406,15 @@ public final class IcebergUtil
             IcebergColumnHandle columnHandle,
             Domain domain)
     {
-        return table.specs().values().stream()
+        List<PartitionSpec> partitionSpecs = table.specs().values().stream()
                 .filter(partitionSpec -> partitionSpecIds.contains(partitionSpec.specId()))
-                .allMatch(spec -> canEnforceConstraintWithinPartitioningSpec(typeOperators, spec, columnHandle, domain));
+                .collect(toImmutableList());
+
+        if (partitionSpecs.isEmpty()) {
+            return false;
+        }
+
+        return partitionSpecs.stream().allMatch(spec -> canEnforceConstraintWithinPartitioningSpec(typeOperators, spec, columnHandle, domain));
     }
 
     private static boolean canEnforceConstraintWithinPartitioningSpec(TypeOperators typeOperators, PartitionSpec spec, IcebergColumnHandle column, Domain domain)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -3803,6 +3803,21 @@ public abstract class BaseIcebergConnectorTest
     }
 
     @Test
+    public void testPredicateOnDataColumnIsNotPushedDown()
+    {
+        try (TestTable testTable = new TestTable(
+                getQueryRunner()::execute,
+                "test_predicate_on_data_column_is_not_pushed_down",
+                "(a integer)")) {
+            assertThat(query("SELECT * FROM " + testTable.getName() + " WHERE a = 10"))
+                    .isNotFullyPushedDown(FilterNode.class);
+            assertUpdate("INSERT INTO " + testTable.getName() + " VALUES 10", 1);
+            assertThat(query("SELECT * FROM " + testTable.getName() + " WHERE a = 10"))
+                    .isNotFullyPushedDown(FilterNode.class);
+        }
+    }
+
+    @Test
     public void testPredicatesWithStructuralTypes()
     {
         String tableName = "test_predicate_with_structural_types";


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
`canEnforceColumnConstraintInSpecs` may incorrectly return True when no partitionSpec match found. This is because stream.allMatch always returns true on empty stream.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

May create incorrect query plan:
without data, plan treats `a` as partition column.
```
trino:default> explain select * FROM iceberg.tmp."jl_iceberg_0325" where a = 'a';
                                            Query Plan
---------------------------------------------------------------------------------------------------
 Trino version: 439.0
 Fragment 0 [SOURCE]
     Output layout: [a, ds]
     Output partitioning: SINGLE []
     Output[columnNames = [a, ds]]
     │   Layout: [a:varchar, ds:varchar]
     │   Estimates: {rows: 0 (0B), cpu: 0, memory: 0B, network: 0B}
     └─ TableScan[table = iceberg:tmp.jl_iceberg_0325$dataFOR VERSION AS OF 6043893226421131063]
            Layout: [a:varchar, ds:varchar]
            Estimates: {rows: 0 (0B), cpu: 0, memory: 0B, network: 0B}
            a := 1:a:varchar
                :: [[a]]
            ds := 2:ds:varchar
```

Issue disappear after a write:
```
trino:default> explain select * FROM iceberg.tmp."jl_iceberg_0325" where a = 'a';
                                                                Query Plan
------------------------------------------------------------------------------------------------------------------------------------------
 Trino version: 439.0
 Fragment 0 [SOURCE]
     Output layout: [a, ds]
     Output partitioning: SINGLE []
     Output[columnNames = [a, ds]]
     │   Layout: [a:varchar, ds:varchar]
     │   Estimates: {rows: 1 (230B), cpu: 0, memory: 0B, network: 0B}
     └─ ScanFilter[table = iceberg:tmp.jl_iceberg_0325$dataFOR VERSION AS OF 637562949208903568, filterPredicate = ("a" = VARCHAR 'a')]
            Layout: [a:varchar, ds:varchar]
            Estimates: {rows: 1 (230B), cpu: 230, memory: 0B, network: 0B}/{rows: 1 (230B), cpu: 230, memory: 0B, network: 0B}
            a := 1:a:varchar
            ds := 2:ds:varchar
```


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```

