### PR TITLE
Retry on "Read timed out." in Delta Lake Databricks tests

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/util/DeltaLakeTestUtils.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/util/DeltaLakeTestUtils.java
@@ -49,9 +49,11 @@ public final class DeltaLakeTestUtils
     public static final String DATABRICKS_COMMUNICATION_FAILURE_ISSUE = "https://github.com/trinodb/trino/issues/14391";
     @Language("RegExp")
     public static final String DATABRICKS_COMMUNICATION_FAILURE_MATCH =
-            "\\Q[Databricks][DatabricksJDBCDriver](500593) Communication link failure. Failed to connect to server. Reason: \\E" +
-            "(HTTP retry after response received with no Retry-After header, error: HTTP Response code: 503|HTTP Response code: 504)" +
-            ", Error message: Unknown.";
+            "\\Q[Databricks][\\E(DatabricksJDBCDriver|JDBCDriver)\\Q](500593) Communication link failure. Failed to connect to server. Reason: \\E" +
+            "(" +
+            "(HTTP retry after response received with no Retry-After header, error: HTTP Response code: 503|HTTP Response code: 504), Error message: Unknown." +
+            "|java.net.SocketTimeoutException: Read timed out." +
+            ")";
     private static final RetryPolicy<QueryResult> CONCURRENT_MODIFICATION_EXCEPTION_RETRY_POLICY = RetryPolicy.<QueryResult>builder()
             .handleIf(throwable -> Throwables.getRootCause(throwable) instanceof ConcurrentModificationException)
             .handleIf(throwable -> throwable.getMessage() != null && throwable.getMessage().contains("Table being modified concurrently"))


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Handle stacktraces like the following:

```
2024-03-28T17:53:19.5139785Z tests               | java.lang.RuntimeException: java.sql.SQLException: [Databricks][JDBCDriver](500593) Communication link failure. Failed to connect to server. Reason: java.net.SocketTimeoutException: Read timed out.
2024-03-28T17:53:19.5143067Z tests               | 	at io.trino.tempto.query.JdbcQueryExecutor.openConnection(JdbcQueryExecutor.java:63)
2024-03-28T17:53:19.5145312Z tests               | 	at io.trino.tempto.query.JdbcQueryExecutor.execute(JdbcQueryExecutor.java:103)
2024-03-28T17:53:19.5147447Z tests               | 	at io.trino.tempto.query.JdbcQueryExecutor.executeQuery(JdbcQueryExecutor.java:84)
2024-03-28T17:53:19.5149984Z tests               | 	at io.trino.tests.product.utils.QueryExecutors$3.lambda$executeQuery$0(QueryExecutors.java:136)
2024-03-28T17:53:19.5152146Z tests               | 	at dev.failsafe.Functions.lambda$toCtxSupplier$11(Functions.java:243)
2024-03-28T17:53:19.5153980Z tests               | 	at dev.failsafe.Functions.lambda$get$0(Functions.java:46)
2024-03-28T17:53:19.5156413Z tests               | 	at dev.failsafe.internal.RetryPolicyExecutor.lambda$apply$0(RetryPolicyExecutor.java:74)
2024-03-28T17:53:19.5158637Z tests               | 	at dev.failsafe.SyncExecutionImpl.executeSync(SyncExecutionImpl.java:187)
2024-03-28T17:53:19.5160671Z tests               | 	at dev.failsafe.FailsafeExecutor.call(FailsafeExecutor.java:376)
2024-03-28T17:53:19.5162474Z tests               | 	at dev.failsafe.FailsafeExecutor.get(FailsafeExecutor.java:112)
2024-03-28T17:53:19.5164475Z tests               | 	at io.trino.tests.product.utils.QueryExecutors$3.executeQuery(QueryExecutors.java:136)
2024-03-28T17:53:19.5167670Z tests               | 	at io.trino.tests.product.deltalake.TestDeltaLakeCreateTableAsSelectCompatibility.testPrestoTypesWithDatabricks(TestDeltaLakeCreateTableAsSelectCompatibility.java:64)
2024-03-28T17:53:19.5171070Z tests               | 	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
2024-03-28T17:53:19.5173257Z tests               | 	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
2024-03-28T17:53:19.5175335Z tests               | 	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:104)
2024-03-28T17:53:19.5177375Z tests               | 	at org.testng.internal.Invoker.invokeMethod(Invoker.java:645)
2024-03-28T17:53:19.5179137Z tests               | 	at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:851)
2024-03-28T17:53:19.5181435Z tests               | 	at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1177)
2024-03-28T17:53:19.5183483Z tests               | 	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:129)
2024-03-28T17:53:19.5185524Z tests               | 	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:112)
2024-03-28T17:53:19.5187650Z tests               | 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
2024-03-28T17:53:19.5190459Z tests               | 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
2024-03-28T17:53:19.5192693Z tests               | 	at java.base/java.lang.Thread.run(Thread.java:1583)
2024-03-28T17:53:19.5195596Z tests               | Caused by: java.sql.SQLException: [Databricks][JDBCDriver](500593) Communication link failure. Failed to connect to server. Reason: java.net.SocketTimeoutException: Read timed out.
2024-03-28T17:53:19.5198706Z tests               | 	at com.databricks.client.hivecommon.api.HS2Client.handleTTransportException(Unknown Source)
2024-03-28T17:53:19.5201426Z tests               | 	at com.databricks.client.spark.jdbc.DownloadableFetchClient.handleTTransportException(Unknown Source)
2024-03-28T17:53:19.5203841Z tests               | 	at com.databricks.client.hivecommon.api.HS2Client.openSession(Unknown Source)
2024-03-28T17:53:19.5206024Z tests               | 	at com.databricks.client.hivecommon.api.HS2Client.<init>(Unknown Source)
2024-03-28T17:53:19.5208107Z tests               | 	at com.databricks.client.spark.jdbc.DownloadableFetchClient.<init>(Unknown Source)
2024-03-28T17:53:19.5210684Z tests               | 	at com.databricks.client.spark.jdbc.DownloadableFetchClientFactory.createClient(Unknown Source)
2024-03-28T17:53:19.5213275Z tests               | 	at com.databricks.client.hivecommon.core.HiveJDBCCommonConnection.connectToServer(Unknown Source)
2024-03-28T17:53:19.5215714Z tests               | 	at com.databricks.client.spark.core.SparkJDBCConnection.connectToServer(Unknown Source)
2024-03-28T17:53:19.5218213Z tests               | 	at com.databricks.client.hivecommon.core.HiveJDBCCommonConnection.establishConnection(Unknown Source)
2024-03-28T17:53:19.5220876Z tests               | 	at com.databricks.client.spark.core.SparkJDBCConnection.establishConnection(Unknown Source)
2024-03-28T17:53:19.5223200Z tests               | 	at com.databricks.client.jdbc.core.LoginTimeoutConnection.connect(Unknown Source)
2024-03-28T17:53:19.5225456Z tests               | 	at com.data
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Related commits:

- e22fdd3b
- ec62980e


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
