### PR TITLE
Replace deprecated for removal Subject#getSubject

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/auth/kerberos/DelegatedUnconstrainedContextProvider.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/kerberos/DelegatedUnconstrainedContextProvider.java
@@ -20,7 +20,6 @@ import javax.security.auth.RefreshFailedException;
 import javax.security.auth.Subject;
 import javax.security.auth.kerberos.KerberosTicket;
 
-import java.security.AccessController;
 import java.util.Set;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
@@ -28,7 +27,7 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 public class DelegatedUnconstrainedContextProvider
         extends AbstractUnconstrainedContextProvider
 {
-    private final Subject subject = Subject.getSubject(AccessController.getContext());
+    private final Subject subject = Subject.current();
 
     @Override
     protected Subject getSubject()


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

It has been deprecated in Java 17, but the replacement was added only in Java 18, so we can switch to it only now, after we switched to Java 21.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

See also d4716de837e45aec8df3d59392594cc53d576c7e.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
