### PR TITLE
Check table existence in Trino instead of Cassandra

### DIFF
--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
@@ -1632,7 +1632,7 @@ public class TestCassandraConnectorTest
 
     private TestCassandraTable testTable(String namePrefix, List<TestCassandraTable.ColumnDefinition> columnDefinitions, List<String> rowsToInsert)
     {
-        return new TestCassandraTable(session::execute, server, KEYSPACE, namePrefix, columnDefinitions, rowsToInsert);
+        return new TestCassandraTable(getQueryRunner(), session::execute, KEYSPACE, namePrefix, columnDefinitions, rowsToInsert);
     }
 
     private void onCassandra(@Language("SQL") String sql)

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraTypeMapping.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraTypeMapping.java
@@ -699,7 +699,7 @@ public class TestCassandraTypeMapping
 
     private TestCassandraTable testTable(String namePrefix, List<ColumnDefinition> columnDefinitions, List<String> rowsToInsert)
     {
-        return new TestCassandraTable(session::execute, server, "tpch", namePrefix, columnDefinitions, rowsToInsert);
+        return new TestCassandraTable(getQueryRunner(), session::execute, "tpch", namePrefix, columnDefinitions, rowsToInsert);
     }
 
     private void assertCassandraQueryFails(@Language("SQL") String sql, String expectedMessage)


### PR DESCRIPTION
## Description

Stress test result of TestCassandraConnectorTest#testTimestampPartitionKey
* 31/100 failed before this change
* 100/100 passed after this change

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
