### PR TITLE
Fix threads leak in SqlTaskManager

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
@@ -338,6 +338,7 @@ public class SqlTaskManager
         }
         taskNotificationExecutor.shutdownNow();
         driverYieldExecutor.shutdownNow();
+        driverTimeoutExecutor.shutdownNow();
     }
 
     @Managed

--- a/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/AccumuloQueryRunner.java
+++ b/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/AccumuloQueryRunner.java
@@ -152,7 +152,6 @@ public final class AccumuloQueryRunner
             throws Exception
     {
         QueryRunner queryRunner = createAccumuloQueryRunner(ImmutableMap.of("http-server.http.port", "8080"));
-        Thread.sleep(10);
         Logger log = Logger.get(AccumuloQueryRunner.class);
         log.info("======== SERVER STARTED ========");
         log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
@@ -215,7 +215,6 @@ public final class BigQueryQueryRunner
                 ImmutableMap.of("http-server.http.port", "8080"),
                 ImmutableMap.of(),
                 TpchTable.getTables());
-        Thread.sleep(10);
         Logger log = Logger.get(BigQueryQueryRunner.class);
         log.info("======== SERVER STARTED ========");
         log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());

--- a/plugin/trino-blackhole/src/test/java/io/trino/plugin/blackhole/BlackHoleQueryRunner.java
+++ b/plugin/trino-blackhole/src/test/java/io/trino/plugin/blackhole/BlackHoleQueryRunner.java
@@ -67,7 +67,6 @@ public final class BlackHoleQueryRunner
             throws Exception
     {
         QueryRunner queryRunner = createQueryRunner(ImmutableMap.of("http-server.http.port", "8080"));
-        Thread.sleep(10);
         Logger log = Logger.get(BlackHoleQueryRunner.class);
         log.info("======== SERVER STARTED ========");
         log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
@@ -268,7 +268,6 @@ public final class DeltaLakeQueryRunner
             copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), TpchTable.getTables());
             log.info("Data directory is: %s", metastoreDirectory);
 
-            Thread.sleep(10);
             Logger log = Logger.get(DeltaLakeQueryRunner.class);
             log.info("======== SERVER STARTED ========");
             log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());
@@ -314,7 +313,6 @@ public final class DeltaLakeQueryRunner
             queryRunner.execute("CREATE SCHEMA tpch WITH (location='s3://" + bucketName + "/tpch')");
             copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), TpchTable.getTables());
 
-            Thread.sleep(10);
             Logger log = Logger.get(DeltaLakeQueryRunner.class);
             log.info("======== SERVER STARTED ========");
             log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
@@ -392,7 +392,6 @@ public final class HiveQueryRunner
                 //.setTpchColumnNaming(ColumnNaming.STANDARD)
                 //.setTpchDecimalTypeMapping(DecimalTypeMapping.DECIMAL)
                 .build();
-        Thread.sleep(10);
         log.info("======== SERVER STARTED ========");
         log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());
     }

--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/MemoryQueryRunner.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/MemoryQueryRunner.java
@@ -131,7 +131,6 @@ public final class MemoryQueryRunner
         QueryRunner queryRunner = createMemoryQueryRunner(
                 ImmutableMap.of("http-server.http.port", "8080"),
                 TpchTable.getTables());
-        Thread.sleep(10);
         Logger log = Logger.get(MemoryQueryRunner.class);
         log.info("======== SERVER STARTED ========");
         log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());
@@ -161,7 +160,6 @@ public final class MemoryQueryRunner
                     })
                     .setInitialTables(TpchTable.getTables())
                     .build();
-            Thread.sleep(10);
             Logger log = Logger.get(MemoryQueryRunner.class);
             log.info("======== SERVER STARTED ========");
             log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoQueryRunner.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoQueryRunner.java
@@ -107,7 +107,6 @@ public final class MongoQueryRunner
                 new MongoServer(),
                 ImmutableMap.of("http-server.http.port", "8080"),
                 TpchTable.getTables());
-        Thread.sleep(10);
         Logger log = Logger.get(MongoQueryRunner.class);
         log.info("======== SERVER STARTED ========");
         log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/PinotQueryRunner.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/PinotQueryRunner.java
@@ -89,7 +89,6 @@ public class PinotQueryRunner
                 ImmutableMap.of("http-server.http.port", "8080"),
                 ImmutableMap.of("pinot.segments-per-split", "10"),
                 Set.of(REGION, NATION, ORDERS, CUSTOMER));
-        Thread.sleep(10);
         Logger log = Logger.get(PinotQueryRunner.class);
         log.info("======== SERVER STARTED ========");
         log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/PrometheusQueryRunner.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/PrometheusQueryRunner.java
@@ -77,7 +77,6 @@ public final class PrometheusQueryRunner
             throws Exception
     {
         QueryRunner queryRunner = createPrometheusQueryRunner(new PrometheusServer(), ImmutableMap.of("http-server.http.port", "8080"), ImmutableMap.of());
-        Thread.sleep(10);
         Logger log = Logger.get(PrometheusQueryRunner.class);
         log.info("======== SERVER STARTED ========");
         log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/RaptorQueryRunner.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/RaptorQueryRunner.java
@@ -177,7 +177,6 @@ public final class RaptorQueryRunner
     {
         Map<String, String> properties = ImmutableMap.of("http-server.http.port", "8080");
         QueryRunner queryRunner = createRaptorQueryRunner(properties, ImmutableList.of(), false, ImmutableMap.of());
-        Thread.sleep(10);
         Logger log = Logger.get(RaptorQueryRunner.class);
         log.info("======== SERVER STARTED ========");
         log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());

--- a/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/integration/ThriftQueryRunner.java
+++ b/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/integration/ThriftQueryRunner.java
@@ -99,7 +99,6 @@ public final class ThriftQueryRunner
         Logging.initialize();
         Map<String, String> properties = ImmutableMap.of("http-server.http.port", "8080");
         QueryRunner queryRunner = createThriftQueryRunner(3, true, properties);
-        Thread.sleep(10);
         Logger log = Logger.get(ThriftQueryRunner.class);
         log.info("======== SERVER STARTED ========");
         log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());

--- a/plugin/trino-tpcds/src/test/java/io/trino/plugin/tpcds/TpcdsQueryRunner.java
+++ b/plugin/trino-tpcds/src/test/java/io/trino/plugin/tpcds/TpcdsQueryRunner.java
@@ -68,7 +68,6 @@ public final class TpcdsQueryRunner
             throws Exception
     {
         QueryRunner queryRunner = createQueryRunner(ImmutableMap.of("http-server.http.port", "8080"));
-        Thread.sleep(10);
         Logger log = Logger.get(TpcdsQueryRunner.class);
         log.info("======== SERVER STARTED ========");
         log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());

--- a/testing/trino-tests/src/test/java/io/trino/tests/tpch/TpchQueryRunner.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/tpch/TpchQueryRunner.java
@@ -33,7 +33,6 @@ public final class TpchQueryRunner
                         .put("sql.default-schema", "tiny")
                         .buildOrThrow())
                 .build();
-        Thread.sleep(10);
         Logger log = Logger.get(TpchQueryRunner.class);
         log.info("======== SERVER STARTED ========");
         log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());


### PR DESCRIPTION
The thread leak matters for test execution. After
`DistributedQueryRunner.close()`, we expect all resources to be released
so that we can allocate resources for another query runner.
