### PR TITLE
Mongo contains function pushdown

### DIFF
--- a/docs/src/main/sphinx/connector/mongodb.md
+++ b/docs/src/main/sphinx/connector/mongodb.md
@@ -39,28 +39,29 @@ will create a catalog named `sales` using the configured connector.
 
 The following configuration properties are available:
 
-| Property name                            | Description                                                                |
-| ---------------------------------------- | -------------------------------------------------------------------------- |
-| `mongodb.connection-url`                 | The connection url that the driver uses to connect to a MongoDB deployment |
-| `mongodb.schema-collection`              | A collection which contains schema information                             |
-| `mongodb.case-insensitive-name-matching` | Match database and collection names case insensitively                     |
-| `mongodb.min-connections-per-host`       | The minimum size of the connection pool per host                           |
-| `mongodb.connections-per-host`           | The maximum size of the connection pool per host                           |
-| `mongodb.max-wait-time`                  | The maximum wait time                                                      |
-| `mongodb.max-connection-idle-time`       | The maximum idle time of a pooled connection                               |
-| `mongodb.connection-timeout`             | The socket connect timeout                                                 |
-| `mongodb.socket-timeout`                 | The socket timeout                                                         |
-| `mongodb.tls.enabled`                    | Use TLS/SSL for connections to mongod/mongos                               |
-| `mongodb.tls.keystore-path`              | Path to the  or JKS key store                                              |
-| `mongodb.tls.truststore-path`            | Path to the  or JKS trust store                                            |
-| `mongodb.tls.keystore-password`          | Password for the key store                                                 |
-| `mongodb.tls.truststore-password`        | Password for the trust store                                               |
-| `mongodb.read-preference`                | The read preference                                                        |
-| `mongodb.write-concern`                  | The write concern                                                          |
-| `mongodb.required-replica-set`           | The required replica set name                                              |
-| `mongodb.cursor-batch-size`              | The number of elements to return in a batch                                |
-| `mongodb.allow-local-scheduling`         | Assign MongoDB splits to a specific worker                                 |
-| `mongodb.dynamic-filtering.wait-timeout` | Duration to wait for completion of dynamic filters during split generation |
+| Property name                                 | Description                                                                |
+|-----------------------------------------------|----------------------------------------------------------------------------|
+| `mongodb.connection-url`                      | The connection url that the driver uses to connect to a MongoDB deployment |
+| `mongodb.schema-collection`                   | A collection which contains schema information                             |
+| `mongodb.case-insensitive-name-matching`      | Match database and collection names case insensitively                     |
+| `mongodb.min-connections-per-host`            | The minimum size of the connection pool per host                           |
+| `mongodb.connections-per-host`                | The maximum size of the connection pool per host                           |
+| `mongodb.max-wait-time`                       | The maximum wait time                                                      |
+| `mongodb.max-connection-idle-time`            | The maximum idle time of a pooled connection                               |
+| `mongodb.connection-timeout`                  | The socket connect timeout                                                 |
+| `mongodb.socket-timeout`                      | The socket timeout                                                         |
+| `mongodb.tls.enabled`                         | Use TLS/SSL for connections to mongod/mongos                               |
+| `mongodb.tls.keystore-path`                   | Path to the  or JKS key store                                              |
+| `mongodb.tls.truststore-path`                 | Path to the  or JKS trust store                                            |
+| `mongodb.tls.keystore-password`               | Password for the key store                                                 |
+| `mongodb.tls.truststore-password`             | Password for the trust store                                               |
+| `mongodb.read-preference`                     | The read preference                                                        |
+| `mongodb.write-concern`                       | The write concern                                                          |
+| `mongodb.required-replica-set`                | The required replica set name                                              |
+| `mongodb.cursor-batch-size`                   | The number of elements to return in a batch                                |
+| `mongodb.allow-local-scheduling`              | Assign MongoDB splits to a specific worker                                 |
+| `mongodb.dynamic-filtering.wait-timeout`      | Duration to wait for completion of dynamic filters during split generation |
+| `mongodb.complex-expression-pushdown-enabled` | Allow complex expression pushdown                                          |
 
 ### `mongodb.connection-url`
 
@@ -219,6 +220,12 @@ This property is optional, and defaults to false.
 Duration to wait for completion of dynamic filters during split generation.
 
 This property is optional; the default is `5s`.
+
+### `mongodb.complex-expression-pushdown-enabled`
+
+Allow complex expression pushdown.
+
+This property is optional; the default is `true`.
 
 (table-definition-label)=
 

--- a/plugin/trino-mongodb/pom.xml
+++ b/plugin/trino-mongodb/pom.xml
@@ -65,6 +65,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-matching</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-plugin-toolkit</artifactId>
         </dependency>
 

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientConfig.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientConfig.java
@@ -51,6 +51,7 @@ public class MongoClientConfig
     private boolean projectionPushDownEnabled = true;
     private boolean allowLocalScheduling;
     private Duration dynamicFilteringWaitTimeout = new Duration(5, SECONDS);
+    private boolean complexExpressionPushdownEnabled = true;
 
     @NotNull
     public String getSchemaCollection()
@@ -283,6 +284,19 @@ public class MongoClientConfig
     public MongoClientConfig setDynamicFilteringWaitTimeout(Duration dynamicFilteringWaitTimeout)
     {
         this.dynamicFilteringWaitTimeout = dynamicFilteringWaitTimeout;
+        return this;
+    }
+
+    public boolean isComplexExpressionPushdownEnabled()
+    {
+        return complexExpressionPushdownEnabled;
+    }
+
+    @Config("mongodb.complex-expression-pushdown-enabled")
+    @ConfigDescription("Allow complex expression pushdown")
+    public MongoClientConfig setComplexExpressionPushdownEnabled(boolean complexExpressionPushdownEnabled)
+    {
+        this.complexExpressionPushdownEnabled = complexExpressionPushdownEnabled;
         return this;
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSessionProperties.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSessionProperties.java
@@ -30,6 +30,7 @@ public final class MongoSessionProperties
 {
     private static final String PROJECTION_PUSHDOWN_ENABLED = "projection_pushdown_enabled";
     public static final String DYNAMIC_FILTERING_WAIT_TIMEOUT = "dynamic_filtering_wait_timeout";
+    public static final String COMPLEX_EXPRESSION_PUSHDOWN = "complex_expression_pushdown";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -47,6 +48,11 @@ public final class MongoSessionProperties
                         "Duration to wait for completion of dynamic filters",
                         mongoConfig.getDynamicFilteringWaitTimeout(),
                         false))
+                .add(booleanProperty(
+                        COMPLEX_EXPRESSION_PUSHDOWN,
+                        "Allow complex expression pushdown",
+                        mongoConfig.isComplexExpressionPushdownEnabled(),
+                        true))
                 .build();
     }
 
@@ -64,5 +70,10 @@ public final class MongoSessionProperties
     public static Duration getDynamicFilteringWaitTimeout(ConnectorSession session)
     {
         return session.getProperty(DYNAMIC_FILTERING_WAIT_TIMEOUT, Duration.class);
+    }
+
+    public static boolean isComplexExpressionPushdown(ConnectorSession session)
+    {
+        return session.getProperty(COMPLEX_EXPRESSION_PUSHDOWN, Boolean.class);
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/TypeUtils.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/TypeUtils.java
@@ -53,6 +53,7 @@ import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MICROSECOND;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
 import static io.trino.spi.type.Timestamps.roundDiv;
 import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.floorDiv;
 import static java.lang.Math.floorMod;
@@ -89,6 +90,14 @@ public final class TypeUtils
                 || type instanceof DecimalType
                 || type instanceof ObjectIdType
                 || PUSHDOWN_SUPPORTED_PRIMITIVE_TYPES.contains(type);
+    }
+
+    public static boolean isPushdownSupportedArrayElementType(Type type)
+    {
+        if (type == TIME_MILLIS || type == VARBINARY) {
+            return false;
+        }
+        return isPushdownSupportedType(type);
     }
 
     public static Optional<Object> translateValue(Object trinoNativeValue, Type type)

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/TypeUtils.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/TypeUtils.java
@@ -14,15 +14,31 @@
 package io.trino.plugin.mongodb;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.primitives.Primitives;
+import com.google.common.primitives.Shorts;
+import com.google.common.primitives.SignedBytes;
+import io.airlift.slice.Slice;
 import io.trino.spi.type.CharType;
 import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Decimals;
+import io.trino.spi.type.Int128;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
+import org.bson.types.Decimal128;
+import org.bson.types.ObjectId;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Optional;
 import java.util.Set;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.Chars.padSpaces;
+import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
@@ -32,7 +48,17 @@ import static io.trino.spi.type.StandardTypes.JSON;
 import static io.trino.spi.type.TimeType.TIME_MILLIS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
+import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MICROSECOND;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
+import static io.trino.spi.type.Timestamps.roundDiv;
 import static io.trino.spi.type.TinyintType.TINYINT;
+import static java.lang.Float.intBitsToFloat;
+import static java.lang.Math.floorDiv;
+import static java.lang.Math.floorMod;
+import static java.lang.Math.toIntExact;
+import static java.time.ZoneOffset.UTC;
+import static java.util.Objects.requireNonNull;
 
 public final class TypeUtils
 {
@@ -63,5 +89,86 @@ public final class TypeUtils
                 || type instanceof DecimalType
                 || type instanceof ObjectIdType
                 || PUSHDOWN_SUPPORTED_PRIMITIVE_TYPES.contains(type);
+    }
+
+    public static Optional<Object> translateValue(Object trinoNativeValue, Type type)
+    {
+        requireNonNull(trinoNativeValue, "trinoNativeValue is null");
+        requireNonNull(type, "type is null");
+        checkArgument(Primitives.wrap(type.getJavaType()).isInstance(trinoNativeValue), "%s (%s) is not a valid representation for %s", trinoNativeValue, trinoNativeValue.getClass(), type);
+
+        if (type == BOOLEAN) {
+            return Optional.of(trinoNativeValue);
+        }
+
+        if (type == TINYINT) {
+            return Optional.of((long) SignedBytes.checkedCast(((Long) trinoNativeValue)));
+        }
+
+        if (type == SMALLINT) {
+            return Optional.of((long) Shorts.checkedCast(((Long) trinoNativeValue)));
+        }
+
+        if (type == INTEGER) {
+            return Optional.of((long) toIntExact(((Long) trinoNativeValue)));
+        }
+
+        if (type == BIGINT) {
+            return Optional.of(trinoNativeValue);
+        }
+
+        if (type == REAL) {
+            return Optional.of(intBitsToFloat(toIntExact((long) trinoNativeValue)));
+        }
+
+        if (type == DOUBLE) {
+            return Optional.of(trinoNativeValue);
+        }
+
+        if (type instanceof DecimalType decimalType) {
+            if (decimalType.isShort()) {
+                return Optional.of(Decimal128.parse(Decimals.toString((long) trinoNativeValue, decimalType.getScale())));
+            }
+            return Optional.of(Decimal128.parse(Decimals.toString((Int128) trinoNativeValue, decimalType.getScale())));
+        }
+
+        if (type instanceof ObjectIdType) {
+            return Optional.of(new ObjectId(((Slice) trinoNativeValue).getBytes()));
+        }
+
+        if (type instanceof CharType charType) {
+            Slice slice = padSpaces(((Slice) trinoNativeValue), charType);
+            return Optional.of(slice.toStringUtf8());
+        }
+
+        if (type instanceof VarcharType) {
+            return Optional.of(((Slice) trinoNativeValue).toStringUtf8());
+        }
+
+        if (type == DATE) {
+            long days = (long) trinoNativeValue;
+            return Optional.of(LocalDate.ofEpochDay(days));
+        }
+
+        if (type == TIME_MILLIS) {
+            long picos = (long) trinoNativeValue;
+            return Optional.of(LocalTime.ofNanoOfDay(roundDiv(picos, PICOSECONDS_PER_NANOSECOND)));
+        }
+
+        if (type == TIMESTAMP_MILLIS) {
+            long epochMicros = (long) trinoNativeValue;
+            long epochSecond = floorDiv(epochMicros, MICROSECONDS_PER_SECOND);
+            int nanoFraction = floorMod(epochMicros, MICROSECONDS_PER_SECOND) * NANOSECONDS_PER_MICROSECOND;
+            Instant instant = Instant.ofEpochSecond(epochSecond, nanoFraction);
+            return Optional.of(LocalDateTime.ofInstant(instant, UTC));
+        }
+
+        if (type == TIMESTAMP_TZ_MILLIS) {
+            long millisUtc = unpackMillisUtc((long) trinoNativeValue);
+            Instant instant = Instant.ofEpochMilli(millisUtc);
+            return Optional.of(LocalDateTime.ofInstant(instant, UTC));
+        }
+
+        return Optional.empty();
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/ContainsRewriteRule.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/ContainsRewriteRule.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.plugin.mongodb.MongoColumnHandle;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.expression.Variable;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.Type;
+import org.bson.Document;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.Optional;
+
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argument;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argumentCount;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.constant;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.variable;
+import static io.trino.plugin.mongodb.TypeUtils.isPushdownSupportedArrayElementType;
+import static io.trino.plugin.mongodb.TypeUtils.translateValue;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+
+public class ContainsRewriteRule
+        implements ConnectorExpressionRule<Call, Document>
+{
+    private static final Capture<Variable> COLUMN = Capture.newCapture();
+    private static final Capture<Constant> VALUE = Capture.newCapture();
+    private static final FunctionName CONTAINS_FUNCTION_NAME = new FunctionName("contains");
+
+    private static final Pattern<Call> PATTERN = call()
+            .with(functionName().equalTo(CONTAINS_FUNCTION_NAME))
+            .with(type().equalTo(BOOLEAN))
+            .with(argumentCount().equalTo(2))
+            .with(argument(0).matching(variable().capturedAs(COLUMN)))
+            .with(argument(1).matching(constant().capturedAs(VALUE)));
+
+    public ContainsRewriteRule()
+    {
+    }
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<Document> rewrite(Call expression, Captures captures, RewriteContext<Document> context)
+    {
+        Variable arrayVariable = captures.get(COLUMN);
+        Constant constValue = captures.get(VALUE);
+
+        String columnName = arrayVariable.getName();
+
+        if (!context.getAssignments().containsKey(columnName)) {
+            return Optional.empty();
+        }
+
+        MongoColumnHandle columnHandle = (MongoColumnHandle) context.getAssignment(columnName);
+        Type elementType = ((ArrayType) columnHandle.type()).getElementType();
+        if (!isPushdownSupportedArrayElementType(elementType)) {
+            return Optional.empty();
+        }
+
+        Optional<Object> mongoValue = translateValueForJson(constValue.getValue(), elementType);
+
+        return mongoValue.map(o -> new Document(columnHandle.getQualifiedName(), o));
+    }
+
+    private Optional<Object> translateValueForJson(Object trinoNativeValue, Type type)
+    {
+        return translateValue(trinoNativeValue, type).map(this::mapValueForJson);
+    }
+
+    private Object mapValueForJson(Object value)
+    {
+        /*
+         * LocalDate and LocalDateTime in org.bson.Document causes an error when using Document.toJson().
+         * So convert it to Date object.
+         */
+        if (value instanceof LocalDate localDate) {
+            return Date.from(localDate.atStartOfDay().toInstant(ZoneOffset.UTC));
+        }
+        if (value instanceof LocalDateTime localDateTime) {
+            return Date.from(localDateTime.toInstant(ZoneOffset.UTC));
+        }
+
+        return value;
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/MongoConnectorExpressionRewriterBuilder.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/MongoConnectorExpressionRewriterBuilder.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.plugin.base.expression.ConnectorExpressionRewriter;
+import org.bson.Document;
+
+import java.util.Set;
+
+public class MongoConnectorExpressionRewriterBuilder
+{
+    private MongoConnectorExpressionRewriterBuilder() {}
+
+    public static ConnectorExpressionRewriter<Document> build()
+    {
+        return new ConnectorExpressionRewriter<Document>(Set.of(
+                new ContainsRewriteRule(),
+                new NotRewriteRule(),
+                new OrRewriteRule()));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/NotRewriteRule.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/NotRewriteRule.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import org.bson.Document;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.spi.expression.StandardFunctions.NOT_FUNCTION_NAME;
+
+public class NotRewriteRule
+        implements ConnectorExpressionRule<Call, Document>
+{
+    private static final Pattern<Call> PATTERN = call().with(functionName().equalTo(NOT_FUNCTION_NAME));
+
+    public NotRewriteRule()
+    {
+    }
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<Document> rewrite(Call expression, Captures captures, RewriteContext<Document> context)
+    {
+        List<Document> childrenPredicates = new ArrayList<>();
+
+        for (ConnectorExpression exp : expression.getArguments()) {
+            Optional<Document> predicate = context.defaultRewrite(exp);
+            if (predicate.isPresent()) {
+                childrenPredicates.add(predicate.get());
+            }
+            else {
+                return Optional.empty();
+            }
+        }
+
+        return Optional.of(new Document("$nor", childrenPredicates));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/OrRewriteRule.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/OrRewriteRule.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import org.bson.Document;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.spi.expression.StandardFunctions.OR_FUNCTION_NAME;
+
+public class OrRewriteRule
+        implements ConnectorExpressionRule<Call, Document>
+{
+    private static final Pattern<Call> PATTERN = call().with(functionName().equalTo(OR_FUNCTION_NAME));
+
+    public OrRewriteRule()
+    {
+    }
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<Document> rewrite(Call expression, Captures captures, RewriteContext<Document> context)
+    {
+        List<Document> childrenPredicates = new ArrayList<>();
+
+        for (ConnectorExpression exp : expression.getArguments()) {
+            Optional<Document> predicate = context.defaultRewrite(exp);
+            if (predicate.isPresent()) {
+                childrenPredicates.add(predicate.get());
+            }
+            else {
+                return Optional.empty();
+            }
+        }
+
+        return Optional.of(new Document("$or", childrenPredicates));
+    }
+}

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoClientConfig.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoClientConfig.java
@@ -48,7 +48,8 @@ public class TestMongoClientConfig
                 .setImplicitRowFieldPrefix("_pos")
                 .setProjectionPushdownEnabled(true)
                 .setAllowLocalScheduling(false)
-                .setDynamicFilteringWaitTimeout(new Duration(5, SECONDS)));
+                .setDynamicFilteringWaitTimeout(new Duration(5, SECONDS))
+                .setComplexExpressionPushdownEnabled(true));
     }
 
     @Test
@@ -74,6 +75,7 @@ public class TestMongoClientConfig
                 .put("mongodb.projection-pushdown-enabled", "false")
                 .put("mongodb.allow-local-scheduling", "true")
                 .put("mongodb.dynamic-filtering.wait-timeout", "2ms")
+                .put("mongodb.complex-expression-pushdown-enabled", "false")
                 .buildOrThrow();
 
         MongoClientConfig expected = new MongoClientConfig()
@@ -94,7 +96,8 @@ public class TestMongoClientConfig
                 .setImplicitRowFieldPrefix("_prefix")
                 .setProjectionPushdownEnabled(false)
                 .setAllowLocalScheduling(true)
-                .setDynamicFilteringWaitTimeout(new Duration(2, MILLISECONDS));
+                .setDynamicFilteringWaitTimeout(new Duration(2, MILLISECONDS))
+                .setComplexExpressionPushdownEnabled(false);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoExpressionRewrite.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoExpressionRewrite.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb;
+
+import io.trino.plugin.base.expression.ConnectorExpressionRewriter;
+import io.trino.plugin.mongodb.expression.MongoConnectorExpressionRewriterBuilder;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.expression.Variable;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.BigintType;
+import io.trino.spi.type.BooleanType;
+import io.trino.testing.TestingConnectorSession;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestMongoExpressionRewrite
+{
+    private final ConnectorExpressionRewriter<Document> connectorExpressionRewriter;
+
+    public TestMongoExpressionRewrite()
+    {
+        this.connectorExpressionRewriter = MongoConnectorExpressionRewriterBuilder.build();
+    }
+
+    @Test
+    public void testContainsFunctionRewrite()
+    {
+        ConnectorExpression expression = buildContainsExpression("col", 1L);
+
+        Optional<Document> predicate = this.connectorExpressionRewriter.rewrite(
+                TestingConnectorSession.builder().build(),
+                expression,
+                Map.of("col", new MongoColumnHandle("col", List.of(), new ArrayType(BigintType.BIGINT), false, false, Optional.empty())));
+
+        assertTrue(predicate.isPresent());
+        assertEquals(new Document("col", 1L), predicate.get());
+    }
+
+    private static Call buildContainsExpression(String variableName, Long value)
+    {
+        return new Call(
+                BooleanType.BOOLEAN,
+                new FunctionName("contains"),
+                List.of(
+                        new Variable(variableName, new ArrayType(BigintType.BIGINT)),
+                        new Constant(value, BigintType.BIGINT)));
+    }
+
+    @Test
+    public void testNotContainsRewrite()
+    {
+        ConnectorExpression expression = buildContainsExpression("col", 1L);
+        ConnectorExpression notExpression = new Call(
+                BooleanType.BOOLEAN,
+                new FunctionName("$not"),
+                List.of(expression));
+        Optional<Document> predicate = this.connectorExpressionRewriter.rewrite(
+                TestingConnectorSession.builder().build(),
+                notExpression,
+                Map.of("col", new MongoColumnHandle("col", List.of(), new ArrayType(BigintType.BIGINT), false, false, Optional.empty())));
+
+        assertTrue(predicate.isPresent());
+        Document expectPredicate = new Document("$nor", List.of(new Document("col", 1L)));
+        assertEquals(expectPredicate, predicate.get());
+    }
+
+    @Test
+    public void testOrContainsRewrite()
+    {
+        ConnectorExpression expression1 = buildContainsExpression("col", 1L);
+        ConnectorExpression expression2 = buildContainsExpression("col", 2L);
+        ConnectorExpression expression3 = buildContainsExpression("col", 3L);
+        ConnectorExpression notExpression = new Call(
+                BooleanType.BOOLEAN,
+                new FunctionName("$or"),
+                List.of(expression1, expression2, expression3));
+        Optional<Document> predicate = this.connectorExpressionRewriter.rewrite(
+                TestingConnectorSession.builder().build(),
+                notExpression,
+                Map.of("col", new MongoColumnHandle("col", List.of(), new ArrayType(BigintType.BIGINT), false, false, Optional.empty())));
+
+        assertTrue(predicate.isPresent());
+        Document actualPredict = predicate.get();
+        assertEquals(1, actualPredict.keySet().size());
+        assertTrue(actualPredict.containsKey("$or"));
+        Set<Document> expectPredicts = Set.of(
+                new Document("col", 1L),
+                new Document("col", 2L),
+                new Document("col", 3L));
+        assertEquals(expectPredicts, Set.copyOf(actualPredict.getList("$or", Document.class)));
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Add "contains" function pushdown for mongo connector.

Tested the following formals:

    WHERE contains(colArray, -1)
    WHERE NOT contains(colArray, 100)
    WHERE NOT contains(colArray, 100) OR NOT contains(colArray, 200)

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Fixes #21043 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
