### PR TITLE
Upgrade clickhouse image in tests

### DIFF
--- a/docs/src/main/sphinx/connector/clickhouse.md
+++ b/docs/src/main/sphinx/connector/clickhouse.md
@@ -19,7 +19,7 @@ from different catalogs accessing ClickHouse or any other supported data source.
 
 To connect to a ClickHouse server, you need:
 
-- ClickHouse (version 21.8 or higher) or Altinity (version 20.8 or higher).
+- ClickHouse (version 23.8 or higher) or Altinity (version 21.8 or higher).
 - Network access from the Trino coordinator and workers to the ClickHouse
   server. Port 8123 is the default port.
 

--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
@@ -594,9 +594,8 @@ public class ClickHouseClient
                         longDecimalReadFunction(UINT64_TYPE, UNNECESSARY),
                         uInt64WriteFunction(getClickHouseServerVersion(session))));
             case IPv4:
-                return Optional.of(ipAddressColumnMapping("IPv4StringToNum(?)"));
             case IPv6:
-                return Optional.of(ipAddressColumnMapping("IPv6StringToNum(?)"));
+                return Optional.of(ipAddressColumnMapping(column.getOriginalTypeName()));
             case Enum8:
             case Enum16:
                 return Optional.of(ColumnMapping.sliceMapping(
@@ -879,7 +878,7 @@ public class ClickHouseClient
         };
     }
 
-    private ColumnMapping ipAddressColumnMapping(String writeBindExpression)
+    private ColumnMapping ipAddressColumnMapping(String clickhouseType)
     {
         return ColumnMapping.sliceMapping(
                 ipAddressType,
@@ -903,17 +902,17 @@ public class ClickHouseClient
 
                     return wrappedBuffer(bytes);
                 },
-                ipAddressWriteFunction(writeBindExpression));
+                ipAddressWriteFunction(clickhouseType));
     }
 
-    private static SliceWriteFunction ipAddressWriteFunction(String bindExpression)
+    private static SliceWriteFunction ipAddressWriteFunction(String clickhouseType)
     {
         return new SliceWriteFunction()
         {
             @Override
             public String getBindExpression()
             {
-                return bindExpression;
+                return format("CAST(? AS %s)", clickhouseType);
             }
 
             @Override

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseTypeMapping.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseTypeMapping.java
@@ -390,7 +390,9 @@ public abstract class BaseClickHouseTypeMapping
         SqlDataTypeTest.create()
                 .addRoundTrip("double", "3.1415926835", DOUBLE, "DOUBLE '3.1415926835'")
                 .addRoundTrip("double", "1.79769E308", DOUBLE, "DOUBLE '1.79769E308'")
-                .addRoundTrip("double", "2.225E-307", DOUBLE, "DOUBLE '2.225E-307'")
+
+                // https://github.com/ClickHouse/ClickHouse/issues/60146
+                // .addRoundTrip("double", "2.225E-307", DOUBLE, "DOUBLE '2.225E-307'")
 
                 .execute(getQueryRunner(), clickhouseCreateAndInsert("tpch.test_double"))
 

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestAltinityConnectorSmokeTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestAltinityConnectorSmokeTest.java
@@ -15,11 +15,9 @@ package io.trino.plugin.clickhouse;
 
 import com.google.common.collect.ImmutableMap;
 import io.trino.testing.QueryRunner;
-import org.junit.jupiter.api.Test;
 
 import static io.trino.plugin.clickhouse.ClickHouseQueryRunner.createClickHouseQueryRunner;
 import static io.trino.plugin.clickhouse.TestingClickHouseServer.ALTINITY_DEFAULT_IMAGE;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestAltinityConnectorSmokeTest
         extends BaseClickHouseConnectorSmokeTest
@@ -33,14 +31,5 @@ public class TestAltinityConnectorSmokeTest
                 ImmutableMap.of(),
                 ImmutableMap.of("clickhouse.map-string-as-varchar", "true"), // To handle string types in TPCH tables as varchar instead of varbinary
                 REQUIRED_TPCH_TABLES);
-    }
-
-    @Test
-    @Override
-    public void testRenameSchema()
-    {
-        // Override because RENAME DATABASE statement isn't supported in Altinity 20.8
-        assertThatThrownBy(super::testRenameSchema)
-                .hasMessageContaining("RENAME DATABASE is not supported");
     }
 }

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
@@ -440,7 +440,7 @@ public class TestClickHouseConnectorTest
         assertUpdate("DROP TABLE " + tableName);
 
         // the column refers by order by must be not null
-        assertQueryFails("CREATE TABLE " + tableName + " (id int NOT NULL, x VARCHAR) WITH (engine = 'MergeTree', order_by = ARRAY['id', 'x'])", ".* Sorting key cannot contain nullable columns.*\\n.*");
+        assertQueryFails("CREATE TABLE " + tableName + " (id int NOT NULL, x VARCHAR) WITH (engine = 'MergeTree', order_by = ARRAY['id', 'x'])", ".*Sorting key contains nullable columns, but merge tree setting `allow_nullable_key` is disabled.*\\n.*");
 
         assertUpdate("CREATE TABLE " + tableName + " (id int NOT NULL, x VARCHAR) WITH (engine = 'MergeTree', order_by = ARRAY['id'], primary_key = ARRAY['id'])");
         assertThat((String) computeScalar("SHOW CREATE TABLE " + tableName))

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestingClickHouseServer.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestingClickHouseServer.java
@@ -29,14 +29,15 @@ import static org.testcontainers.utility.MountableFile.forClasspathResource;
 public class TestingClickHouseServer
         implements Closeable
 {
-    private static final DockerImageName CLICKHOUSE_IMAGE = DockerImageName.parse("yandex/clickhouse-server");
-    public static final DockerImageName CLICKHOUSE_LATEST_IMAGE = CLICKHOUSE_IMAGE.withTag("21.11.10.1");
-    public static final DockerImageName CLICKHOUSE_DEFAULT_IMAGE = CLICKHOUSE_IMAGE.withTag("21.8.14.5"); // EOL is 31 Aug 2022
+    private static final DockerImageName CLICKHOUSE_IMAGE = DockerImageName.parse("clickhouse/clickhouse-server");
+    public static final DockerImageName CLICKHOUSE_LATEST_IMAGE = CLICKHOUSE_IMAGE.withTag("24.1.8.22");   // EOL by Apr 2025
+    public static final DockerImageName CLICKHOUSE_DEFAULT_IMAGE = CLICKHOUSE_IMAGE.withTag("23.8.12.13"); // EOL by Jun 2024
 
     // Altinity Stable Builds Life-Cycle Table https://docs.altinity.com/altinitystablebuilds/#altinity-stable-builds-life-cycle-table
-    private static final DockerImageName ALTINITY_IMAGE = DockerImageName.parse("altinity/clickhouse-server").asCompatibleSubstituteFor("yandex/clickhouse-server");
-    public static final DockerImageName ALTINITY_LATEST_IMAGE = ALTINITY_IMAGE.withTag("21.8.13.1.altinitystable");
-    public static final DockerImageName ALTINITY_DEFAULT_IMAGE = ALTINITY_IMAGE.withTag("20.8.4.11_aes"); // EOL is 02 December 2022
+    // On Mac/arm try `21.8.12.29.altinitydev.arm` instead of the specified stable build
+    private static final DockerImageName ALTINITY_IMAGE = DockerImageName.parse("altinity/clickhouse-server").asCompatibleSubstituteFor("clickhouse/clickhouse-server");
+    public static final DockerImageName ALTINITY_LATEST_IMAGE = ALTINITY_IMAGE.withTag("23.8.8.21.altinitystable");  // EOL is 27 Dec 2026
+    public static final DockerImageName ALTINITY_DEFAULT_IMAGE = ALTINITY_IMAGE.withTag("21.8.15.15.altinitystable"); // EOL is 30 Aug 2024
 
     private final ClickHouseContainer dockerContainer;
 


### PR DESCRIPTION
## Description
I'm going to invest some time into making ClickHouse connector more functional. This is the first PR in a (hopefully) longer series.

Changes:
- Upgrade ClickHouse docker images (both by ClickHouse and Altinity). I was picking lts/stable builds from both providers.
- Fix unit tests to let them work against newer version. I had to disable one case in `testDouble` due to [bug in ClickHouse itself](https://github.com/ClickHouse/ClickHouse/issues/60146).
- Changed the way IP addresses are casted upon ingestion from Trino. Previous implementation couldn't handle NULL values properly.

## Additional context and related issues
None.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
