### PR TITLE
docs: Clarify error behavior of subscript operator and suggest element_at alternative

### DIFF
--- a/docs/src/main/sphinx/functions/map.md
+++ b/docs/src/main/sphinx/functions/map.md
@@ -2,7 +2,9 @@
 
 ## Subscript operator: \[\]
 
-The `[]` operator is used to retrieve the value corresponding to a given key from a map:
+The `[]` operator is used to retrieve the value corresponding to a given key from a map.
+This operator throws an error if the key is not contained in the map.
+See also `element_at` function that returns `NULL` in such case.
 
 ```
 SELECT name_to_age_map['Bob'] AS bob_age;


### PR DESCRIPTION
## Description

This commit updates the documentation to clearly state that using the subscript operator `[]` will result in an error if the specified key does not exist. 

It also recommends using the `element_at` function as a safer alternative when there is a possibility that the key might not be present. This change aims to improve clarity and aid developers in handling potential errors more effectively.

cf. https://trinodb.slack.com/archives/CLEDR9V7G/p1702021254436669?thread_ts=1702003731.904799&cid=CLEDR9V7G

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
