### PR TITLE
Make AdaptivePlanner optional in the FTE scheduler

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
@@ -797,9 +797,9 @@ public class EventDrivenFaultTolerantQueryScheduler
             this.adaptivePlanner = requireNonNull(adaptivePlanner, "adaptivePlanner is null");
             this.stageEstimationForEagerParentEnabled = stageEstimationForEagerParentEnabled;
             this.schedulerSpan = tracer.spanBuilder("scheduler")
-                .setParent(Context.current().with(queryStateMachine.getSession().getQuerySpan()))
-                .setAttribute(TrinoAttributes.QUERY_ID, queryStateMachine.getQueryId().toString())
-                .startSpan();
+                    .setParent(Context.current().with(queryStateMachine.getSession().getQuerySpan()))
+                    .setAttribute(TrinoAttributes.QUERY_ID, queryStateMachine.getQueryId().toString())
+                    .startSpan();
 
             if (log.isDebugEnabled()) {
                 eventDebugInfos = Optional.of(new EventDebugInfos(queryStateMachine.getQueryId().toString(), EVENTS_DEBUG_INFOS_PER_BUCKET));

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
@@ -219,8 +219,7 @@ public class EventDrivenFaultTolerantQueryScheduler
     private final FailureDetector failureDetector;
     private final DynamicFilterService dynamicFilterService;
     private final TaskExecutionStats taskExecutionStats;
-    private final AdaptivePlanner adaptivePlanner;
-    private final boolean adaptiveQueryPlanningEnabled;
+    private final Optional<AdaptivePlanner> adaptivePlanner;
     private final SubPlan originalPlan;
     private final boolean stageEstimationForEagerParentEnabled;
 
@@ -275,8 +274,9 @@ public class EventDrivenFaultTolerantQueryScheduler
         this.failureDetector = requireNonNull(failureDetector, "failureDetector is null");
         this.dynamicFilterService = requireNonNull(dynamicFilterService, "dynamicFilterService is null");
         this.taskExecutionStats = requireNonNull(taskExecutionStats, "taskExecutionStats is null");
-        this.adaptivePlanner = requireNonNull(adaptivePlanner, "adaptivePlanner is null");
-        this.adaptiveQueryPlanningEnabled = isFaultTolerantExecutionAdaptiveQueryPlanningEnabled(queryStateMachine.getSession());
+        this.adaptivePlanner = isFaultTolerantExecutionAdaptiveQueryPlanningEnabled(queryStateMachine.getSession()) ?
+                Optional.of(requireNonNull(adaptivePlanner, "adaptivePlanner is null")) :
+                Optional.empty();
         this.originalPlan = requireNonNull(originalPlan, "originalPlan is null");
 
         this.stageEstimationForEagerParentEnabled = isFaultTolerantExecutionStageEstimationForEagerParentEnabled(queryStateMachine.getSession());
@@ -361,8 +361,7 @@ public class EventDrivenFaultTolerantQueryScheduler
                     getFaultTolerantExecutionRuntimeAdaptivePartitioningPartitionCount(session),
                     getFaultTolerantExecutionRuntimeAdaptivePartitioningMaxTaskSize(session),
                     stageEstimationForEagerParentEnabled,
-                    adaptivePlanner,
-                    adaptiveQueryPlanningEnabled);
+                    adaptivePlanner);
             queryExecutor.submit(scheduler::run);
         }
         catch (Throwable t) {
@@ -717,8 +716,7 @@ public class EventDrivenFaultTolerantQueryScheduler
         private SubPlan plan;
         private List<SubPlan> planInTopologicalOrder;
 
-        private final AdaptivePlanner adaptivePlanner;
-        private final boolean adaptiveQueryPlanningEnabled;
+        private final Optional<AdaptivePlanner> adaptivePlanner;
 
         private final Map<StageId, StageExecution> stageExecutions = new HashMap<>();
         private final Map<SubPlan, IsReadyForExecutionResult> isReadyForExecutionCache = new HashMap<>();
@@ -764,8 +762,7 @@ public class EventDrivenFaultTolerantQueryScheduler
                 int runtimeAdaptivePartitioningPartitionCount,
                 DataSize runtimeAdaptivePartitioningMaxTaskSize,
                 boolean stageEstimationForEagerParentEnabled,
-                AdaptivePlanner adaptivePlanner,
-                boolean adaptiveQueryPlanningEnabled)
+                Optional<AdaptivePlanner> adaptivePlanner)
         {
             this.queryStateMachine = requireNonNull(queryStateMachine, "queryStateMachine is null");
             this.metadata = requireNonNull(metadata, "metadata is null");
@@ -798,7 +795,6 @@ public class EventDrivenFaultTolerantQueryScheduler
             this.runtimeAdaptivePartitioningPartitionCount = runtimeAdaptivePartitioningPartitionCount;
             this.runtimeAdaptivePartitioningMaxTaskSizeInBytes = requireNonNull(runtimeAdaptivePartitioningMaxTaskSize, "runtimeAdaptivePartitioningMaxTaskSize is null").toBytes();
             this.adaptivePlanner = requireNonNull(adaptivePlanner, "adaptivePlanner is null");
-            this.adaptiveQueryPlanningEnabled = adaptiveQueryPlanningEnabled;
             this.stageEstimationForEagerParentEnabled = stageEstimationForEagerParentEnabled;
             this.schedulerSpan = tracer.spanBuilder("scheduler")
                 .setParent(Context.current().with(queryStateMachine.getSession().getQuerySpan()))
@@ -1094,7 +1090,7 @@ public class EventDrivenFaultTolerantQueryScheduler
         {
             // Re-optimize plan here based on available runtime statistics.
             // Fragments changed due to re-optimization as well as their downstream stages are expected to be assigned new fragment ids.
-            if (!adaptiveQueryPlanningEnabled) {
+            if (adaptivePlanner.isEmpty()) {
                 return plan;
             }
 
@@ -1124,7 +1120,7 @@ public class EventDrivenFaultTolerantQueryScheduler
                 // already ready for execution.
                 if (isReadyForExecutionResult.isReadyForExecution()
                         && (oldValue == null || !oldValue.isReadyForExecution())) {
-                    return adaptivePlanner.optimize(plan, createRuntimeInfoProvider());
+                    return adaptivePlanner.get().optimize(plan, createRuntimeInfoProvider());
                 }
             }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Make AdaptivePlanner optional in the FTE scheduler instead of having a separate boolean field indicating whether the planner is to be used.

Reduces potential for inadvertent erroneous use; simplifies method signatures.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
