### PR TITLE
Require deprecation annotation on deprecated methods

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/uri/ConnectionProperties.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/ConnectionProperties.java
@@ -296,6 +296,7 @@ final class ConnectionProperties
     /**
      * @deprecated use {@link AssumeLiteralUnderscoreInMetadataCallsForNonConformingClients}
      */
+    @Deprecated
     private static class AssumeLiteralNamesInMetadataCallsForNonConformingClients
             extends AbstractConnectionProperty<String, Boolean>
     {

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestExpressionCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestExpressionCompiler.java
@@ -632,6 +632,7 @@ public class TestExpressionCompiler
     }
 
     @Test
+    @SuppressWarnings("BigDecimalEquals") // it is intentional to compare BigDecimals with equals
     public void testBinaryOperatorsDecimalBigint()
     {
         for (BigDecimal left : decimalLefts) {
@@ -687,6 +688,7 @@ public class TestExpressionCompiler
     }
 
     @Test
+    @SuppressWarnings("BigDecimalEquals") // it is intentional to compare BigDecimals with equals
     public void testBinaryOperatorsBigintDecimal()
     {
         for (Long left : longLefts) {
@@ -743,6 +745,7 @@ public class TestExpressionCompiler
     }
 
     @Test
+    @SuppressWarnings("BigDecimalEquals") // it is intentional to compare BigDecimals with equals
     public void testBinaryOperatorsDecimalInteger()
     {
         for (BigDecimal left : decimalLefts) {
@@ -798,6 +801,7 @@ public class TestExpressionCompiler
     }
 
     @Test
+    @SuppressWarnings("BigDecimalEquals") // it is intentional to compare BigDecimals with equals
     public void testBinaryOperatorsIntegerDecimal()
     {
         for (Integer left : intLefts) {
@@ -1681,6 +1685,7 @@ public class TestExpressionCompiler
     }
 
     @Test
+    @SuppressWarnings("BigDecimalEquals") // it is intentional to compare BigDecimals with equals
     public void testSimpleCase()
     {
         for (Double value : doubleLefts) {

--- a/pom.xml
+++ b/pom.xml
@@ -2706,6 +2706,7 @@
                                     -Xep:RethrowReflectiveOperationExceptionAsLinkageError:OFF \
                                     -Xep:StaticAssignmentOfThrowable:ERROR \
                                     -Xep:StreamResourceLeak:ERROR \
+                                    -Xep:SuppressWarningsDeprecated:ERROR \
                                     -Xep:UnicodeEscape:ERROR \
                                     -Xep:UnnecessaryLongToIntConversion:ERROR \
                                     -Xep:UnnecessaryMethodReference:ERROR \

--- a/pom.xml
+++ b/pom.xml
@@ -2657,6 +2657,7 @@
                                     -Xep:BadInstanceof:ERROR \
                                     -Xep:BoxedPrimitiveConstructor:ERROR \
                                     -Xep:ClassCanBeStatic:ERROR \
+                                    -Xep:ClassName:ERROR \
                                     -Xep:CompareToZero:ERROR \
                                     -Xep:DefaultCharset:ERROR \
                                     -Xep:DepAnn:ERROR \

--- a/pom.xml
+++ b/pom.xml
@@ -2661,6 +2661,7 @@
                                     -Xep:CompareToZero:ERROR \
                                     -Xep:DefaultCharset:ERROR \
                                     -Xep:DepAnn:ERROR \
+                                    -Xep:DeprecatedVariable:ERROR \
                                     -Xep:DistinctVarargsChecker:ERROR \
                                     -Xep:DoNotCallSuggester:OFF \
                                     -Xep:EmptyBlockTag:ERROR \

--- a/pom.xml
+++ b/pom.xml
@@ -2707,6 +2707,7 @@
                                     -Xep:StaticAssignmentOfThrowable:ERROR \
                                     -Xep:StreamResourceLeak:ERROR \
                                     -Xep:SuppressWarningsDeprecated:ERROR \
+                                    -Xep:ThreeLetterTimeZoneID:ERROR \
                                     -Xep:UnicodeEscape:ERROR \
                                     -Xep:UnnecessaryLongToIntConversion:ERROR \
                                     -Xep:UnnecessaryMethodReference:ERROR \

--- a/pom.xml
+++ b/pom.xml
@@ -2655,6 +2655,7 @@
                                     -Xep:ArgumentSelectionDefectChecker:ERROR \
                                     -Xep:BadComparable:ERROR \
                                     -Xep:BadInstanceof:ERROR \
+                                    -Xep:BigDecimalEquals:ERROR \
                                     -Xep:BoxedPrimitiveConstructor:ERROR \
                                     -Xep:ClassCanBeStatic:ERROR \
                                     -Xep:ClassName:ERROR \

--- a/pom.xml
+++ b/pom.xml
@@ -2659,6 +2659,7 @@
                                     -Xep:ClassCanBeStatic:ERROR \
                                     -Xep:CompareToZero:ERROR \
                                     -Xep:DefaultCharset:ERROR \
+                                    -Xep:DepAnn:ERROR \
                                     -Xep:DistinctVarargsChecker:ERROR \
                                     -Xep:DoNotCallSuggester:OFF \
                                     -Xep:EmptyBlockTag:ERROR \

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Standard.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Standard.java
@@ -77,6 +77,7 @@ public final class Standard
     /**
      * @deprecated please use {@link EnvironmentContainers#configureTempto} instead.
      */
+    @Deprecated
     public static final String CONTAINER_TEMPTO_PROFILE_CONFIG = "/docker/presto-product-tests/conf/tempto/tempto-configuration-profile-config-file.yaml";
 
     private final DockerFiles dockerFiles;


### PR DESCRIPTION
Item documented with a `@deprecated` javadoc note should be annotated with `@Deprecated` for the deprecation to be fully effective for API consumers.
