### PR TITLE
Use boolean or aggregation in correlated exists

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -149,6 +149,7 @@ import io.trino.sql.planner.iterative.rule.PushDownDereferencesThroughTopN;
 import io.trino.sql.planner.iterative.rule.PushDownDereferencesThroughTopNRanking;
 import io.trino.sql.planner.iterative.rule.PushDownDereferencesThroughWindow;
 import io.trino.sql.planner.iterative.rule.PushDownProjectionsFromPatternRecognition;
+import io.trino.sql.planner.iterative.rule.PushFilterThroughBoolOrAggregation;
 import io.trino.sql.planner.iterative.rule.PushFilterThroughCountAggregation;
 import io.trino.sql.planner.iterative.rule.PushInequalityFilterExpressionBelowJoinRuleSet;
 import io.trino.sql.planner.iterative.rule.PushJoinIntoTableScan;
@@ -601,6 +602,7 @@ public class PlanOptimizers
                                 .addAll(columnPruningRules)
                                 .add(new InlineProjections())
                                 .addAll(new PushFilterThroughCountAggregation(plannerContext).rules()) // must run after PredicatePushDown and after TransformFilteringSemiJoinToInnerJoin
+                                .addAll(new PushFilterThroughBoolOrAggregation(plannerContext).rules())
                                 .build()));
 
         // Perform redirection before CBO rules to ensure stats from destination connector are used

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushFilterThroughBoolOrAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushFilterThroughBoolOrAggregation.java
@@ -1,0 +1,299 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.spi.function.CatalogSchemaFunctionName;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.ir.Coalesce;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.planner.DomainTranslator;
+import io.trino.sql.planner.DomainTranslator.ExtractionResult;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.SymbolsExtractor;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.iterative.Rule.Context;
+import io.trino.sql.planner.iterative.Rule.Result;
+import io.trino.sql.planner.plan.AggregationNode;
+import io.trino.sql.planner.plan.AggregationNode.Aggregation;
+import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.FilterNode;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.ProjectNode;
+import io.trino.sql.planner.plan.ValuesNode;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.metadata.GlobalFunctionCatalog.builtinFunctionName;
+import static io.trino.spi.predicate.Domain.singleValue;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.sql.ir.Booleans.FALSE;
+import static io.trino.sql.ir.Booleans.TRUE;
+import static io.trino.sql.ir.IrUtils.combineConjuncts;
+import static io.trino.sql.ir.IrUtils.extractConjuncts;
+import static io.trino.sql.planner.DomainTranslator.getExtractionResult;
+import static io.trino.sql.planner.plan.AggregationNode.Step.SINGLE;
+import static io.trino.sql.planner.plan.Patterns.aggregation;
+import static io.trino.sql.planner.plan.Patterns.filter;
+import static io.trino.sql.planner.plan.Patterns.project;
+import static io.trino.sql.planner.plan.Patterns.source;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.partitioningBy;
+
+/**
+ * Push down aggregation's bool_or based on filter predicate.
+ * <p>
+ * This rule transforms plans with a FilterNode above an AggregationNode.
+ * The AggregationNode must be grouped and contain a single aggregation
+ * assignment with `bool_or()` function.
+ * <p>
+ * If the filter predicate is `false` for the aggregation's result value `false` or `null`,
+ * then the aggregation can removed from the aggregation node, and
+ * applied as a filter below the AggregationNode. After such transformation,
+ * any group such that no rows of that group pass the filter, is removed
+ * by the pushed down FilterNode, and so it is not processed by the
+ * AggregationNode. Before the transformation, the group would be processed
+ * by the AggregationNode, and return `false` or `null`, which would then be filtered out
+ * by the root FilterNode.
+ * <p>
+ * After the symbol pushdown, it is checked whether the root FilterNode is
+ * still needed, based on the fact that the aggregation never returns `false` or `null`.
+ * <p>
+ * Transforms:
+ * <pre> {@code
+ * - filter (aggr_bool AND predicate)
+ *   - aggregation
+ *     group by a
+ *     aggr_bool <- bool_or(s)
+ *       - source (a, s)
+ *       }
+ * </pre>
+ * into:
+ * <pre> {@code
+ * - filter (predicate)
+ *   - project (aggr_bool=true)
+ *     - aggregation
+ *       group by a
+ *         - filter (s)
+ *           - source (a, s)
+ *       }
+ * </pre>
+ */
+public class PushFilterThroughBoolOrAggregation
+{
+    private static final CatalogSchemaFunctionName BOOL_OR = builtinFunctionName("bool_or");
+
+    private final PlannerContext plannerContext;
+
+    public PushFilterThroughBoolOrAggregation(PlannerContext plannerContext)
+    {
+        this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
+    }
+
+    public Set<Rule<?>> rules()
+    {
+        return ImmutableSet.of(
+                new PushFilterThroughBoolOrAggregationWithoutProject(plannerContext),
+                new PushFilterThroughBoolOrAggregationWithProject(plannerContext));
+    }
+
+    @VisibleForTesting
+    public static final class PushFilterThroughBoolOrAggregationWithoutProject
+            implements Rule<FilterNode>
+    {
+        private static final Capture<AggregationNode> AGGREGATION = newCapture();
+
+        private final PlannerContext plannerContext;
+        private final Pattern<FilterNode> pattern;
+
+        public PushFilterThroughBoolOrAggregationWithoutProject(PlannerContext plannerContext)
+        {
+            this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
+            this.pattern = filter()
+                    .with(source().matching(aggregation()
+                            .matching(PushFilterThroughBoolOrAggregation::isGroupedBoolOr)
+                            .capturedAs(AGGREGATION)));
+        }
+
+        @Override
+        public Pattern<FilterNode> getPattern()
+        {
+            return pattern;
+        }
+
+        @Override
+        public Result apply(FilterNode node, Captures captures, Context context)
+        {
+            return pushFilter(node, captures.get(AGGREGATION), Optional.empty(), plannerContext, context);
+        }
+    }
+
+    @VisibleForTesting
+    public static final class PushFilterThroughBoolOrAggregationWithProject
+            implements Rule<FilterNode>
+    {
+        private static final Capture<ProjectNode> PROJECT = newCapture();
+        private static final Capture<AggregationNode> AGGREGATION = newCapture();
+
+        private final PlannerContext plannerContext;
+        private final Pattern<FilterNode> pattern;
+
+        public PushFilterThroughBoolOrAggregationWithProject(PlannerContext plannerContext)
+        {
+            this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
+            this.pattern = filter()
+                    .with(source().matching(project()
+                            .matching(ProjectNode::isIdentity)
+                            .capturedAs(PROJECT)
+                            .with(source().matching(aggregation()
+                                    .matching(PushFilterThroughBoolOrAggregation::isGroupedBoolOr)
+                                    .capturedAs(AGGREGATION)))));
+        }
+
+        @Override
+        public Pattern<FilterNode> getPattern()
+        {
+            return pattern;
+        }
+
+        @Override
+        public Result apply(FilterNode node, Captures captures, Context context)
+        {
+            return pushFilter(node, captures.get(AGGREGATION), Optional.of(captures.get(PROJECT)), plannerContext, context);
+        }
+    }
+
+    private static Result pushFilter(FilterNode filterNode, AggregationNode aggregationNode, Optional<ProjectNode> projectNode, PlannerContext plannerContext, Context context)
+    {
+        Symbol boolOrSymbol = getOnlyElement(aggregationNode.getAggregations().keySet());
+        Aggregation aggregation = getOnlyElement(aggregationNode.getAggregations().values());
+
+        ExtractionResult extractionResult = getExtractionResult(plannerContext, context.getSession(), filterNode.getPredicate());
+        TupleDomain<Symbol> tupleDomain = extractionResult.getTupleDomain();
+        Expression remainingExpression = extractionResult.getRemainingExpression();
+
+        if (tupleDomain.isNone()) {
+            // Filter predicate is never satisfied. Replace filter with empty values.
+            return Result.ofPlanNode(new ValuesNode(filterNode.getId(), filterNode.getOutputSymbols(), ImmutableList.of()));
+        }
+
+        // boolOrSymbol (in remaining expressions) should only be used in Coalesce(boolOrSymbol, FALSE) expression
+        List<Expression> conjuncts = extractConjuncts(remainingExpression);
+        Map<Boolean, List<Expression>> expressions = conjuncts.stream()
+                .filter(expression -> SymbolsExtractor.extractUnique(expression).contains(boolOrSymbol))
+                .collect(partitioningBy(expression -> isSupportedCoalesce(expression, boolOrSymbol)));
+
+        // unsupported expressions present
+        if (!expressions.get(Boolean.FALSE).isEmpty()) {
+            return Result.empty();
+        }
+        Optional<Expression> boolOrCoalesce = Optional.ofNullable(expressions.get(Boolean.TRUE)).filter(expr -> !expr.isEmpty()).map(List::getFirst);
+        Optional<Domain> boolOrDomain = Optional.ofNullable(tupleDomain.getDomains().get().get(boolOrSymbol));
+        if (boolOrDomain.isPresent() && !boolOrDomain.get().equals(singleValue(BOOLEAN, true))) {
+            return Result.empty();
+        }
+
+        if (boolOrCoalesce.isEmpty() && boolOrDomain.isEmpty()) {
+            return Result.empty();
+        }
+
+        // Push down the aggregation's symbol.
+        FilterNode source = new FilterNode(
+                context.getIdAllocator().getNextId(),
+                aggregationNode.getSource(),
+                aggregation.getArguments().getFirst());
+
+        // Remove boolOr symbol from the aggregation.
+        AggregationNode newAggregationNode = AggregationNode.builderFrom(aggregationNode)
+                .setSource(source)
+                .setAggregations(ImmutableMap.of())
+                .build();
+
+        // Add boolOr projection.
+        ProjectNode newProjectNode = new ProjectNode(
+                context.getIdAllocator().getNextId(),
+                newAggregationNode,
+                Assignments.builder()
+                        .putIdentities(source.getOutputSymbols())
+                        .put(boolOrSymbol, TRUE)
+                        .build());
+
+        // Restore identity projection if it is present in the original plan.
+        PlanNode filterSource = projectNode.map(project -> project.replaceChildren(ImmutableList.of(newProjectNode))).orElse(newProjectNode);
+
+        if (boolOrCoalesce.isPresent()) {
+            remainingExpression = combineConjuncts(conjuncts.stream().filter(expression -> !expression.equals(boolOrCoalesce.get())).toList());
+        }
+
+        TupleDomain<Symbol> newTupleDomain = tupleDomain.filter((symbol, domain) -> !symbol.equals(boolOrSymbol));
+        Expression newPredicate = combineConjuncts(
+                DomainTranslator.toPredicate(newTupleDomain),
+                remainingExpression);
+        if (!newPredicate.equals(TRUE)) {
+            return Result.ofPlanNode(new FilterNode(filterNode.getId(), filterSource, newPredicate));
+        }
+
+        return Result.ofPlanNode(filterSource);
+    }
+
+    private static boolean isSupportedCoalesce(Expression expression, Symbol boolOrSymbol)
+    {
+        if (!(expression instanceof Coalesce coalesce) || coalesce.operands().size() != 2) {
+            return false;
+        }
+        Expression firstOperand = coalesce.operands().getFirst();
+        Expression secondOperand = coalesce.operands().getLast();
+
+        return firstOperand.equals(boolOrSymbol.toSymbolReference()) && secondOperand.equals(FALSE);
+    }
+
+    public static boolean isGroupedBoolOr(AggregationNode node)
+    {
+        if (!isGroupedAggregation(node)) {
+            return false;
+        }
+
+        if (node.getAggregations().size() != 1) {
+            return false;
+        }
+
+        Aggregation aggregation = getOnlyElement(node.getAggregations().values());
+        if (aggregation.getFilter().isPresent() || aggregation.getMask().isPresent()) {
+            return false;
+        }
+
+        return aggregation.getResolvedFunction().name().equals(BOOL_OR) && aggregation.getArguments().getFirst() instanceof Reference;
+    }
+
+    private static boolean isGroupedAggregation(AggregationNode node)
+    {
+        return node.hasNonEmptyGroupingSet() &&
+               node.getGroupingSetCount() == 1 &&
+               node.getStep() == SINGLE;
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/JoinMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/JoinMatcher.java
@@ -64,6 +64,7 @@ public final class JoinMatcher
     private final Optional<Expression> filter;
     private final Optional<DistributionType> distributionType;
     private final Optional<Boolean> spillable;
+    private final Optional<Boolean> maySkipOutputDuplicates;
     // LEFT_SYMBOL -> RIGHT_SYMBOL
     private final Optional<List<DynamicFilterPattern>> expectedDynamicFilter;
 
@@ -74,6 +75,7 @@ public final class JoinMatcher
             Optional<Expression> filter,
             Optional<DistributionType> distributionType,
             Optional<Boolean> spillable,
+            Optional<Boolean> maySkipOutputDuplicates,
             Optional<List<DynamicFilterPattern>> expectedDynamicFilter)
     {
         this.joinType = requireNonNull(joinType, "joinType is null");
@@ -85,6 +87,7 @@ public final class JoinMatcher
         this.filter = requireNonNull(filter, "filter cannot be null");
         this.distributionType = requireNonNull(distributionType, "distributionType is null");
         this.spillable = requireNonNull(spillable, "spillable is null");
+        this.maySkipOutputDuplicates = requireNonNull(maySkipOutputDuplicates, "MaySkipOutputDuplicates is null");
         this.expectedDynamicFilter = requireNonNull(expectedDynamicFilter, "expectedDynamicFilter is null");
     }
 
@@ -128,6 +131,10 @@ public final class JoinMatcher
         }
 
         if (spillable.isPresent() && !spillable.equals(joinNode.isSpillable())) {
+            return NO_MATCH;
+        }
+
+        if (maySkipOutputDuplicates.isPresent() && maySkipOutputDuplicates.get() != joinNode.isMaySkipOutputDuplicates()) {
             return NO_MATCH;
         }
 
@@ -211,6 +218,7 @@ public final class JoinMatcher
         private Optional<List<PlanMatchPattern.DynamicFilterPattern>> dynamicFilter = Optional.empty();
         private Optional<DistributionType> distributionType = Optional.empty();
         private Optional<Boolean> expectedSpillable = Optional.empty();
+        private Optional<Boolean> expectedMaySkipOutputDuplicates = Optional.empty();
         private PlanMatchPattern left;
         private PlanMatchPattern right;
         private Optional<Expression> filter = Optional.empty();
@@ -288,6 +296,14 @@ public final class JoinMatcher
         }
 
         @CanIgnoreReturnValue
+        public Builder maySkipOutputDuplicates(Boolean expectedMaySkipOutputDuplicates)
+        {
+            this.expectedMaySkipOutputDuplicates = Optional.of(expectedMaySkipOutputDuplicates);
+
+            return this;
+        }
+
+        @CanIgnoreReturnValue
         public Builder left(PlanMatchPattern left)
         {
             this.left = left;
@@ -320,6 +336,7 @@ public final class JoinMatcher
                                     filter,
                                     distributionType,
                                     expectedSpillable,
+                                    expectedMaySkipOutputDuplicates,
                                     dynamicFilter));
         }
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushFilterThroughBoolOrAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushFilterThroughBoolOrAggregation.java
@@ -1,0 +1,448 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.sql.ir.Coalesce;
+import io.trino.sql.ir.Comparison;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Logical;
+import io.trino.sql.ir.Not;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.rule.PushFilterThroughBoolOrAggregation.PushFilterThroughBoolOrAggregationWithProject;
+import io.trino.sql.planner.iterative.rule.PushFilterThroughBoolOrAggregation.PushFilterThroughBoolOrAggregationWithoutProject;
+import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
+import io.trino.sql.planner.plan.AggregationNode;
+import io.trino.sql.planner.plan.Assignments;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.sql.ir.Booleans.FALSE;
+import static io.trino.sql.ir.Booleans.TRUE;
+import static io.trino.sql.ir.Comparison.Operator.EQUAL;
+import static io.trino.sql.ir.Comparison.Operator.GREATER_THAN;
+import static io.trino.sql.ir.Logical.Operator.AND;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.singleGroupingSet;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestPushFilterThroughBoolOrAggregation
+        extends BaseRuleTest
+{
+    @Test
+    public void testDoesNotFireWithNonGroupedAggregation()
+    {
+        tester().assertThat(new PushFilterThroughBoolOrAggregationWithoutProject(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol g = p.symbol("g", BIGINT);
+                    Symbol bool = p.symbol("bool", BOOLEAN);
+                    Symbol aggrBool = p.symbol("aggrbool", BOOLEAN);
+                    return p.filter(
+                            new Comparison(EQUAL, aggrBool.toSymbolReference(), TRUE),
+                            p.aggregation(builder -> builder
+                                    .globalGrouping()
+                                    .addAggregation(aggrBool, PlanBuilder.aggregation("bool_or", ImmutableList.of(bool.toSymbolReference())), ImmutableList.of(BOOLEAN), bool)
+                                    .source(p.values(g, bool))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireWithMultipleAggregations()
+    {
+        tester().assertThat(new PushFilterThroughBoolOrAggregationWithoutProject(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol g = p.symbol("g", BIGINT);
+                    Symbol bool = p.symbol("bool", BOOLEAN);
+                    Symbol aggrBool = p.symbol("aggrbool", BOOLEAN);
+                    Symbol avg = p.symbol("avg", BIGINT);
+                    return p.filter(
+                            new Comparison(EQUAL, aggrBool.toSymbolReference(), TRUE),
+                            p.aggregation(builder -> builder
+                                    .singleGroupingSet(g)
+                                    .addAggregation(aggrBool, PlanBuilder.aggregation("bool_or", ImmutableList.of(bool.toSymbolReference())), ImmutableList.of(BOOLEAN), bool)
+                                    .addAggregation(avg, PlanBuilder.aggregation("avg", ImmutableList.of(g.toSymbolReference())), ImmutableList.of(BIGINT))
+                                    .source(p.values(g, bool))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireWithNoAggregations()
+    {
+        tester().assertThat(new PushFilterThroughBoolOrAggregationWithoutProject(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol g = p.symbol("g", BIGINT);
+                    Symbol bool = p.symbol("bool", BOOLEAN);
+                    return p.filter(
+                            TRUE,
+                            p.aggregation(builder -> builder
+                                    .singleGroupingSet(g)
+                                    .source(p.values(g, bool))));
+                })
+                .doesNotFire();
+
+        tester().assertThat(new PushFilterThroughBoolOrAggregationWithoutProject(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol g = p.symbol("g", BIGINT);
+                    return p.filter(
+                            TRUE,
+                            p.aggregation(builder -> builder
+                                    .singleGroupingSet(g)
+                                    .source(p.values(g))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireWithNoBoolOrAggregation()
+    {
+        tester().assertThat(new PushFilterThroughBoolOrAggregationWithoutProject(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol g = p.symbol("g", BIGINT);
+                    Symbol bool = p.symbol("bool", BOOLEAN);
+                    Symbol avg = p.symbol("avg", DOUBLE);
+                    return p.filter(
+                            new Comparison(GREATER_THAN, avg.toSymbolReference(), new Constant(DOUBLE, 0d)),
+                            p.aggregation(builder -> builder
+                                    .singleGroupingSet(g)
+                                    .addAggregation(
+                                            avg,
+                                            PlanBuilder.aggregation("avg", ImmutableList.of(g.toSymbolReference())),
+                                            ImmutableList.of(BIGINT))
+                                    .source(p.values(g, bool))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testFilterPredicateFalse()
+    {
+        tester().assertThat(new PushFilterThroughBoolOrAggregationWithoutProject(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol g = p.symbol("g", BIGINT);
+                    Symbol bool = p.symbol("bool", BOOLEAN);
+                    Symbol aggrBool = p.symbol("aggrbool", BOOLEAN);
+                    return p.filter(
+                            new Logical(AND,
+                                    ImmutableList.of(new Comparison(EQUAL, aggrBool.toSymbolReference(), TRUE),
+                                            new Comparison(EQUAL, aggrBool.toSymbolReference(), FALSE))),
+                            p.aggregation(builder -> builder
+                                    .singleGroupingSet(g)
+                                    .addAggregation(
+                                            aggrBool,
+                                            PlanBuilder.aggregation("bool_or", ImmutableList.of(bool.toSymbolReference())),
+                                            ImmutableList.of(BOOLEAN))
+                                    .source(p.values(g, bool))));
+                })
+                .matches(
+                        values("g", "aggrbool"));
+    }
+
+    @Test
+    public void testDoesNotFireWhenFilterPredicateTrue()
+    {
+        tester().assertThat(new PushFilterThroughBoolOrAggregationWithoutProject(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol g = p.symbol("g", BIGINT);
+                    Symbol bool = p.symbol("bool", BOOLEAN);
+                    Symbol aggrBool = p.symbol("aggrbool", BOOLEAN);
+                    return p.filter(
+                            TRUE,
+                            p.aggregation(builder -> builder
+                                    .singleGroupingSet(g)
+                                    .addAggregation(
+                                            aggrBool,
+                                            PlanBuilder.aggregation("bool_or", ImmutableList.of(bool.toSymbolReference())),
+                                            ImmutableList.of(BOOLEAN))
+                                    .source(p.values(g, bool))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireWhenFilterPredicateCoalesceWithOtherSymbol()
+    {
+        tester().assertThat(new PushFilterThroughBoolOrAggregationWithoutProject(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol g = p.symbol("g", BIGINT);
+                    Symbol other = p.symbol("other", BOOLEAN);
+                    Symbol bool = p.symbol("bool", BOOLEAN);
+                    Symbol aggrBool = p.symbol("aggrbool", BOOLEAN);
+                    return p.filter(
+                            new Coalesce(other.toSymbolReference(), TRUE, FALSE),
+                            p.aggregation(builder -> builder
+                                    .singleGroupingSet(g)
+                                    .addAggregation(
+                                            aggrBool,
+                                            PlanBuilder.aggregation("bool_or", ImmutableList.of(bool.toSymbolReference())),
+                                            ImmutableList.of(BOOLEAN))
+                                    .source(p.values(g, bool))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireWhenFilterPredicateNotCoalesce()
+    {
+        tester().assertThat(new PushFilterThroughBoolOrAggregationWithoutProject(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol g = p.symbol("g", BIGINT);
+                    Symbol bool = p.symbol("bool", BOOLEAN);
+                    Symbol aggrBool = p.symbol("aggrbool", BOOLEAN);
+                    return p.filter(
+                            new Not(new Coalesce(aggrBool.toSymbolReference(), TRUE)),
+                            p.aggregation(builder -> builder
+                                    .singleGroupingSet(g)
+                                    .addAggregation(
+                                            aggrBool,
+                                            PlanBuilder.aggregation("bool_or", ImmutableList.of(bool.toSymbolReference())),
+                                            ImmutableList.of(BOOLEAN))
+                                    .source(p.values(g, bool))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testPushDownSymbolAndRemoveFilter()
+    {
+        tester().assertThat(new PushFilterThroughBoolOrAggregationWithoutProject(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol g = p.symbol("g", BIGINT);
+                    Symbol bool = p.symbol("bool", BOOLEAN);
+                    Symbol aggrBool = p.symbol("aggrbool", BOOLEAN);
+                    return p.filter(
+                            new Coalesce(aggrBool.toSymbolReference(), TRUE),
+                            p.aggregation(builder -> builder
+                                    .singleGroupingSet(g, bool)
+                                    .addAggregation(
+                                            aggrBool,
+                                            PlanBuilder.aggregation("bool_or", ImmutableList.of(bool.toSymbolReference())),
+                                            ImmutableList.of(BOOLEAN))
+                                    .source(p.values(g, bool))));
+                }).doesNotFire();
+
+        tester().assertThat(new PushFilterThroughBoolOrAggregationWithoutProject(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol g = p.symbol("g", BIGINT);
+                    Symbol bool = p.symbol("bool", BOOLEAN);
+                    Symbol aggrBool = p.symbol("aggrbool", BOOLEAN);
+                    return p.filter(
+                            new Coalesce(aggrBool.toSymbolReference(), FALSE),
+                            p.aggregation(builder -> builder
+                                    .singleGroupingSet(g, bool)
+                                    .addAggregation(
+                                            aggrBool,
+                                            PlanBuilder.aggregation("bool_or", ImmutableList.of(bool.toSymbolReference())),
+                                            ImmutableList.of(BOOLEAN))
+                                    .source(p.values(g, bool))));
+                })
+                .matches(
+                        project(
+                                ImmutableMap.of("g", expression(new Reference(BIGINT, "g")),
+                                        "bool", expression(new Reference(BOOLEAN, "bool")),
+                                        "aggrbool", expression(TRUE)),
+                                aggregation(
+                                        singleGroupingSet("g", "bool"),
+                                        ImmutableMap.of(),
+                                        Optional.empty(),
+                                        AggregationNode.Step.SINGLE,
+                                        filter(
+                                                new Reference(BOOLEAN, "bool"),
+                                                values("g", "bool")))));
+    }
+
+    @Test
+    public void testPushDownSymbolAndSimplifyFilter()
+    {
+        tester().assertThat(new PushFilterThroughBoolOrAggregationWithoutProject(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol g = p.symbol("g", BIGINT);
+                    Symbol bool = p.symbol("bool", BOOLEAN);
+                    Symbol aggrBool = p.symbol("aggrbool", BOOLEAN);
+                    return p.filter(
+                            new Logical(AND,
+                                    ImmutableList.of(
+                                            new Comparison(EQUAL, aggrBool.toSymbolReference(), TRUE),
+                                            new Coalesce(aggrBool.toSymbolReference(), FALSE))),
+                            p.aggregation(builder -> builder
+                                    .singleGroupingSet(g, bool)
+                                    .addAggregation(
+                                            aggrBool,
+                                            PlanBuilder.aggregation("bool_or", ImmutableList.of(bool.toSymbolReference())),
+                                            ImmutableList.of(BOOLEAN))
+                                    .source(p.values(g, bool))));
+                })
+                .matches(
+                        project(
+                                ImmutableMap.of("g", expression(new Reference(BIGINT, "g")),
+                                        "bool", expression(new Reference(BOOLEAN, "bool")),
+                                        "aggrbool", expression(TRUE)),
+                                aggregation(
+                                        singleGroupingSet("g", "bool"),
+                                        ImmutableMap.of(),
+                                        Optional.empty(),
+                                        AggregationNode.Step.SINGLE,
+                                        filter(
+                                                new Reference(BOOLEAN, "bool"),
+                                                values("g", "bool")))));
+    }
+
+    @Test
+    public void testPushDownSymbolAndRetainFilter()
+    {
+        tester().assertThat(new PushFilterThroughBoolOrAggregationWithoutProject(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol g = p.symbol("g", BIGINT);
+                    Symbol bool = p.symbol("bool", BOOLEAN);
+                    Symbol aggrBool = p.symbol("aggrbool", BOOLEAN);
+                    return p.filter(
+                            new Logical(AND,
+                                    ImmutableList.of(
+                                            new Comparison(GREATER_THAN, g.toSymbolReference(), new Constant(BIGINT, 5L)),
+                                            new Coalesce(aggrBool.toSymbolReference(), FALSE))),
+                            p.aggregation(builder -> builder
+                                    .singleGroupingSet(g, bool)
+                                    .addAggregation(
+                                            aggrBool,
+                                            PlanBuilder.aggregation("bool_or", ImmutableList.of(bool.toSymbolReference())),
+                                            ImmutableList.of(BOOLEAN))
+                                    .source(p.values(g, bool))));
+                })
+                .matches(
+                        filter(
+                                new Comparison(GREATER_THAN, new Reference(BIGINT, "g"), new Constant(BIGINT, 5L)),
+                                project(
+                                        ImmutableMap.of("g", expression(new Reference(BIGINT, "g")),
+                                                "bool", expression(new Reference(BOOLEAN, "bool")),
+                                                "aggrbool", expression(TRUE)),
+                                        aggregation(
+                                                singleGroupingSet("g", "bool"),
+                                                ImmutableMap.of(),
+                                                Optional.empty(),
+                                                AggregationNode.Step.SINGLE,
+                                                filter(
+                                                        new Reference(BOOLEAN, "bool"),
+                                                        values("g", "bool"))))));
+    }
+
+    @Test
+    public void testWithProject()
+    {
+        tester().assertThat(new PushFilterThroughBoolOrAggregationWithProject(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol g = p.symbol("g", BIGINT);
+                    Symbol bool = p.symbol("bool", BOOLEAN);
+                    Symbol aggrBool = p.symbol("aggrbool", BOOLEAN);
+                    return p.filter(
+                            new Comparison(EQUAL, aggrBool.toSymbolReference(), TRUE),
+                            p.project(
+                                    Assignments.identity(aggrBool),
+                                    p.aggregation(builder -> builder
+                                            .singleGroupingSet(g)
+                                            .addAggregation(
+                                                    aggrBool,
+                                                    PlanBuilder.aggregation("bool_or", ImmutableList.of(bool.toSymbolReference())),
+                                                    ImmutableList.of(BOOLEAN))
+                                            .source(p.values(g, bool)))));
+                })
+                .matches(
+                        project(
+                                ImmutableMap.of("aggrbool", expression(new Reference(BOOLEAN, "aggrbool"))),
+                                project(
+                                        ImmutableMap.of("g", expression(new Reference(BIGINT, "g")),
+                                                "bool", expression(new Reference(BOOLEAN, "bool")),
+                                                "aggrbool", expression(TRUE)),
+                                        aggregation(
+                                                ImmutableMap.of(),
+                                                filter(
+                                                        new Reference(BOOLEAN, "bool"),
+                                                        values("g", "bool"))))));
+
+        tester().assertThat(new PushFilterThroughBoolOrAggregationWithProject(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol g = p.symbol("g", BIGINT);
+                    Symbol bool = p.symbol("bool", BOOLEAN);
+                    Symbol aggrBool = p.symbol("aggrbool", BOOLEAN);
+                    return p.filter(
+                            new Logical(AND,
+                                    ImmutableList.of(
+                                            new Comparison(EQUAL, aggrBool.toSymbolReference(), TRUE),
+                                            new Coalesce(aggrBool.toSymbolReference(), FALSE))),
+                            p.project(
+                                    Assignments.identity(aggrBool, g),
+                                    p.aggregation(builder -> builder
+                                            .singleGroupingSet(g)
+                                            .addAggregation(
+                                                    aggrBool,
+                                                    PlanBuilder.aggregation("bool_or", ImmutableList.of(bool.toSymbolReference())),
+                                                    ImmutableList.of(BOOLEAN))
+                                            .source(p.values(g, bool)))));
+                })
+                .matches(
+                        project(
+                                ImmutableMap.of("aggrbool", expression(new Reference(BOOLEAN, "aggrbool"))),
+                                project(
+                                        ImmutableMap.of("g", expression(new Reference(BIGINT, "g")),
+                                                "bool", expression(new Reference(BOOLEAN, "bool")),
+                                                "aggrbool", expression(TRUE)),
+                                        aggregation(
+                                                ImmutableMap.of(),
+                                                filter(
+                                                        new Reference(BOOLEAN, "bool"),
+                                                        values("g", "bool"))))));
+
+        tester().assertThat(new PushFilterThroughBoolOrAggregationWithProject(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol g = p.symbol("g", BIGINT);
+                    Symbol bool = p.symbol("bool", BOOLEAN);
+                    Symbol aggrBool = p.symbol("aggrbool", BOOLEAN);
+                    return p.filter(
+                            new Logical(AND,
+                                    ImmutableList.of(
+                                            new Comparison(GREATER_THAN, g.toSymbolReference(), new Constant(BIGINT, 5L)),
+                                            new Coalesce(aggrBool.toSymbolReference(), FALSE))),
+                            p.project(
+                                    Assignments.identity(aggrBool, g),
+                                    p.aggregation(builder -> builder
+                                            .singleGroupingSet(g)
+                                            .addAggregation(aggrBool, PlanBuilder.aggregation("bool_or", ImmutableList.of(bool.toSymbolReference())), ImmutableList.of(BOOLEAN))
+                                            .source(p.values(g, bool)))));
+                })
+                .matches(
+                        filter(
+                                new Comparison(GREATER_THAN, new Reference(BIGINT, "g"), new Constant(BIGINT, 5L)),
+                                project(
+                                        ImmutableMap.of("aggrbool", expression(new Reference(BOOLEAN, "aggrbool")), "g", expression(new Reference(BIGINT, "g"))),
+                                        project(
+                                                ImmutableMap.of("g", expression(new Reference(BIGINT, "g")),
+                                                        "bool", expression(new Reference(BOOLEAN, "bool")),
+                                                        "aggrbool", expression(TRUE)),
+                                                aggregation(
+                                                        ImmutableMap.of(),
+                                                        filter(
+                                                                new Reference(BOOLEAN, "bool"),
+                                                                values("g", "bool")))))));
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestCorrelatedAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestCorrelatedAggregation.java
@@ -461,6 +461,37 @@ public class TestCorrelatedAggregation
     }
 
     @Test
+    public void testBoolOrAggregation()
+    {
+        // without projection
+        assertThat(assertions.query("""
+                SELECT * FROM
+                (VALUES  1, 2, 3, 4) t(key)
+                LEFT JOIN
+                LATERAL (SELECT bool_or(value) FROM (VALUES (2, null), (3, false), (4, true)) t2(key, value) WHERE t2.key <= t.key)
+                ON TRUE"""))
+                .matches("VALUES (1, null), (2, null), (3, false), (4, true)");
+
+        // with projection
+        assertThat(assertions.query("""
+                SELECT * FROM
+                (VALUES  1, 2, 3, 4) t(key)
+                LEFT JOIN
+                LATERAL (SELECT bool_or(value), true FROM (VALUES (2, null), (3, false), (4, true)) t2(key, value) WHERE t2.key <= t.key)
+                ON TRUE"""))
+                .matches("VALUES (1, null, true) ,(2, null, true), (3, false, true), (4, true, true)");
+
+        // with projection and distinct
+        assertThat(assertions.query("""
+                SELECT * FROM
+                (VALUES  1, 2, 3, 4) t(key)
+                LEFT JOIN
+                LATERAL (SELECT bool_or(distinct value), true FROM (VALUES (2, null), (3, false), (4, true)) t2(key, value) WHERE t2.key <= t.key)
+                ON TRUE"""))
+                .matches("VALUES (1, null, true), (2, null, true), (3, false, true), (4, true, true)");
+    }
+
+    @Test
     public void testChecksum()
     {
         assertThat(assertions.query("SELECT * FROM " +

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestSubqueries.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestSubqueries.java
@@ -105,13 +105,13 @@ public class TestSubqueries
                 "VALUES true",
                 anyTree(
                         aggregation(
-                                ImmutableMap.of("COUNT", aggregationFunction("count", ImmutableList.of())),
+                                ImmutableMap.of("AGGRBOOL", aggregationFunction("bool_or", ImmutableList.of("SUBQUERY"))),
                                 aggregation -> aggregation.isStreamable() && aggregation.getStep() == SINGLE,
                                 node(JoinNode.class,
                                         anyTree(
                                                 values("y")),
                                         project(
-                                                ImmutableMap.of("NON_NULL", expression(TRUE)),
+                                                ImmutableMap.of("SUBQUERY", expression(TRUE)),
                                                 values("x"))))));
 
         assertions.assertQueryAndPlan(
@@ -119,13 +119,13 @@ public class TestSubqueries
                 "VALUES false",
                 anyTree(
                         aggregation(
-                                ImmutableMap.of("COUNT", aggregationFunction("count", ImmutableList.of())),
+                                ImmutableMap.of("AGGRBOOL", aggregationFunction("bool_or", ImmutableList.of("SUBQUERY"))),
                                 aggregation -> aggregation.isStreamable() && aggregation.getStep() == SINGLE,
                                 node(JoinNode.class,
                                         anyTree(
                                                 values("y")),
                                         project(
-                                                ImmutableMap.of("NON_NULL", expression(TRUE)),
+                                                ImmutableMap.of("SUBQUERY", expression(TRUE)),
                                                 values("x"))))));
     }
 
@@ -514,14 +514,14 @@ public class TestSubqueries
                 "VALUES false, true",
                 anyTree(
                         aggregation(
-                                ImmutableMap.of("COUNT", aggregationFunction("count", ImmutableList.of())),
+                                ImmutableMap.of("AGGRBOOL", aggregationFunction("bool_or", ImmutableList.of("SUBQUERYTRUE"))),
                                 aggregation -> aggregation.isStreamable() && aggregation.getStep() == SINGLE,
                                 node(JoinNode.class,
                                         anyTree(
                                                 values("t2_b")),
                                         anyTree(
                                                 project(
-                                                        ImmutableMap.of("NON_NULL", expression(TRUE)),
+                                                        ImmutableMap.of("SUBQUERYTRUE", expression(TRUE)),
                                                         anyTree(
                                                                 aggregation(
                                                                         ImmutableMap.of(),
@@ -539,14 +539,14 @@ public class TestSubqueries
                 "VALUES false, true",
                 anyTree(
                         aggregation(
-                                ImmutableMap.of("COUNT", aggregationFunction("count", ImmutableList.of())),
+                                ImmutableMap.of("AGGRBOOL", aggregationFunction("bool_or", ImmutableList.of("SUBQUERY"))),
                                 aggregation -> aggregation.isStreamable() && aggregation.getStep() == SINGLE,
                                 node(JoinNode.class,
                                         anyTree(
                                                 values("t2_b")),
                                         anyTree(
                                                 project(
-                                                        ImmutableMap.of("NON_NULL", expression(TRUE)),
+                                                        ImmutableMap.of("SUBQUERY", expression(TRUE)),
                                                         aggregation(
                                                                 ImmutableMap.of(),
                                                                 FINAL,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Improve performance of correlated exists by replacing count aggregation with bool_or,
which reduced the need to use additional symbol with mask. As a result, aggregation can be
marked as streaming and join can be marked as may skip duplicates.

[after_q21.txt](https://github.com/trinodb/trino/files/15235050/after_q21.txt)
[before_q21.txt](https://github.com/trinodb/trino/files/15235051/before_q21.txt)

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```
# General
* Improve performance of non-equality correlated exists queries. ({issue}`issuenumber`)
```