### PR TITLE
Fix tracing context propagation during connector invocation

### DIFF
--- a/core/trino-main/src/test/java/io/trino/execution/TestConnectorTracingContextPropagation.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestConnectorTracingContextPropagation.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution;
+
+import com.google.common.collect.ImmutableMap;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.trino.connector.MockConnectorFactory;
+import io.trino.connector.MockConnectorPlugin;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.StandaloneQueryRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+public class TestConnectorTracingContextPropagation
+{
+    private static final String CATALOG_NAME = "test_catalog";
+    private static final String CONNECTOR_NAME = "test_connector";
+
+    @Test
+    public void testTracingContextCapture()
+    {
+        AtomicReference<Context> capturedContext = new AtomicReference<>();
+
+        try (QueryRunner queryRunner = new StandaloneQueryRunner(testSessionBuilder().build())) {
+            queryRunner.installPlugin(new MockConnectorPlugin(MockConnectorFactory.builder()
+                    .withName(CONNECTOR_NAME)
+                    .withData(table -> { // invoked in ConnectorPageSourceProvider
+                        capturedContext.set(Context.current());
+                        return List.of(List.of());
+                    })
+                    .build()));
+            queryRunner.createCatalog(CATALOG_NAME, CONNECTOR_NAME, ImmutableMap.of());
+
+            queryRunner.execute("SELECT COUNT(*) FROM %s.test.test".formatted(CATALOG_NAME));
+        }
+
+        assertThat(capturedContext.get())
+                .matches(ctx -> Span.fromContext(ctx).getSpanContext().isValid(), "valid tracing context");
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
After migrating from Trino 435 to the current version, we noticed that the tracing context no longer propagated into our custom connectors. Connector spans are detached from the parent span and stored as separate traces.

**Trino 435**
<img width="356" alt="Screenshot 2024-04-12 at 13 35 10" src="https://github.com/trinodb/trino/assets/11261786/8a80b559-9e22-40a0-b196-b1bb53774fff">

**Trino 444**
<img width="205" alt="Screenshot 2024-04-12 at 13 37 52" src="https://github.com/trinodb/trino/assets/11261786/0e78e4a0-49fb-4e1f-b20c-f890a0be93fe">

This PR fixes span propagation. It also adds a test to cover any possible future regressions.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Fixed tracing context propagation in connector
```
