### PR TITLE
Columnar evaluation of filter sub-expressions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/FeaturesConfig.java
+++ b/core/trino-main/src/main/java/io/trino/FeaturesConfig.java
@@ -119,6 +119,8 @@ public class FeaturesConfig
     private boolean hideInaccessibleColumns;
     private boolean forceSpillingJoin;
 
+    private boolean columnarFilterEvaluationEnabled = true;
+
     private boolean faultTolerantExecutionExchangeEncryptionEnabled = true;
 
     public enum DataIntegrityVerification
@@ -483,6 +485,19 @@ public class FeaturesConfig
     public FeaturesConfig setForceSpillingJoin(boolean forceSpillingJoin)
     {
         this.forceSpillingJoin = forceSpillingJoin;
+        return this;
+    }
+
+    public boolean isColumnarFilterEvaluationEnabled()
+    {
+        return columnarFilterEvaluationEnabled;
+    }
+
+    @Config("experimental.columnar-filter-evaluation.enabled")
+    @ConfigDescription("Enables columnar evaluation of filters")
+    public FeaturesConfig setColumnarFilterEvaluationEnabled(boolean columnarFilterEvaluationEnabled)
+    {
+        this.columnarFilterEvaluationEnabled = columnarFilterEvaluationEnabled;
         return this;
     }
 

--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -212,6 +212,7 @@ public final class SystemSessionProperties
     public static final String PAGE_PARTITIONING_BUFFER_POOL_SIZE = "page_partitioning_buffer_pool_size";
     public static final String IDLE_WRITER_MIN_DATA_SIZE_THRESHOLD = "idle_writer_min_data_size_threshold";
     public static final String CLOSE_IDLE_WRITERS_TRIGGER_DURATION = "close_idle_writers_trigger_duration";
+    public static final String COLUMNAR_FILTER_EVALUATION_ENABLED = "columnar_filter_evaluation_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -1066,6 +1067,11 @@ public final class SystemSessionProperties
                         FORCE_SPILLING_JOIN,
                         "Force the usage of spliing join operator in favor of the non-spilling one, even if spill is not enabled",
                         featuresConfig.isForceSpillingJoin(),
+                        false),
+                booleanProperty(
+                        COLUMNAR_FILTER_EVALUATION_ENABLED,
+                        "Enables columnar evaluation of filters",
+                        featuresConfig.isColumnarFilterEvaluationEnabled(),
                         false),
                 integerProperty(PAGE_PARTITIONING_BUFFER_POOL_SIZE,
                         "Maximum number of free buffers in the per task partitioned page buffer pool. Setting this to zero effectively disables the pool",
@@ -1929,5 +1935,10 @@ public final class SystemSessionProperties
     public static Duration getCloseIdleWritersTriggerDuration(Session session)
     {
         return session.getSystemProperty(CLOSE_IDLE_WRITERS_TRIGGER_DURATION, Duration.class);
+    }
+
+    public static boolean isColumnarFilterEvaluationEnabled(Session session)
+    {
+        return session.getSystemProperty(COLUMNAR_FILTER_EVALUATION_ENABLED, Boolean.class);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionManager.java
@@ -321,12 +321,18 @@ public class FunctionManager
 
     public static FunctionManager createTestingFunctionManager()
     {
+        return createTestingFunctionManager(new InternalFunctionBundle());
+    }
+
+    public static FunctionManager createTestingFunctionManager(FunctionBundle functionBundle)
+    {
         TypeOperators typeOperators = new TypeOperators();
         GlobalFunctionCatalog functionCatalog = new GlobalFunctionCatalog(
                 () -> { throw new UnsupportedOperationException(); },
                 () -> { throw new UnsupportedOperationException(); },
                 () -> { throw new UnsupportedOperationException(); });
         functionCatalog.addFunctions(SystemFunctionBundle.create(new FeaturesConfig(), typeOperators, new BlockTypeOperators(typeOperators), UNKNOWN));
+        functionCatalog.addFunctions(functionBundle);
         return new FunctionManager(CatalogServiceProvider.fail(), functionCatalog, LanguageFunctionProvider.DISABLED);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/index/DynamicTupleFilterFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/index/DynamicTupleFilterFactory.java
@@ -24,6 +24,7 @@ import io.trino.operator.project.PageProjection;
 import io.trino.spi.Page;
 import io.trino.spi.type.Type;
 import io.trino.sql.gen.PageFunctionCompiler;
+import io.trino.sql.gen.columnar.PageFilterEvaluator;
 import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.sql.relational.Expressions;
 import io.trino.type.BlockTypeOperators;
@@ -97,7 +98,7 @@ public class DynamicTupleFilterFactory
     {
         TuplePageFilter filter = new TuplePageFilter(filterTuple, filterEqualOperators, outputFilterChannels);
         return () -> new PageProcessor(
-                Optional.of(filter),
+                Optional.of(new PageFilterEvaluator(filter)),
                 outputProjections.stream()
                         .map(Supplier::get)
                         .collect(toImmutableList()), initialBatchSize);

--- a/core/trino-main/src/main/java/io/trino/operator/project/PageProcessorMetrics.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/PageProcessorMetrics.java
@@ -31,9 +31,9 @@ public class PageProcessorMetrics
     private long projectionTimeNanos;
     private boolean hasProjection;
 
-    public void recordFilterTimeSince(long startNanos)
+    public void recordFilterTime(long filterTimeNanos)
     {
-        filterTimeNanos += System.nanoTime() - startNanos;
+        this.filterTimeNanos += filterTimeNanos;
         hasFilter = true;
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/project/SelectedPositions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/SelectedPositions.java
@@ -16,10 +16,15 @@ package io.trino.operator.project;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkPositionIndexes;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
+import static java.lang.System.arraycopy;
+import static java.util.Objects.checkFromIndexSize;
 import static java.util.Objects.requireNonNull;
 
 public class SelectedPositions
 {
+    private static final SelectedPositions EMPTY = positionsRange(0, 0);
+
     private final boolean isList;
     private final int[] positions;
     private final int offset;
@@ -82,5 +87,320 @@ public class SelectedPositions
         int newOffset = this.offset + start;
         int newLength = end - start;
         return new SelectedPositions(isList, positions, newOffset, newLength);
+    }
+
+    /**
+     * Returns a new SelectedPositions containing all the positions which are not present in `otherPositions`
+     */
+    public SelectedPositions difference(SelectedPositions otherPositions)
+    {
+        if (isEmpty() || otherPositions.isEmpty()) {
+            return this;
+        }
+
+        int resultPositionsCount = 0;
+        if (isList && otherPositions.isList()) {
+            int[] result = new int[size];
+            int currentIndex = offset;
+            int endIndex = offset + size;
+            int currentPosition = positions[currentIndex];
+
+            int[] otherPositionsList = otherPositions.getPositions();
+            int otherCurrentIndex = otherPositions.getOffset();
+            int otherEndIndex = otherPositions.getOffset() + otherPositions.size();
+            int otherCurrentPosition = otherPositionsList[otherCurrentIndex];
+
+            while (true) {
+                if (currentPosition < otherCurrentPosition) {
+                    result[resultPositionsCount++] = currentPosition;
+                    currentIndex++;
+                    if (currentIndex >= endIndex) {
+                        break;
+                    }
+                    currentPosition = positions[currentIndex];
+                }
+                else {
+                    if (currentPosition == otherCurrentPosition) {
+                        currentIndex++;
+                        if (currentIndex >= endIndex) {
+                            break;
+                        }
+                        currentPosition = positions[currentIndex];
+                    }
+
+                    otherCurrentIndex++;
+                    if (otherCurrentIndex >= otherEndIndex) {
+                        resultPositionsCount = copyList(positions, currentIndex, endIndex, result, resultPositionsCount);
+                        return positionsList(result, 0, resultPositionsCount);
+                    }
+                    otherCurrentPosition = otherPositionsList[otherCurrentIndex];
+                }
+            }
+            return positionsList(result, 0, resultPositionsCount);
+        }
+        else if (!isList && otherPositions.isList()) {
+            int[] result = new int[size];
+            int currentPosition = offset;
+            int endPosition = offset + size;
+
+            int[] otherPositionsList = otherPositions.getPositions();
+            int otherCurrentIndex = otherPositions.getOffset();
+            int otherEndIndex = otherPositions.getOffset() + otherPositions.size();
+            int otherCurrentPosition = otherPositionsList[otherCurrentIndex];
+
+            while (true) {
+                if (currentPosition < otherCurrentPosition) {
+                    result[resultPositionsCount++] = currentPosition;
+                    currentPosition++;
+                    if (currentPosition >= endPosition) {
+                        break;
+                    }
+                }
+                else {
+                    if (currentPosition == otherCurrentPosition) {
+                        currentPosition++;
+                        if (currentPosition >= endPosition) {
+                            break;
+                        }
+                    }
+                    otherCurrentIndex++;
+                    if (otherCurrentIndex >= otherEndIndex) {
+                        resultPositionsCount = copyRange(currentPosition, endPosition, result, resultPositionsCount);
+                        return positionsList(result, 0, resultPositionsCount);
+                    }
+                    otherCurrentPosition = otherPositionsList[otherCurrentIndex];
+                }
+            }
+            return positionsList(result, 0, resultPositionsCount);
+        }
+        else if (isList && !otherPositions.isList()) {
+            int[] result = new int[size];
+            int currentIndex = offset;
+            int endIndex = offset + size;
+            int currentPosition = positions[currentIndex];
+
+            int otherCurrentPosition = otherPositions.getOffset();
+            int otherEndPosition = otherPositions.getOffset() + otherPositions.size();
+
+            while (true) {
+                if (currentPosition < otherCurrentPosition) {
+                    result[resultPositionsCount++] = currentPosition;
+                    currentIndex++;
+                    if (currentIndex >= endIndex) {
+                        break;
+                    }
+                    currentPosition = positions[currentIndex];
+                }
+                else {
+                    if (currentPosition == otherCurrentPosition) {
+                        currentIndex++;
+                        if (currentIndex >= endIndex) {
+                            break;
+                        }
+                        currentPosition = positions[currentIndex];
+                    }
+                    otherCurrentPosition++;
+                    if (otherCurrentPosition >= otherEndPosition) {
+                        resultPositionsCount = copyList(positions, currentIndex, endIndex, result, resultPositionsCount);
+                        return positionsList(result, 0, resultPositionsCount);
+                    }
+                }
+            }
+            return positionsList(result, 0, resultPositionsCount);
+        }
+
+        verify(!isList && !otherPositions.isList());
+        // both are ranges
+        int endPosition = offset + size;
+        int otherEndPosition = otherPositions.getOffset() + otherPositions.size();
+
+        if (!overlaps(offset, size, otherPositions.getOffset(), otherPositions.size())) {
+            return this;
+        }
+
+        if (offset < otherPositions.getOffset()) {
+            if (endPosition <= otherEndPosition) {
+                return positionsRange(offset, otherPositions.getOffset() - offset);
+            }
+            int[] result = new int[size - otherPositions.size()];
+            resultPositionsCount = copyRange(offset, otherPositions.getOffset(), result, resultPositionsCount);
+            resultPositionsCount = copyRange(otherEndPosition, endPosition, result, resultPositionsCount);
+            return positionsList(result, 0, resultPositionsCount);
+        }
+        // otherPositions.getOffset() <= offset
+        if (otherEndPosition < endPosition) {
+            return positionsRange(otherEndPosition, endPosition - otherEndPosition);
+        }
+        return EMPTY;
+    }
+
+    public SelectedPositions union(SelectedPositions otherPositions)
+    {
+        if (otherPositions.isEmpty()) {
+            return this;
+        }
+        if (isEmpty()) {
+            return otherPositions;
+        }
+
+        if (isList && otherPositions.isList()) {
+            int[] result = new int[size + otherPositions.size()];
+            int resultPositionsCount = 0;
+            int currentIndex = offset;
+            int endIndex = offset + size;
+            int currentPosition = positions[currentIndex];
+
+            int[] otherPositionsList = otherPositions.getPositions();
+            int otherCurrentIndex = otherPositions.getOffset();
+            int otherEndIndex = otherPositions.getOffset() + otherPositions.size();
+            int otherCurrentPosition = otherPositionsList[otherCurrentIndex];
+
+            while (true) {
+                if (currentPosition < otherCurrentPosition) {
+                    result[resultPositionsCount++] = currentPosition;
+                    currentIndex++;
+
+                    if (currentIndex >= endIndex) {
+                        resultPositionsCount = copyList(otherPositionsList, otherCurrentIndex, otherEndIndex, result, resultPositionsCount);
+                        return positionsList(result, 0, resultPositionsCount);
+                    }
+                    currentPosition = positions[currentIndex];
+                }
+                else if (currentPosition == otherCurrentPosition) {
+                    result[resultPositionsCount++] = currentPosition;
+                    currentIndex++;
+                    otherCurrentIndex++;
+
+                    if (currentIndex >= endIndex) {
+                        resultPositionsCount = copyList(otherPositionsList, otherCurrentIndex, otherEndIndex, result, resultPositionsCount);
+                        return positionsList(result, 0, resultPositionsCount);
+                    }
+
+                    if (otherCurrentIndex >= otherEndIndex) {
+                        resultPositionsCount = copyList(positions, currentIndex, endIndex, result, resultPositionsCount);
+                        return positionsList(result, 0, resultPositionsCount);
+                    }
+                    currentPosition = positions[currentIndex];
+                    otherCurrentPosition = otherPositionsList[otherCurrentIndex];
+                }
+                else {
+                    result[resultPositionsCount++] = otherCurrentPosition;
+                    otherCurrentIndex++;
+
+                    if (otherCurrentIndex >= otherEndIndex) {
+                        resultPositionsCount = copyList(positions, currentIndex, endIndex, result, resultPositionsCount);
+                        return positionsList(result, 0, resultPositionsCount);
+                    }
+                    otherCurrentPosition = otherPositionsList[otherCurrentIndex];
+                }
+            }
+            // unreachable
+        }
+        else if (!isList && otherPositions.isList()) {
+            return union(offset, size, otherPositions.getPositions(), otherPositions.getOffset(), otherPositions.size());
+        }
+        else if (isList && !otherPositions.isList()) {
+            return union(otherPositions.getOffset(), otherPositions.size(), positions, offset, size);
+        }
+        // both are ranges
+        verify(!isList && !otherPositions.isList());
+        int otherOffset = otherPositions.getOffset();
+        int otherSize = otherPositions.size();
+
+        if (overlaps(offset, size, otherOffset, otherSize)) {
+            int endOffset = Math.max(offset + size, otherOffset + otherSize);
+            int startOffset = Math.min(offset, otherOffset);
+            return positionsRange(startOffset, endOffset - startOffset);
+        }
+
+        // There's no overlap
+        int[] result = new int[size + otherPositions.size()];
+        int resultPositionsCount = 0;
+        if (offset < otherOffset) {
+            resultPositionsCount = copyRange(offset, offset + size, result, resultPositionsCount);
+            resultPositionsCount = copyRange(otherOffset, otherOffset + otherSize, result, resultPositionsCount);
+        }
+        else {
+            resultPositionsCount = copyRange(otherOffset, otherOffset + otherSize, result, resultPositionsCount);
+            resultPositionsCount = copyRange(offset, offset + size, result, resultPositionsCount);
+        }
+        return positionsList(result, 0, resultPositionsCount);
+    }
+
+    private static SelectedPositions union(int rangeStart, int rangeSize, int[] positions, int offset, int size)
+    {
+        int[] result = new int[rangeSize + size];
+        int resultPositionsCount = 0;
+        int rangeEndPosition = rangeStart + rangeSize;
+        int rangeCurrentPosition = rangeStart;
+
+        int listCurrentIndex = offset;
+        int listEndIndex = offset + size;
+        int listCurrentPosition = positions[listCurrentIndex];
+
+        while (true) {
+            if (rangeCurrentPosition < listCurrentPosition) {
+                result[resultPositionsCount++] = rangeCurrentPosition;
+                rangeCurrentPosition++;
+
+                if (rangeCurrentPosition >= rangeEndPosition) {
+                    resultPositionsCount = copyList(positions, listCurrentIndex, listEndIndex, result, resultPositionsCount);
+                    return positionsList(result, 0, resultPositionsCount);
+                }
+            }
+            else if (rangeCurrentPosition == listCurrentPosition) {
+                result[resultPositionsCount++] = rangeCurrentPosition;
+                rangeCurrentPosition++;
+                listCurrentIndex++;
+
+                if (rangeCurrentPosition >= rangeEndPosition) {
+                    resultPositionsCount = copyList(positions, listCurrentIndex, listEndIndex, result, resultPositionsCount);
+                    return positionsList(result, 0, resultPositionsCount);
+                }
+
+                if (listCurrentIndex >= listEndIndex) {
+                    resultPositionsCount = copyRange(rangeCurrentPosition, rangeEndPosition, result, resultPositionsCount);
+                    return positionsList(result, 0, resultPositionsCount);
+                }
+                listCurrentPosition = positions[listCurrentIndex];
+            }
+            else {
+                result[resultPositionsCount++] = listCurrentPosition;
+                listCurrentIndex++;
+
+                if (listCurrentIndex >= listEndIndex) {
+                    resultPositionsCount = copyRange(rangeCurrentPosition, rangeEndPosition, result, resultPositionsCount);
+                    return positionsList(result, 0, resultPositionsCount);
+                }
+                listCurrentPosition = positions[listCurrentIndex];
+            }
+        }
+    }
+
+    private static int copyRange(int rangeStart, int rangeEnd, int[] result, int offset)
+    {
+        checkFromIndexSize(offset, rangeEnd - rangeStart, result.length);
+        while (rangeStart < rangeEnd) {
+            result[offset++] = rangeStart++;
+        }
+        return offset;
+    }
+
+    private static int copyList(int[] positions, int startIndex, int endIndex, int[] result, int offset)
+    {
+        int remainingLength = endIndex - startIndex;
+        arraycopy(positions, startIndex, result, offset, remainingLength);
+        return offset + remainingLength;
+    }
+
+    private static boolean overlaps(int leftOffset, int leftSize, int rightOffset, int rightSize)
+    {
+        return isNotFullyBefore(leftOffset + leftSize, rightOffset)
+                && isNotFullyBefore(rightOffset + rightSize, leftOffset);
+    }
+
+    private static boolean isNotFullyBefore(int leftHigh, int rightLow)
+    {
+        return leftHigh >= rightLow;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -134,6 +134,7 @@ import io.trino.sql.gen.JoinCompiler;
 import io.trino.sql.gen.JoinFilterFunctionCompiler;
 import io.trino.sql.gen.OrderingCompiler;
 import io.trino.sql.gen.PageFunctionCompiler;
+import io.trino.sql.gen.columnar.ColumnarFilterCompiler;
 import io.trino.sql.parser.SqlParser;
 import io.trino.sql.planner.CompilerConfig;
 import io.trino.sql.planner.LocalExecutionPlanner;
@@ -310,6 +311,8 @@ public class ServerMainModule
         newExporter(binder).export(ExpressionCompiler.class).withGeneratedName();
         binder.bind(PageFunctionCompiler.class).in(Scopes.SINGLETON);
         newExporter(binder).export(PageFunctionCompiler.class).withGeneratedName();
+        binder.bind(ColumnarFilterCompiler.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(ColumnarFilterCompiler.class).withGeneratedName();
         configBinder(binder).bindConfig(TaskManagerConfig.class);
 
         // TODO: use conditional module

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/AndFilterEvaluator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/AndFilterEvaluator.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.gen.columnar;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.operator.project.SelectedPositions;
+import io.trino.spi.Page;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.sql.relational.RowExpression;
+import io.trino.sql.relational.SpecialForm;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.sql.relational.SpecialForm.Form.AND;
+
+public final class AndFilterEvaluator
+        implements FilterEvaluator
+{
+    public static Optional<Supplier<FilterEvaluator>> createAndExpressionEvaluator(ColumnarFilterCompiler compiler, SpecialForm specialForm)
+    {
+        checkArgument(specialForm.form() == AND, "specialForm %s should be AND", specialForm);
+        checkArgument(specialForm.arguments().size() >= 2, "AND expression %s should have at least 2 arguments", specialForm);
+
+        ImmutableList.Builder<Supplier<FilterEvaluator>> builder = ImmutableList.builder();
+        for (RowExpression expression : specialForm.arguments()) {
+            Optional<Supplier<FilterEvaluator>> subExpressionEvaluator = FilterEvaluator.createColumnarFilterEvaluator(expression, compiler);
+            if (subExpressionEvaluator.isEmpty()) {
+                return Optional.empty();
+            }
+            builder.add(subExpressionEvaluator.get());
+        }
+        List<Supplier<FilterEvaluator>> subExpressionEvaluators = builder.build();
+        return Optional.of(() -> new AndFilterEvaluator(subExpressionEvaluators.stream().map(Supplier::get).collect(toImmutableList())));
+    }
+
+    private final List<FilterEvaluator> subFilterEvaluators;
+
+    private AndFilterEvaluator(List<FilterEvaluator> subFilterEvaluators)
+    {
+        checkArgument(subFilterEvaluators.size() >= 2, "must have at least 2 subexpressions to AND");
+        this.subFilterEvaluators = subFilterEvaluators;
+    }
+
+    @Override
+    public SelectionResult evaluate(ConnectorSession session, SelectedPositions activePositions, Page page)
+    {
+        long filterTimeNanos = 0;
+        for (FilterEvaluator evaluator : subFilterEvaluators) {
+            SelectionResult result = evaluator.evaluate(session, activePositions, page);
+            filterTimeNanos += result.filterTimeNanos();
+            activePositions = result.selectedPositions();
+        }
+        return new SelectionResult(activePositions, filterTimeNanos);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/BetweenInlineColumnarFilterGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/BetweenInlineColumnarFilterGenerator.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.gen.columnar;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.bytecode.BytecodeBlock;
+import io.airlift.bytecode.ClassDefinition;
+import io.airlift.bytecode.MethodDefinition;
+import io.airlift.bytecode.Parameter;
+import io.airlift.bytecode.Scope;
+import io.airlift.bytecode.Variable;
+import io.airlift.bytecode.control.ForLoop;
+import io.airlift.bytecode.control.IfStatement;
+import io.trino.metadata.FunctionManager;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.spi.Page;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.sql.gen.CallSiteBinder;
+import io.trino.sql.relational.CallExpression;
+import io.trino.sql.relational.InputReferenceExpression;
+import io.trino.sql.relational.SpecialForm;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.bytecode.Access.FINAL;
+import static io.airlift.bytecode.Access.PUBLIC;
+import static io.airlift.bytecode.Access.a;
+import static io.airlift.bytecode.Parameter.arg;
+import static io.airlift.bytecode.ParameterizedType.type;
+import static io.airlift.bytecode.expression.BytecodeExpressions.add;
+import static io.airlift.bytecode.expression.BytecodeExpressions.constantInt;
+import static io.airlift.bytecode.expression.BytecodeExpressions.lessThan;
+import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static io.trino.sql.gen.columnar.CallColumnarFilterGenerator.generateInvocation;
+import static io.trino.sql.gen.columnar.ColumnarFilterCompiler.createClassInstance;
+import static io.trino.sql.gen.columnar.ColumnarFilterCompiler.declareBlockVariables;
+import static io.trino.sql.gen.columnar.ColumnarFilterCompiler.generateBlockMayHaveNull;
+import static io.trino.sql.gen.columnar.ColumnarFilterCompiler.generateBlockPositionNotNull;
+import static io.trino.sql.gen.columnar.ColumnarFilterCompiler.generateGetInputChannels;
+import static io.trino.sql.gen.columnar.ColumnarFilterCompiler.updateOutputPositions;
+import static io.trino.sql.relational.Expressions.call;
+import static io.trino.sql.relational.SpecialForm.Form.BETWEEN;
+import static io.trino.util.CompilerUtils.makeClassName;
+import static java.util.Objects.requireNonNull;
+
+public class BetweenInlineColumnarFilterGenerator
+{
+    private final InputReferenceExpression valueExpression;
+    private final CallExpression leftExpression;
+    private final CallExpression rightExpression;
+    private final FunctionManager functionManager;
+
+    public BetweenInlineColumnarFilterGenerator(SpecialForm specialForm, FunctionManager functionManager)
+    {
+        checkArgument(specialForm.form() == BETWEEN, "specialForm should be BETWEEN");
+        checkArgument(specialForm.arguments().size() == 3, "BETWEEN should have 3 arguments %s", specialForm.arguments());
+        checkArgument(specialForm.functionDependencies().size() == 1, "BETWEEN should have 1 functional dependency %s", specialForm.functionDependencies());
+        this.functionManager = requireNonNull(functionManager, "functionManager is null");
+
+        // Between requires evaluate once semantic for the value being tested
+        // Until we can pre-project it into a temporary variable, we apply columnar evaluation only on InputReference
+        checkArgument(specialForm.arguments().getFirst() instanceof InputReferenceExpression, "valueExpression is not an InputReference");
+        this.valueExpression = (InputReferenceExpression) specialForm.arguments().get(0);
+        ResolvedFunction lessThanOrEqual = specialForm.getOperatorDependency(LESS_THAN_OR_EQUAL);
+        this.leftExpression = call(lessThanOrEqual, specialForm.arguments().get(1), valueExpression);
+        this.rightExpression = call(lessThanOrEqual, valueExpression, specialForm.arguments().get(2));
+    }
+
+    public Supplier<ColumnarFilter> generateColumnarFilter()
+    {
+        ClassDefinition classDefinition = new ClassDefinition(
+                a(PUBLIC, FINAL),
+                makeClassName(ColumnarFilter.class.getSimpleName() + "_between", Optional.empty()),
+                type(Object.class),
+                type(ColumnarFilter.class));
+        CallSiteBinder callSiteBinder = new CallSiteBinder();
+
+        classDefinition.declareDefaultConstructor(a(PUBLIC));
+
+        generateGetInputChannels(callSiteBinder, classDefinition, valueExpression);
+
+        generateFilterRangeMethod(callSiteBinder, classDefinition);
+        generateFilterListMethod(callSiteBinder, classDefinition);
+
+        return createClassInstance(callSiteBinder, classDefinition);
+    }
+
+    private void generateFilterRangeMethod(CallSiteBinder binder, ClassDefinition classDefinition)
+    {
+        Parameter session = arg("session", ConnectorSession.class);
+        Parameter outputPositions = arg("outputPositions", int[].class);
+        Parameter offset = arg("offset", int.class);
+        Parameter size = arg("size", int.class);
+        Parameter page = arg("page", Page.class);
+
+        MethodDefinition method = classDefinition.declareMethod(
+                a(PUBLIC),
+                "filterPositionsRange",
+                type(int.class),
+                ImmutableList.of(session, outputPositions, offset, size, page));
+        Scope scope = method.getScope();
+        BytecodeBlock body = method.getBody();
+
+        declareBlockVariables(ImmutableList.of(valueExpression), page, scope, body);
+
+        Variable outputPositionsCount = scope.declareVariable("outputPositionsCount", body, constantInt(0));
+        Variable position = scope.declareVariable(int.class, "position");
+        Variable result = scope.declareVariable(boolean.class, "result");
+
+        IfStatement ifStatement = new IfStatement()
+                .condition(generateBlockMayHaveNull(ImmutableList.of(valueExpression), scope));
+        body.append(ifStatement);
+
+        /* if (block_0.mayHaveNull()) {
+         *     for (position = offset; position < offset + size; position++) {
+         *         if (!block_0.isNull(position)) {
+         *             boolean result = less_than_or_equal(constant, block_0, position);
+         *             if (result) {
+         *                 result = less_than_or_equal(block_0, position, constant);
+         *             }
+         *             outputPositions[outputPositionsCount] = position;
+         *             outputPositionsCount += result ? 1 : 0;
+         *         }
+         *     }
+         * }
+         */
+        ifStatement.ifTrue(new ForLoop("nullable range based loop")
+                .initialize(position.set(offset))
+                .condition(lessThan(position, add(offset, size)))
+                .update(position.increment())
+                .body(new IfStatement()
+                        .condition(generateBlockPositionNotNull(ImmutableList.of(valueExpression), scope, position))
+                        .ifTrue(computeAndAssignResult(binder, scope, result, position, outputPositions, outputPositionsCount))));
+
+        /* for (position = offset; position < offset + size; position++) {
+         *     boolean result = less_than_or_equal(constant, block_0, position);
+         *     if (result) {
+         *         result = less_than_or_equal(block_0, position, constant);
+         *     }
+         *     outputPositions[outputPositionsCount] = position;
+         *     outputPositionsCount += result ? 1 : 0;
+         * }
+         */
+        ifStatement.ifFalse(new ForLoop("non-nullable range based loop")
+                .initialize(position.set(offset))
+                .condition(lessThan(position, add(offset, size)))
+                .update(position.increment())
+                .body(computeAndAssignResult(binder, scope, result, position, outputPositions, outputPositionsCount)));
+
+        body.append(outputPositionsCount.ret());
+    }
+
+    private void generateFilterListMethod(CallSiteBinder binder, ClassDefinition classDefinition)
+    {
+        Parameter session = arg("session", ConnectorSession.class);
+        Parameter outputPositions = arg("outputPositions", int[].class);
+        Parameter activePositions = arg("activePositions", int[].class);
+        Parameter offset = arg("offset", int.class);
+        Parameter size = arg("size", int.class);
+        Parameter page = arg("page", Page.class);
+
+        MethodDefinition method = classDefinition.declareMethod(
+                a(PUBLIC),
+                "filterPositionsList",
+                type(int.class),
+                ImmutableList.of(session, outputPositions, activePositions, offset, size, page));
+        Scope scope = method.getScope();
+        BytecodeBlock body = method.getBody();
+
+        declareBlockVariables(ImmutableList.of(valueExpression), page, scope, body);
+
+        Variable outputPositionsCount = scope.declareVariable("outputPositionsCount", body, constantInt(0));
+        Variable index = scope.declareVariable(int.class, "index");
+        Variable position = scope.declareVariable(int.class, "position");
+        Variable result = scope.declareVariable(boolean.class, "result");
+
+        IfStatement ifStatement = new IfStatement()
+                .condition(generateBlockMayHaveNull(ImmutableList.of(valueExpression), scope));
+        body.append(ifStatement);
+
+        /* if (block_0.mayHaveNull()) {
+         *     for (int index = offset; index < offset + size; index++) {
+         *         int position = activePositions[index];
+         *         if (!block_0.isNull(position)) {
+         *             boolean result = less_than_or_equal(constant, block_0, position);
+         *             if (result) {
+         *                 result = less_than_or_equal(block_0, position, constant);
+         *             }
+         *             outputPositions[outputPositionsCount] = position;
+         *             outputPositionsCount += result ? 1 : 0;
+         *         }
+         *     }
+         * }
+         */
+        ifStatement.ifTrue(new ForLoop("nullable positions loop")
+                .initialize(index.set(offset))
+                .condition(lessThan(index, add(offset, size)))
+                .update(index.increment())
+                .body(new BytecodeBlock()
+                        .append(position.set(activePositions.getElement(index)))
+                        .append(new IfStatement()
+                                .condition(generateBlockPositionNotNull(ImmutableList.of(valueExpression), scope, position))
+                                .ifTrue(computeAndAssignResult(binder, scope, result, position, outputPositions, outputPositionsCount)))));
+
+        /* for (int index = offset; index < offset + size; index++) {
+         *     int position = activePositions[index];
+         *     boolean result = less_than_or_equal(constant, block_0, position);
+         *     if (result) {
+         *         result = less_than_or_equal(block_0, position, constant);
+         *     }
+         *     outputPositions[outputPositionsCount] = position;
+         *     outputPositionsCount += result ? 1 : 0;
+         * }
+         */
+        ifStatement.ifFalse(new ForLoop("non-nullable positions loop")
+                .initialize(index.set(offset))
+                .condition(lessThan(index, add(offset, size)))
+                .update(index.increment())
+                .body(new BytecodeBlock()
+                        .append(position.set(activePositions.getElement(index)))
+                        .append(computeAndAssignResult(binder, scope, result, position, outputPositions, outputPositionsCount))));
+
+        body.append(outputPositionsCount.ret());
+    }
+
+    private BytecodeBlock computeAndAssignResult(CallSiteBinder binder, Scope scope, Variable result, Variable position, Parameter outputPositions, Variable outputPositionsCount)
+    {
+        return new BytecodeBlock()
+                .append(generateInvocation(functionManager, binder, leftExpression, scope, position)
+                        .putVariable(result))
+                .append(new IfStatement()
+                        .condition(result)
+                        .ifTrue(generateInvocation(functionManager, binder, rightExpression, scope, position)
+                                .putVariable(result)))
+                .append(updateOutputPositions(result, position, outputPositions, outputPositionsCount));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/CallColumnarFilterGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/CallColumnarFilterGenerator.java
@@ -1,0 +1,450 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.gen.columnar;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.bytecode.BytecodeBlock;
+import io.airlift.bytecode.BytecodeNode;
+import io.airlift.bytecode.ClassDefinition;
+import io.airlift.bytecode.FieldDefinition;
+import io.airlift.bytecode.MethodDefinition;
+import io.airlift.bytecode.Parameter;
+import io.airlift.bytecode.Scope;
+import io.airlift.bytecode.Variable;
+import io.airlift.bytecode.control.ForLoop;
+import io.airlift.bytecode.control.IfStatement;
+import io.airlift.bytecode.expression.BytecodeExpression;
+import io.trino.metadata.FunctionManager;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.spi.Page;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.function.FunctionNullability;
+import io.trino.spi.function.InvocationConvention;
+import io.trino.spi.function.ScalarFunctionImplementation;
+import io.trino.sql.gen.Binding;
+import io.trino.sql.gen.CallSiteBinder;
+import io.trino.sql.relational.CallExpression;
+import io.trino.sql.relational.ConstantExpression;
+import io.trino.sql.relational.InputReferenceExpression;
+import io.trino.sql.relational.RowExpression;
+import io.trino.type.FunctionType;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.bytecode.Access.FINAL;
+import static io.airlift.bytecode.Access.PRIVATE;
+import static io.airlift.bytecode.Access.PUBLIC;
+import static io.airlift.bytecode.Access.a;
+import static io.airlift.bytecode.Parameter.arg;
+import static io.airlift.bytecode.ParameterizedType.type;
+import static io.airlift.bytecode.expression.BytecodeExpressions.add;
+import static io.airlift.bytecode.expression.BytecodeExpressions.constantInt;
+import static io.airlift.bytecode.expression.BytecodeExpressions.lessThan;
+import static io.airlift.bytecode.instruction.Constant.loadBoolean;
+import static io.airlift.bytecode.instruction.Constant.loadDouble;
+import static io.airlift.bytecode.instruction.Constant.loadLong;
+import static io.airlift.bytecode.instruction.Constant.loadString;
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION;
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.sql.gen.BytecodeUtils.invoke;
+import static io.trino.sql.gen.BytecodeUtils.loadConstant;
+import static io.trino.sql.gen.columnar.ColumnarFilterCompiler.createClassInstance;
+import static io.trino.sql.gen.columnar.ColumnarFilterCompiler.declareBlockVariables;
+import static io.trino.sql.gen.columnar.ColumnarFilterCompiler.generateBlockMayHaveNull;
+import static io.trino.sql.gen.columnar.ColumnarFilterCompiler.generateBlockPositionNotNull;
+import static io.trino.sql.gen.columnar.ColumnarFilterCompiler.generateGetInputChannels;
+import static io.trino.sql.gen.columnar.ColumnarFilterCompiler.updateOutputPositions;
+import static io.trino.util.CompilerUtils.makeClassName;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class CallColumnarFilterGenerator
+{
+    private final CallExpression callExpression;
+    private final FunctionManager functionManager;
+
+    public CallColumnarFilterGenerator(CallExpression callExpression, FunctionManager functionManager)
+    {
+        callExpression.arguments().forEach(rowExpression -> {
+            if (!(rowExpression instanceof InputReferenceExpression) && !(rowExpression instanceof ConstantExpression)) {
+                throw new UnsupportedOperationException("Call expression with unsupported argument: " + rowExpression);
+            }
+            if (rowExpression instanceof ConstantExpression constant) {
+                if (constant.value() == null) {
+                    throw new UnsupportedOperationException("Call expressions with null constant are not supported");
+                }
+            }
+        });
+        callExpression.resolvedFunction().signature().getArgumentTypes().forEach(type -> {
+            if (type instanceof FunctionType) {
+                throw new UnsupportedOperationException("Functions with lambda arguments are not supported");
+            }
+        });
+        if (callExpression.resolvedFunction().functionNullability().isReturnNullable()) {
+            throw new UnsupportedOperationException("Functions with nullable return types are not supported");
+        }
+        this.callExpression = callExpression;
+        this.functionManager = requireNonNull(functionManager, "functionManager is null");
+    }
+
+    public Supplier<ColumnarFilter> generateColumnarFilter()
+    {
+        ClassDefinition classDefinition = new ClassDefinition(
+                a(PUBLIC, FINAL),
+                makeClassName(ColumnarFilter.class.getSimpleName() + callExpression.resolvedFunction().signature().getName(), Optional.empty()),
+                type(Object.class),
+                type(ColumnarFilter.class));
+
+        CallSiteBinder callSiteBinder = new CallSiteBinder();
+        CachedInstanceBinder cachedInstanceBinder = new CachedInstanceBinder(classDefinition, callSiteBinder);
+
+        generateGetInputChannels(callSiteBinder, classDefinition, callExpression);
+
+        generateFilterRangeMethod(classDefinition, callSiteBinder, cachedInstanceBinder);
+        generateFilterListMethod(classDefinition, callSiteBinder, cachedInstanceBinder);
+
+        generateConstructor(classDefinition, cachedInstanceBinder);
+        return createClassInstance(callSiteBinder, classDefinition);
+    }
+
+    private void generateFilterRangeMethod(ClassDefinition classDefinition, CallSiteBinder callSiteBinder, CachedInstanceBinder cachedInstanceBinder)
+    {
+        Parameter session = arg("session", ConnectorSession.class);
+        Parameter outputPositions = arg("outputPositions", int[].class);
+        Parameter offset = arg("offset", int.class);
+        Parameter size = arg("size", int.class);
+        Parameter page = arg("page", Page.class);
+
+        MethodDefinition method = classDefinition.declareMethod(
+                a(PUBLIC),
+                "filterPositionsRange",
+                type(int.class),
+                ImmutableList.of(session, outputPositions, offset, size, page));
+        Scope scope = method.getScope();
+        BytecodeBlock body = method.getBody();
+
+        declareBlockVariables(callExpression.arguments(), page, scope, body);
+
+        Variable outputPositionsCount = scope.declareVariable("outputPositionsCount", body, constantInt(0));
+        Variable position = scope.declareVariable(int.class, "position");
+        Variable result = scope.declareVariable(boolean.class, "result");
+
+        FunctionNullability functionNullability = callExpression.resolvedFunction().functionNullability();
+        IfStatement ifStatement = new IfStatement()
+                .condition(generateBlockMayHaveNull(callExpression.arguments(), functionNullability.getArgumentNullable(), scope));
+        body.append(ifStatement);
+        Function<MethodHandle, BytecodeNode> instance = instanceFactory -> scope.getThis().getField(cachedInstanceBinder.getCachedInstance(instanceFactory));
+
+        /* if (block_0.mayHaveNull() || block_1.mayHaveNull()...) {
+         *     for (position = offset; position < offset + size; position++) {
+         *         if (!block_0.isNull(position) && !block_1.isNull(position)...) {
+         *             boolean result = call_function(position, block_0, block_1, ...);
+         *             outputPositions[outputPositionsCount] = position;
+         *             outputPositionsCount += result ? 1 : 0;
+         *         }
+         *     }
+         * }
+         */
+        ifStatement.ifTrue(new ForLoop("nullable range based loop")
+                .initialize(position.set(offset))
+                .condition(lessThan(position, add(offset, size)))
+                .update(position.increment())
+                .body(new IfStatement()
+                        .condition(generateBlockPositionNotNull(callExpression.arguments(), functionNullability.getArgumentNullable(), scope, position))
+                        .ifTrue(new BytecodeBlock()
+                                .append(generateFullInvocation(functionManager, instance, callSiteBinder, callExpression, scope, position)
+                                        .putVariable(result))
+                                .append(updateOutputPositions(result, position, outputPositions, outputPositionsCount)))));
+
+        /* for (position = offset; position < offset + size; position++) {
+         *     boolean result = call_function(position, block_0, block_1, ...);
+         *     outputPositions[outputPositionsCount] = position;
+         *     outputPositionsCount += result ? 1 : 0;
+         * }
+         */
+        ifStatement.ifFalse(new ForLoop("nullable function range based loop")
+                .initialize(position.set(offset))
+                .condition(lessThan(position, add(offset, size)))
+                .update(position.increment())
+                .body(new BytecodeBlock()
+                        .append(generateFullInvocation(functionManager, instance, callSiteBinder, callExpression, scope, position)
+                                .putVariable(result))
+                        .append(updateOutputPositions(result, position, outputPositions, outputPositionsCount))));
+
+        body.append(outputPositionsCount.ret());
+    }
+
+    private void generateFilterListMethod(ClassDefinition classDefinition, CallSiteBinder callSiteBinder, CachedInstanceBinder cachedInstanceBinder)
+    {
+        Parameter session = arg("session", ConnectorSession.class);
+        Parameter outputPositions = arg("outputPositions", int[].class);
+        Parameter activePositions = arg("activePositions", int[].class);
+        Parameter offset = arg("offset", int.class);
+        Parameter size = arg("size", int.class);
+        Parameter page = arg("page", Page.class);
+
+        MethodDefinition method = classDefinition.declareMethod(
+                a(PUBLIC),
+                "filterPositionsList",
+                type(int.class),
+                ImmutableList.of(session, outputPositions, activePositions, offset, size, page));
+        Scope scope = method.getScope();
+        BytecodeBlock body = method.getBody();
+
+        declareBlockVariables(callExpression.arguments(), page, scope, body);
+
+        Variable outputPositionsCount = scope.declareVariable("outputPositionsCount", body, constantInt(0));
+        Variable index = scope.declareVariable(int.class, "index");
+        Variable position = scope.declareVariable(int.class, "position");
+        Variable result = scope.declareVariable(boolean.class, "result");
+
+        FunctionNullability functionNullability = callExpression.resolvedFunction().functionNullability();
+        IfStatement ifStatement = new IfStatement()
+                .condition(generateBlockMayHaveNull(callExpression.arguments(), functionNullability.getArgumentNullable(), scope));
+        body.append(ifStatement);
+        Function<MethodHandle, BytecodeNode> instance = instanceFactory -> scope.getThis().getField(cachedInstanceBinder.getCachedInstance(instanceFactory));
+
+        /* if (block_0.mayHaveNull() || block_1.mayHaveNull()...) {
+         *     for (int index = offset; index < offset + size; index++) {
+         *         int position = activePositions[index];
+         *         if (!block_0.isNull(position) && !block_1.isNull(position)...) {
+         *             boolean result = call_function(position, block_0, block_1, ...);
+         *             outputPositions[outputPositionsCount] = position;
+         *             outputPositionsCount += result ? 1 : 0;
+         *         }
+         *     }
+         * }
+         */
+        ifStatement.ifTrue(new ForLoop("nullable positions loop")
+                .initialize(index.set(offset))
+                .condition(lessThan(index, add(offset, size)))
+                .update(index.increment())
+                .body(new BytecodeBlock()
+                        .append(position.set(activePositions.getElement(index)))
+                        .append(new IfStatement()
+                                .condition(generateBlockPositionNotNull(callExpression.arguments(), functionNullability.getArgumentNullable(), scope, position))
+                                .ifTrue(new BytecodeBlock()
+                                        .append(generateFullInvocation(functionManager, instance, callSiteBinder, callExpression, scope, position)
+                                                .putVariable(result))
+                                        .append(updateOutputPositions(result, position, outputPositions, outputPositionsCount))))));
+
+        /* for (int index = offset; index < offset + size; index++) {
+         *     int position = activePositions[index];
+         *     boolean result = call_function(position, block_0, block_1, ...);
+         *     outputPositions[outputPositionsCount] = position;
+         *     outputPositionsCount += result ? 1 : 0;
+         * }
+         */
+        ifStatement.ifFalse(new ForLoop("non-nullable positions loop")
+                .initialize(index.set(offset))
+                .condition(lessThan(index, add(offset, size)))
+                .update(index.increment())
+                .body(new BytecodeBlock()
+                        .append(position.set(activePositions.getElement(index)))
+                        .append(generateFullInvocation(functionManager, instance, callSiteBinder, callExpression, scope, position)
+                                .putVariable(result))
+                        .append(updateOutputPositions(result, position, outputPositions, outputPositionsCount))));
+
+        body.append(outputPositionsCount.ret());
+    }
+
+    static BytecodeBlock generateInvocation(
+            FunctionManager functionManager,
+            CallSiteBinder binder,
+            CallExpression callExpression,
+            Scope scope,
+            BytecodeExpression position)
+    {
+        return generateFullInvocation(
+                functionManager,
+                _ -> {
+                    throw new IllegalArgumentException("Simple method invocation can not be used with functions that require an instance factory");
+                },
+                binder,
+                callExpression,
+                scope,
+                position);
+    }
+
+    private static BytecodeBlock generateFullInvocation(
+            FunctionManager functionManager,
+            Function<MethodHandle, BytecodeNode> instanceFactory,
+            CallSiteBinder binder,
+            CallExpression callExpression,
+            Scope scope,
+            BytecodeExpression position)
+    {
+        ResolvedFunction resolvedFunction = callExpression.resolvedFunction();
+        String functionName = resolvedFunction.signature().getName().getFunctionName();
+        BytecodeBlock block = new BytecodeBlock()
+                .setDescription("invoke " + functionName);
+
+        ScalarFunctionImplementation implementation = getScalarFunctionImplementation(functionManager, callExpression);
+
+        Binding binding = binder.bind(implementation.getMethodHandle());
+
+        Optional<BytecodeNode> instance = implementation.getInstanceFactory()
+                .map(instanceFactory);
+
+        // Index of current parameter in the MethodHandle
+        int currentParameterIndex = 0;
+        MethodType methodType = binding.getType();
+        boolean instanceIsBound = false;
+        while (currentParameterIndex < methodType.parameterArray().length) {
+            Class<?> type = methodType.parameterArray()[currentParameterIndex];
+            if (instance.isPresent() && !instanceIsBound) {
+                checkState(type.equals(implementation.getInstanceFactory().get().type().returnType()), "Mismatched type for instance parameter");
+                block.append(instance.get());
+                instanceIsBound = true;
+            }
+            else if (type == ConnectorSession.class) {
+                block.append(scope.getVariable("session"));
+            }
+            currentParameterIndex++;
+        }
+        for (RowExpression argumentExpression : callExpression.arguments()) {
+            if (argumentExpression instanceof InputReferenceExpression inputReference) {
+                block.append(generateInputReference(scope.getVariable("block_" + inputReference.field()), position));
+            }
+            else if (argumentExpression instanceof ConstantExpression constant) {
+                block.append(generateConstant(binder, constant));
+            }
+            else {
+                throw new UnsupportedOperationException(format("CallExpression %s is not supported", callExpression));
+            }
+        }
+        block.append(invoke(binding, functionName));
+        return block;
+    }
+
+    private static ScalarFunctionImplementation getScalarFunctionImplementation(FunctionManager functionManager, CallExpression callExpression)
+    {
+        ResolvedFunction resolvedFunction = callExpression.resolvedFunction();
+        List<RowExpression> argumentExpressions = callExpression.arguments();
+
+        ImmutableList.Builder<InvocationConvention.InvocationArgumentConvention> builder = ImmutableList.builderWithExpectedSize(argumentExpressions.size());
+        for (RowExpression argumentExpression : argumentExpressions) {
+            if (argumentExpression instanceof InputReferenceExpression) {
+                builder.add(BLOCK_POSITION);
+            }
+            else if (argumentExpression instanceof ConstantExpression) {
+                builder.add(NEVER_NULL);
+            }
+            else {
+                throw new UnsupportedOperationException(format("CallExpression %s is not supported", callExpression));
+            }
+        }
+
+        InvocationConvention invocationConvention = new InvocationConvention(
+                builder.build(),
+                FAIL_ON_NULL,
+                true,
+                true);
+        return functionManager.getScalarFunctionImplementation(resolvedFunction, invocationConvention);
+    }
+
+    private static BytecodeNode generateInputReference(BytecodeExpression block, BytecodeExpression position)
+    {
+        BytecodeBlock blockAndPosition = new BytecodeBlock();
+        blockAndPosition.append(block);
+        blockAndPosition.append(position);
+        return blockAndPosition;
+    }
+
+    private static BytecodeNode generateConstant(CallSiteBinder callSiteBinder, ConstantExpression constant)
+    {
+        Object value = constant.value();
+        Class<?> javaType = constant.type().getJavaType();
+
+        BytecodeBlock block = new BytecodeBlock();
+
+        // use LDC for primitives (boolean, short, int, long, float, double)
+        block.comment("constant " + constant.type().getTypeSignature());
+        if (javaType == boolean.class) {
+            return block.append(loadBoolean((Boolean) value));
+        }
+        if (javaType == long.class) {
+            return block.append(loadLong((Long) value));
+        }
+        if (javaType == double.class) {
+            return block.append(loadDouble((Double) value));
+        }
+        if (javaType == String.class) {
+            return block.append(loadString((String) value));
+        }
+
+        // bind constant object directly into the call-site using invoke dynamic
+        Binding binding = callSiteBinder.bind(value, constant.type().getJavaType());
+
+        return new BytecodeBlock()
+                .setDescription("constant " + constant.type())
+                .comment(constant.toString())
+                .append(loadConstant(binding));
+    }
+
+    private static void generateConstructor(ClassDefinition classDefinition, CachedInstanceBinder cachedInstanceBinder)
+    {
+        MethodDefinition constructorDefinition = classDefinition.declareConstructor(a(PUBLIC));
+
+        BytecodeBlock body = constructorDefinition.getBody();
+        Variable thisVariable = constructorDefinition.getThis();
+
+        body.comment("super();")
+                .append(thisVariable)
+                .invokeConstructor(Object.class);
+
+        cachedInstanceBinder.generateInitializations(thisVariable, body);
+        body.ret();
+    }
+
+    private static final class CachedInstanceBinder
+    {
+        private final ClassDefinition classDefinition;
+        private final CallSiteBinder callSiteBinder;
+        private Optional<FieldDefinition> field = Optional.empty();
+        private Optional<MethodHandle> method = Optional.empty();
+
+        public CachedInstanceBinder(ClassDefinition classDefinition, CallSiteBinder callSiteBinder)
+        {
+            this.classDefinition = requireNonNull(classDefinition, "classDefinition is null");
+            this.callSiteBinder = requireNonNull(callSiteBinder, "callSiteBinder is null");
+        }
+
+        public FieldDefinition getCachedInstance(MethodHandle methodHandle)
+        {
+            if (field.isEmpty()) {
+                field = Optional.of(classDefinition.declareField(a(PRIVATE, FINAL), "__cachedInstance", methodHandle.type().returnType()));
+                method = Optional.of(methodHandle);
+            }
+            return field.get();
+        }
+
+        public void generateInitializations(Variable thisVariable, BytecodeBlock block)
+        {
+            if (field.isPresent()) {
+                Binding binding = callSiteBinder.bind(method.orElseThrow());
+                block.append(thisVariable)
+                        .append(invoke(binding, "instanceFieldConstructor"))
+                        .putField(field.get());
+            }
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/ColumnarFilter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/ColumnarFilter.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.gen.columnar;
+
+import io.trino.operator.project.InputChannels;
+import io.trino.spi.Page;
+import io.trino.spi.connector.ConnectorSession;
+
+/**
+ * Implementations of this interface evaluate a filter on the input Page.
+ * <p>
+ * {@link FilterEvaluator} will call one of filterPositionsRange or filterPositionsList depending on whether the
+ * active SelectionPositions are stored in a list or in a range.
+ * <p>
+ * Implementations are expected to operate on a Page containing only the required channels specified by getInputChannels.
+ * <p>
+ * Currently, the implementations of this interface except IS_NULL and NOT(IS_NULL),
+ * don't explicitly handle NULLs or indeterminate values, and just return FALSE for those cases.
+ * This will need to change to allow ColumnarFilter implementations to be composed in all cases (e.g. NOT filters).
+ * ColumnarFilter implementations are never composed, {@link FilterEvaluator} implementations may be composed.
+ * <p>
+ */
+public interface ColumnarFilter
+{
+    /**
+     * @param outputPositions list of positions active after evaluating this filter on the input loadedPage
+     * @param offset start of input positions range evaluated by this filter
+     * @param size length of input positions range evaluated by this filter
+     * @param loadedPage input Page after using {@link ColumnarFilter#getInputChannels} to load only the required channels
+     * @return count of positions active after evaluating this filter on the input loadedPage
+     */
+    int filterPositionsRange(ConnectorSession session, int[] outputPositions, int offset, int size, Page loadedPage);
+
+    /**
+     * @param outputPositions list of positions active after evaluating this filter on the input loadedPage
+     * @param activePositions input positions list evaluated by this filter
+     * @param offset index in activePositions where the input positions evaluated by this filter start
+     * @param size length after offset in activePositions where the input positions evaluated by this filter end
+     * @param loadedPage input Page after using {@link ColumnarFilter#getInputChannels} to load only the required channels
+     * @return count of positions active after evaluating this filter on the input loadedPage
+     */
+    int filterPositionsList(ConnectorSession session, int[] outputPositions, int[] activePositions, int offset, int size, Page loadedPage);
+
+    /**
+     * @return InputChannels of input Page that this filter operates on
+     */
+    InputChannels getInputChannels();
+}

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/ColumnarFilterCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/ColumnarFilterCompiler.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.gen.columnar;
+
+import com.google.common.base.Throwables;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.inject.Inject;
+import io.airlift.bytecode.BytecodeBlock;
+import io.airlift.bytecode.ClassDefinition;
+import io.airlift.bytecode.Parameter;
+import io.airlift.bytecode.Scope;
+import io.airlift.bytecode.Variable;
+import io.airlift.bytecode.expression.BytecodeExpression;
+import io.airlift.bytecode.expression.BytecodeExpressions;
+import io.airlift.jmx.CacheStatsMBean;
+import io.airlift.log.Logger;
+import io.trino.cache.NonEvictableLoadingCache;
+import io.trino.metadata.FunctionManager;
+import io.trino.operator.project.InputChannels;
+import io.trino.operator.project.PageFieldsToInputParametersRewriter;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.Block;
+import io.trino.sql.gen.CallSiteBinder;
+import io.trino.sql.planner.CompilerConfig;
+import io.trino.sql.relational.CallExpression;
+import io.trino.sql.relational.InputReferenceExpression;
+import io.trino.sql.relational.RowExpression;
+import io.trino.sql.relational.SpecialForm;
+import jakarta.annotation.Nullable;
+import org.objectweb.asm.MethodTooLargeException;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
+
+import java.lang.reflect.Constructor;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.bytecode.Access.PUBLIC;
+import static io.airlift.bytecode.Access.a;
+import static io.airlift.bytecode.ParameterizedType.type;
+import static io.airlift.bytecode.expression.BytecodeExpressions.add;
+import static io.airlift.bytecode.expression.BytecodeExpressions.constantFalse;
+import static io.airlift.bytecode.expression.BytecodeExpressions.constantInt;
+import static io.airlift.bytecode.expression.BytecodeExpressions.constantTrue;
+import static io.airlift.bytecode.expression.BytecodeExpressions.inlineIf;
+import static io.trino.cache.SafeCaches.buildNonEvictableCache;
+import static io.trino.operator.project.PageFieldsToInputParametersRewriter.rewritePageFieldsToInputParameters;
+import static io.trino.spi.StandardErrorCode.COMPILER_ERROR;
+import static io.trino.sql.gen.BytecodeUtils.invoke;
+import static io.trino.sql.gen.columnar.FilterEvaluator.isNotExpression;
+import static io.trino.sql.gen.columnar.IsNotNullColumnarFilter.createIsNotNullColumnarFilter;
+import static io.trino.sql.gen.columnar.IsNullColumnarFilter.createIsNullColumnarFilter;
+import static io.trino.sql.relational.SpecialForm.Form.BETWEEN;
+import static io.trino.sql.relational.SpecialForm.Form.IN;
+import static io.trino.sql.relational.SpecialForm.Form.IS_NULL;
+import static io.trino.util.CompilerUtils.defineClass;
+import static java.util.Collections.nCopies;
+import static java.util.Objects.requireNonNull;
+
+public class ColumnarFilterCompiler
+{
+    private static final Logger log = Logger.get(ColumnarFilterCompiler.class);
+
+    private final FunctionManager functionManager;
+    // Optional is used to cache failure to generate filter for unsupported cases
+    private final NonEvictableLoadingCache<RowExpression, Optional<Supplier<ColumnarFilter>>> filterCache;
+    private final CacheStatsMBean filterCacheStats;
+
+    @Inject
+    public ColumnarFilterCompiler(FunctionManager functionManager, CompilerConfig config)
+    {
+        this(functionManager, config.getExpressionCacheSize());
+    }
+
+    public ColumnarFilterCompiler(FunctionManager functionManager, int expressionCacheSize)
+    {
+        this.functionManager = requireNonNull(functionManager, "functionManager is null");
+        if (expressionCacheSize > 0) {
+            filterCache = buildNonEvictableCache(
+                    CacheBuilder.newBuilder()
+                            .recordStats()
+                            .maximumSize(expressionCacheSize),
+                    CacheLoader.from(this::generateFilterInternal));
+            filterCacheStats = new CacheStatsMBean(filterCache);
+        }
+        else {
+            filterCache = null;
+            filterCacheStats = null;
+        }
+    }
+
+    @Nullable
+    @Managed
+    @Nested
+    public CacheStatsMBean getFilterCache()
+    {
+        return filterCacheStats;
+    }
+
+    public Optional<Supplier<ColumnarFilter>> generateFilter(RowExpression filter)
+    {
+        if (filterCache == null) {
+            return generateFilterInternal(filter);
+        }
+        return filterCache.getUnchecked(filter);
+    }
+
+    private Optional<Supplier<ColumnarFilter>> generateFilterInternal(RowExpression filter)
+    {
+        try {
+            if (filter instanceof CallExpression callExpression) {
+                if (isNotExpression(callExpression)) {
+                    // "not(is_null(input_reference))" is handled explicitly as it is easy.
+                    // more generic cases like "not(equal(input_reference, constant))" are not handled yet
+                    if (callExpression.arguments().getFirst() instanceof SpecialForm specialForm && specialForm.form() == IS_NULL) {
+                        return Optional.of(createIsNotNullColumnarFilter(specialForm));
+                    }
+                    return Optional.empty();
+                }
+                return Optional.of(new CallColumnarFilterGenerator(callExpression, functionManager).generateColumnarFilter());
+            }
+            else if (filter instanceof SpecialForm specialForm) {
+                if (specialForm.form() == IS_NULL) {
+                    return Optional.of(createIsNullColumnarFilter(specialForm));
+                }
+                if (specialForm.form() == IN) {
+                    return Optional.of(new InColumnarFilterGenerator(specialForm, functionManager).generateColumnarFilter());
+                }
+                if (specialForm.form() == BETWEEN) {
+                    return Optional.of(new BetweenInlineColumnarFilterGenerator(specialForm, functionManager).generateColumnarFilter());
+                }
+            }
+            return Optional.empty();
+        }
+        catch (Throwable t) {
+            if (t instanceof UnsupportedOperationException || t.getCause() instanceof UnsupportedOperationException) {
+                log.debug("Unsupported filter for columnar evaluation %s, %s", filter, t);
+            }
+            else {
+                log.warn("Failed to compile filter %s for columnar evaluation, %s", filter, t);
+            }
+            return Optional.empty();
+        }
+    }
+
+    static void generateGetInputChannels(CallSiteBinder callSiteBinder, ClassDefinition classDefinition, RowExpression rowExpression)
+    {
+        PageFieldsToInputParametersRewriter.Result result = rewritePageFieldsToInputParameters(rowExpression);
+
+        // getInputChannels
+        classDefinition.declareMethod(a(PUBLIC), "getInputChannels", type(InputChannels.class))
+                .getBody()
+                .append(invoke(callSiteBinder.bind(result.getInputChannels(), InputChannels.class), "getInputChannels"))
+                .retObject();
+    }
+
+    static Supplier<ColumnarFilter> createClassInstance(CallSiteBinder binder, ClassDefinition classDefinition)
+    {
+        Constructor<? extends ColumnarFilter> filterConstructor;
+        try {
+            Class<? extends ColumnarFilter> functionClass = defineClass(classDefinition, ColumnarFilter.class, binder.getBindings(), ColumnarFilterCompiler.class.getClassLoader());
+            filterConstructor = functionClass.getConstructor();
+        }
+        catch (Exception e) {
+            if (Throwables.getRootCause(e) instanceof MethodTooLargeException) {
+                throw new TrinoException(COMPILER_ERROR,
+                        "Query exceeded maximum filters. Please reduce the number of filters referenced and re-run the query.", e);
+            }
+            throw new TrinoException(COMPILER_ERROR, e.getCause());
+        }
+
+        return () -> {
+            try {
+                return filterConstructor.newInstance();
+            }
+            catch (ReflectiveOperationException e) {
+                throw new TrinoException(COMPILER_ERROR, e);
+            }
+        };
+    }
+
+    static void declareBlockVariables(List<RowExpression> rowExpressions, Parameter page, Scope scope, BytecodeBlock body)
+    {
+        int channel = 0;
+        Set<Integer> inputFields = new HashSet<>(); // There may be multiple InputReferenceExpression on the same input block
+        for (RowExpression rowExpression : rowExpressions) {
+            if (!(rowExpression instanceof InputReferenceExpression inputReference)) {
+                continue;
+            }
+            if (inputFields.contains(inputReference.field())) {
+                continue;
+            }
+            scope.declareVariable(
+                    "block_" + inputReference.field(),
+                    body,
+                    page.invoke(
+                            "getBlock",
+                            Block.class,
+                            constantInt(channel)));
+            inputFields.add(inputReference.field());
+            channel++;
+        }
+    }
+
+    static BytecodeExpression generateBlockMayHaveNull(List<RowExpression> rowExpressions, Scope scope)
+    {
+        return generateBlockMayHaveNull(rowExpressions, nCopies(rowExpressions.size(), false), scope);
+    }
+
+    static BytecodeExpression generateBlockMayHaveNull(List<RowExpression> rowExpressions, List<Boolean> isNullableArgument, Scope scope)
+    {
+        checkArgument(
+                rowExpressions.size() == isNullableArgument.size(),
+                "rowExpressions size %s does not match isNullableArgument size %s",
+                rowExpressions.size(),
+                isNullableArgument.size());
+        BytecodeExpression mayHaveNull = constantFalse();
+        for (int i = 0; i < rowExpressions.size(); i++) {
+            RowExpression rowExpression = rowExpressions.get(i);
+            // Function with nullable argument should get adapted to a MethodHandle which returns false on NULL, so explicit isNull check isn't needed
+            if (rowExpression instanceof InputReferenceExpression inputReference && !isNullableArgument.get(i)) {
+                mayHaveNull = BytecodeExpressions.or(
+                        mayHaveNull,
+                        scope.getVariable("block_" + inputReference.field()).invoke("mayHaveNull", boolean.class));
+            }
+        }
+        return mayHaveNull;
+    }
+
+    static BytecodeExpression generateBlockPositionNotNull(List<RowExpression> rowExpressions, Scope scope, Variable position)
+    {
+        return generateBlockPositionNotNull(rowExpressions, nCopies(rowExpressions.size(), false), scope, position);
+    }
+
+    static BytecodeExpression generateBlockPositionNotNull(List<RowExpression> rowExpressions, List<Boolean> isNullableArgument, Scope scope, Variable position)
+    {
+        checkArgument(
+                rowExpressions.size() == isNullableArgument.size(),
+                "rowExpressions size %s does not match isNullableArgument size %s",
+                rowExpressions.size(),
+                isNullableArgument.size());
+        BytecodeExpression isNotNull = constantTrue();
+        for (int i = 0; i < rowExpressions.size(); i++) {
+            RowExpression rowExpression = rowExpressions.get(i);
+            // Function with nullable argument should get adapted to a MethodHandle which returns false on NULL, so explicit isNull check isn't needed
+            if (rowExpression instanceof InputReferenceExpression inputReference && !isNullableArgument.get(i)) {
+                isNotNull = BytecodeExpressions.and(
+                        isNotNull,
+                        BytecodeExpressions.not(scope.getVariable("block_" + inputReference.field()).invoke("isNull", boolean.class, position)));
+            }
+        }
+        return isNotNull;
+    }
+
+    static BytecodeBlock updateOutputPositions(Variable result, Variable position, Parameter outputPositions, Variable outputPositionsCount)
+    {
+        return new BytecodeBlock()
+                .append(outputPositions.setElement(outputPositionsCount, position))
+                .append(outputPositionsCount.set(
+                        add(outputPositionsCount, inlineIf(result, constantInt(1), constantInt(0)))));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/ColumnarFilterEvaluator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/ColumnarFilterEvaluator.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.gen.columnar;
+
+import io.trino.operator.project.SelectedPositions;
+import io.trino.spi.Page;
+import io.trino.spi.connector.ConnectorSession;
+
+import static io.trino.operator.project.SelectedPositions.positionsList;
+import static io.trino.operator.project.SelectedPositions.positionsRange;
+import static java.util.Objects.requireNonNull;
+
+public final class ColumnarFilterEvaluator
+        implements FilterEvaluator
+{
+    private final ColumnarFilter filter;
+    private int[] outputPositions = new int[0];
+
+    public ColumnarFilterEvaluator(ColumnarFilter filter)
+    {
+        this.filter = requireNonNull(filter, "filter is null");
+    }
+
+    @Override
+    public SelectionResult evaluate(ConnectorSession session, SelectedPositions activePositions, Page page)
+    {
+        if (activePositions.isEmpty()) {
+            return new SelectionResult(activePositions, 0);
+        }
+        // Should load only the blocks necessary for evaluating the kernel and unwrap lazy blocks
+        Page loadedPage = filter.getInputChannels().getInputChannels(page);
+        if (outputPositions.length < activePositions.size()) {
+            outputPositions = new int[activePositions.size()];
+        }
+        int outputPositionsCount;
+        long start = System.nanoTime();
+        if (activePositions.isList()) {
+            outputPositionsCount = filter.filterPositionsList(session, outputPositions, activePositions.getPositions(), activePositions.getOffset(), activePositions.size(), loadedPage);
+        }
+        else {
+            outputPositionsCount = filter.filterPositionsRange(session, outputPositions, activePositions.getOffset(), activePositions.size(), loadedPage);
+            // full range was selected
+            if (outputPositionsCount == activePositions.size()) {
+                return new SelectionResult(positionsRange(activePositions.getOffset(), outputPositionsCount), System.nanoTime() - start);
+            }
+        }
+        return new SelectionResult(positionsList(outputPositions, 0, outputPositionsCount), System.nanoTime() - start);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/DictionaryAwareColumnarFilter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/DictionaryAwareColumnarFilter.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.gen.columnar;
+
+import io.trino.operator.project.InputChannels;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.DictionaryBlock;
+import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.spi.connector.ConnectorSession;
+
+import static com.google.common.base.Verify.verify;
+import static java.lang.System.arraycopy;
+
+public final class DictionaryAwareColumnarFilter
+        implements ColumnarFilter
+{
+    private final ColumnarFilter columnarFilter;
+
+    private Block lastInputDictionary;
+    private boolean[] lastOutputDictionary;
+
+    public DictionaryAwareColumnarFilter(ColumnarFilter columnarFilter)
+    {
+        verify(columnarFilter.getInputChannels().size() == 1, "Dictionary aware filtering must have only one input");
+        this.columnarFilter = columnarFilter;
+    }
+
+    @Override
+    public int filterPositionsRange(ConnectorSession session, int[] outputPositions, int offset, int size, Page loadedPage)
+    {
+        Block block = loadedPage.getBlock(0);
+        if (block instanceof RunLengthEncodedBlock runLengthEncodedBlock) {
+            return processRle(session, outputPositions, offset, size, runLengthEncodedBlock);
+        }
+        else if (block instanceof DictionaryBlock dictionaryBlock) {
+            try {
+                return processDictionary(session, outputPositions, offset, size, dictionaryBlock);
+            }
+            catch (Exception ignored) {
+                // Processing of dictionary failed, but we ignore the exception here
+                // and force reprocessing of the whole block using the normal code.
+                // The second pass may not fail due to filtering.
+                lastOutputDictionary = null;
+            }
+        }
+
+        return columnarFilter.filterPositionsRange(session, outputPositions, offset, size, loadedPage);
+    }
+
+    @Override
+    public int filterPositionsList(ConnectorSession session, int[] outputPositions, int[] activePositions, int offset, int size, Page loadedPage)
+    {
+        Block block = loadedPage.getBlock(0);
+        if (block instanceof RunLengthEncodedBlock runLengthEncodedBlock) {
+            return processRle(session, outputPositions, activePositions, offset, size, runLengthEncodedBlock);
+        }
+        else if (block instanceof DictionaryBlock dictionaryBlock) {
+            try {
+                return processDictionary(session, outputPositions, activePositions, offset, size, dictionaryBlock);
+            }
+            catch (Exception ignored) {
+                // Processing of dictionary failed, but we ignore the exception here
+                // and force reprocessing of the whole block using the normal code.
+                // The second pass may not fail due to filtering.
+                lastOutputDictionary = null;
+            }
+        }
+
+        return columnarFilter.filterPositionsList(session, outputPositions, activePositions, offset, size, loadedPage);
+    }
+
+    @Override
+    public InputChannels getInputChannels()
+    {
+        return columnarFilter.getInputChannels();
+    }
+
+    private int processRle(ConnectorSession session, int[] outputPositions, int[] activePositions, int offset, int size, RunLengthEncodedBlock runLengthEncodedBlock)
+    {
+        Block value = runLengthEncodedBlock.getValue();
+        boolean[] selectedPositionsMask = selectedDictionaryMask(session, value);
+        if (!selectedPositionsMask[0]) {
+            return 0;
+        }
+        arraycopy(activePositions, offset, outputPositions, 0, size);
+        return size;
+    }
+
+    private int processRle(ConnectorSession session, int[] outputPositions, int offset, int size, RunLengthEncodedBlock runLengthEncodedBlock)
+    {
+        Block value = runLengthEncodedBlock.getValue();
+        boolean[] selectedPositionsMask = selectedDictionaryMask(session, value);
+        if (!selectedPositionsMask[0]) {
+            return 0;
+        }
+        for (int index = 0; index < size; index++) {
+            outputPositions[index] = offset + index;
+        }
+        return size;
+    }
+
+    private int processDictionary(ConnectorSession session, int[] outputPositions, int offset, int size, DictionaryBlock dictionaryBlock)
+    {
+        boolean[] dictionaryMask = selectedDictionaryMask(session, dictionaryBlock.getDictionary());
+        int selectedPositionsCount = 0;
+        for (int position = offset; position < offset + size; position++) {
+            outputPositions[selectedPositionsCount] = position;
+            selectedPositionsCount += dictionaryMask[dictionaryBlock.getId(position)] ? 1 : 0;
+        }
+        return selectedPositionsCount;
+    }
+
+    private int processDictionary(ConnectorSession session, int[] outputPositions, int[] activePositions, int offset, int size, DictionaryBlock dictionaryBlock)
+    {
+        boolean[] dictionaryMask = selectedDictionaryMask(session, dictionaryBlock.getDictionary());
+        int selectedPositionsCount = 0;
+        for (int index = offset; index < offset + size; index++) {
+            int position = activePositions[index];
+            outputPositions[selectedPositionsCount] = position;
+            selectedPositionsCount += dictionaryMask[dictionaryBlock.getId(position)] ? 1 : 0;
+        }
+        return selectedPositionsCount;
+    }
+
+    private boolean[] selectedDictionaryMask(ConnectorSession session, Block dictionary)
+    {
+        if (lastInputDictionary == dictionary) {
+            return lastOutputDictionary;
+        }
+
+        int positionCount = dictionary.getPositionCount();
+        int[] selectedPositions = new int[positionCount];
+        int selectedPositionsCount = columnarFilter.filterPositionsRange(session, selectedPositions, 0, positionCount, new Page(positionCount, dictionary));
+
+        boolean[] positionsMask = new boolean[positionCount];
+        for (int index = 0; index < selectedPositionsCount; index++) {
+            positionsMask[selectedPositions[index]] = true;
+        }
+        lastInputDictionary = dictionary;
+        lastOutputDictionary = positionsMask;
+        return positionsMask;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/FilterEvaluator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/FilterEvaluator.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.gen.columnar;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.operator.project.SelectedPositions;
+import io.trino.spi.Page;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.function.CatalogSchemaFunctionName;
+import io.trino.spi.type.Type;
+import io.trino.sql.relational.CallExpression;
+import io.trino.sql.relational.ConstantExpression;
+import io.trino.sql.relational.InputReferenceExpression;
+import io.trino.sql.relational.RowExpression;
+import io.trino.sql.relational.SpecialForm;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.metadata.GlobalFunctionCatalog.isBuiltinFunctionName;
+import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.sql.gen.columnar.AndFilterEvaluator.createAndExpressionEvaluator;
+import static io.trino.sql.gen.columnar.OrFilterEvaluator.createOrExpressionEvaluator;
+import static io.trino.sql.relational.DeterminismEvaluator.isDeterministic;
+import static io.trino.sql.relational.Expressions.call;
+import static io.trino.sql.relational.SpecialForm.Form.AND;
+import static io.trino.sql.relational.SpecialForm.Form.BETWEEN;
+import static io.trino.sql.relational.SpecialForm.Form.IN;
+import static io.trino.sql.relational.SpecialForm.Form.IS_NULL;
+import static io.trino.sql.relational.SpecialForm.Form.OR;
+import static io.trino.type.UnknownType.UNKNOWN;
+
+/**
+ * Used by PageProcessor to evaluate filter expression on input Page.
+ * <p>
+ * Implementations handle dictionary aware processing through {@link DictionaryAwareColumnarFilter}.
+ */
+public sealed interface FilterEvaluator
+        permits AndFilterEvaluator, ColumnarFilterEvaluator, OrFilterEvaluator, PageFilterEvaluator
+{
+    SelectionResult evaluate(ConnectorSession session, SelectedPositions activePositions, Page page);
+
+    record SelectionResult(SelectedPositions selectedPositions, long filterTimeNanos) {}
+
+    static Optional<Supplier<FilterEvaluator>> createColumnarFilterEvaluator(
+            boolean columnarFilterEvaluationEnabled,
+            Optional<RowExpression> filter,
+            ColumnarFilterCompiler columnarFilterCompiler)
+    {
+        if (columnarFilterEvaluationEnabled && filter.isPresent()) {
+            return createColumnarFilterEvaluator(filter.get(), columnarFilterCompiler);
+        }
+        return Optional.empty();
+    }
+
+    static Optional<Supplier<FilterEvaluator>> createColumnarFilterEvaluator(RowExpression rowExpression, ColumnarFilterCompiler compiler)
+    {
+        // Eventually this should use RowExpressionVisitor when we handle nested RowExpressions
+        if (rowExpression instanceof CallExpression callExpression) {
+            if (isNotExpression(callExpression)) {
+                // "not(is_null(input_reference))" is handled explicitly as it is easy.
+                // more generic cases like "not(equal(input_reference, constant))" are not handled yet
+                if (callExpression.arguments().getFirst() instanceof SpecialForm specialFormArg && specialFormArg.form() == IS_NULL) {
+                    return createIsNotNullExpressionEvaluator(compiler, callExpression);
+                }
+                return Optional.empty();
+            }
+            return createCallExpressionEvaluator(compiler, callExpression);
+        }
+        if (rowExpression instanceof SpecialForm specialFormArg) {
+            if (specialFormArg.form() == IS_NULL) {
+                return createIsNullExpressionEvaluator(compiler, specialFormArg);
+            }
+            if (specialFormArg.form() == AND) {
+                return createAndExpressionEvaluator(compiler, specialFormArg);
+            }
+            if (specialFormArg.form() == OR) {
+                return createOrExpressionEvaluator(compiler, specialFormArg);
+            }
+            if (specialFormArg.form() == BETWEEN) {
+                return createBetweenEvaluator(compiler, specialFormArg);
+            }
+            if (specialFormArg.form() == IN) {
+                return createInExpressionEvaluator(compiler, specialFormArg);
+            }
+        }
+        return Optional.empty();
+    }
+
+    static boolean isNotExpression(CallExpression callExpression)
+    {
+        CatalogSchemaFunctionName functionName = callExpression.resolvedFunction().name();
+        return isBuiltinFunctionName(functionName) && functionName.getFunctionName().equals("$not");
+    }
+
+    private static Optional<Supplier<FilterEvaluator>> createBetweenEvaluator(ColumnarFilterCompiler compiler, SpecialForm specialForm)
+    {
+        checkArgument(specialForm.form() == BETWEEN, "specialForm should be BETWEEN");
+        checkArgument(specialForm.arguments().size() == 3, "BETWEEN should have 3 arguments %s", specialForm.arguments());
+        checkArgument(specialForm.functionDependencies().size() == 1, "BETWEEN should have 1 functional dependency %s", specialForm.functionDependencies());
+
+        ResolvedFunction lessThanOrEqual = specialForm.getOperatorDependency(LESS_THAN_OR_EQUAL);
+        // Between requires evaluate once semantic for the value being tested
+        // Until we can pre-project it into a temporary variable, we apply columnar evaluation only on InputReference
+        RowExpression valueExpression = specialForm.arguments().get(0);
+        if (!(valueExpression instanceof InputReferenceExpression)) {
+            return Optional.empty();
+        }
+
+        // When the min and max arguments of a BETWEEN expression are both constants, evaluating them inline is cheaper than AND-ing subexpressions
+        if (specialForm.arguments().get(1) instanceof ConstantExpression && specialForm.arguments().get(2) instanceof ConstantExpression) {
+            Optional<Supplier<ColumnarFilter>> compiledFilter = compiler.generateFilter(specialForm);
+            return compiledFilter.map(filterSupplier -> () -> createDictionaryAwareEvaluator(filterSupplier.get()));
+        }
+        return createAndExpressionEvaluator(
+                compiler,
+                new SpecialForm(
+                        AND,
+                        BOOLEAN,
+                        ImmutableList.of(
+                                call(lessThanOrEqual, specialForm.arguments().get(1), valueExpression),
+                                call(lessThanOrEqual, valueExpression, specialForm.arguments().get(2))),
+                        ImmutableList.of()));
+    }
+
+    private static Optional<Supplier<FilterEvaluator>> createInExpressionEvaluator(ColumnarFilterCompiler compiler, SpecialForm specialForm)
+    {
+        checkArgument(specialForm.form() == IN, "specialForm %s should be IN", specialForm);
+        Optional<Supplier<ColumnarFilter>> compiledFilter = compiler.generateFilter(specialForm);
+        return compiledFilter.map(filterSupplier -> () -> createDictionaryAwareEvaluator(filterSupplier.get()));
+    }
+
+    private static Optional<Supplier<FilterEvaluator>> createCallExpressionEvaluator(ColumnarFilterCompiler compiler, CallExpression callExpression)
+    {
+        Optional<Supplier<ColumnarFilter>> compiledFilter = compiler.generateFilter(callExpression);
+        boolean isDeterministic = isDeterministic(callExpression);
+        return compiledFilter.map(filterSupplier -> () -> {
+            ColumnarFilter filter = filterSupplier.get();
+            return filter.getInputChannels().size() == 1 && isDeterministic ? createDictionaryAwareEvaluator(filter) : new ColumnarFilterEvaluator(filter);
+        });
+    }
+
+    private static Optional<Supplier<FilterEvaluator>> createIsNotNullExpressionEvaluator(ColumnarFilterCompiler compiler, CallExpression callExpression)
+    {
+        checkArgument(isNotExpression(callExpression), "callExpression %s should be not", callExpression);
+        checkArgument(callExpression.arguments().size() == 1);
+        SpecialForm specialForm = (SpecialForm) callExpression.arguments().getFirst();
+        checkArgument(specialForm.form() == IS_NULL, "specialForm %s should be IS_NULL", specialForm);
+        Type argumentType = specialForm.arguments().getFirst().type();
+        checkArgument(!argumentType.equals(UNKNOWN), "argumentType %s should not be UNKNOWN", argumentType);
+
+        Optional<Supplier<ColumnarFilter>> compiledFilter = compiler.generateFilter(callExpression);
+        return compiledFilter.map(filterSupplier -> () -> createDictionaryAwareEvaluator(filterSupplier.get()));
+    }
+
+    private static Optional<Supplier<FilterEvaluator>> createIsNullExpressionEvaluator(ColumnarFilterCompiler compiler, SpecialForm specialForm)
+    {
+        checkArgument(specialForm.form() == IS_NULL, "specialForm %s should be IS_NULL", specialForm);
+        Type argumentType = specialForm.arguments().getFirst().type();
+        checkArgument(!argumentType.equals(UNKNOWN), "argumentType %s should not be UNKNOWN", argumentType);
+
+        Optional<Supplier<ColumnarFilter>> compiledFilter = compiler.generateFilter(specialForm);
+        return compiledFilter.map(filterSupplier -> () -> createDictionaryAwareEvaluator(filterSupplier.get()));
+    }
+
+    private static FilterEvaluator createDictionaryAwareEvaluator(ColumnarFilter filter)
+    {
+        checkArgument(filter.getInputChannels().size() == 1, "filter should have 1 input channel");
+        return new ColumnarFilterEvaluator(new DictionaryAwareColumnarFilter(filter));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/InColumnarFilterGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/InColumnarFilterGenerator.java
@@ -1,0 +1,371 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.gen.columnar;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.primitives.Primitives;
+import io.airlift.bytecode.BytecodeBlock;
+import io.airlift.bytecode.ClassDefinition;
+import io.airlift.bytecode.MethodDefinition;
+import io.airlift.bytecode.Parameter;
+import io.airlift.bytecode.Scope;
+import io.airlift.bytecode.Variable;
+import io.airlift.bytecode.control.ForLoop;
+import io.airlift.bytecode.control.IfStatement;
+import io.airlift.bytecode.control.SwitchStatement;
+import io.airlift.bytecode.expression.BytecodeExpression;
+import io.airlift.bytecode.instruction.LabelNode;
+import io.airlift.slice.Slice;
+import io.trino.metadata.FunctionManager;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.spi.Page;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.type.Type;
+import io.trino.sql.gen.Binding;
+import io.trino.sql.gen.CallSiteBinder;
+import io.trino.sql.gen.InCodeGenerator;
+import io.trino.sql.relational.ConstantExpression;
+import io.trino.sql.relational.InputReferenceExpression;
+import io.trino.sql.relational.RowExpression;
+import io.trino.sql.relational.SpecialForm;
+import io.trino.util.FastutilSetHelper;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Throwables.throwIfUnchecked;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.bytecode.Access.FINAL;
+import static io.airlift.bytecode.Access.PUBLIC;
+import static io.airlift.bytecode.Access.a;
+import static io.airlift.bytecode.Parameter.arg;
+import static io.airlift.bytecode.ParameterizedType.type;
+import static io.airlift.bytecode.control.SwitchStatement.switchBuilder;
+import static io.airlift.bytecode.expression.BytecodeExpressions.add;
+import static io.airlift.bytecode.expression.BytecodeExpressions.constantFalse;
+import static io.airlift.bytecode.expression.BytecodeExpressions.constantInt;
+import static io.airlift.bytecode.expression.BytecodeExpressions.constantTrue;
+import static io.airlift.bytecode.expression.BytecodeExpressions.invokeStatic;
+import static io.airlift.bytecode.expression.BytecodeExpressions.lessThan;
+import static io.airlift.bytecode.instruction.JumpInstruction.jump;
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
+import static io.trino.spi.function.InvocationConvention.simpleConvention;
+import static io.trino.spi.function.OperatorType.EQUAL;
+import static io.trino.spi.function.OperatorType.HASH_CODE;
+import static io.trino.spi.function.OperatorType.INDETERMINATE;
+import static io.trino.sql.gen.BytecodeUtils.loadConstant;
+import static io.trino.sql.gen.SqlTypeBytecodeExpression.constantType;
+import static io.trino.sql.gen.columnar.ColumnarFilterCompiler.createClassInstance;
+import static io.trino.sql.gen.columnar.ColumnarFilterCompiler.declareBlockVariables;
+import static io.trino.sql.gen.columnar.ColumnarFilterCompiler.generateBlockMayHaveNull;
+import static io.trino.sql.gen.columnar.ColumnarFilterCompiler.generateBlockPositionNotNull;
+import static io.trino.sql.gen.columnar.ColumnarFilterCompiler.generateGetInputChannels;
+import static io.trino.sql.gen.columnar.ColumnarFilterCompiler.updateOutputPositions;
+import static io.trino.sql.relational.SpecialForm.Form.IN;
+import static io.trino.util.CompilerUtils.makeClassName;
+import static io.trino.util.FastutilSetHelper.toFastutilHashSet;
+import static java.lang.Math.toIntExact;
+
+public class InColumnarFilterGenerator
+{
+    private final InputReferenceExpression valueExpression;
+    private final boolean useSwitchCase;
+    private final Set<Object> constantValues;
+
+    private final MethodHandle equalsMethodHandle;
+    private final MethodHandle hashCodeMethodHandle;
+
+    public InColumnarFilterGenerator(SpecialForm specialForm, FunctionManager functionManager)
+    {
+        checkArgument(specialForm.form() == IN, "specialForm should be IN");
+        checkArgument(specialForm.arguments().size() >= 2, "At least two arguments are required");
+        if (!(specialForm.arguments().getFirst() instanceof InputReferenceExpression)) {
+            throw new UnsupportedOperationException("IN clause columnar evaluation is supported only on input references");
+        }
+        valueExpression = (InputReferenceExpression) specialForm.arguments().getFirst();
+        List<RowExpression> expressions = specialForm.arguments().subList(1, specialForm.arguments().size());
+        expressions.forEach(expression -> {
+            if (!(expression instanceof ConstantExpression)) {
+                throw new UnsupportedOperationException("IN clause columnar evaluation is supported only on input reference against constants");
+            }
+        });
+        List<ConstantExpression> testExpressions = expressions.stream()
+                .map(ConstantExpression.class::cast)
+                .collect(toImmutableList());
+
+        checkArgument(specialForm.functionDependencies().size() == 3);
+        ResolvedFunction resolvedEqualsFunction = specialForm.getOperatorDependency(EQUAL);
+        ResolvedFunction resolvedHashCodeFunction = specialForm.getOperatorDependency(HASH_CODE);
+        ResolvedFunction resolvedIsIndeterminate = specialForm.getOperatorDependency(INDETERMINATE);
+        equalsMethodHandle = functionManager.getScalarFunctionImplementation(resolvedEqualsFunction, simpleConvention(NULLABLE_RETURN, NEVER_NULL, NEVER_NULL)).getMethodHandle();
+        hashCodeMethodHandle = functionManager.getScalarFunctionImplementation(resolvedHashCodeFunction, simpleConvention(FAIL_ON_NULL, NEVER_NULL)).getMethodHandle();
+        MethodHandle indeterminateMethodHandle = functionManager.getScalarFunctionImplementation(resolvedIsIndeterminate, simpleConvention(FAIL_ON_NULL, NEVER_NULL)).getMethodHandle();
+
+        ImmutableSet.Builder<Object> constantValuesBuilder = ImmutableSet.builder();
+        for (ConstantExpression testValue : testExpressions) {
+            if (isDeterminateConstant(testValue, indeterminateMethodHandle)) {
+                constantValuesBuilder.add(testValue.value());
+            }
+        }
+        constantValues = constantValuesBuilder.build();
+        useSwitchCase = useSwitchCaseGeneration(valueExpression.type(), expressions);
+    }
+
+    public Supplier<ColumnarFilter> generateColumnarFilter()
+    {
+        ClassDefinition classDefinition = new ClassDefinition(
+                a(PUBLIC, FINAL),
+                makeClassName(ColumnarFilter.class.getSimpleName() + "_in", Optional.empty()),
+                type(Object.class),
+                type(ColumnarFilter.class));
+        CallSiteBinder callSiteBinder = new CallSiteBinder();
+
+        classDefinition.declareDefaultConstructor(a(PUBLIC));
+
+        generateGetInputChannels(callSiteBinder, classDefinition, valueExpression);
+
+        Set<?> constantValuesSet = toFastutilHashSet(constantValues, valueExpression.type(), hashCodeMethodHandle, equalsMethodHandle);
+        Binding constant = callSiteBinder.bind(constantValuesSet, constantValuesSet.getClass());
+
+        generateFilterRangeMethod(callSiteBinder, classDefinition, constantValuesSet, constant);
+        generateFilterListMethod(callSiteBinder, classDefinition, constantValuesSet, constant);
+
+        return createClassInstance(callSiteBinder, classDefinition);
+    }
+
+    private void generateFilterRangeMethod(CallSiteBinder binder, ClassDefinition classDefinition, Set<?> constantValuesSet, Binding constant)
+    {
+        Parameter session = arg("session", ConnectorSession.class);
+        Parameter outputPositions = arg("outputPositions", int[].class);
+        Parameter offset = arg("offset", int.class);
+        Parameter size = arg("size", int.class);
+        Parameter page = arg("page", Page.class);
+
+        MethodDefinition method = classDefinition.declareMethod(
+                a(PUBLIC),
+                "filterPositionsRange",
+                type(int.class),
+                ImmutableList.of(session, outputPositions, offset, size, page));
+        Scope scope = method.getScope();
+        BytecodeBlock body = method.getBody();
+
+        declareBlockVariables(ImmutableList.of(valueExpression), page, scope, body);
+
+        Variable outputPositionsCount = scope.declareVariable("outputPositionsCount", body, constantInt(0));
+        Variable position = scope.declareVariable(int.class, "position");
+        Variable result = scope.declareVariable(boolean.class, "result");
+
+        IfStatement ifStatement = new IfStatement()
+                .condition(generateBlockMayHaveNull(ImmutableList.of(valueExpression), scope));
+        body.append(ifStatement);
+
+        ifStatement.ifTrue(new ForLoop("nullable range based loop")
+                .initialize(position.set(offset))
+                .condition(lessThan(position, add(offset, size)))
+                .update(position.increment())
+                .body(new IfStatement()
+                        .condition(generateBlockPositionNotNull(ImmutableList.of(valueExpression), scope, position))
+                        .ifTrue(new BytecodeBlock()
+                                .append(generateSetContainsCall(binder, scope, constantValuesSet, constant, position, result))
+                                .append(updateOutputPositions(result, position, outputPositions, outputPositionsCount)))));
+
+        ifStatement.ifFalse(new ForLoop("non-nullable range based loop")
+                .initialize(position.set(offset))
+                .condition(lessThan(position, add(offset, size)))
+                .update(position.increment())
+                .body(new BytecodeBlock()
+                        .append(generateSetContainsCall(binder, scope, constantValuesSet, constant, position, result))
+                        .append(updateOutputPositions(result, position, outputPositions, outputPositionsCount))));
+
+        body.append(outputPositionsCount.ret());
+    }
+
+    private void generateFilterListMethod(CallSiteBinder binder, ClassDefinition classDefinition, Set<?> constantValuesSet, Binding constant)
+    {
+        Parameter session = arg("session", ConnectorSession.class);
+        Parameter outputPositions = arg("outputPositions", int[].class);
+        Parameter activePositions = arg("activePositions", int[].class);
+        Parameter offset = arg("offset", int.class);
+        Parameter size = arg("size", int.class);
+        Parameter page = arg("page", Page.class);
+
+        MethodDefinition method = classDefinition.declareMethod(
+                a(PUBLIC),
+                "filterPositionsList",
+                type(int.class),
+                ImmutableList.of(session, outputPositions, activePositions, offset, size, page));
+        Scope scope = method.getScope();
+        BytecodeBlock body = method.getBody();
+
+        declareBlockVariables(ImmutableList.of(valueExpression), page, scope, body);
+
+        Variable outputPositionsCount = scope.declareVariable("outputPositionsCount", body, constantInt(0));
+        Variable index = scope.declareVariable(int.class, "index");
+        Variable position = scope.declareVariable(int.class, "position");
+        Variable result = scope.declareVariable(boolean.class, "result");
+
+        IfStatement ifStatement = new IfStatement()
+                .condition(generateBlockMayHaveNull(ImmutableList.of(valueExpression), scope));
+        body.append(ifStatement);
+
+        ifStatement.ifTrue(new ForLoop("nullable positions loop")
+                .initialize(index.set(offset))
+                .condition(lessThan(index, add(offset, size)))
+                .update(index.increment())
+                .body(new BytecodeBlock()
+                        .append(position.set(activePositions.getElement(index)))
+                        .append(new IfStatement()
+                                .condition(generateBlockPositionNotNull(ImmutableList.of(valueExpression), scope, position))
+                                .ifTrue(new BytecodeBlock()
+                                        .append(generateSetContainsCall(binder, scope, constantValuesSet, constant, position, result))
+                                        .append(updateOutputPositions(result, position, outputPositions, outputPositionsCount))))));
+
+        ifStatement.ifFalse(new ForLoop("non-nullable positions loop")
+                .initialize(index.set(offset))
+                .condition(lessThan(index, add(offset, size)))
+                .update(index.increment())
+                .body(new BytecodeBlock()
+                        .append(position.set(activePositions.getElement(index)))
+                        .append(generateSetContainsCall(binder, scope, constantValuesSet, constant, position, result))
+                        .append(updateOutputPositions(result, position, outputPositions, outputPositionsCount))));
+
+        body.append(outputPositionsCount.ret());
+    }
+
+    private BytecodeBlock generateSetContainsCall(CallSiteBinder binder, Scope scope, Set<?> constantValuesSet, Binding constant, BytecodeExpression position, Variable result)
+    {
+        Type valueType = valueExpression.type();
+        Class<?> javaType = valueType.getJavaType();
+
+        Class<?> callType = javaType;
+        if (!callType.isPrimitive() && callType != Slice.class) {
+            callType = Object.class;
+        }
+        String methodName = "get" + Primitives.wrap(callType).getSimpleName();
+        BytecodeExpression value = constantType(binder, valueType)
+                .invoke(methodName, callType, scope.getVariable("block_" + valueExpression.field()), position);
+        if (callType != javaType) {
+            value = value.cast(javaType);
+        }
+
+        if (useSwitchCase) {
+            // A white-list is used to select types eligible for DIRECT_SWITCH.
+            // For these types, it's safe to not use Trino HASH_CODE and EQUAL operator.
+            LabelNode end = new LabelNode("end");
+            LabelNode match = new LabelNode("match");
+            LabelNode defaultLabel = new LabelNode("default");
+
+            SwitchStatement.SwitchBuilder switchBuilder = switchBuilder();
+            BytecodeBlock matchBlock = new BytecodeBlock()
+                    .setDescription("match")
+                    .visitLabel(match)
+                    .append(result.set(constantTrue()))
+                    .gotoLabel(end);
+            BytecodeBlock defaultCaseBlock = new BytecodeBlock()
+                    .setDescription("default")
+                    .visitLabel(defaultLabel)
+                    .append(result.set(constantFalse()))
+                    .gotoLabel(end);
+            for (Object constantValue : constantValues) {
+                switchBuilder.addCase(toIntExact((Long) constantValue), jump(match));
+            }
+            switchBuilder.defaultCase(jump(defaultLabel));
+
+            Variable expression = scope.createTempVariable(javaType);
+            return new BytecodeBlock()
+                    .comment("lookupSwitch(<stackValue>))")
+                    .append(expression.set(value))
+                    .append(new IfStatement()
+                            .condition(invokeStatic(InCodeGenerator.class, "isInteger", boolean.class, expression))
+                            .ifFalse(new BytecodeBlock()
+                                    .gotoLabel(defaultLabel)))
+                    .append(switchBuilder.expression(expression.cast(int.class)).build())
+                    .append(matchBlock)
+                    .append(defaultCaseBlock)
+                    .visitLabel(end);
+        }
+        return new BytecodeBlock()
+                .comment("inListSet.contains(<stackValue>)")
+                .append(new BytecodeBlock()
+                        .comment("value")
+                        .append(value)
+                        .comment("set")
+                        .append(loadConstant(constant))
+                        .invokeStatic(FastutilSetHelper.class, "in", boolean.class, javaType.isPrimitive() ? javaType : Object.class, constantValuesSet.getClass())
+                        .putVariable(result));
+    }
+
+    private static boolean isDeterminateConstant(RowExpression expression, MethodHandle isIndeterminateFunction)
+    {
+        if (!(expression instanceof ConstantExpression constantExpression)) {
+            return false;
+        }
+        Object value = constantExpression.value();
+        // NULL constants are skipped as they do not satisfy IN filter
+        // NULL positions will need to be handled differently to allow IN filters to be composed (e.g. NOT IN)
+        if (value == null) {
+            return false;
+        }
+        try {
+            return !(boolean) isIndeterminateFunction.invoke(value);
+        }
+        catch (Throwable t) {
+            throwIfUnchecked(t);
+            throw new RuntimeException(t);
+        }
+    }
+
+    static boolean useSwitchCaseGeneration(Type type, List<RowExpression> values)
+    {
+        // FastutilSetHelper#in does not work correctly for indeterminate values stored in structural types
+        // https://github.com/trinodb/trino/issues/17213
+        // Until we support HASH_SWITCH strategy for code generation here, we treat structural type as an unsupported case
+        // and fall back to existing expression evaluator for small lists
+        if (!type.getTypeParameters().isEmpty()) {
+            throw new UnsupportedOperationException("Structural type not supported");
+        }
+        if (values.size() >= 8) {
+            // Lookup in Set is generally faster than switch case for not super tiny IN lists.
+            // Tipping point is between 5 and 10 (using round 8)
+            return false;
+        }
+
+        if (type.getJavaType() != long.class) {
+            return false;
+        }
+        for (RowExpression expression : values) {
+            if (!(expression instanceof ConstantExpression)) {
+                throw new UnsupportedOperationException("IN clause columnar evaluation is supported only on input reference against constants");
+            }
+            Object constant = ((ConstantExpression) expression).value();
+            // NULL constants are skipped as they do not satisfy IN filter
+            // NULL positions will need to be handled differently to allow IN filters to be composed (e.g. NOT IN)
+            if (constant == null) {
+                continue;
+            }
+            long longConstant = ((Number) constant).longValue();
+            if (longConstant < Integer.MIN_VALUE || longConstant > Integer.MAX_VALUE) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/IsNotNullColumnarFilter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/IsNotNullColumnarFilter.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.gen.columnar;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.operator.project.InputChannels;
+import io.trino.spi.Page;
+import io.trino.spi.block.ByteArrayBlock;
+import io.trino.spi.block.ValueBlock;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.sql.relational.InputReferenceExpression;
+import io.trino.sql.relational.SpecialForm;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.sql.relational.SpecialForm.Form.IS_NULL;
+import static java.lang.System.arraycopy;
+
+public final class IsNotNullColumnarFilter
+        implements ColumnarFilter
+{
+    private final InputChannels inputChannels;
+
+    public static Supplier<ColumnarFilter> createIsNotNullColumnarFilter(SpecialForm specialForm)
+    {
+        checkArgument(specialForm.form() == IS_NULL, "specialForm %s should be IS_NULL", specialForm);
+        checkArgument(specialForm.arguments().size() == 1, "specialForm %s should have single argument", specialForm);
+        if (!(specialForm.arguments().getFirst() instanceof InputReferenceExpression inputReference)) {
+            throw new UnsupportedOperationException("NOT(IS_NULL) columnar evaluation is supported only for InputReferenceExpression");
+        }
+        return () -> new IsNotNullColumnarFilter(inputReference);
+    }
+
+    private IsNotNullColumnarFilter(InputReferenceExpression inputReference)
+    {
+        List<Integer> channels = ImmutableList.of(inputReference.field());
+        this.inputChannels = new InputChannels(channels, channels);
+    }
+
+    @Override
+    public InputChannels getInputChannels()
+    {
+        return inputChannels;
+    }
+
+    @Override
+    public int filterPositionsRange(ConnectorSession session, int[] outputPositions, int offset, int size, Page page)
+    {
+        ValueBlock block = (ValueBlock) page.getBlock(0);
+        int nonNullPositionsCount = 0;
+        int position;
+        if (block.mayHaveNull()) {
+            Optional<ByteArrayBlock> isNullsBlock = block.getNulls();
+            if (isNullsBlock.isPresent()) {
+                byte[] isNull = isNullsBlock.get().getRawValues();
+                int isNullOffset = isNullsBlock.get().getRawValuesOffset();
+                for (position = offset; position < offset + size; position++) {
+                    outputPositions[nonNullPositionsCount] = position;
+                    nonNullPositionsCount += isNull[isNullOffset + position] == 0 ? 1 : 0;
+                }
+                return nonNullPositionsCount;
+            }
+        }
+
+        for (position = offset; position < offset + size; position++) {
+            outputPositions[nonNullPositionsCount++] = position;
+        }
+        return nonNullPositionsCount;
+    }
+
+    @Override
+    public int filterPositionsList(ConnectorSession session, int[] outputPositions, int[] activePositions, int offset, int size, Page page)
+    {
+        ValueBlock block = (ValueBlock) page.getBlock(0);
+        if (block.mayHaveNull()) {
+            Optional<ByteArrayBlock> isNullsBlock = block.getNulls();
+            if (isNullsBlock.isPresent()) {
+                int nonNullPositionsCount = 0;
+                byte[] isNull = isNullsBlock.get().getRawValues();
+                int isNullOffset = isNullsBlock.get().getRawValuesOffset();
+                for (int index = offset; index < offset + size; index++) {
+                    int position = activePositions[index];
+                    outputPositions[nonNullPositionsCount] = position;
+                    nonNullPositionsCount += isNull[isNullOffset + position] == 0 ? 1 : 0;
+                }
+                return nonNullPositionsCount;
+            }
+        }
+
+        arraycopy(activePositions, offset, outputPositions, 0, size);
+        return size;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/IsNullColumnarFilter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/IsNullColumnarFilter.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.gen.columnar;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.operator.project.InputChannels;
+import io.trino.spi.Page;
+import io.trino.spi.block.ByteArrayBlock;
+import io.trino.spi.block.ValueBlock;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.sql.relational.InputReferenceExpression;
+import io.trino.sql.relational.SpecialForm;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.sql.relational.SpecialForm.Form.IS_NULL;
+
+public final class IsNullColumnarFilter
+        implements ColumnarFilter
+{
+    private final InputChannels inputChannels;
+
+    public static Supplier<ColumnarFilter> createIsNullColumnarFilter(SpecialForm specialForm)
+    {
+        checkArgument(specialForm.form() == IS_NULL, "specialForm %s should be IS_NULL", specialForm);
+        checkArgument(specialForm.arguments().size() == 1, "specialForm %s should have single argument", specialForm);
+        if (!(specialForm.arguments().getFirst() instanceof InputReferenceExpression inputReference)) {
+            throw new UnsupportedOperationException("IS_NULL columnar evaluation is supported only for InputReferenceExpression");
+        }
+        return () -> new IsNullColumnarFilter(inputReference);
+    }
+
+    private IsNullColumnarFilter(InputReferenceExpression inputReference)
+    {
+        List<Integer> channels = ImmutableList.of(inputReference.field());
+        this.inputChannels = new InputChannels(channels, channels);
+    }
+
+    @Override
+    public InputChannels getInputChannels()
+    {
+        return inputChannels;
+    }
+
+    @Override
+    public int filterPositionsRange(ConnectorSession session, int[] outputPositions, int offset, int size, Page page)
+    {
+        ValueBlock block = (ValueBlock) page.getBlock(0);
+        if (!block.mayHaveNull()) {
+            return 0;
+        }
+
+        Optional<ByteArrayBlock> isNullsBlock = block.getNulls();
+        if (isNullsBlock.isEmpty()) {
+            return 0;
+        }
+
+        byte[] isNull = isNullsBlock.get().getRawValues();
+        int isNullOffset = isNullsBlock.get().getRawValuesOffset();
+        int nullPositionsCount = 0;
+        for (int position = offset; position < offset + size; position++) {
+            outputPositions[nullPositionsCount] = position;
+            nullPositionsCount += isNull[isNullOffset + position];
+        }
+        return nullPositionsCount;
+    }
+
+    @Override
+    public int filterPositionsList(ConnectorSession session, int[] outputPositions, int[] activePositions, int offset, int size, Page page)
+    {
+        ValueBlock block = (ValueBlock) page.getBlock(0);
+        if (!block.mayHaveNull()) {
+            return 0;
+        }
+
+        Optional<ByteArrayBlock> isNullsBlock = block.getNulls();
+        if (isNullsBlock.isEmpty()) {
+            return 0;
+        }
+
+        byte[] isNull = isNullsBlock.get().getRawValues();
+        int isNullOffset = isNullsBlock.get().getRawValuesOffset();
+        int nullPositionsCount = 0;
+        for (int index = offset; index < offset + size; index++) {
+            int position = activePositions[index];
+            outputPositions[nullPositionsCount] = position;
+            nullPositionsCount += isNull[isNullOffset + position];
+        }
+        return nullPositionsCount;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/OrFilterEvaluator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/OrFilterEvaluator.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.gen.columnar;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.operator.project.SelectedPositions;
+import io.trino.spi.Page;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.sql.relational.RowExpression;
+import io.trino.sql.relational.SpecialForm;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.sql.relational.SpecialForm.Form.OR;
+
+public final class OrFilterEvaluator
+        implements FilterEvaluator
+{
+    public static Optional<Supplier<FilterEvaluator>> createOrExpressionEvaluator(ColumnarFilterCompiler compiler, SpecialForm specialForm)
+    {
+        checkArgument(specialForm.form() == OR, "specialForm %s should be OR", specialForm);
+        checkArgument(specialForm.arguments().size() >= 2, "OR expression %s should have at least 2 arguments", specialForm);
+
+        ImmutableList.Builder<Supplier<FilterEvaluator>> builder = ImmutableList.builder();
+        for (RowExpression expression : specialForm.arguments()) {
+            Optional<Supplier<FilterEvaluator>> subExpressionEvaluator = FilterEvaluator.createColumnarFilterEvaluator(expression, compiler);
+            if (subExpressionEvaluator.isEmpty()) {
+                return Optional.empty();
+            }
+            builder.add(subExpressionEvaluator.get());
+        }
+        List<Supplier<FilterEvaluator>> subExpressionEvaluators = builder.build();
+        return Optional.of(() -> new OrFilterEvaluator(subExpressionEvaluators.stream().map(Supplier::get).collect(toImmutableList())));
+    }
+
+    private final List<FilterEvaluator> subFilterEvaluators;
+
+    private OrFilterEvaluator(List<FilterEvaluator> subFilterEvaluators)
+    {
+        checkArgument(subFilterEvaluators.size() >= 2, "must have at least 2 subexpressions to OR");
+        this.subFilterEvaluators = subFilterEvaluators;
+    }
+
+    @Override
+    public SelectionResult evaluate(ConnectorSession session, SelectedPositions activePositions, Page page)
+    {
+        long filterTimeNanos = 0;
+        SelectionResult result = subFilterEvaluators.getFirst().evaluate(session, activePositions, page);
+        SelectedPositions accumulatedPositions = result.selectedPositions();
+        filterTimeNanos += result.filterTimeNanos();
+        activePositions = activePositions.difference(accumulatedPositions);
+        for (int index = 1; index < subFilterEvaluators.size() - 1; index++) {
+            FilterEvaluator evaluator = subFilterEvaluators.get(index);
+            result = evaluator.evaluate(session, activePositions, page);
+            SelectedPositions selectedPositions = result.selectedPositions();
+            filterTimeNanos += result.filterTimeNanos();
+            accumulatedPositions = accumulatedPositions.union(selectedPositions);
+            activePositions = activePositions.difference(selectedPositions);
+        }
+        result = subFilterEvaluators.getLast().evaluate(session, activePositions, page);
+        filterTimeNanos += result.filterTimeNanos();
+        accumulatedPositions = accumulatedPositions.union(result.selectedPositions());
+        return new SelectionResult(accumulatedPositions, filterTimeNanos);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/PageFilterEvaluator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/PageFilterEvaluator.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.gen.columnar;
+
+import io.trino.operator.project.DictionaryAwarePageFilter;
+import io.trino.operator.project.PageFilter;
+import io.trino.operator.project.SelectedPositions;
+import io.trino.spi.Page;
+import io.trino.spi.connector.ConnectorSession;
+
+public final class PageFilterEvaluator
+        implements FilterEvaluator
+{
+    private final PageFilter filter;
+
+    public PageFilterEvaluator(PageFilter filter)
+    {
+        if (filter.getInputChannels().size() == 1 && filter.isDeterministic()) {
+            this.filter = new DictionaryAwarePageFilter(filter);
+        }
+        else {
+            this.filter = filter;
+        }
+    }
+
+    @Override
+    public SelectionResult evaluate(ConnectorSession session, SelectedPositions activePositions, Page page)
+    {
+        Page inputPage = filter.getInputChannels().getInputChannels(page);
+        long start = System.nanoTime();
+        SelectedPositions selectedPositions = filter.filter(session, inputPage);
+        return new SelectionResult(selectedPositions, System.nanoTime() - start);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
+++ b/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
@@ -157,6 +157,7 @@ import io.trino.sql.gen.JoinCompiler;
 import io.trino.sql.gen.JoinFilterFunctionCompiler;
 import io.trino.sql.gen.OrderingCompiler;
 import io.trino.sql.gen.PageFunctionCompiler;
+import io.trino.sql.gen.columnar.ColumnarFilterCompiler;
 import io.trino.sql.parser.SqlParser;
 import io.trino.sql.planner.AdaptivePlanner;
 import io.trino.sql.planner.CompilerConfig;
@@ -284,6 +285,7 @@ public class PlanTester
     private final AnalyzePropertyManager analyzePropertyManager;
 
     private final PageFunctionCompiler pageFunctionCompiler;
+    private final ColumnarFilterCompiler filterCompiler;
     private final ExpressionCompiler expressionCompiler;
     private final JoinFilterFunctionCompiler joinFilterFunctionCompiler;
     private final JoinCompiler joinCompiler;
@@ -402,7 +404,8 @@ public class PlanTester
 
         this.plannerContext = new PlannerContext(metadata, typeOperators, blockEncodingSerde, typeManager, functionManager, languageFunctionManager, tracer);
         this.pageFunctionCompiler = new PageFunctionCompiler(functionManager, 0);
-        this.expressionCompiler = new ExpressionCompiler(functionManager, pageFunctionCompiler);
+        this.filterCompiler = new ColumnarFilterCompiler(functionManager, 0);
+        this.expressionCompiler = new ExpressionCompiler(functionManager, pageFunctionCompiler, filterCompiler);
         this.joinFilterFunctionCompiler = new JoinFilterFunctionCompiler(functionManager);
 
         this.statementAnalyzerFactory = new StatementAnalyzerFactory(

--- a/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
@@ -47,6 +47,7 @@ import io.trino.sql.gen.JoinCompiler;
 import io.trino.sql.gen.JoinFilterFunctionCompiler;
 import io.trino.sql.gen.OrderingCompiler;
 import io.trino.sql.gen.PageFunctionCompiler;
+import io.trino.sql.gen.columnar.ColumnarFilterCompiler;
 import io.trino.sql.planner.CompilerConfig;
 import io.trino.sql.planner.LocalExecutionPlanner;
 import io.trino.sql.planner.NodePartitioningManager;
@@ -151,6 +152,7 @@ public final class TaskTestUtils
                 CatalogServiceProvider.fail());
 
         PageFunctionCompiler pageFunctionCompiler = new PageFunctionCompiler(PLANNER_CONTEXT.getFunctionManager(), 0);
+        ColumnarFilterCompiler columnarFilterCompiler = new ColumnarFilterCompiler(PLANNER_CONTEXT.getFunctionManager(), 0);
         return new LocalExecutionPlanner(
                 PLANNER_CONTEXT,
                 Optional.empty(),
@@ -159,7 +161,7 @@ public final class TaskTestUtils
                 nodePartitioningManager,
                 new PageSinkManager(CatalogServiceProvider.fail()),
                 new MockDirectExchangeClientSupplier(),
-                new ExpressionCompiler(PLANNER_CONTEXT.getFunctionManager(), pageFunctionCompiler),
+                new ExpressionCompiler(PLANNER_CONTEXT.getFunctionManager(), pageFunctionCompiler, columnarFilterCompiler),
                 pageFunctionCompiler,
                 new JoinFilterFunctionCompiler(PLANNER_CONTEXT.getFunctionManager()),
                 new IndexJoinLookupStats(),

--- a/core/trino-main/src/test/java/io/trino/metadata/TestingFunctionResolution.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestingFunctionResolution.java
@@ -26,6 +26,7 @@ import io.trino.sql.PlannerContext;
 import io.trino.sql.analyzer.TypeSignatureProvider;
 import io.trino.sql.gen.ExpressionCompiler;
 import io.trino.sql.gen.PageFunctionCompiler;
+import io.trino.sql.gen.columnar.ColumnarFilterCompiler;
 import io.trino.sql.ir.Call;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.planner.TestingPlannerContext;
@@ -105,7 +106,7 @@ public class TestingFunctionResolution
 
     public ExpressionCompiler getExpressionCompiler()
     {
-        return new ExpressionCompiler(plannerContext.getFunctionManager(), getPageFunctionCompiler());
+        return new ExpressionCompiler(plannerContext.getFunctionManager(), getPageFunctionCompiler(), getColumnarFilterCompiler());
     }
 
     public PageFunctionCompiler getPageFunctionCompiler()
@@ -121,6 +122,16 @@ public class TestingFunctionResolution
     public Collection<FunctionMetadata> listGlobalFunctions()
     {
         return inTransaction(metadata::listGlobalFunctions);
+    }
+
+    public ColumnarFilterCompiler getColumnarFilterCompiler()
+    {
+        return getColumnarFilterCompiler(0);
+    }
+
+    public ColumnarFilterCompiler getColumnarFilterCompiler(int expressionCacheSize)
+    {
+        return new ColumnarFilterCompiler(plannerContext.getFunctionManager(), expressionCacheSize);
     }
 
     public ResolvedFunction resolveOperator(OperatorType operatorType, List<? extends Type> argumentTypes)

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkScanFilterAndProjectOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkScanFilterAndProjectOperator.java
@@ -34,6 +34,7 @@ import io.trino.spi.type.Type;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.gen.ExpressionCompiler;
 import io.trino.sql.gen.PageFunctionCompiler;
+import io.trino.sql.gen.columnar.ColumnarFilterCompiler;
 import io.trino.sql.ir.Call;
 import io.trino.sql.ir.Cast;
 import io.trino.sql.ir.Comparison;
@@ -161,8 +162,9 @@ public class BenchmarkScanFilterAndProjectOperator
                     .collect(toImmutableList());
 
             PageFunctionCompiler pageFunctionCompiler = new PageFunctionCompiler(PLANNER_CONTEXT.getFunctionManager(), 0);
-            PageProcessor pageProcessor = new ExpressionCompiler(PLANNER_CONTEXT.getFunctionManager(), pageFunctionCompiler).compilePageProcessor(Optional.of(getFilter(type)), projections).get();
-            CursorProcessor cursorProcessor = new ExpressionCompiler(PLANNER_CONTEXT.getFunctionManager(), pageFunctionCompiler).compileCursorProcessor(Optional.of(getFilter(type)), projections, "key").get();
+            ColumnarFilterCompiler compiler = new ColumnarFilterCompiler(PLANNER_CONTEXT.getFunctionManager(), 0);
+            PageProcessor pageProcessor = new ExpressionCompiler(PLANNER_CONTEXT.getFunctionManager(), pageFunctionCompiler, compiler).compilePageProcessor(Optional.of(getFilter(type)), projections).get();
+            CursorProcessor cursorProcessor = new ExpressionCompiler(PLANNER_CONTEXT.getFunctionManager(), pageFunctionCompiler, compiler).compileCursorProcessor(Optional.of(getFilter(type)), projections, "key").get();
 
             createTaskContext();
             createScanFilterAndProjectOperatorFactories(createInputPages(types), pageProcessor, cursorProcessor, columnHandles, types);

--- a/core/trino-main/src/test/java/io/trino/operator/TestColumnarPageProcessor.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestColumnarPageProcessor.java
@@ -20,6 +20,7 @@ import io.trino.spi.Page;
 import io.trino.spi.type.Type;
 import io.trino.sql.gen.ExpressionCompiler;
 import io.trino.sql.gen.PageFunctionCompiler;
+import io.trino.sql.gen.columnar.ColumnarFilterCompiler;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -80,7 +81,7 @@ public class TestColumnarPageProcessor
 
     private PageProcessor newPageProcessor()
     {
-        return new ExpressionCompiler(functionManager, new PageFunctionCompiler(functionManager, 0))
+        return new ExpressionCompiler(functionManager, new PageFunctionCompiler(functionManager, 0), new ColumnarFilterCompiler(functionManager, 0))
                 .compilePageProcessor(Optional.empty(), ImmutableList.of(field(0, types.get(0)), field(1, types.get(1))), MAX_BATCH_SIZE).get();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/project/TestPageProcessor.java
+++ b/core/trino-main/src/test/java/io/trino/operator/project/TestPageProcessor.java
@@ -32,6 +32,7 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.type.Type;
 import io.trino.sql.gen.ExpressionProfiler;
 import io.trino.sql.gen.PageFunctionCompiler;
+import io.trino.sql.gen.columnar.PageFilterEvaluator;
 import io.trino.sql.relational.CallExpression;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
@@ -107,7 +108,7 @@ public class TestPageProcessor
     @Test
     public void testFilterNoColumns()
     {
-        PageProcessor pageProcessor = new PageProcessor(Optional.of(new TestingPageFilter(positionsRange(0, 50))), ImmutableList.of());
+        PageProcessor pageProcessor = new PageProcessor(Optional.of(new PageFilterEvaluator(new TestingPageFilter(positionsRange(0, 50)))), ImmutableList.of());
 
         Page inputPage = new Page(createLongSequenceBlock(0, 100));
 
@@ -126,7 +127,7 @@ public class TestPageProcessor
     public void testPartialFilter()
     {
         PageProcessor pageProcessor = new PageProcessor(
-                Optional.of(new TestingPageFilter(positionsRange(25, 50))),
+                Optional.of(new PageFilterEvaluator(new TestingPageFilter(positionsRange(25, 50)))),
                 ImmutableList.of(new InputPageProjection(0, BIGINT)),
                 OptionalInt.of(MAX_BATCH_SIZE));
 
@@ -142,7 +143,7 @@ public class TestPageProcessor
     @Test
     public void testSelectAllFilter()
     {
-        PageProcessor pageProcessor = new PageProcessor(Optional.of(new SelectAllFilter()), ImmutableList.of(new InputPageProjection(0, BIGINT)), OptionalInt.of(MAX_BATCH_SIZE));
+        PageProcessor pageProcessor = new PageProcessor(Optional.of(new PageFilterEvaluator(new SelectAllFilter())), ImmutableList.of(new InputPageProjection(0, BIGINT)), OptionalInt.of(MAX_BATCH_SIZE));
 
         Page inputPage = new Page(createLongSequenceBlock(0, 100));
 
@@ -156,7 +157,7 @@ public class TestPageProcessor
     @Test
     public void testSelectNoneFilter()
     {
-        PageProcessor pageProcessor = new PageProcessor(Optional.of(new SelectNoneFilter()), ImmutableList.of(new InputPageProjection(0, BIGINT)));
+        PageProcessor pageProcessor = new PageProcessor(Optional.of(new PageFilterEvaluator(new SelectNoneFilter())), ImmutableList.of(new InputPageProjection(0, BIGINT)));
 
         Page inputPage = new Page(createLongSequenceBlock(0, 100));
 
@@ -171,7 +172,7 @@ public class TestPageProcessor
     @Test
     public void testProjectEmptyPage()
     {
-        PageProcessor pageProcessor = new PageProcessor(Optional.of(new SelectAllFilter()), ImmutableList.of(new InputPageProjection(0, BIGINT)));
+        PageProcessor pageProcessor = new PageProcessor(Optional.of(new PageFilterEvaluator(new SelectAllFilter())), ImmutableList.of(new InputPageProjection(0, BIGINT)));
 
         Page inputPage = new Page(createLongSequenceBlock(0, 0));
 
@@ -187,7 +188,7 @@ public class TestPageProcessor
     @Test
     public void testSelectNoneFilterLazyLoad()
     {
-        PageProcessor pageProcessor = new PageProcessor(Optional.of(new SelectNoneFilter()), ImmutableList.of(new InputPageProjection(1, BIGINT)));
+        PageProcessor pageProcessor = new PageProcessor(Optional.of(new PageFilterEvaluator(new SelectNoneFilter())), ImmutableList.of(new InputPageProjection(1, BIGINT)));
 
         // if channel 1 is loaded, test will fail
         Page inputPage = new Page(createLongSequenceBlock(0, 100), new LazyBlock(100, () -> {
@@ -204,7 +205,7 @@ public class TestPageProcessor
     @Test
     public void testProjectLazyLoad()
     {
-        PageProcessor pageProcessor = new PageProcessor(Optional.of(new SelectAllFilter()), ImmutableList.of(new LazyPagePageProjection()), OptionalInt.of(MAX_BATCH_SIZE));
+        PageProcessor pageProcessor = new PageProcessor(Optional.of(new PageFilterEvaluator(new SelectAllFilter())), ImmutableList.of(new LazyPagePageProjection()), OptionalInt.of(MAX_BATCH_SIZE));
 
         // if channel 1 is loaded, test will fail
         Page inputPage = new Page(createLongSequenceBlock(0, 100), new LazyBlock(100, () -> {
@@ -323,7 +324,7 @@ public class TestPageProcessor
     public void testRetainedSize()
     {
         PageProcessor pageProcessor = new PageProcessor(
-                Optional.of(new SelectAllFilter()),
+                Optional.of(new PageFilterEvaluator(new SelectAllFilter())),
                 ImmutableList.of(new InputPageProjection(0, VARCHAR), new InputPageProjection(1, VARCHAR)),
                 OptionalInt.of(MAX_BATCH_SIZE));
 

--- a/core/trino-main/src/test/java/io/trino/operator/project/TestSelectedPositions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/project/TestSelectedPositions.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.project;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static io.trino.operator.project.SelectedPositions.positionsList;
+import static io.trino.operator.project.SelectedPositions.positionsRange;
+import static io.trino.testing.DataProviders.cartesianProduct;
+import static io.trino.testing.DataProviders.toDataProvider;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestSelectedPositions
+{
+    private static final Random RANDOM = new Random(38844897);
+    private static final SelectedPositions EMPTY_LIST = positionsList(new int[10], 5, 0);
+    private static final SelectedPositions EMPTY_RANGE = positionsRange(13, 0);
+    private static final SelectedPositions NON_EMPTY_LIST = positionsList(new int[10], 5, 5);
+    private static final SelectedPositions NON_EMPTY_RANGE = positionsRange(13, 7);
+
+    @Test
+    public void testEmpty()
+    {
+        assertThat(EMPTY_LIST.union(EMPTY_LIST)).isEqualTo(EMPTY_LIST);
+        assertThat(EMPTY_LIST.union(EMPTY_RANGE)).isEqualTo(EMPTY_LIST);
+        assertThat(EMPTY_RANGE.union(EMPTY_LIST)).isEqualTo(EMPTY_RANGE);
+        assertThat(EMPTY_RANGE.union(EMPTY_RANGE)).isEqualTo(EMPTY_RANGE);
+
+        assertThat(EMPTY_LIST.union(NON_EMPTY_LIST)).isEqualTo(NON_EMPTY_LIST);
+        assertThat(EMPTY_LIST.union(NON_EMPTY_RANGE)).isEqualTo(NON_EMPTY_RANGE);
+        assertThat(NON_EMPTY_LIST.union(EMPTY_LIST)).isEqualTo(NON_EMPTY_LIST);
+        assertThat(NON_EMPTY_RANGE.union(EMPTY_LIST)).isEqualTo(NON_EMPTY_RANGE);
+        assertThat(EMPTY_RANGE.union(NON_EMPTY_RANGE)).isEqualTo(NON_EMPTY_RANGE);
+        assertThat(NON_EMPTY_RANGE.union(EMPTY_LIST)).isEqualTo(NON_EMPTY_RANGE);
+
+        assertThat(EMPTY_LIST.difference(NON_EMPTY_LIST)).isEqualTo(EMPTY_LIST);
+        assertThat(NON_EMPTY_LIST.difference(EMPTY_LIST)).isEqualTo(NON_EMPTY_LIST);
+        assertThat(EMPTY_RANGE.difference(NON_EMPTY_RANGE)).isEqualTo(EMPTY_RANGE);
+        assertThat(NON_EMPTY_RANGE.difference(EMPTY_RANGE)).isEqualTo(NON_EMPTY_RANGE);
+    }
+
+    @ParameterizedTest
+    @MethodSource("inputSizes")
+    public void testListsUnionAndDifference(int size, int maxGroupSize)
+    {
+        int[] positions = generateList(size, maxGroupSize);
+        // no overlap
+        SelectedPositions listA = positionsList(positions, 0, size / 2);
+        SelectedPositions listB = positionsList(positions, size / 2, size - (size / 2));
+        assertUnionAndDifference(listA, listB);
+
+        // full overlap
+        assertUnionAndDifference(listA, listA);
+        assertUnionAndDifference(listB, listB);
+
+        // partial overlap
+        listA = positionsList(positions, 0, (3 * size) / 4);
+        listB = positionsList(positions, size / 4, size - (size / 4));
+        assertUnionAndDifference(listA, listB);
+
+        // subset
+        listB = positionsList(positions, size / 4, size / 4);
+        assertUnionAndDifference(listA, listB);
+    }
+
+    @ParameterizedTest
+    @MethodSource("inputSizes")
+    public void testListRangeUnionAndDifference(int size, int maxGroupSize)
+    {
+        int[] positions = generateList(size, maxGroupSize);
+        // list fully after range
+        SelectedPositions list = positionsList(positions, size / 2, size / 2);
+        SelectedPositions range = positionsRange(0, positions[size / 4]);
+        assertUnionAndDifference(list, range);
+
+        // list fully before range
+        list = positionsList(positions, 0, size);
+        range = positionsRange(list.getPositions()[list.getOffset() + list.size()] + 1, size);
+        assertUnionAndDifference(list, range);
+
+        // partial overlap
+        list = positionsList(positions, size / 4, size / 2);
+        range = positionsRange(positions[0], list.getPositions()[list.size() - 1] - positions[0]);
+        assertUnionAndDifference(list, range);
+        range = positionsRange(list.getPositions()[list.getOffset()], positions[size - 1] - list.getPositions()[list.getOffset()]);
+        assertUnionAndDifference(list, range);
+
+        // subset
+        list = positionsList(positions, 0, size);
+        range = positionsRange(positions[0], positions[size - 1] - positions[0]);
+        assertUnionAndDifference(list, range);
+
+        // full overlap
+        for (int position = 0; position < size; position++) {
+            positions[position] = position;
+        }
+        list = positionsList(positions, 0, size);
+        range = positionsRange(0, size);
+        assertUnionAndDifference(list, range);
+    }
+
+    @Test
+    public void testRangesUnionAndDifference()
+    {
+        // no overlap
+        SelectedPositions rangeA = positionsRange(0, 1024);
+        SelectedPositions rangeB = positionsRange(2000, 100);
+        assertUnionAndDifference(rangeA, rangeB);
+
+        // full overlap
+        assertUnionAndDifference(rangeA, rangeA);
+        assertUnionAndDifference(rangeB, rangeB);
+
+        // partial overlap
+        rangeA = positionsRange(0, 1024);
+        rangeB = positionsRange(1000, 1000);
+        assertUnionAndDifference(rangeA, rangeB);
+
+        // subset
+        rangeB = positionsRange(300, 700);
+        assertUnionAndDifference(rangeA, rangeB);
+    }
+
+    private static Object[][] inputSizes()
+    {
+        return cartesianProduct(
+                Stream.of(1024, 8096, 65536).collect(toDataProvider()),
+                Stream.of(1, 10, 100, 200, 500).collect(toDataProvider()));
+    }
+
+    private static int[] generateList(int size, int maxGroupSize)
+    {
+        IntArrayList groupedList = new IntArrayList();
+        int position = 0;
+        while (groupedList.size() < size) {
+            boolean skip = RANDOM.nextBoolean();
+            int groupSize = Math.min(RANDOM.nextInt(1, maxGroupSize + 1), size - groupedList.size());
+            if (!skip) {
+                for (int i = 0; i < groupSize; i++) {
+                    groupedList.add(position + i);
+                }
+            }
+            position += groupSize;
+        }
+        return groupedList.elements();
+    }
+
+    private static void assertUnionAndDifference(SelectedPositions positionsA, SelectedPositions positionsB)
+    {
+        assertUnion(positionsA, positionsB);
+        assertUnion(positionsB, positionsA);
+        assertDifference(positionsA, positionsB);
+        assertDifference(positionsB, positionsA);
+    }
+
+    private static void assertUnion(SelectedPositions positionsA, SelectedPositions positionsB)
+    {
+        SelectedPositions result = positionsA.union(positionsB);
+        assertThat(toSet(result)).isEqualTo(Sets.union(toSet(positionsA), toSet(positionsB)));
+        if (result.isList()) {
+            int[] activePositions = new int[result.size()];
+            System.arraycopy(result.getPositions(), result.getOffset(), activePositions, 0, result.size());
+            assertThat(activePositions).isSorted();
+            assertThat(activePositions).doesNotHaveDuplicates();
+        }
+    }
+
+    private static void assertDifference(SelectedPositions positionsA, SelectedPositions positionsB)
+    {
+        SelectedPositions result = positionsA.difference(positionsB);
+        assertThat(toSet(result)).isEqualTo(Sets.difference(toSet(positionsA), toSet(positionsB)));
+        if (result.isList()) {
+            int[] activePositions = new int[result.size()];
+            System.arraycopy(result.getPositions(), result.getOffset(), activePositions, 0, result.size());
+            assertThat(activePositions).isSorted();
+            assertThat(activePositions).doesNotHaveDuplicates();
+        }
+    }
+
+    private static Set<Integer> toSet(SelectedPositions positions)
+    {
+        ImmutableSet.Builder<Integer> builder = ImmutableSet.builder();
+        if (positions.isList()) {
+            for (int index = positions.getOffset(); index < positions.getOffset() + positions.size(); index++) {
+                builder.add(positions.getPositions()[index]);
+            }
+        }
+        else {
+            for (int position = positions.getOffset(); position < positions.getOffset() + positions.size(); position++) {
+                builder.add(position);
+            }
+        }
+        return builder.build();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestFeaturesConfig.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestFeaturesConfig.java
@@ -64,6 +64,7 @@ public class TestFeaturesConfig
                 .setIncrementalHashArrayLoadFactorEnabled(true)
                 .setHideInaccessibleColumns(false)
                 .setForceSpillingJoin(false)
+                .setColumnarFilterEvaluationEnabled(true)
                 .setFaultTolerantExecutionExchangeEncryptionEnabled(true));
     }
 
@@ -97,6 +98,7 @@ public class TestFeaturesConfig
                 .put("incremental-hash-array-load-factor.enabled", "false")
                 .put("hide-inaccessible-columns", "true")
                 .put("force-spilling-join-operator", "true")
+                .put("experimental.columnar-filter-evaluation.enabled", "false")
                 .put("fault-tolerant-execution.exchange-encryption-enabled", "false")
                 .buildOrThrow();
 
@@ -127,6 +129,7 @@ public class TestFeaturesConfig
                 .setIncrementalHashArrayLoadFactorEnabled(false)
                 .setHideInaccessibleColumns(true)
                 .setForceSpillingJoin(true)
+                .setColumnarFilterEvaluationEnabled(false)
                 .setFaultTolerantExecutionExchangeEncryptionEnabled(false);
         assertFullMapping(properties, expected);
     }

--- a/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkAndColumnarFilterTpchData.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkAndColumnarFilterTpchData.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.gen;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.operator.DriverYieldSignal;
+import io.trino.operator.project.PageProcessor;
+import io.trino.spi.Page;
+import io.trino.spi.PageBuilder;
+import io.trino.sql.relational.CallExpression;
+import io.trino.sql.relational.InputReferenceExpression;
+import io.trino.sql.relational.RowExpression;
+import io.trino.sql.relational.SpecialForm;
+import io.trino.sql.relational.SpecialForm.Form;
+import io.trino.tpch.LineItem;
+import io.trino.tpch.LineItemColumn;
+import io.trino.tpch.LineItemGenerator;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.jmh.Benchmarks.benchmark;
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static io.trino.spi.function.OperatorType.LESS_THAN;
+import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.relational.Expressions.constant;
+import static io.trino.sql.relational.Expressions.field;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(2)
+@Warmup(iterations = 15, time = 1)
+@Measurement(iterations = 10, time = 1)
+public class BenchmarkAndColumnarFilterTpchData
+{
+    private static final TestingFunctionResolution FUNCTION_RESOLUTION = new TestingFunctionResolution();
+
+    private static final int EXTENDED_PRICE = 0;
+    private static final int DISCOUNT = 1;
+    private static final int SHIP_DATE = 2;
+    private static final int QUANTITY = 3;
+
+    private static final Slice MIN_SHIP_DATE = utf8Slice("1994-01-01");
+    private static final Slice MAX_SHIP_DATE = utf8Slice("1995-01-01");
+
+    private Page inputPage;
+    private PageProcessor processor;
+
+    @Param({"true", "false"})
+    public boolean columnarEvaluationEnabled;
+
+    @Setup
+    public void setup()
+    {
+        inputPage = createInputPage();
+
+        RowExpression filterExpression = createFilterExpression(FUNCTION_RESOLUTION);
+        ExpressionCompiler expressionCompiler = FUNCTION_RESOLUTION.getExpressionCompiler();
+        List<? extends RowExpression> projections = ImmutableList.of(new InputReferenceExpression(EXTENDED_PRICE, DOUBLE));
+        processor = expressionCompiler.compilePageProcessor(columnarEvaluationEnabled, Optional.of(filterExpression), projections, Optional.empty())
+                .get();
+    }
+
+    @Benchmark
+    public List<Optional<Page>> compiled()
+    {
+        return ImmutableList.copyOf(
+                processor.process(
+                        null,
+                        new DriverYieldSignal(),
+                        newSimpleAggregatedMemoryContext().newLocalMemoryContext(PageProcessor.class.getSimpleName()),
+                        inputPage));
+    }
+
+    private static Page createInputPage()
+    {
+        PageBuilder pageBuilder = new PageBuilder(ImmutableList.of(DOUBLE, DOUBLE, VARCHAR, DOUBLE));
+        LineItemGenerator lineItemGenerator = new LineItemGenerator(1, 1, 1);
+        Iterator<LineItem> iterator = lineItemGenerator.iterator();
+        for (int i = 0; i < 10_000; i++) {
+            pageBuilder.declarePosition();
+
+            LineItem lineItem = iterator.next();
+            DOUBLE.writeDouble(pageBuilder.getBlockBuilder(EXTENDED_PRICE), lineItem.extendedPrice());
+            DOUBLE.writeDouble(pageBuilder.getBlockBuilder(DISCOUNT), lineItem.discount());
+            VARCHAR.writeSlice(pageBuilder.getBlockBuilder(SHIP_DATE), Slices.wrappedBuffer(LineItemColumn.SHIP_DATE.getString(lineItem).getBytes(UTF_8)));
+            DOUBLE.writeDouble(pageBuilder.getBlockBuilder(QUANTITY), lineItem.quantity());
+        }
+        return pageBuilder.build();
+    }
+
+    // where shipdate >= '1994-01-01'
+    //    and shipdate < '1995-01-01'
+    //    and discount >= 0.05
+    //    and discount <= 0.07
+    //    and quantity < 24;
+    private static RowExpression createFilterExpression(TestingFunctionResolution functionResolution)
+    {
+        return new SpecialForm(
+                Form.AND,
+                BOOLEAN,
+                ImmutableList.of(
+                        new CallExpression(
+                                functionResolution.resolveOperator(LESS_THAN_OR_EQUAL, ImmutableList.of(VARCHAR, VARCHAR)),
+                                ImmutableList.of(constant(MIN_SHIP_DATE, VARCHAR), field(SHIP_DATE, VARCHAR))),
+                        new SpecialForm(
+                                Form.AND,
+                                BOOLEAN,
+                                ImmutableList.of(
+                                        new CallExpression(
+                                                functionResolution.resolveOperator(LESS_THAN, ImmutableList.of(VARCHAR, VARCHAR)),
+                                                ImmutableList.of(field(SHIP_DATE, VARCHAR), constant(MAX_SHIP_DATE, VARCHAR))),
+                                        new SpecialForm(
+                                                Form.AND,
+                                                BOOLEAN,
+                                                ImmutableList.of(
+                                                        new CallExpression(
+                                                                functionResolution.resolveOperator(LESS_THAN_OR_EQUAL, ImmutableList.of(DOUBLE, DOUBLE)),
+                                                                ImmutableList.of(constant(0.05, DOUBLE), field(DISCOUNT, DOUBLE))),
+                                                        new SpecialForm(
+                                                                Form.AND,
+                                                                BOOLEAN,
+                                                                ImmutableList.of(
+                                                                        new CallExpression(
+                                                                                functionResolution.resolveOperator(LESS_THAN_OR_EQUAL, ImmutableList.of(DOUBLE, DOUBLE)),
+                                                                                ImmutableList.of(field(DISCOUNT, DOUBLE), constant(0.07, DOUBLE))),
+                                                                        new CallExpression(
+                                                                                functionResolution.resolveOperator(LESS_THAN, ImmutableList.of(DOUBLE, DOUBLE)),
+                                                                                ImmutableList.of(field(QUANTITY, DOUBLE), constant(24.0, DOUBLE)))),
+                                                                ImmutableList.of())),
+                                                ImmutableList.of())),
+                                ImmutableList.of())),
+                ImmutableList.of());
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        benchmark(BenchmarkAndColumnarFilterTpchData.class).run();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkColumnarFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkColumnarFilter.java
@@ -1,0 +1,268 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.gen;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.memory.context.LocalMemoryContext;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.operator.DriverYieldSignal;
+import io.trino.operator.WorkProcessor;
+import io.trino.operator.project.PageProcessor;
+import io.trino.operator.project.PageProcessorMetrics;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.IntArrayBlock;
+import io.trino.spi.block.LongArrayBlock;
+import io.trino.spi.block.ShortArrayBlock;
+import io.trino.spi.function.OperatorType;
+import io.trino.spi.type.StandardTypes;
+import io.trino.spi.type.Type;
+import io.trino.sql.relational.RowExpression;
+import io.trino.sql.relational.SpecialForm;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static io.trino.jmh.Benchmarks.benchmark;
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static io.trino.sql.relational.Expressions.call;
+import static io.trino.sql.relational.Expressions.constant;
+import static io.trino.sql.relational.Expressions.field;
+import static java.lang.Math.toIntExact;
+import static org.openjdk.jmh.annotations.Scope.Thread;
+
+@State(Thread)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(1)
+@Warmup(iterations = 15, time = 1)
+@Measurement(iterations = 15, time = 1)
+public class BenchmarkColumnarFilter
+{
+    private static final Random RANDOM = new Random(5376453765L);
+    private static final long CONSTANT = 8456;
+    private static final TestingFunctionResolution FUNCTION_RESOLUTION = new TestingFunctionResolution();
+
+    private PageProcessor compiledProcessor;
+    private final List<Page> inputPages = new ArrayList<>();
+    @Param({"true", "false"})
+    public boolean columnarEvaluationEnabled;
+    @Param({"0", "10"})
+    public int nullsPercentage;
+    @Param({
+            "BETWEEN",
+            "LESS_THAN",
+            "IS_NULL",
+            "IS_NOT_NULL",
+    })
+    public FilterProvider filterProvider;
+    public String dataType = StandardTypes.INTEGER;
+
+    public enum FilterProvider
+    {
+        BETWEEN {
+            @Override
+            RowExpression getExpression(Type type)
+            {
+                return new SpecialForm(
+                        SpecialForm.Form.BETWEEN,
+                        BOOLEAN,
+                        ImmutableList.of(field(0, type), constant(CONSTANT - 5, type), constant(CONSTANT + 5, type)),
+                        ImmutableList.of(FUNCTION_RESOLUTION.resolveOperator(LESS_THAN_OR_EQUAL, ImmutableList.of(type, type))));
+            }
+        },
+        LESS_THAN {
+            @Override
+            RowExpression getExpression(Type type)
+            {
+                return call(
+                        FUNCTION_RESOLUTION.resolveOperator(OperatorType.LESS_THAN, ImmutableList.of(type, type)),
+                        constant(CONSTANT, type),
+                        field(0, type));
+            }
+        },
+        IS_NULL {
+            @Override
+            RowExpression getExpression(Type type)
+            {
+                return new SpecialForm(
+                        SpecialForm.Form.IS_NULL,
+                        BOOLEAN,
+                        ImmutableList.of(field(0, type)),
+                        ImmutableList.of());
+            }
+        },
+        IS_NOT_NULL {
+            @Override
+            RowExpression getExpression(Type type)
+            {
+                return call(
+                        FUNCTION_RESOLUTION.resolveFunction("$not", fromTypes(BOOLEAN)),
+                        new SpecialForm(
+                                SpecialForm.Form.IS_NULL,
+                                BOOLEAN,
+                                ImmutableList.of(field(0, type)),
+                                ImmutableList.of()));
+            }
+        }
+        /**/;
+
+        abstract RowExpression getExpression(Type type);
+    }
+
+    @Setup
+    public void setup()
+    {
+        for (int pageCount = 0; pageCount < 20; pageCount++) {
+            Block block = switch (dataType) {
+                case StandardTypes.BIGINT -> createLongsBlock(8192, nullsPercentage);
+                case StandardTypes.INTEGER -> createIntsBlock(8192, nullsPercentage);
+                case StandardTypes.SMALLINT -> createShortsBlock(8192, nullsPercentage);
+                default -> throw new UnsupportedOperationException();
+            };
+            inputPages.add(new Page(block.getPositionCount(), block));
+        }
+
+        Type type = switch (dataType) {
+            case StandardTypes.BIGINT -> BIGINT;
+            case StandardTypes.INTEGER -> INTEGER;
+            case StandardTypes.SMALLINT -> SMALLINT;
+            default -> throw new UnsupportedOperationException();
+        };
+        ExpressionCompiler expressionCompiler = FUNCTION_RESOLUTION.getExpressionCompiler();
+        compiledProcessor = expressionCompiler.compilePageProcessor(
+                        columnarEvaluationEnabled,
+                        Optional.of(filterProvider.getExpression(type)),
+                        ImmutableList.of(field(0, type)),
+                        Optional.empty())
+                .get();
+    }
+
+    @Benchmark
+    public long evaluateFilter()
+    {
+        LocalMemoryContext context = newSimpleAggregatedMemoryContext().newLocalMemoryContext(PageProcessor.class.getSimpleName());
+        long outputRows = 0;
+        for (Page inputPage : inputPages) {
+            WorkProcessor<Page> workProcessor = compiledProcessor.createWorkProcessor(
+                    null,
+                    new DriverYieldSignal(),
+                    context,
+                    new PageProcessorMetrics(),
+                    inputPage);
+            if (workProcessor.process() && !workProcessor.isFinished()) {
+                outputRows += workProcessor.getResult().getPositionCount();
+            }
+        }
+        return outputRows;
+    }
+
+    public static void runAllCombinations()
+    {
+        for (boolean columnarEvaluationEnabled : ImmutableList.of(false, true)) {
+            for (FilterProvider filterProvider : FilterProvider.values()) {
+                for (String dataType : ImmutableList.of(StandardTypes.BIGINT, StandardTypes.INTEGER, StandardTypes.SMALLINT)) {
+                    for (int nullsPercentage : ImmutableList.of(0, 10)) {
+                        BenchmarkColumnarFilter benchmark = new BenchmarkColumnarFilter();
+                        benchmark.filterProvider = filterProvider;
+                        benchmark.dataType = dataType;
+                        benchmark.columnarEvaluationEnabled = columnarEvaluationEnabled;
+                        benchmark.nullsPercentage = nullsPercentage;
+                        benchmark.setup();
+                        benchmark.evaluateFilter();
+                    }
+                }
+            }
+        }
+    }
+
+    private static Block createShortsBlock(int positionsCount, int nullsPercentage)
+    {
+        short[] values = new short[positionsCount];
+        boolean[] isNull = new boolean[positionsCount];
+        for (int i = 0; i < positionsCount; i++) {
+            if (RANDOM.nextInt(100) < nullsPercentage) {
+                isNull[i] = true;
+            }
+            else {
+                values[i] = (short) RANDOM.nextInt(toIntExact(CONSTANT - 10), toIntExact(CONSTANT + 10));
+            }
+        }
+        return new ShortArrayBlock(positionsCount, Optional.of(isNull), values);
+    }
+
+    private static Block createIntsBlock(int positionsCount, int nullsPercentage)
+    {
+        int[] values = new int[positionsCount];
+        boolean[] isNull = new boolean[positionsCount];
+        for (int i = 0; i < positionsCount; i++) {
+            if (RANDOM.nextInt(100) < nullsPercentage) {
+                isNull[i] = true;
+            }
+            else {
+                values[i] = RANDOM.nextInt(toIntExact(CONSTANT - 10), toIntExact(CONSTANT + 10));
+            }
+        }
+        return new IntArrayBlock(positionsCount, Optional.of(isNull), values);
+    }
+
+    private static Block createLongsBlock(int positionsCount, int nullsPercentage)
+    {
+        long[] values = new long[positionsCount];
+        boolean[] isNull = new boolean[positionsCount];
+        for (int i = 0; i < positionsCount; i++) {
+            if (RANDOM.nextInt(100) < nullsPercentage) {
+                isNull[i] = true;
+            }
+            else {
+                values[i] = RANDOM.nextInt(toIntExact(CONSTANT - 10), toIntExact(CONSTANT + 10));
+            }
+        }
+        return new LongArrayBlock(positionsCount, Optional.of(isNull), values);
+    }
+
+    static {
+        try {
+            // pollute the profile
+            runAllCombinations();
+        }
+        catch (Throwable throwable) {
+            throw new RuntimeException(throwable);
+        }
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        benchmark(BenchmarkColumnarFilter.class)
+                .withOptions(optionsBuilder -> optionsBuilder.jvmArgsAppend("-Xmx4g", "-Xms4g"))
+                .run();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkPageProcessor2.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkPageProcessor2.java
@@ -30,6 +30,7 @@ import io.trino.spi.connector.RecordSet;
 import io.trino.spi.function.OperatorType;
 import io.trino.spi.type.Type;
 import io.trino.sql.PlannerContext;
+import io.trino.sql.gen.columnar.ColumnarFilterCompiler;
 import io.trino.sql.ir.Call;
 import io.trino.sql.ir.Cast;
 import io.trino.sql.ir.Comparison;
@@ -127,12 +128,13 @@ public class BenchmarkPageProcessor2
 
         FunctionManager functionManager = createTestingFunctionManager();
         PageFunctionCompiler pageFunctionCompiler = new PageFunctionCompiler(functionManager, 0);
+        ColumnarFilterCompiler columnarFilterCompiler = new ColumnarFilterCompiler(functionManager, 0);
 
         inputPage = createPage(types, dictionaryBlocks);
-        pageProcessor = new ExpressionCompiler(functionManager, pageFunctionCompiler).compilePageProcessor(Optional.of(getFilter(type)), projections).get();
+        pageProcessor = new ExpressionCompiler(functionManager, pageFunctionCompiler, columnarFilterCompiler).compilePageProcessor(Optional.of(getFilter(type)), projections).get();
 
         recordSet = new PageRecordSet(types, inputPage);
-        cursorProcessor = new ExpressionCompiler(functionManager, pageFunctionCompiler).compileCursorProcessor(Optional.of(getFilter(type)), projections, "key").get();
+        cursorProcessor = new ExpressionCompiler(functionManager, pageFunctionCompiler, columnarFilterCompiler).compileCursorProcessor(Optional.of(getFilter(type)), projections, "key").get();
     }
 
     @Benchmark

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestBenchmarkColumnarFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestBenchmarkColumnarFilter.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.gen;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+
+public class TestBenchmarkColumnarFilter
+{
+    @Test
+    public void testBenchmarkAndPageFilter()
+    {
+        for (boolean columnarEvaluationEnabled : ImmutableList.of(true, false)) {
+            BenchmarkAndColumnarFilterTpchData benchmark = new BenchmarkAndColumnarFilterTpchData();
+            benchmark.columnarEvaluationEnabled = columnarEvaluationEnabled;
+            benchmark.setup();
+            benchmark.compiled();
+        }
+    }
+
+    @Test
+    public void testBenchmarkNullablePageFilter()
+    {
+        BenchmarkColumnarFilter.runAllCombinations();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestColumnarFilters.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestColumnarFilters.java
@@ -1,0 +1,921 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.gen;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.FullConnectorSession;
+import io.trino.memory.context.LocalMemoryContext;
+import io.trino.metadata.FunctionBundle;
+import io.trino.metadata.InternalFunctionBundle;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.operator.DriverYieldSignal;
+import io.trino.operator.WorkProcessor;
+import io.trino.operator.project.PageProcessor;
+import io.trino.operator.project.PageProcessorMetrics;
+import io.trino.spi.Page;
+import io.trino.spi.block.ArrayBlockBuilder;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.DictionaryBlock;
+import io.trino.spi.block.IntArrayBlock;
+import io.trino.spi.block.IntArrayBlockBuilder;
+import io.trino.spi.block.LazyBlock;
+import io.trino.spi.block.LazyBlockLoader;
+import io.trino.spi.block.LongArrayBlock;
+import io.trino.spi.block.VariableWidthBlockBuilder;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.function.LiteralParameters;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlNullable;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.function.TypeParameter;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.StandardTypes;
+import io.trino.spi.type.Type;
+import io.trino.sql.gen.columnar.ColumnarFilterCompiler;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.planner.CompilerConfig;
+import io.trino.sql.relational.RowExpression;
+import io.trino.sql.relational.SpecialForm;
+import io.trino.testing.TestingSession;
+import io.trino.type.LikePattern;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.stream.Stream;
+
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static io.trino.metadata.FunctionManager.createTestingFunctionManager;
+import static io.trino.spi.block.BlockTestUtils.assertBlockEquals;
+import static io.trino.spi.function.OperatorType.EQUAL;
+import static io.trino.spi.function.OperatorType.HASH_CODE;
+import static io.trino.spi.function.OperatorType.IDENTICAL;
+import static io.trino.spi.function.OperatorType.INDETERMINATE;
+import static io.trino.spi.function.OperatorType.LESS_THAN;
+import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static io.trino.sql.gen.columnar.FilterEvaluator.createColumnarFilterEvaluator;
+import static io.trino.sql.relational.Expressions.call;
+import static io.trino.sql.relational.Expressions.constant;
+import static io.trino.sql.relational.Expressions.constantNull;
+import static io.trino.sql.relational.Expressions.field;
+import static io.trino.sql.relational.SpecialForm.Form.AND;
+import static io.trino.sql.relational.SpecialForm.Form.BETWEEN;
+import static io.trino.sql.relational.SpecialForm.Form.IN;
+import static io.trino.sql.relational.SpecialForm.Form.IS_NULL;
+import static io.trino.sql.relational.SpecialForm.Form.OR;
+import static io.trino.testing.DataProviders.cartesianProduct;
+import static io.trino.testing.DataProviders.toDataProvider;
+import static io.trino.testing.DataProviders.trueFalse;
+import static io.trino.type.LikePatternType.LIKE_PATTERN;
+import static java.lang.Double.doubleToLongBits;
+import static java.lang.Math.toIntExact;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestColumnarFilters
+{
+    private static final Random RANDOM = new Random(5376453765L);
+    private static final long CONSTANT = 64992484L;
+    private static final int ROW_NUM_CHANNEL = 0;
+    private static final int DOUBLE_CHANNEL = 1;
+    private static final int INT_CHANNEL_B = 2;
+    private static final int STRING_CHANNEL = 3;
+    private static final int INT_CHANNEL_A = 4;
+    private static final int INT_CHANNEL_C = 5;
+    private static final int ARRAY_CHANNEL = 6;
+    private static final Type ARRAY_CHANNEL_TYPE = new ArrayType(INTEGER);
+    private static final FullConnectorSession FULL_CONNECTOR_SESSION = new FullConnectorSession(
+            TestingSession.testSessionBuilder().build(),
+            ConnectorIdentity.ofUser("test"));
+    private static final FunctionBundle FUNCTION_BUNDLE = InternalFunctionBundle.builder()
+            .scalar(NullableReturnFunction.class)
+            .scalar(ConnectorSessionFunction.class)
+            .scalar(InstanceFactoryFunction.class)
+            .scalar(CustomIsDistinctFrom.class)
+            .build();
+    private static final TestingFunctionResolution FUNCTION_RESOLUTION = new TestingFunctionResolution(FUNCTION_BUNDLE);
+    private static final ColumnarFilterCompiler COMPILER = new ColumnarFilterCompiler(createTestingFunctionManager(FUNCTION_BUNDLE), new CompilerConfig());
+
+    @ParameterizedTest
+    @MethodSource("inputProviders")
+    public void testIsNotDistinctFrom(NullsProvider nullsProvider, boolean dictionaryEncoded)
+    {
+        List<Page> inputPages = createInputPages(nullsProvider, dictionaryEncoded);
+        // col IS NOT DISTINCT FROM constant
+        RowExpression isNotDistinctFromFilter = call(
+                FUNCTION_RESOLUTION.resolveOperator(IDENTICAL, ImmutableList.of(INTEGER, INTEGER)),
+                constant(CONSTANT, INTEGER),
+                field(INT_CHANNEL_A, INTEGER));
+        assertThatColumnarFilterEvaluationIsSupported(isNotDistinctFromFilter);
+        verifyFilter(inputPages, isNotDistinctFromFilter);
+
+        // colA IS NOT DISTINCT FROM NULL
+        isNotDistinctFromFilter = call(
+                FUNCTION_RESOLUTION.resolveOperator(IDENTICAL, ImmutableList.of(INTEGER, INTEGER)),
+                constantNull(INTEGER),
+                field(INT_CHANNEL_A, INTEGER));
+        assertThatColumnarFilterEvaluationIsNotSupported(isNotDistinctFromFilter);
+        verifyFilter(inputPages, isNotDistinctFromFilter);
+
+        // colA IS NOT DISTINCT FROM colB
+        isNotDistinctFromFilter = call(
+                FUNCTION_RESOLUTION.resolveOperator(IDENTICAL, ImmutableList.of(INTEGER, INTEGER)),
+                field(INT_CHANNEL_C, INTEGER),
+                field(INT_CHANNEL_A, INTEGER));
+        assertThatColumnarFilterEvaluationIsSupported(isNotDistinctFromFilter);
+        verifyFilter(inputPages, isNotDistinctFromFilter);
+    }
+
+    @Test
+    public void testIsDistinctFrom()
+    {
+        List<Page> inputPages = createInputPages(NullsProvider.RANDOM_NULLS, false);
+        // col IS DISTINCT FROM constant
+        RowExpression isDistinctFromFilter = createNotExpression(call(
+                FUNCTION_RESOLUTION.resolveOperator(IDENTICAL, ImmutableList.of(INTEGER, INTEGER)),
+                constant(CONSTANT, INTEGER),
+                field(INT_CHANNEL_A, INTEGER)));
+        // IS DISTINCT is not supported in columnar evaluation yet
+        assertThatColumnarFilterEvaluationIsNotSupported(isDistinctFromFilter);
+        verifyFilter(inputPages, isDistinctFromFilter);
+
+        // colA IS DISTINCT FROM colB
+        isDistinctFromFilter = createNotExpression(call(
+                FUNCTION_RESOLUTION.resolveOperator(IDENTICAL, ImmutableList.of(INTEGER, INTEGER)),
+                field(INT_CHANNEL_B, INTEGER),
+                field(INT_CHANNEL_A, INTEGER)));
+        // IS DISTINCT is not supported in columnar evaluation yet
+        assertThatColumnarFilterEvaluationIsNotSupported(isDistinctFromFilter);
+        verifyFilter(inputPages, isDistinctFromFilter);
+    }
+
+    @ParameterizedTest
+    @MethodSource("inputProviders")
+    public void testIsNull(NullsProvider nullsProvider, boolean dictionaryEncoded)
+    {
+        List<Page> inputPages = createInputPages(nullsProvider, dictionaryEncoded);
+        RowExpression isNullFilter = new SpecialForm(IS_NULL, BOOLEAN, ImmutableList.of(field(INT_CHANNEL_A, INTEGER)), ImmutableList.of());
+        assertThatColumnarFilterEvaluationIsSupported(isNullFilter);
+        verifyFilter(inputPages, isNullFilter);
+    }
+
+    @Test
+    public void testNullableReturnFunction()
+    {
+        List<Page> inputPages = createInputPages(NullsProvider.RANDOM_NULLS, false);
+        // custom_is_null(col, NULL)
+        RowExpression customNullableReturnFilter = call(
+                FUNCTION_RESOLUTION.functionCallBuilder("custom_is_null")
+                        .addArgument(VARCHAR, new Reference(VARCHAR, "symbol"))
+                        .build()
+                        .function(),
+                field(STRING_CHANNEL, VARCHAR));
+        // Functions with nullable return are not supported in columnar evaluation yet
+        assertThatColumnarFilterEvaluationIsNotSupported(customNullableReturnFilter);
+        verifyFilter(inputPages, customNullableReturnFilter);
+    }
+
+    @ParameterizedTest
+    @MethodSource("inputProviders")
+    public void testConnectorSessionFunction(NullsProvider nullsProvider, boolean dictionaryEncoded)
+    {
+        List<Page> inputPages = createInputPages(nullsProvider, dictionaryEncoded);
+        // is_user_admin(connectorSession)
+        RowExpression customConnectorSessionFilter = call(
+                FUNCTION_RESOLUTION.functionCallBuilder("is_user_admin")
+                        .build()
+                        .function());
+        assertThatColumnarFilterEvaluationIsSupported(customConnectorSessionFilter);
+        verifyFilter(inputPages, customConnectorSessionFilter);
+    }
+
+    @ParameterizedTest
+    @MethodSource("inputProviders")
+    public void testInstanceFactoryFunction(NullsProvider nullsProvider, boolean dictionaryEncoded)
+    {
+        List<Page> inputPages = createInputPages(nullsProvider, dictionaryEncoded);
+        // is_answer_to_universe(col)
+        RowExpression customInstanceFactoryFilter = call(
+                FUNCTION_RESOLUTION.functionCallBuilder("is_answer_to_universe")
+                        .addArgument(INTEGER, new Reference(INTEGER, "symbol"))
+                        .build()
+                        .function(),
+                field(INT_CHANNEL_A, INTEGER));
+        assertThatColumnarFilterEvaluationIsSupported(customInstanceFactoryFilter);
+        verifyFilter(inputPages, customInstanceFactoryFilter);
+    }
+
+    @ParameterizedTest
+    @MethodSource("inputProviders")
+    public void testIsNotNull(NullsProvider nullsProvider, boolean dictionaryEncoded)
+    {
+        List<Page> inputPages = createInputPages(nullsProvider, dictionaryEncoded);
+        RowExpression isNotNullFilter = createNotExpression(
+                new SpecialForm(IS_NULL, BOOLEAN, ImmutableList.of(field(INT_CHANNEL_A, INTEGER)), ImmutableList.of()));
+        assertThatColumnarFilterEvaluationIsSupported(isNotNullFilter);
+        verifyFilter(inputPages, isNotNullFilter);
+    }
+
+    @Test
+    public void testNot()
+    {
+        List<Page> inputPages = createInputPages(NullsProvider.RANDOM_NULLS, false);
+        RowExpression notNullFilter = createNotExpression(call(
+                FUNCTION_RESOLUTION.resolveOperator(EQUAL, ImmutableList.of(INTEGER, INTEGER)),
+                constant(CONSTANT, INTEGER),
+                field(INT_CHANNEL_A, INTEGER)));
+        // NOT is not supported in columnar evaluation yet
+        assertThatColumnarFilterEvaluationIsNotSupported(notNullFilter);
+        verifyFilter(inputPages, notNullFilter);
+    }
+
+    @ParameterizedTest
+    @MethodSource("inputProviders")
+    public void testLike(NullsProvider nullsProvider, boolean dictionaryEncoded)
+    {
+        List<Page> inputPages = createInputPages(nullsProvider, dictionaryEncoded);
+        RowExpression likeFilter = call(
+                FUNCTION_RESOLUTION.resolveFunction("$like", fromTypes(VARCHAR, LIKE_PATTERN)),
+                field(STRING_CHANNEL, VARCHAR),
+                constant(LikePattern.compile(Long.toString(CONSTANT), Optional.empty()), LIKE_PATTERN));
+        assertThatColumnarFilterEvaluationIsSupported(likeFilter);
+        verifyFilter(inputPages, likeFilter);
+    }
+
+    @ParameterizedTest
+    @MethodSource("inputProviders")
+    public void testLessThan(NullsProvider nullsProvider, boolean dictionaryEncoded)
+    {
+        List<Page> inputPages = createInputPages(nullsProvider, dictionaryEncoded);
+        // constant < col
+        RowExpression lessThanFilter = call(
+                FUNCTION_RESOLUTION.resolveOperator(LESS_THAN, ImmutableList.of(INTEGER, INTEGER)),
+                constant(CONSTANT, INTEGER),
+                field(INT_CHANNEL_A, INTEGER));
+        assertThatColumnarFilterEvaluationIsSupported(lessThanFilter);
+        verifyFilter(inputPages, lessThanFilter);
+
+        // col < constant
+        lessThanFilter = call(
+                FUNCTION_RESOLUTION.resolveOperator(LESS_THAN, ImmutableList.of(DOUBLE, DOUBLE)),
+                field(DOUBLE_CHANNEL, DOUBLE),
+                constant((double) CONSTANT, DOUBLE));
+        assertThatColumnarFilterEvaluationIsSupported(lessThanFilter);
+        verifyFilter(inputPages, lessThanFilter);
+
+        // colA < colB
+        lessThanFilter = call(
+                FUNCTION_RESOLUTION.resolveOperator(LESS_THAN, ImmutableList.of(INTEGER, INTEGER)),
+                field(INT_CHANNEL_C, INTEGER),
+                field(INT_CHANNEL_A, INTEGER));
+        assertThatColumnarFilterEvaluationIsSupported(lessThanFilter);
+        verifyFilter(inputPages, lessThanFilter);
+    }
+
+    @ParameterizedTest
+    @MethodSource("inputProviders")
+    public void testBetween(NullsProvider nullsProvider, boolean dictionaryEncoded)
+    {
+        List<Page> inputPages = createInputPages(nullsProvider, dictionaryEncoded);
+        // col BETWEEN constantA AND constantB
+        RowExpression betweenFilter = new SpecialForm(
+                BETWEEN,
+                BOOLEAN,
+                ImmutableList.of(field(INT_CHANNEL_A, INTEGER), constant(CONSTANT - 5, INTEGER), constant(CONSTANT + 5, INTEGER)),
+                ImmutableList.of(FUNCTION_RESOLUTION.resolveOperator(LESS_THAN_OR_EQUAL, ImmutableList.of(INTEGER, INTEGER))));
+        assertThatColumnarFilterEvaluationIsSupported(betweenFilter);
+        verifyFilter(inputPages, betweenFilter);
+
+        // colA BETWEEN colB AND constant
+        betweenFilter = new SpecialForm(
+                BETWEEN,
+                BOOLEAN,
+                ImmutableList.of(field(INT_CHANNEL_A, INTEGER), field(INT_CHANNEL_B, INTEGER), constant(CONSTANT + 5, INTEGER)),
+                ImmutableList.of(FUNCTION_RESOLUTION.resolveOperator(LESS_THAN_OR_EQUAL, ImmutableList.of(INTEGER, INTEGER))));
+        assertThatColumnarFilterEvaluationIsSupported(betweenFilter);
+        verifyFilter(inputPages, betweenFilter);
+
+        // colA BETWEEN colB AND colC
+        betweenFilter = new SpecialForm(
+                BETWEEN,
+                BOOLEAN,
+                ImmutableList.of(field(INT_CHANNEL_A, INTEGER), field(INT_CHANNEL_B, INTEGER), field(INT_CHANNEL_C, INTEGER)),
+                ImmutableList.of(FUNCTION_RESOLUTION.resolveOperator(LESS_THAN_OR_EQUAL, ImmutableList.of(INTEGER, INTEGER))));
+        assertThatColumnarFilterEvaluationIsSupported(betweenFilter);
+        verifyFilter(inputPages, betweenFilter);
+    }
+
+    @ParameterizedTest
+    @MethodSource("inputProviders")
+    public void testOr(NullsProvider nullsProvider, boolean dictionaryEncoded)
+    {
+        List<Page> inputPages = createInputPages(nullsProvider, dictionaryEncoded);
+        ResolvedFunction customIsDistinctFrom = FUNCTION_RESOLUTION.functionCallBuilder("custom_is_distinct_from")
+                .addArgument(INTEGER, new Reference(INTEGER, "left"))
+                .addArgument(INTEGER, new Reference(INTEGER, "right"))
+                .build()
+                .function();
+        RowExpression orFilter = new SpecialForm(
+                OR,
+                BOOLEAN,
+                ImmutableList.of(
+                        call(
+                                customIsDistinctFrom,
+                                field(INT_CHANNEL_A, INTEGER),
+                                constant(CONSTANT - 5, INTEGER)),
+                        call(
+                                customIsDistinctFrom,
+                                field(INT_CHANNEL_C, INTEGER),
+                                constant(CONSTANT + 5, INTEGER)),
+                        call(
+                                customIsDistinctFrom,
+                                field(INT_CHANNEL_B, INTEGER),
+                                constant(CONSTANT, INTEGER))),
+                ImmutableList.of());
+        assertThatColumnarFilterEvaluationIsSupported(orFilter);
+        verifyFilter(inputPages, orFilter);
+    }
+
+    @ParameterizedTest
+    @MethodSource("inputProviders")
+    public void testAnd(NullsProvider nullsProvider, boolean dictionaryEncoded)
+    {
+        List<Page> inputPages = createInputPages(nullsProvider, dictionaryEncoded);
+        ResolvedFunction customIsDistinctFromIntegers = FUNCTION_RESOLUTION.functionCallBuilder("custom_is_distinct_from")
+                .addArgument(INTEGER, new Reference(INTEGER, "left"))
+                .addArgument(INTEGER, new Reference(INTEGER, "right"))
+                .build()
+                .function();
+        ResolvedFunction customIsDistinctFromVarchars = FUNCTION_RESOLUTION.functionCallBuilder("custom_is_distinct_from")
+                .addArgument(VARCHAR, new Reference(VARCHAR, "left"))
+                .addArgument(VARCHAR, new Reference(VARCHAR, "right"))
+                .build()
+                .function();
+        RowExpression andFilter = new SpecialForm(
+                AND,
+                BOOLEAN,
+                ImmutableList.of(
+                        call(
+                                customIsDistinctFromIntegers,
+                                field(INT_CHANNEL_A, INTEGER),
+                                constant(CONSTANT - 5, INTEGER)),
+                        call(
+                                customIsDistinctFromVarchars,
+                                field(STRING_CHANNEL, VARCHAR),
+                                constant(Slices.utf8Slice(Long.toString(CONSTANT + 5)), VARCHAR)),
+                        call(
+                                customIsDistinctFromIntegers,
+                                field(INT_CHANNEL_B, INTEGER),
+                                constant(CONSTANT, INTEGER))),
+                ImmutableList.of());
+        assertThatColumnarFilterEvaluationIsSupported(andFilter);
+        verifyFilter(inputPages, andFilter);
+    }
+
+    @ParameterizedTest
+    @MethodSource("inputProviders")
+    public void testIn(NullsProvider nullsProvider, boolean dictionaryEncoded)
+    {
+        List<Page> inputPages = createInputPages(nullsProvider, dictionaryEncoded);
+        List<ResolvedFunction> functionalDependencies = getInFunctionalDependencies(INTEGER);
+        // INTEGER type with small number of constants
+        List<RowExpression> arguments = ImmutableList.<RowExpression>builder()
+                .add(field(INT_CHANNEL_A, INTEGER))
+                .add(constant(null, INTEGER))
+                .addAll(buildConstantsList(INTEGER, 3))
+                .build();
+        RowExpression inFilter = new SpecialForm(IN, BOOLEAN, arguments, functionalDependencies);
+        assertThatColumnarFilterEvaluationIsSupported(inFilter);
+        verifyFilter(inputPages, inFilter);
+
+        // INTEGER type with large number of constants
+        arguments = ImmutableList.<RowExpression>builder()
+                .add(field(INT_CHANNEL_A, INTEGER))
+                .add(constant(null, INTEGER))
+                .addAll(buildConstantsList(INTEGER, 100))
+                .build();
+        inFilter = new SpecialForm(IN, BOOLEAN, arguments, functionalDependencies);
+        assertThatColumnarFilterEvaluationIsSupported(inFilter);
+        verifyFilter(inputPages, inFilter);
+
+        functionalDependencies = getInFunctionalDependencies(VARCHAR);
+        // VARCHAR type with small number of constants
+        arguments = ImmutableList.<RowExpression>builder()
+                .add(field(STRING_CHANNEL, VARCHAR))
+                .add(constant(null, VARCHAR))
+                .addAll(buildConstantsList(VARCHAR, 3))
+                .build();
+        inFilter = new SpecialForm(IN, BOOLEAN, arguments, functionalDependencies);
+        assertThatColumnarFilterEvaluationIsSupported(inFilter);
+        verifyFilter(inputPages, inFilter);
+
+        // VARCHAR type with large number of constants
+        arguments = ImmutableList.<RowExpression>builder()
+                .add(field(STRING_CHANNEL, VARCHAR))
+                .add(constant(null, VARCHAR))
+                .addAll(buildConstantsList(VARCHAR, 100))
+                .build();
+        inFilter = new SpecialForm(IN, BOOLEAN, arguments, functionalDependencies);
+        assertThatColumnarFilterEvaluationIsSupported(inFilter);
+        verifyFilter(inputPages, inFilter);
+    }
+
+    @ParameterizedTest
+    @MethodSource("inputProviders")
+    public void testInStructuralType(NullsProvider nullsProvider)
+    {
+        List<Page> inputPages = createInputPages(nullsProvider, false);
+        List<ResolvedFunction> functionalDependencies = getInFunctionalDependencies(ARRAY_CHANNEL_TYPE);
+        // Structural type with indeterminate constants and small list
+        List<RowExpression> arguments = ImmutableList.<RowExpression>builder()
+                .add(field(ARRAY_CHANNEL, ARRAY_CHANNEL_TYPE))
+                .add(constant(null, ARRAY_CHANNEL_TYPE))
+                .add(constant(createIntArray(), ARRAY_CHANNEL_TYPE))
+                .add(constant(createIntArray(CONSTANT, null), ARRAY_CHANNEL_TYPE))
+                .add(constant(createIntArray(CONSTANT + 2), ARRAY_CHANNEL_TYPE))
+                .add(constant(createIntArray(CONSTANT, CONSTANT + 1), ARRAY_CHANNEL_TYPE))
+                .build();
+        RowExpression inFilter = new SpecialForm(IN, BOOLEAN, arguments, functionalDependencies);
+        // Structural types in "IN" clause are not supported for columnar evaluation yet
+        assertThatColumnarFilterEvaluationIsNotSupported(inFilter);
+        verifyFilter(inputPages, inFilter);
+
+        // Structural type with indeterminate constants and large list
+        arguments = ImmutableList.<RowExpression>builder()
+                .add(field(ARRAY_CHANNEL, ARRAY_CHANNEL_TYPE))
+                .add(constant(null, ARRAY_CHANNEL_TYPE))
+                .add(constant(createIntArray(), ARRAY_CHANNEL_TYPE))
+                .add(constant(createIntArray(CONSTANT, null), ARRAY_CHANNEL_TYPE))
+                .add(constant(createIntArray(CONSTANT + 2), ARRAY_CHANNEL_TYPE))
+                .add(constant(createIntArray(CONSTANT, CONSTANT + 1), ARRAY_CHANNEL_TYPE))
+                .add(constant(createIntArray(CONSTANT, CONSTANT + 1, CONSTANT + 2), ARRAY_CHANNEL_TYPE))
+                .add(constant(createIntArray(CONSTANT + 2, null), ARRAY_CHANNEL_TYPE))
+                .add(constant(createIntArray(CONSTANT - 2, CONSTANT, CONSTANT - 1), ARRAY_CHANNEL_TYPE))
+                .add(constant(createIntArray(CONSTANT, CONSTANT + 1), ARRAY_CHANNEL_TYPE))
+                .build();
+        inFilter = new SpecialForm(IN, BOOLEAN, arguments, functionalDependencies);
+        // Structural types in "IN" clause are not supported for columnar evaluation yet
+        assertThatColumnarFilterEvaluationIsNotSupported(inFilter);
+        verifyFilter(inputPages, inFilter);
+    }
+
+    public enum NullsProvider
+    {
+        NO_NULLS {
+            @Override
+            Optional<boolean[]> getNulls(int positionCount)
+            {
+                return Optional.empty();
+            }
+        },
+        NO_NULLS_WITH_MAY_HAVE_NULL {
+            @Override
+            Optional<boolean[]> getNulls(int positionCount)
+            {
+                return Optional.of(new boolean[positionCount]);
+            }
+        },
+        ALL_NULLS {
+            @Override
+            Optional<boolean[]> getNulls(int positionCount)
+            {
+                boolean[] nulls = new boolean[positionCount];
+                Arrays.fill(nulls, true);
+                return Optional.of(nulls);
+            }
+        },
+        RANDOM_NULLS {
+            @Override
+            Optional<boolean[]> getNulls(int positionCount)
+            {
+                boolean[] nulls = new boolean[positionCount];
+                for (int i = 0; i < positionCount; i++) {
+                    nulls[i] = RANDOM.nextBoolean();
+                }
+                return Optional.of(nulls);
+            }
+        },
+        GROUPED_NULLS {
+            @Override
+            Optional<boolean[]> getNulls(int positionCount)
+            {
+                boolean[] nulls = new boolean[positionCount];
+                int maxGroupSize = 23;
+                int position = 0;
+                while (position < positionCount) {
+                    int remaining = positionCount - position;
+                    int groupSize = Math.min(RANDOM.nextInt(maxGroupSize) + 1, remaining);
+                    Arrays.fill(nulls, position, position + groupSize, RANDOM.nextBoolean());
+                    position += groupSize;
+                }
+                return Optional.of(nulls);
+            }
+        };
+
+        abstract Optional<boolean[]> getNulls(int positionCount);
+    }
+
+    private static Object[][] inputProviders()
+    {
+        return cartesianProduct(nullsProviders(), trueFalse());
+    }
+
+    private static Object[][] nullsProviders()
+    {
+        return Stream.of(NullsProvider.values()).collect(toDataProvider());
+    }
+
+    private static RowExpression createNotExpression(RowExpression expression)
+    {
+        return call(FUNCTION_RESOLUTION.resolveFunction("$not", fromTypes(BOOLEAN)), expression);
+    }
+
+    private static List<Page> processFilter(List<Page> inputPages, boolean columnarEvaluationEnabled, RowExpression filter)
+    {
+        PageProcessor compiledProcessor = FUNCTION_RESOLUTION.getExpressionCompiler().compilePageProcessor(
+                        columnarEvaluationEnabled,
+                        Optional.of(filter),
+                        ImmutableList.of(field(ROW_NUM_CHANNEL, BIGINT)),
+                        Optional.empty())
+                .get();
+        LocalMemoryContext context = newSimpleAggregatedMemoryContext().newLocalMemoryContext(PageProcessor.class.getSimpleName());
+        ImmutableList.Builder<Page> outputPagesBuilder = ImmutableList.builder();
+        for (Page inputPage : inputPages) {
+            WorkProcessor<Page> workProcessor = compiledProcessor.createWorkProcessor(
+                    FULL_CONNECTOR_SESSION,
+                    new DriverYieldSignal(),
+                    context,
+                    new PageProcessorMetrics(),
+                    inputPage);
+            if (workProcessor.process() && !workProcessor.isFinished()) {
+                outputPagesBuilder.add(workProcessor.getResult());
+            }
+        }
+        return outputPagesBuilder.build();
+    }
+
+    private static List<Page> createInputPages(NullsProvider nullsProvider, boolean dictionaryEncoded)
+    {
+        ImmutableList.Builder<Page> builder = ImmutableList.builder();
+        long rowCount = 0;
+        for (int pageCount = 0; pageCount < 20; pageCount++) {
+            int positionsCount = RANDOM.nextInt(1024, 8192);
+            long finalRowCount = rowCount;
+            builder.add(new Page(
+                    positionsCount,
+                    createRowNumberBlock(finalRowCount, positionsCount),
+                    lazyBlock(positionsCount, () -> createDoublesBlock(positionsCount, nullsProvider, dictionaryEncoded)),
+                    lazyBlock(positionsCount, () -> createIntsBlock(positionsCount, nullsProvider, dictionaryEncoded)),
+                    lazyBlock(positionsCount, () -> createStringsBlock(positionsCount, nullsProvider, dictionaryEncoded)),
+                    lazyBlock(positionsCount, () -> createIntsBlock(positionsCount, nullsProvider, dictionaryEncoded)),
+                    lazyBlock(positionsCount, () -> createIntsBlock(positionsCount, nullsProvider, dictionaryEncoded)),
+                    lazyBlock(positionsCount, () -> createArraysBlock(positionsCount, nullsProvider))));
+            rowCount += positionsCount;
+        }
+        return builder.build();
+    }
+
+    private static Block lazyBlock(int positionCount, LazyBlockLoader loader)
+    {
+        return new LazyBlock(positionCount, loader);
+    }
+
+    private static Block createRowNumberBlock(long start, int positionsCount)
+    {
+        long[] values = new long[positionsCount];
+        for (int i = 0; i < positionsCount; i++) {
+            values[i] = start + i;
+        }
+        return new LongArrayBlock(positionsCount, Optional.empty(), values);
+    }
+
+    private static Block createIntsBlock(int positionsCount, NullsProvider nullsProvider, boolean dictionaryEncoded)
+    {
+        if (dictionaryEncoded) {
+            boolean containsNulls = nullsProvider != NullsProvider.NO_NULLS && nullsProvider != NullsProvider.NO_NULLS_WITH_MAY_HAVE_NULL;
+            int nonNullDictionarySize = 20;
+            int dictionarySize = nonNullDictionarySize + (containsNulls ? 1 : 0); // last element in dictionary denotes null
+            int[] dictionaryValues = new int[dictionarySize];
+            for (int i = 0; i < nonNullDictionarySize; i++) {
+                dictionaryValues[i] = toIntExact(CONSTANT - 10 + i);
+            }
+            Optional<boolean[]> dictionaryIsNull = getDictionaryIsNull(nullsProvider, dictionarySize);
+            Block dictionary = new IntArrayBlock(dictionarySize, dictionaryIsNull, dictionaryValues);
+            return createDictionaryBlock(positionsCount, nullsProvider, dictionary);
+        }
+
+        Optional<boolean[]> isNull = nullsProvider.getNulls(positionsCount);
+        assertThat(isNull.isEmpty() || isNull.get().length == positionsCount).isTrue();
+        int[] values = new int[positionsCount];
+        for (int i = 0; i < positionsCount; i++) {
+            if (isNull.isEmpty() || !isNull.get()[i]) {
+                values[i] = toIntExact(RANDOM.nextLong(CONSTANT - 10, CONSTANT + 10));
+            }
+        }
+        return new IntArrayBlock(positionsCount, isNull, values);
+    }
+
+    private static Block createDoublesBlock(int positionsCount, NullsProvider nullsProvider, boolean dictionaryEncoded)
+    {
+        if (dictionaryEncoded) {
+            boolean containsNulls = nullsProvider != NullsProvider.NO_NULLS && nullsProvider != NullsProvider.NO_NULLS_WITH_MAY_HAVE_NULL;
+            int nonNullDictionarySize = 200;
+            int dictionarySize = nonNullDictionarySize + (containsNulls ? 1 : 0); // last element in dictionary denotes null
+            long[] dictionaryValues = new long[dictionarySize];
+            for (int i = 0; i < nonNullDictionarySize; i++) {
+                dictionaryValues[i] = doubleToLongBits(CONSTANT - 100 + i);
+            }
+            Optional<boolean[]> dictionaryIsNull = getDictionaryIsNull(nullsProvider, dictionarySize);
+            Block dictionary = new LongArrayBlock(dictionarySize, dictionaryIsNull, dictionaryValues);
+            return createDictionaryBlock(positionsCount, nullsProvider, dictionary);
+        }
+
+        Optional<boolean[]> isNull = nullsProvider.getNulls(positionsCount);
+        assertThat(isNull.isEmpty() || isNull.get().length == positionsCount).isTrue();
+        long[] values = new long[positionsCount];
+        for (int i = 0; i < positionsCount; i++) {
+            if (isNull.isEmpty() || !isNull.get()[i]) {
+                values[i] = doubleToLongBits(RANDOM.nextDouble(CONSTANT - 100, CONSTANT + 100));
+            }
+        }
+        return new LongArrayBlock(positionsCount, isNull, values);
+    }
+
+    private static Block createStringsBlock(int positionsCount, NullsProvider nullsProvider, boolean dictionaryEncoded)
+    {
+        if (dictionaryEncoded) {
+            boolean containsNulls = nullsProvider != NullsProvider.NO_NULLS && nullsProvider != NullsProvider.NO_NULLS_WITH_MAY_HAVE_NULL;
+            int nonNullDictionarySize = 20;
+            int dictionarySize = nonNullDictionarySize + (containsNulls ? 1 : 0); // last element in dictionary denotes null
+            VariableWidthBlockBuilder builder = new VariableWidthBlockBuilder(null, dictionarySize, dictionarySize * 10);
+            for (int i = 0; i < nonNullDictionarySize; i++) {
+                builder.writeEntry(Slices.utf8Slice(Long.toString(CONSTANT - 10 + i)));
+            }
+            if (containsNulls) {
+                builder.appendNull();
+            }
+            return createDictionaryBlock(positionsCount, nullsProvider, builder.build());
+        }
+
+        Optional<boolean[]> isNull = nullsProvider.getNulls(positionsCount);
+        assertThat(isNull.isEmpty() || isNull.get().length == positionsCount).isTrue();
+        VariableWidthBlockBuilder builder = new VariableWidthBlockBuilder(null, positionsCount, positionsCount * 10);
+        for (int i = 0; i < positionsCount; i++) {
+            if (isNull.isPresent() && isNull.get()[i]) {
+                builder.appendNull();
+            }
+            else {
+                builder.writeEntry(Slices.utf8Slice(Long.toString(RANDOM.nextLong(CONSTANT - 10, CONSTANT + 10))));
+            }
+        }
+        return builder.build();
+    }
+
+    private static Block createArraysBlock(int positionsCount, NullsProvider nullsProvider)
+    {
+        ArrayBlockBuilder builder = new ArrayBlockBuilder(INTEGER, null, positionsCount);
+        Optional<boolean[]> isNull = nullsProvider.getNulls(positionsCount);
+        assertThat(isNull.isEmpty() || isNull.get().length == positionsCount).isTrue();
+        for (int position = 0; position < positionsCount; position++) {
+            if (isNull.isPresent() && isNull.get()[position]) {
+                builder.appendNull();
+            }
+            else {
+                builder.buildEntry(elementBuilder -> {
+                    int valuesCount = RANDOM.nextInt(4);
+                    for (int i = 0; i < valuesCount; i++) {
+                        INTEGER.writeInt(elementBuilder, toIntExact(CONSTANT + i));
+                    }
+                    // Add a NULL value in the array 10% of the time
+                    if (RANDOM.nextInt(100) < 10) {
+                        elementBuilder.appendNull();
+                    }
+                });
+            }
+        }
+        return builder.build();
+    }
+
+    private static Optional<boolean[]> getDictionaryIsNull(NullsProvider nullsProvider, int dictionarySize)
+    {
+        Optional<boolean[]> dictionaryIsNull = Optional.empty();
+        if (nullsProvider != NullsProvider.NO_NULLS) {
+            dictionaryIsNull = Optional.of(new boolean[dictionarySize]);
+            if (nullsProvider != NullsProvider.NO_NULLS_WITH_MAY_HAVE_NULL) {
+                dictionaryIsNull.get()[dictionarySize - 1] = true;
+            }
+        }
+        return dictionaryIsNull;
+    }
+
+    private static Block createDictionaryBlock(int positionsCount, NullsProvider nullsProvider, Block dictionary)
+    {
+        Optional<boolean[]> isNull = nullsProvider.getNulls(positionsCount);
+        assertThat(isNull.isEmpty() || isNull.get().length == positionsCount).isTrue();
+        boolean containsNulls = nullsProvider != NullsProvider.NO_NULLS && nullsProvider != NullsProvider.NO_NULLS_WITH_MAY_HAVE_NULL;
+        int dictionarySize = dictionary.getPositionCount();
+        int nonNullDictionarySize = dictionarySize - (containsNulls ? 1 : 0);
+        int[] ids = new int[positionsCount];
+        for (int i = 0; i < positionsCount; i++) {
+            if (isNull.isPresent() && isNull.get()[i]) {
+                ids[i] = dictionarySize - 1;
+            }
+            else {
+                ids[i] = RANDOM.nextInt(nonNullDictionarySize);
+            }
+        }
+        return DictionaryBlock.create(positionsCount, dictionary, ids);
+    }
+
+    private static List<ResolvedFunction> getInFunctionalDependencies(Type type)
+    {
+        return ImmutableList.of(
+                FUNCTION_RESOLUTION.resolveOperator(EQUAL, ImmutableList.of(type, type)),
+                FUNCTION_RESOLUTION.resolveOperator(HASH_CODE, ImmutableList.of(type)),
+                FUNCTION_RESOLUTION.resolveOperator(INDETERMINATE, ImmutableList.of(type)));
+    }
+
+    private static List<RowExpression> buildConstantsList(Type type, int size)
+    {
+        ImmutableList.Builder<RowExpression> builder = ImmutableList.builder();
+        for (long i = 0; i < size; i++) {
+            if (type == INTEGER) {
+                builder.add(constant(CONSTANT + i, type));
+            }
+            else if (type == VARCHAR) {
+                builder.add(constant(Slices.utf8Slice(Long.toString(RANDOM.nextLong(CONSTANT + i))), type));
+            }
+            else {
+                throw new UnsupportedOperationException();
+            }
+        }
+        return builder.build();
+    }
+
+    private static Block createIntArray(Long... values)
+    {
+        IntArrayBlockBuilder builder = new IntArrayBlockBuilder(null, values.length);
+        for (Long value : values) {
+            if (value == null) {
+                builder.appendNull();
+            }
+            else {
+                INTEGER.writeInt(builder, toIntExact(value));
+            }
+        }
+        return builder.build();
+    }
+
+    private static void verifyFilter(List<Page> inputPages, RowExpression filter)
+    {
+        // Tests the ColumnarFilter#filterPositionsRange implementation
+        verifyFilterInternal(inputPages, filter);
+
+        // Tests the ColumnarFilter#filterPositionsList implementation
+        ResolvedFunction customIsDistinctFrom = FUNCTION_RESOLUTION.functionCallBuilder("custom_is_distinct_from")
+                .addArgument(INTEGER, new Reference(INTEGER, "left"))
+                .addArgument(INTEGER, new Reference(INTEGER, "right"))
+                .build()
+                .function();
+        RowExpression andFilter = new SpecialForm(
+                AND,
+                BOOLEAN,
+                ImmutableList.of(call(customIsDistinctFrom, constant(CONSTANT + 3, INTEGER), field(INT_CHANNEL_A, INTEGER)), filter),
+                ImmutableList.of());
+        // Adding an IS DISTINCT FROM filter first creates a list of filtered positions as input to
+        // the filter implementation being tested while also keeping NULLs as input
+        verifyFilterInternal(inputPages, andFilter);
+    }
+
+    private static void verifyFilterInternal(List<Page> inputPages, RowExpression filter)
+    {
+        List<Page> outputPagesExpected = processFilter(inputPages, false, filter);
+        List<Page> outputPagesActual = processFilter(inputPages, true, filter);
+        assertThat(outputPagesExpected.size()).isEqualTo(outputPagesActual.size());
+
+        for (int pageCount = 0; pageCount < outputPagesActual.size(); pageCount++) {
+            assertPageEquals(ImmutableList.of(BIGINT), outputPagesActual.get(pageCount), outputPagesExpected.get(pageCount));
+        }
+    }
+
+    private static void assertPageEquals(List<Type> types, Page actual, Page expected)
+    {
+        assertThat(actual.getChannelCount()).isEqualTo(expected.getChannelCount());
+        assertThat(actual.getPositionCount()).isEqualTo(expected.getPositionCount());
+        assertThat(types.size()).isEqualTo(actual.getChannelCount());
+
+        for (int channel = 0; channel < types.size(); channel++) {
+            assertBlockEquals(types.get(channel), actual.getBlock(channel), expected.getBlock(channel));
+        }
+    }
+
+    private static void assertThatColumnarFilterEvaluationIsSupported(RowExpression filterExpression)
+    {
+        assertThat(createColumnarFilterEvaluator(filterExpression, COMPILER)).isPresent();
+    }
+
+    private static void assertThatColumnarFilterEvaluationIsNotSupported(RowExpression filterExpression)
+    {
+        assertThat(createColumnarFilterEvaluator(filterExpression, COMPILER)).isEmpty();
+    }
+
+    @ScalarFunction("custom_is_distinct_from")
+    public static final class CustomIsDistinctFrom
+    {
+        private CustomIsDistinctFrom() {}
+
+        @TypeParameter("T")
+        @SqlType(StandardTypes.BOOLEAN)
+        public static boolean isDistinctFromLong(@SqlNullable @SqlType("T") Long left, @SqlNullable @SqlType("T") Long right)
+        {
+            if (left == null && right == null) {
+                return false;
+            }
+            if (left == null || right == null) {
+                return true;
+            }
+            return left.equals(right);
+        }
+
+        @TypeParameter("T")
+        @SqlType(StandardTypes.BOOLEAN)
+        public static boolean isDistinctFromSlice(@SqlNullable @SqlType("T") Slice left, @SqlNullable @SqlType("T") Slice right)
+        {
+            if (left == null && right == null) {
+                return false;
+            }
+            if (left == null || right == null) {
+                return true;
+            }
+            return left.equals(right);
+        }
+    }
+
+    @ScalarFunction("custom_is_null")
+    public static final class NullableReturnFunction
+    {
+        private NullableReturnFunction() {}
+
+        @LiteralParameters("x")
+        @SqlType(StandardTypes.BOOLEAN)
+        @SqlNullable
+        public static Boolean customIsNullVarchar(@SqlNullable @SqlType("varchar(x)") Slice slice)
+        {
+            return slice == null ? null : false;
+        }
+    }
+
+    @ScalarFunction("is_user_admin")
+    public static final class ConnectorSessionFunction
+    {
+        private ConnectorSessionFunction() {}
+
+        @LiteralParameters("x")
+        @SqlType(StandardTypes.BOOLEAN)
+        public static boolean isUserAdmin(ConnectorSession session)
+        {
+            return "admin".equals(session.getUser());
+        }
+    }
+
+    @ScalarFunction("is_answer_to_universe")
+    public static final class InstanceFactoryFunction
+    {
+        private final long precomputed;
+
+        public InstanceFactoryFunction()
+        {
+            this.precomputed = Long.parseLong("42");
+        }
+
+        @SqlType(StandardTypes.BOOLEAN)
+        public boolean isAnswerToUniverse(@SqlType(StandardTypes.INTEGER) long value)
+        {
+            return precomputed == value;
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestDictionaryAwareColumnarFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestDictionaryAwareColumnarFilter.java
@@ -1,0 +1,329 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.gen;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.FullConnectorSession;
+import io.trino.operator.project.InputChannels;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.DictionaryBlock;
+import io.trino.spi.block.LongArrayBlock;
+import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.sql.gen.columnar.ColumnarFilter;
+import io.trino.sql.gen.columnar.DictionaryAwareColumnarFilter;
+import io.trino.testing.TestingSession;
+import it.unimi.dsi.fastutil.ints.IntArraySet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+
+import static io.airlift.testing.Assertions.assertInstanceOf;
+import static io.trino.block.BlockAssertions.createLongSequenceBlock;
+import static io.trino.block.BlockAssertions.createLongsBlock;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestDictionaryAwareColumnarFilter
+{
+    private static final FullConnectorSession FULL_CONNECTOR_SESSION = new FullConnectorSession(
+            TestingSession.testSessionBuilder().build(),
+            ConnectorIdentity.ofUser("test"));
+
+    @Test
+    public void testGetInputChannels()
+    {
+        DictionaryAwareColumnarFilter filter = new DictionaryAwareColumnarFilter(new ColumnarFilter() {
+            @Override
+            public int filterPositionsRange(ConnectorSession session, int[] outputPositions, int offset, int size, Page loadedPage)
+            {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public int filterPositionsList(ConnectorSession session, int[] outputPositions, int[] activePositions, int offset, int size, Page loadedPage)
+            {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public InputChannels getInputChannels()
+            {
+                return new InputChannels(3);
+            }
+        });
+        assertThat(filter.getInputChannels().getInputChannels()).isEqualTo(ImmutableList.of(3));
+    }
+
+    @Test
+    public void testSimpleBlock()
+    {
+        Block block = createLongSequenceBlock(0, 100);
+        testFilter(block, LongArrayBlock.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("io.trino.testing.DataProviders#trueFalse")
+    public void testRleBlock(boolean usePositionsList)
+    {
+        testRleBlock(true, usePositionsList);
+        testRleBlock(false, usePositionsList);
+    }
+
+    private static void testRleBlock(boolean filterRange, boolean usePositionsList)
+    {
+        DictionaryAwareColumnarFilter filter = createDictionaryAwareColumnarFilter(filterRange, LongArrayBlock.class);
+        RunLengthEncodedBlock match = (RunLengthEncodedBlock) RunLengthEncodedBlock.create(createLongSequenceBlock(4, 5), 100);
+        testFilter(filter, match, filterRange, usePositionsList);
+        RunLengthEncodedBlock noMatch = (RunLengthEncodedBlock) RunLengthEncodedBlock.create(createLongSequenceBlock(0, 1), 100);
+        testFilter(filter, noMatch, filterRange, usePositionsList);
+    }
+
+    @ParameterizedTest
+    @MethodSource("io.trino.testing.DataProviders#trueFalse")
+    public void testRleBlockWithFailure(boolean usePositionsList)
+    {
+        DictionaryAwareColumnarFilter filter = createDictionaryAwareColumnarFilter(true, LongArrayBlock.class);
+        RunLengthEncodedBlock fail = (RunLengthEncodedBlock) RunLengthEncodedBlock.create(createLongSequenceBlock(-10, -9), 100);
+        assertThatThrownBy(() -> testFilter(filter, fail, true, usePositionsList))
+                .isInstanceOf(NegativeValueException.class)
+                .hasMessage("value is negative: -10");
+    }
+
+    @Test
+    public void testDictionaryBlock()
+    {
+        // match some
+        testFilter(createDictionaryBlock(20, 100), LongArrayBlock.class);
+
+        // match none
+        testFilter(createDictionaryBlock(20, 0), LongArrayBlock.class);
+
+        // match all
+        testFilter(DictionaryBlock.create(100, createLongSequenceBlock(4, 5), new int[100]), LongArrayBlock.class);
+    }
+
+    @Test
+    public void testDictionaryBlockWithFailure()
+    {
+        assertThatThrownBy(() -> testFilter(createDictionaryBlockWithFailure(20, 100), LongArrayBlock.class))
+                .isInstanceOf(NegativeValueException.class)
+                .hasMessage("value is negative: -10");
+    }
+
+    @Test
+    public void testDictionaryBlockProcessingWithUnusedFailure()
+    {
+        // match some
+        testFilter(createDictionaryBlockWithUnusedEntries(20, 100), DictionaryBlock.class);
+
+        // match none, blockSize must be > 1 to actually create a DictionaryBlock
+        testFilter(createDictionaryBlockWithUnusedEntries(20, 2), DictionaryBlock.class);
+
+        // match all
+        testFilter(DictionaryBlock.create(100, createLongsBlock(4, 5, -1), new int[100]), DictionaryBlock.class);
+    }
+
+    private static Block createDictionaryBlock(int dictionarySize, int blockSize)
+    {
+        Block dictionary = createLongSequenceBlock(0, dictionarySize);
+        int[] ids = new int[blockSize];
+        Arrays.setAll(ids, index -> index % dictionarySize);
+        return DictionaryBlock.create(ids.length, dictionary, ids);
+    }
+
+    private static Block createDictionaryBlockWithFailure(int dictionarySize, int blockSize)
+    {
+        Block dictionary = createLongSequenceBlock(-10, dictionarySize - 10);
+        int[] ids = new int[blockSize];
+        Arrays.setAll(ids, index -> index % dictionarySize);
+        return DictionaryBlock.create(ids.length, dictionary, ids);
+    }
+
+    private static Block createDictionaryBlockWithUnusedEntries(int dictionarySize, int blockSize)
+    {
+        Block dictionary = createLongSequenceBlock(-10, dictionarySize);
+        int[] ids = new int[blockSize];
+        Arrays.setAll(ids, index -> (index % dictionarySize) + 10);
+        return DictionaryBlock.create(ids.length, dictionary, ids);
+    }
+
+    private static void testFilter(Block block, Class<? extends Block> expectedType)
+    {
+        testFilter(block, true, true, expectedType);
+        testFilter(block, true, false, expectedType);
+        testFilter(block, false, true, expectedType);
+        testFilter(block, false, false, expectedType);
+    }
+
+    private static void testFilter(Block block, boolean selectRange, boolean usePositionsList, Class<? extends Block> expectedType)
+    {
+        DictionaryAwareColumnarFilter filter = createDictionaryAwareColumnarFilter(selectRange, expectedType);
+        testFilter(filter, block, selectRange, usePositionsList);
+        // exercise dictionary caching code
+        testFilter(filter, block, selectRange, usePositionsList);
+    }
+
+    private static DictionaryAwareColumnarFilter createDictionaryAwareColumnarFilter(boolean selectRange, Class<? extends Block> expectedType)
+    {
+        return new DictionaryAwareColumnarFilter(new TestingDictionaryFilter(selectRange, expectedType));
+    }
+
+    private static void testFilter(DictionaryAwareColumnarFilter filter, Block block, boolean selectRange, boolean usePositionsList)
+    {
+        int[] outputPositions = new int[block.getPositionCount()];
+        int outputPositionsCount;
+        if (usePositionsList) {
+            outputPositionsCount = filter.filterPositionsList(FULL_CONNECTOR_SESSION, outputPositions, toPositionsList(0, block.getPositionCount()), 0, block.getPositionCount(), new Page(block));
+        }
+        else {
+            outputPositionsCount = filter.filterPositionsRange(FULL_CONNECTOR_SESSION, outputPositions, 0, block.getPositionCount(), new Page(block));
+        }
+        IntSet actualSelectedPositions = new IntArraySet(Arrays.copyOfRange(outputPositions, 0, outputPositionsCount));
+        IntSet expectedSelectedPositions = new IntArraySet(block.getPositionCount());
+        for (int position = 0; position < block.getPositionCount(); position++) {
+            if (isSelected(selectRange, BIGINT.getLong(block, position))) {
+                expectedSelectedPositions.add(position);
+            }
+        }
+        assertThat(actualSelectedPositions).isEqualTo(expectedSelectedPositions);
+    }
+
+    private static int[] toPositionsList(int offset, int length)
+    {
+        int[] positions = new int[length];
+        for (int index = 0; index < length; index++) {
+            positions[index] = offset + index;
+        }
+        return positions;
+    }
+
+    private static boolean isSelected(boolean filterRange, long value)
+    {
+        if (value < 0) {
+            throw new IllegalArgumentException("value is negative: " + value);
+        }
+
+        boolean selected;
+        if (filterRange) {
+            selected = value > 3 && value < 11;
+        }
+        else {
+            selected = value % 3 == 1;
+        }
+        return selected;
+    }
+
+    /**
+     * Filter for the dictionary.  This will fail if the input block is a DictionaryBlock
+     */
+    private static class TestingDictionaryFilter
+            implements ColumnarFilter
+    {
+        private final boolean selectRange;
+        private Class<? extends Block> expectedType;
+
+        public TestingDictionaryFilter(boolean selectRange, Class<? extends Block> expectedType)
+        {
+            this.selectRange = selectRange;
+            this.expectedType = expectedType;
+        }
+
+        public void setExpectedType(Class<? extends Block> expectedType)
+        {
+            this.expectedType = expectedType;
+        }
+
+        @Override
+        public InputChannels getInputChannels()
+        {
+            return new InputChannels(3);
+        }
+
+        @Override
+        public int filterPositionsRange(ConnectorSession session, int[] outputPositions, int offset, int size, Page loadedPage)
+        {
+            assertThat(loadedPage.getChannelCount()).isEqualTo(1);
+            Block block = loadedPage.getBlock(0);
+
+            int outputPositionsCount = 0;
+            for (int position = offset; position < offset + size; position++) {
+                long value = BIGINT.getLong(block, position);
+                verifyPositive(value);
+
+                boolean selected = isSelected(selectRange, value);
+                if (selected) {
+                    outputPositions[outputPositionsCount] = position;
+                    outputPositionsCount++;
+                }
+            }
+
+            // verify the input block is the expected type (this is to assure that
+            // dictionary processing enabled and disabled as expected)
+            // this check is performed last so that dictionary processing that fails
+            // is not checked (only the fall back processing is checked)
+            assertInstanceOf(block, expectedType);
+            return outputPositionsCount;
+        }
+
+        @Override
+        public int filterPositionsList(ConnectorSession session, int[] outputPositions, int[] activePositions, int offset, int size, Page loadedPage)
+        {
+            assertThat(loadedPage.getChannelCount()).isEqualTo(1);
+            Block block = loadedPage.getBlock(0);
+
+            int outputPositionsCount = 0;
+            for (int index = offset; index < offset + size; index++) {
+                int position = activePositions[index];
+                long value = BIGINT.getLong(block, position);
+                verifyPositive(value);
+
+                boolean selected = isSelected(selectRange, value);
+                if (selected) {
+                    outputPositions[outputPositionsCount] = position;
+                    outputPositionsCount++;
+                }
+            }
+
+            // verify the input block is the expected type (this is to assure that
+            // dictionary processing enabled and disabled as expected)
+            // this check is performed last so that dictionary processing that fails
+            // is not checked (only the fall back processing is checked)
+            assertInstanceOf(block, expectedType);
+            return outputPositionsCount;
+        }
+
+        private static void verifyPositive(long value)
+        {
+            if (value < 0) {
+                throw new NegativeValueException(value);
+            }
+        }
+    }
+
+    private static class NegativeValueException
+            extends RuntimeException
+    {
+        public NegativeValueException(long value)
+        {
+            super("value is negative: " + value);
+        }
+    }
+}

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -497,6 +497,18 @@
                                     <newValue>"lastEndTimeScaledDistribution"</newValue>
                                     <justification>added new stats</justification>
                                 </item>
+                                <item>
+                                    <code>java.method.addedToInterface</code>
+                                    <new>method java.util.Optional&lt;io.trino.spi.block.ByteArrayBlock&gt; io.trino.spi.block.ValueBlock::getNulls()</new>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityIncreased</code>
+                                    <new>method byte[] io.trino.spi.block.ByteArrayBlock::getRawValues()</new>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityIncreased</code>
+                                    <new>method int io.trino.spi.block.ByteArrayBlock::getRawValuesOffset()</new>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlock.java
@@ -416,6 +416,12 @@ public final class ArrayBlock
         return this;
     }
 
+    @Override
+    public Optional<ByteArrayBlock> getNulls()
+    {
+        return BlockUtil.getNulls(valueIsNull, arrayOffset, positionCount);
+    }
+
     public <T> T apply(ArrayBlockFunction<T> function, int position)
     {
         checkReadablePosition(this, position);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/BlockUtil.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/BlockUtil.java
@@ -17,6 +17,7 @@ import io.airlift.slice.Slice;
 import jakarta.annotation.Nullable;
 
 import java.util.Arrays;
+import java.util.Optional;
 
 import static java.lang.Math.ceil;
 import static java.lang.Math.clamp;
@@ -368,5 +369,26 @@ final class BlockUtil
             case ValueBlock valueBlock -> blockBuilder.appendRange(valueBlock, offset, length);
             case LazyBlock _ -> throw new IllegalStateException("Did not expect LazyBlock after loading " + rawBlock.getClass().getSimpleName());
         }
+    }
+
+    /**
+     * Ideally, the underlying nulls array in Block implementations should be a byte array instead of a boolean array.
+     * This method is used to perform that conversion until the Block implementations are changed.
+     */
+    static Optional<ByteArrayBlock> getNulls(@Nullable boolean[] valueIsNull, int arrayOffset, int positionCount)
+    {
+        if (valueIsNull == null) {
+            return Optional.empty();
+        }
+        byte[] booleansAsBytes = new byte[positionCount];
+        boolean foundAnyNull = false;
+        for (int i = 0; i < positionCount; i++) {
+            booleansAsBytes[i] = (byte) (valueIsNull[arrayOffset + i] ? 1 : 0);
+            foundAnyNull = foundAnyNull || valueIsNull[arrayOffset + i];
+        }
+        if (!foundAnyNull) {
+            return Optional.empty();
+        }
+        return Optional.of(new ByteArrayBlock(booleansAsBytes.length, Optional.empty(), booleansAsBytes));
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlock.java
@@ -73,6 +73,22 @@ public final class ByteArrayBlock
         retainedSizeInBytes = (INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values));
     }
 
+    /**
+     * Gets the raw byte array that keeps the actual data values.
+     */
+    public byte[] getRawValues()
+    {
+        return values;
+    }
+
+    /**
+     * Gets the offset into raw byte array where the data values start.
+     */
+    public int getRawValuesOffset()
+    {
+        return arrayOffset;
+    }
+
     @Override
     public long getSizeInBytes()
     {
@@ -226,23 +242,19 @@ public final class ByteArrayBlock
         return "ByteArrayBlock{positionCount=" + getPositionCount() + '}';
     }
 
+    @Override
+    public Optional<ByteArrayBlock> getNulls()
+    {
+        return BlockUtil.getNulls(valueIsNull, arrayOffset, positionCount);
+    }
+
     Slice getValuesSlice()
     {
         return Slices.wrappedBuffer(values, arrayOffset, positionCount);
     }
 
-    int getRawValuesOffset()
-    {
-        return arrayOffset;
-    }
-
     boolean[] getRawValueIsNull()
     {
         return valueIsNull;
-    }
-
-    byte[] getRawValues()
-    {
-        return values;
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Fixed12Block.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Fixed12Block.java
@@ -249,6 +249,12 @@ public final class Fixed12Block
         return "Fixed12Block{positionCount=" + getPositionCount() + '}';
     }
 
+    @Override
+    public Optional<ByteArrayBlock> getNulls()
+    {
+        return BlockUtil.getNulls(valueIsNull, positionOffset, positionCount);
+    }
+
     /**
      * At position * 3 in the values, write a little endian long followed by a little endian int.
      */

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlock.java
@@ -241,6 +241,12 @@ public final class Int128ArrayBlock
         return "Int128ArrayBlock{positionCount=" + getPositionCount() + '}';
     }
 
+    @Override
+    public Optional<ByteArrayBlock> getNulls()
+    {
+        return BlockUtil.getNulls(valueIsNull, positionOffset, positionCount);
+    }
+
     int getRawOffset()
     {
         return positionOffset;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlock.java
@@ -225,6 +225,12 @@ public final class IntArrayBlock
         return "IntArrayBlock{positionCount=" + getPositionCount() + '}';
     }
 
+    @Override
+    public Optional<ByteArrayBlock> getNulls()
+    {
+        return BlockUtil.getNulls(valueIsNull, arrayOffset, positionCount);
+    }
+
     boolean[] getRawValueIsNull()
     {
         return valueIsNull;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlock.java
@@ -224,6 +224,12 @@ public final class LongArrayBlock
         return "LongArrayBlock{positionCount=" + getPositionCount() + '}';
     }
 
+    @Override
+    public Optional<ByteArrayBlock> getNulls()
+    {
+        return BlockUtil.getNulls(valueIsNull, arrayOffset, positionCount);
+    }
+
     int getRawValuesOffset()
     {
         return arrayOffset;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/MapBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/MapBlock.java
@@ -602,6 +602,12 @@ public final class MapBlock
         return this;
     }
 
+    @Override
+    public Optional<ByteArrayBlock> getNulls()
+    {
+        return BlockUtil.getNulls(mapIsNull, startOffset, positionCount);
+    }
+
     // only visible for testing
     public boolean isHashTablesPresent()
     {

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
@@ -492,4 +492,10 @@ public final class RowBlock
     {
         return this;
     }
+
+    @Override
+    public Optional<ByteArrayBlock> getNulls()
+    {
+        return BlockUtil.getNulls(rowIsNull, 0, positionCount);
+    }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlock.java
@@ -223,6 +223,12 @@ public final class ShortArrayBlock
         return "ShortArrayBlock{positionCount=" + getPositionCount() + '}';
     }
 
+    @Override
+    public Optional<ByteArrayBlock> getNulls()
+    {
+        return BlockUtil.getNulls(valueIsNull, arrayOffset, positionCount);
+    }
+
     int getRawValuesOffset()
     {
         return arrayOffset;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ValueBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ValueBlock.java
@@ -13,6 +13,10 @@
  */
 package io.trino.spi.block;
 
+import io.trino.spi.Experimental;
+
+import java.util.Optional;
+
 public non-sealed interface ValueBlock
         extends Block
 {
@@ -39,4 +43,12 @@ public non-sealed interface ValueBlock
     {
         return position;
     }
+
+    /**
+     * Returns a ByteArrayBlock specifying whether the current positions in the Block contain a NULL.
+     * Returns Optional.empty() when there are no NULLs in the Block.
+     * The returned ByteArrayBlock must not contain NULL values.
+     */
+    @Experimental(eta = "2025-01-01")
+    Optional<ByteArrayBlock> getNulls();
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlock.java
@@ -322,4 +322,10 @@ public final class VariableWidthBlock
     {
         return "VariableWidthBlock{positionCount=" + getPositionCount() + ", slice=" + slice + '}';
     }
+
+    @Override
+    public Optional<ByteArrayBlock> getNulls()
+    {
+        return BlockUtil.getNulls(valueIsNull, arrayOffset, positionCount);
+    }
 }

--- a/lib/trino-parquet/pom.xml
+++ b/lib/trino-parquet/pom.xml
@@ -138,6 +138,13 @@
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-main</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/BenchmarkColumnarFilterParquetData.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/BenchmarkColumnarFilterParquetData.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.trino.memory.context.LocalMemoryContext;
+import io.trino.metadata.Metadata;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.operator.DriverYieldSignal;
+import io.trino.operator.WorkProcessor;
+import io.trino.operator.project.PageProcessor;
+import io.trino.operator.project.PageProcessorMetrics;
+import io.trino.parquet.metadata.ParquetMetadata;
+import io.trino.parquet.reader.MetadataReader;
+import io.trino.parquet.reader.ParquetReader;
+import io.trino.parquet.reader.TestingParquetDataSource;
+import io.trino.parquet.writer.ParquetWriterOptions;
+import io.trino.spi.Page;
+import io.trino.spi.function.OperatorType;
+import io.trino.spi.type.Type;
+import io.trino.sql.gen.ExpressionCompiler;
+import io.trino.sql.relational.CallExpression;
+import io.trino.sql.relational.InputReferenceExpression;
+import io.trino.sql.relational.RowExpression;
+import io.trino.sql.relational.SpecialForm;
+import io.trino.sql.relational.SpecialForm.Form;
+import io.trino.tpch.LineItem;
+import io.trino.tpch.LineItemColumn;
+import io.trino.tpch.TpchColumn;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.jmh.Benchmarks.benchmark;
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static io.trino.parquet.BenchmarkFileFormatsUtils.createTpchDataSet;
+import static io.trino.parquet.ParquetTestUtils.createParquetReader;
+import static io.trino.parquet.ParquetTestUtils.writeParquetFile;
+import static io.trino.spi.function.OperatorType.LESS_THAN;
+import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.relational.Expressions.constant;
+import static io.trino.sql.relational.Expressions.field;
+import static io.trino.tpch.TpchTable.LINE_ITEM;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(2)
+@Warmup(iterations = 10, time = 2)
+@Measurement(iterations = 10, time = 2)
+public class BenchmarkColumnarFilterParquetData
+{
+    private static final TestingFunctionResolution FUNCTION_RESOLUTION = new TestingFunctionResolution();
+
+    private static final int EXTENDED_PRICE = 0;
+    private static final int DISCOUNT = 1;
+    private static final int SHIP_DATE = 2;
+    private static final int QUANTITY = 3;
+    private static final int SHIP_MODE = 4;
+
+    private static final Slice MIN_SHIP_DATE = utf8Slice("1994-01-01");
+    private static final Slice MAX_SHIP_DATE = utf8Slice("1995-01-01");
+    private static final Slice SHIP = utf8Slice("MAIL");
+    private static final Slice MAIL = utf8Slice("SHIP");
+    private static final ResolvedFunction EQUALS = FUNCTION_RESOLUTION.getMetadata().resolveOperator(OperatorType.EQUAL, ImmutableList.of(VARCHAR, VARCHAR));
+    private static final ResolvedFunction HASH_CODE = FUNCTION_RESOLUTION.getMetadata().resolveOperator(OperatorType.HASH_CODE, ImmutableList.of(VARCHAR));
+    private static final List<Type> TYPES = ImmutableList.of(DOUBLE, DOUBLE, VARCHAR, DOUBLE, VARCHAR);
+
+    private ParquetMetadata parquetMetadata;
+    private ParquetDataSource dataSource;
+    private List<String> columnNames;
+    private PageProcessor compiledProcessor;
+
+    @Param({"true", "false"})
+    public boolean columnarEvaluationEnabled;
+
+    @Param({
+            "AND",
+            "BETWEEN",
+            "IN",
+    })
+    public FilterProvider filterProvider;
+
+    public enum FilterProvider
+    {
+        AND {
+            // where shipdate >= '1994-01-01'
+            //    and shipdate < '1995-01-01'
+            //    and discount >= 0.05
+            //    and discount <= 0.07
+            //    and quantity < 24;
+            @Override
+            RowExpression getExpression()
+            {
+                return new SpecialForm(
+                        Form.AND,
+                        BOOLEAN,
+                        ImmutableList.of(
+                                new CallExpression(
+                                        FUNCTION_RESOLUTION.resolveOperator(LESS_THAN_OR_EQUAL, ImmutableList.of(VARCHAR, VARCHAR)),
+                                        ImmutableList.of(constant(MIN_SHIP_DATE, VARCHAR), field(SHIP_DATE, VARCHAR))),
+                                new SpecialForm(
+                                        Form.AND,
+                                        BOOLEAN,
+                                        ImmutableList.of(
+                                                new CallExpression(
+                                                        FUNCTION_RESOLUTION.resolveOperator(LESS_THAN, ImmutableList.of(VARCHAR, VARCHAR)),
+                                                        ImmutableList.of(field(SHIP_DATE, VARCHAR), constant(MAX_SHIP_DATE, VARCHAR))),
+                                                new SpecialForm(
+                                                        Form.AND,
+                                                        BOOLEAN,
+                                                        ImmutableList.of(
+                                                                new CallExpression(
+                                                                        FUNCTION_RESOLUTION.resolveOperator(LESS_THAN_OR_EQUAL, ImmutableList.of(DOUBLE, DOUBLE)),
+                                                                        ImmutableList.of(constant(0.05, DOUBLE), field(DISCOUNT, DOUBLE))),
+                                                                new SpecialForm(
+                                                                        Form.AND,
+                                                                        BOOLEAN,
+                                                                        ImmutableList.of(
+                                                                                new CallExpression(
+                                                                                        FUNCTION_RESOLUTION.resolveOperator(LESS_THAN_OR_EQUAL, ImmutableList.of(DOUBLE, DOUBLE)),
+                                                                                        ImmutableList.of(field(DISCOUNT, DOUBLE), constant(0.07, DOUBLE))),
+                                                                                new CallExpression(
+                                                                                        FUNCTION_RESOLUTION.resolveOperator(LESS_THAN, ImmutableList.of(DOUBLE, DOUBLE)),
+                                                                                        ImmutableList.of(field(QUANTITY, DOUBLE), constant(24.0, DOUBLE)))),
+                                                                        ImmutableList.of())),
+                                                        ImmutableList.of())),
+                                        ImmutableList.of())),
+                        ImmutableList.of());
+            }
+        },
+        BETWEEN {
+            // where shipdate BETWEEN '1994-01-01' and '1995-01-01'
+            @Override
+            RowExpression getExpression()
+            {
+                return new SpecialForm(
+                        Form.BETWEEN,
+                        BOOLEAN,
+                        ImmutableList.of(field(SHIP_DATE, VARCHAR), constant(MIN_SHIP_DATE, VARCHAR), constant(MAX_SHIP_DATE, VARCHAR)),
+                        ImmutableList.of(FUNCTION_RESOLUTION.resolveOperator(LESS_THAN_OR_EQUAL, ImmutableList.of(VARCHAR, VARCHAR))));
+            }
+        },
+        IN {
+            @Override
+            RowExpression getExpression()
+            {
+                Metadata metadata = FUNCTION_RESOLUTION.getMetadata();
+                List<ResolvedFunction> functionalDependencies = ImmutableList.of(
+                        EQUALS,
+                        HASH_CODE,
+                        metadata.resolveOperator(OperatorType.INDETERMINATE, ImmutableList.of(VARCHAR)));
+                return new SpecialForm(
+                        Form.IN,
+                        BOOLEAN,
+                        ImmutableList.of(field(SHIP_MODE, VARCHAR), constant(SHIP, VARCHAR), constant(MAIL, VARCHAR)),
+                        functionalDependencies);
+            }
+        }
+        /**/;
+
+        abstract RowExpression getExpression();
+    }
+
+    @Setup
+    public void setup()
+            throws IOException
+    {
+        RowExpression filterExpression = filterProvider.getExpression();
+        ExpressionCompiler expressionCompiler = FUNCTION_RESOLUTION.getExpressionCompiler();
+        compiledProcessor = expressionCompiler.compilePageProcessor(
+                        columnarEvaluationEnabled,
+                        Optional.of(filterExpression),
+                        ImmutableList.of(new InputReferenceExpression(EXTENDED_PRICE, DOUBLE)),
+                        Optional.empty())
+                .get();
+
+        List<TpchColumn<LineItem>> columns = ImmutableList.of(
+                LineItemColumn.EXTENDED_PRICE,
+                LineItemColumn.DISCOUNT,
+                LineItemColumn.SHIP_DATE,
+                LineItemColumn.QUANTITY,
+                LineItemColumn.SHIP_MODE);
+        BenchmarkFileFormatsUtils.TestData testData = createTpchDataSet(LINE_ITEM, columns);
+
+        dataSource = new TestingParquetDataSource(
+                writeParquetFile(
+                        ParquetWriterOptions.builder().build(),
+                        testData.columnTypes(),
+                        testData.columnNames(),
+                        testData.pages()),
+                new ParquetReaderOptions());
+        parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+        columnNames = columns.stream()
+                .map(TpchColumn::getColumnName)
+                .collect(toImmutableList());
+    }
+
+    @Benchmark
+    public long compiled()
+            throws IOException
+    {
+        ParquetReader reader = createParquetReader(dataSource, parquetMetadata, newSimpleAggregatedMemoryContext(), TYPES, columnNames);
+        LocalMemoryContext context = newSimpleAggregatedMemoryContext().newLocalMemoryContext(PageProcessor.class.getSimpleName());
+        Page inputPage = reader.nextPage();
+        long outputRows = 0;
+        while (inputPage != null) {
+            WorkProcessor<Page> workProcessor = compiledProcessor.createWorkProcessor(
+                    null,
+                    new DriverYieldSignal(),
+                    context,
+                    new PageProcessorMetrics(),
+                    inputPage);
+            if (workProcessor.process() && !workProcessor.isFinished()) {
+                outputRows += workProcessor.getResult().getPositionCount();
+            }
+            inputPage = reader.nextPage();
+        }
+        return outputRows;
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        benchmark(BenchmarkColumnarFilterParquetData.class)
+                .withOptions(optionsBuilder -> optionsBuilder.jvmArgsAppend("-Xmx4g", "-Xms4g", "--add-modules=jdk.incubator.vector"))
+                .run();
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/BenchmarkFileFormatsUtils.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/BenchmarkFileFormatsUtils.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slices;
+import io.airlift.units.DataSize;
+import io.trino.spi.Page;
+import io.trino.spi.PageBuilder;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.type.Type;
+import io.trino.tpch.TpchColumn;
+import io.trino.tpch.TpchEntity;
+import io.trino.tpch.TpchTable;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static java.util.stream.Collectors.toList;
+
+public final class BenchmarkFileFormatsUtils
+{
+    private static final long MIN_DATA_SIZE = DataSize.of(50, MEGABYTE).toBytes();
+
+    private BenchmarkFileFormatsUtils()
+    {
+    }
+
+    @SafeVarargs
+    public static <E extends TpchEntity> TestData createTpchDataSet(TpchTable<E> tpchTable, TpchColumn<E>... columns)
+    {
+        return createTpchDataSet(tpchTable, ImmutableList.copyOf(columns));
+    }
+
+    public static <E extends TpchEntity> TestData createTpchDataSet(TpchTable<E> tpchTable, List<TpchColumn<E>> columns)
+    {
+        List<String> columnNames = columns.stream().map(TpchColumn::getColumnName).collect(toList());
+        List<Type> columnTypes = columns.stream().map(BenchmarkFileFormatsUtils::getColumnType)
+                .map(type -> !DATE.equals(type) ? type : createUnboundedVarcharType())
+                .collect(toImmutableList());
+
+        PageBuilder pageBuilder = new PageBuilder(columnTypes);
+        ImmutableList.Builder<Page> pages = ImmutableList.builder();
+        long dataSize = 0;
+        for (E row : tpchTable.createGenerator(10, 1, 1)) {
+            pageBuilder.declarePosition();
+            for (int i = 0; i < columns.size(); i++) {
+                TpchColumn<E> column = columns.get(i);
+                BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(i);
+                switch (column.getType().getBase()) {
+                    case IDENTIFIER -> BIGINT.writeLong(blockBuilder, column.getIdentifier(row));
+                    case INTEGER -> INTEGER.writeLong(blockBuilder, column.getInteger(row));
+                    case DATE, VARCHAR -> createUnboundedVarcharType().writeSlice(blockBuilder, Slices.utf8Slice(column.getString(row)));
+                    case DOUBLE -> DOUBLE.writeDouble(blockBuilder, column.getDouble(row));
+                }
+            }
+            if (pageBuilder.isFull()) {
+                Page page = pageBuilder.build();
+                pages.add(page);
+                pageBuilder.reset();
+                dataSize += page.getSizeInBytes();
+
+                if (dataSize >= MIN_DATA_SIZE) {
+                    break;
+                }
+            }
+        }
+        if (!pageBuilder.isEmpty()) {
+            pages.add(pageBuilder.build());
+        }
+        return new TestData(columnNames, columnTypes, pages.build());
+    }
+
+    public static Type getColumnType(TpchColumn<?> input)
+    {
+        return switch (input.getType().getBase()) {
+            case IDENTIFIER -> BIGINT;
+            case INTEGER -> INTEGER;
+            case DATE -> DATE;
+            case DOUBLE -> DOUBLE;
+            case VARCHAR -> createUnboundedVarcharType();
+        };
+    }
+
+    public record TestData(List<String> columnNames, List<Type> columnTypes, List<Page> pages)
+    {
+        public TestData(List<String> columnNames, List<Type> columnTypes, List<Page> pages)
+        {
+            this.columnNames = ImmutableList.copyOf(columnNames);
+            this.columnTypes = ImmutableList.copyOf(columnTypes);
+            this.pages = ImmutableList.copyOf(pages);
+        }
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/TestBenchmarkColumnarFilterParquetData.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/TestBenchmarkColumnarFilterParquetData.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet;
+
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+public class TestBenchmarkColumnarFilterParquetData
+{
+    @Test
+    public void testBenchmark()
+            throws Throwable
+    {
+        for (boolean columnarEvaluationEnabled : ImmutableList.of(true, false)) {
+            for (BenchmarkColumnarFilterParquetData.FilterProvider filterProvider : BenchmarkColumnarFilterParquetData.FilterProvider.values()) {
+                BenchmarkColumnarFilterParquetData benchmark = new BenchmarkColumnarFilterParquetData();
+                benchmark.columnarEvaluationEnabled = columnarEvaluationEnabled;
+                benchmark.filterProvider = filterProvider;
+                benchmark.setup();
+                benchmark.compiled();
+            }
+        }
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOrcPageSourceMemoryTracking.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOrcPageSourceMemoryTracking.java
@@ -48,6 +48,7 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.Type;
 import io.trino.sql.gen.ExpressionCompiler;
 import io.trino.sql.gen.PageFunctionCompiler;
+import io.trino.sql.gen.columnar.ColumnarFilterCompiler;
 import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.sql.relational.RowExpression;
 import io.trino.testing.TestingConnectorSession;
@@ -140,7 +141,10 @@ public class TestOrcPageSourceMemoryTracking
     private static final int NUM_ROWS = 50000;
     private static final int STRIPE_ROWS = 20000;
     private static final FunctionManager functionManager = createTestingFunctionManager();
-    private static final ExpressionCompiler EXPRESSION_COMPILER = new ExpressionCompiler(functionManager, new PageFunctionCompiler(functionManager, 0));
+    private static final ExpressionCompiler EXPRESSION_COMPILER = new ExpressionCompiler(
+            functionManager,
+            new PageFunctionCompiler(functionManager, 0),
+            new ColumnarFilterCompiler(functionManager, 0));
     private static final ConnectorSession UNCACHED_SESSION = HiveTestUtils.getHiveSession(new HiveConfig(), new OrcReaderConfig().setTinyStripeThreshold(DataSize.of(0, BYTE)));
     private static final ConnectorSession CACHED_SESSION = SESSION;
 


### PR DESCRIPTION
## Description
This optimizes evaluation of simple filters by applying columnar evaluation to sub-expressions within the filters. 
It allows usage of dictionary/rle block aware processing and unwrapping of lazy blocks when there are multiple sub-expressions in a filter. 
This also reduces profile pollution in filter evaluation. Currently this supports only a subset of filters which operate directly on InputExpression and ConstantExpression.
We fall back to existing filter evaluation when column evaluation is not supported for some filter expression.

```
Local machine with JDK 22 (M1 CPU macbook)
BenchmarkColumnarFilter.evaluateFilter
(columnarEvaluationEnabled)  (filterProvider)  (nullsPercentage)   Mode  Cnt      Score     Error  Units
                       true           BETWEEN                  0  thrpt   15   2203.916 ?  18.455  ops/s
                      false           BETWEEN                  0  thrpt   15   3072.933 ?   8.241  ops/s
                       true           BETWEEN                 10  thrpt   15   2042.097 ?  30.165  ops/s
                      false           BETWEEN                 10  thrpt   15   1232.512 ?  15.047  ops/s
                       true         LESS_THAN                  0  thrpt   15   4515.833 ?  49.236  ops/s
                      false         LESS_THAN                  0  thrpt   15   3126.317 ?  19.410  ops/s
                       true         LESS_THAN                 10  thrpt   15   3953.351 ?  43.148  ops/s
                      false         LESS_THAN                 10  thrpt   15   1255.524 ?  11.680  ops/s
                       true           IS_NULL                  0  thrpt   15  20260.839 ? 303.403  ops/s
                      false           IS_NULL                  0  thrpt   15  11989.862 ?  62.450  ops/s
                       true           IS_NULL                 10  thrpt   15   8080.294 ?  36.815  ops/s
                      false           IS_NULL                 10  thrpt   15   4902.407 ?  35.330  ops/s
                       true       IS_NOT_NULL                  0  thrpt   15  13508.364 ?  97.596  ops/s
                      false       IS_NOT_NULL                  0  thrpt   15  11402.267 ?  54.198  ops/s
                       true       IS_NOT_NULL                 10  thrpt   15   3367.371 ?  18.684  ops/s
                      false       IS_NOT_NULL                 10  thrpt   15   2940.802 ?  23.757  ops/s

BenchmarkAndColumnarFilterTpchData.compiled
(columnarEvaluationEnabled)   Mode  Cnt     Score    Error  Units
                       true  thrpt   20  5966.938 ? 53.333  ops/s
                      false  thrpt   20  4701.945 ? 53.065  ops/s

BenchmarkColumnarFilterParquetData.compiled
(columnarEvaluationEnabled)  (filterProvider)   Mode  Cnt   Score   Error  Units
                       true               AND  thrpt   20  54.152 ? 0.284  ops/s
                      false               AND  thrpt   20  20.267 ? 0.105  ops/s
                       true           BETWEEN  thrpt   20  63.060 ? 0.240  ops/s
                      false           BETWEEN  thrpt   20  59.476 ? 2.829  ops/s
                       true                IN  thrpt   20  65.069 ? 0.337  ops/s
                      false                IN  thrpt   20  63.776 ? 1.372  ops/s
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Improve performance of queries with simple predicates. This optimization can be disabled using the `experimental.columnar-filter-evaluation.enabled` configuration property or `columnar_filter_evaluation_enabled` session property.  ({issue}`21375`)
```
