### PR TITLE
Delta Lake Azure Smoke Tests:Rewrite test to avoid flakiness

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -65,7 +65,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.google.common.collect.Sets.union;
-import static io.airlift.concurrent.MoreFutures.tryGetFutureValue;
 import static io.trino.SystemSessionProperties.ENABLE_DYNAMIC_FILTERING;
 import static io.trino.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static io.trino.plugin.base.util.Closables.closeAllSuppress;
@@ -2532,7 +2531,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
                     .collect(toImmutableList());
 
             long successfulInsertsCount = futures.stream()
-                    .map(future -> tryGetFutureValue(future, 20, SECONDS).orElseThrow(() -> new RuntimeException("Wait timed out")))
+                    .map(MoreFutures::getFutureValue)
                     .filter(success -> success)
                     .count();
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeLocalConcurrentWritesTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeLocalConcurrentWritesTest.java
@@ -49,7 +49,6 @@ import java.util.stream.LongStream;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
-import static io.airlift.concurrent.MoreFutures.tryGetFutureValue;
 import static io.trino.plugin.deltalake.DeltaLakeConnectorFactory.CONNECTOR_NAME;
 import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.DELTA_CATALOG;
 import static io.trino.plugin.deltalake.TestingDeltaLakeUtils.getConnectorService;
@@ -220,7 +219,7 @@ public class TestDeltaLakeLocalConcurrentWritesTest
                     .collect(toImmutableList());
 
             long successfulInsertsCount = futures.stream()
-                    .map(future -> tryGetFutureValue(future, 20, SECONDS).orElseThrow(() -> new RuntimeException("Wait timed out")))
+                    .map(MoreFutures::getFutureValue)
                     .filter(success -> success)
                     .count();
 
@@ -345,7 +344,7 @@ public class TestDeltaLakeLocalConcurrentWritesTest
                     .collect(toImmutableList());
 
             long successfulInsertsCount = futures.stream()
-                    .map(future -> tryGetFutureValue(future, 20, SECONDS).orElseThrow(() -> new RuntimeException("Wait timed out")))
+                    .map(MoreFutures::getFutureValue)
                     .filter(success -> success)
                     .count();
 
@@ -585,7 +584,7 @@ public class TestDeltaLakeLocalConcurrentWritesTest
                     .collect(toImmutableList());
 
             long successfulInsertsCount = futures.stream()
-                    .map(future -> tryGetFutureValue(future, 20, SECONDS).orElseThrow(() -> new RuntimeException("Wait timed out")))
+                    .map(MoreFutures::getFutureValue)
                     .filter(success -> success)
                     .count();
             assertThat(successfulInsertsCount).isGreaterThanOrEqualTo(1);
@@ -643,7 +642,7 @@ public class TestDeltaLakeLocalConcurrentWritesTest
                     .collect(toImmutableList());
 
             long successfulInsertsCount = futures.stream()
-                    .map(future -> tryGetFutureValue(future, 20, SECONDS).orElseThrow(() -> new RuntimeException("Wait timed out")))
+                    .map(MoreFutures::getFutureValue)
                     .filter(success -> success)
                     .count();
             assertThat(successfulInsertsCount).isGreaterThanOrEqualTo(1);


### PR DESCRIPTION
Avoid test flakiness on Azure generated a too small timeout
duration for slow rename concurrent operations.

On Azure, at the time of this writing, renaming concurrently
more than 2 files to the same target file at the same time
can cause on Azure some of the `rename` operations to take
even about 2 minutes.

Fixes #21554

Created Azure Storage follow-up https://github.com/Azure/azure-sdk-for-java/issues/39774
