### PR TITLE
Add explicit location for the cloned table

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDeleteCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDeleteCompatibility.java
@@ -529,7 +529,9 @@ public class TestDeltaLakeDeleteCompatibility
             onDelta().executeQuery("DELETE FROM default." + baseTableName + " WHERE a = 1 OR a = 3");
 
             // The cloned table has 'p' (absolute path) storageType for deletion vector
-            onDelta().executeQuery("CREATE TABLE default." + tableName + " SHALLOW CLONE " + baseTableName);
+            onDelta().executeQuery("" +
+                    "CREATE TABLE default." + tableName + " SHALLOW CLONE " + baseTableName + " " +
+                    "LOCATION 's3://" + bucketName + "/databricks-compatibility-test-clone-" + baseTableName + "'");
 
             List<Row> expected = ImmutableList.of(row(2, 22), row(4, 44));
             assertThat(onDelta().executeQuery("SELECT * FROM default." + tableName)).contains(expected);


### PR DESCRIPTION
At the time of this writing, the metastore of the product test has the location for the `default` schema set to

```
hdfs://hadoop-master:9000/user/hive/warehouse
```

Use an explicit location for the cloned table in order to avoid writing the cloned table to hdfs.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.