### PR TITLE
Remove "experimental" from BigQuery Arrow config property

### DIFF
--- a/docs/src/main/sphinx/connector/bigquery.md
+++ b/docs/src/main/sphinx/connector/bigquery.md
@@ -93,12 +93,12 @@ number of partitions based on server constraints.
 (bigquery-arrow-serialization-support)=
 ### Arrow serialization support
 
-This is an experimental feature which introduces support for using Apache Arrow
+This is a feature which introduces support for using Apache Arrow
 as the serialization format when reading from BigQuery.  Please note there are
 a few caveats:
 
 - Using Apache Arrow serialization is disabled by default. In order to enable
-  it, set the `bigquery.experimental.arrow-serialization.enabled`
+  it, set the `bigquery.arrow-serialization.enabled`
   configuration property to `true` and add
   `--add-opens=java.base/java.nio=ALL-UNNAMED` to the Trino
   {ref}`jvm-config`.
@@ -140,7 +140,7 @@ a few caveats:
 | `bigquery.credentials-file`                         | The path to the JSON credentials file                                                                                                                           | None. See the [requirements](bigquery-requirements) section. |
 | `bigquery.case-insensitive-name-matching`           | Match dataset and table names case-insensitively                                                                                                                | `false`                                              |
 | `bigquery.query-results-cache.enabled`              | Enable [query results cache](https://cloud.google.com/bigquery/docs/cached-results)                                                                             | `false`                                              |
-| `bigquery.experimental.arrow-serialization.enabled` | Enable using Apache Arrow serialization when reading data from BigQuery. Please read this [section](bigquery-arrow-serialization-support) before enabling this feature. | `false`                                              |
+| `bigquery.arrow-serialization.enabled`              | Enable using Apache Arrow serialization when reading data from BigQuery. Please read this [section](bigquery-arrow-serialization-support) before enabling this feature. | `false`                                              |
 | `bigquery.rpc-proxy.enabled`                        | Use a proxy for communication with BigQuery.                                                                                                                    | `false`                                              |
 | `bigquery.rpc-proxy.uri`                            | Proxy URI to use if connecting through a proxy.                                                                                                                 |                                                      |
 | `bigquery.rpc-proxy.username`                       | Proxy user name to use if connecting through a proxy.                                                                                                           |                                                      |

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConfig.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConfig.java
@@ -17,6 +17,7 @@ import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.ConfigHidden;
 import io.airlift.configuration.DefunctConfig;
+import io.airlift.configuration.LegacyConfig;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDuration;
 import io.trino.plugin.base.logging.SessionInterpolatedValues;
@@ -39,7 +40,7 @@ public class BigQueryConfig
 {
     public static final int DEFAULT_MAX_READ_ROWS_RETRIES = 3;
     public static final String VIEWS_ENABLED = "bigquery.views-enabled";
-    public static final String EXPERIMENTAL_ARROW_SERIALIZATION_ENABLED = "bigquery.experimental.arrow-serialization.enabled";
+    public static final String ARROW_SERIALIZATION_ENABLED = "bigquery.arrow-serialization.enabled";
 
     private Optional<String> projectId = Optional.empty();
     private Optional<String> parentProjectId = Optional.empty();
@@ -119,8 +120,9 @@ public class BigQueryConfig
         return arrowSerializationEnabled;
     }
 
-    @Config(EXPERIMENTAL_ARROW_SERIALIZATION_ENABLED)
-    @ConfigDescription("Enables experimental Arrow serialization while reading data")
+    @Config(ARROW_SERIALIZATION_ENABLED)
+    @LegacyConfig("bigquery.experimental.arrow-serialization.enabled")
+    @ConfigDescription("Enables Arrow serialization while reading data")
     public BigQueryConfig setArrowSerializationEnabled(boolean arrowSerializationEnabled)
     {
         this.arrowSerializationEnabled = arrowSerializationEnabled;

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorModule.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorModule.java
@@ -42,7 +42,7 @@ import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigBinder.configBinder;
-import static io.trino.plugin.bigquery.BigQueryConfig.EXPERIMENTAL_ARROW_SERIALIZATION_ENABLED;
+import static io.trino.plugin.bigquery.BigQueryConfig.ARROW_SERIALIZATION_ENABLED;
 import static java.lang.annotation.ElementType.CONSTRUCTOR;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
@@ -151,7 +151,7 @@ public class BigQueryConnectorModule
 
             if (!openedModules.contains("java.base/java.nio")) {
                 binder.addError(
-                        "BigQuery connector requires additional JVM arguments to run when '" + EXPERIMENTAL_ARROW_SERIALIZATION_ENABLED + "' is enabled. " +
+                        "BigQuery connector requires additional JVM arguments to run when '" + ARROW_SERIALIZATION_ENABLED + "' is enabled. " +
                                 "Please add '--add-opens=java.base/java.nio=ALL-UNNAMED' to the JVM configuration.");
             }
         }

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryArrowSerialization.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryArrowSerialization.java
@@ -39,7 +39,7 @@ public class TestBigQueryArrowSerialization
     {
         return BigQueryQueryRunner.createQueryRunner(
                 ImmutableMap.of(),
-                ImmutableMap.of("bigquery.experimental.arrow-serialization.enabled", "true"),
+                ImmutableMap.of("bigquery.arrow-serialization.enabled", "true"),
                 ImmutableList.of());
     }
 

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryArrowTypeMapping.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryArrowTypeMapping.java
@@ -26,7 +26,7 @@ public class TestBigQueryArrowTypeMapping
     {
         return BigQueryQueryRunner.createQueryRunner(
                 ImmutableMap.of(),
-                ImmutableMap.of("bigquery.skip-view-materialization", "true", "bigquery.experimental.arrow-serialization.enabled", "true"),
+                ImmutableMap.of("bigquery.skip-view-materialization", "true", "bigquery.arrow-serialization.enabled", "true"),
                 ImmutableList.of());
     }
 }

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConfig.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConfig.java
@@ -63,7 +63,7 @@ public class TestBigQueryConfig
                 .put("bigquery.parent-project-id", "ppid")
                 .put("bigquery.parallelism", "20")
                 .put("bigquery.views-enabled", "true")
-                .put("bigquery.experimental.arrow-serialization.enabled", "true")
+                .put("bigquery.arrow-serialization.enabled", "true")
                 .put("bigquery.view-expire-duration", "30m")
                 .put("bigquery.skip-view-materialization", "true")
                 .put("bigquery.view-materialization-project", "vmproject")


### PR DESCRIPTION
## Description

It was experimental more than 1 year. I think we can remove experimental clarification now. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
