### PR TITLE
Remove unsafe generics from PlanNodeSearcher

### DIFF
--- a/core/trino-main/src/main/java/io/trino/likematcher/LikeMatcher.java
+++ b/core/trino-main/src/main/java/io/trino/likematcher/LikeMatcher.java
@@ -91,12 +91,12 @@ public class LikeMatcher
 
         int patternStart = 0;
         int patternEnd = parsed.size() - 1;
-        if (parsed.size() > 0 && parsed.get(0) instanceof Literal literal) {
+        if (parsed.size() > 0 && parsed.getFirst() instanceof Literal literal) {
             prefix = literal.value().getBytes(UTF_8);
             patternStart++;
         }
 
-        if (parsed.size() > 1 && parsed.get(parsed.size() - 1) instanceof Literal literal) {
+        if (parsed.size() > 1 && parsed.getLast() instanceof Literal literal) {
             suffix = literal.value().getBytes(UTF_8);
             patternEnd--;
         }

--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionBinder.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionBinder.java
@@ -394,7 +394,7 @@ class FunctionBinder
             int variableArgumentCount = signature.getArgumentTypes().size() - fixedArgumentNullability.size();
             argumentNullability = ImmutableList.<Boolean>builder()
                     .addAll(fixedArgumentNullability)
-                    .addAll(nCopies(variableArgumentCount, argumentNullability.get(argumentNullability.size() - 1)))
+                    .addAll(nCopies(variableArgumentCount, argumentNullability.getLast()))
                     .build();
         }
         newMetadata.argumentNullability(argumentNullability);

--- a/core/trino-main/src/main/java/io/trino/metadata/SignatureBinder.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SignatureBinder.java
@@ -427,7 +427,7 @@ public class SignatureBinder
             List<TypeSignature> formalTypeParameterTypeSignatures = formalTypeSignature.getTypeParametersAsTypeSignatures();
             resultBuilder.add(new FunctionSolver(
                     getLambdaArgumentTypeSignatures(formalTypeSignature),
-                    formalTypeParameterTypeSignatures.get(formalTypeParameterTypeSignatures.size() - 1),
+                    formalTypeParameterTypeSignatures.getLast(),
                     actualTypeSignatureProvider));
             return true;
         }
@@ -646,7 +646,7 @@ public class SignatureBinder
 
         ImmutableList.Builder<TypeSignature> builder = ImmutableList.builder();
         builder.addAll(formalTypeSignatures);
-        TypeSignature lastTypeSignature = formalTypeSignatures.get(formalTypeSignatures.size() - 1);
+        TypeSignature lastTypeSignature = formalTypeSignatures.getLast();
         for (int i = 1; i < variableArityArgumentsCount; i++) {
             builder.add(lastTypeSignature);
         }

--- a/core/trino-main/src/main/java/io/trino/operator/Driver.java
+++ b/core/trino-main/src/main/java/io/trino/operator/Driver.java
@@ -195,7 +195,7 @@ public class Driver
     {
         checkLockHeld("Lock must be held to call isTerminatingOrDoneInternal");
 
-        boolean terminatingOrDone = state.get() != State.ALIVE || activeOperators.isEmpty() || activeOperators.get(activeOperators.size() - 1).isFinished() || driverContext.isTerminatingOrDone();
+        boolean terminatingOrDone = state.get() != State.ALIVE || activeOperators.isEmpty() || activeOperators.getLast().isFinished() || driverContext.isTerminatingOrDone();
         if (terminatingOrDone) {
             state.compareAndSet(State.ALIVE, State.NEED_DESTRUCTION);
         }

--- a/core/trino-main/src/main/java/io/trino/operator/VariableWidthData.java
+++ b/core/trino-main/src/main/java/io/trino/operator/VariableWidthData.java
@@ -110,7 +110,7 @@ public final class VariableWidthData
             return EMPTY_CHUNK;
         }
 
-        byte[] openChunk = chunks.isEmpty() ? EMPTY_CHUNK : chunks.get(chunks.size() - 1);
+        byte[] openChunk = chunks.isEmpty() ? EMPTY_CHUNK : chunks.getLast();
         if (openChunk.length - openChunkOffset < size) {
             // record unused space as free bytes
             freeBytes += (openChunk.length - openChunkOffset);

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/minmaxn/TypedHeap.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/minmaxn/TypedHeap.java
@@ -388,7 +388,7 @@ public final class TypedHeap
             openChunkOffset = newSize;
         }
         else {
-            openChunkOffset = newSlices.get(newSlices.size() - 1).length;
+            openChunkOffset = newSlices.getLast().length;
         }
 
         return new VariableWidthData(newSlices, openChunkOffset);

--- a/core/trino-main/src/main/java/io/trino/operator/join/JoinUtils.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/JoinUtils.java
@@ -110,7 +110,7 @@ public final class JoinUtils
                 dynamicFilters.isEmpty(),
                 "Dynamic filters %s present in a join with a DynamicFilterSourceNode on it's build side", dynamicFilters);
         verify(dynamicFilterSourceNodes.size() == 1, "Expected only 1 dynamic filter source node");
-        return dynamicFilterSourceNodes.get(0).getDynamicFilters();
+        return getOnlyElement(dynamicFilterSourceNodes).getDynamicFilters();
     }
 
     public static Optional<DynamicFilterId> getSemiJoinDynamicFilterId(SemiJoinNode semiJoinNode)
@@ -128,7 +128,7 @@ public final class JoinUtils
                 dynamicFilterId.isEmpty(),
                 "Dynamic filter %s present in a semi join with a DynamicFilterSourceNode on it's filtering source side", dynamicFilterId);
         verify(dynamicFilterSourceNodes.size() == 1, "Expected only 1 dynamic filter source node");
-        return Optional.of(getOnlyElement(dynamicFilterSourceNodes.get(0).getDynamicFilters().keySet()));
+        return Optional.of(getOnlyElement(getOnlyElement(dynamicFilterSourceNodes).getDynamicFilters().keySet()));
     }
 
     private static boolean isRemoteReplicatedExchange(PlanNode node)

--- a/core/trino-main/src/main/java/io/trino/operator/join/JoinUtils.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/JoinUtils.java
@@ -97,7 +97,7 @@ public final class JoinUtils
 
     public static Map<DynamicFilterId, Symbol> getJoinDynamicFilters(JoinNode joinNode)
     {
-        List<DynamicFilterSourceNode> dynamicFilterSourceNodes = PlanNodeSearcher.searchFrom(joinNode.getRight())
+        List<PlanNode> dynamicFilterSourceNodes = PlanNodeSearcher.searchFrom(joinNode.getRight())
                 .where(DynamicFilterSourceNode.class::isInstance)
                 .recurseOnlyWhen(node -> node instanceof ExchangeNode || node instanceof ProjectNode)
                 .findAll();
@@ -110,12 +110,12 @@ public final class JoinUtils
                 dynamicFilters.isEmpty(),
                 "Dynamic filters %s present in a join with a DynamicFilterSourceNode on it's build side", dynamicFilters);
         verify(dynamicFilterSourceNodes.size() == 1, "Expected only 1 dynamic filter source node");
-        return getOnlyElement(dynamicFilterSourceNodes).getDynamicFilters();
+        return ((DynamicFilterSourceNode) getOnlyElement(dynamicFilterSourceNodes)).getDynamicFilters();
     }
 
     public static Optional<DynamicFilterId> getSemiJoinDynamicFilterId(SemiJoinNode semiJoinNode)
     {
-        List<DynamicFilterSourceNode> dynamicFilterSourceNodes = PlanNodeSearcher.searchFrom(semiJoinNode.getFilteringSource())
+        List<PlanNode> dynamicFilterSourceNodes = PlanNodeSearcher.searchFrom(semiJoinNode.getFilteringSource())
                 .where(DynamicFilterSourceNode.class::isInstance)
                 .recurseOnlyWhen(node -> node instanceof ExchangeNode || node instanceof ProjectNode)
                 .findAll();
@@ -128,7 +128,7 @@ public final class JoinUtils
                 dynamicFilterId.isEmpty(),
                 "Dynamic filter %s present in a semi join with a DynamicFilterSourceNode on it's filtering source side", dynamicFilterId);
         verify(dynamicFilterSourceNodes.size() == 1, "Expected only 1 dynamic filter source node");
-        return Optional.of(getOnlyElement(getOnlyElement(dynamicFilterSourceNodes).getDynamicFilters().keySet()));
+        return Optional.of(getOnlyElement(((DynamicFilterSourceNode) getOnlyElement(dynamicFilterSourceNodes)).getDynamicFilters().keySet()));
     }
 
     private static boolean isRemoteReplicatedExchange(PlanNode node)

--- a/core/trino-main/src/main/java/io/trino/operator/window/matcher/IrRowPatternToProgramRewriter.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/matcher/IrRowPatternToProgramRewriter.java
@@ -118,7 +118,7 @@ public class IrRowPatternToProgramRewriter
                 instructions.set(splitPosition, new Split(splitTarget, instructions.size()));
             }
 
-            process(parts.get(parts.size() - 1));
+            process(parts.getLast());
 
             for (int position : jumpPositions) {
                 instructions.set(position, new Jump(instructions.size()));
@@ -173,7 +173,7 @@ public class IrRowPatternToProgramRewriter
                 instructions.set(splitPosition, new Split(splitTarget, instructions.size()));
             }
 
-            concatenation(parts.get(parts.size() - 1));
+            concatenation(parts.getLast());
 
             for (int position : jumpPositions) {
                 instructions.set(position, new Jump(instructions.size()));

--- a/core/trino-main/src/main/java/io/trino/sql/gen/SwitchCodeGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/SwitchCodeGenerator.java
@@ -50,9 +50,9 @@ public class SwitchCodeGenerator
         requireNonNull(specialForm, "specialForm is null");
         returnType = specialForm.getType();
         List<RowExpression> arguments = specialForm.getArguments();
-        value = arguments.get(0);
+        value = arguments.getFirst();
 
-        RowExpression last = arguments.get(arguments.size() - 1);
+        RowExpression last = arguments.getLast();
         if (last instanceof SpecialForm && ((SpecialForm) last).getForm() == WHEN) {
             whenClauses = arguments.subList(1, arguments.size()).stream()
                     .map(SpecialForm.class::cast)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DecorrelateInnerUnnestWithGlobalAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DecorrelateInnerUnnestWithGlobalAggregation.java
@@ -143,7 +143,7 @@ public class DecorrelateInnerUnnestWithGlobalAggregation
         AggregationNode reducingAggregation = (AggregationNode) globalAggregations.getLast();
 
         // find unnest in subquery
-        Optional<UnnestNode> subqueryUnnest = PlanNodeSearcher.searchFrom(reducingAggregation.getSource(), context.getLookup())
+        Optional<PlanNode> subqueryUnnest = PlanNodeSearcher.searchFrom(reducingAggregation.getSource(), context.getLookup())
                 .where(node -> isSupportedUnnest(node, correlatedJoinNode.getCorrelation(), context.getLookup()))
                 .recurseOnlyWhen(node -> node instanceof ProjectNode || isGroupedAggregation(node))
                 .findFirst();
@@ -152,7 +152,7 @@ public class DecorrelateInnerUnnestWithGlobalAggregation
             return Result.empty();
         }
 
-        UnnestNode unnestNode = subqueryUnnest.get();
+        UnnestNode unnestNode = (UnnestNode) subqueryUnnest.get();
 
         // assign unique id to input rows to restore semantics of aggregations after rewrite
         PlanNode input = new AssignUniqueId(

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DecorrelateInnerUnnestWithGlobalAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DecorrelateInnerUnnestWithGlobalAggregation.java
@@ -140,7 +140,7 @@ public class DecorrelateInnerUnnestWithGlobalAggregation
         }
 
         // if there are multiple global aggregations, the one that is closest to the source is the "reducing" aggregation, because it reduces multiple input rows to single output row
-        AggregationNode reducingAggregation = (AggregationNode) globalAggregations.get(globalAggregations.size() - 1);
+        AggregationNode reducingAggregation = (AggregationNode) globalAggregations.getLast();
 
         // find unnest in subquery
         Optional<UnnestNode> subqueryUnnest = PlanNodeSearcher.searchFrom(reducingAggregation.getSource(), context.getLookup())

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DecorrelateUnnest.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DecorrelateUnnest.java
@@ -182,8 +182,8 @@ public class DecorrelateUnnest
         Optional<UnnestNode> subqueryUnnest = PlanNodeSearcher.searchFrom(searchRoot, context.getLookup())
                 .where(node -> isSupportedUnnest(node, correlatedJoinNode.getCorrelation(), context.getLookup()))
                 .recurseOnlyWhen(node -> node instanceof ProjectNode ||
-                        (node instanceof LimitNode && ((LimitNode) node).getCount() > 0) ||
-                        (node instanceof TopNNode && ((TopNNode) node).getCount() > 0))
+                        (node instanceof LimitNode limitNode && limitNode.getCount() > 0) ||
+                        (node instanceof TopNNode topNNode && topNNode.getCount() > 0))
                 .findFirst();
 
         if (subqueryUnnest.isEmpty()) {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DecorrelateUnnest.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DecorrelateUnnest.java
@@ -169,17 +169,17 @@ public class DecorrelateUnnest
         PlanNode searchRoot = correlatedJoinNode.getSubquery();
 
         // 1. find EnforceSingleRowNode in the subquery
-        Optional<EnforceSingleRowNode> enforceSingleRow = PlanNodeSearcher.searchFrom(searchRoot, context.getLookup())
+        Optional<PlanNode> enforceSingleRow = PlanNodeSearcher.searchFrom(searchRoot, context.getLookup())
                 .where(EnforceSingleRowNode.class::isInstance)
                 .recurseOnlyWhen(planNode -> false)
                 .findFirst();
 
         if (enforceSingleRow.isPresent()) {
-            searchRoot = enforceSingleRow.get().getSource();
+            searchRoot = ((EnforceSingleRowNode) enforceSingleRow.get()).getSource();
         }
 
         // 2. find correlated UnnestNode in the subquery
-        Optional<UnnestNode> subqueryUnnest = PlanNodeSearcher.searchFrom(searchRoot, context.getLookup())
+        Optional<PlanNode> subqueryUnnest = PlanNodeSearcher.searchFrom(searchRoot, context.getLookup())
                 .where(node -> isSupportedUnnest(node, correlatedJoinNode.getCorrelation(), context.getLookup()))
                 .recurseOnlyWhen(node -> node instanceof ProjectNode ||
                         (node instanceof LimitNode limitNode && limitNode.getCount() > 0) ||
@@ -190,7 +190,7 @@ public class DecorrelateUnnest
             return Result.empty();
         }
 
-        UnnestNode unnestNode = subqueryUnnest.get();
+        UnnestNode unnestNode = (UnnestNode) subqueryUnnest.get();
 
         // assign unique id to input rows
         Symbol uniqueSymbol = context.getSymbolAllocator().newSymbol("unique", BIGINT);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/GatherAndMergeWindows.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/GatherAndMergeWindows.java
@@ -162,7 +162,7 @@ public final class GatherAndMergeWindows
 
             WindowNode newTarget = (WindowNode) target.replaceChildren(ImmutableList.of(newTargetChild));
             Set<Symbol> newTargetOutputs = ImmutableSet.copyOf(newTarget.getOutputSymbols());
-            if (!newTargetOutputs.containsAll(projects.get(projects.size() - 1).getOutputSymbols())) {
+            if (!newTargetOutputs.containsAll(projects.getLast().getOutputSymbols())) {
                 // The new target node is hiding some of the projections, which makes this rewrite incorrect.
                 return Optional.empty();
             }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PlanNodeSearcher.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PlanNodeSearcher.java
@@ -151,7 +151,7 @@ public class PlanNodeSearcher
             checkArgument(
                     node.getSources().size() == 1,
                     "Unable to remove plan node as it contains 0 or more than 1 children");
-            return node.getSources().get(0);
+            return getOnlyElement(node.getSources());
         }
         if (recurseOnlyWhen.test(node)) {
             List<PlanNode> sources = node.getSources().stream()
@@ -175,7 +175,7 @@ public class PlanNodeSearcher
             checkArgument(
                     node.getSources().size() == 1,
                     "Unable to remove plan node as it contains 0 or more than 1 children");
-            return node.getSources().get(0);
+            return getOnlyElement(node.getSources());
         }
         if (recurseOnlyWhen.test(node)) {
             List<PlanNode> sources = node.getSources();
@@ -183,7 +183,7 @@ public class PlanNodeSearcher
                 return node;
             }
             if (sources.size() == 1) {
-                return replaceChildren(node, ImmutableList.of(removeFirstRecursive(sources.get(0))));
+                return replaceChildren(node, ImmutableList.of(removeFirstRecursive(getOnlyElement(sources))));
             }
             throw new IllegalArgumentException("Unable to remove first node when a node has multiple children, use removeAll instead");
         }
@@ -228,7 +228,7 @@ public class PlanNodeSearcher
             return node;
         }
         if (sources.size() == 1) {
-            return replaceChildren(node, ImmutableList.of(replaceFirstRecursive(node, sources.get(0))));
+            return replaceChildren(node, ImmutableList.of(replaceFirstRecursive(node, getOnlyElement(sources))));
         }
         throw new IllegalArgumentException("Unable to replace first node when a node has multiple children, use replaceAll instead");
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PlanNodeSearcher.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PlanNodeSearcher.java
@@ -86,21 +86,21 @@ public class PlanNodeSearcher
         return this;
     }
 
-    public <T extends PlanNode> Optional<T> findFirst()
+    public Optional<PlanNode> findFirst()
     {
         return findFirstRecursive(node);
     }
 
-    private <T extends PlanNode> Optional<T> findFirstRecursive(PlanNode node)
+    private Optional<PlanNode> findFirstRecursive(PlanNode node)
     {
         node = lookup.resolve(node);
 
         if (where.test(node)) {
-            return Optional.of((T) node);
+            return Optional.of(node);
         }
         if (recurseOnlyWhen.test(node)) {
             for (PlanNode source : node.getSources()) {
-                Optional<T> found = findFirstRecursive(source);
+                Optional<PlanNode> found = findFirstRecursive(source);
                 if (found.isPresent()) {
                     return found;
                 }
@@ -112,24 +112,24 @@ public class PlanNodeSearcher
     /**
      * Return a list of matching nodes ordered as in pre-order traversal of the plan tree.
      */
-    public <T extends PlanNode> List<T> findAll()
+    public List<PlanNode> findAll()
     {
-        ImmutableList.Builder<T> nodes = ImmutableList.builder();
+        ImmutableList.Builder<PlanNode> nodes = ImmutableList.builder();
         findAllRecursive(node, nodes);
         return nodes.build();
     }
 
-    public <T extends PlanNode> T findOnlyElement()
+    public PlanNode findOnlyElement()
     {
         return getOnlyElement(findAll());
     }
 
-    private <T extends PlanNode> void findAllRecursive(PlanNode node, ImmutableList.Builder<T> nodes)
+    private void findAllRecursive(PlanNode node, ImmutableList.Builder<PlanNode> nodes)
     {
         node = lookup.resolve(node);
 
         if (where.test(node)) {
-            nodes.add((T) node);
+            nodes.add(node);
         }
         if (recurseOnlyWhen.test(node)) {
             for (PlanNode source : node.getSources()) {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/sanity/VerifyNoFilteredAggregations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/sanity/VerifyNoFilteredAggregations.java
@@ -32,8 +32,9 @@ public final class VerifyNoFilteredAggregations
     {
         searchFrom(plan)
                 .where(AggregationNode.class::isInstance)
-                .<AggregationNode>findAll()
+                .findAll()
                 .stream()
+                .map(AggregationNode.class::cast)
                 .flatMap(node -> node.getAggregations().values().stream())
                 .filter(aggregation -> aggregation.getFilter().isPresent())
                 .forEach(ignored -> {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/sanity/VerifyUseConnectorNodePartitioningSet.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/sanity/VerifyUseConnectorNodePartitioningSet.java
@@ -33,8 +33,9 @@ public final class VerifyUseConnectorNodePartitioningSet
     {
         searchFrom(plan)
                 .where(TableScanNode.class::isInstance)
-                .<TableScanNode>findAll()
+                .findAll()
                 .stream()
+                .map(TableScanNode.class::cast)
                 .filter(scan -> scan.getUseConnectorNodePartitioning().isEmpty())
                 .forEach(scan -> {
                     throw new IllegalStateException(format("TableScanNode (%s) doesn't have useConnectorNodePartitioning set", scan));

--- a/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
+++ b/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
@@ -208,6 +208,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
@@ -943,6 +944,8 @@ public class PlanTester
     {
         return searchFrom(node)
                 .where(TableScanNode.class::isInstance)
-                .findAll();
+                .findAll().stream()
+                .map(TableScanNode.class::cast)
+                .collect(toImmutableList());
     }
 }

--- a/core/trino-main/src/main/java/io/trino/type/FunctionParametricType.java
+++ b/core/trino-main/src/main/java/io/trino/type/FunctionParametricType.java
@@ -49,6 +49,6 @@ public final class FunctionParametricType
                 parameters);
         List<Type> types = parameters.stream().map(TypeParameter::getType).collect(toList());
 
-        return new FunctionType(types.subList(0, types.size() - 1), types.get(types.size() - 1));
+        return new FunctionType(types.subList(0, types.size() - 1), types.getLast());
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestJsonTable.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestJsonTable.java
@@ -550,7 +550,7 @@ public class TestJsonTable
         try {
             getPlanTester().inTransaction(transactionSession -> {
                 Plan queryPlan = getPlanTester().createPlan(transactionSession, sql, ImmutableList.of(), CREATED, WarningCollector.NOOP, createPlanOptimizersStatsCollector());
-                TableFunctionNode tableFunctionNode = getOnlyElement(PlanNodeSearcher.searchFrom(queryPlan.getRoot()).where(TableFunctionNode.class::isInstance).findAll());
+                TableFunctionNode tableFunctionNode = (TableFunctionNode) getOnlyElement(PlanNodeSearcher.searchFrom(queryPlan.getRoot()).where(TableFunctionNode.class::isInstance).findAll());
                 JsonTablePlanNode actualPlan = ((JsonTable.JsonTableFunctionHandle) tableFunctionNode.getHandle().getFunctionHandle()).processingPlan();
                 assertThat(actualPlan)
                         .usingComparator(planComparator())

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -334,7 +334,7 @@ public final class SqlFormatter
                 process(columns.get(i), indent + 1);
                 builder.append(",\n");
             }
-            process(columns.get(columns.size() - 1), indent + 1);
+            process(columns.getLast(), indent + 1);
             builder.append(")");
         }
 
@@ -444,7 +444,7 @@ public final class SqlFormatter
                         .append(" ");
             }
             builder.append("(");
-            process(node.getSiblings().get(node.getSiblings().size() - 1));
+            process(node.getSiblings().getLast());
             builder.append(")");
             return null;
         }
@@ -2610,7 +2610,7 @@ public final class SqlFormatter
                     append(indent, elements.get(i))
                             .append(",\n");
                 }
-                append(indent, elements.get(elements.size() - 1))
+                append(indent, elements.getLast())
                         .append("\n");
             }
         }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/QualifiedName.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/QualifiedName.java
@@ -74,7 +74,7 @@ public class QualifiedName
         else {
             List<Identifier> subList = originalParts.subList(0, originalParts.size() - 1);
             this.prefix = Optional.of(new QualifiedName(subList));
-            this.suffix = mapIdentifier(originalParts.get(originalParts.size() - 1));
+            this.suffix = mapIdentifier(originalParts.getLast());
         }
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
@@ -610,7 +610,7 @@ public final class SortedRangeSet
                 unioned.add(toUnion.get(i).union(toUnion.get(i + 1)));
             }
             if (toUnion.size() % 2 != 0) {
-                unioned.add(toUnion.get(toUnion.size() - 1));
+                unioned.add(toUnion.getLast());
             }
             toUnion = unioned;
         }

--- a/core/trino-spi/src/main/java/io/trino/spi/resourcegroups/ResourceGroupId.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/resourcegroups/ResourceGroupId.java
@@ -62,7 +62,7 @@ public final class ResourceGroupId
 
     public String getLastSegment()
     {
-        return segments.get(segments.size() - 1);
+        return segments.getLast();
     }
 
     @JsonValue

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/openxjson/JsonWriter.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/openxjson/JsonWriter.java
@@ -289,7 +289,7 @@ final class JsonWriter
         if (scopes.isEmpty()) {
             throw new IllegalStateException("Nesting problem");
         }
-        return scopes.get(scopes.size() - 1);
+        return scopes.getLast();
     }
 
     private void replaceCurrentScope(Scope topOfStack)

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -2898,7 +2898,7 @@ public class TestDeltaLakeConnectorTest
                                 .isTrue();
                     }
                     else {
-                        TableFinishNode finishNode = searchFrom(plan.getRoot())
+                        TableFinishNode finishNode = (TableFinishNode) searchFrom(plan.getRoot())
                                 .where(TableFinishNode.class::isInstance)
                                 .findOnlyElement();
                         assertThat(finishNode.getTarget() instanceof TableWriterNode.MergeTarget)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
@@ -346,7 +346,7 @@ public class ParquetPageSourceFactory
         }
 
         List<org.apache.parquet.schema.Type> subfieldTypes = subFieldTypesOptional.get();
-        org.apache.parquet.schema.Type type = subfieldTypes.get(subfieldTypes.size() - 1);
+        org.apache.parquet.schema.Type type = subfieldTypes.getLast();
         for (int i = subfieldTypes.size() - 2; i >= 0; --i) {
             GroupType groupType = subfieldTypes.get(i).asGroupType();
             type = new GroupType(groupType.getRepetition(), groupType.getName(), ImmutableList.of(type));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/InternalHiveSplitFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/InternalHiveSplitFactory.java
@@ -211,11 +211,11 @@ public class InternalHiveSplitFactory
                 start,
                 blocks.get(0).getStart());
         checkArgument(
-                start + length == blocks.get(blocks.size() - 1).getEnd(),
+                start + length == blocks.getLast().getEnd(),
                 "Split (%s) end (%s) does not match last block end (%s)",
                 path,
                 start + length,
-                blocks.get(blocks.size() - 1).getEnd());
+                blocks.getLast().getEnd());
         for (int i = 1; i < blocks.size(); i++) {
             checkArgument(
                     blocks.get(i - 1).getEnd() == blocks.get(i).getStart(),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestReaderProjectionsAdapter.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestReaderProjectionsAdapter.java
@@ -269,7 +269,7 @@ public class TestReaderProjectionsAdapter
                 builder.appendNull();
             }
             else {
-                int lastDereference = dereferences.get(dereferences.size() - 1);
+                int lastDereference = dereferences.getLast();
 
                 finalType.appendTo(currentData.getRawFieldBlock(lastDereference), currentData.getRawIndex(), builder);
             }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -1035,8 +1035,8 @@ public class IcebergPageSourceProvider
             Optional<Long> startRowPosition = Optional.empty();
             Optional<Long> endRowPosition = Optional.empty();
             if (!rowGroups.isEmpty()) {
-                startRowPosition = Optional.of(rowGroups.get(0).fileRowOffset());
-                RowGroupInfo lastRowGroup = rowGroups.get(rowGroups.size() - 1);
+                startRowPosition = Optional.of(rowGroups.getFirst().fileRowOffset());
+                RowGroupInfo lastRowGroup = rowGroups.getLast();
                 endRowPosition = Optional.of(lastRowGroup.fileRowOffset() + lastRowGroup.blockMetaData().getRowCount());
             }
 
@@ -1489,7 +1489,7 @@ public class IcebergPageSourceProvider
         }
 
         // Construct a stripped version of the original column type containing only the selected field and the hierarchy of its parents
-        org.apache.parquet.schema.Type type = subfieldTypes.get(subfieldTypes.size() - 1);
+        org.apache.parquet.schema.Type type = subfieldTypes.getLast();
         for (int i = subfieldTypes.size() - 2; i >= 0; --i) {
             GroupType groupType = subfieldTypes.get(i).asGroupType();
             type = new GroupType(groupType.getRepetition(), groupType.getName(), ImmutableList.of(type));

--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisSplitManager.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisSplitManager.java
@@ -151,7 +151,7 @@ public class KinesisSplitManager
                 internalStreamDescription.addAllShards(describeStreamResult.getStreamDescription().getShards());
 
                 if (describeStreamResult.getStreamDescription().getHasMoreShards() && (shards.size() > 0)) {
-                    exclusiveStartShardId = shards.get(shards.size() - 1).getShardId();
+                    exclusiveStartShardId = shards.getLast().getShardId();
                 }
                 else {
                     exclusiveStartShardId = null;

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSource.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSource.java
@@ -414,7 +414,7 @@ public class MongoPageSource
         checkArgument(columnHandle.isDbRefField(), "columnHandle is not a dbRef field: %s", columnHandle);
         List<String> dereferenceNames = columnHandle.getDereferenceNames();
         checkState(!dereferenceNames.isEmpty(), "dereferenceNames is empty");
-        String leafColumnName = dereferenceNames.get(dereferenceNames.size() - 1);
+        String leafColumnName = dereferenceNames.getLast();
         return switch (leafColumnName) {
             case DATABASE_NAME -> dbRefValue.getDatabaseName();
             case COLLECTION_NAME -> dbRefValue.getCollectionName();

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixSplitManager.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixSplitManager.java
@@ -135,17 +135,17 @@ public class PhoenixSplitManager
             long regionSize = -1;
             List<InputSplit> inputSplits = new ArrayList<>(splits.size());
             for (List<Scan> scans : queryPlan.getScans()) {
-                HRegionLocation location = regionLocator.getRegionLocation(scans.get(0).getStartRow(), false);
+                HRegionLocation location = regionLocator.getRegionLocation(scans.getFirst().getStartRow(), false);
                 String regionLocation = location.getHostname();
 
                 if (log.isDebugEnabled()) {
                     log.debug(
                             "Scan count[%d] : %s ~ %s",
                             scans.size(),
-                            Bytes.toStringBinary(scans.get(0).getStartRow()),
-                            Bytes.toStringBinary(scans.get(scans.size() - 1).getStopRow()));
+                            Bytes.toStringBinary(scans.getFirst().getStartRow()),
+                            Bytes.toStringBinary(scans.getLast().getStopRow()));
                     log.debug("First scan : %swith scanAttribute : %s [scanCache, cacheBlock, scanBatch] : [%d, %s, %d] and  regionLocation : %s",
-                            scans.get(0), scans.get(0).getAttributesMap(), scans.get(0).getCaching(), scans.get(0).getCacheBlocks(), scans.get(0).getBatch(), regionLocation);
+                            scans.getFirst(), scans.getFirst().getAttributesMap(), scans.getFirst().getCaching(), scans.getFirst().getCacheBlocks(), scans.getFirst().getBatch(), regionLocation);
                     for (int i = 0, limit = scans.size(); i < limit; i++) {
                         log.debug("EXPECTED_UPPER_REGION_KEY[%d] : %s", i, Bytes.toStringBinary(scans.get(i).getAttribute(EXPECTED_UPPER_REGION_KEY)));
                     }

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/PinotSqlFormatter.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/PinotSqlFormatter.java
@@ -642,7 +642,7 @@ public class PinotSqlFormatter
 
             if (arguments.size() % 2 != 0) {
                 builder.append(" ELSE ")
-                        .append(arguments.get(arguments.size() - 1));
+                        .append(arguments.getLast());
             }
             return builder.append(" END").toString();
         }

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusSplit.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusSplit.java
@@ -357,9 +357,9 @@ public class TestPrometheusSplit
 
         TemporalAmount expectedMaxQueryAsTime = java.time.Duration.ofMillis(maxQueryRangeDuration.toMillis() +
                 ((splitTimes.size() - 1) * OFFSET_MILLIS));
-        String lastSplit = splitTimes.get(splitTimes.size() - 1);
+        String lastSplit = splitTimes.getLast();
         Instant lastSplitAsTime = ofEpochMilli(longFromDecimalSecondString(lastSplit));
-        String earliestSplit = splitTimes.get(0);
+        String earliestSplit = splitTimes.getFirst();
         Instant earliestSplitAsTime = ofEpochMilli(longFromDecimalSecondString(earliestSplit));
         TemporalAmount queryChunkAsTime = java.time.Duration.ofMillis(queryChunkSizeDuration.toMillis());
         java.time.Duration actualMaxDuration = Duration.between(earliestSplitAsTime
@@ -391,9 +391,9 @@ public class TestPrometheusSplit
 
         TemporalAmount expectedMaxQueryAsTime = java.time.Duration.ofMillis(new io.airlift.units.Duration(10, TimeUnit.MINUTES).toMillis() +
                 ((splitTimes.size() - 1) * OFFSET_MILLIS));
-        String lastSplit = splitTimes.get(splitTimes.size() - 1);
+        String lastSplit = splitTimes.getLast();
         Instant lastSplitAsTime = ofEpochMilli(longFromDecimalSecondString(lastSplit));
-        String earliestSplit = splitTimes.get(0);
+        String earliestSplit = splitTimes.getFirst();
         Instant earliestSplitAsTime = ofEpochMilli(longFromDecimalSecondString(earliestSplit));
         TemporalAmount queryChunkAsTime = java.time.Duration.ofMillis(queryChunkSizeDuration.toMillis());
         java.time.Duration actualMaxDuration = Duration.between(earliestSplitAsTime

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorMetadata.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorMetadata.java
@@ -483,7 +483,7 @@ public class RaptorMetadata
 
         // Always add new columns to the end.
         List<TableColumn> existingColumns = dao.listTableColumns(table.getSchemaName(), table.getTableName());
-        TableColumn lastColumn = existingColumns.get(existingColumns.size() - 1);
+        TableColumn lastColumn = existingColumns.getLast();
         long columnId = lastColumn.getColumnId() + 1;
         int ordinalPosition = lastColumn.getOrdinalPosition() + 1;
 

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/util/TestPrioritizedFifoExecutor.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/util/TestPrioritizedFifoExecutor.java
@@ -98,7 +98,7 @@ public class TestPrioritizedFifoExecutor
         assertThat(counter.get()).isEqualTo(totalTasks);
         // since this is a fifo executor with one thread and completeLatch is decremented inside the future,
         // the last future may not be done yet, but all the rest must be
-        futures.get(futures.size() - 1).get(1, TimeUnit.MINUTES);
+        futures.getLast().get(1, TimeUnit.MINUTES);
         for (Future<?> future : futures) {
             assertThat(future.isDone()).isTrue();
         }

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestTableRedirection.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestTableRedirection.java
@@ -406,7 +406,7 @@ public class TestTableRedirection
                 1,
                 // Verify the insert plan instead of through a successive SELECT, because insertion is a no-op for Mock connector
                 plan -> {
-                    TableFinishNode finishNode = searchFrom(plan.getRoot())
+                    TableFinishNode finishNode = (TableFinishNode) searchFrom(plan.getRoot())
                             .where(TableFinishNode.class::isInstance)
                             .findOnlyElement();
                     TableWriterNode.InsertTarget insertTarget = ((TableWriterNode.InsertTarget) finishNode.getTarget());
@@ -424,7 +424,7 @@ public class TestTableRedirection
                 0,
                 // Verify the insert plan instead of through a successive SELECT, because deletion is a no-op for Mock connector
                 plan -> {
-                    TableFinishNode finishNode = searchFrom(plan.getRoot())
+                    TableFinishNode finishNode = (TableFinishNode) searchFrom(plan.getRoot())
                             .where(TableFinishNode.class::isInstance)
                             .findOnlyElement();
                     TableWriterNode.MergeTarget mergeTarget = (TableWriterNode.MergeTarget) finishNode.getTarget();
@@ -442,7 +442,7 @@ public class TestTableRedirection
                 0,
                 // Verify the insert plan instead of through a successive SELECT, because update is a no-op for Mock connector
                 plan -> {
-                    TableFinishNode finishNode = searchFrom(plan.getRoot())
+                    TableFinishNode finishNode = (TableFinishNode) searchFrom(plan.getRoot())
                             .where(TableFinishNode.class::isInstance)
                             .findOnlyElement();
                     TableWriterNode.MergeTarget mergeTarget = (TableWriterNode.MergeTarget) finishNode.getTarget();
@@ -463,7 +463,7 @@ public class TestTableRedirection
     private Consumer<Plan> verifySingleTableScan(String schemaName, String tableName)
     {
         return plan -> {
-            TableScanNode tableScan = searchFrom(plan.getRoot())
+            TableScanNode tableScan = (TableScanNode) searchFrom(plan.getRoot())
                     .where(TableScanNode.class::isInstance)
                     .findOnlyElement();
             SchemaTableName actual = ((MockConnectorTableHandle) tableScan.getTable().getConnectorHandle()).getTableName();

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestServer.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestServer.java
@@ -54,6 +54,7 @@ import java.util.stream.Stream;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.getStackTraceAsString;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static com.google.common.net.HttpHeaders.X_FORWARDED_HOST;
 import static com.google.common.net.HttpHeaders.X_FORWARDED_PORT;
@@ -161,8 +162,8 @@ public class TestServer
         assertThat(first.getData()).isNull();
 
         assertThat(last.getColumns()).hasSize(1);
-        assertThat(last.getColumns().get(0).getName()).isEqualTo("Catalog");
-        assertThat(last.getColumns().get(0).getType()).isEqualTo("varchar(6)");
+        assertThat(getOnlyElement(last.getColumns()).getName()).isEqualTo("Catalog");
+        assertThat(getOnlyElement(last.getColumns()).getType()).isEqualTo("varchar(6)");
         assertThat(last.getStats().getState()).isEqualTo("FINISHED");
 
         assertThat(data).isPresent();

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestServer.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestServer.java
@@ -152,8 +152,8 @@ public class TestServer
                 .map(JsonResponse::getValue)
                 .collect(toImmutableList());
 
-        QueryResults first = queryResults.get(0);
-        QueryResults last = queryResults.get(queryResults.size() - 1);
+        QueryResults first = queryResults.getFirst();
+        QueryResults last = queryResults.getLast();
 
         Optional<QueryResults> data = queryResults.stream().filter(results -> results.getData() != null).findFirst();
 


### PR DESCRIPTION
Let the caller do the cast explicitly if needed, avoid heap pollution.
