### PR TITLE
Change GroupedAccumulatorState groupId from long to int

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/AccumulatorCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/AccumulatorCompiler.java
@@ -356,7 +356,7 @@ public final class AccumulatorCompiler
 
     private static void generateSetGroupCount(ClassDefinition definition, List<FieldDefinition> stateFields)
     {
-        Parameter groupCount = arg("groupCount", long.class);
+        Parameter groupCount = arg("groupCount", int.class);
 
         MethodDefinition method = definition.declareMethod(a(PUBLIC), "setGroupCount", type(void.class), groupCount);
         BytecodeBlock body = method.getBody();
@@ -781,7 +781,7 @@ public final class AccumulatorCompiler
         for (FieldDefinition stateField : stateFields) {
             if (grouped) {
                 Variable groupIds = scope.getVariable("groupIds");
-                loopBody.append(thisVariable.getField(stateField).invoke("setGroupId", void.class, groupIds.getElement(position).cast(long.class)));
+                loopBody.append(thisVariable.getField(stateField).invoke("setGroupId", void.class, groupIds.getElement(position)));
             }
             loopBody.append(thisVariable.getField(stateField));
         }
@@ -805,7 +805,7 @@ public final class AccumulatorCompiler
         Variable groupIds = scope.getVariable("groupIds");
         for (FieldDefinition stateField : stateFields) {
             BytecodeExpression state = scope.getThis().getField(stateField);
-            block.append(state.invoke("setGroupId", void.class, groupIds.getElement(position).cast(long.class)));
+            block.append(state.invoke("setGroupId", void.class, groupIds.getElement(position)));
         }
     }
 
@@ -875,14 +875,14 @@ public final class AccumulatorCompiler
             BytecodeExpression stateSerializer = thisVariable.getField(getOnlyElement(stateFieldAndDescriptors).getStateSerializerField());
             BytecodeExpression state = thisVariable.getField(getOnlyElement(stateFieldAndDescriptors).getStateField());
 
-            body.append(state.invoke("setGroupId", void.class, groupId.cast(long.class)))
+            body.append(state.invoke("setGroupId", void.class, groupId))
                     .append(stateSerializer.invoke("serialize", void.class, state.cast(AccumulatorState.class), out))
                     .ret();
         }
         else {
             for (StateFieldAndDescriptor stateFieldAndDescriptor : stateFieldAndDescriptors) {
                 BytecodeExpression state = thisVariable.getField(stateFieldAndDescriptor.getStateField());
-                body.append(state.invoke("setGroupId", void.class, groupId.cast(long.class)));
+                body.append(state.invoke("setGroupId", void.class, groupId));
             }
 
             generateSerializeState(definition, stateFieldAndDescriptors, out, thisVariable, body);
@@ -966,7 +966,7 @@ public final class AccumulatorCompiler
 
         for (FieldDefinition stateField : stateFields) {
             BytecodeExpression state = thisVariable.getField(stateField);
-            body.append(state.invoke("setGroupId", void.class, groupId.cast(long.class)));
+            body.append(state.invoke("setGroupId", void.class, groupId));
             states.add(state);
         }
 

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/AggregationLoopBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/AggregationLoopBuilder.java
@@ -194,7 +194,7 @@ final class AggregationLoopBuilder
             Variable groupId = scope.declareVariable(int.class, "groupId");
             invokeFunction.append(groupId.set(aggregationParameters.groupIds().get().getElement(position)));
             for (Parameter stateParameter : aggregationParameters.states()) {
-                invokeFunction.append(stateParameter.cast(GroupedAccumulatorState.class).invoke("setGroupId", void.class, groupId.cast(long.class)));
+                invokeFunction.append(stateParameter.cast(GroupedAccumulatorState.class).invoke("setGroupId", void.class, groupId));
             }
         }
         invokeFunction.append(invoke(binder.bind(function), "input", aggregationArguments.build()));

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/DistinctAccumulatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/DistinctAccumulatorFactory.java
@@ -202,7 +202,7 @@ public class DistinctAccumulatorFactory
         }
 
         @Override
-        public void setGroupCount(long groupCount)
+        public void setGroupCount(int groupCount)
         {
             accumulator.setGroupCount(groupCount);
         }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/GroupedAccumulator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/GroupedAccumulator.java
@@ -21,7 +21,7 @@ public interface GroupedAccumulator
 {
     long getEstimatedSize();
 
-    void setGroupCount(long groupCount);
+    void setGroupCount(int groupCount);
 
     void addInput(int[] groupIds, Page page, AggregationMask mask);
 

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/GroupedMapAggregationState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/GroupedMapAggregationState.java
@@ -20,8 +20,6 @@ import io.trino.spi.type.Type;
 
 import java.lang.invoke.MethodHandle;
 
-import static java.lang.Math.toIntExact;
-
 public class GroupedMapAggregationState
         extends AbstractMapAggregationState
         implements GroupedAccumulatorState
@@ -53,15 +51,15 @@ public class GroupedMapAggregationState
     }
 
     @Override
-    public void setGroupId(long groupId)
+    public void setGroupId(int groupId)
     {
-        this.groupId = toIntExact(groupId);
+        this.groupId = groupId;
     }
 
     @Override
-    public void ensureCapacity(long size)
+    public void ensureCapacity(int size)
     {
-        setMaxGroupId(toIntExact(size));
+        setMaxGroupId(size);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/LongApproximateMostFrequentStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/LongApproximateMostFrequentStateFactory.java
@@ -84,7 +84,7 @@ public class LongApproximateMostFrequentStateFactory
         }
 
         @Override
-        public void ensureCapacity(long size)
+        public void ensureCapacity(int size)
         {
             histograms.ensureCapacity(size);
         }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/NumericHistogramStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/NumericHistogramStateFactory.java
@@ -42,7 +42,7 @@ public class NumericHistogramStateFactory
         private long size;
 
         @Override
-        public void ensureCapacity(long size)
+        public void ensureCapacity(int size)
         {
             histograms.ensureCapacity(size);
         }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedAccumulatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedAccumulatorFactory.java
@@ -207,7 +207,7 @@ public class OrderedAccumulatorFactory
         }
 
         @Override
-        public void setGroupCount(long groupCount)
+        public void setGroupCount(int groupCount)
         {
             this.groupCount = max(this.groupCount, groupCount);
             accumulator.setGroupCount(groupCount);

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/StringApproximateMostFrequentStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/StringApproximateMostFrequentStateFactory.java
@@ -85,7 +85,7 @@ public class StringApproximateMostFrequentStateFactory
         }
 
         @Override
-        public void ensureCapacity(long size)
+        public void ensureCapacity(int size)
         {
             histograms.ensureCapacity(size);
         }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/arrayagg/GroupArrayAggregationState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/arrayagg/GroupArrayAggregationState.java
@@ -25,7 +25,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.clamp;
-import static java.lang.Math.toIntExact;
 
 public final class GroupArrayAggregationState
         extends AbstractGroupedAccumulatorState
@@ -55,10 +54,10 @@ public final class GroupArrayAggregationState
     }
 
     @Override
-    public void ensureCapacity(long maxGroupId)
+    public void ensureCapacity(int maxGroupId)
     {
         checkArgument(maxGroupId + 1 < MAX_ARRAY_SIZE, "Maximum array size exceeded");
-        int requiredSize = toIntExact(maxGroupId + 1);
+        int requiredSize = maxGroupId + 1;
         if (requiredSize > groupHeadPositions.length) {
             int newSize = clamp(requiredSize * 2L, 1024, MAX_ARRAY_SIZE);
             int oldSize = groupHeadPositions.length;

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/histogram/GroupedHistogramState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/histogram/GroupedHistogramState.java
@@ -44,9 +44,9 @@ public class GroupedHistogramState
     }
 
     @Override
-    public void ensureCapacity(long size)
+    public void ensureCapacity(int size)
     {
-        histogram.setMaxGroupId(toIntExact(size));
+        histogram.setMaxGroupId(size);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/listagg/GroupListaggAggregationState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/listagg/GroupListaggAggregationState.java
@@ -28,7 +28,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.operator.VariableWidthData.POINTER_SIZE;
 import static java.lang.Math.clamp;
-import static java.lang.Math.toIntExact;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 
 public class GroupListaggAggregationState
@@ -79,16 +78,16 @@ public class GroupListaggAggregationState
     }
 
     @Override
-    public void setGroupId(long groupId)
+    public void setGroupId(int groupId)
     {
-        this.groupId = toIntExact(groupId);
+        this.groupId = groupId;
     }
 
     @Override
-    public void ensureCapacity(long maxGroupId)
+    public void ensureCapacity(int maxGroupId)
     {
         checkArgument(maxGroupId + 1 < MAX_ARRAY_SIZE, "Maximum array size exceeded");
-        int requiredSize = toIntExact(maxGroupId + 1);
+        int requiredSize = maxGroupId + 1;
         if (requiredSize > groupHeadPositions.length) {
             int newSize = clamp(requiredSize * 2L, 1024, MAX_ARRAY_SIZE);
             int oldSize = groupHeadPositions.length;

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/minmaxbyn/MinMaxByNStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/minmaxbyn/MinMaxByNStateFactory.java
@@ -87,7 +87,7 @@ public final class MinMaxByNStateFactory
         private final LongFunction<TypedKeyValueHeap> heapFactory;
 
         private final ObjectBigArray<TypedKeyValueHeap> heaps = new ObjectBigArray<>();
-        private long groupId;
+        private int groupId;
         private long size;
 
         public GroupedMinMaxByNState(LongFunction<TypedKeyValueHeap> heapFactory)
@@ -96,13 +96,13 @@ public final class MinMaxByNStateFactory
         }
 
         @Override
-        public final void setGroupId(long groupId)
+        public final void setGroupId(int groupId)
         {
             this.groupId = groupId;
         }
 
         @Override
-        public final void ensureCapacity(long size)
+        public final void ensureCapacity(int size)
         {
             heaps.ensureCapacity(size);
         }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/minmaxn/MinMaxNStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/minmaxn/MinMaxNStateFactory.java
@@ -85,7 +85,7 @@ public final class MinMaxNStateFactory
         private final LongFunction<TypedHeap> heapFactory;
 
         private final ObjectBigArray<TypedHeap> heaps = new ObjectBigArray<>();
-        private long groupId;
+        private int groupId;
         private long size;
 
         public GroupedMinMaxNState(LongFunction<TypedHeap> heapFactory)
@@ -94,13 +94,13 @@ public final class MinMaxNStateFactory
         }
 
         @Override
-        public final void setGroupId(long groupId)
+        public final void setGroupId(int groupId)
         {
             this.groupId = groupId;
         }
 
         @Override
-        public final void ensureCapacity(long size)
+        public final void ensureCapacity(int size)
         {
             heaps.ensureCapacity(size);
         }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/multimapagg/GroupedMultimapAggregationState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/multimapagg/GroupedMultimapAggregationState.java
@@ -21,8 +21,6 @@ import io.trino.spi.type.Type;
 
 import java.lang.invoke.MethodHandle;
 
-import static java.lang.Math.toIntExact;
-
 public final class GroupedMultimapAggregationState
         extends AbstractMultimapAggregationState
         implements GroupedAccumulatorState
@@ -54,15 +52,15 @@ public final class GroupedMultimapAggregationState
     }
 
     @Override
-    public void setGroupId(long groupId)
+    public void setGroupId(int groupId)
     {
-        this.groupId = toIntExact(groupId);
+        this.groupId = groupId;
     }
 
     @Override
-    public void ensureCapacity(long size)
+    public void ensureCapacity(int size)
     {
-        setMaxGroupId(toIntExact(size));
+        setMaxGroupId(size);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/AbstractGroupedAccumulatorState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/AbstractGroupedAccumulatorState.java
@@ -18,15 +18,15 @@ import io.trino.spi.function.GroupedAccumulatorState;
 public abstract class AbstractGroupedAccumulatorState
         implements GroupedAccumulatorState
 {
-    private long groupId;
+    private int groupId;
 
     @Override
-    public final void setGroupId(long groupId)
+    public final void setGroupId(int groupId)
     {
         this.groupId = groupId;
     }
 
-    protected final long getGroupId()
+    protected final int getGroupId()
     {
         return groupId;
     }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/HyperLogLogStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/HyperLogLogStateFactory.java
@@ -44,7 +44,7 @@ public class HyperLogLogStateFactory
         private long size;
 
         @Override
-        public void ensureCapacity(long size)
+        public void ensureCapacity(int size)
         {
             hlls.ensureCapacity(size);
         }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowAndLongStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowAndLongStateFactory.java
@@ -52,10 +52,10 @@ public class LongDecimalWithOverflowAndLongStateFactory
         private LongBigArray overflows; // lazily initialized on the first overflow
 
         @Override
-        public void ensureCapacity(long size)
+        public void ensureCapacity(int size)
         {
             longs.ensureCapacity(size);
-            unscaledDecimals.ensureCapacity(size * 2);
+            unscaledDecimals.ensureCapacity(size * 2L);
             if (overflows != null) {
                 overflows.ensureCapacity(size);
             }
@@ -82,13 +82,13 @@ public class LongDecimalWithOverflowAndLongStateFactory
         @Override
         public long[] getDecimalArray()
         {
-            return unscaledDecimals.getSegment(getGroupId() * 2);
+            return unscaledDecimals.getSegment(getGroupId() * 2L);
         }
 
         @Override
         public int getDecimalArrayOffset()
         {
-            return unscaledDecimals.getOffset(getGroupId() * 2);
+            return unscaledDecimals.getOffset(getGroupId() * 2L);
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowStateFactory.java
@@ -54,10 +54,10 @@ public class LongDecimalWithOverflowStateFactory
         private LongBigArray overflows; // lazily initialized on the first overflow
 
         @Override
-        public void ensureCapacity(long size)
+        public void ensureCapacity(int size)
         {
             isNotNull.ensureCapacity(size);
-            unscaledDecimals.ensureCapacity(size * 2);
+            unscaledDecimals.ensureCapacity(size * 2L);
             if (overflows != null) {
                 overflows.ensureCapacity(size);
             }
@@ -78,13 +78,13 @@ public class LongDecimalWithOverflowStateFactory
         @Override
         public long[] getDecimalArray()
         {
-            return unscaledDecimals.getSegment(getGroupId() * 2);
+            return unscaledDecimals.getSegment(getGroupId() * 2L);
         }
 
         @Override
         public int getDecimalArrayOffset()
         {
-            return unscaledDecimals.getOffset(getGroupId() * 2);
+            return unscaledDecimals.getOffset(getGroupId() * 2L);
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/QuantileDigestAndPercentileStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/QuantileDigestAndPercentileStateFactory.java
@@ -46,7 +46,7 @@ public class QuantileDigestAndPercentileStateFactory
         private long size;
 
         @Override
-        public void ensureCapacity(long size)
+        public void ensureCapacity(int size)
         {
             digests.ensureCapacity(size);
             percentiles.ensureCapacity(size);

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/QuantileDigestStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/QuantileDigestStateFactory.java
@@ -44,7 +44,7 @@ public class QuantileDigestStateFactory
         private long size;
 
         @Override
-        public void ensureCapacity(long size)
+        public void ensureCapacity(int size)
         {
             qdigests.ensureCapacity(size);
         }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/StateCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/StateCompiler.java
@@ -473,19 +473,19 @@ public final class StateCompiler
                 .append(constructor.getThis())
                 .invokeConstructor(Object.class);
 
-        FieldDefinition groupIdField = definition.declareField(a(PRIVATE), "groupId", long.class);
+        FieldDefinition groupIdField = definition.declareField(a(PRIVATE), "groupId", int.class);
 
         Class<?> valueElementType = inOutGetterReturnType(type);
         FieldDefinition valueField = definition.declareField(a(PRIVATE, FINAL), "value", getBigArrayType(valueElementType));
         constructor.getBody().append(constructor.getThis().setField(valueField, newInstance(valueField.getType())));
-        Function<Scope, BytecodeExpression> valueGetter = scope -> scope.getThis().getField(valueField).invoke("get", valueElementType, scope.getThis().getField(groupIdField));
+        Function<Scope, BytecodeExpression> valueGetter = scope -> scope.getThis().getField(valueField).invoke("get", valueElementType, scope.getThis().getField(groupIdField).cast(long.class));
 
         Optional<FieldDefinition> nullField;
         Function<Scope, BytecodeExpression> nullGetter;
         if (type.getJavaType().isPrimitive()) {
             nullField = Optional.of(definition.declareField(a(PRIVATE, FINAL), "valueIdNull", BooleanBigArray.class));
             constructor.getBody().append(constructor.getThis().setField(nullField.get(), newInstance(BooleanBigArray.class, constantTrue())));
-            nullGetter = scope -> scope.getThis().getField(nullField.get()).invoke("get", boolean.class, scope.getThis().getField(groupIdField));
+            nullGetter = scope -> scope.getThis().getField(nullField.get()).invoke("get", boolean.class, scope.getThis().getField(groupIdField).cast(long.class));
         }
         else {
             nullField = Optional.empty();
@@ -502,15 +502,15 @@ public final class StateCompiler
         Function<Scope, BytecodeNode> setNullGenerator = scope -> {
             Variable thisVariable = scope.getThis();
             BytecodeBlock bytecodeBlock = new BytecodeBlock();
-            nullField.ifPresent(field -> bytecodeBlock.append(thisVariable.getField(field).invoke("set", void.class, thisVariable.getField(groupIdField), constantTrue())));
-            bytecodeBlock.append(thisVariable.getField(valueField).invoke("set", void.class, thisVariable.getField(groupIdField), defaultValue(valueElementType)));
+            nullField.ifPresent(field -> bytecodeBlock.append(thisVariable.getField(field).invoke("set", void.class, thisVariable.getField(groupIdField).cast(long.class), constantTrue())));
+            bytecodeBlock.append(thisVariable.getField(valueField).invoke("set", void.class, thisVariable.getField(groupIdField).cast(long.class), defaultValue(valueElementType)));
             return bytecodeBlock;
         };
         BiFunction<Scope, BytecodeExpression, BytecodeNode> setValueGenerator = (scope, value) -> {
             Variable thisVariable = scope.getThis();
             BytecodeBlock bytecodeBlock = new BytecodeBlock();
-            nullField.ifPresent(field -> bytecodeBlock.append(thisVariable.getField(field).invoke("set", void.class, thisVariable.getField(groupIdField), constantFalse())));
-            bytecodeBlock.append(thisVariable.getField(valueField).invoke("set", void.class, thisVariable.getField(groupIdField), value.cast(valueElementType)));
+            nullField.ifPresent(field -> bytecodeBlock.append(thisVariable.getField(field).invoke("set", void.class, thisVariable.getField(groupIdField).cast(long.class), constantFalse())));
+            bytecodeBlock.append(thisVariable.getField(valueField).invoke("set", void.class, thisVariable.getField(groupIdField).cast(long.class), value.cast(valueElementType)));
             return bytecodeBlock;
         };
 
@@ -563,7 +563,7 @@ public final class StateCompiler
 
     private static void inOutGroupedSetGroupId(ClassDefinition definition, FieldDefinition groupIdField)
     {
-        Parameter groupIdArg = arg("groupId", long.class);
+        Parameter groupIdArg = arg("groupId", int.class);
         MethodDefinition method = definition.declareMethod(a(PUBLIC), "setGroupId", type(void.class), groupIdArg);
         method.getBody()
                 .append(method.getThis().setField(groupIdField, groupIdArg))
@@ -572,13 +572,13 @@ public final class StateCompiler
 
     private static void inOutGroupedEnsureCapacity(ClassDefinition definition, FieldDefinition valueField, Optional<FieldDefinition> nullField)
     {
-        Parameter size = arg("size", long.class);
+        Parameter size = arg("size", int.class);
         MethodDefinition method = definition.declareMethod(a(PUBLIC), "ensureCapacity", type(void.class), size);
         Variable thisVariable = method.getThis();
         BytecodeBlock body = method.getBody();
 
-        body.append(thisVariable.getField(valueField).invoke("ensureCapacity", void.class, size));
-        nullField.ifPresent(field -> body.append(thisVariable.getField(field).invoke("ensureCapacity", void.class, size)));
+        body.append(thisVariable.getField(valueField).invoke("ensureCapacity", void.class, size.cast(long.class)));
+        nullField.ifPresent(field -> body.append(thisVariable.getField(field).invoke("ensureCapacity", void.class, size.cast(long.class))));
         body.ret();
     }
 
@@ -894,7 +894,7 @@ public final class StateCompiler
                 .invokeConstructor(AbstractGroupedAccumulatorState.class);
 
         // Create ensureCapacity
-        MethodDefinition ensureCapacity = definition.declareMethod(a(PUBLIC), "ensureCapacity", type(void.class), arg("size", long.class));
+        MethodDefinition ensureCapacity = definition.declareMethod(a(PUBLIC), "ensureCapacity", type(void.class), arg("size", int.class));
 
         // Generate fields, constructor, and ensureCapacity
         List<FieldDefinition> fieldDefinitions = new ArrayList<>();
@@ -958,7 +958,7 @@ public final class StateCompiler
                 .append(getter.getThis().getField(field).invoke(
                         "get",
                         stateField.getType(),
-                        getter.getThis().invoke("getGroupId", long.class))
+                        getter.getThis().invoke("getGroupId", int.class).cast(long.class))
                         .ret());
 
         // Generate setter
@@ -968,13 +968,13 @@ public final class StateCompiler
                 .append(setter.getThis().getField(field).invoke(
                         "set",
                         void.class,
-                        setter.getThis().invoke("getGroupId", long.class),
+                        setter.getThis().invoke("getGroupId", int.class).cast(long.class),
                         value))
                 .ret();
 
         Scope ensureCapacityScope = ensureCapacity.getScope();
         ensureCapacity.getBody()
-                .append(ensureCapacity.getThis().getField(field).invoke("ensureCapacity", void.class, ensureCapacityScope.getVariable("size")));
+                .append(ensureCapacity.getThis().getField(field).invoke("ensureCapacity", void.class, ensureCapacityScope.getVariable("size").cast(long.class)));
 
         // Initialize field in constructor
         constructor.getBody()

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/TDigestAndPercentileArrayStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/TDigestAndPercentileArrayStateFactory.java
@@ -48,7 +48,7 @@ public class TDigestAndPercentileArrayStateFactory
         private long size;
 
         @Override
-        public void ensureCapacity(long size)
+        public void ensureCapacity(int size)
         {
             digests.ensureCapacity(size);
             percentilesArray.ensureCapacity(size);

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/TDigestAndPercentileStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/TDigestAndPercentileStateFactory.java
@@ -46,7 +46,7 @@ public class TDigestAndPercentileStateFactory
         private long size;
 
         @Override
-        public void ensureCapacity(long size)
+        public void ensureCapacity(int size)
         {
             digests.ensureCapacity(size);
             percentiles.ensureCapacity(size);

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/TDigestStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/TDigestStateFactory.java
@@ -44,7 +44,7 @@ public class TDigestStateFactory
         private long size;
 
         @Override
-        public void ensureCapacity(long size)
+        public void ensureCapacity(int size)
         {
             digests.ensureCapacity(size);
         }

--- a/core/trino-main/src/main/java/io/trino/type/setdigest/SetDigestStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/type/setdigest/SetDigestStateFactory.java
@@ -42,17 +42,17 @@ public class SetDigestStateFactory
             implements GroupedAccumulatorState, SetDigestState
     {
         private final ObjectBigArray<SetDigest> digests = new ObjectBigArray<>();
-        private long groupId;
+        private int groupId;
         private long size;
 
         @Override
-        public void setGroupId(long groupId)
+        public void setGroupId(int groupId)
         {
             this.groupId = groupId;
         }
 
         @Override
-        public void ensureCapacity(long size)
+        public void ensureCapacity(int size)
         {
             digests.ensureCapacity(size);
         }

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -445,6 +445,20 @@
                                     <code>java.method.removed</code>
                                     <old>method void io.trino.spi.TrinoException::&lt;init&gt;(io.trino.spi.ErrorCode, java.lang.String, java.lang.Throwable)</old>
                                 </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.parameterTypeChanged</code>
+                                    <old>parameter void io.trino.spi.function.GroupedAccumulatorState::setGroupId(===long===)</old>
+                                    <new>parameter void io.trino.spi.function.GroupedAccumulatorState::setGroupId(===int===)</new>
+                                    <parameterIndex>0</parameterIndex>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.parameterTypeChanged</code>
+                                    <old>parameter void io.trino.spi.function.GroupedAccumulatorState::ensureCapacity(===long===)</old>
+                                    <new>parameter void io.trino.spi.function.GroupedAccumulatorState::ensureCapacity(===int===)</new>
+                                    <parameterIndex>0</parameterIndex>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/function/GroupedAccumulatorState.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/GroupedAccumulatorState.java
@@ -16,7 +16,7 @@ package io.trino.spi.function;
 public interface GroupedAccumulatorState
         extends AccumulatorState
 {
-    void setGroupId(long groupId);
+    void setGroupId(int groupId);
 
-    void ensureCapacity(long size);
+    void ensureCapacity(int size);
 }

--- a/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/SpatialPartitioningStateFactory.java
+++ b/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/SpatialPartitioningStateFactory.java
@@ -119,13 +119,13 @@ public class SpatialPartitioningStateFactory
         }
 
         @Override
-        public void setGroupId(long groupId)
+        public void setGroupId(int groupId)
         {
             this.groupId = groupId;
         }
 
         @Override
-        public void ensureCapacity(long size)
+        public void ensureCapacity(int size)
         {
             partitionCounts.ensureCapacity(size);
             counts.ensureCapacity(size);
@@ -195,7 +195,7 @@ public class SpatialPartitioningStateFactory
         @Override
         public long getEstimatedSize()
         {
-            return INSTANCE_SIZE + (envelope != null ? envelope.estimateMemorySize() * (1 + samples.size()) : 0);
+            return INSTANCE_SIZE + (envelope != null ? (long) envelope.estimateMemorySize() * (1 + samples.size()) : 0);
         }
     }
 }

--- a/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/aggregation/GeometryStateFactory.java
+++ b/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/aggregation/GeometryStateFactory.java
@@ -42,7 +42,7 @@ public class GeometryStateFactory
     {
         private final ObjectBigArray<OGCGeometry> geometries = new ObjectBigArray<>();
 
-        private long groupId;
+        private int groupId;
         private long size;
 
         @Override
@@ -61,7 +61,7 @@ public class GeometryStateFactory
         }
 
         @Override
-        public void ensureCapacity(long size)
+        public void ensureCapacity(int size)
         {
             geometries.ensureCapacity(size);
         }
@@ -73,7 +73,7 @@ public class GeometryStateFactory
         }
 
         @Override
-        public final void setGroupId(long groupId)
+        public final void setGroupId(int groupId)
         {
             this.groupId = groupId;
         }

--- a/plugin/trino-ml/src/main/java/io/trino/plugin/ml/EvaluateClassifierPredictionsStateFactory.java
+++ b/plugin/trino-ml/src/main/java/io/trino/plugin/ml/EvaluateClassifierPredictionsStateFactory.java
@@ -45,11 +45,11 @@ public class EvaluateClassifierPredictionsStateFactory
         private final ObjectBigArray<Map<String, Integer>> truePositives = new ObjectBigArray<>();
         private final ObjectBigArray<Map<String, Integer>> falsePositives = new ObjectBigArray<>();
         private final ObjectBigArray<Map<String, Integer>> falseNegatives = new ObjectBigArray<>();
-        private long groupId;
+        private int groupId;
         private long memoryUsage;
 
         @Override
-        public void setGroupId(long groupId)
+        public void setGroupId(int groupId)
         {
             this.groupId = groupId;
         }
@@ -91,7 +91,7 @@ public class EvaluateClassifierPredictionsStateFactory
         }
 
         @Override
-        public void ensureCapacity(long size)
+        public void ensureCapacity(int size)
         {
             truePositives.ensureCapacity(size);
             falsePositives.ensureCapacity(size);

--- a/plugin/trino-ml/src/main/java/io/trino/plugin/ml/LearnStateFactory.java
+++ b/plugin/trino-ml/src/main/java/io/trino/plugin/ml/LearnStateFactory.java
@@ -52,18 +52,18 @@ public class LearnStateFactory
         private final ObjectBigArray<List<FeatureVector>> featureVectorsArray = new ObjectBigArray<>();
         private final SliceBigArray parametersArray = new SliceBigArray();
         private final BiMap<String, Integer> labelEnumeration = HashBiMap.create();
-        private long groupId;
+        private int groupId;
         private int nextLabel;
         private long size;
 
         @Override
-        public void setGroupId(long groupId)
+        public void setGroupId(int groupId)
         {
             this.groupId = groupId;
         }
 
         @Override
-        public void ensureCapacity(long size)
+        public void ensureCapacity(int size)
         {
             labelsArray.ensureCapacity(size);
             featureVectorsArray.ensureCapacity(size);


### PR DESCRIPTION
## Description
Internally groupId has been an `int` for a while now, and this change makes it possible to write more efficient state implementations.

## Release notes

(X) Release notes are required, with the following suggested text:

```markdown
# SPI
* GroupedAccumulatorState group id and capacity are now `int` type. ({issue}`issuenumber`)
```
