### PR TITLE
Use double checked locking in OperatorAdaptor

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperators.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperators.java
@@ -524,8 +524,7 @@ public class TypeOperators
             return switch (operatorConvention.operatorType()) {
                 case EQUAL, IS_DISTINCT_FROM, COMPARISON_UNORDERED_LAST, COMPARISON_UNORDERED_FIRST, LESS_THAN, LESS_THAN_OR_EQUAL ->
                         List.of(operatorConvention.type(), operatorConvention.type());
-                case READ_VALUE, HASH_CODE, XX_HASH_64, INDETERMINATE ->
-                        List.of(operatorConvention.type());
+                case READ_VALUE, HASH_CODE, XX_HASH_64, INDETERMINATE -> List.of(operatorConvention.type());
                 default -> throw new IllegalArgumentException("Unsupported operator type: " + operatorConvention.operatorType());
             };
         }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperators.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperators.java
@@ -192,17 +192,21 @@ public class TypeOperators
     private class OperatorAdaptor
     {
         private final OperatorConvention operatorConvention;
-        private MethodHandle adapted;
+        private volatile MethodHandle adapted;
 
         public OperatorAdaptor(OperatorConvention operatorConvention)
         {
             this.operatorConvention = operatorConvention;
         }
 
-        public synchronized MethodHandle get()
+        public MethodHandle get()
         {
             if (adapted == null) {
-                adapted = adaptOperator(operatorConvention);
+                synchronized (this) {
+                    if (adapted == null) {
+                        adapted = adaptOperator(operatorConvention);
+                    }
+                }
             }
             return adapted;
         }


### PR DESCRIPTION

## Description

    Synchronizing on get() method causes planning
    congestion when there is high query concurrency.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
