### PR TITLE
Add more assertions to the concurrent writes tests

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -2399,18 +2399,18 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
 
             assertThat(successfulInsertsCount).isGreaterThanOrEqualTo(1);
             assertQuery(
+                    "SELECT version, operation, isolation_level, read_version, is_blind_append FROM \"" + tableName + "$history\"",
+                    "VALUES (0, 'CREATE TABLE AS SELECT', 'WriteSerializable', 0, true)" +
+                            LongStream.rangeClosed(1, successfulInsertsCount)
+                                    .boxed()
+                                    .map(version -> "(%s, 'WRITE', 'WriteSerializable', %s, false)".formatted(version, version - 1))
+                                    .collect(joining(", ", ", ", "")));
+            assertQuery(
                     "SELECT * FROM " + tableName,
                     "VALUES (0, 10)" +
                             LongStream.rangeClosed(1, successfulInsertsCount)
                                     .boxed()
                                     .map("(%d, 10)"::formatted)
-                                    .collect(joining(", ", ", ", "")));
-            assertQuery(
-                    "SELECT version, operation, isolation_level, read_version FROM \"" + tableName + "$history\"",
-                    "VALUES (0, 'CREATE TABLE AS SELECT', 'WriteSerializable', 0)" +
-                            LongStream.rangeClosed(1, successfulInsertsCount)
-                                    .boxed()
-                                    .map(version -> "(%s, 'WRITE', 'WriteSerializable', %s)".formatted(version, version - 1))
                                     .collect(joining(", ", ", ", "")));
         }
         finally {

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeLocalConcurrentWritesTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeLocalConcurrentWritesTest.java
@@ -226,18 +226,18 @@ public class TestDeltaLakeLocalConcurrentWritesTest
 
             assertThat(successfulInsertsCount).isGreaterThanOrEqualTo(1);
             assertQuery(
+                    "SELECT version, operation, isolation_level, read_version, is_blind_append FROM \"" + tableName + "$history\"",
+                    "VALUES (0, 'CREATE TABLE AS SELECT', 'WriteSerializable', 0, true)" +
+                            LongStream.rangeClosed(1, successfulInsertsCount)
+                                    .boxed()
+                                    .map(version -> "(%s, 'WRITE', 'WriteSerializable', %s, false)".formatted(version, version - 1))
+                                    .collect(joining(", ", ", ", "")));
+            assertQuery(
                     "SELECT * FROM " + tableName,
                     "VALUES (0, 10)" +
                             LongStream.rangeClosed(1, successfulInsertsCount)
                                     .boxed()
                                     .map("(%d, 10)"::formatted)
-                                    .collect(joining(", ", ", ", "")));
-            assertQuery(
-                    "SELECT version, operation, isolation_level, read_version FROM \"" + tableName + "$history\"",
-                    "VALUES (0, 'CREATE TABLE AS SELECT', 'WriteSerializable', 0)" +
-                            LongStream.rangeClosed(1, successfulInsertsCount)
-                                    .boxed()
-                                    .map(version -> "(%s, 'WRITE', 'WriteSerializable', %s)".formatted(version, version - 1))
                                     .collect(joining(", ", ", ", "")));
         }
         finally {
@@ -303,11 +303,11 @@ public class TestDeltaLakeLocalConcurrentWritesTest
                                     .map("(%d, 10)"::formatted)
                                     .collect(joining(", ", ", ", "")));
             assertQuery(
-                    "SELECT version, operation, isolation_level, read_version FROM \"" + tableName + "$history\"",
-                    "VALUES (0, 'CREATE TABLE AS SELECT', 'WriteSerializable', 0)" +
+                    "SELECT version, operation, isolation_level, read_version, is_blind_append FROM \"" + tableName + "$history\"",
+                    "VALUES (0, 'CREATE TABLE AS SELECT', 'WriteSerializable', 0, true)" +
                             LongStream.rangeClosed(1, successfulInsertsCount)
                                     .boxed()
-                                    .map(version -> "(%s, 'WRITE', 'WriteSerializable', %s)".formatted(version, version - 1))
+                                    .map(version -> "(%s, 'WRITE', 'WriteSerializable', %s, false)".formatted(version, version - 1))
                                     .collect(joining(", ", ", ", "")));
         }
         finally {


### PR DESCRIPTION
Relates to https://github.com/trinodb/trino/issues/21324

It is not a fix, rather an enrichment of the assertions done in the test.