### PR TITLE
Remove deprecated constructors from DriverConnectionFactory

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DriverConnectionFactory.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DriverConnectionFactory.java
@@ -37,36 +37,6 @@ public class DriverConnectionFactory
     private final CredentialPropertiesProvider<String, String> credentialPropertiesProvider;
     private final TracingDataSource dataSource;
 
-    /**
-     * @deprecated Use {@link #builder(Driver, String, CredentialProvider)} instead.
-     */
-    @Deprecated
-    public DriverConnectionFactory(Driver driver, BaseJdbcConfig config, CredentialProvider credentialProvider)
-    {
-        this(driver,
-                config.getConnectionUrl(),
-                new Properties(),
-                credentialProvider);
-    }
-
-    /**
-     * @deprecated Use {@link #builder(Driver, String, CredentialProvider)} instead.
-     */
-    @Deprecated
-    public DriverConnectionFactory(Driver driver, String connectionUrl, Properties connectionProperties, CredentialProvider credentialProvider)
-    {
-        this(driver, connectionUrl, connectionProperties, new DefaultCredentialPropertiesProvider(credentialProvider), OpenTelemetry.noop());
-    }
-
-    /**
-     * @deprecated Use {@link #builder(Driver, String, CredentialProvider)} instead.
-     */
-    @Deprecated
-    public DriverConnectionFactory(Driver driver, String connectionUrl, Properties connectionProperties, CredentialProvider credentialProvider, OpenTelemetry openTelemetry)
-    {
-        this(driver, connectionUrl, connectionProperties, new DefaultCredentialPropertiesProvider(credentialProvider), openTelemetry);
-    }
-
     public DriverConnectionFactory(
             Driver driver,
             String connectionUrl,


### PR DESCRIPTION
## Description

Fixes https://github.com/trinodb/trino/issues/20881

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
