### PR TITLE
Fix incorrect effective predicate derivation for non-equatable type

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/EffectivePredicateExtractor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/EffectivePredicateExtractor.java
@@ -217,6 +217,7 @@ public class EffectivePredicateExtractor
                     .collect(toImmutableList());
 
             List<Expression> projectionEqualities = nonIdentityAssignments.stream()
+                    .filter(assignment -> assignment.getKey().type().isComparable() || assignment.getKey().type().isOrderable())
                     .filter(assignment -> Sets.intersection(SymbolsExtractor.extractUnique(assignment.getValue()), newlyAssignedSymbols).isEmpty())
                     .map(ENTRY_TO_EQUALITY)
                     .collect(toImmutableList());

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestIssue21508.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestIssue21508.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestIssue21508
+{
+    @Test
+    public void test()
+    {
+        try (QueryAssertions assertions = new QueryAssertions()) {
+            assertThat(assertions.query(
+                    """
+                    WITH t(k) AS (SELECT 1 WHERE random() >= 0)
+                    SELECT *
+                    FROM t
+                    WHERE k IN (
+                        SELECT k
+                        FROM t
+                        WHERE cardinality((VALUES empty_approx_set())) = 0)
+                    """))
+                    .matches("VALUES 1");
+        }
+    }
+}


### PR DESCRIPTION
EffectivePredicateExtractor was incorrectly deriving an equality predicate for a type that's no comparable or orderable.

Fixes #21508 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( x) Release notes are required, with the following suggested text:

```markdown
# General
* TBD. ({issue}`21508`)
```
