### PR TITLE
Stop listing files when exact checkpoint found in Delta Lake time travel

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogAccess.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogAccess.java
@@ -248,6 +248,9 @@ public class TransactionLogAccess
                 }
 
                 long version = checkpoint.get().version();
+                if (version == endVersion) {
+                    return checkpoint;
+                }
                 if (version > endVersion || (latestCheckpoint.isPresent() && version < latestCheckpoint.get().version())) {
                     continue;
                 }


### PR DESCRIPTION
## Description

We can stop listing files if the checkpoint file version is same as time travel version. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
