### PR TITLE
Update Redis version requirement

### DIFF
--- a/docs/src/main/sphinx/connector/redis.md
+++ b/docs/src/main/sphinx/connector/redis.md
@@ -18,7 +18,7 @@ string and hash types are supported.
 Requirements for using the connector in a catalog to connect to a Redis data
 source are:
 
-- Redis 2.8.0 or higher (Redis Cluster is not supported)
+- Redis 5.0.14 or higher (Redis Cluster is not supported)
 - Network access, by default on port 6379, from the Trino coordinator and
   workers to Redis.
 


### PR DESCRIPTION
## Description

Recent PR upgraded testing.. adjusting docs .. but 5.0.0  (https://github.com/redis/redis/releases/tag/5.0.0) is still very old so maybe we should even go with 6.0.0 (https://github.com/redis/redis/releases/tag/6.0.0)

We could also use https://github.com/redis/redis/releases/tag/5.0.14 .. since that has a lot of security issues fixed and is a least a bit newer .. and also what we use in testing now.

## Additional context and related issues

https://github.com/trinodb/trino/pull/21431#issuecomment-2041156140

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
