### PR TITLE
Ignore PRs with stale-ignore label

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,6 +19,7 @@ jobs:
           days-before-pr-close: 21
           close-pr-message: 'Closing this pull request, as it has been stale for six weeks. Feel free to re-open at any time.'
           stale-pr-label: 'stale'
+          exempt-pr-labels: 'stale-ignore'
           start-date: '2023-01-01T00:00:00Z'
           exempt-draft-pr: true
           operations-per-run: 200


### PR DESCRIPTION
## Description

This setup allows maintainers to add a label `stale-ignore` to a PR and it would then not be processed by the stale bot. It would prevent labelling with `stale`, notification to devrel team and autoclosing. 

If we want this feature someone with GitHub admin access has to add the label .. ideally with description. 

## Additional context and related issues

https://github.com/trinodb/trino/pull/20755#issuecomment-2043258150

and there are other PRs where this would be helpful.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
