### PR TITLE
Fixed integer overflow for merged ORC diskRange

### DIFF
--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcDataSourceUtils.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcDataSourceUtils.java
@@ -46,8 +46,15 @@ public final class OrcDataSourceUtils
         DiskRange last = ranges.get(0);
         for (int i = 1; i < ranges.size(); i++) {
             DiskRange current = ranges.get(i);
-            DiskRange merged = last.span(current);
-            if (merged.getLength() <= maxReadSizeBytes && last.getEnd() + maxMergeDistanceBytes >= current.getOffset()) {
+            DiskRange merged = null;
+            boolean blockTooLong = false;
+            try {
+                merged = last.span(current);
+            }
+            catch (ArithmeticException e) {
+                blockTooLong = true;
+            }
+            if (!blockTooLong && merged.getLength() <= maxReadSizeBytes && last.getEnd() + maxMergeDistanceBytes >= current.getOffset()) {
                 last = merged;
             }
             else {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
While merging small reads, if the first range and second range are more than 2
GB apart, mergeAdjacentDiskRanges() throw "interger overflow" ArithmeticException because
merging those two ranges is too big to fit in a DiskRange
There was similar fix for parquet already. https://github.com/trinodb/trino/pull/2761

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Hudi, Iceberg
* Fix reading from large ORC files. ({issue}`21587`)
```
