### PR TITLE
Fix jaccard_index

### DIFF
--- a/core/trino-main/src/main/java/io/trino/type/setdigest/SetDigest.java
+++ b/core/trino-main/src/main/java/io/trino/type/setdigest/SetDigest.java
@@ -174,11 +174,11 @@ public class SetDigest
             return exactIntersectionCardinality(a, b) / (double) minUnion.size();
         }
 
-        int intersection = 0;
+        int hashCollisions = 0;
         int i = 0;
         for (long key : minUnion) {
             if (a.minhash.containsKey(key) && b.minhash.containsKey(key)) {
-                intersection++;
+                hashCollisions++;
             }
             i++;
             if (i >= sizeOfSmallerSet) {
@@ -186,7 +186,7 @@ public class SetDigest
             }
         }
 
-        return intersection / (double) sizeOfSmallerSet;
+        return hashCollisions / (double) sizeOfSmallerSet;
     }
 
     public void add(long value)

--- a/core/trino-main/src/main/java/io/trino/type/setdigest/SetDigest.java
+++ b/core/trino-main/src/main/java/io/trino/type/setdigest/SetDigest.java
@@ -169,6 +169,11 @@ public class SetDigest
         LongSortedSet minUnion = new LongRBTreeSet(a.minhash.keySet());
         minUnion.addAll(b.minhash.keySet());
 
+        // For small, exact sets we can calculate an exact jaccard_index
+        if (a.isExact() && b.isExact()) {
+            return exactIntersectionCardinality(a, b) / (double) minUnion.size();
+        }
+
         int intersection = 0;
         int i = 0;
         for (long key : minUnion) {
@@ -180,6 +185,7 @@ public class SetDigest
                 break;
             }
         }
+
         return intersection / (double) sizeOfSmallerSet;
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestSetDigestFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestSetDigestFunctions.java
@@ -77,6 +77,11 @@ public class TestSetDigestFunctions
                 "SELECT jaccard_index(make_set_digest(v1), make_set_digest(v2)) " +
                         "FROM (VALUES (1, 1), (NULL,2), (2, 3), (NULL, 4)) T(v1, v2)"))
                 .matches("VALUES CAST(0.5 AS DOUBLE)");
+
+        assertThat(assertions.query(
+                "SELECT jaccard_index(make_set_digest(value), make_set_digest(value1)) " +
+                        "FROM (VALUES (1,4),(2,5),(3,6),(4,7),(5,8)) T(value,value1)"))
+                .matches("VALUES CAST(0.25 AS DOUBLE)");
     }
 
     @Test


### PR DESCRIPTION
Jacaard index is defined as:

![Jaccard-formula](https://github.com/trinodb/trino/assets/66972/986c0ace-f031-4440-8be2-bd0559e5c738)

Fixes https://github.com/trinodb/trino/issues/21331
