### PR TITLE
Adjust MetadataListing error code based on cause

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataListing.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataListing.java
@@ -45,6 +45,7 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.connector.system.jdbc.FilterUtil.tryGetSingleVarcharValue;
+import static io.trino.plugin.base.util.Exceptions.findErrorCode;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.StandardErrorCode.TABLE_REDIRECTION_ERROR;
 import static java.util.function.Function.identity;
@@ -349,12 +350,9 @@ public final class MetadataListing
 
     private static TrinoException handleListingException(RuntimeException exception, String type, String catalogName)
     {
-        ErrorCodeSupplier result = GENERIC_INTERNAL_ERROR;
-        if (exception instanceof TrinoException trinoException) {
-            result = trinoException::getErrorCode;
-        }
+        ErrorCodeSupplier errorCodeSupplier = findErrorCode(exception).orElse(GENERIC_INTERNAL_ERROR);
         return new TrinoException(
-                result,
+                errorCodeSupplier,
                 "Error listing %s for catalog %s: %s".formatted(type, catalogName, exception.getMessage()),
                 exception);
     }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/util/Exceptions.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/util/Exceptions.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.util;
+
+import io.trino.spi.ErrorCodeSupplier;
+import io.trino.spi.TrinoException;
+
+import java.util.Optional;
+
+import static com.google.common.base.Throwables.getCausalChain;
+
+public final class Exceptions
+{
+    private Exceptions() {}
+
+    public static Optional<ErrorCodeSupplier> findErrorCode(Throwable throwable)
+    {
+        return getCausalChain(throwable).stream()
+                .filter(TrinoException.class::isInstance)
+                .map(TrinoException.class::cast)
+                .findFirst()
+                .map(e -> e::getErrorCode);
+    }
+}

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/util/TestExceptions.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/util/TestExceptions.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.util;
+
+import io.trino.spi.ErrorCodeSupplier;
+import io.trino.spi.TrinoException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.trino.plugin.base.util.Exceptions.findErrorCode;
+import static io.trino.spi.StandardErrorCode.TOO_MANY_REQUESTS_FAILED;
+import static io.trino.spi.StandardErrorCode.USER_CANCELED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestExceptions
+{
+    @Test
+    void testFindErrorCodeWithTrinoException()
+    {
+        Throwable exception = new TrinoException(TOO_MANY_REQUESTS_FAILED, "fake exception");
+        Optional<ErrorCodeSupplier> errorCodeSupplier = findErrorCode(exception);
+        assertThat(errorCodeSupplier.orElseThrow().toErrorCode()).isEqualTo(TOO_MANY_REQUESTS_FAILED.toErrorCode());
+    }
+
+    @Test
+    void testFindErrorCodeWithRuntimeException()
+    {
+        Throwable exception = new RuntimeException();
+        Optional<ErrorCodeSupplier> errorCodeSupplier = findErrorCode(exception);
+        assertThat(errorCodeSupplier).isEmpty();
+    }
+
+    @Test
+    void testFindErrorCodeWithExceptionStack()
+    {
+        Throwable exception1 = new TrinoException(USER_CANCELED, "fake exception");
+        Throwable exception2 = new RuntimeException(exception1);
+        assertThat(findErrorCode(exception2).orElseThrow().toErrorCode()).isEqualTo(USER_CANCELED.toErrorCode());
+
+        Throwable exception3 = new RuntimeException(exception2);
+        assertThat(findErrorCode(exception3).orElseThrow().toErrorCode()).isEqualTo(USER_CANCELED.toErrorCode());
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Find exception with error code in stack trace and use it in new TrinoException.

For example. In case stack trace looks like:
```
java.lang.RuntimeException
   io.trino.spi.TrinoException (USER_ERROR)

```
MetadataListening was throwing `GENERIC_INTERNAL_ERROR` instead `USER_ERROR`. After this PR error code will be searching stack trace for error code if present.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
