### PR TITLE
Indicate constraint in HiveTableHandle.toString 

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePartitionManager.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePartitionManager.java
@@ -17,7 +17,6 @@ import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import io.trino.plugin.hive.metastore.SemiTransactionalHiveMetastore;
 import io.trino.plugin.hive.util.HiveBucketing.HiveBucketFilter;
@@ -169,7 +168,12 @@ public class HivePartitionManager
                 partitions.getBucketHandle(),
                 partitions.getBucketFilter(),
                 handle.getAnalyzePartitionValues(),
-                Sets.union(handle.getConstraintColumns(), constraint.getPredicateColumns().orElseGet(ImmutableSet::of)),
+                ImmutableSet.<HiveColumnHandle>builder()
+                        .addAll(handle.getConstraintColumns())
+                        .addAll(constraint.getPredicateColumns().orElseGet(ImmutableSet::of).stream()
+                                .map(HiveColumnHandle.class::cast)
+                                .collect(toImmutableList()))
+                        .build(),
                 handle.getProjectedColumns(),
                 handle.getTransaction(),
                 handle.isRecordScannedFiles(),

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableHandle.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableHandle.java
@@ -53,8 +53,8 @@ public class HiveTableHandle
     private final Optional<HiveBucketHandle> bucketHandle;
     private final Optional<HiveBucketFilter> bucketFilter;
     private final Optional<List<List<String>>> analyzePartitionValues;
-    private final Set<ColumnHandle> constraintColumns;
-    private final Set<ColumnHandle> projectedColumns;
+    private final Set<HiveColumnHandle> constraintColumns;
+    private final Set<HiveColumnHandle> projectedColumns;
     private final AcidTransaction transaction;
     private final boolean recordScannedFiles;
     private final Optional<Long> maxScannedFileSize;
@@ -131,7 +131,7 @@ public class HiveTableHandle
             Optional<HiveBucketHandle> bucketHandle,
             Optional<HiveBucketFilter> bucketFilter,
             Optional<List<List<String>>> analyzePartitionValues,
-            Set<ColumnHandle> constraintColumns,
+            Set<HiveColumnHandle> constraintColumns,
             AcidTransaction transaction,
             boolean recordScannedFiles,
             Optional<Long> maxSplitFileSize)
@@ -150,7 +150,7 @@ public class HiveTableHandle
                 bucketFilter,
                 analyzePartitionValues,
                 constraintColumns,
-                ImmutableSet.<ColumnHandle>builder().addAll(partitionColumns).addAll(dataColumns).build(),
+                ImmutableSet.<HiveColumnHandle>builder().addAll(partitionColumns).addAll(dataColumns).build(),
                 transaction,
                 recordScannedFiles,
                 maxSplitFileSize);
@@ -169,8 +169,8 @@ public class HiveTableHandle
             Optional<HiveBucketHandle> bucketHandle,
             Optional<HiveBucketFilter> bucketFilter,
             Optional<List<List<String>>> analyzePartitionValues,
-            Set<ColumnHandle> constraintColumns,
-            Set<ColumnHandle> projectedColumns,
+            Set<HiveColumnHandle> constraintColumns,
+            Set<HiveColumnHandle> projectedColumns,
             AcidTransaction transaction,
             boolean recordScannedFiles,
             Optional<Long> maxSplitFileSize)
@@ -239,7 +239,7 @@ public class HiveTableHandle
                 maxScannedFileSize);
     }
 
-    public HiveTableHandle withProjectedColumns(Set<ColumnHandle> projectedColumns)
+    public HiveTableHandle withProjectedColumns(Set<HiveColumnHandle> projectedColumns)
     {
         return new HiveTableHandle(
                 schemaName,
@@ -397,14 +397,14 @@ public class HiveTableHandle
 
     // do not serialize constraint columns as they are not needed on workers
     @JsonIgnore
-    public Set<ColumnHandle> getConstraintColumns()
+    public Set<HiveColumnHandle> getConstraintColumns()
     {
         return constraintColumns;
     }
 
     // do not serialize projected columns as they are not needed on workers
     @JsonIgnore
-    public Set<ColumnHandle> getProjectedColumns()
+    public Set<HiveColumnHandle> getProjectedColumns()
     {
         return projectedColumns;
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableHandle.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableHandle.java
@@ -481,6 +481,12 @@ public class HiveTableHandle
     {
         StringBuilder builder = new StringBuilder();
         builder.append(schemaName).append(":").append(tableName);
+        if (!constraintColumns.isEmpty()) {
+            builder.append(" constraint on ");
+            builder.append(constraintColumns.stream()
+                    .map(HiveColumnHandle::getName)
+                    .collect(joining(", ", "[", "]")));
+        }
         bucketHandle.ifPresent(bucket -> {
             builder.append(" buckets=").append(bucket.getReadBucketCount());
             if (!bucket.getSortedBy().isEmpty()) {


### PR DESCRIPTION
The `toString` is used by `EXPLAIN` to provide information for the user.


relates

- https://github.com/trinodb/trino/pull/21573