### PR TITLE
Try reading data from underlying source if the data has been corrupted

### DIFF
--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInputHelper.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInputHelper.java
@@ -24,7 +24,6 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.trino.filesystem.Location;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -75,7 +74,6 @@ public class AlluxioInputHelper
     }
 
     public int doCacheRead(long position, byte[] bytes, int offset, int length)
-            throws IOException
     {
         Span span = tracer.spanBuilder("Alluxio.readCached")
                 .setAttribute(CACHE_KEY, cacheKey)
@@ -104,7 +102,6 @@ public class AlluxioInputHelper
     }
 
     private int doInternalCacheRead(long position, byte[] bytes, int offset, int length)
-            throws IOException
     {
         // TODO: Support reading cache hits from the back as well
         if (length == 0) {
@@ -113,11 +110,10 @@ public class AlluxioInputHelper
         int remainingLength = length;
         while (remainingLength > 0) {
             int bytesReadFromCache = readPageFromCache(position, bytes, offset, remainingLength);
-            if (bytesReadFromCache == 0) {
+            // When dealing with concurrent access for a new file, CacheManager#put doesn't guarantee the page is fully written,
+            // and trying to access the page could return -1, so we read the data from source and update the cache.
+            if (bytesReadFromCache <= 0) {
                 break;
-            }
-            if (bytesReadFromCache < 0) {
-                throw new IOException("Read %d bytes from cache".formatted(bytesReadFromCache));
             }
             position += bytesReadFromCache;
             remainingLength -= bytesReadFromCache;

--- a/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestAlluxioCacheFileSystemAccessOperations.java
+++ b/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestAlluxioCacheFileSystemAccessOperations.java
@@ -115,8 +115,8 @@ public class TestAlluxioCacheFileSystemAccessOperations
         assertCacheOperations(location, content, readTimes,
                 ImmutableMultiset.<CacheOperationSpan>builder()
                         .addCopies(new CacheOperationSpan("Alluxio.readCached", location.toString(), 11), readTimes)
-                        .addCopies(new CacheOperationSpan("AlluxioCacheManager.get", cacheKey(location, 0), 0, 11), readTimes)
-                        .add(new CacheOperationSpan("AlluxioCacheManager.put", cacheKey(location, 0), 0, 11))
+                        .addCopies(new CacheOperationSpan("AlluxioCacheManager.get", cacheKey(location, cacheKeyProvider.currentCacheVersion()), 0, 11), readTimes)
+                        .add(new CacheOperationSpan("AlluxioCacheManager.put", cacheKey(location, cacheKeyProvider.currentCacheVersion()), 0, 11))
                         .add(new CacheOperationSpan("Alluxio.writeCache", location.toString(), 11))
                         .add(new CacheOperationSpan("Alluxio.readExternal", location.toString(), 11))
                         .build());
@@ -132,8 +132,8 @@ public class TestAlluxioCacheFileSystemAccessOperations
                 ImmutableMultiset.<CacheOperationSpan>builder()
                         .add(new CacheOperationSpan("Alluxio.readExternal", location.toString(), 16))
                         .add(new CacheOperationSpan("Alluxio.writeCache", location.toString(), 16))
-                        .add(new CacheOperationSpan("AlluxioCacheManager.put", cacheKey(location, 1), 0, 16))
-                        .addCopies(new CacheOperationSpan("AlluxioCacheManager.get", cacheKey(location, 1), 0, 16), readTimes)
+                        .add(new CacheOperationSpan("AlluxioCacheManager.put", cacheKey(location, cacheKeyProvider.currentCacheVersion()), 0, 16))
+                        .addCopies(new CacheOperationSpan("AlluxioCacheManager.get", cacheKey(location, cacheKeyProvider.currentCacheVersion()), 0, 16), readTimes)
                         .addCopies(new CacheOperationSpan("Alluxio.readCached", location.toString(), 16), readTimes)
                         .build());
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fixes https://github.com/trinodb/trino/issues/21342 and https://github.com/trinodb/trino/issues/21147.

These exists a race condition in Alluxio cache which occurs when two different threads are trying to read a same file, 
then it fails to read the data file with the following message

```
	Caused by: java.io.IOException: Read -1 bytes from cache
		at io.trino.filesystem.alluxio.AlluxioInputHelper.doInternalCacheRead(AlluxioInputHelper.java:120)
		at io.trino.filesystem.alluxio.AlluxioInputHelper.lambda$doCacheRead$0(AlluxioInputHelper.java:89)
		at io.trino.filesystem.alluxio.AlluxioTracing.withTracing(AlluxioTracing.java:29)
		at io.trino.filesystem.alluxio.AlluxioInputHelper.doCacheRead(AlluxioInputHelper.java:87)
		at io.trino.filesystem.alluxio.AlluxioInput.readFully(AlluxioInput.java:79)
		at io.trino.filesystem.alluxio.AlluxioInput.readTail(AlluxioInput.java:128)
		at io.trino.filesystem.TrinoInput.readTail(TrinoInput.java:43)
		at io.trino.filesystem.tracing.TracingInput.lambda$readTail$3(TracingInput.java:81)
		at io.trino.filesystem.tracing.Tracing.withTracing(Tracing.java:47)
		at io.trino.filesystem.tracing.TracingInput.readTail(TracingInput.java:81)
		at io.trino.plugin.hive.parquet.MemoryParquetDataSource.<init>(MemoryParquetDataSource.java:56)
		at io.trino.plugin.hive.parquet.ParquetPageSourceFactory.createDataSource(ParquetPageSourceFactory.java:319)
		at io.trino.plugin.hive.parquet.ParquetPageSourceFactory.createPageSource(ParquetPageSourceFactory.java:222)
		... 20 more
```

CacheMaanger#put doesn't guarantee that file is written by Alluxio and it is ready to be read. From the CacheManager Javadocs

```
Puts a page into the cache manager. This method is best effort. It is possible that this put operation returns without page written.
```
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

We could reproduce this issue by increasing the repeated test count in `TestIcebergMinioParquetCachingConnectorSmokeTest#testDeleteRowsConcurrently`

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
