### PR TITLE
Support type mapping configs in Snowflake Connector

### DIFF
--- a/docs/src/main/sphinx/connector/snowflake.md
+++ b/docs/src/main/sphinx/connector/snowflake.md
@@ -74,6 +74,9 @@ Trino supports the following Snowflake data types:
 
 Complete list of [Snowflake data types](https://docs.snowflake.com/en/sql-reference/intro-summary-data-types.html).
 
+```{include} jdbc-type-mapping.fragment
+```
+
 (snowflake-sql-support)=
 
 ## SQL support


### PR DESCRIPTION
## Description
Second part of https://github.com/trinodb/trino/pull/21012.

Support config properties `unsupported-type-handling` and `jdbc-types-mapped-to-varchar`.



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Snowflake
* Support type mapping configuration properties `unsupported-type-handling` and `jdbc-types-mapped-to-varchar`. ({issue}`21528`)
```
