### PR TITLE
Enable enum equality predicate pushdown for ClickHouse connector

### DIFF
--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
@@ -620,8 +620,7 @@ public class ClickHouseClient
                         createUnboundedVarcharType(),
                         varcharReadFunction(createUnboundedVarcharType()),
                         varcharWriteFunction(),
-                        // TODO (https://github.com/trinodb/trino/issues/7100) Currently pushdown would not work and may require a custom bind expression
-                        DISABLE_PUSHDOWN));
+                        CLICKHOUSE_PUSHDOWN_CONTROLLER));
 
             case FixedString: // FixedString(n)
             case String:


### PR DESCRIPTION
## Description
Partially addresses #7100 .

Enables equality predicate pushdown for [enum](https://clickhouse.com/docs/en/sql-reference/data-types/enum) types. It's similar to VARCHAR (from Trino's perspective), but is not that "general-purpose". Until ClickHouse fully supports collation (atm it's only implemented for ORDER BY clause) range predicates are not pushed down.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Submitted https://github.com/ClickHouse/ClickHouse/issues/62701 for unexpected behaviour.

Next I'll be looking at Decimals, time types and aggregate functions.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X ) Release notes are required, with the following suggested text:

```markdown
# Section
* Enable enum equality predicate pushdown. ({issue}`7100`)
```
