### PR TITLE
Add builders for MySQL, PostgreSQL, BigQuery query runners

### DIFF
--- a/plugin/trino-bigquery/pom.xml
+++ b/plugin/trino-bigquery/pom.xml
@@ -359,6 +359,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>log-manager</artifactId>
             <scope>runtime</scope>

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryFailureRecoveryTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryFailureRecoveryTest.java
@@ -43,17 +43,17 @@ public abstract class BaseBigQueryFailureRecoveryTest
             Map<String, String> coordinatorProperties)
             throws Exception
     {
-        return BigQueryQueryRunner.createQueryRunner(
-                configProperties,
-                coordinatorProperties,
-                ImmutableMap.of(),
-                requiredTpchTables,
-                runner -> {
+        return BigQueryQueryRunner.builder()
+                .setExtraProperties(configProperties)
+                .setCoordinatorProperties(coordinatorProperties)
+                .setInitialTables(requiredTpchTables)
+                .setAdditionalSetup(runner -> {
                     runner.installPlugin(new FileSystemExchangePlugin());
                     runner.loadExchangeManager("filesystem", ImmutableMap.<String, String>builder()
                             .put("exchange.base-directories", System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager")
                             .buildOrThrow());
-                });
+                })
+                .build();
     }
 
     @Override

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
@@ -26,8 +26,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.airlift.log.Logger;
-import io.trino.Session;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
@@ -43,7 +43,6 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
 
 import static com.google.cloud.bigquery.BigQuery.DatasetDeleteOption.deleteContents;
 import static com.google.cloud.bigquery.BigQuery.DatasetListOption.labelFilter;
@@ -62,67 +61,69 @@ public final class BigQueryQueryRunner
 
     private BigQueryQueryRunner() {}
 
-    public static QueryRunner createQueryRunner(
-            Map<String, String> extraProperties,
-            Map<String, String> connectorProperties,
-            Iterable<TpchTable<?>> tables)
-            throws Exception
+    public static Builder builder()
     {
-        return createQueryRunner(extraProperties, ImmutableMap.of(), connectorProperties, tables, runner -> {});
+        return new Builder();
     }
 
-    public static QueryRunner createQueryRunner(
-            Map<String, String> extraProperties,
-            Map<String, String> coordinatorProperties,
-            Map<String, String> connectorProperties,
-            Iterable<TpchTable<?>> tables,
-            Consumer<QueryRunner> moreSetup)
-            throws Exception
+    public static final class Builder
+            extends DistributedQueryRunner.Builder<Builder>
     {
-        QueryRunner queryRunner = null;
-        try {
-            queryRunner = DistributedQueryRunner.builder(createSession())
-                    .setExtraProperties(extraProperties)
-                    .setCoordinatorProperties(coordinatorProperties)
-                    .setAdditionalSetup(moreSetup)
-                    .build();
+        private Map<String, String> connectorProperties = ImmutableMap.of();
+        private List<TpchTable<?>> initialTables = ImmutableList.of();
 
-            queryRunner.installPlugin(new TpchPlugin());
-            queryRunner.createCatalog("tpch", "tpch");
-
-            // note: additional copy via ImmutableList so that if fails on nulls
-            connectorProperties = new HashMap<>(ImmutableMap.copyOf(connectorProperties));
-            connectorProperties.putIfAbsent("bigquery.views-enabled", "true");
-            connectorProperties.putIfAbsent("bigquery.view-expire-duration", "30m");
-            connectorProperties.putIfAbsent("bigquery.rpc-retries", "4");
-            connectorProperties.putIfAbsent("bigquery.rpc-retry-delay", "200ms");
-            connectorProperties.putIfAbsent("bigquery.rpc-retry-delay-multiplier", "1.5");
-            connectorProperties.putIfAbsent("bigquery.rpc-timeout", "8s");
-
-            queryRunner.installPlugin(new BigQueryPlugin());
-            queryRunner.createCatalog(
-                    "bigquery",
-                    "bigquery",
-                    connectorProperties);
-
-            queryRunner.execute(createSession(), "CREATE SCHEMA IF NOT EXISTS " + TPCH_SCHEMA);
-            queryRunner.execute(createSession(), "CREATE SCHEMA IF NOT EXISTS " + TEST_SCHEMA);
-            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), tables);
-
-            return queryRunner;
+        private Builder()
+        {
+            super(testSessionBuilder()
+                    .setCatalog("bigquery")
+                    .setSchema(TPCH_SCHEMA)
+                    .build());
         }
-        catch (Throwable e) {
-            closeAllSuppress(e, queryRunner);
-            throw e;
-        }
-    }
 
-    public static Session createSession()
-    {
-        return testSessionBuilder()
-                .setCatalog("bigquery")
-                .setSchema(TPCH_SCHEMA)
-                .build();
+        @CanIgnoreReturnValue
+        public Builder setConnectorProperties(Map<String, String> connectorProperties)
+        {
+            this.connectorProperties = connectorProperties;
+            return this;
+        }
+
+        public Builder setInitialTables(Iterable<TpchTable<?>> initialTables)
+        {
+            this.initialTables = ImmutableList.copyOf(requireNonNull(initialTables, "initialTables is null"));
+            return this;
+        }
+
+        @Override
+        public DistributedQueryRunner build()
+                throws Exception
+        {
+            DistributedQueryRunner queryRunner = super.build();
+            try {
+                queryRunner.installPlugin(new TpchPlugin());
+                queryRunner.createCatalog("tpch", "tpch");
+
+                // note: additional copy via ImmutableList so that if fails on nulls
+                Map<String, String> connectorProperties = new HashMap<>(ImmutableMap.copyOf(this.connectorProperties));
+                connectorProperties.putIfAbsent("bigquery.views-enabled", "true");
+                connectorProperties.putIfAbsent("bigquery.view-expire-duration", "30m");
+                connectorProperties.putIfAbsent("bigquery.rpc-retries", "4");
+                connectorProperties.putIfAbsent("bigquery.rpc-retry-delay", "200ms");
+                connectorProperties.putIfAbsent("bigquery.rpc-retry-delay-multiplier", "1.5");
+                connectorProperties.putIfAbsent("bigquery.rpc-timeout", "8s");
+
+                queryRunner.installPlugin(new BigQueryPlugin());
+                queryRunner.createCatalog("bigquery", "bigquery", connectorProperties);
+
+                queryRunner.execute("CREATE SCHEMA IF NOT EXISTS " + TPCH_SCHEMA);
+                queryRunner.execute("CREATE SCHEMA IF NOT EXISTS " + TEST_SCHEMA);
+                copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, queryRunner.getDefaultSession(), initialTables);
+                return queryRunner;
+            }
+            catch (Throwable e) {
+                closeAllSuppress(e, queryRunner);
+                throw e;
+            }
+        }
     }
 
     public static class BigQuerySqlExecutor
@@ -211,10 +212,10 @@ public final class BigQueryQueryRunner
     public static void main(String[] args)
             throws Exception
     {
-        QueryRunner queryRunner = createQueryRunner(
-                ImmutableMap.of("http-server.http.port", "8080"),
-                ImmutableMap.of(),
-                TpchTable.getTables());
+        QueryRunner queryRunner = BigQueryQueryRunner.builder()
+                .setExtraProperties(Map.of("http-server.http.port", "8080"))
+                .setInitialTables(TpchTable.getTables())
+                .build();
         Logger log = Logger.get(BigQueryQueryRunner.class);
         log.info("======== SERVER STARTED ========");
         log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryArrowSerialization.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryArrowSerialization.java
@@ -13,13 +13,13 @@
  */
 package io.trino.plugin.bigquery;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.bigquery.BigQueryQueryRunner.BigQuerySqlExecutor;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.QueryRunner;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
 
 import static io.trino.testing.TestingNames.randomNameSuffix;
 
@@ -37,10 +37,9 @@ public class TestBigQueryArrowSerialization
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return BigQueryQueryRunner.createQueryRunner(
-                ImmutableMap.of(),
-                ImmutableMap.of("bigquery.arrow-serialization.enabled", "true"),
-                ImmutableList.of());
+        return BigQueryQueryRunner.builder()
+                .setConnectorProperties(Map.of("bigquery.arrow-serialization.enabled", "true"))
+                .build();
     }
 
     @Test

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryArrowTypeMapping.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryArrowTypeMapping.java
@@ -13,9 +13,9 @@
  */
 package io.trino.plugin.bigquery;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.trino.testing.QueryRunner;
+
+import java.util.Map;
 
 public class TestBigQueryArrowTypeMapping
         extends BaseBigQueryTypeMapping
@@ -24,9 +24,8 @@ public class TestBigQueryArrowTypeMapping
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return BigQueryQueryRunner.createQueryRunner(
-                ImmutableMap.of(),
-                ImmutableMap.of("bigquery.skip-view-materialization", "true", "bigquery.arrow-serialization.enabled", "true"),
-                ImmutableList.of());
+        return BigQueryQueryRunner.builder()
+                .setConnectorProperties(Map.of("bigquery.skip-view-materialization", "true", "bigquery.arrow-serialization.enabled", "true"))
+                .build();
     }
 }

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryAvroConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryAvroConnectorTest.java
@@ -13,11 +13,11 @@
  */
 package io.trino.plugin.bigquery;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.testing.QueryRunner;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -41,10 +41,10 @@ public class TestBigQueryAvroConnectorTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return BigQueryQueryRunner.createQueryRunner(
-                ImmutableMap.of(),
-                ImmutableMap.of("bigquery.job.label-name", "trino_query", "bigquery.job.label-format", "q_$QUERY_ID__t_$TRACE_TOKEN"),
-                REQUIRED_TPCH_TABLES);
+        return BigQueryQueryRunner.builder()
+                .setConnectorProperties(Map.of("bigquery.job.label-name", "trino_query", "bigquery.job.label-format", "q_$QUERY_ID__t_$TRACE_TOKEN"))
+                .setInitialTables(REQUIRED_TPCH_TABLES)
+                .build();
     }
 
     @Override

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryAvroTypeMapping.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryAvroTypeMapping.java
@@ -13,9 +13,9 @@
  */
 package io.trino.plugin.bigquery;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.trino.testing.QueryRunner;
+
+import java.util.Map;
 
 public class TestBigQueryAvroTypeMapping
         extends BaseBigQueryTypeMapping
@@ -24,9 +24,8 @@ public class TestBigQueryAvroTypeMapping
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return BigQueryQueryRunner.createQueryRunner(
-                ImmutableMap.of(),
-                ImmutableMap.of("bigquery.skip-view-materialization", "true"),
-                ImmutableList.of());
+        return BigQueryQueryRunner.builder()
+                .setConnectorProperties(Map.of("bigquery.skip-view-materialization", "true"))
+                .build();
     }
 }

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryCaseInsensitiveMapping.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryCaseInsensitiveMapping.java
@@ -13,8 +13,6 @@
  */
 package io.trino.plugin.bigquery;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.plugin.bigquery.BigQueryQueryRunner.BigQuerySqlExecutor;
 import io.trino.testing.AbstractTestQueryFramework;
@@ -23,6 +21,7 @@ import io.trino.testing.sql.TestTable;
 import io.trino.testing.sql.TestView;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -43,10 +42,9 @@ public class TestBigQueryCaseInsensitiveMapping
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return BigQueryQueryRunner.createQueryRunner(
-                ImmutableMap.of(),
-                ImmutableMap.of("bigquery.case-insensitive-name-matching", "true"),
-                ImmutableList.of());
+        return BigQueryQueryRunner.builder()
+                .setConnectorProperties(Map.of("bigquery.case-insensitive-name-matching", "true"))
+                .build();
     }
 
     @Test

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryMetadataCaching.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryMetadataCaching.java
@@ -13,11 +13,11 @@
  */
 package io.trino.plugin.bigquery;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.QueryRunner;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
 
 import static io.trino.plugin.bigquery.BigQueryQueryRunner.BigQuerySqlExecutor;
 import static io.trino.testing.TestingNames.randomNameSuffix;
@@ -33,10 +33,9 @@ public class TestBigQueryMetadataCaching
             throws Exception
     {
         this.bigQuerySqlExecutor = new BigQuerySqlExecutor();
-        return BigQueryQueryRunner.createQueryRunner(
-                ImmutableMap.of(),
-                ImmutableMap.of("bigquery.metadata.cache-ttl", "5m"),
-                ImmutableList.of());
+        return BigQueryQueryRunner.builder()
+                .setConnectorProperties(Map.of("bigquery.metadata.cache-ttl", "5m"))
+                .build();
     }
 
     @Test

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryWithDifferentProjectIdConnectorSmokeTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryWithDifferentProjectIdConnectorSmokeTest.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.bigquery;
 
-import com.google.common.collect.ImmutableMap;
 import io.trino.testing.QueryRunner;
 import org.junit.jupiter.api.Test;
 
@@ -37,10 +36,10 @@ public class TestBigQueryWithDifferentProjectIdConnectorSmokeTest
     {
         this.alternateProjectId = requireNonNull(System.getProperty("testing.alternate-bq-project-id"), "testing.alternate-bq-project-id system property not set");
 
-        QueryRunner queryRunner = BigQueryQueryRunner.createQueryRunner(
-                ImmutableMap.of(),
-                ImmutableMap.of("bigquery.project-id", alternateProjectId),
-                REQUIRED_TPCH_TABLES);
+        QueryRunner queryRunner = BigQueryQueryRunner.builder()
+                .setConnectorProperties(Map.of("bigquery.project-id", alternateProjectId))
+                .setInitialTables(REQUIRED_TPCH_TABLES)
+                .build();
         queryRunner.createCatalog(SERVICE_ACCOUNT_CATALOG, "bigquery", Map.of());
         return queryRunner;
     }

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryWithProxyTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryWithProxyTest.java
@@ -13,8 +13,6 @@
  */
 package io.trino.plugin.bigquery;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Resources;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.QueryRunner;
@@ -24,6 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.net.URISyntaxException;
+import java.util.Map;
 
 public class TestBigQueryWithProxyTest
         extends AbstractTestQueryFramework
@@ -36,16 +35,13 @@ public class TestBigQueryWithProxyTest
                 .withSSLCertificate(fromResources("proxy/cert.pem").toPath())
                 .build());
         proxy.start();
-        QueryRunner queryRunner = BigQueryQueryRunner.createQueryRunner(
-                ImmutableMap.of(),
-                ImmutableMap.of(
+        return BigQueryQueryRunner.builder()
+                .setConnectorProperties(Map.of(
                         "bigquery.rpc-proxy.enabled", "true",
                         "bigquery.rpc-proxy.uri", proxy.getProxyEndpoint(),
                         "bigquery.rpc-proxy.truststore-path", fromResources("proxy/truststore.jks").getAbsolutePath(),
-                        "bigquery.rpc-proxy.truststore-password", "123456"),
-                ImmutableSet.of());
-
-        return queryRunner;
+                        "bigquery.rpc-proxy.truststore-password", "123456"))
+                .build();
     }
 
     @Test

--- a/plugin/trino-mysql/pom.xml
+++ b/plugin/trino-mysql/pom.xml
@@ -110,6 +110,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>log-manager</artifactId>
             <scope>runtime</scope>

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlFailureRecoveryTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlFailureRecoveryTest.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static io.trino.plugin.mysql.MySqlQueryRunner.createMySqlQueryRunner;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.abort;
 
@@ -44,17 +43,16 @@ public abstract class BaseMySqlFailureRecoveryTest
             Map<String, String> coordinatorProperties)
             throws Exception
     {
-        return createMySqlQueryRunner(
-                closeAfterClass(new TestingMySqlServer()),
-                configProperties,
-                coordinatorProperties,
-                Map.of(),
-                requiredTpchTables,
-                runner -> {
+        return MySqlQueryRunner.builder(closeAfterClass(new TestingMySqlServer()))
+                .setExtraProperties(configProperties)
+                .setCoordinatorProperties(coordinatorProperties)
+                .setInitialTables(requiredTpchTables)
+                .setAdditionalSetup(runner -> {
                     runner.installPlugin(new FileSystemExchangePlugin());
                     runner.loadExchangeManager("filesystem", ImmutableMap.of(
                             "exchange.base-directories", System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager"));
-                });
+                })
+                .build();
     }
 
     @Test

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseTestMySqlTableStatisticsTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseTestMySqlTableStatisticsTest.java
@@ -32,7 +32,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Streams.stream;
-import static io.trino.plugin.mysql.MySqlQueryRunner.createMySqlQueryRunner;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.sql.TestTable.fromColumns;
 import static io.trino.tpch.TpchTable.ORDERS;
@@ -67,11 +66,10 @@ public abstract class BaseTestMySqlTableStatisticsTest
     {
         mysqlServer = closeAfterClass(new TestingMySqlServer(dockerImageName, false));
 
-        return createMySqlQueryRunner(
-                mysqlServer,
-                Map.of(),
-                Map.of("case-insensitive-name-matching", "true"),
-                List.of(ORDERS));
+        return MySqlQueryRunner.builder(mysqlServer)
+                .addConnectorProperties(Map.of("case-insensitive-name-matching", "true"))
+                .setInitialTables(List.of(ORDERS))
+                .build();
     }
 
     @Override

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/MySqlQueryRunner.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/MySqlQueryRunner.java
@@ -14,7 +14,7 @@
 package io.trino.plugin.mysql;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.airlift.log.Logger;
 import io.trino.Session;
 import io.trino.plugin.tpch.TpchPlugin;
@@ -23,13 +23,14 @@ import io.trino.testing.QueryRunner;
 import io.trino.tpch.TpchTable;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
 
 import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
 import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.util.Objects.requireNonNull;
 
 public final class MySqlQueryRunner
 {
@@ -37,56 +38,59 @@ public final class MySqlQueryRunner
 
     private static final String TPCH_SCHEMA = "tpch";
 
-    public static QueryRunner createMySqlQueryRunner(TestingMySqlServer server, TpchTable<?>... tables)
-            throws Exception
+    public static Builder builder(TestingMySqlServer server)
     {
-        return createMySqlQueryRunner(server, ImmutableMap.of(), ImmutableMap.of(), ImmutableList.copyOf(tables));
+        return new Builder()
+                .addConnectorProperties(Map.of(
+                        "connection-url", server.getJdbcUrl(),
+                        "connection-user", server.getUsername(),
+                        "connection-password", server.getPassword()));
     }
 
-    public static QueryRunner createMySqlQueryRunner(
-            TestingMySqlServer server,
-            Map<String, String> extraProperties,
-            Map<String, String> connectorProperties,
-            Iterable<TpchTable<?>> tables)
-            throws Exception
+    public static final class Builder
+            extends DistributedQueryRunner.Builder<Builder>
     {
-        return createMySqlQueryRunner(server, extraProperties, ImmutableMap.of(), connectorProperties, tables, runner -> {});
-    }
+        private final Map<String, String> connectorProperties = new HashMap<>();
+        private List<TpchTable<?>> initialTables = ImmutableList.of();
 
-    public static QueryRunner createMySqlQueryRunner(
-            TestingMySqlServer server,
-            Map<String, String> extraProperties,
-            Map<String, String> coordinatorProperties,
-            Map<String, String> connectorProperties,
-            Iterable<TpchTable<?>> tables,
-            Consumer<QueryRunner> moreSetup)
-            throws Exception
-    {
-        QueryRunner queryRunner = DistributedQueryRunner.builder(createSession())
-                .setExtraProperties(extraProperties)
-                .setCoordinatorProperties(coordinatorProperties)
-                .setAdditionalSetup(moreSetup)
-                .build();
-        try {
-            queryRunner.installPlugin(new TpchPlugin());
-            queryRunner.createCatalog("tpch", "tpch");
-
-            // note: additional copy via ImmutableList so that if fails on nulls
-            connectorProperties = new HashMap<>(ImmutableMap.copyOf(connectorProperties));
-            connectorProperties.putIfAbsent("connection-url", server.getJdbcUrl());
-            connectorProperties.putIfAbsent("connection-user", server.getUsername());
-            connectorProperties.putIfAbsent("connection-password", server.getPassword());
-
-            queryRunner.installPlugin(new MySqlPlugin());
-            queryRunner.createCatalog("mysql", "mysql", connectorProperties);
-
-            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), tables);
-
-            return queryRunner;
+        private Builder()
+        {
+            super(createSession());
         }
-        catch (Throwable e) {
-            closeAllSuppress(e, queryRunner);
-            throw e;
+
+        @CanIgnoreReturnValue
+        public Builder addConnectorProperties(Map<String, String> connectorProperties)
+        {
+            this.connectorProperties.putAll(connectorProperties);
+            return this;
+        }
+
+        public Builder setInitialTables(Iterable<TpchTable<?>> initialTables)
+        {
+            this.initialTables = ImmutableList.copyOf(requireNonNull(initialTables, "initialTables is null"));
+            return this;
+        }
+
+        @Override
+        public DistributedQueryRunner build()
+                throws Exception
+        {
+            DistributedQueryRunner queryRunner = super.build();
+            try {
+                queryRunner.installPlugin(new TpchPlugin());
+                queryRunner.createCatalog("tpch", "tpch");
+
+                queryRunner.installPlugin(new MySqlPlugin());
+                queryRunner.createCatalog("mysql", "mysql", connectorProperties);
+
+                copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), initialTables);
+
+                return queryRunner;
+            }
+            catch (Throwable e) {
+                closeAllSuppress(e, queryRunner);
+                throw e;
+            }
         }
     }
 
@@ -101,11 +105,10 @@ public final class MySqlQueryRunner
     public static void main(String[] args)
             throws Exception
     {
-        QueryRunner queryRunner = createMySqlQueryRunner(
-                new TestingMySqlServer(),
-                ImmutableMap.of("http-server.http.port", "8080"),
-                ImmutableMap.of(),
-                TpchTable.getTables());
+        QueryRunner queryRunner = builder(new TestingMySqlServer())
+                .setExtraProperties(Map.of("http-server.http.port", "8080"))
+                .setInitialTables(TpchTable.getTables())
+                .build();
 
         Logger log = Logger.get(MySqlQueryRunner.class);
         log.info("======== SERVER STARTED ========");

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlAutomaticJoinPushdown.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlAutomaticJoinPushdown.java
@@ -13,14 +13,12 @@
  */
 package io.trino.plugin.mysql;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.jdbc.BaseAutomaticJoinPushdownTest;
 import io.trino.testing.MaterializedRow;
 import io.trino.testing.QueryRunner;
 import org.junit.jupiter.api.Test;
 
-import static io.trino.plugin.mysql.MySqlQueryRunner.createMySqlQueryRunner;
 import static java.lang.String.format;
 import static org.junit.jupiter.api.Assumptions.abort;
 
@@ -35,14 +33,12 @@ public class TestMySqlAutomaticJoinPushdown
     {
         mySqlServer = closeAfterClass(new TestingMySqlServer());
 
-        return createMySqlQueryRunner(
-                mySqlServer,
-                ImmutableMap.of(),
-                ImmutableMap.<String, String>builder()
+        return MySqlQueryRunner.builder(mySqlServer)
+                .addConnectorProperties(ImmutableMap.<String, String>builder()
                         .put("metadata.cache-ttl", "0m")
                         .put("metadata.cache-missing", "false")
-                        .buildOrThrow(),
-                ImmutableList.of());
+                        .buildOrThrow())
+                .build();
     }
 
     @Test

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlCaseInsensitiveMapping.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlCaseInsensitiveMapping.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.mysql;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.jdbc.BaseCaseInsensitiveMappingTest;
 import io.trino.testing.QueryRunner;
@@ -23,7 +22,6 @@ import java.nio.file.Path;
 
 import static io.trino.plugin.base.mapping.RuleBasedIdentifierMappingUtils.REFRESH_PERIOD_DURATION;
 import static io.trino.plugin.base.mapping.RuleBasedIdentifierMappingUtils.createRuleBasedIdentifierMappingFile;
-import static io.trino.plugin.mysql.MySqlQueryRunner.createMySqlQueryRunner;
 import static java.util.Objects.requireNonNull;
 
 // With case-insensitive-name-matching enabled colliding schema/table names are considered as errors.
@@ -40,15 +38,13 @@ public class TestMySqlCaseInsensitiveMapping
     {
         mappingFile = createRuleBasedIdentifierMappingFile();
         mySqlServer = closeAfterClass(new TestingMySqlServer());
-        return createMySqlQueryRunner(
-                mySqlServer,
-                ImmutableMap.of(),
-                ImmutableMap.<String, String>builder()
+        return MySqlQueryRunner.builder(mySqlServer)
+                .addConnectorProperties(ImmutableMap.<String, String>builder()
                         .put("case-insensitive-name-matching", "true")
                         .put("case-insensitive-name-matching.config-file", mappingFile.toFile().getAbsolutePath())
                         .put("case-insensitive-name-matching.config-file.refresh-period", REFRESH_PERIOD_DURATION.toString())
-                        .buildOrThrow(),
-                ImmutableList.of());
+                        .buildOrThrow())
+                .build();
     }
 
     @Override

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlConnectorTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlConnectorTest.java
@@ -13,10 +13,8 @@
  */
 package io.trino.plugin.mysql;
 
-import com.google.common.collect.ImmutableMap;
 import io.trino.testing.QueryRunner;
 
-import static io.trino.plugin.mysql.MySqlQueryRunner.createMySqlQueryRunner;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestMySqlConnectorTest
@@ -27,7 +25,9 @@ public class TestMySqlConnectorTest
             throws Exception
     {
         mySqlServer = closeAfterClass(new TestingMySqlServer(false));
-        return createMySqlQueryRunner(mySqlServer, ImmutableMap.of(), ImmutableMap.of(), REQUIRED_TPCH_TABLES);
+        return MySqlQueryRunner.builder(mySqlServer)
+                .setInitialTables(REQUIRED_TPCH_TABLES)
+                .build();
     }
 
     @Override

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlGlobalTransactionMyConnectorSmokeTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlGlobalTransactionMyConnectorSmokeTest.java
@@ -13,12 +13,9 @@
  */
 package io.trino.plugin.mysql;
 
-import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.jdbc.BaseJdbcConnectorSmokeTest;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
-
-import static io.trino.plugin.mysql.MySqlQueryRunner.createMySqlQueryRunner;
 
 public class TestMySqlGlobalTransactionMyConnectorSmokeTest
         extends BaseJdbcConnectorSmokeTest
@@ -30,7 +27,9 @@ public class TestMySqlGlobalTransactionMyConnectorSmokeTest
             throws Exception
     {
         mySqlServer = closeAfterClass(new TestingMySqlServer(true));
-        return createMySqlQueryRunner(mySqlServer, ImmutableMap.of(), ImmutableMap.of(), REQUIRED_TPCH_TABLES);
+        return MySqlQueryRunner.builder(mySqlServer)
+                .setInitialTables(REQUIRED_TPCH_TABLES)
+                .build();
     }
 
     @Override

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlLegacyConnectorTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlLegacyConnectorTest.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.mysql;
 
-import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.sql.planner.plan.AggregationNode;
 import io.trino.sql.planner.plan.ExchangeNode;
@@ -27,7 +26,6 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.trino.plugin.mysql.MySqlQueryRunner.createMySqlQueryRunner;
 import static io.trino.plugin.mysql.TestingMySqlServer.LEGACY_IMAGE;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,7 +39,9 @@ public class TestMySqlLegacyConnectorTest
             throws Exception
     {
         mySqlServer = closeAfterClass(new TestingMySqlServer(LEGACY_IMAGE, false));
-        return createMySqlQueryRunner(mySqlServer, ImmutableMap.of(), ImmutableMap.of(), REQUIRED_TPCH_TABLES);
+        return MySqlQueryRunner.builder(mySqlServer)
+                .setInitialTables(REQUIRED_TPCH_TABLES)
+                .build();
     }
 
     @Test

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTimeMappingsWithServerTimeZone.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTimeMappingsWithServerTimeZone.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.mysql;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.spi.type.TimeZoneKey;
@@ -36,7 +35,6 @@ import java.sql.Statement;
 import java.time.ZoneId;
 import java.util.Map;
 
-import static io.trino.plugin.mysql.MySqlQueryRunner.createMySqlQueryRunner;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.TimeType.createTimeType;
 import static io.trino.spi.type.TimestampType.createTimestampType;
@@ -58,7 +56,8 @@ public class TestMySqlTimeMappingsWithServerTimeZone
             throws Exception
     {
         mySqlServer = closeAfterClass(new TestingMySqlServer(ZoneId.of("Pacific/Apia")));
-        return createMySqlQueryRunner(mySqlServer, ImmutableMap.of(), ImmutableMap.of(), ImmutableList.of());
+        return MySqlQueryRunner.builder(mySqlServer)
+                .build();
     }
 
     @Test

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTypeMapping.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTypeMapping.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.mysql;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.plugin.jdbc.UnsupportedTypeHandling;
@@ -52,7 +51,6 @@ import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.DECIMAL_MAPPI
 import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.DECIMAL_ROUNDING_MODE;
 import static io.trino.plugin.jdbc.TypeHandlingJdbcSessionProperties.UNSUPPORTED_TYPE_HANDLING;
 import static io.trino.plugin.jdbc.UnsupportedTypeHandling.CONVERT_TO_VARCHAR;
-import static io.trino.plugin.mysql.MySqlQueryRunner.createMySqlQueryRunner;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.CharType.createCharType;
@@ -109,7 +107,8 @@ public class TestMySqlTypeMapping
             throws Exception
     {
         mySqlServer = closeAfterClass(new TestingMySqlServer());
-        return createMySqlQueryRunner(mySqlServer, ImmutableMap.of(), ImmutableMap.of(), ImmutableList.of());
+        return MySqlQueryRunner.builder(mySqlServer)
+                .build();
     }
 
     @Test

--- a/plugin/trino-postgresql/pom.xml
+++ b/plugin/trino-postgresql/pom.xml
@@ -105,6 +105,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>concurrent</artifactId>
             <scope>runtime</scope>

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/BasePostgresFailureRecoveryTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/BasePostgresFailureRecoveryTest.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static io.trino.plugin.postgresql.PostgreSqlQueryRunner.createPostgreSqlQueryRunner;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.abort;
 
@@ -44,17 +43,16 @@ public abstract class BasePostgresFailureRecoveryTest
             Map<String, String> coordinatorProperties)
             throws Exception
     {
-        return createPostgreSqlQueryRunner(
-                closeAfterClass(new TestingPostgreSqlServer()),
-                configProperties,
-                coordinatorProperties,
-                Map.of(),
-                requiredTpchTables,
-                runner -> {
+        return PostgreSqlQueryRunner.builder(closeAfterClass(new TestingPostgreSqlServer()))
+                .setExtraProperties(configProperties)
+                .setCoordinatorProperties(configProperties)
+                .setInitialTables(requiredTpchTables)
+                .setAdditionalSetup(runner -> {
                     runner.installPlugin(new FileSystemExchangePlugin());
                     runner.loadExchangeManager("filesystem", ImmutableMap.of(
                             "exchange.base-directories", System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager"));
-                });
+                })
+                .build();
     }
 
     @Test

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestJoinReorderingWithJoinPushdown.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestJoinReorderingWithJoinPushdown.java
@@ -25,7 +25,6 @@ import java.util.Map;
 
 import static io.trino.plugin.jdbc.JdbcJoinPushdownSessionProperties.JOIN_PUSHDOWN_STRATEGY;
 import static io.trino.plugin.jdbc.JdbcMetadataSessionProperties.JOIN_PUSHDOWN_ENABLED;
-import static io.trino.plugin.postgresql.PostgreSqlQueryRunner.createPostgreSqlQueryRunner;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
@@ -44,11 +43,9 @@ public class TestJoinReorderingWithJoinPushdown
             throws Exception
     {
         TestingPostgreSqlServer postgreSqlServer = closeAfterClass(new TestingPostgreSqlServer());
-        QueryRunner queryRunner = createPostgreSqlQueryRunner(
-                postgreSqlServer,
-                Map.of(),
-                Map.of(),
-                List.of(CUSTOMER, NATION));
+        QueryRunner queryRunner = PostgreSqlQueryRunner.builder(postgreSqlServer)
+                .setInitialTables(List.of(CUSTOMER, NATION))
+                .build();
 
         postgreSqlServer.execute("ANALYZE " + CUSTOMER.getTableName());
         postgreSqlServer.execute("ANALYZE " + NATION.getTableName());

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlAutomaticJoinPushdown.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlAutomaticJoinPushdown.java
@@ -18,11 +18,6 @@ import io.trino.testing.QueryRunner;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-import java.util.Map;
-
-import static io.trino.plugin.postgresql.PostgreSqlQueryRunner.createPostgreSqlQueryRunner;
-
 public class TestPostgreSqlAutomaticJoinPushdown
         extends BaseAutomaticJoinPushdownTest
 {
@@ -33,11 +28,8 @@ public class TestPostgreSqlAutomaticJoinPushdown
             throws Exception
     {
         this.postgreSqlServer = closeAfterClass(new TestingPostgreSqlServer());
-        return createPostgreSqlQueryRunner(
-                postgreSqlServer,
-                Map.of(),
-                Map.of(),
-                List.of());
+        return PostgreSqlQueryRunner.builder(postgreSqlServer)
+                .build();
     }
 
     @Test

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlCaseInsensitiveMapping.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlCaseInsensitiveMapping.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.postgresql;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import io.trino.plugin.jdbc.BaseCaseInsensitiveMappingTest;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.sql.SqlExecutor;
@@ -39,15 +38,13 @@ public class TestPostgreSqlCaseInsensitiveMapping
     {
         mappingFile = createRuleBasedIdentifierMappingFile();
         postgreSqlServer = closeAfterClass(new TestingPostgreSqlServer());
-        return PostgreSqlQueryRunner.createPostgreSqlQueryRunner(
-                postgreSqlServer,
-                ImmutableMap.of(),
-                ImmutableMap.<String, String>builder()
+        return PostgreSqlQueryRunner.builder(postgreSqlServer)
+                .addConnectorProperties(ImmutableMap.<String, String>builder()
                         .put("case-insensitive-name-matching", "true")
                         .put("case-insensitive-name-matching.config-file", mappingFile.toFile().getAbsolutePath())
                         .put("case-insensitive-name-matching.config-file.refresh-period", REFRESH_PERIOD_DURATION.toString())
-                        .buildOrThrow(),
-                ImmutableSet.of());
+                        .buildOrThrow())
+                .build();
     }
 
     @Override

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -46,7 +46,6 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.UUID;
@@ -56,7 +55,6 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static io.airlift.slice.Slices.utf8Slice;
-import static io.trino.plugin.postgresql.PostgreSqlQueryRunner.createPostgreSqlQueryRunner;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.exchange;
@@ -87,7 +85,9 @@ public class TestPostgreSqlConnectorTest
             throws Exception
     {
         postgreSqlServer = closeAfterClass(new TestingPostgreSqlServer());
-        return createPostgreSqlQueryRunner(postgreSqlServer, Map.of(), Map.of(), REQUIRED_TPCH_TABLES);
+        return PostgreSqlQueryRunner.builder(postgreSqlServer)
+                .setInitialTables(REQUIRED_TPCH_TABLES)
+                .build();
     }
 
     @BeforeAll

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlJdbcConnectionCreation.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlJdbcConnectionCreation.java
@@ -38,10 +38,10 @@ import java.util.Properties;
 
 import static io.airlift.configuration.ConfigurationAwareModule.combine;
 import static io.airlift.testing.Closeables.closeAllSuppress;
-import static io.trino.plugin.postgresql.PostgreSqlQueryRunner.createSession;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.spi.connector.ConnectorMetadata.MODIFYING_ROWS_MESSAGE;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
+import static io.trino.testing.TestingSession.testSessionBuilder;
 import static io.trino.tpch.TpchTable.NATION;
 import static io.trino.tpch.TpchTable.REGION;
 import static java.util.Objects.requireNonNull;
@@ -97,7 +97,10 @@ public class TestPostgreSqlJdbcConnectionCreation
             ConnectionCountingConnectionFactory connectionCountingConnectionFactory)
             throws Exception
     {
-        QueryRunner queryRunner = DistributedQueryRunner.builder(createSession())
+        QueryRunner queryRunner = DistributedQueryRunner.builder(testSessionBuilder()
+                        .setCatalog("postgresql")
+                        .setSchema("tpch")
+                        .build())
                 // to make sure we always open connections in the same way
                 .setCoordinatorProperties(ImmutableMap.of("node-scheduler.include-coordinator", "false"))
                 .build();
@@ -111,7 +114,7 @@ public class TestPostgreSqlJdbcConnectionCreation
                     "connection-url", server.getJdbcUrl(),
                     "connection-user", server.getUser(),
                     "connection-password", server.getPassword()));
-            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), tables);
+            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, queryRunner.getDefaultSession(), tables);
             return queryRunner;
         }
         catch (Throwable e) {

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlTableStatistics.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlTableStatistics.java
@@ -23,9 +23,9 @@ import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
-import static io.trino.plugin.postgresql.PostgreSqlQueryRunner.createPostgreSqlQueryRunner;
 import static io.trino.testing.sql.TestTable.fromColumns;
 import static io.trino.tpch.TpchTable.ORDERS;
 import static java.lang.String.format;
@@ -42,16 +42,10 @@ public class TestPostgreSqlTableStatistics
             throws Exception
     {
         postgreSqlServer = closeAfterClass(new TestingPostgreSqlServer());
-        return createPostgreSqlQueryRunner(
-                postgreSqlServer,
-                ImmutableMap.of(),
-                ImmutableMap.<String, String>builder()
-                        .put("connection-url", postgreSqlServer.getJdbcUrl())
-                        .put("connection-user", postgreSqlServer.getUser())
-                        .put("connection-password", postgreSqlServer.getPassword())
-                        .put("case-insensitive-name-matching", "true")
-                        .buildOrThrow(),
-                ImmutableList.of(ORDERS));
+        return PostgreSqlQueryRunner.builder(postgreSqlServer)
+                .addConnectorProperties(Map.of("case-insensitive-name-matching", "true"))
+                .setInitialTables(List.of(ORDERS))
+                .build();
     }
 
     @Test

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.postgresql;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.plugin.jdbc.UnsupportedTypeHandling;
 import io.trino.spi.type.ArrayType;
@@ -53,6 +52,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -69,7 +69,6 @@ import static io.trino.plugin.jdbc.UnsupportedTypeHandling.IGNORE;
 import static io.trino.plugin.postgresql.PostgreSqlConfig.ArrayMapping.AS_ARRAY;
 import static io.trino.plugin.postgresql.PostgreSqlConfig.ArrayMapping.AS_JSON;
 import static io.trino.plugin.postgresql.PostgreSqlConfig.ArrayMapping.DISABLED;
-import static io.trino.plugin.postgresql.PostgreSqlQueryRunner.createPostgreSqlQueryRunner;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.CharType.createCharType;
@@ -145,11 +144,9 @@ public class TestPostgreSqlTypeMapping
             throws Exception
     {
         postgreSqlServer = closeAfterClass(new TestingPostgreSqlServer());
-        return createPostgreSqlQueryRunner(
-                postgreSqlServer,
-                ImmutableMap.of(),
-                ImmutableMap.of("jdbc-types-mapped-to-varchar", "Tsrange, Inet" /* make sure that types are compared case insensitively */),
-                ImmutableList.of());
+        return PostgreSqlQueryRunner.builder(postgreSqlServer)
+                .addConnectorProperties(Map.of("jdbc-types-mapped-to-varchar", "Tsrange, Inet" /* make sure that types are compared case insensitively */))
+                .build();
     }
 
     @BeforeAll

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestRemoteQueryCommentLogging.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestRemoteQueryCommentLogging.java
@@ -14,13 +14,13 @@
 package io.trino.plugin.postgresql;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.QueryRunner;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 
-import static io.trino.plugin.postgresql.PostgreSqlQueryRunner.createPostgreSqlQueryRunner;
+import java.util.Map;
+
 import static io.trino.tpch.TpchTable.CUSTOMER;
 import static io.trino.tpch.TpchTable.NATION;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,13 +37,10 @@ public class TestRemoteQueryCommentLogging
             throws Exception
     {
         postgreSqlServer = closeAfterClass(new TestingPostgreSqlServer());
-        QueryRunner queryRunner = createPostgreSqlQueryRunner(
-                postgreSqlServer,
-                ImmutableMap.of(),
-                ImmutableMap.of("query.comment-format", "query executed by $USER"),
-                ImmutableList.of(CUSTOMER, NATION));
-
-        return queryRunner;
+        return PostgreSqlQueryRunner.builder(postgreSqlServer)
+                .addConnectorProperties(Map.of("query.comment-format", "query executed by $USER"))
+                .setInitialTables(ImmutableList.of(CUSTOMER, NATION))
+                .build();
     }
 
     @Test

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestRemoteQueryCommentLoggingDisabledByDefault.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestRemoteQueryCommentLoggingDisabledByDefault.java
@@ -14,13 +14,11 @@
 package io.trino.plugin.postgresql;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.QueryRunner;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 
-import static io.trino.plugin.postgresql.PostgreSqlQueryRunner.createPostgreSqlQueryRunner;
 import static io.trino.tpch.TpchTable.CUSTOMER;
 import static io.trino.tpch.TpchTable.NATION;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,13 +35,9 @@ public class TestRemoteQueryCommentLoggingDisabledByDefault
             throws Exception
     {
         postgreSqlServer = closeAfterClass(new TestingPostgreSqlServer());
-        QueryRunner queryRunner = createPostgreSqlQueryRunner(
-                postgreSqlServer,
-                ImmutableMap.of(),
-                ImmutableMap.of(),
-                ImmutableList.of(CUSTOMER, NATION));
-
-        return queryRunner;
+        return PostgreSqlQueryRunner.builder(postgreSqlServer)
+                .setInitialTables(ImmutableList.of(CUSTOMER, NATION))
+                .build();
     }
 
     @Test


### PR DESCRIPTION
Avoid multiple overloads. Make setup easier to follow.

extracted from https://github.com/trinodb/trino/pull/21588