### PR TITLE
Update docker-images version to 93

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
         <dep.aws-sdk.version>1.12.689</dep.aws-sdk.version>
         <dep.cassandra.version>4.17.0</dep.cassandra.version>
         <dep.confluent.version>7.5.1</dep.confluent.version>
-        <dep.docker.images.version>92</dep.docker.images.version>
+        <dep.docker.images.version>93</dep.docker.images.version>
         <dep.drift.version>1.21</dep.drift.version>
         <dep.errorprone.version>2.26.1</dep.errorprone.version>
         <dep.flyway.version>10.10.0</dep.flyway.version>


### PR DESCRIPTION
## Description

This bump contains: https://github.com/trinodb/docker-images/compare/92...93


## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
