### PR TITLE
Add mongodb dynamic filter support

### DIFF
--- a/docs/src/main/sphinx/connector/mongodb.md
+++ b/docs/src/main/sphinx/connector/mongodb.md
@@ -60,6 +60,7 @@ The following configuration properties are available:
 | `mongodb.required-replica-set`           | The required replica set name                                              |
 | `mongodb.cursor-batch-size`              | The number of elements to return in a batch                                |
 | `mongodb.allow-local-scheduling`         | Assign MongoDB splits to a specific worker                                 |
+| `mongodb.dynamic-filtering.wait-timeout` | Duration to wait for completion of dynamic filters during split generation |
 
 ### `mongodb.connection-url`
 
@@ -212,6 +213,12 @@ MongoDB node. Note that a shared deployment is not recommended, and enabling
 this property can lead to resource contention.
 
 This property is optional, and defaults to false.
+
+### `mongodb.dynamic-filtering.wait-timeout`
+
+Duration to wait for completion of dynamic filters during split generation.
+
+This property is optional; the default is `5s`.
 
 (table-definition-label)=
 

--- a/plugin/trino-mongodb/pom.xml
+++ b/plugin/trino-mongodb/pom.xml
@@ -49,6 +49,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
             <artifactId>opentelemetry-mongo-3.1</artifactId>
         </dependency>
@@ -210,6 +215,12 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientConfig.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientConfig.java
@@ -18,9 +18,13 @@ import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.configuration.DefunctConfig;
 import io.airlift.configuration.LegacyConfig;
+import io.airlift.units.Duration;
+import io.airlift.units.MinDuration;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 @DefunctConfig({"mongodb.connection-per-host", "mongodb.socket-keep-alive", "mongodb.seeds", "mongodb.credentials"})
 public class MongoClientConfig
@@ -46,6 +50,7 @@ public class MongoClientConfig
     private String implicitRowFieldPrefix = "_pos";
     private boolean projectionPushDownEnabled = true;
     private boolean allowLocalScheduling;
+    private Duration dynamicFilteringWaitTimeout = new Duration(5, SECONDS);
 
     @NotNull
     public String getSchemaCollection()
@@ -263,6 +268,21 @@ public class MongoClientConfig
     public MongoClientConfig setAllowLocalScheduling(boolean allowLocalScheduling)
     {
         this.allowLocalScheduling = allowLocalScheduling;
+        return this;
+    }
+
+    @MinDuration("0ms")
+    @NotNull
+    public Duration getDynamicFilteringWaitTimeout()
+    {
+        return dynamicFilteringWaitTimeout;
+    }
+
+    @Config("mongodb.dynamic-filtering.wait-timeout")
+    @ConfigDescription("Duration to wait for completion of dynamic filters during split generation")
+    public MongoClientConfig setDynamicFilteringWaitTimeout(Duration dynamicFilteringWaitTimeout)
+    {
+        this.dynamicFilteringWaitTimeout = dynamicFilteringWaitTimeout;
         return this;
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSessionProperties.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSessionProperties.java
@@ -15,18 +15,21 @@ package io.trino.plugin.mongodb;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
+import io.airlift.units.Duration;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.session.PropertyMetadata;
 
 import java.util.List;
 
+import static io.trino.plugin.base.session.PropertyMetadataUtil.durationProperty;
 import static io.trino.spi.session.PropertyMetadata.booleanProperty;
 
 public final class MongoSessionProperties
         implements SessionPropertiesProvider
 {
     private static final String PROJECTION_PUSHDOWN_ENABLED = "projection_pushdown_enabled";
+    public static final String DYNAMIC_FILTERING_WAIT_TIMEOUT = "dynamic_filtering_wait_timeout";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -38,6 +41,11 @@ public final class MongoSessionProperties
                         PROJECTION_PUSHDOWN_ENABLED,
                         "Read only required fields from a row type",
                         mongoConfig.isProjectionPushdownEnabled(),
+                        false))
+                .add(durationProperty(
+                        DYNAMIC_FILTERING_WAIT_TIMEOUT,
+                        "Duration to wait for completion of dynamic filters",
+                        mongoConfig.getDynamicFilteringWaitTimeout(),
                         false))
                 .build();
     }
@@ -51,5 +59,10 @@ public final class MongoSessionProperties
     public static boolean isProjectionPushdownEnabled(ConnectorSession session)
     {
         return session.getProperty(PROJECTION_PUSHDOWN_ENABLED, Boolean.class);
+    }
+
+    public static Duration getDynamicFilteringWaitTimeout(ConnectorSession session)
+    {
+        return session.getProperty(DYNAMIC_FILTERING_WAIT_TIMEOUT, Duration.class);
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSplitManager.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSplitManager.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.mongodb;
 
+import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
@@ -23,11 +24,17 @@ import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.connector.FixedSplitSource;
 
+import java.util.concurrent.CompletableFuture;
+
+import static io.trino.plugin.mongodb.MongoSessionProperties.getDynamicFilteringWaitTimeout;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 public class MongoSplitManager
         implements ConnectorSplitManager
 {
+    private static final ConnectorSplitSource.ConnectorSplitBatch EMPTY_BATCH = new ConnectorSplitSource.ConnectorSplitBatch(ImmutableList.of(), false);
+
     private final MongoServerDetailsProvider serverDetailsProvider;
 
     @Inject
@@ -45,7 +52,59 @@ public class MongoSplitManager
             Constraint constraint)
     {
         MongoSplit split = new MongoSplit(serverDetailsProvider.getServerAddress());
+        return new MongoSplitSource(session, dynamicFilter, new FixedSplitSource(split));
+    }
 
-        return new FixedSplitSource(split);
+    private static class MongoSplitSource
+            implements ConnectorSplitSource
+    {
+        private final DynamicFilter dynamicFilter;
+        private final long startNanos;
+        private final long dynamicFilteringTimeoutNanos;
+
+        private final ConnectorSplitSource delegateSplitSource;
+
+        public MongoSplitSource(ConnectorSession session, DynamicFilter dynamicFilter, ConnectorSplitSource delegateSplitSource)
+        {
+            this.dynamicFilter = requireNonNull(dynamicFilter, "dynamicFilter is null");
+            this.dynamicFilteringTimeoutNanos = (long) getDynamicFilteringWaitTimeout(session).getValue(NANOSECONDS);
+            this.startNanos = System.nanoTime();
+            this.delegateSplitSource = requireNonNull(delegateSplitSource, "delegateSplitSource is null");
+        }
+
+        @Override
+        public CompletableFuture<ConnectorSplitBatch> getNextBatch(int maxSize)
+        {
+            long remainingTimeoutNanos = getRemainingTimeoutNanos();
+            if (remainingTimeoutNanos > 0 && dynamicFilter.isAwaitable()) {
+                // wait for dynamic filter and yield
+                return dynamicFilter.isBlocked()
+                        .thenApply(ignored -> EMPTY_BATCH)
+                        .completeOnTimeout(EMPTY_BATCH, remainingTimeoutNanos, NANOSECONDS);
+            }
+
+            return delegateSplitSource.getNextBatch(maxSize);
+        }
+
+        @Override
+        public void close()
+        {
+            delegateSplitSource.close();
+        }
+
+        @Override
+        public boolean isFinished()
+        {
+            if (getRemainingTimeoutNanos() > 0 && dynamicFilter.isAwaitable()) {
+                return false;
+            }
+
+            return delegateSplitSource.isFinished();
+        }
+
+        private long getRemainingTimeoutNanos()
+        {
+            return dynamicFilteringTimeoutNanos - (System.nanoTime() - startNanos);
+        }
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoTableHandle.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoTableHandle.java
@@ -59,4 +59,15 @@ public record MongoTableHandle(
                 projectedColumns,
                 limit);
     }
+
+    public MongoTableHandle withConstraint(TupleDomain<ColumnHandle> constraint)
+    {
+        return new MongoTableHandle(
+                schemaTableName,
+                remoteTableName,
+                filter,
+                constraint,
+                projectedColumns,
+                limit);
+    }
 }

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoClientConfig.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoClientConfig.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.mongodb;
 
 import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -21,6 +22,8 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class TestMongoClientConfig
 {
@@ -44,7 +47,8 @@ public class TestMongoClientConfig
                 .setRequiredReplicaSetName(null)
                 .setImplicitRowFieldPrefix("_pos")
                 .setProjectionPushdownEnabled(true)
-                .setAllowLocalScheduling(false));
+                .setAllowLocalScheduling(false)
+                .setDynamicFilteringWaitTimeout(new Duration(5, SECONDS)));
     }
 
     @Test
@@ -69,6 +73,7 @@ public class TestMongoClientConfig
                 .put("mongodb.implicit-row-field-prefix", "_prefix")
                 .put("mongodb.projection-pushdown-enabled", "false")
                 .put("mongodb.allow-local-scheduling", "true")
+                .put("mongodb.dynamic-filtering.wait-timeout", "2ms")
                 .buildOrThrow();
 
         MongoClientConfig expected = new MongoClientConfig()
@@ -88,7 +93,8 @@ public class TestMongoClientConfig
                 .setRequiredReplicaSetName("replica_set")
                 .setImplicitRowFieldPrefix("_prefix")
                 .setProjectionPushdownEnabled(false)
-                .setAllowLocalScheduling(true);
+                .setAllowLocalScheduling(true)
+                .setDynamicFilteringWaitTimeout(new Duration(2, MILLISECONDS));
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoDynamicFiltering.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoDynamicFiltering.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.primitives.Ints;
+import io.opentelemetry.api.trace.Span;
+import io.trino.Session;
+import io.trino.execution.QueryStats;
+import io.trino.metadata.QualifiedObjectName;
+import io.trino.metadata.Split;
+import io.trino.metadata.TableHandle;
+import io.trino.operator.OperatorStats;
+import io.trino.security.AllowAllAccessControl;
+import io.trino.spi.QueryId;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.DynamicFilter;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.split.SplitSource;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.tpch.TpchTable;
+import io.trino.transaction.TransactionId;
+import io.trino.transaction.TransactionManager;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
+import static io.trino.SystemSessionProperties.JOIN_REORDERING_STRATEGY;
+import static io.trino.plugin.mongodb.MongoQueryRunner.createMongoQueryRunner;
+import static io.trino.plugin.mongodb.MongoSessionProperties.DYNAMIC_FILTERING_WAIT_TIMEOUT;
+import static io.trino.spi.connector.Constraint.alwaysTrue;
+import static io.trino.sql.planner.OptimizerConfig.JoinDistributionType.BROADCAST;
+import static io.trino.sql.planner.OptimizerConfig.JoinReorderingStrategy.NONE;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestMongoDynamicFiltering
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        MongoServer server = closeAfterClass(new MongoServer());
+        return createMongoQueryRunner(
+                server,
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                ImmutableMap.of("mongodb.dynamic-filtering.wait-timeout", "1h"),
+                TpchTable.getTables(),
+                runner -> {});
+    }
+
+    @Test
+    @Timeout(30)
+    public void testIncompleteDynamicFilterTimeout()
+            throws Exception
+    {
+        QueryRunner runner = getQueryRunner();
+        TransactionManager transactionManager = runner.getTransactionManager();
+        TransactionId transactionId = transactionManager.beginTransaction(false);
+        Session session = Session.builder(getSession())
+                .setCatalogSessionProperty("mongodb", DYNAMIC_FILTERING_WAIT_TIMEOUT, "1s")
+                .build()
+                .beginTransactionId(transactionId, transactionManager, new AllowAllAccessControl());
+        QualifiedObjectName tableName = new QualifiedObjectName("mongodb", "tpch", "orders");
+        Optional<TableHandle> tableHandle = runner.getPlannerContext().getMetadata().getTableHandle(session, tableName);
+        assertThat(tableHandle.isPresent()).isTrue();
+        CompletableFuture<Void> dynamicFilterBlocked = new CompletableFuture<>();
+        try {
+            SplitSource splitSource = runner.getSplitManager()
+                    .getSplits(session, Span.getInvalid(), tableHandle.get(), new BlockedDynamicFilter(dynamicFilterBlocked), alwaysTrue());
+            List<Split> splits = new ArrayList<>();
+            while (!splitSource.isFinished()) {
+                splits.addAll(splitSource.getNextBatch(1000).get().getSplits());
+            }
+            splitSource.close();
+            assertThat(splits.isEmpty()).isFalse();
+        }
+        finally {
+            dynamicFilterBlocked.complete(null);
+        }
+    }
+
+    private static class BlockedDynamicFilter
+            implements DynamicFilter
+    {
+        private final CompletableFuture<?> isBlocked;
+
+        public BlockedDynamicFilter(CompletableFuture<?> isBlocked)
+        {
+            this.isBlocked = requireNonNull(isBlocked, "isBlocked is null");
+        }
+
+        @Override
+        public Set<ColumnHandle> getColumnsCovered()
+        {
+            return ImmutableSet.of();
+        }
+
+        @Override
+        public CompletableFuture<?> isBlocked()
+        {
+            return isBlocked;
+        }
+
+        @Override
+        public boolean isComplete()
+        {
+            return false;
+        }
+
+        @Override
+        public boolean isAwaitable()
+        {
+            return true;
+        }
+
+        @Override
+        public TupleDomain<ColumnHandle> getCurrentPredicate()
+        {
+            return TupleDomain.all();
+        }
+    }
+
+    @Test
+    public void testJoinDynamicFilteringSingleValue()
+    {
+        // Join lineitem with a single row of orders
+        assertDynamicFiltering(
+                "SELECT * FROM lineitem JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.comment = 'nstructions sleep furiously among '",
+                withBroadcastJoin(),
+                6,
+                6);
+    }
+
+    @Test
+    public void testJoinDynamicFilteringBlockProbeSide()
+    {
+        // Wait for both build sides to finish before starting the scan of 'lineitem' table (should be very selective given the dynamic filters).
+        assertDynamicFiltering(
+                "SELECT l.comment" +
+                        " FROM  lineitem l, part p, orders o" +
+                        " WHERE l.orderkey = o.orderkey AND o.comment = 'nstructions sleep furiously among '" +
+                        " AND p.partkey = l.partkey AND p.comment = 'onic deposits'",
+                withBroadcastJoinNonReordering(),
+                1,
+                1);
+    }
+
+    private void assertDynamicFiltering(@Language("SQL") String selectQuery, Session session, int expectedRowCount, int... expectedOperatorRowsRead)
+    {
+        QueryRunner runner = getDistributedQueryRunner();
+        QueryRunner.MaterializedResultWithPlan result = runner.executeWithPlan(session, selectQuery);
+
+        assertThat(result.result().getRowCount()).isEqualTo(expectedRowCount);
+        assertThat(getOperatorRowsRead(runner, result.queryId())).isEqualTo(Ints.asList(expectedOperatorRowsRead));
+    }
+
+    private Session withBroadcastJoin()
+    {
+        return Session.builder(getSession())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, BROADCAST.name())
+                .build();
+    }
+
+    private Session withBroadcastJoinNonReordering()
+    {
+        return Session.builder(getSession())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, BROADCAST.name())
+                .setSystemProperty(JOIN_REORDERING_STRATEGY, NONE.name())
+                .build();
+    }
+
+    private static List<Integer> getOperatorRowsRead(QueryRunner runner, QueryId queryId)
+    {
+        QueryStats stats = runner.getCoordinator().getQueryManager().getFullQueryInfo(queryId).getQueryStats();
+        return stats.getOperatorSummaries()
+                .stream()
+                .filter(summary -> summary.getDynamicFilterSplitsProcessed() > 0)
+                .map(OperatorStats::getInputPositions)
+                .map(Math::toIntExact)
+                .collect(toImmutableList());
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Add support of dynamic filter to mongodb connector.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Add the following configuration property:

- `dynamic-filtering.wait-timeout`
  - Maximum [duration](prop-type-duration) for which Trino waits for dynamic
    filters to be collected from the build side of joins before starting a
    MongoDB query. Using a large timeout can potentially result in more detailed
    dynamic filters. However, it can also increase latency for some queries.
    Defaults to `5s`.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# MongoDB
* Improve performance of queries with selective joins. ({issue}`21355`)
```
