### PR TITLE
[Fix](BigQuery) Rectify the serialization key naming issue caused by the Jackson framework.

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryColumnHandle.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryColumnHandle.java
@@ -50,7 +50,7 @@ public class BigQueryColumnHandle
             @JsonProperty("name") String name,
             @JsonProperty("trinoType") Type trinoType,
             @JsonProperty("bigqueryType") StandardSQLTypeName bigqueryType,
-            @JsonProperty("isPushdownSupported") boolean isPushdownSupported,
+            @JsonProperty("pushdownSupported") boolean isPushdownSupported,
             @JsonProperty("mode") Field.Mode mode,
             @JsonProperty("subColumns") List<BigQueryColumnHandle> subColumns,
             @JsonProperty("description") String description,


### PR DESCRIPTION
## Description

The Jackson framework serializes the `isPushDownSupported` field of `BigQueryColumnHandle` as `pushDownSupported`. However, the `@JsonProperty` in the `BigQueryColumnHandle` constructor specifies `key=isPushDownSupported`, causing the deserialization process to be unable to locate this key. Consequently, the field `isPushDownSupported` of `BigQueryColumnHandle` remains `false` during deserialization.

Here is a demo test:
The jackson version used here is 2.17.0

![image](https://github.com/trinodb/trino/assets/43782773/876cce25-97ec-44c0-beff-d1f0e7e561bf)

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
