### PR TITLE
Lazy computation of some fields in QueryMetadata and QueryStatistics

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryMetadata.java
@@ -20,6 +20,7 @@ import io.trino.spi.Unstable;
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
 
@@ -44,7 +45,7 @@ public class QueryMetadata
     private final Optional<String> plan;
     private final Optional<String> jsonPlan;
 
-    private final Optional<String> payload;
+    private final Supplier<Optional<String>> payloadProvider;
 
     @JsonCreator
     @Unstable
@@ -62,6 +63,35 @@ public class QueryMetadata
             Optional<String> jsonPlan,
             Optional<String> payload)
     {
+        this(
+                queryId,
+                transactionId,
+                query,
+                updateType,
+                preparedQuery,
+                queryState,
+                tables,
+                routines,
+                uri,
+                plan,
+                jsonPlan,
+                () -> payload);
+    }
+
+    public QueryMetadata(
+            String queryId,
+            Optional<String> transactionId,
+            String query,
+            Optional<String> updateType,
+            Optional<String> preparedQuery,
+            String queryState,
+            List<TableInfo> tables,
+            List<RoutineInfo> routines,
+            URI uri,
+            Optional<String> plan,
+            Optional<String> jsonPlan,
+            Supplier<Optional<String>> payloadProvider)
+    {
         this.queryId = requireNonNull(queryId, "queryId is null");
         this.transactionId = requireNonNull(transactionId, "transactionId is null");
         this.query = requireNonNull(query, "query is null");
@@ -73,7 +103,7 @@ public class QueryMetadata
         this.uri = requireNonNull(uri, "uri is null");
         this.plan = requireNonNull(plan, "plan is null");
         this.jsonPlan = requireNonNull(jsonPlan, "jsonPlan is null");
-        this.payload = requireNonNull(payload, "payload is null");
+        this.payloadProvider = requireNonNull(payloadProvider, "payloadProvider is null");
     }
 
     @JsonProperty
@@ -145,6 +175,6 @@ public class QueryMetadata
     @JsonProperty
     public Optional<String> getPayload()
     {
-        return payload;
+        return payloadProvider.get();
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryStatistics.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryStatistics.java
@@ -20,6 +20,7 @@ import io.trino.spi.Unstable;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
 
@@ -77,7 +78,7 @@ public class QueryStatistics
      * Operator summaries serialized to JSON. Serialization format and structure
      * can change without preserving backward compatibility.
      */
-    private final List<String> operatorSummaries;
+    private final Supplier<List<String>> operatorSummariesProvider;
     private final List<QueryPlanOptimizerStatistics> optimizerRulesSummaries;
     /**
      * Plan node stats and costs serialized to JSON. Serialization format and structure
@@ -131,6 +132,95 @@ public class QueryStatistics
             List<QueryPlanOptimizerStatistics> optimizerRulesSummaries,
             Optional<String> planNodeStatsAndCosts)
     {
+        this(
+                cpuTime,
+                failedCpuTime,
+                wallTime,
+                queuedTime,
+                scheduledTime,
+                failedScheduledTime,
+                resourceWaitingTime,
+                analysisTime,
+                planningTime,
+                planningCpuTime,
+                executionTime,
+                inputBlockedTime,
+                failedInputBlockedTime,
+                outputBlockedTime,
+                failedOutputBlockedTime,
+                physicalInputReadTime,
+                peakUserMemoryBytes,
+                peakTaskUserMemory,
+                peakTaskTotalMemory,
+                physicalInputBytes,
+                physicalInputRows,
+                processedInputBytes,
+                processedInputRows,
+                internalNetworkBytes,
+                internalNetworkRows,
+                totalBytes,
+                totalRows,
+                outputBytes,
+                outputRows,
+                writtenBytes,
+                writtenRows,
+                spilledBytes,
+                cumulativeMemory,
+                failedCumulativeMemory,
+                stageGcStatistics,
+                completedSplits,
+                complete,
+                cpuTimeDistribution,
+                outputBufferUtilization,
+                () -> operatorSummaries,
+                optimizerRulesSummaries,
+                planNodeStatsAndCosts);
+    }
+
+    public QueryStatistics(
+            Duration cpuTime,
+            Duration failedCpuTime,
+            Duration wallTime,
+            Duration queuedTime,
+            Optional<Duration> scheduledTime,
+            Optional<Duration> failedScheduledTime,
+            Optional<Duration> resourceWaitingTime,
+            Optional<Duration> analysisTime,
+            Optional<Duration> planningTime,
+            Optional<Duration> planningCpuTime,
+            Optional<Duration> executionTime,
+            Optional<Duration> inputBlockedTime,
+            Optional<Duration> failedInputBlockedTime,
+            Optional<Duration> outputBlockedTime,
+            Optional<Duration> failedOutputBlockedTime,
+            Optional<Duration> physicalInputReadTime,
+            long peakUserMemoryBytes,
+            long peakTaskUserMemory,
+            long peakTaskTotalMemory,
+            long physicalInputBytes,
+            long physicalInputRows,
+            long processedInputBytes,
+            long processedInputRows,
+            long internalNetworkBytes,
+            long internalNetworkRows,
+            long totalBytes,
+            long totalRows,
+            long outputBytes,
+            long outputRows,
+            long writtenBytes,
+            long writtenRows,
+            long spilledBytes,
+            double cumulativeMemory,
+            double failedCumulativeMemory,
+            List<StageGcStatistics> stageGcStatistics,
+            int completedSplits,
+            boolean complete,
+            List<StageCpuDistribution> cpuTimeDistribution,
+            List<StageOutputBufferUtilization> outputBufferUtilization,
+            Supplier<List<String>> operatorSummariesProvider,
+            List<QueryPlanOptimizerStatistics> optimizerRulesSummaries,
+            Optional<String> planNodeStatsAndCosts)
+    {
         this.cpuTime = requireNonNull(cpuTime, "cpuTime is null");
         this.failedCpuTime = requireNonNull(failedCpuTime, "failedCpuTime is null");
         this.wallTime = requireNonNull(wallTime, "wallTime is null");
@@ -170,7 +260,7 @@ public class QueryStatistics
         this.complete = complete;
         this.cpuTimeDistribution = requireNonNull(cpuTimeDistribution, "cpuTimeDistribution is null");
         this.outputBufferUtilization = requireNonNull(outputBufferUtilization, "outputBufferUtilization is null");
-        this.operatorSummaries = requireNonNull(operatorSummaries, "operatorSummaries is null");
+        this.operatorSummariesProvider = requireNonNull(operatorSummariesProvider, "operatorSummariesProvider is null");
         this.optimizerRulesSummaries = requireNonNull(optimizerRulesSummaries, "optimizerRulesSummaries is null");
         this.planNodeStatsAndCosts = requireNonNull(planNodeStatsAndCosts, "planNodeStatsAndCosts is null");
     }
@@ -412,7 +502,7 @@ public class QueryStatistics
     @JsonProperty
     public List<String> getOperatorSummaries()
     {
-        return operatorSummaries;
+        return operatorSummariesProvider.get();
     }
 
     @JsonProperty


### PR DESCRIPTION
## Description
1. Let's compute `QueryCompletedEvent` only once, even if there is multiple event listeners.
2. Let's compute `QueryMetadata#paylaod` and `QueryStatistics#operatorSummaries` lazily because of heaviness (CPU and memory) of these computation.

## Motivation

A lot of CPU cycles released

Fixes a regression introduced in https://github.com/trinodb/trino/commit/7f3047691383beb5320900b0adb94e684dbfe82a (https://github.com/trinodb/trino/pull/12968) -- `QueryCompletedEvent` was being created multiple times, and it's sometimes quite expensive.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
