### PR TITLE
Fix potentially incorrect table read version for writes on Delta Lake

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -1741,26 +1741,20 @@ public class DeltaLakeMetadata
         // This check acts as a safeguard in cases where the input columns may differ from the table metadata case-sensitively
         checkAllColumnsPassedOnInsert(tableMetadata, inputColumns);
 
-        return createInsertHandle(session, retryMode, table, inputColumns);
+        return createInsertHandle(retryMode, table, inputColumns);
     }
 
-    private DeltaLakeInsertTableHandle createInsertHandle(ConnectorSession session, RetryMode retryMode, DeltaLakeTableHandle table, List<DeltaLakeColumnHandle> inputColumns)
+    private DeltaLakeInsertTableHandle createInsertHandle(RetryMode retryMode, DeltaLakeTableHandle table, List<DeltaLakeColumnHandle> inputColumns)
     {
         String tableLocation = table.getLocation();
-        try {
-            TrinoFileSystem fileSystem = fileSystemFactory.create(session);
-            return new DeltaLakeInsertTableHandle(
-                    table.getSchemaTableName(),
-                    tableLocation,
-                    table.getMetadataEntry(),
-                    table.getProtocolEntry(),
-                    inputColumns,
-                    getMandatoryCurrentVersion(fileSystem, tableLocation, table.getReadVersion()),
-                    retryMode != NO_RETRIES);
-        }
-        catch (IOException e) {
-            throw new TrinoException(GENERIC_INTERNAL_ERROR, e);
-        }
+        return new DeltaLakeInsertTableHandle(
+                table.getSchemaTableName(),
+                tableLocation,
+                table.getMetadataEntry(),
+                table.getProtocolEntry(),
+                inputColumns,
+                table.getReadVersion(),
+                retryMode != NO_RETRIES);
     }
 
     private void checkAllColumnsPassedOnInsert(ConnectorTableMetadata tableMetadata, List<DeltaLakeColumnHandle> insertColumns)
@@ -2046,7 +2040,7 @@ public class DeltaLakeMetadata
                 .filter(column -> column.getColumnType() != SYNTHESIZED)
                 .collect(toImmutableList());
 
-        DeltaLakeInsertTableHandle insertHandle = createInsertHandle(session, retryMode, handle, inputColumns);
+        DeltaLakeInsertTableHandle insertHandle = createInsertHandle(retryMode, handle, inputColumns);
 
         return new DeltaLakeMergeTableHandle(handle, insertHandle);
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -2406,11 +2406,11 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
                                     .map("(%d, 10)"::formatted)
                                     .collect(joining(", ", ", ", "")));
             assertQuery(
-                    "SELECT version, operation, isolation_level, read_version FROM \"" + tableName + "$history\"",
-                    "VALUES (0, 'CREATE TABLE AS SELECT', 'WriteSerializable', 0)" +
+                    "SELECT version, operation, isolation_level, read_version, is_blind_append FROM \"" + tableName + "$history\"",
+                    "VALUES (0, 'CREATE TABLE AS SELECT', 'WriteSerializable', 0, true)" +
                             LongStream.rangeClosed(1, successfulInsertsCount)
                                     .boxed()
-                                    .map(version -> "(%s, 'WRITE', 'WriteSerializable', %s)".formatted(version, version - 1))
+                                    .map(version -> "(%s, 'WRITE', 'WriteSerializable', %s, false)".formatted(version, version - 1))
                                     .collect(joining(", ", ", ", "")));
         }
         finally {
@@ -2458,13 +2458,13 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
                     "SELECT * FROM " + tableName,
                     "VALUES (0, 10), (1, 10), (11, 20), (1, 20), (22, 30)");
             assertQuery(
-                    "SELECT version, operation, isolation_level, read_version FROM \"" + tableName + "$history\"",
+                    "SELECT operation, isolation_level, is_blind_append FROM \"" + tableName + "$history\"",
                     """
                             VALUES
-                                (0, 'CREATE TABLE AS SELECT', 'WriteSerializable', 0),
-                                (1, 'WRITE', 'WriteSerializable', 0),
-                                (2, 'WRITE', 'WriteSerializable', 1),
-                                (3, 'WRITE', 'WriteSerializable', 2)
+                                ('CREATE TABLE AS SELECT', 'WriteSerializable', true),
+                                ('WRITE', 'WriteSerializable', false),
+                                ('WRITE', 'WriteSerializable', false),
+                                ('WRITE', 'WriteSerializable', true)
                             """);
         }
         finally {

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
@@ -447,7 +447,7 @@ public class TestDeltaLakeFileOperations
                         .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000001.json", "InputFile.newStream"))
                         .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000002.json", "InputFile.newStream"))
                         .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000003.json", "InputFile.newStream"))
-                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000004.json", "InputFile.exists"), 2)
+                        .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000004.json", "InputFile.exists"))
                         .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000004.json", "OutputFile.createOrOverwrite"))
                         .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000004.json", "InputFile.newStream"))
                         .addCopies(new FileOperation(DATA, "key=domain1/", "InputFile.newInput"), 2)

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeLocalConcurrentWritesTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeLocalConcurrentWritesTest.java
@@ -153,13 +153,13 @@ public class TestDeltaLakeLocalConcurrentWritesTest
                     .forEach(MoreFutures::getDone);
 
             assertThat(query("SELECT * FROM " + tableName)).matches("VALUES (1, 10), (11, 20), (21, 30)");
-            assertQuery("SELECT version, operation, isolation_level, read_version FROM \"" + tableName + "$history\"",
+            assertQuery("SELECT version, operation, isolation_level, read_version, is_blind_append FROM \"" + tableName + "$history\"",
                     """
                             VALUES
-                                (0, 'CREATE TABLE', 'WriteSerializable', 0),
-                                (1, 'WRITE', 'WriteSerializable', 0),
-                                (2, 'WRITE', 'WriteSerializable', 1),
-                                (3, 'WRITE', 'WriteSerializable', 2)
+                                (0, 'CREATE TABLE', 'WriteSerializable', 0, true),
+                                (1, 'WRITE', 'WriteSerializable', 0, true),
+                                (2, 'WRITE', 'WriteSerializable', 1, true),
+                                (3, 'WRITE', 'WriteSerializable', 2, true)
                             """);
         }
         finally {
@@ -233,11 +233,11 @@ public class TestDeltaLakeLocalConcurrentWritesTest
                                     .map("(%d, 10)"::formatted)
                                     .collect(joining(", ", ", ", "")));
             assertQuery(
-                    "SELECT version, operation, isolation_level, read_version FROM \"" + tableName + "$history\"",
-                    "VALUES (0, 'CREATE TABLE AS SELECT', 'WriteSerializable', 0)" +
+                    "SELECT version, operation, isolation_level, read_version, is_blind_append FROM \"" + tableName + "$history\"",
+                    "VALUES (0, 'CREATE TABLE AS SELECT', 'WriteSerializable', 0, true)" +
                             LongStream.rangeClosed(1, successfulInsertsCount)
                                     .boxed()
-                                    .map(version -> "(%s, 'WRITE', 'WriteSerializable', %s)".formatted(version, version - 1))
+                                    .map(version -> "(%s, 'WRITE', 'WriteSerializable', %s, false)".formatted(version, version - 1))
                                     .collect(joining(", ", ", ", "")));
         }
         finally {
@@ -303,11 +303,11 @@ public class TestDeltaLakeLocalConcurrentWritesTest
                                     .map("(%d, 10)"::formatted)
                                     .collect(joining(", ", ", ", "")));
             assertQuery(
-                    "SELECT version, operation, isolation_level, read_version FROM \"" + tableName + "$history\"",
-                    "VALUES (0, 'CREATE TABLE AS SELECT', 'WriteSerializable', 0)" +
+                    "SELECT version, operation, isolation_level, read_version, is_blind_append FROM \"" + tableName + "$history\"",
+                    "VALUES (0, 'CREATE TABLE AS SELECT', 'WriteSerializable', 0, true)" +
                             LongStream.rangeClosed(1, successfulInsertsCount)
                                     .boxed()
-                                    .map(version -> "(%s, 'WRITE', 'WriteSerializable', %s)".formatted(version, version - 1))
+                                    .map(version -> "(%s, 'WRITE', 'WriteSerializable', %s, false)".formatted(version, version - 1))
                                     .collect(joining(", ", ", ", "")));
         }
         finally {
@@ -356,13 +356,13 @@ public class TestDeltaLakeLocalConcurrentWritesTest
                     "SELECT * FROM " + tableName,
                     "VALUES (0, 10), (1, 10), (11, 20), (1, 20), (22, 30)");
             assertQuery(
-                    "SELECT version, operation, isolation_level, read_version FROM \"" + tableName + "$history\"",
+                    "SELECT operation, isolation_level, is_blind_append FROM \"" + tableName + "$history\"",
                     """
                             VALUES
-                                (0, 'CREATE TABLE AS SELECT', 'WriteSerializable', 0),
-                                (1, 'WRITE', 'WriteSerializable', 0),
-                                (2, 'WRITE', 'WriteSerializable', 1),
-                                (3, 'WRITE', 'WriteSerializable', 2)
+                                ('CREATE TABLE AS SELECT', 'WriteSerializable', true),
+                                ('WRITE', 'WriteSerializable', false),
+                                ('WRITE', 'WriteSerializable', false),
+                                ('WRITE', 'WriteSerializable', true)
                             """);
         }
         finally {
@@ -409,13 +409,13 @@ public class TestDeltaLakeLocalConcurrentWritesTest
                     "SELECT * FROM " + tableName,
                     "VALUES (0, 10), (11, 20), (22, 30), (1, 40), (13, 40), (25, 40)");
             assertQuery(
-                    "SELECT version, operation, isolation_level, read_version FROM \"" + tableName + "$history\"",
+                    "SELECT operation, isolation_level, is_blind_append FROM \"" + tableName + "$history\"",
                     """
                             VALUES
-                                (0, 'CREATE TABLE AS SELECT', 'WriteSerializable', 0),
-                                (1, 'WRITE', 'WriteSerializable', 0),
-                                (2, 'WRITE', 'WriteSerializable', 1),
-                                (3, 'WRITE', 'WriteSerializable', 2)
+                                ('CREATE TABLE AS SELECT', 'WriteSerializable', true),
+                                ('WRITE', 'WriteSerializable', false),
+                                ('WRITE', 'WriteSerializable', false),
+                                ('WRITE', 'WriteSerializable', false)
                             """);
         }
         finally {
@@ -472,14 +472,14 @@ public class TestDeltaLakeLocalConcurrentWritesTest
                                 (55, 60), (56,60), (57, 60), (58,60)
                             """);
             assertQuery(
-                    "SELECT version, operation, isolation_level, read_version FROM \"" + tableName + "$history\"",
+                    "SELECT version, operation, isolation_level, read_version, is_blind_append FROM \"" + tableName + "$history\"",
                     """
                             VALUES
-                                (0, 'CREATE TABLE AS SELECT', 'WriteSerializable', 0),
-                                (1, 'WRITE', 'WriteSerializable', 0),
-                                (2, 'WRITE', 'WriteSerializable', 1),
-                                (3, 'WRITE', 'WriteSerializable', 2),
-                                (4, 'WRITE', 'WriteSerializable', 3)
+                                (0, 'CREATE TABLE AS SELECT', 'WriteSerializable', 0, true),
+                                (1, 'WRITE', 'WriteSerializable', 0, true),
+                                (2, 'WRITE', 'WriteSerializable', 1, false),
+                                (3, 'WRITE', 'WriteSerializable', 2, false),
+                                (4, 'WRITE', 'WriteSerializable', 3, false)
                             """);
         }
         finally {


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

In the context of concurrent operations, it may potentially happen that between the time when the version of table has been initially read for scanning and the time when the planning of the write operation begins that a new version of the table is current. Nevertheless, use in performing the write operations the version of the table initially read as reference for beginning the operation to ensure the consistency of the operation.

This strategy helps in unintentionally skipping the processing of transaction log information corresponding to other concurrent operations.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Fixes https://github.com/trinodb/trino/issues/21324

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Delta Lake
* Ensure read consistency while performing write operations. ({issue}`issuenumber`)
```
