### PR TITLE
Remove deprecated arguments from Hive flush_metadata_cache

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/procedure/FlushMetadataCacheProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/procedure/FlushMetadataCacheProcedure.java
@@ -42,11 +42,6 @@ public class FlushMetadataCacheProcedure
 
     private static final String PARAM_SCHEMA_NAME = "SCHEMA_NAME";
     private static final String PARAM_TABLE_NAME = "TABLE_NAME";
-    // Other procedures use plural naming, but it's kept for backward compatibility
-    @Deprecated
-    private static final String PARAM_PARTITION_COLUMN = "PARTITION_COLUMN";
-    @Deprecated
-    private static final String PARAM_PARTITION_VALUE = "PARTITION_VALUE";
     private static final String PARAM_PARTITION_COLUMNS = "PARTITION_COLUMNS";
     private static final String PARAM_PARTITION_VALUES = "PARTITION_VALUES";
 
@@ -62,19 +57,12 @@ public class FlushMetadataCacheProcedure
             PARAM_PARTITION_COLUMNS.toLowerCase(ENGLISH),
             PARAM_PARTITION_VALUES.toLowerCase(ENGLISH));
 
-    private static final String INVALID_PARTITION_PARAMS_ERROR_MESSAGE = format(
-            "Procedure should only be invoked with single pair of partition definition named params: %1$s and %2$s or %3$s and %4$s",
-            PARAM_PARTITION_COLUMNS.toLowerCase(ENGLISH),
-            PARAM_PARTITION_VALUES.toLowerCase(ENGLISH),
-            PARAM_PARTITION_COLUMN.toLowerCase(ENGLISH),
-            PARAM_PARTITION_VALUE.toLowerCase(ENGLISH));
-
     private static final MethodHandle FLUSH_HIVE_METASTORE_CACHE;
 
     static {
         try {
             FLUSH_HIVE_METASTORE_CACHE = lookup().unreflect(FlushMetadataCacheProcedure.class.getMethod(
-                    "flushMetadataCache", String.class, String.class, List.class, List.class, List.class, List.class));
+                    "flushMetadataCache", String.class, String.class, List.class, List.class));
         }
         catch (ReflectiveOperationException e) {
             throw new AssertionError(e);
@@ -99,9 +87,7 @@ public class FlushMetadataCacheProcedure
                         new Procedure.Argument(PARAM_SCHEMA_NAME, VARCHAR, false, null),
                         new Procedure.Argument(PARAM_TABLE_NAME, VARCHAR, false, null),
                         new Procedure.Argument(PARAM_PARTITION_COLUMNS, new ArrayType(VARCHAR), false, null),
-                        new Procedure.Argument(PARAM_PARTITION_VALUES, new ArrayType(VARCHAR), false, null),
-                        new Procedure.Argument(PARAM_PARTITION_COLUMN, new ArrayType(VARCHAR), false, null),
-                        new Procedure.Argument(PARAM_PARTITION_VALUE, new ArrayType(VARCHAR), false, null)),
+                        new Procedure.Argument(PARAM_PARTITION_VALUES, new ArrayType(VARCHAR), false, null)),
                 FLUSH_HIVE_METASTORE_CACHE.bindTo(this),
                 true);
     }
@@ -110,25 +96,14 @@ public class FlushMetadataCacheProcedure
             String schemaName,
             String tableName,
             List<String> partitionColumns,
-            List<String> partitionValues,
-            List<String> partitionColumn,
-            List<String> partitionValue)
+            List<String> partitionValues)
     {
-        Optional<List<String>> optionalPartitionColumns = Optional.ofNullable(partitionColumns);
-        Optional<List<String>> optionalPartitionValues = Optional.ofNullable(partitionValues);
-        Optional<List<String>> optionalPartitionColumn = Optional.ofNullable(partitionColumn);
-        Optional<List<String>> optionalPartitionValue = Optional.ofNullable(partitionValue);
-        checkState(partitionParamsUsed(optionalPartitionColumns, optionalPartitionValues, optionalPartitionColumn, optionalPartitionValue)
-                        || deprecatedPartitionParamsUsed(optionalPartitionColumns, optionalPartitionValues, optionalPartitionColumn, optionalPartitionValue)
-                        || partitionParamsNotUsed(optionalPartitionColumns, optionalPartitionValues, optionalPartitionColumn, optionalPartitionValue),
-                INVALID_PARTITION_PARAMS_ERROR_MESSAGE);
-
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
             doFlushMetadataCache(
                     Optional.ofNullable(schemaName),
                     Optional.ofNullable(tableName),
-                    optionalPartitionColumns.or(() -> optionalPartitionColumn).orElse(ImmutableList.of()),
-                    optionalPartitionValues.or(() -> optionalPartitionValue).orElse(ImmutableList.of()));
+                    Optional.ofNullable(partitionColumns).orElse(ImmutableList.of()),
+                    Optional.ofNullable(partitionValues).orElse(ImmutableList.of()));
         }
     }
 
@@ -155,35 +130,5 @@ public class FlushMetadataCacheProcedure
         else {
             throw new TrinoException(StandardErrorCode.INVALID_PROCEDURE_ARGUMENT, "Illegal parameter set passed. " + PROCEDURE_USAGE_EXAMPLES);
         }
-    }
-
-    private boolean partitionParamsNotUsed(
-            Optional<List<String>> partitionColumns,
-            Optional<List<String>> partitionValues,
-            Optional<List<String>> partitionColumn,
-            Optional<List<String>> partitionValue)
-    {
-        return partitionColumns.isEmpty() && partitionValues.isEmpty()
-                && partitionColumn.isEmpty() && partitionValue.isEmpty();
-    }
-
-    private boolean partitionParamsUsed(
-            Optional<List<String>> partitionColumns,
-            Optional<List<String>> partitionValues,
-            Optional<List<String>> partitionColumn,
-            Optional<List<String>> partitionValue)
-    {
-        return (partitionColumns.isPresent() || partitionValues.isPresent())
-                && partitionColumn.isEmpty() && partitionValue.isEmpty();
-    }
-
-    private boolean deprecatedPartitionParamsUsed(
-            Optional<List<String>> partitionColumns,
-            Optional<List<String>> partitionValues,
-            Optional<List<String>> partitionColumn,
-            Optional<List<String>> partitionValue)
-    {
-        return (partitionColumn.isPresent() || partitionValue.isPresent())
-                && partitionColumns.isEmpty() && partitionValues.isEmpty();
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHive3OnDataLake.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHive3OnDataLake.java
@@ -294,24 +294,6 @@ public class TestHive3OnDataLake
                         partitionColumn));
     }
 
-    @Test
-    public void testFlushPartitionCacheWithDeprecatedPartitionParams()
-    {
-        String tableName = "nation_" + randomNameSuffix();
-        String fullyQualifiedTestTableName = getFullyQualifiedTestTableName(tableName);
-        String partitionColumn = "regionkey";
-
-        testFlushPartitionCache(
-                tableName,
-                fullyQualifiedTestTableName,
-                partitionColumn,
-                format(
-                        "CALL system.flush_metadata_cache(schema_name => '%s', table_name => '%s', partition_column => ARRAY['%s'], partition_value => ARRAY['0'])",
-                        HIVE_TEST_SCHEMA,
-                        tableName,
-                        partitionColumn));
-    }
-
     private void testFlushPartitionCache(String tableName, String fullyQualifiedTestTableName, String partitionColumn, String flushCacheProcedureSql)
     {
         // Create table with partition on regionkey

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastoreWithQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastoreWithQueryRunner.java
@@ -173,19 +173,8 @@ public class TestCachingHiveMetastoreWithQueryRunner
         assertThatThrownBy(() -> getQueryRunner().execute("CALL system.flush_metadata_cache(schema_name => 'dummy_schema')"))
                 .hasMessage(illegalParameterMessage);
 
-        assertThatThrownBy(() -> getQueryRunner().execute("CALL system.flush_metadata_cache(schema_name => 'dummy_schema', table_name => 'dummy_table', partition_column => ARRAY['dummy_partition'])"))
+        assertThatThrownBy(() -> getQueryRunner().execute("CALL system.flush_metadata_cache(schema_name => 'dummy_schema', table_name => 'dummy_table', partition_columns => ARRAY['dummy_partition'])"))
                 .hasMessage("Parameters partition_column and partition_value should have same length");
-
-        assertThatThrownBy(
-                () -> getQueryRunner().execute("CALL system.flush_metadata_cache(" +
-                        "partition_columns => ARRAY['example'], " +
-                        "partition_values => ARRAY['0'], " +
-                        "partition_column => ARRAY['example'], " +
-                        "partition_value => ARRAY['0']" +
-                        ")"))
-                .hasMessage(
-                        "Procedure should only be invoked with single pair of partition definition named params: " +
-                                "partition_columns and partition_values or partition_column and partition_value");
     }
 
     @Test


### PR DESCRIPTION
## Description

These parameters have been deprecated since 2022 Oct.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Remove deprecated `PARTITION_COLUMN` and `PARTITION_VALUE` arguments. Use `PARTITION_COLUMNS` and `PARTITION_VALUES` instead. ({issue}`issuenumber`)
```
