### PR TITLE
Relax test assertion in BaseOracleFailureRecoveryTest

### DIFF
--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleFailureRecoveryTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleFailureRecoveryTest.java
@@ -87,4 +87,12 @@ public abstract class BaseOracleFailureRecoveryTest
                 .withCleanupQuery(cleanupQuery)
                 .isCoordinatorOnly();
     }
+
+    @Override
+    protected boolean checkNoRemainingTmpTables()
+    {
+        // we could not ensure that tmp tables are always promptly removed in Oracle.
+        // checking if tmp_trino tables are deleted immediatelly after DML operation renders test flaky.
+        return false;
+    }
 }

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseFailureRecoveryTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseFailureRecoveryTest.java
@@ -411,16 +411,23 @@ public abstract class BaseFailureRecoveryTest
             }
         }
 
-        assertThat(remainingTemporaryTables.isEmpty())
-                .as("There should be no remaining tmp_trino tables that are queryable. They are:\n%s",
-                        remainingTemporaryTables.entrySet().stream()
-                                .map(entry -> "\tFor queryId [%s] (prefix [%s]) remaining tables: [%s]\n\t\tWith errors: [%s]".formatted(
-                                        entry.getKey(),
-                                        temporaryTableNamePrefix(entry.getKey()),
-                                        Joiner.on(",").join(entry.getValue()),
-                                        Joiner.on("],\n[").join(assertionErrorMessages.get(entry.getKey())).replace("\n", "\n\t\t\t")))
-                                .collect(joining("\n")))
-                .isTrue();
+        if (checkNoRemainingTmpTables()) {
+            assertThat(remainingTemporaryTables.isEmpty())
+                    .as("There should be no remaining tmp_trino tables that are queryable. They are:\n%s",
+                            remainingTemporaryTables.entrySet().stream()
+                                    .map(entry -> "\tFor queryId [%s] (prefix [%s]) remaining tables: [%s]\n\t\tWith errors: [%s]".formatted(
+                                            entry.getKey(),
+                                            temporaryTableNamePrefix(entry.getKey()),
+                                            Joiner.on(",").join(entry.getValue()),
+                                            Joiner.on("],\n[").join(assertionErrorMessages.get(entry.getKey())).replace("\n", "\n\t\t\t")))
+                                    .collect(joining("\n")))
+                    .isTrue();
+        }
+    }
+
+    protected boolean checkNoRemainingTmpTables()
+    {
+        return true;
     }
 
     protected class FailureRecoveryAssert


### PR DESCRIPTION
We could not ensure that tmp tables are always promptly removed in Oracle. Checking if tmp_trino tables are deleted immediatelly after DML operation renders TestOracleQueryFailureRecoveryTest and TestOracleTaskFailureRecoveryTest test flaky.

fixes: https://github.com/trinodb/trino/issues/20309
