### PR TITLE
Support bitwise_and_agg, bitwise_or_agg pushdown for Snowflake connector

### DIFF
--- a/docs/src/main/sphinx/connector/snowflake.md
+++ b/docs/src/main/sphinx/connector/snowflake.md
@@ -329,6 +329,8 @@ The connector supports pushdown for a number of operations:
 - {func}`corr`
 - {func}`regr_intercept`
 - {func}`regr_slope`
+- {func}`bitwise_and_agg`
+- {func}`bitwise_or_agg`
 
 ```{include} pushdown-correctness-behavior.fragment
 ```

--- a/plugin/trino-snowflake/pom.xml
+++ b/plugin/trino-snowflake/pom.xml
@@ -40,6 +40,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-matching</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-plugin-toolkit</artifactId>
         </dependency>
 

--- a/plugin/trino-snowflake/src/main/java/io/trino/plugin/snowflake/ImplementBitwiseAndAgg.java
+++ b/plugin/trino-snowflake/src/main/java/io/trino/plugin/snowflake/ImplementBitwiseAndAgg.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.snowflake;
+
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.aggregation.AggregateFunctionRule;
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcExpression;
+import io.trino.plugin.jdbc.expression.ParameterizedExpression;
+import io.trino.spi.connector.AggregateFunction;
+import io.trino.spi.expression.Variable;
+
+import java.util.Optional;
+
+import static com.google.common.base.Verify.verify;
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.plugin.base.aggregation.AggregateFunctionPatterns.basicAggregation;
+import static io.trino.plugin.base.aggregation.AggregateFunctionPatterns.functionName;
+import static io.trino.plugin.base.aggregation.AggregateFunctionPatterns.singleArgument;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.variable;
+import static io.trino.spi.type.BigintType.BIGINT;
+
+/**
+ * Implements {@code bitwise_and_agg(x)} for bigint column
+ */
+public class ImplementBitwiseAndAgg
+        implements AggregateFunctionRule<JdbcExpression, ParameterizedExpression>
+{
+    private static final Capture<Variable> ARGUMENT = newCapture();
+
+    @Override
+    public Pattern<AggregateFunction> getPattern()
+    {
+        return basicAggregation()
+                .with(functionName().equalTo("bitwise_and_agg"))
+                .with(singleArgument().matching(
+                        variable()
+                                .with(type().equalTo(BIGINT))
+                                .capturedAs(ARGUMENT)));
+    }
+
+    @Override
+    public Optional<JdbcExpression> rewrite(AggregateFunction aggregateFunction, Captures captures, AggregateFunctionRule.RewriteContext<ParameterizedExpression> context)
+    {
+        Variable argument = captures.get(ARGUMENT);
+        JdbcColumnHandle columnHandle = (JdbcColumnHandle) context.getAssignment(argument.getName());
+        verify(columnHandle.getColumnType().equals(aggregateFunction.getOutputType()));
+
+        ParameterizedExpression rewrittenArgument = context.rewriteExpression(argument).orElseThrow();
+        return Optional.of(new JdbcExpression(
+                "bitand_agg(%s)".formatted(rewrittenArgument.expression()),
+                rewrittenArgument.parameters(),
+                columnHandle.getJdbcTypeHandle()));
+    }
+}

--- a/plugin/trino-snowflake/src/main/java/io/trino/plugin/snowflake/ImplementBitwiseOrAgg.java
+++ b/plugin/trino-snowflake/src/main/java/io/trino/plugin/snowflake/ImplementBitwiseOrAgg.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.snowflake;
+
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.aggregation.AggregateFunctionRule;
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcExpression;
+import io.trino.plugin.jdbc.expression.ParameterizedExpression;
+import io.trino.spi.connector.AggregateFunction;
+import io.trino.spi.expression.Variable;
+
+import java.util.Optional;
+
+import static com.google.common.base.Verify.verify;
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.plugin.base.aggregation.AggregateFunctionPatterns.basicAggregation;
+import static io.trino.plugin.base.aggregation.AggregateFunctionPatterns.functionName;
+import static io.trino.plugin.base.aggregation.AggregateFunctionPatterns.singleArgument;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.variable;
+import static io.trino.spi.type.BigintType.BIGINT;
+
+/**
+ * Implements {@code bitwise_and_agg(x)} for bigint column
+ */
+public class ImplementBitwiseOrAgg
+        implements AggregateFunctionRule<JdbcExpression, ParameterizedExpression>
+{
+    private static final Capture<Variable> ARGUMENT = newCapture();
+
+    @Override
+    public Pattern<AggregateFunction> getPattern()
+    {
+        return basicAggregation()
+                .with(functionName().equalTo("bitwise_or_agg"))
+                .with(singleArgument().matching(
+                        variable()
+                                .with(type().equalTo(BIGINT))
+                                .capturedAs(ARGUMENT)));
+    }
+
+    @Override
+    public Optional<JdbcExpression> rewrite(AggregateFunction aggregateFunction, Captures captures, RewriteContext<ParameterizedExpression> context)
+    {
+        Variable argument = captures.get(ARGUMENT);
+        JdbcColumnHandle columnHandle = (JdbcColumnHandle) context.getAssignment(argument.getName());
+        verify(columnHandle.getColumnType().equals(aggregateFunction.getOutputType()));
+
+        ParameterizedExpression rewrittenArgument = context.rewriteExpression(argument).orElseThrow();
+        return Optional.of(new JdbcExpression(
+                "bitor_agg(%s)".formatted(rewrittenArgument.expression()),
+                rewrittenArgument.parameters(),
+                columnHandle.getJdbcTypeHandle()));
+    }
+}

--- a/plugin/trino-snowflake/src/main/java/io/trino/plugin/snowflake/SnowflakeClient.java
+++ b/plugin/trino-snowflake/src/main/java/io/trino/plugin/snowflake/SnowflakeClient.java
@@ -198,6 +198,8 @@ public class SnowflakeClient
                         .add(new ImplementCorr())
                         .add(new ImplementRegrIntercept())
                         .add(new ImplementRegrSlope())
+                        .add(new ImplementBitwiseAndAgg())
+                        .add(new ImplementBitwiseOrAgg())
                         .build());
     }
 


### PR DESCRIPTION


<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Snowflake
* Support pushdown bitwise_and_agg and bitwise_or_agg on bigint type column. ({issue}`issuenumber`)
```
