### PR TITLE
Remove duplicate doc and clarify JDBC vs REST

### DIFF
--- a/docs/src/main/sphinx/object-storage/metastores.md
+++ b/docs/src/main/sphinx/object-storage/metastores.md
@@ -496,8 +496,9 @@ The REST catalog does not support [view management](sql-view-management) or
 ### JDBC catalog
 
 The Iceberg JDBC catalog is supported for the Iceberg connector.  At a minimum,
-`iceberg.jdbc-catalog.driver-class`, `iceberg.jdbc-catalog.connection-url`
-and `iceberg.jdbc-catalog.catalog-name` must be configured. When using any
+`iceberg.jdbc-catalog.driver-class`, `iceberg.jdbc-catalog.connection-url`,
+`iceberg.jdbc-catalog.default-warehouse-dir`, and
+`iceberg.jdbc-catalog.catalog-name` must be configured. When using any
 database besides PostgreSQL, a JDBC driver jar file must be placed in the plugin
 directory.
 
@@ -511,12 +512,8 @@ Refer to [Iceberg repository](https://github.com/apache/iceberg/blob/main/core/s
 for creating those tables.
 :::
 
-At a minimum, `iceberg.jdbc-catalog.driver-class`,
-`iceberg.jdbc-catalog.connection-url`, and
-`iceberg.jdbc-catalog.catalog-name` must be configured. When using any
-database besides PostgreSQL, a JDBC driver jar file must be placed in the plugin
-directory. The following example shows a minimal catalog configuration using an
-Iceberg REST metadata catalog:
+The following example shows a minimal catalog configuration using an
+Iceberg JDBC metadata catalog:
 
 ```text
 connector.name=iceberg


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The metastore documentation for the JDBC catalog currently repeats a couple sentences.  In addition, the text refers to the REST metadata catalog when I think it should refer to JDBC.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
