### PR TITLE
Reduce optimizer.max-reordered-joins default to 8

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/OptimizerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/OptimizerConfig.java
@@ -42,7 +42,7 @@ public class OptimizerConfig
     private double joinMultiClauseIndependenceFactor = 0.25;
 
     private JoinReorderingStrategy joinReorderingStrategy = JoinReorderingStrategy.AUTOMATIC;
-    private int maxReorderedJoins = 9;
+    private int maxReorderedJoins = 8;
     private int maxPrefetchedInformationSchemaPrefixes = 100;
 
     private boolean enableStatsCalculator = true;

--- a/core/trino-main/src/test/java/io/trino/cost/TestOptimizerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/cost/TestOptimizerConfig.java
@@ -47,7 +47,7 @@ public class TestOptimizerConfig
                 .setJoinDistributionType(JoinDistributionType.AUTOMATIC)
                 .setJoinMultiClauseIndependenceFactor(0.25)
                 .setJoinReorderingStrategy(JoinReorderingStrategy.AUTOMATIC)
-                .setMaxReorderedJoins(9)
+                .setMaxReorderedJoins(8)
                 .setMaxPrefetchedInformationSchemaPrefixes(100)
                 .setColocatedJoinsEnabled(true)
                 .setSpatialJoinsEnabled(true)

--- a/docs/src/main/sphinx/admin/properties-optimizer.md
+++ b/docs/src/main/sphinx/admin/properties-optimizer.md
@@ -104,7 +104,7 @@ for any reason a cost could not be computed, the `ELIMINATE_CROSS_JOINS` strateg
 ## `optimizer.max-reordered-joins`
 
 - **Type:** {ref}`prop-type-integer`
-- **Default value:** `9`
+- **Default value:** `8`
 
 When optimizer.join-reordering-strategy is set to cost-based, this property determines
 the maximum number of joins that can be reordered at once.


### PR DESCRIPTION
## Description
Reduces planning time for tpcds/q64 from 11.8s to 6.6s at sf1k by reducing the default of optimizer.max-reordered-joins to 8 from 9. q64 is the only TPC query affected, it has a different join order but it’s execution was not slowed compared to before.
Further reduction to 7 helps some more with planning time but the plan for q72 becomes worse, so we leave it at 8.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Improve planning time for queries with large number of joins. ({issue}`21360`)
```
