### PR TITLE
Add WITH SESSION clause

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -44,6 +44,10 @@ standaloneFunctionSpecification
     : functionSpecification EOF
     ;
 
+standaloneSessionSpecification
+    : sessionSpecification EOF
+    ;
+
 statement
     : rootQuery                                                        #statementDefault
     | USE schema=identifier                                            #use
@@ -198,11 +202,23 @@ statement
     ;
 
 rootQuery
-    : withFunction? query
+    : queryScoped? query
+    ;
+
+queryScoped
+    : WITH withFunction? withSession?
     ;
 
 withFunction
-    : WITH functionSpecification (',' functionSpecification)*
+    : functionSpecification (',' functionSpecification)*
+    ;
+
+withSession
+    : sessionSpecification (',' sessionSpecification)*
+    ;
+
+sessionSpecification
+    : SESSION qualifiedName EQ expression
     ;
 
 query

--- a/core/trino-main/src/main/java/io/trino/Session.java
+++ b/core/trino-main/src/main/java/io/trino/Session.java
@@ -55,9 +55,11 @@ import java.util.stream.Collectors;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static io.trino.SystemSessionProperties.TIME_ZONE_ID;
 import static io.trino.client.ProtocolHeaders.TRINO_HEADERS;
 import static io.trino.spi.StandardErrorCode.CATALOG_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.NOT_FOUND;
+import static io.trino.spi.type.TimeZoneKey.getTimeZoneKey;
 import static io.trino.sql.SqlPath.EMPTY_PATH;
 import static io.trino.util.Failures.checkCondition;
 import static java.util.Objects.requireNonNull;
@@ -407,6 +409,11 @@ public final class Session
                     .putAll(catalogEntry.getValue());
         }
 
+        return withProperties(systemProperties, catalogProperties);
+    }
+
+    public Session withProperties(Map<String, String> systemProperties, Map<String, Map<String, String>> catalogProperties)
+    {
         return new Session(
                 queryId,
                 querySpan,
@@ -419,7 +426,9 @@ public final class Session
                 schema,
                 path,
                 traceToken,
-                timeZoneKey,
+                Optional.ofNullable(systemProperties.get(TIME_ZONE_ID))
+                        .map(TimeZoneKey::getTimeZoneKey)
+                        .orElse(timeZoneKey),
                 locale,
                 remoteUserAddress,
                 userAgent,

--- a/core/trino-main/src/main/java/io/trino/dispatcher/DispatchManager.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/DispatchManager.java
@@ -110,7 +110,7 @@ public class DispatchManager
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.sessionSupplier = requireNonNull(sessionSupplier, "sessionSupplier is null");
         this.sessionPropertyDefaults = requireNonNull(sessionPropertyDefaults, "sessionPropertyDefaults is null");
-        this.sessionPropertyManager = sessionPropertyManager;
+        this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
         this.tracer = requireNonNull(tracer, "tracer is null");
 
         this.maxQueryLength = queryManagerConfig.getMaxQueryLength();

--- a/core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQueryFactory.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQueryFactory.java
@@ -38,6 +38,7 @@ import io.trino.security.AccessControl;
 import io.trino.server.protocol.Slug;
 import io.trino.spi.TrinoException;
 import io.trino.spi.resourcegroups.ResourceGroupId;
+import io.trino.sql.SessionSpecificationEvaluator;
 import io.trino.sql.tree.Statement;
 import io.trino.transaction.TransactionId;
 import io.trino.transaction.TransactionManager;
@@ -59,6 +60,7 @@ public class LocalDispatchQueryFactory
     private final TransactionManager transactionManager;
     private final AccessControl accessControl;
     private final Metadata metadata;
+    private final SessionSpecificationEvaluator sessionSpecificationEvaluator;
     private final QueryMonitor queryMonitor;
     private final LocationFactory locationFactory;
 
@@ -77,6 +79,7 @@ public class LocalDispatchQueryFactory
             QueryManager queryManager,
             QueryManagerConfig queryManagerConfig,
             TransactionManager transactionManager,
+            SessionSpecificationEvaluator sessionSpecificationEvaluator,
             AccessControl accessControl,
             Metadata metadata,
             QueryMonitor queryMonitor,
@@ -92,6 +95,7 @@ public class LocalDispatchQueryFactory
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
+        this.sessionSpecificationEvaluator = requireNonNull(sessionSpecificationEvaluator, "sessionSpecificationEvaluator is null");
         this.queryMonitor = requireNonNull(queryMonitor, "queryMonitor is null");
         this.locationFactory = requireNonNull(locationFactory, "locationFactory is null");
         this.executionFactories = requireNonNull(executionFactories, "executionFactories is null");
@@ -132,6 +136,7 @@ public class LocalDispatchQueryFactory
                 planOptimizersStatsCollector,
                 getQueryType(preparedQuery.getStatement()),
                 faultTolerantExecutionExchangeEncryptionEnabled,
+                Optional.of(sessionSpecificationEvaluator.getSessionSpecificationApplier(preparedQuery)),
                 version);
 
         // It is important that `queryCreatedEvent` is called here. Moving it past the `executor.submit` below

--- a/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
@@ -112,6 +112,7 @@ import io.trino.server.ui.WebUiModule;
 import io.trino.server.ui.WorkerResource;
 import io.trino.spi.VersionEmbedder;
 import io.trino.sql.PlannerContext;
+import io.trino.sql.SessionSpecificationEvaluator;
 import io.trino.sql.analyzer.AnalyzerFactory;
 import io.trino.sql.analyzer.QueryExplainerFactory;
 import io.trino.sql.planner.OptimizerStatsMBeanExporter;
@@ -210,6 +211,8 @@ public class CoordinatorModule
 
         // dispatcher
         binder.bind(DispatchManager.class).in(Scopes.SINGLETON);
+        // WITH SESSION interpreter
+        binder.bind(SessionSpecificationEvaluator.class).in(Scopes.SINGLETON);
         // export under the old name, for backwards compatibility
         newExporter(binder).export(DispatchManager.class).as(generator -> generator.generatedNameOf(QueryManager.class));
         binder.bind(FailedDispatchQueryFactory.class).in(Scopes.SINGLETON);

--- a/core/trino-main/src/main/java/io/trino/sql/SessionSpecificationEvaluator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/SessionSpecificationEvaluator.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Table;
+import com.google.inject.Inject;
+import io.trino.Session;
+import io.trino.execution.QueryPreparer.PreparedQuery;
+import io.trino.metadata.SessionPropertyManager;
+import io.trino.security.AccessControl;
+import io.trino.security.SecurityContext;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.CatalogHandle;
+import io.trino.spi.session.PropertyMetadata;
+import io.trino.spi.type.Type;
+import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.NodeRef;
+import io.trino.sql.tree.Parameter;
+import io.trino.sql.tree.QualifiedName;
+import io.trino.sql.tree.Query;
+import io.trino.sql.tree.SessionSpecification;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.trino.execution.ParameterExtractor.bindParameters;
+import static io.trino.metadata.MetadataUtil.getRequiredCatalogHandle;
+import static io.trino.metadata.SessionPropertyManager.evaluatePropertyValue;
+import static io.trino.metadata.SessionPropertyManager.serializeSessionProperty;
+import static io.trino.spi.StandardErrorCode.CATALOG_NOT_FOUND;
+import static io.trino.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
+import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class SessionSpecificationEvaluator
+{
+    private final PlannerContext plannerContext;
+    private final AccessControl accessControl;
+    private final SessionPropertyManager sessionPropertyManager;
+
+    @Inject
+    public SessionSpecificationEvaluator(PlannerContext plannerContext, AccessControl accessControl, SessionPropertyManager sessionPropertyManager)
+    {
+        this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+        this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
+    }
+
+    public SessionSpecificationsApplier getSessionSpecificationApplier(PreparedQuery preparedQuery)
+    {
+        if (!(preparedQuery.getStatement() instanceof Query queryStatement)) {
+            return session -> session;
+        }
+        return session -> prepareSession(session, queryStatement.getSessionProperties(), bindParameters(preparedQuery.getStatement(), preparedQuery.getParameters()));
+    }
+
+    public Session prepareSession(Session session, List<SessionSpecification> specifications, Map<NodeRef<Parameter>, Expression> parameters)
+    {
+        ResolvedSessionSpecifications resolvedSessionSpecifications = resolve(session, parameters, specifications);
+        return overrideProperties(session, resolvedSessionSpecifications);
+    }
+
+    public ResolvedSessionSpecifications resolve(Session session, Map<NodeRef<Parameter>, Expression> parameters, List<SessionSpecification> specifications)
+    {
+        ImmutableMap.Builder<String, String> sessionProperties = ImmutableMap.builder();
+        Table<String, String, String> catalogProperties = HashBasedTable.create();
+        Set<QualifiedName> seenPropertyNames = new HashSet<>();
+
+        for (SessionSpecification specification : specifications) {
+            List<String> nameParts = specification.getName().getParts();
+
+            if (!seenPropertyNames.add(specification.getName())) {
+                throw semanticException(INVALID_SESSION_PROPERTY, specification, "Session property %s already set", specification.getName());
+            }
+
+            if (nameParts.size() == 1) {
+                Optional<PropertyMetadata<?>> systemSessionPropertyMetadata = sessionPropertyManager.getSystemSessionPropertyMetadata(nameParts.getFirst());
+                if (systemSessionPropertyMetadata.isEmpty()) {
+                    throw semanticException(INVALID_SESSION_PROPERTY, specification, "Session property %s does not exist", specification.getName());
+                }
+                sessionProperties.put(nameParts.getFirst(), toSessionValue(session, parameters, specification, systemSessionPropertyMetadata.get()));
+            }
+
+            if (nameParts.size() == 2) {
+                CatalogHandle catalogHandle = getRequiredCatalogHandle(plannerContext.getMetadata(), session, specification, nameParts.getFirst());
+                Optional<PropertyMetadata<?>> connectorSessionPropertyMetadata = sessionPropertyManager.getConnectorSessionPropertyMetadata(catalogHandle, nameParts.getLast());
+                if (connectorSessionPropertyMetadata.isEmpty()) {
+                    throw semanticException(INVALID_SESSION_PROPERTY, specification, "Session property %s does not exist", specification.getName());
+                }
+                catalogProperties.put(nameParts.get(0), nameParts.get(1), toSessionValue(session, parameters, specification, connectorSessionPropertyMetadata.get()));
+            }
+        }
+
+        return new ResolvedSessionSpecifications(sessionProperties.buildOrThrow(), catalogProperties.rowMap());
+    }
+
+    public Session overrideProperties(Session session, ResolvedSessionSpecifications resolvedSessionSpecifications)
+    {
+        requireNonNull(resolvedSessionSpecifications, "resolvedSessionSpecifications is null");
+
+        validateSystemProperties(session, resolvedSessionSpecifications.systemProperties());
+
+        // Catalog session properties were already evaluated so we need to evaluate overrides
+        if (session.getTransactionId().isPresent()) {
+            validateCatalogProperties(session, resolvedSessionSpecifications.catalogProperties());
+        }
+
+        // NOTE: properties are validated before calling overrideProperties
+        Map<String, String> systemProperties = new HashMap<>();
+        systemProperties.putAll(session.getSystemProperties());
+        systemProperties.putAll(resolvedSessionSpecifications.systemProperties());
+
+        Map<String, Map<String, String>> catalogProperties = new HashMap<>(session.getCatalogProperties());
+        for (Map.Entry<String, Map<String, String>> catalogEntry : resolvedSessionSpecifications.catalogProperties().entrySet()) {
+            catalogProperties.computeIfAbsent(catalogEntry.getKey(), id -> new HashMap<>())
+                    .putAll(catalogEntry.getValue());
+        }
+
+        return session.withProperties(systemProperties, catalogProperties);
+    }
+
+    private String toSessionValue(Session session, Map<NodeRef<Parameter>, Expression> parameters, SessionSpecification specification, PropertyMetadata<?> propertyMetadata)
+    {
+        Type type = propertyMetadata.getSqlType();
+        Object objectValue;
+
+        try {
+            objectValue = evaluatePropertyValue(specification.getValue(), type, session, plannerContext, accessControl, parameters);
+        }
+        catch (TrinoException e) {
+            throw new TrinoException(
+                    INVALID_SESSION_PROPERTY,
+                    format("Unable to set session property '%s' to '%s': %s", specification.getName(), specification.getValue(), e.getRawMessage()));
+        }
+
+        String value = serializeSessionProperty(type, objectValue);
+        // verify the SQL value can be decoded by the property
+        try {
+            propertyMetadata.decode(objectValue);
+        }
+        catch (RuntimeException e) {
+            throw semanticException(INVALID_SESSION_PROPERTY, specification, "%s", e.getMessage());
+        }
+
+        return value;
+    }
+
+    private void validateSystemProperties(Session session, Map<String, String> systemProperties)
+    {
+        for (Map.Entry<String, String> property : systemProperties.entrySet()) {
+            // verify permissions
+            accessControl.checkCanSetSystemSessionProperty(session.getIdentity(), session.getQueryId(), property.getKey());
+            // validate session property value
+            sessionPropertyManager.validateSystemSessionProperty(property.getKey(), property.getValue());
+        }
+    }
+
+    private void validateCatalogProperties(Session session, Map<String, Map<String, String>> catalogsProperties)
+    {
+        checkState(session.getTransactionId().isPresent(), "Not in transaction");
+        for (Map.Entry<String, Map<String, String>> catalogProperties : catalogsProperties.entrySet()) {
+            CatalogHandle catalogHandle = plannerContext.getMetadata().getCatalogHandle(session, catalogProperties.getKey())
+                    .orElseThrow(() -> new TrinoException(CATALOG_NOT_FOUND, "Catalog '%s' not found".formatted(catalogProperties.getKey())));
+
+            for (Map.Entry<String, String> catalogProperty : catalogProperties.getValue().entrySet()) {
+                // verify permissions
+                accessControl.checkCanSetCatalogSessionProperty(new SecurityContext(session.getRequiredTransactionId(), session.getIdentity(), session.getQueryId(), session.getStart()), catalogProperties.getKey(), catalogProperty.getKey());
+                // validate catalog session property value
+                sessionPropertyManager.validateCatalogSessionProperty(catalogProperties.getKey(), catalogHandle, catalogProperty.getKey(), catalogProperty.getValue());
+            }
+        }
+    }
+
+    public record ResolvedSessionSpecifications(Map<String, String> systemProperties, Map<String, Map<String, String>> catalogProperties)
+    {
+        public ResolvedSessionSpecifications
+        {
+            systemProperties = ImmutableMap.copyOf(requireNonNull(systemProperties, "systemProperties is null"));
+            catalogProperties = ImmutableMap.copyOf(requireNonNull(catalogProperties, "catalogProperties is null"));
+        }
+    }
+
+    @FunctionalInterface
+    public interface SessionSpecificationsApplier
+            extends Function<Session, Session>
+    {
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/dispatcher/TestLocalDispatchQuery.java
+++ b/core/trino-main/src/test/java/io/trino/dispatcher/TestLocalDispatchQuery.java
@@ -120,6 +120,7 @@ public class TestLocalDispatchQuery
                 createPlanOptimizersStatsCollector(),
                 Optional.of(QueryType.DATA_DEFINITION),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
         QueryMonitor queryMonitor = new QueryMonitor(
                 JsonCodec.jsonCodec(StageInfo.class),

--- a/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
+++ b/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
@@ -243,6 +243,7 @@ public abstract class BaseDataDefinitionTaskTest
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestCallTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCallTask.java
@@ -171,6 +171,7 @@ public class TestCallTask
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestCommitTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCommitTask.java
@@ -144,6 +144,7 @@ public class TestCommitTask
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateCatalogTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateCatalogTask.java
@@ -82,6 +82,7 @@ public class TestCreateCatalogTask
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
 
         this.queryRunner = queryRunner;

--- a/core/trino-main/src/test/java/io/trino/execution/TestDeallocateTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestDeallocateTask.java
@@ -112,6 +112,7 @@ public class TestDeallocateTask
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
         Deallocate deallocate = new Deallocate(new Identifier(statementName));
         new DeallocateTask().execute(deallocate, stateMachine, emptyList(), WarningCollector.NOOP);

--- a/core/trino-main/src/test/java/io/trino/execution/TestDropCatalogTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestDropCatalogTask.java
@@ -116,6 +116,7 @@ public class TestDropCatalogTask
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/TestPrepareTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestPrepareTask.java
@@ -136,6 +136,7 @@ public class TestPrepareTask
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
         Prepare prepare = new Prepare(identifier(statementName), statement);
         new PrepareTask(new SqlParser()).execute(prepare, stateMachine, emptyList(), WarningCollector.NOOP);

--- a/core/trino-main/src/test/java/io/trino/execution/TestQueryStateMachine.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestQueryStateMachine.java
@@ -865,6 +865,7 @@ public class TestQueryStateMachine
                     createPlanOptimizersStatsCollector(),
                     QUERY_TYPE,
                     true,
+                    Optional.empty(),
                     new NodeVersion("test"));
             stateMachine.setInputs(INPUTS);
             stateMachine.setOutput(OUTPUT);

--- a/core/trino-main/src/test/java/io/trino/execution/TestResetSessionTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestResetSessionTask.java
@@ -119,6 +119,7 @@ public class TestResetSessionTask
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
 
         getFutureValue(new ResetSessionTask(metadata, sessionPropertyManager).execute(

--- a/core/trino-main/src/test/java/io/trino/execution/TestRollbackTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestRollbackTask.java
@@ -136,6 +136,7 @@ public class TestRollbackTask
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetPathTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetPathTask.java
@@ -123,6 +123,7 @@ public class TestSetPathTask
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetRoleTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetRoleTask.java
@@ -172,6 +172,7 @@ public class TestSetRoleTask
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
         new SetRoleTask(metadata, accessControl).execute(setRole, stateMachine, ImmutableList.of(), WarningCollector.NOOP);
         return stateMachine;

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetSessionAuthorizationTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetSessionAuthorizationTask.java
@@ -124,6 +124,7 @@ public class TestSetSessionAuthorizationTask
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
         return stateMachine;
     }

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetSessionTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetSessionTask.java
@@ -207,6 +207,7 @@ public class TestSetSessionTask
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
         getFutureValue(new SetSessionTask(plannerContext, accessControl, sessionPropertyManager).execute(new SetSession(qualifiedPropName, expression), stateMachine, parameters, WarningCollector.NOOP));
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetTimeZoneTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetTimeZoneTask.java
@@ -266,6 +266,7 @@ public class TestSetTimeZoneTask
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestStartTransactionTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestStartTransactionTask.java
@@ -265,6 +265,7 @@ public class TestStartTransactionTask
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestingPlannerContext.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestingPlannerContext.java
@@ -77,14 +77,12 @@ public final class TestingPlannerContext
         public Builder withMetadata(Metadata metadata)
         {
             checkState(this.metadata == null, "metadata already set");
-            checkState(this.transactionManager == null, "transactionManager already set");
             this.metadata = requireNonNull(metadata, "metadata is null");
             return this;
         }
 
         public Builder withTransactionManager(TransactionManager transactionManager)
         {
-            checkState(this.metadata == null, "metadata already set");
             checkState(this.transactionManager == null, "transactionManager already set");
             this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
             return this;

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestSessionSpecifications.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestSessionSpecifications.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.trino.FeaturesConfig;
+import io.trino.Session;
+import io.trino.SystemSessionProperties;
+import io.trino.metadata.AbstractMockMetadata;
+import io.trino.metadata.MetadataManager;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.metadata.SessionPropertyManager;
+import io.trino.metadata.TypeRegistry;
+import io.trino.security.AllowAllAccessControl;
+import io.trino.spi.connector.CatalogHandle;
+import io.trino.spi.function.OperatorType;
+import io.trino.spi.session.PropertyMetadata;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeManager;
+import io.trino.spi.type.TypeOperators;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.SessionSpecificationEvaluator;
+import io.trino.sql.parser.SqlParser;
+import io.trino.sql.tree.SessionSpecification;
+import io.trino.transaction.TestingTransactionManager;
+import io.trino.transaction.TransactionManager;
+import io.trino.type.InternalTypeManager;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.sql.planner.TestingPlannerContext.plannerContextBuilder;
+import static io.trino.testing.TestingSession.testSession;
+import static io.trino.testing.TransactionBuilder.transaction;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestSessionSpecifications
+{
+    private static final SqlParser SQL_PARSER = new SqlParser();
+    private static final SessionPropertyManager SESSION_PROPERTY_MANAGER = new SessionPropertyManager(ImmutableSet.of(new SystemSessionProperties()), catalogHandle -> Map.of(
+            "catalog_property", PropertyMetadata.stringProperty("catalog_property", "Test catalog property", "", false)));
+
+    @Test
+    public void testParseSystemSessionProperty()
+    {
+        assertThatThrownBy(() -> analyze("SESSION invalid_key = 'invalid_value'"))
+                .hasMessageContaining("line 1:1: Session property invalid_key does not exist");
+
+        assertThatThrownBy(() -> analyze("SESSION optimize_hash_generation = 'invalid_value'"))
+                .hasMessageContaining("Unable to set session property 'optimize_hash_generation' to ''invalid_value'': Cannot cast type varchar(13) to boolean");
+
+        assertThat(analyze("SESSION optimize_hash_generation = true").getSystemProperties())
+                .isEqualTo(Map.of("optimize_hash_generation", "true"));
+
+        assertThat(analyze("SESSION optimize_hash_generation = CAST('true' AS boolean)").getSystemProperties())
+                .isEqualTo(Map.of("optimize_hash_generation", "true"));
+
+        assertThatThrownBy(() -> analyze("SESSION optimize_hash_generation = true", "SESSION optimize_hash_generation = false"))
+                .hasMessageContaining("line 1:1: Session property optimize_hash_generation already set");
+    }
+
+    @Test
+    public void testCatalogSessionProperty()
+    {
+        assertThatThrownBy(() -> analyze("SESSION test.invalid_key = 'invalid_value'"))
+                .hasMessageContaining("line 1:1: Session property test.invalid_key does not exist");
+
+        assertThatThrownBy(() -> analyze("SESSION test.catalog_property = true"))
+                .hasMessageContaining("Unable to set session property 'test.catalog_property' to 'true': Cannot cast type boolean to varchar");
+
+        assertThat(analyze("SESSION test.catalog_property = 'true'").getCatalogProperties("test"))
+                .isEqualTo(Map.of("catalog_property", "true"));
+
+        assertThat(analyze("SESSION test.catalog_property = CAST(true AS varchar)").getCatalogProperties("test"))
+                .isEqualTo(Map.of("catalog_property", "true"));
+
+        assertThatThrownBy(() -> analyze("SESSION test.catalog_property = 'true'", "SESSION test.catalog_property = 'false'").getCatalogProperties("test"))
+                .hasMessageContaining("line 1:1: Session property test.catalog_property already set");
+    }
+
+    private static Session analyze(@Language("SQL") String... statements)
+    {
+        ImmutableList.Builder<SessionSpecification> sessionSpecifications = ImmutableList.builder();
+        for (String statement : statements) {
+            sessionSpecifications.add(SQL_PARSER.createSessionSpecification(statement));
+        }
+
+        TransactionManager transactionManager = new TestingTransactionManager();
+        PlannerContext plannerContext = plannerContextBuilder()
+                .withMetadata(new MockMetadata())
+                .withTransactionManager(transactionManager)
+                .build();
+
+        return transaction(transactionManager, plannerContext.getMetadata(), new AllowAllAccessControl())
+                .execute(testSession(), transactionSession -> {
+                    SessionSpecificationEvaluator evaluator = new SessionSpecificationEvaluator(plannerContext, new AllowAllAccessControl(), SESSION_PROPERTY_MANAGER);
+                    return evaluator.prepareSession(transactionSession, sessionSpecifications.build(), Map.of());
+                });
+    }
+
+    private static class MockMetadata
+            extends AbstractMockMetadata
+    {
+        private final MetadataManager delegate;
+
+        public MockMetadata()
+        {
+            FeaturesConfig featuresConfig = new FeaturesConfig();
+            TypeOperators typeOperators = new TypeOperators();
+
+            TypeRegistry typeRegistry = new TypeRegistry(typeOperators, featuresConfig);
+            TypeManager typeManager = new InternalTypeManager(typeRegistry);
+            this.delegate = MetadataManager.testMetadataManagerBuilder()
+                    .withTypeManager(typeManager)
+                    .build();
+        }
+
+        @Override
+        public ResolvedFunction getCoercion(OperatorType operatorType, Type fromType, Type toType)
+        {
+            return delegate.getCoercion(operatorType, fromType, toType);
+        }
+
+        @Override
+        public Optional<CatalogHandle> getCatalogHandle(Session session, String catalogName)
+        {
+            return Optional.of(CatalogHandle.fromId(catalogName + ":NORMAL:v1"));
+        }
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/QueryUtil.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/QueryUtil.java
@@ -271,6 +271,7 @@ public final class QueryUtil
     {
         return new Query(
                 ImmutableList.of(),
+                ImmutableList.of(),
                 Optional.empty(),
                 body,
                 Optional.empty(),

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -137,6 +137,7 @@ import io.trino.sql.tree.SampledRelation;
 import io.trino.sql.tree.SecurityCharacteristic;
 import io.trino.sql.tree.Select;
 import io.trino.sql.tree.SelectItem;
+import io.trino.sql.tree.SessionSpecification;
 import io.trino.sql.tree.SetColumnType;
 import io.trino.sql.tree.SetPath;
 import io.trino.sql.tree.SetProperties;
@@ -641,15 +642,29 @@ public final class SqlFormatter
         @Override
         protected Void visitQuery(Query node, Integer indent)
         {
-            if (!node.getFunctions().isEmpty()) {
+            if (!node.getFunctions().isEmpty() || !node.getSessionProperties().isEmpty()) {
                 builder.append("WITH\n");
-                Iterator<FunctionSpecification> functions = node.getFunctions().iterator();
-                while (functions.hasNext()) {
-                    process(functions.next(), indent + 1);
-                    if (functions.hasNext()) {
-                        builder.append(',');
+
+                if (!node.getFunctions().isEmpty()) {
+                    Iterator<FunctionSpecification> functions = node.getFunctions().iterator();
+                    while (functions.hasNext()) {
+                        process(functions.next(), indent + 1);
+                        if (functions.hasNext()) {
+                            builder.append(',');
+                        }
+                        builder.append('\n');
                     }
-                    builder.append('\n');
+                }
+
+                if (!node.getSessionProperties().isEmpty()) {
+                    Iterator<SessionSpecification> sessionProperty = node.getSessionProperties().iterator();
+                    while (sessionProperty.hasNext()) {
+                        process(sessionProperty.next(), indent + 1);
+                        if (sessionProperty.hasNext()) {
+                            builder.append(',');
+                        }
+                        builder.append('\n');
+                    }
                 }
             }
 
@@ -2304,6 +2319,16 @@ public final class SqlFormatter
                 builder.append("\n");
             }
             process(node.getStatement(), indent);
+            return null;
+        }
+
+        @Override
+        protected Void visitSessionSpecification(SessionSpecification node, Integer indent)
+        {
+            append(indent, "SESSION ")
+                    .append(formatName(node.getName()))
+                    .append(" = ")
+                    .append(formatExpression(node.getExpression()));
             return null;
         }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -645,26 +645,22 @@ public final class SqlFormatter
             if (!node.getFunctions().isEmpty() || !node.getSessionProperties().isEmpty()) {
                 builder.append("WITH\n");
 
-                if (!node.getFunctions().isEmpty()) {
-                    Iterator<FunctionSpecification> functions = node.getFunctions().iterator();
-                    while (functions.hasNext()) {
-                        process(functions.next(), indent + 1);
-                        if (functions.hasNext()) {
-                            builder.append(',');
-                        }
-                        builder.append('\n');
+                Iterator<FunctionSpecification> functions = node.getFunctions().iterator();
+                while (functions.hasNext()) {
+                    process(functions.next(), indent + 1);
+                    if (functions.hasNext()) {
+                        builder.append(',');
                     }
+                    builder.append('\n');
                 }
 
-                if (!node.getSessionProperties().isEmpty()) {
-                    Iterator<SessionSpecification> sessionProperty = node.getSessionProperties().iterator();
-                    while (sessionProperty.hasNext()) {
-                        process(sessionProperty.next(), indent + 1);
-                        if (sessionProperty.hasNext()) {
-                            builder.append(',');
-                        }
-                        builder.append('\n');
+                Iterator<SessionSpecification> sessionProperties = node.getSessionProperties().iterator();
+                while (sessionProperties.hasNext()) {
+                    process(sessionProperties.next(), indent + 1);
+                    if (sessionProperties.hasNext()) {
+                        builder.append(',');
                     }
+                    builder.append('\n');
                 }
             }
 
@@ -2328,7 +2324,7 @@ public final class SqlFormatter
             append(indent, "SESSION ")
                     .append(formatName(node.getName()))
                     .append(" = ")
-                    .append(formatExpression(node.getExpression()));
+                    .append(formatExpression(node.getValue()));
             return null;
         }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -238,6 +238,7 @@ import io.trino.sql.tree.SearchedCaseExpression;
 import io.trino.sql.tree.SecurityCharacteristic;
 import io.trino.sql.tree.Select;
 import io.trino.sql.tree.SelectItem;
+import io.trino.sql.tree.SessionSpecification;
 import io.trino.sql.tree.SetColumnType;
 import io.trino.sql.tree.SetPath;
 import io.trino.sql.tree.SetProperties;
@@ -1097,9 +1098,15 @@ class AstBuilder
 
         return new Query(
                 getLocation(context),
-                Optional.ofNullable(context.withFunction())
+                Optional.ofNullable(context.queryScoped())
+                        .map(SqlBaseParser.QueryScopedContext::withFunction)
                         .map(SqlBaseParser.WithFunctionContext::functionSpecification)
                         .map(contexts -> visit(contexts, FunctionSpecification.class))
+                        .orElseGet(ImmutableList::of),
+                Optional.ofNullable(context.queryScoped())
+                        .map(SqlBaseParser.QueryScopedContext::withSession)
+                        .map(SqlBaseParser.WithSessionContext::sessionSpecification)
+                        .map(contexts -> visit(contexts, SessionSpecification.class))
                         .orElseGet(ImmutableList::of),
                 query.getWith(),
                 query.getQueryBody(),
@@ -1115,6 +1122,7 @@ class AstBuilder
 
         return new Query(
                 getLocation(context),
+                ImmutableList.of(),
                 ImmutableList.of(),
                 visitIfPresent(context.with(), With.class),
                 body.getQueryBody(),
@@ -1212,6 +1220,7 @@ class AstBuilder
             return new Query(
                     getLocation(context),
                     ImmutableList.of(),
+                    ImmutableList.of(),
                     Optional.empty(),
                     new QuerySpecification(
                             getLocation(context),
@@ -1231,6 +1240,7 @@ class AstBuilder
 
         return new Query(
                 getLocation(context),
+                ImmutableList.of(),
                 ImmutableList.of(),
                 Optional.empty(),
                 term,
@@ -3737,6 +3747,15 @@ class AstBuilder
                 (ReturnsClause) visit(context.returnsClause()),
                 visit(context.routineCharacteristic(), RoutineCharacteristic.class),
                 statement);
+    }
+
+    @Override
+    public Node visitSessionSpecification(SqlBaseParser.SessionSpecificationContext context)
+    {
+        return new SessionSpecification(
+                getLocation(context),
+                getQualifiedName(context.qualifiedName()),
+                (Expression) visit(context.expression()));
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -414,6 +414,12 @@ class AstBuilder
         return visit(context.functionSpecification());
     }
 
+    @Override
+    public Node visitStandaloneSessionSpecification(SqlBaseParser.StandaloneSessionSpecificationContext context)
+    {
+        return visit(context.sessionSpecification());
+    }
+
     // ******************* statements **********************
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/SqlParser.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/SqlParser.java
@@ -23,6 +23,7 @@ import io.trino.sql.tree.Node;
 import io.trino.sql.tree.NodeLocation;
 import io.trino.sql.tree.PathSpecification;
 import io.trino.sql.tree.RowPattern;
+import io.trino.sql.tree.SessionSpecification;
 import io.trino.sql.tree.Statement;
 import org.antlr.v4.runtime.ANTLRErrorListener;
 import org.antlr.v4.runtime.BaseErrorListener;
@@ -118,6 +119,11 @@ public class SqlParser
     public FunctionSpecification createFunctionSpecification(String sql)
     {
         return (FunctionSpecification) invokeParser("function specification", sql, SqlBaseParser::standaloneFunctionSpecification);
+    }
+
+    public SessionSpecification createSessionSpecification(String sql)
+    {
+        return (SessionSpecification) invokeParser("session specification", sql, SqlBaseParser::standaloneSessionSpecification);
     }
 
     private Node invokeParser(String name, String sql, Function<SqlBaseParser, ParserRuleContext> parseFunction)

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
@@ -1237,6 +1237,11 @@ public abstract class AstVisitor<R, C>
         return visitNode(node, context);
     }
 
+    protected R visitSessionSpecification(SessionSpecification node, C context)
+    {
+        return visitNode(node, context);
+    }
+
     protected R visitParameterDeclaration(ParameterDeclaration node, C context)
     {
         return visitNode(node, context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Query.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Query.java
@@ -27,6 +27,7 @@ public class Query
         extends Statement
 {
     private final List<FunctionSpecification> functions;
+    private final List<SessionSpecification> sessionProperties;
     private final Optional<With> with;
     private final QueryBody queryBody;
     private final Optional<OrderBy> orderBy;
@@ -35,30 +36,33 @@ public class Query
 
     public Query(
             List<FunctionSpecification> functions,
+            List<SessionSpecification> sessionProperties,
             Optional<With> with,
             QueryBody queryBody,
             Optional<OrderBy> orderBy,
             Optional<Offset> offset,
             Optional<Node> limit)
     {
-        this(Optional.empty(), functions, with, queryBody, orderBy, offset, limit);
+        this(Optional.empty(), functions, sessionProperties, with, queryBody, orderBy, offset, limit);
     }
 
     public Query(
             NodeLocation location,
             List<FunctionSpecification> functions,
+            List<SessionSpecification> sessionProperties,
             Optional<With> with,
             QueryBody queryBody,
             Optional<OrderBy> orderBy,
             Optional<Offset> offset,
             Optional<Node> limit)
     {
-        this(Optional.of(location), functions, with, queryBody, orderBy, offset, limit);
+        this(Optional.of(location), functions, sessionProperties, with, queryBody, orderBy, offset, limit);
     }
 
     private Query(
             Optional<NodeLocation> location,
             List<FunctionSpecification> functions,
+            List<SessionSpecification> sessionProperties,
             Optional<With> with,
             QueryBody queryBody,
             Optional<OrderBy> orderBy,
@@ -66,7 +70,8 @@ public class Query
             Optional<Node> limit)
     {
         super(location);
-        requireNonNull(functions, "function si snull");
+        requireNonNull(functions, "function si snull"); // TODO: fix me
+        requireNonNull(sessionProperties, "sessionProperties is null");
         requireNonNull(with, "with is null");
         requireNonNull(queryBody, "queryBody is null");
         requireNonNull(orderBy, "orderBy is null");
@@ -75,6 +80,7 @@ public class Query
         checkArgument(!limit.isPresent() || limit.get() instanceof FetchFirst || limit.get() instanceof Limit, "limit must be optional of either FetchFirst or Limit type");
 
         this.functions = ImmutableList.copyOf(functions);
+        this.sessionProperties = ImmutableList.copyOf(sessionProperties);
         this.with = with;
         this.queryBody = queryBody;
         this.orderBy = orderBy;
@@ -85,6 +91,11 @@ public class Query
     public List<FunctionSpecification> getFunctions()
     {
         return functions;
+    }
+
+    public List<SessionSpecification> getSessionProperties()
+    {
+        return sessionProperties;
     }
 
     public Optional<With> getWith()
@@ -123,6 +134,7 @@ public class Query
     {
         ImmutableList.Builder<Node> nodes = ImmutableList.builder();
         nodes.addAll(functions);
+        nodes.addAll(sessionProperties);
         with.ifPresent(nodes::add);
         nodes.add(queryBody);
         orderBy.ifPresent(nodes::add);
@@ -136,6 +148,7 @@ public class Query
     {
         return toStringHelper(this)
                 .add("functions", functions.isEmpty() ? null : functions)
+                .add("sessionProperties", sessionProperties.isEmpty() ? null : sessionProperties)
                 .add("with", with.orElse(null))
                 .add("queryBody", queryBody)
                 .add("orderBy", orderBy)
@@ -156,6 +169,7 @@ public class Query
         }
         Query o = (Query) obj;
         return Objects.equals(functions, o.functions) &&
+                Objects.equals(sessionProperties, o.sessionProperties) &&
                 Objects.equals(with, o.with) &&
                 Objects.equals(queryBody, o.queryBody) &&
                 Objects.equals(orderBy, o.orderBy) &&
@@ -166,7 +180,7 @@ public class Query
     @Override
     public int hashCode()
     {
-        return Objects.hash(functions, with, queryBody, orderBy, offset, limit);
+        return Objects.hash(functions, sessionProperties, with, queryBody, orderBy, offset, limit);
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Query.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Query.java
@@ -70,7 +70,7 @@ public class Query
             Optional<Node> limit)
     {
         super(location);
-        requireNonNull(functions, "function si snull"); // TODO: fix me
+        requireNonNull(functions, "functions is null");
         requireNonNull(sessionProperties, "sessionProperties is null");
         requireNonNull(with, "with is null");
         requireNonNull(queryBody, "queryBody is null");

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/SessionSpecification.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/SessionSpecification.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class SessionSpecification
+        extends Node
+{
+    private final QualifiedName name;
+    private final Expression expression;
+
+    public SessionSpecification(QualifiedName name, Expression expression)
+    {
+        this(Optional.empty(), name, expression);
+    }
+
+    public SessionSpecification(NodeLocation location, QualifiedName name, Expression expression)
+    {
+        this(Optional.of(location), name, expression);
+    }
+
+    public SessionSpecification(Optional<NodeLocation> location, QualifiedName name, Expression expression)
+    {
+        super(location);
+        this.name = requireNonNull(name, "name is null");
+        this.expression = requireNonNull(expression, "expression is null");
+    }
+
+    public QualifiedName getName()
+    {
+        return name;
+    }
+
+    public Expression getExpression()
+    {
+        return expression;
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitSessionSpecification(this, context);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name, expression);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        return (obj instanceof SessionSpecification other) &&
+                Objects.equals(name, other.name) &&
+                Objects.equals(expression, other.expression);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("name", name)
+                .add("expression", expression)
+                .toString();
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/SessionSpecification.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/SessionSpecification.java
@@ -26,23 +26,23 @@ public class SessionSpecification
         extends Node
 {
     private final QualifiedName name;
-    private final Expression expression;
+    private final Expression value;
 
-    public SessionSpecification(QualifiedName name, Expression expression)
+    public SessionSpecification(QualifiedName name, Expression value)
     {
-        this(Optional.empty(), name, expression);
+        this(Optional.empty(), name, value);
     }
 
-    public SessionSpecification(NodeLocation location, QualifiedName name, Expression expression)
+    public SessionSpecification(NodeLocation location, QualifiedName name, Expression value)
     {
-        this(Optional.of(location), name, expression);
+        this(Optional.of(location), name, value);
     }
 
-    public SessionSpecification(Optional<NodeLocation> location, QualifiedName name, Expression expression)
+    public SessionSpecification(Optional<NodeLocation> location, QualifiedName name, Expression value)
     {
         super(location);
         this.name = requireNonNull(name, "name is null");
-        this.expression = requireNonNull(expression, "expression is null");
+        this.value = requireNonNull(value, "value is null");
     }
 
     public QualifiedName getName()
@@ -50,9 +50,9 @@ public class SessionSpecification
         return name;
     }
 
-    public Expression getExpression()
+    public Expression getValue()
     {
-        return expression;
+        return value;
     }
 
     @Override
@@ -70,7 +70,7 @@ public class SessionSpecification
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, expression);
+        return Objects.hash(name, value);
     }
 
     @Override
@@ -78,7 +78,7 @@ public class SessionSpecification
     {
         return (obj instanceof SessionSpecification other) &&
                 Objects.equals(name, other.name) &&
-                Objects.equals(expression, other.expression);
+                Objects.equals(value, other.value);
     }
 
     @Override
@@ -86,7 +86,7 @@ public class SessionSpecification
     {
         return toStringHelper(this)
                 .add("name", name)
-                .add("expression", expression)
+                .add("expression", value)
                 .toString();
     }
 }

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/ParserAssert.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/ParserAssert.java
@@ -70,6 +70,11 @@ public class ParserAssert
         return createAssertion(new SqlParser()::createFunctionSpecification, sql);
     }
 
+    public static AssertProvider<ParserAssert> sessionSpecification(String sql)
+    {
+        return createAssertion(new SqlParser()::createSessionSpecification, sql);
+    }
+
     private static Expression createExpression(String expression)
     {
         return new SqlParser().createExpression(expression);

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -171,6 +171,7 @@ import io.trino.sql.tree.Row;
 import io.trino.sql.tree.SearchedCaseExpression;
 import io.trino.sql.tree.Select;
 import io.trino.sql.tree.SelectItem;
+import io.trino.sql.tree.SessionSpecification;
 import io.trino.sql.tree.SetColumnType;
 import io.trino.sql.tree.SetPath;
 import io.trino.sql.tree.SetProperties;
@@ -226,6 +227,7 @@ import io.trino.sql.tree.With;
 import io.trino.sql.tree.WithQuery;
 import io.trino.sql.tree.ZeroOrMoreQuantifier;
 import io.trino.sql.tree.ZeroOrOneQuantifier;
+import org.assertj.core.api.AssertProvider;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -2024,6 +2026,7 @@ public class TestSqlParser
                 .isEqualTo(new CreateTableAsSelect(location(1, 1), qualifiedName(location(1, 14), "foo"), new Query(
                         location(1, 21),
                         ImmutableList.of(),
+                        ImmutableList.of(),
                         Optional.empty(),
                         new QuerySpecification(
                                 location(1, 21),
@@ -2049,6 +2052,7 @@ public class TestSqlParser
                 .isEqualTo(new CreateTableAsSelect(location(1, 1), qualifiedName(location(1, 14), "foo"), new Query(
                         location(1, 24),
                         ImmutableList.of(),
+                        ImmutableList.of(),
                         Optional.empty(),
                         new QuerySpecification(
                                 location(1, 24),
@@ -2073,6 +2077,7 @@ public class TestSqlParser
         assertThat(statement("CREATE TABLE foo(x,y) AS SELECT a,b FROM t"))
                 .isEqualTo(new CreateTableAsSelect(location(1, 1), qualifiedName(location(1, 14), "foo"), new Query(
                         location(1, 26),
+                        ImmutableList.of(),
                         ImmutableList.of(),
                         Optional.empty(),
                         new QuerySpecification(
@@ -2103,6 +2108,7 @@ public class TestSqlParser
                 .isEqualTo(new CreateTableAsSelect(location(1, 1), qualifiedName(location(1, 25), "foo"), new Query(
                         location(1, 32),
                         ImmutableList.of(),
+                        ImmutableList.of(),
                         Optional.empty(),
                         new QuerySpecification(
                                 location(1, 32),
@@ -2128,6 +2134,7 @@ public class TestSqlParser
                 .isEqualTo(new CreateTableAsSelect(location(1, 1), qualifiedName(location(1, 25), "foo"), new Query(
                         location(1, 35),
                         ImmutableList.of(),
+                        ImmutableList.of(),
                         Optional.empty(),
                         new QuerySpecification(
                                 location(1, 35),
@@ -2152,6 +2159,7 @@ public class TestSqlParser
         assertThat(statement("CREATE OR REPLACE TABLE foo(x,y) AS SELECT a,b FROM t"))
                 .isEqualTo(new CreateTableAsSelect(location(1, 1), qualifiedName(location(1, 25), "foo"), new Query(
                         location(1, 37),
+                        ImmutableList.of(),
                         ImmutableList.of(),
                         Optional.empty(),
                         new QuerySpecification(
@@ -2182,6 +2190,7 @@ public class TestSqlParser
                 .isEqualTo(new CreateTableAsSelect(location(1, 1), qualifiedName(location(1, 28), "foo"), new Query(
                         location(1, 35),
                         ImmutableList.of(),
+                        ImmutableList.of(),
                         Optional.empty(),
                         new QuerySpecification(
                                 location(1, 35),
@@ -2207,6 +2216,7 @@ public class TestSqlParser
                 .isEqualTo(new CreateTableAsSelect(location(1, 1), qualifiedName(location(1, 28), "foo"), new Query(
                         location(1, 38),
                         ImmutableList.of(),
+                        ImmutableList.of(),
                         Optional.empty(),
                         new QuerySpecification(
                                 location(1, 38),
@@ -2231,6 +2241,7 @@ public class TestSqlParser
         assertThat(statement("CREATE TABLE IF NOT EXISTS foo(x,y) AS SELECT a,b FROM t"))
                 .isEqualTo(new CreateTableAsSelect(location(1, 1), qualifiedName(location(1, 28), "foo"), new Query(
                         location(1, 40),
+                        ImmutableList.of(),
                         ImmutableList.of(),
                         Optional.empty(),
                         new QuerySpecification(
@@ -2261,6 +2272,7 @@ public class TestSqlParser
                 .isEqualTo(new CreateTableAsSelect(location(1, 1), qualifiedName(location(1, 14), "foo"), new Query(
                         location(1, 21),
                         ImmutableList.of(),
+                        ImmutableList.of(),
                         Optional.empty(),
                         new QuerySpecification(
                                 location(1, 21),
@@ -2286,6 +2298,7 @@ public class TestSqlParser
                 .isEqualTo(new CreateTableAsSelect(location(1, 1), qualifiedName(location(1, 14), "foo"), new Query(
                         location(1, 24),
                         ImmutableList.of(),
+                        ImmutableList.of(),
                         Optional.empty(),
                         new QuerySpecification(
                                 location(1, 24),
@@ -2310,6 +2323,7 @@ public class TestSqlParser
         assertThat(statement("CREATE TABLE foo(x,y) AS SELECT a,b FROM t WITH NO DATA"))
                 .isEqualTo(new CreateTableAsSelect(location(1, 1), qualifiedName(location(1, 14), "foo"), new Query(
                         location(1, 26),
+                        ImmutableList.of(),
                         ImmutableList.of(),
                         Optional.empty(),
                         new QuerySpecification(
@@ -2347,6 +2361,7 @@ public class TestSqlParser
                         qualifiedName(location(1, 14), "foo"),
                         new Query(
                                 location(4, 1),
+                                ImmutableList.of(),
                                 ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
@@ -2391,6 +2406,7 @@ public class TestSqlParser
                         new Query(
                                 location(4, 1),
                                 ImmutableList.of(),
+                                ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
                                         location(4, 1),
@@ -2430,6 +2446,7 @@ public class TestSqlParser
                         qualifiedName(location(1, 14), "foo"),
                         new Query(
                                 location(4, 1),
+                                ImmutableList.of(),
                                 ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
@@ -2472,6 +2489,7 @@ public class TestSqlParser
                         new Query(
                                 location(4, 1),
                                 ImmutableList.of(),
+                                ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
                                         location(4, 1),
@@ -2516,6 +2534,7 @@ public class TestSqlParser
                         new Query(
                                 location(4, 1),
                                 ImmutableList.of(),
+                                ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
                                         location(4, 1),
@@ -2556,6 +2575,7 @@ public class TestSqlParser
                         qualifiedName(location(1, 14), "foo"),
                         new Query(
                                 location(4, 1),
+                                ImmutableList.of(),
                                 ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
@@ -2597,6 +2617,7 @@ public class TestSqlParser
                         qualifiedName(location(1, 14), "foo"),
                         new Query(
                                 location(4, 1),
+                                ImmutableList.of(),
                                 ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
@@ -2642,6 +2663,7 @@ public class TestSqlParser
                         new Query(
                                 location(4, 1),
                                 ImmutableList.of(),
+                                ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
                                         location(4, 1),
@@ -2683,6 +2705,7 @@ public class TestSqlParser
                         new Query(
                                 location(4, 1),
                                 ImmutableList.of(),
+                                ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
                                         location(4, 1),
@@ -2723,6 +2746,7 @@ public class TestSqlParser
                         qualifiedName(location(1, 14), "foo"),
                         new Query(
                                 location(4, 1),
+                                ImmutableList.of(),
                                 ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
@@ -2788,6 +2812,7 @@ public class TestSqlParser
         QualifiedName table = QualifiedName.of("foo");
 
         Query query = new Query(
+                ImmutableList.of(),
                 ImmutableList.of(),
                 Optional.of(new With(false, ImmutableList.of(
                         new WithQuery(
@@ -3678,6 +3703,7 @@ public class TestSqlParser
         assertStatement("WITH a (t, u) AS (SELECT * FROM x), b AS (SELECT * FROM y) TABLE z",
                 new Query(
                         ImmutableList.of(),
+                        ImmutableList.of(),
                         Optional.of(new With(false, ImmutableList.of(
                                 new WithQuery(
                                         identifier("a"),
@@ -3698,6 +3724,7 @@ public class TestSqlParser
 
         assertStatement("WITH RECURSIVE a AS (SELECT * FROM x) TABLE y",
                 new Query(
+                        ImmutableList.of(),
                         ImmutableList.of(),
                         Optional.of(new With(true, ImmutableList.of(
                                 new WithQuery(
@@ -4244,6 +4271,7 @@ public class TestSqlParser
                                         new Query(
                                                 location(1, 17),
                                                 ImmutableList.of(),
+                                                ImmutableList.of(),
                                                 Optional.empty(),
                                                 new QuerySpecification(
                                                         location(1, 17),
@@ -4273,6 +4301,7 @@ public class TestSqlParser
                                 new TableSubquery(
                                         new Query(
                                                 location(1, 17),
+                                                ImmutableList.of(),
                                                 ImmutableList.of(),
                                                 Optional.empty(),
                                                 new QuerySpecification(
@@ -4309,6 +4338,7 @@ public class TestSqlParser
                                         new Query(
                                                 location(2, 4),
                                                 ImmutableList.of(),
+                                                ImmutableList.of(),
                                                 Optional.of(
                                                         new With(
                                                                 location(2, 4),
@@ -4319,6 +4349,7 @@ public class TestSqlParser
                                                                                 new Identifier(location(2, 9), "t", false),
                                                                                 new Query(
                                                                                         location(2, 15),
+                                                                                        ImmutableList.of(),
                                                                                         ImmutableList.of(),
                                                                                         Optional.empty(),
                                                                                         new QuerySpecification(
@@ -4694,6 +4725,7 @@ public class TestSqlParser
                         new Query(
                                 new NodeLocation(1, 31),
                                 ImmutableList.of(),
+                                ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
                                         new NodeLocation(1, 31),
@@ -4732,6 +4764,7 @@ public class TestSqlParser
                         new Query(
                                 new NodeLocation(1, 100),
                                 ImmutableList.of(),
+                                ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
                                         new NodeLocation(1, 100),
@@ -4768,6 +4801,7 @@ public class TestSqlParser
                         QualifiedName.of(ImmutableList.of(new Identifier(new NodeLocation(1, 26), "a", false))),
                         new Query(
                                 new NodeLocation(1, 61),
+                                ImmutableList.of(),
                                 ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
@@ -4809,6 +4843,7 @@ public class TestSqlParser
                                 new Identifier(new NodeLocation(1, 52), "matview", false))),
                         new Query(
                                 new NodeLocation(3, 5),
+                                ImmutableList.of(),
                                 ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
@@ -4859,6 +4894,7 @@ public class TestSqlParser
                         new Query(
                                 new NodeLocation(3, 5),
                                 ImmutableList.of(),
+                                ImmutableList.of(),
                                 Optional.of(new With(
                                         new NodeLocation(3, 5),
                                         false,
@@ -4868,6 +4904,7 @@ public class TestSqlParser
                                                         new Identifier(new NodeLocation(3, 10), "a", false),
                                                         new Query(
                                                                 new NodeLocation(3, 23),
+                                                                ImmutableList.of(),
                                                                 ImmutableList.of(),
                                                                 Optional.empty(),
                                                                 new QuerySpecification(
@@ -4897,6 +4934,7 @@ public class TestSqlParser
                                                         new Identifier(new NodeLocation(3, 41), "b", false),
                                                         new Query(
                                                                 new NodeLocation(3, 47),
+                                                                ImmutableList.of(),
                                                                 ImmutableList.of(),
                                                                 Optional.empty(),
                                                                 new QuerySpecification(
@@ -5336,6 +5374,7 @@ public class TestSqlParser
                         new Query(
                                 location(1, 1),
                                 ImmutableList.of(),
+                                ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
                                         location(1, 1),
@@ -5366,6 +5405,7 @@ public class TestSqlParser
                 .isEqualTo(
                         new Query(
                                 location(1, 1),
+                                ImmutableList.of(),
                                 ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
@@ -5710,6 +5750,7 @@ public class TestSqlParser
         return new Query(
                 location(1, 1),
                 ImmutableList.of(),
+                ImmutableList.of(),
                 Optional.empty(),
                 new QuerySpecification(
                         location(1, 1),
@@ -5890,6 +5931,41 @@ public class TestSqlParser
                         Optional.of(JsonQuery.QuotesBehavior.OMIT),
                         JsonQuery.EmptyOrErrorBehavior.EMPTY_ARRAY,
                         JsonQuery.EmptyOrErrorBehavior.ERROR));
+    }
+
+    @Test
+    public void testSessionSpecification()
+    {
+        AssertProvider<ParserAssert> statement = statement("""
+                WITH
+                  SESSION key = 'value',                  
+                  SESSION key2 = DECIMAL '10.0'
+                SELECT 1
+                """);
+
+        assertThat(statement)
+                .isEqualTo(new Query(
+                        location(1, 1),
+                        ImmutableList.of(),
+                        ImmutableList.of(
+                                new SessionSpecification(location(2, 3), QualifiedName.of(ImmutableList.of(new Identifier(location(2, 11), "key", false))), new StringLiteral(location(2, 17), "value")),
+                                new SessionSpecification(location(3, 3), QualifiedName.of(ImmutableList.of(new Identifier(location(3, 11), "key2", false))), new DecimalLiteral(location(3, 18), "10.0"))),
+                        Optional.empty(),
+                        new QuerySpecification(
+                                location(4, 1),
+                                new Select(location(4, 1), false, ImmutableList.of(new SingleColumn(location(4, 8), new LongLiteral(location(4, 8),"1"), Optional.empty()))),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                ImmutableList.of(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty()),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()
+                ));
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserRoutines.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserRoutines.java
@@ -42,7 +42,6 @@ import io.trino.sql.tree.ReturnStatement;
 import io.trino.sql.tree.ReturnsClause;
 import io.trino.sql.tree.SecurityCharacteristic;
 import io.trino.sql.tree.Select;
-import io.trino.sql.tree.SessionSpecification;
 import io.trino.sql.tree.StringLiteral;
 import io.trino.sql.tree.VariableDeclaration;
 import io.trino.sql.tree.WhileStatement;
@@ -96,22 +95,6 @@ class TestSqlParserRoutines
                                 ImmutableList.of(),
                                 new ReturnStatement(location(), literal(42))),
                         selectList(new FunctionCall(QualifiedName.of("answer"), ImmutableList.of()))));
-    }
-
-    @Test
-    void testInlineSession()
-    {
-        assertThat(statement("""
-                WITH
-                    SESSION session_key = 'property',
-                    SESSION catalog.catalog_session_key = 'catalog_property'
-                SELECT foo()
-                """))
-                .ignoringLocation()
-                .isEqualTo(query(ImmutableList.of(
-                        new SessionSpecification(QualifiedName.of("session_key"), literal("property")),
-                        new SessionSpecification(QualifiedName.of("catalog", "catalog_session_key"), literal("catalog_property"))),
-                    selectList(new FunctionCall(QualifiedName.of("foo"), ImmutableList.of()))));
     }
 
     @Test
@@ -351,27 +334,6 @@ class TestSqlParserRoutines
         return new Query(
                 ImmutableList.of(function),
                 ImmutableList.of(),
-                Optional.empty(),
-                new QuerySpecification(
-                        select,
-                        Optional.empty(),
-                        Optional.empty(),
-                        Optional.empty(),
-                        Optional.empty(),
-                        ImmutableList.of(),
-                        Optional.empty(),
-                        Optional.empty(),
-                        Optional.empty()),
-                Optional.empty(),
-                Optional.empty(),
-                Optional.empty());
-    }
-
-    private static Query query(List<SessionSpecification> sessionSpecifications, Select select)
-    {
-        return new Query(
-                ImmutableList.of(),
-                sessionSpecifications,
                 Optional.empty(),
                 new QuerySpecification(
                         select,

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestWithSession.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestWithSession.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.parser;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.sql.tree.BooleanLiteral;
+import io.trino.sql.tree.FunctionCall;
+import io.trino.sql.tree.QualifiedName;
+import io.trino.sql.tree.Query;
+import io.trino.sql.tree.QuerySpecification;
+import io.trino.sql.tree.Select;
+import io.trino.sql.tree.SessionSpecification;
+import io.trino.sql.tree.StringLiteral;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.sql.QueryUtil.selectList;
+import static io.trino.sql.parser.ParserAssert.statement;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestWithSession
+{
+    @Test
+    void testInlineSession()
+    {
+        assertThat(statement("""
+                WITH
+                    SESSION session_key = 'property',
+                    SESSION catalog.catalog_session_key = 'catalog_property',
+                    SESSION catalog.catalog_session_key2 = true
+                SELECT foo()
+                """))
+                .ignoringLocation()
+                .isEqualTo(query(ImmutableList.of(
+                                new SessionSpecification(QualifiedName.of("session_key"), stringLiteral("property")),
+                                new SessionSpecification(QualifiedName.of("catalog", "catalog_session_key"), stringLiteral("catalog_property")),
+                                new SessionSpecification(QualifiedName.of("catalog", "catalog_session_key2"), booleanLiteral(true))),
+                        selectList(new FunctionCall(QualifiedName.of("foo"), ImmutableList.of()))));
+    }
+
+    private static Query query(List<SessionSpecification> sessionSpecifications, Select select)
+    {
+        return new Query(
+                ImmutableList.of(),
+                sessionSpecifications,
+                Optional.empty(),
+                new QuerySpecification(
+                        select,
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        ImmutableList.of(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+    }
+
+    private static StringLiteral stringLiteral(String literal)
+    {
+        return new StringLiteral(literal);
+    }
+
+    private static BooleanLiteral booleanLiteral(boolean value)
+    {
+        return new BooleanLiteral(Boolean.toString(value));
+    }
+}

--- a/service/trino-verifier/src/main/java/io/trino/verifier/QueryRewriter.java
+++ b/service/trino-verifier/src/main/java/io/trino/verifier/QueryRewriter.java
@@ -205,10 +205,10 @@ public class QueryRewriter
                     querySpecification.getOffset(),
                     Optional.of(new Limit(new LongLiteral("0"))));
 
-            zeroRowsQuery = new io.trino.sql.tree.Query(ImmutableList.of(), createSelectClause.getWith(), innerQuery, Optional.empty(), Optional.empty(), Optional.empty());
+            zeroRowsQuery = new io.trino.sql.tree.Query(ImmutableList.of(), ImmutableList.of(), createSelectClause.getWith(), innerQuery, Optional.empty(), Optional.empty(), Optional.empty());
         }
         else {
-            zeroRowsQuery = new io.trino.sql.tree.Query(ImmutableList.of(), createSelectClause.getWith(), innerQuery, Optional.empty(), Optional.empty(), Optional.of(new Limit(new LongLiteral("0"))));
+            zeroRowsQuery = new io.trino.sql.tree.Query(ImmutableList.of(), ImmutableList.of(), createSelectClause.getWith(), innerQuery, Optional.empty(), Optional.empty(), Optional.of(new Limit(new LongLiteral("0"))));
         }
 
         ImmutableList.Builder<Column> columns = ImmutableList.builder();

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -6607,6 +6607,19 @@ public abstract class AbstractTestEngineOnlyQueries
     }
 
     @Test
+    public void testInlineSession()
+    {
+        assertThat(query("WITH SESSION time_zone_id = 'Europe/Wonderland' SELECT current_timezone()"))
+            .failure()
+            .hasMessageContaining("Time zone not supported: Europe/Wonderland");
+
+        assertThat(query("WITH SESSION time_zone_id = 'Europe/Warsaw' SELECT current_timezone()"))
+            .succeeds()
+            .skippingTypesCheck()
+            .matches("VALUES 'Europe/Warsaw'");
+    }
+
+    @Test
     public void testInlineSqlFunctions()
     {
         assertThat(query("""


### PR DESCRIPTION
Release notes: `Add WITH SESSION clause`

```
 WITH
    SESSION session_key = 'property',
    SESSION catalog.catalog_session_key = 'catalog_property'
SELECT 1
```