### PR TITLE
Fail Driver on exception from processNewSources

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/executor/timesharing/PrioritizedSplitRunner.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/timesharing/PrioritizedSplitRunner.java
@@ -217,6 +217,11 @@ public final class PrioritizedSplitRunner
         }
     }
 
+    public void markFailed(Throwable cause)
+    {
+        finishedFuture.setException(cause);
+    }
+
     public void setReady()
     {
         lastReady.set(ticker.read());

--- a/core/trino-main/src/main/java/io/trino/execution/executor/timesharing/TimeSharingTaskExecutor.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/timesharing/TimeSharingTaskExecutor.java
@@ -600,6 +600,7 @@ public class TimeSharingTaskExecutor
                                 log.error(t, "Error processing %s", split.getInfo());
                             }
                         }
+                        split.markFailed(t);
                         splitFinished(split);
                     }
                     finally {

--- a/core/trino-main/src/main/java/io/trino/execution/executor/timesharing/TimeSharingTaskExecutor.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/timesharing/TimeSharingTaskExecutor.java
@@ -594,10 +594,10 @@ public class TimeSharingTaskExecutor
                         // ignore random errors due to driver thread interruption
                         if (!split.isDestroyed()) {
                             if (t instanceof TrinoException trinoException) {
-                                log.error(t, "Error processing %s: %s: %s", split.getInfo(), trinoException.getErrorCode().getName(), trinoException.getMessage());
+                                log.debug(t, "Error processing %s: %s: %s", split.getInfo(), trinoException.getErrorCode().getName(), trinoException.getMessage());
                             }
                             else {
-                                log.error(t, "Error processing %s", split.getInfo());
+                                log.debug(t, "Error processing %s", split.getInfo());
                             }
                         }
                         split.markFailed(t);


### PR DESCRIPTION
Exceptions thrown from processNewSources were not handled correctly. We just logged an error and marked the PrioritizedSplitRunner as finished. The for which the PSR were executing remained RUNNING and query hang indefinitely.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# General
* Fix rare case when queries could hang.
```
