### PR TITLE
Drop testing with unsupported Redis version

### DIFF
--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/util/RedisServer.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/util/RedisServer.java
@@ -22,7 +22,7 @@ import java.io.Closeable;
 public class RedisServer
         implements Closeable
 {
-    public static final String DEFAULT_VERSION = "2.8.9";
+    public static final String DEFAULT_VERSION = "5.0.14";
     public static final String LATEST_VERSION = "7.0.0";
     private static final int PORT = 6379;
 


### PR DESCRIPTION
Per https://redis.io/docs/about/releases/ only two major releases prior to the current one are considered supported. As of this writing, the latest version is 7.2, to 5.x is the oldest still supported version.
