### PR TITLE
Fix error message in TrinoRestCatalog.listTables

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -194,7 +194,7 @@ public class TrinoRestCatalog
                 // Namespace may have been deleted during listing
             }
             catch (RESTException e) {
-                throw new TrinoException(ICEBERG_CATALOG_ERROR, format("Failed to list tables from namespaces: %s", namespaces), e);
+                throw new TrinoException(ICEBERG_CATALOG_ERROR, format("Failed to list tables from namespace: %s", restNamespace), e);
             }
         }
         return tables.build();


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
