### PR TITLE
Fix thread leak in MinioClient

### DIFF
--- a/testing/trino-testing-containers/pom.xml
+++ b/testing/trino-testing-containers/pom.xml
@@ -28,6 +28,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>dev.failsafe</groupId>
             <artifactId>failsafe</artifactId>
         </dependency>

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/minio/MinioClient.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/minio/MinioClient.java
@@ -31,8 +31,10 @@ import io.minio.MakeBucketArgs;
 import io.minio.PutObjectArgs;
 import io.minio.RemoveObjectArgs;
 import io.minio.Result;
+import io.minio.http.HttpUtils;
 import io.minio.messages.Event;
 import io.minio.messages.NotificationRecords;
+import okhttp3.OkHttpClient;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -51,6 +53,7 @@ import static io.minio.messages.EventType.OBJECT_ACCESSED_ANY;
 import static io.minio.messages.EventType.OBJECT_CREATED_ANY;
 import static io.minio.messages.EventType.OBJECT_REMOVED_ANY;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.regex.Matcher.quoteReplacement;
 
 public class MinioClient
@@ -64,6 +67,7 @@ public class MinioClient
 
     private static final Set<String> createdBuckets = Sets.newConcurrentHashSet();
 
+    private final OkHttpClient httpClient;
     private final io.minio.MinioClient client;
     private final ListeningExecutorService executor = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(32));
 
@@ -80,7 +84,13 @@ public class MinioClient
 
     public MinioClient(String endpoint, String accessKey, String secretKey)
     {
+        // This is Minio default HTTP client creation code with timeout values copied from MinioClient.builder()
+        long fiveMinutes = MINUTES.toMillis(5);
+        httpClient = HttpUtils.newDefaultHttpClient(fiveMinutes, fiveMinutes, fiveMinutes);
         client = io.minio.MinioClient.builder()
+                // Pass explicit HTTP client instance to MinioClient builder. This seems the only way
+                // to be able to close the client properly later on.
+                .httpClient(httpClient)
                 .endpoint(endpoint)
                 .credentials(accessKey, secretKey)
                 .build();
@@ -244,6 +254,8 @@ public class MinioClient
     @Override
     public void close()
     {
+        httpClient.dispatcher().executorService().shutdown();
+        httpClient.connectionPool().evictAll();
         executor.shutdownNow();
     }
 


### PR DESCRIPTION
Our `MinioClient` wraps MinIO's own `MinioClient` (`io.minio.MinioClient`). The MinIO `MinioClient` builder creates a new `OkHttpClient` and previously we were not closing the HTTP client, which resulted in leaking threads (`OkHttpClient` has an executor service). There seems to be no way to dispose of MinIO's `MinioClient`'s resources, so create the HTTP client explicitly so that we can close it.
