### PR TITLE
Use assertThatThrownBy in testMaxRowsExceedsLimit

### DIFF
--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/BaseTestJdbcResultSet.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/BaseTestJdbcResultSet.java
@@ -1149,13 +1149,15 @@ public abstract class BaseTestJdbcResultSet
         }
     }
 
-    @Test(expectedExceptions = SQLException.class, expectedExceptionsMessageRegExp = "Max rows exceeds limit of 2147483647")
+    @Test
     public void testMaxRowsExceedsLimit()
             throws Exception
     {
         try (ConnectedStatement connectedStatement = newStatement()) {
             connectedStatement.getStatement().setLargeMaxRows(Integer.MAX_VALUE * 10L);
-            connectedStatement.getStatement().getMaxRows();
+            assertThatThrownBy(() -> connectedStatement.getStatement().getMaxRows())
+                    .isInstanceOf(SQLException.class)
+                    .hasMessage("Max rows exceeds limit of 2147483647");
         }
     }
 


### PR DESCRIPTION
## Description

This line is the last usage of `@Test` with expectedExceptions. 
Fixes https://github.com/trinodb/trino/issues/6974

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
