### PR TITLE
Fix invalid pushdown of predicate that may fail

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
@@ -972,19 +972,27 @@ public class PredicatePushDown
                 }
             }
 
-            List<Expression> leftCandidates = extractConjuncts(leftEffectivePredicate).stream()
+            List<Expression> leftConjuncts = extractConjuncts(leftEffectivePredicate).stream()
+                    .filter(expression -> !mayFail(plannerContext, expression) && isDeterministic(expression))
+                    .toList();
+
+            List<Expression> leftCandidates = leftConjuncts.stream()
                     .filter(EqualityInference::isInferenceCandidate)
                     .toList();
 
-            List<Expression> leftResiduals = extractConjuncts(leftEffectivePredicate).stream()
+            List<Expression> leftResiduals = leftConjuncts.stream()
                     .filter(conjunct -> !isInferenceCandidate(conjunct))
                     .toList();
 
-            List<Expression> rightCandidates = extractConjuncts(rightEffectivePredicate).stream()
+            List<Expression> rightConjuncts = extractConjuncts(rightEffectivePredicate).stream()
+                    .filter(expression -> !mayFail(plannerContext, expression) && isDeterministic(expression))
+                    .toList();
+
+            List<Expression> rightCandidates = rightConjuncts.stream()
                     .filter(EqualityInference::isInferenceCandidate)
                     .toList();
 
-            List<Expression> rightResiduals = extractConjuncts(rightEffectivePredicate).stream()
+            List<Expression> rightResiduals = rightConjuncts.stream()
                     .filter(conjunct -> !isInferenceCandidate(conjunct))
                     .toList();
 

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJoin.java
@@ -324,5 +324,18 @@ public class TestJoin
                 WHERE CAST(t.y AS int) = 1
                 """))
                 .matches("VALUES ('a', '1', 'a', '1')");
+
+        assertThat(assertions.query(
+                """
+                WITH
+                    a(k, v) AS (VALUES if(random() >= 0, (1, CAST('10' AS varchar)))),
+                    b(k, v) AS (VALUES if(random() >= 0, (1, CAST('foo' AS varchar)))),
+                    t AS (
+                		SELECT k, CAST(v AS BIGINT) v1, v
+                		FROM a)
+                SELECT t.k, b.k
+                FROM t JOIN b ON t.k = b.k AND t.v1 = 10 AND t.v = b.v
+                """))
+                .returnsEmptyResult();
     }
 }


### PR DESCRIPTION
Derived predicates from the left/right branch of an inner join that may fail during evaluation were being incorrectly pushed down to the other side.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# General
* TBD. ({issue}`issuenumber`)
```
