### PR TITLE
Add support for the custom hive catalog to support Hive3

### DIFF
--- a/docs/src/main/sphinx/object-storage/metastores.md
+++ b/docs/src/main/sphinx/object-storage/metastores.md
@@ -182,6 +182,13 @@ properties:
 * - `hive.metastore.thrift.txn-lock-max-wait`
   - Maximum time to wait to acquire hive transaction lock.
   - `10m`
+* - `hive.metastore.thrift.catalog-name`
+  - The term "Hive metastore catalog name" refers to the abstraction concept
+    within Hive, enabling various systems to connect to distinct, independent
+    catalogs stored in the metastore. By default, the catalog name in Hive
+    metastore is set to "hive." When this configuration property is left empty,
+    the default catalog of the Hive metastore will be accessed.
+  -
 :::
 
 Use the following configuration properties for HTTP client transport mode, so

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/DefaultThriftMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/DefaultThriftMetastoreClientFactory.java
@@ -45,6 +45,7 @@ public class DefaultThriftMetastoreClientFactory
     private final int readTimeoutMillis;
     private final HiveMetastoreAuthentication metastoreAuthentication;
     private final String hostname;
+    private final Optional<String> catalogName;
 
     private final MetastoreSupportsDateStatistics metastoreSupportsDateStatistics = new MetastoreSupportsDateStatistics();
     private final AtomicInteger chosenGetTableAlternative = new AtomicInteger(Integer.MAX_VALUE);
@@ -57,7 +58,8 @@ public class DefaultThriftMetastoreClientFactory
             Duration connectTimeout,
             Duration readTimeout,
             HiveMetastoreAuthentication metastoreAuthentication,
-            String hostname)
+            String hostname,
+            Optional<String> catalogName)
     {
         this.sslContext = requireNonNull(sslContext, "sslContext is null");
         this.socksProxy = requireNonNull(socksProxy, "socksProxy is null");
@@ -65,6 +67,7 @@ public class DefaultThriftMetastoreClientFactory
         this.readTimeoutMillis = toIntExact(readTimeout.toMillis());
         this.metastoreAuthentication = requireNonNull(metastoreAuthentication, "metastoreAuthentication is null");
         this.hostname = requireNonNull(hostname, "hostname is null");
+        this.catalogName = requireNonNull(catalogName, "catalogName is null");
     }
 
     @Inject
@@ -84,7 +87,8 @@ public class DefaultThriftMetastoreClientFactory
                 config.getConnectTimeout(),
                 config.getReadTimeout(),
                 metastoreAuthentication,
-                nodeManager.getCurrentNode().getHost());
+                nodeManager.getCurrentNode().getHost(),
+                config.getCatalogName());
     }
 
     @Override
@@ -107,6 +111,7 @@ public class DefaultThriftMetastoreClientFactory
         return new ThriftHiveMetastoreClient(
                 transportSupplier,
                 hostname,
+                catalogName,
                 metastoreSupportsDateStatistics,
                 true,
                 chosenGetTableAlternative,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/HttpThriftMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/HttpThriftMetastoreClientFactory.java
@@ -81,6 +81,7 @@ public class HttpThriftMetastoreClientFactory
         return new ThriftHiveMetastoreClient(
                 () -> createHttpTransport(uri),
                 hostname,
+                Optional.empty(),
                 new MetastoreSupportsDateStatistics(),
                 false,
                 chosenGetTableAlternative,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreConfig.java
@@ -28,6 +28,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 import java.io.File;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 @DefunctConfig("hive.metastore.thrift.batch-fetch.enabled")
@@ -47,6 +48,7 @@ public class ThriftMetastoreConfig
     private long delegationTokenCacheMaximumSize = 1000;
     private boolean deleteFilesOnDrop;
     private Duration maxWaitForTransactionLock = new Duration(10, TimeUnit.MINUTES);
+    private String catalogName;
 
     private boolean tlsEnabled;
     private File keystorePath;
@@ -345,6 +347,19 @@ public class ThriftMetastoreConfig
     public ThriftMetastoreConfig setWriteStatisticsThreads(int writeStatisticsThreads)
     {
         this.writeStatisticsThreads = writeStatisticsThreads;
+        return this;
+    }
+
+    public Optional<String> getCatalogName()
+    {
+        return Optional.ofNullable(catalogName);
+    }
+
+    @Config("hive.metastore.thrift.catalog-name")
+    @ConfigDescription("Hive metastore thrift catalog name")
+    public ThriftMetastoreConfig setCatalogName(String catalogName)
+    {
+        this.catalogName = catalogName;
         return this;
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveCustomCatalogConnectorSmokeTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveCustomCatalogConnectorSmokeTest.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import io.trino.plugin.hive.containers.HiveHadoop;
+import io.trino.plugin.hive.containers.HiveMinioDataLake;
+import io.trino.plugin.hive.metastore.Database;
+import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
+import io.trino.spi.security.PrincipalType;
+import io.trino.testing.BaseConnectorSmokeTest;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.TestingConnectorBehavior;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.trino.plugin.hive.HiveMetadata.MODIFYING_NON_TRANSACTIONAL_TABLE_MESSAGE;
+import static io.trino.plugin.hive.HiveQueryRunner.TPCH_SCHEMA;
+import static io.trino.plugin.hive.TestingHiveUtils.getConnectorService;
+import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static io.trino.testing.QueryAssertions.copyTpchTables;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
+import static io.trino.testing.containers.Minio.MINIO_REGION;
+import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestHiveCustomCatalogConnectorSmokeTest
+        extends BaseConnectorSmokeTest
+{
+    private static final String HIVE_CUSTOM_CATALOG = "custom";
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        String bucketName = "test-hive-metastore-catalog-smoke-test-" + randomNameSuffix();
+        HiveMinioDataLake hiveMinioDataLake = closeAfterClass(new HiveMinioDataLake(bucketName, HiveHadoop.HIVE3_IMAGE));
+        hiveMinioDataLake.start();
+
+        // Inserting into metastore's database directly because the Hive does not expose a way to create a custom catalog
+        hiveMinioDataLake.getHiveHadoop().runOnMetastore("INSERT INTO CTLGS VALUES (2, '%s', 'Custom catalog', 's3://%s/custom')".formatted(HIVE_CUSTOM_CATALOG, bucketName));
+
+        QueryRunner queryRunner = HiveQueryRunner.builder()
+                .addHiveProperty("hive.metastore", "thrift")
+                .addHiveProperty("hive.metastore.uri", hiveMinioDataLake.getHiveHadoop().getHiveMetastoreEndpoint().toString())
+                .addHiveProperty("hive.metastore.thrift.catalog-name", HIVE_CUSTOM_CATALOG)
+                .addHiveProperty("fs.hadoop.enabled", "false")
+                .addHiveProperty("fs.native-s3.enabled", "true")
+                .addHiveProperty("s3.path-style-access", "true")
+                .addHiveProperty("s3.region", MINIO_REGION)
+                .addHiveProperty("s3.endpoint", hiveMinioDataLake.getMinio().getMinioAddress())
+                .addHiveProperty("s3.aws-access-key", MINIO_ACCESS_KEY)
+                .addHiveProperty("s3.aws-secret-key", MINIO_SECRET_KEY)
+                .setCreateTpchSchemas(false) // Create the required tpch tables after the initialisation of the query runner
+                .build();
+
+        HiveMetastore metastore = getConnectorService(queryRunner, HiveMetastoreFactory.class)
+                .createMetastore(Optional.empty());
+        metastore.createDatabase(createDatabaseMetastoreObject(TPCH_SCHEMA, Optional.of("s3://%s/%s".formatted(bucketName, TPCH_SCHEMA))));
+        copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, REQUIRED_TPCH_TABLES);
+
+        return queryRunner;
+    }
+
+    @Override
+    protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
+    {
+        return switch (connectorBehavior) {
+            case SUPPORTS_MULTI_STATEMENT_WRITES -> true;
+            case SUPPORTS_CREATE_MATERIALIZED_VIEW,
+                 SUPPORTS_RENAME_SCHEMA,
+                 SUPPORTS_TOPN_PUSHDOWN,
+                 SUPPORTS_TRUNCATE -> false;
+            default -> super.hasBehavior(connectorBehavior);
+        };
+    }
+
+    @Test
+    @Override
+    public void testRowLevelDelete()
+    {
+        assertThatThrownBy(super::testRowLevelDelete)
+                .hasMessage(MODIFYING_NON_TRANSACTIONAL_TABLE_MESSAGE);
+    }
+
+    @Test
+    @Override
+    public void testRowLevelUpdate()
+    {
+        assertThatThrownBy(super::testRowLevelUpdate)
+                .hasMessage(MODIFYING_NON_TRANSACTIONAL_TABLE_MESSAGE);
+    }
+
+    @Test
+    @Override
+    public void testUpdate()
+    {
+        assertThatThrownBy(super::testUpdate)
+                .hasMessage(MODIFYING_NON_TRANSACTIONAL_TABLE_MESSAGE);
+    }
+
+    @Test
+    @Override
+    public void testMerge()
+    {
+        assertThatThrownBy(super::testMerge)
+                .hasMessage(MODIFYING_NON_TRANSACTIONAL_TABLE_MESSAGE);
+    }
+
+    @Test
+    @Override
+    public void testShowCreateTable()
+    {
+        assertThat((String) computeScalar("SHOW CREATE TABLE region"))
+                .isEqualTo("""
+                        CREATE TABLE hive.tpch.region (
+                           regionkey bigint,
+                           name varchar(25),
+                           comment varchar(152)
+                        )
+                        WITH (
+                           format = 'ORC'
+                        )""");
+    }
+
+    @Test
+    @Override
+    public void testCreateSchemaWithNonLowercaseOwnerName()
+    {
+        // Override because HivePrincipal's username is case-sensitive unlike TrinoPrincipal
+        assertThatThrownBy(super::testCreateSchemaWithNonLowercaseOwnerName)
+                .hasMessageContaining("Access Denied: Cannot create schema")
+                .hasStackTraceContaining("CREATE SCHEMA");
+    }
+
+    @Test
+    @Override
+    public void testRenameSchema()
+    {
+        String schemaName = getSession().getSchema().orElseThrow();
+        assertQueryFails(
+                format("ALTER SCHEMA %s RENAME TO %s", schemaName, schemaName + randomNameSuffix()),
+                "Hive metastore does not support renaming schemas");
+    }
+
+    private static Database createDatabaseMetastoreObject(String name, Optional<String> locationBase)
+    {
+        return Database.builder()
+                .setLocation(locationBase.map(base -> base + "/" + name))
+                .setDatabaseName(name)
+                .setOwnerName(Optional.of("public"))
+                .setOwnerType(Optional.of(PrincipalType.ROLE))
+                .build();
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/TestHiveMetastoreCatalogs.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/TestHiveMetastoreCatalogs.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.metastore;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
+import io.trino.plugin.hive.HiveQueryRunner;
+import io.trino.plugin.hive.containers.HiveHadoop;
+import io.trino.plugin.hive.containers.HiveMinioDataLake;
+import io.trino.spi.security.PrincipalType;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.plugin.hive.TestingHiveUtils.getConnectorService;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
+import static io.trino.testing.containers.Minio.MINIO_REGION;
+import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestHiveMetastoreCatalogs
+        extends AbstractTestQueryFramework
+{
+    private static final String TRINO_HIVE_CATALOG = "hive_catalog";
+    private static final String TRINO_HIVE_CUSTOM_CATALOG = "hive_custom_catalog";
+    private static final String HIVE_CUSTOM_CATALOG = "custom";
+
+    private String bucketName;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        this.bucketName = "test-hive-metastore-catalogs-" + randomNameSuffix();
+        HiveMinioDataLake hiveMinioDataLake = closeAfterClass(new HiveMinioDataLake(bucketName, HiveHadoop.HIVE3_IMAGE));
+        hiveMinioDataLake.start();
+
+        QueryRunner queryRunner = HiveQueryRunner.builder()
+                .setHiveProperties(buildHiveProperties(hiveMinioDataLake))
+                .setCreateTpchSchemas(false)
+                .build();
+
+        hiveMinioDataLake.getHiveHadoop().runOnMetastore("INSERT INTO CTLGS VALUES (2, '%s', 'Custom catalog', 's3://%s/custom')".formatted(HIVE_CUSTOM_CATALOG, bucketName));
+
+        queryRunner.createCatalog(TRINO_HIVE_CUSTOM_CATALOG, "hive", ImmutableMap.<String, String>builder()
+                .put("hive.metastore.thrift.catalog-name", HIVE_CUSTOM_CATALOG)
+                .putAll(buildHiveProperties(hiveMinioDataLake))
+                .buildOrThrow());
+
+        queryRunner.createCatalog(TRINO_HIVE_CATALOG, "hive", ImmutableMap.<String, String>builder()
+                .put("hive.metastore.thrift.catalog-name", "hive") // HiveMetastore uses "hive" as the default catalog name
+                .putAll(buildHiveProperties(hiveMinioDataLake))
+                .buildOrThrow());
+
+        return queryRunner;
+    }
+
+    private static Map<String, String> buildHiveProperties(HiveMinioDataLake hiveMinioDataLake)
+    {
+        return ImmutableMap.<String, String>builder()
+                .put("hive.metastore", "thrift")
+                .put("hive.metastore.uri", hiveMinioDataLake.getHiveHadoop().getHiveMetastoreEndpoint().toString())
+                .put("fs.hadoop.enabled", "false")
+                .put("fs.native-s3.enabled", "true")
+                .put("s3.path-style-access", "true")
+                .put("s3.region", MINIO_REGION)
+                .put("s3.endpoint", hiveMinioDataLake.getMinio().getMinioAddress())
+                .put("s3.aws-access-key", MINIO_ACCESS_KEY)
+                .put("s3.aws-secret-key", MINIO_SECRET_KEY)
+                .buildOrThrow();
+    }
+
+    @Test
+    public void testShowTables()
+    {
+        assertThat(query("SHOW SCHEMAS")).matches("VALUES VARCHAR 'default', VARCHAR 'information_schema'");
+
+        HiveMetastore metastore = getConnectorService(getQueryRunner(), HiveMetastoreFactory.class)
+                .createMetastore(Optional.empty());
+
+        String defaultCatalogSchema = "default_catalog_schema";
+        metastore.createDatabase(createDatabaseMetastoreObject(defaultCatalogSchema, Optional.of("s3://%s/%s".formatted(bucketName, defaultCatalogSchema))));
+
+        Session defaultCatalogSession = testSessionBuilder()
+                .setCatalog("hive")
+                .setSchema(defaultCatalogSchema)
+                .build();
+        Session hiveCatalogSession = testSessionBuilder()
+                .setCatalog(TRINO_HIVE_CATALOG)
+                .setSchema(defaultCatalogSchema)
+                .build();
+        assertUpdate(defaultCatalogSession, "CREATE TABLE tabledefault (data integer)");
+        assertUpdate(defaultCatalogSession, "INSERT INTO tabledefault VALUES (1),(2),(3),(4)", 4);
+
+        String customCatalogSchema = "custom_catalog_schema";
+        assertUpdate(
+                testSessionBuilder()
+                        .setCatalog(TRINO_HIVE_CUSTOM_CATALOG)
+                        .build(),
+                "CREATE SCHEMA " + customCatalogSchema);
+        Session customCatalogSession = testSessionBuilder()
+                .setCatalog(TRINO_HIVE_CUSTOM_CATALOG)
+                .setSchema(customCatalogSchema)
+                .build();
+        assertUpdate(customCatalogSession, "CREATE TABLE tablecustom (data integer)");
+        assertUpdate(customCatalogSession, "INSERT INTO tablecustom VALUES (4),(5),(6),(7)", 4);
+
+        // schemas from the default Hive catalog are not visible in the custom Hive catalog and vice versa
+        assertThat(computeActual(defaultCatalogSession, "SHOW SCHEMAS").getOnlyColumn())
+                .containsOnly("default", "default_catalog_schema", "information_schema");
+        assertThat(computeActual(hiveCatalogSession, "SHOW SCHEMAS").getOnlyColumn())
+                .containsOnly("default", "default_catalog_schema", "information_schema");
+        assertThat(computeActual(customCatalogSession, "SHOW SCHEMAS").getOnlyColumn())
+                .containsOnly(customCatalogSchema, "information_schema");
+
+        // tables from the default Hive catalog are not visible in the custom Hive catalog and vice versa
+        assertThat(computeActual(defaultCatalogSession, "SHOW TABLES IN " + defaultCatalogSchema).getOnlyColumn())
+                .containsOnly("tabledefault");
+        assertThat(computeActual(hiveCatalogSession, "SHOW TABLES IN " + defaultCatalogSchema).getOnlyColumn())
+                .containsOnly("tabledefault");
+        assertThat(computeActual(customCatalogSession, "SHOW TABLES IN " + customCatalogSchema).getOnlyColumn())
+                .containsOnly("tablecustom");
+        assertThat((String) computeScalar(customCatalogSession, format("SHOW CREATE TABLE %s.tablecustom", customCatalogSchema)))
+                .isEqualTo("""
+                        CREATE TABLE hive_custom_catalog.custom_catalog_schema.tablecustom (
+                           data integer
+                        )
+                        WITH (
+                           format = 'ORC'
+                        )""");
+
+        // select query : join hive's and custom catalog's table
+        assertQuery("SELECT a.data from hive.default_catalog_schema.tabledefault a, hive_custom_catalog.custom_catalog_schema.tablecustom b WHERE a.data = b.data", "SELECT 4");
+
+        assertUpdate(defaultCatalogSession, "DROP SCHEMA " + defaultCatalogSchema + " CASCADE");
+        assertUpdate(customCatalogSession, "DROP SCHEMA " + customCatalogSchema + " CASCADE");
+    }
+
+    private static Database createDatabaseMetastoreObject(String name, Optional<String> locationBase)
+    {
+        return Database.builder()
+                .setLocation(locationBase.map(base -> base + "/" + name))
+                .setDatabaseName(name)
+                .setOwnerName(Optional.of("public"))
+                .setOwnerType(Optional.of(PrincipalType.ROLE))
+                .build();
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftHiveMetastoreClient.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftHiveMetastoreClient.java
@@ -19,6 +19,7 @@ import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransport;
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -44,6 +45,7 @@ public class TestThriftHiveMetastoreClient
                     return new TTransportMock();
                 },
                 "dummy",
+                Optional.empty(),
                 new MetastoreSupportsDateStatistics(),
                 true,
                 new AtomicInteger(),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftMetastoreConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftMetastoreConfig.java
@@ -58,7 +58,8 @@ public class TestThriftMetastoreConfig
                 .setDeleteFilesOnDrop(false)
                 .setMaxWaitForTransactionLock(new Duration(10, MINUTES))
                 .setAssumeCanonicalPartitionKeys(false)
-                .setWriteStatisticsThreads(20));
+                .setWriteStatisticsThreads(20)
+                .setCatalogName(null));
     }
 
     @Test
@@ -90,6 +91,7 @@ public class TestThriftMetastoreConfig
                 .put("hive.metastore.thrift.write-statistics-threads", "10")
                 .put("hive.metastore.thrift.assume-canonical-partition-keys", "true")
                 .put("hive.metastore.thrift.use-spark-table-statistics-fallback", "false")
+                .put("hive.metastore.thrift.catalog-name", "custom_catalog_name")
                 .buildOrThrow();
 
         ThriftMetastoreConfig expected = new ThriftMetastoreConfig()
@@ -113,7 +115,8 @@ public class TestThriftMetastoreConfig
                 .setMaxWaitForTransactionLock(new Duration(5, MINUTES))
                 .setAssumeCanonicalPartitionKeys(true)
                 .setWriteStatisticsThreads(10)
-                .setUseSparkTableStatisticsFallback(false);
+                .setUseSparkTableStatisticsFallback(false)
+                .setCatalogName("custom_catalog_name");
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestingTokenAwareMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestingTokenAwareMetastoreClientFactory.java
@@ -46,7 +46,7 @@ public class TestingTokenAwareMetastoreClientFactory
 
     public TestingTokenAwareMetastoreClientFactory(Optional<HostAndPort> socksProxy, URI uri, Duration timeout, MetastoreClientAdapterProvider metastoreClientAdapterProvider)
     {
-        this.factory = new DefaultThriftMetastoreClientFactory(Optional.empty(), socksProxy, timeout, timeout, AUTHENTICATION, "localhost");
+        this.factory = new DefaultThriftMetastoreClientFactory(Optional.empty(), socksProxy, timeout, timeout, AUTHENTICATION, "localhost", Optional.empty());
         this.address = requireNonNull(uri, "uri is null");
         this.metastoreClientAdapterProvider = requireNonNull(metastoreClientAdapterProvider, "metastoreClientAdapterProvider is null");
     }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveMetastoreClientFactory.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveMetastoreClientFactory.java
@@ -35,7 +35,8 @@ public final class TestHiveMetastoreClientFactory
             new Duration(10, SECONDS),
             new Duration(10, SECONDS),
             new NoHiveMetastoreAuthentication(),
-            "localhost");
+            "localhost",
+            Optional.empty());
 
     @Inject
     @Named("databases.hive.metastore.host")


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Currently Trino is constrained to utilize the default hive catalog (referred to as `"hive"`) when interfacing with the hive metastore. Consequently, users are confined to employing only a two-level hierarchy (`schema.table`) within a Trino catalog/connector. In contrast, Hive thrift allows for custom hive catalog names as the parent of the schema, enabling the utilization of a three-level hierarchy such as `hive-catalog.schema.table`.

Hive Thrift API supports custom catalog since [Hive3](https://issues.apache.org/jira/browse/HIVE-18685?jql=project%20in%20(THRIFT%2C%20HIVE)%20AND%20text%20~%20%22support%20catalog%22)
Therefore, at high level, this PR has the following changes

1. Customize the hive catalog name within Trino's catalog settings and transmit it via the factories to the Thrift client --> `StaticMetastoreConfig` , `StaticTokenAwareHttpMetastoreClientFactory` , `StaticTokenAwareMetastoreClientFactory` , `ThriftMetastoreClientFactory`, 'DefaultThriftMetastoreClientFactory', `HttpThriftMetastoreClientFactory` 
2. Thrift client to support custom catalog:  `ThriftHiveMetastoreClient` 
3. There will be 1:1 mapping between Trino catalog and hive catalog.
4.  `"hive"` will be the default catalog name.


Thanks to @dain @electrum @hashhar @findinpath @anusudarsan @samssh @mosabua 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Above approach was discussed at a few places, so adopted in the PR as well.
[one](https://github.com/trinodb/trino/issues/10287#issuecomment-1426688247)
[two](https://github.com/trinodb/trino/issues/10287#issuecomment-2037405278)

@samssh please let us know, if anything is missing or need to take care of.
Fixes https://github.com/trinodb/trino/issues/10287

co-author : @samssh, he has worked on the similar change. 

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Add support for specifying catalog name in Thrift metastore. (`#10287`)
```
