### PR TITLE
Ignore stopped containers in resource leak detector

### DIFF
--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/junit/ReportLeakedContainers.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/junit/ReportLeakedContainers.java
@@ -81,6 +81,8 @@ public final class ReportLeakedContainers
 
             List<Container> containers = dockerClient.listContainersCmd()
                     .withLabelFilter(Map.of(DockerClientFactory.TESTCONTAINERS_SESSION_ID_LABEL, DockerClientFactory.SESSION_ID))
+                    // ignore status "exited" - for example, failed containers after using `withStartupAttempts()`
+                    .withStatusFilter(List.of("created", "restarting", "running", "paused"))
                     .exec()
                     .stream()
                     .filter(container -> !ignoredIds.contains(container.getId()))


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Stopped containers can be left behind when using
`withStartupAttempts()`. They should only use up disk space, not other resources, and will still be cleaned up by testcontainers on exit.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
