### PR TITLE
Allow creating temp tables for BigQuery materialized views

### DIFF
--- a/plugin/trino-bigquery/pom.xml
+++ b/plugin/trino-bigquery/pom.xml
@@ -377,6 +377,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-trace</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-client</artifactId>
             <scope>test</scope>

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitManager.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitManager.java
@@ -134,11 +134,11 @@ public class BigQuerySplitManager
             // Storage API doesn't support reading wildcard tables
             return ImmutableList.of(BigQuerySplit.forViewStream(columns, filter));
         }
-        if (type == MATERIALIZED_VIEW || type == EXTERNAL) {
-            // Storage API doesn't support reading materialized views and external tables
+        if (type == EXTERNAL) {
+            // Storage API doesn't support reading external tables
             return ImmutableList.of(BigQuerySplit.forViewStream(columns, filter));
         }
-        if (type == VIEW) {
+        if (type == VIEW || type == MATERIALIZED_VIEW) {
             if (isSkipViewMaterialization(session)) {
                 return ImmutableList.of(BigQuerySplit.forViewStream(columns, filter));
             }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ReadSessionCreator.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ReadSessionCreator.java
@@ -38,6 +38,7 @@ import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Optional;
 
+import static com.google.cloud.bigquery.TableDefinition.Type.MATERIALIZED_VIEW;
 import static com.google.cloud.bigquery.TableDefinition.Type.SNAPSHOT;
 import static com.google.cloud.bigquery.TableDefinition.Type.TABLE;
 import static com.google.cloud.bigquery.TableDefinition.Type.VIEW;
@@ -152,7 +153,7 @@ public class ReadSessionCreator
         if (tableType == TABLE || tableType == SNAPSHOT) {
             return remoteTable;
         }
-        if (tableType == VIEW) {
+        if (tableType == VIEW || tableType == MATERIALIZED_VIEW) {
             if (!viewEnabled) {
                 throw new TrinoException(NOT_SUPPORTED, format(
                         "Views are not enabled. You can enable views by setting '%s' to true. Notice additional cost may occur.",


### PR DESCRIPTION
## Description

Allow creating temp tables for BigQuery materialized views so that users can read the object using storage API. 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# BigQuery
* Create temporary tables and use BigQuery storage API by default when reading materialized views. ({issue}`21487`)
```
