### PR TITLE
Use default catalog name in TestDeltaLakeRenameToWithGlueMetastore

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaLakeRenameToWithGlueMetastore.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaLakeRenameToWithGlueMetastore.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.TestInstance;
 
 import java.nio.file.Path;
 
+import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.DELTA_CATALOG;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.lang.String.format;
@@ -34,7 +35,6 @@ public class TestDeltaLakeRenameToWithGlueMetastore
         extends AbstractTestQueryFramework
 {
     protected static final String SCHEMA = "test_delta_lake_rename_to_with_glue_" + randomNameSuffix();
-    protected static final String CATALOG_NAME = "test_delta_lake_rename_to_with_glue";
 
     private Path schemaLocation;
 
@@ -43,7 +43,7 @@ public class TestDeltaLakeRenameToWithGlueMetastore
             throws Exception
     {
         Session deltaLakeSession = testSessionBuilder()
-                .setCatalog(CATALOG_NAME)
+                .setCatalog(DELTA_CATALOG)
                 .setSchema(SCHEMA)
                 .build();
 


### PR DESCRIPTION
## Description

Fix broken test: https://github.com/trinodb/trino/actions/runs/8638182101/job/23682452532
https://github.com/trinodb/trino/commit/5697711476278bdfda3a064266d176e09651f3db seems the cause. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
