### PR TITLE
Add builders for Oracle, SQL Server query runners

### DIFF
--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/H2QueryRunner.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/H2QueryRunner.java
@@ -84,7 +84,7 @@ public final class H2QueryRunner
             queryRunner.installPlugin(new JdbcPlugin("base_jdbc", module));
             queryRunner.createCatalog("jdbc", "base_jdbc", properties);
 
-            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), tables);
+            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, tables);
 
             return queryRunner;
         }

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
@@ -87,6 +87,7 @@ public final class BigQueryQueryRunner
             return this;
         }
 
+        @CanIgnoreReturnValue
         public Builder setInitialTables(Iterable<TpchTable<?>> initialTables)
         {
             this.initialTables = ImmutableList.copyOf(requireNonNull(initialTables, "initialTables is null"));

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
@@ -117,7 +117,7 @@ public final class BigQueryQueryRunner
 
                 queryRunner.execute("CREATE SCHEMA IF NOT EXISTS " + TPCH_SCHEMA);
                 queryRunner.execute("CREATE SCHEMA IF NOT EXISTS " + TEST_SCHEMA);
-                copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, queryRunner.getDefaultSession(), initialTables);
+                copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, initialTables);
                 return queryRunner;
             }
             catch (Throwable e) {

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraQueryRunner.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraQueryRunner.java
@@ -73,7 +73,7 @@ public final class CassandraQueryRunner
         queryRunner.createCatalog("cassandra", "cassandra", connectorProperties);
 
         createKeyspace(server.getSession(), "tpch");
-        copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createCassandraSession("tpch"), tables);
+        copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, tables);
         for (TpchTable<?> table : tables) {
             server.refreshSizeEstimates("tpch", table.getTableName());
         }

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/ScyllaQueryRunner.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/ScyllaQueryRunner.java
@@ -62,7 +62,7 @@ public final class ScyllaQueryRunner
             queryRunner.createCatalog("cassandra", "cassandra", connectorProperties);
 
             createKeyspace(server.getSession(), "tpch");
-            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession("tpch"), tables);
+            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, tables);
             for (TpchTable<?> table : tables) {
                 server.refreshSizeEstimates("tpch", table.getTableName());
             }

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/ClickHouseQueryRunner.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/ClickHouseQueryRunner.java
@@ -72,7 +72,7 @@ public final class ClickHouseQueryRunner
             queryRunner.installPlugin(new ClickHousePlugin());
             queryRunner.createCatalog("clickhouse", "clickhouse", connectorProperties);
             queryRunner.execute("CREATE SCHEMA " + TPCH_SCHEMA);
-            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), tables);
+            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, tables);
             return queryRunner;
         }
         catch (Throwable e) {

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
@@ -265,7 +265,7 @@ public final class DeltaLakeQueryRunner
                             "hive.metastore", "file",
                             "hive.metastore.catalog.dir", metastoreDirectory.toUri().toString()));
 
-            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), TpchTable.getTables());
+            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, TpchTable.getTables());
             log.info("Data directory is: %s", metastoreDirectory);
 
             Logger log = Logger.get(DeltaLakeQueryRunner.class);
@@ -310,7 +310,7 @@ public final class DeltaLakeQueryRunner
                     runner -> {});
 
             queryRunner.execute("CREATE SCHEMA tpch WITH (location='s3://" + bucketName + "/tpch')");
-            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), TpchTable.getTables());
+            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, TpchTable.getTables());
 
             Logger log = Logger.get(DeltaLakeQueryRunner.class);
             log.info("======== SERVER STARTED ========");

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -134,7 +134,7 @@ public class TestDeltaLakeConnectorTest
 
             queryRunner.execute("CREATE SCHEMA " + SCHEMA + " WITH (location = 's3://" + bucketName + "/" + SCHEMA + "')");
             queryRunner.execute("CREATE SCHEMA schemawithoutunderscore WITH (location = 's3://" + bucketName + "/schemawithoutunderscore')");
-            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, queryRunner.getDefaultSession(), REQUIRED_TPCH_TABLES);
+            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, REQUIRED_TPCH_TABLES);
         }
         catch (Throwable e) {
             closeAllSuppress(e, queryRunner);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
@@ -270,8 +270,7 @@ public final class HiveQueryRunner
                     .createMetastore(Optional.empty());
             if (metastore.getDatabase(TPCH_SCHEMA).isEmpty()) {
                 metastore.createDatabase(createDatabaseMetastoreObject(TPCH_SCHEMA, initialSchemasLocationBase));
-                Session session = queryRunner.getDefaultSession();
-                copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, session, initialTables);
+                copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, initialTables);
             }
 
             if (tpchBucketedCatalogEnabled && metastore.getDatabase(TPCH_BUCKETED_SCHEMA).isEmpty()) {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/SchemaInitializer.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/SchemaInitializer.java
@@ -52,7 +52,7 @@ public class SchemaInitializer
                 .map(entry -> entry.getKey() + " = " + entry.getValue())
                 .collect(Collectors.joining(", ", " WITH ( ", " )"));
         queryRunner.execute("CREATE SCHEMA IF NOT EXISTS " + schemaName + (this.schemaProperties.size() > 0 ? schemaProperties : ""));
-        copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, queryRunner.getDefaultSession(), clonedTpchTables);
+        copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, clonedTpchTables);
     }
 
     public static Builder builder()

--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/IgniteQueryRunner.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/IgniteQueryRunner.java
@@ -59,7 +59,7 @@ public final class IgniteQueryRunner
             queryRunner.installPlugin(new IgnitePlugin());
             queryRunner.createCatalog("ignite", "ignite", connectorProperties);
 
-            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), tables);
+            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, tables);
             return queryRunner;
         }
         catch (Throwable e) {

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/KuduQueryRunnerFactory.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/KuduQueryRunnerFactory.java
@@ -94,8 +94,7 @@ public final class KuduQueryRunnerFactory
         QueryRunner runner = null;
         try {
             String kuduSchema = kuduSchemaEmulationPrefix.isPresent() ? "tpch" : "default";
-            Session session = createSession(kuduSchema, kuduSessionProperties);
-            runner = DistributedQueryRunner.builder(session)
+            runner = DistributedQueryRunner.builder(createSession(kuduSchema, kuduSessionProperties))
                     .setExtraProperties(extraProperties)
                     .build();
 
@@ -104,7 +103,7 @@ public final class KuduQueryRunnerFactory
 
             installKuduConnector(kuduServer.getMasterAddress(), runner, kuduSchema, kuduSchemaEmulationPrefix);
 
-            copyTpchTables(runner, "tpch", TINY_SCHEMA_NAME, session, tables);
+            copyTpchTables(runner, "tpch", TINY_SCHEMA_NAME, tables);
 
             return runner;
         }

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/MariaDbQueryRunner.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/MariaDbQueryRunner.java
@@ -65,7 +65,7 @@ public final class MariaDbQueryRunner
             queryRunner.installPlugin(new MariaDbPlugin());
             queryRunner.createCatalog("mariadb", "mariadb", connectorProperties);
 
-            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), tables);
+            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, tables);
 
             return queryRunner;
         }

--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/MemoryQueryRunner.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/MemoryQueryRunner.java
@@ -106,7 +106,7 @@ public final class MemoryQueryRunner
                 queryRunner.installPlugin(new TpchPlugin());
                 queryRunner.createCatalog("tpch", "tpch", ImmutableMap.of());
 
-                copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), initialTables);
+                copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, initialTables);
 
                 return queryRunner;
             }

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoQueryRunner.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoQueryRunner.java
@@ -78,7 +78,7 @@ public final class MongoQueryRunner
             queryRunner.createCatalog("mongodb", "mongodb", connectorProperties);
             queryRunner.execute("CREATE SCHEMA mongodb." + TPCH_SCHEMA);
 
-            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), tables);
+            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, tables);
             return queryRunner;
         }
         catch (Throwable e) {

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/MySqlQueryRunner.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/MySqlQueryRunner.java
@@ -16,7 +16,6 @@ package io.trino.plugin.mysql;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.airlift.log.Logger;
-import io.trino.Session;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
@@ -55,7 +54,10 @@ public final class MySqlQueryRunner
 
         private Builder()
         {
-            super(createSession());
+            super(testSessionBuilder()
+                    .setCatalog("mysql")
+                    .setSchema(TPCH_SCHEMA)
+                    .build());
         }
 
         @CanIgnoreReturnValue
@@ -84,7 +86,7 @@ public final class MySqlQueryRunner
                 queryRunner.installPlugin(new MySqlPlugin());
                 queryRunner.createCatalog("mysql", "mysql", connectorProperties);
 
-                copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), initialTables);
+                copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, initialTables);
 
                 return queryRunner;
             }
@@ -93,14 +95,6 @@ public final class MySqlQueryRunner
                 throw e;
             }
         }
-    }
-
-    private static Session createSession()
-    {
-        return testSessionBuilder()
-                .setCatalog("mysql")
-                .setSchema(TPCH_SCHEMA)
-                .build();
     }
 
     public static void main(String[] args)

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/MySqlQueryRunner.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/MySqlQueryRunner.java
@@ -65,6 +65,7 @@ public final class MySqlQueryRunner
             return this;
         }
 
+        @CanIgnoreReturnValue
         public Builder setInitialTables(Iterable<TpchTable<?>> initialTables)
         {
             this.initialTables = ImmutableList.copyOf(requireNonNull(initialTables, "initialTables is null"));

--- a/plugin/trino-oracle/pom.xml
+++ b/plugin/trino-oracle/pom.xml
@@ -110,6 +110,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.oracle.database.nls</groupId>
             <artifactId>orai18n</artifactId>
             <scope>runtime</scope>

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/OracleQueryRunner.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/OracleQueryRunner.java
@@ -13,16 +13,18 @@
  */
 package io.trino.plugin.oracle;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.airlift.log.Logger;
-import io.trino.Session;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
 import io.trino.tpch.TpchTable;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
 
 import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.trino.plugin.oracle.TestingOracleServer.TEST_PASS;
@@ -31,86 +33,84 @@ import static io.trino.plugin.oracle.TestingOracleServer.TEST_USER;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
 import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.util.Objects.requireNonNull;
 
 public final class OracleQueryRunner
 {
     private OracleQueryRunner() {}
 
-    public static QueryRunner createOracleQueryRunner(
-            TestingOracleServer server,
-            Map<String, String> extraProperties,
-            Map<String, String> connectorProperties,
-            Iterable<TpchTable<?>> tables)
-            throws Exception
+    public static Builder builder(TestingOracleServer server)
     {
-        return createOracleQueryRunner(server, extraProperties, Map.of(), connectorProperties, tables, queryRunner -> {});
+        return new Builder()
+                .addConnectorProperties(ImmutableMap.<String, String>builder()
+                        .put("connection-url", server.getJdbcUrl())
+                        .put("connection-user", TEST_USER)
+                        .put("connection-password", TEST_PASS)
+                        .buildOrThrow());
     }
 
-    public static QueryRunner createOracleQueryRunner(
-            TestingOracleServer server,
-            Map<String, String> extraProperties,
-            Map<String, String> coordinatorProperties,
-            Map<String, String> connectorProperties,
-            Iterable<TpchTable<?>> tables,
-            Consumer<QueryRunner> moreSetup)
-            throws Exception
+    public static final class Builder
+            extends DistributedQueryRunner.Builder<Builder>
     {
-        QueryRunner queryRunner = null;
-        try {
-            queryRunner = DistributedQueryRunner.builder(createSession())
-                    .setExtraProperties(extraProperties)
-                    .setCoordinatorProperties(coordinatorProperties)
-                    .setAdditionalSetup(moreSetup)
-                    .build();
+        private final Map<String, String> connectorProperties = new HashMap<>();
+        private List<TpchTable<?>> initialTables = ImmutableList.of();
 
-            queryRunner.installPlugin(new TpchPlugin());
-            queryRunner.createCatalog("tpch", "tpch");
-
-            queryRunner.installPlugin(new OraclePlugin());
-            queryRunner.createCatalog("oracle", "oracle", connectorProperties);
-
-            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), tables);
-
-            return queryRunner;
+        private Builder()
+        {
+            super(testSessionBuilder()
+                    .setCatalog("oracle")
+                    .setSchema(TEST_SCHEMA)
+                    .build());
         }
-        catch (Throwable e) {
-            closeAllSuppress(e, queryRunner, server);
-            throw e;
+
+        @CanIgnoreReturnValue
+        public Builder addConnectorProperties(Map<String, String> connectorProperties)
+        {
+            this.connectorProperties.putAll(requireNonNull(connectorProperties, "connectorProperties is null"));
+            return this;
         }
-    }
 
-    public static Session createSession()
-    {
-        return testSessionBuilder()
-                .setCatalog("oracle")
-                .setSchema(TEST_SCHEMA)
-                .build();
-    }
+        public Builder setInitialTables(Iterable<TpchTable<?>> initialTables)
+        {
+            this.initialTables = ImmutableList.copyOf(requireNonNull(initialTables, "initialTables is null"));
+            return self();
+        }
 
-    public static Map<String, String> connectionProperties(TestingOracleServer server)
-    {
-        return ImmutableMap.<String, String>builder()
-                .put("connection-url", server.getJdbcUrl())
-                .put("connection-user", TEST_USER)
-                .put("connection-password", TEST_PASS)
-                .buildOrThrow();
+        @Override
+        public DistributedQueryRunner build()
+                throws Exception
+        {
+            DistributedQueryRunner queryRunner = super.build();
+            try {
+                queryRunner.installPlugin(new TpchPlugin());
+                queryRunner.createCatalog("tpch", "tpch");
+
+                queryRunner.installPlugin(new OraclePlugin());
+                queryRunner.createCatalog("oracle", "oracle", connectorProperties);
+
+                copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, queryRunner.getDefaultSession(), initialTables);
+
+                return queryRunner;
+            }
+            catch (Throwable e) {
+                closeAllSuppress(e, queryRunner);
+                throw e;
+            }
+        }
     }
 
     public static void main(String[] args)
             throws Exception
     {
         TestingOracleServer server = new TestingOracleServer();
-        QueryRunner queryRunner = createOracleQueryRunner(
-                server,
-                ImmutableMap.of("http-server.http.port", "8080"),
-                ImmutableMap.<String, String>builder()
-                        .put("connection-url", server.getJdbcUrl())
-                        .put("connection-user", TEST_USER)
-                        .put("connection-password", TEST_PASS)
+        QueryRunner queryRunner = builder(server)
+                .addExtraProperty("http-server.http.port", "8080")
+                .addConnectorProperties(ImmutableMap.<String, String>builder()
                         .put("oracle.connection-pool.enabled", "false")
                         .put("oracle.remarks-reporting.enabled", "false")
-                        .buildOrThrow(),
-                TpchTable.getTables());
+                        .buildOrThrow())
+                .setInitialTables(TpchTable.getTables())
+                .build();
 
         Logger log = Logger.get(OracleQueryRunner.class);
         log.info("======== SERVER STARTED ========");

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/OracleQueryRunner.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/OracleQueryRunner.java
@@ -70,6 +70,7 @@ public final class OracleQueryRunner
             return this;
         }
 
+        @CanIgnoreReturnValue
         public Builder setInitialTables(Iterable<TpchTable<?>> initialTables)
         {
             this.initialTables = ImmutableList.copyOf(requireNonNull(initialTables, "initialTables is null"));
@@ -88,7 +89,7 @@ public final class OracleQueryRunner
                 queryRunner.installPlugin(new OraclePlugin());
                 queryRunner.createCatalog("oracle", "oracle", connectorProperties);
 
-                copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, queryRunner.getDefaultSession(), initialTables);
+                copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, initialTables);
 
                 return queryRunner;
             }

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleCaseInsensitiveMapping.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleCaseInsensitiveMapping.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.oracle;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.jdbc.BaseCaseInsensitiveMappingTest;
 import io.trino.testing.QueryRunner;
@@ -24,7 +23,6 @@ import java.util.Optional;
 
 import static io.trino.plugin.base.mapping.RuleBasedIdentifierMappingUtils.REFRESH_PERIOD_DURATION;
 import static io.trino.plugin.base.mapping.RuleBasedIdentifierMappingUtils.createRuleBasedIdentifierMappingFile;
-import static io.trino.plugin.oracle.OracleQueryRunner.createOracleQueryRunner;
 import static io.trino.plugin.oracle.TestingOracleServer.TEST_USER;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -43,16 +41,13 @@ public class TestOracleCaseInsensitiveMapping
     {
         mappingFile = createRuleBasedIdentifierMappingFile();
         oracleServer = closeAfterClass(new TestingOracleServer());
-        return createOracleQueryRunner(
-                oracleServer,
-                ImmutableMap.of(),
-                ImmutableMap.<String, String>builder()
-                        .putAll(OracleQueryRunner.connectionProperties(oracleServer))
+        return OracleQueryRunner.builder(oracleServer)
+                .addConnectorProperties(ImmutableMap.<String, String>builder()
                         .put("case-insensitive-name-matching", "true")
                         .put("case-insensitive-name-matching.config-file", mappingFile.toFile().getAbsolutePath())
                         .put("case-insensitive-name-matching.config-file.refresh-period", REFRESH_PERIOD_DURATION.toString())
-                        .buildOrThrow(),
-                ImmutableList.of());
+                        .buildOrThrow())
+                .build();
     }
 
     @Override

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleConnectorTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleConnectorTest.java
@@ -21,9 +21,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
-import static io.trino.plugin.oracle.TestingOracleServer.TEST_PASS;
 import static io.trino.plugin.oracle.TestingOracleServer.TEST_SCHEMA;
-import static io.trino.plugin.oracle.TestingOracleServer.TEST_USER;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.IntStream.range;
@@ -40,17 +38,13 @@ public class TestOracleConnectorTest
             throws Exception
     {
         oracleServer = new TestingOracleServer();
-        return OracleQueryRunner.createOracleQueryRunner(
-                oracleServer,
-                ImmutableMap.of(),
-                ImmutableMap.<String, String>builder()
-                        .put("connection-url", oracleServer.getJdbcUrl())
-                        .put("connection-user", TEST_USER)
-                        .put("connection-password", TEST_PASS)
+        return OracleQueryRunner.builder(oracleServer)
+                .addConnectorProperties(ImmutableMap.<String, String>builder()
                         .put("oracle.connection-pool.enabled", "false")
                         .put("oracle.remarks-reporting.enabled", "true")
-                        .buildOrThrow(),
-                REQUIRED_TPCH_TABLES);
+                        .buildOrThrow())
+                .setInitialTables(REQUIRED_TPCH_TABLES)
+                .build();
     }
 
     @AfterAll
@@ -84,7 +78,8 @@ public class TestOracleConnectorTest
     @Override
     protected SqlExecutor onRemoteDatabase()
     {
-        return new SqlExecutor() {
+        return new SqlExecutor()
+        {
             @Override
             public boolean supportsMultiRowInsert()
             {

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOraclePoolConnectorSmokeTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOraclePoolConnectorSmokeTest.java
@@ -13,14 +13,13 @@
  */
 package io.trino.plugin.oracle;
 
-import com.google.common.collect.ImmutableMap;
 import io.airlift.testing.Closeables;
 import io.trino.testing.QueryRunner;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.TestInstance;
 
-import static io.trino.plugin.oracle.TestingOracleServer.TEST_PASS;
-import static io.trino.plugin.oracle.TestingOracleServer.TEST_USER;
+import java.util.Map;
+
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
 @TestInstance(PER_CLASS)
@@ -34,16 +33,10 @@ public class TestOraclePoolConnectorSmokeTest
             throws Exception
     {
         oracleServer = new TestingOracleServer();
-        return OracleQueryRunner.createOracleQueryRunner(
-                oracleServer,
-                ImmutableMap.of(),
-                ImmutableMap.<String, String>builder()
-                        .put("connection-url", oracleServer.getJdbcUrl())
-                        .put("connection-user", TEST_USER)
-                        .put("connection-password", TEST_PASS)
-                        .put("oracle.connection-pool.enabled", "true")
-                        .buildOrThrow(),
-                REQUIRED_TPCH_TABLES);
+        return OracleQueryRunner.builder(oracleServer)
+                .addConnectorProperties(Map.of("oracle.connection-pool.enabled", "true"))
+                .setInitialTables(REQUIRED_TPCH_TABLES)
+                .build();
     }
 
     @AfterAll

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleTypeMapping.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleTypeMapping.java
@@ -13,13 +13,9 @@
  */
 package io.trino.plugin.oracle;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.sql.SqlExecutor;
-
-import static io.trino.plugin.oracle.TestingOracleServer.TEST_PASS;
-import static io.trino.plugin.oracle.TestingOracleServer.TEST_USER;
 
 public class TestOracleTypeMapping
         extends AbstractTestOracleTypeMapping
@@ -31,17 +27,12 @@ public class TestOracleTypeMapping
             throws Exception
     {
         this.oracleServer = closeAfterClass(new TestingOracleServer());
-        return OracleQueryRunner.createOracleQueryRunner(
-                oracleServer,
-                ImmutableMap.of(),
-                ImmutableMap.<String, String>builder()
-                        .put("connection-url", oracleServer.getJdbcUrl())
-                        .put("connection-user", TEST_USER)
-                        .put("connection-password", TEST_PASS)
+        return OracleQueryRunner.builder(oracleServer)
+                .addConnectorProperties(ImmutableMap.<String, String>builder()
                         .put("oracle.connection-pool.enabled", "false")
                         .put("oracle.remarks-reporting.enabled", "false")
-                        .buildOrThrow(),
-                ImmutableList.of());
+                        .buildOrThrow())
+                .build();
     }
 
     @Override

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/PostgreSqlQueryRunner.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/PostgreSqlQueryRunner.java
@@ -67,6 +67,7 @@ public final class PostgreSqlQueryRunner
             return this;
         }
 
+        @CanIgnoreReturnValue
         public Builder setInitialTables(Iterable<TpchTable<?>> initialTables)
         {
             this.initialTables = ImmutableList.copyOf(requireNonNull(initialTables, "initialTables is null"));

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/PostgreSqlQueryRunner.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/PostgreSqlQueryRunner.java
@@ -16,7 +16,6 @@ package io.trino.plugin.postgresql;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.airlift.log.Logger;
-import io.trino.Session;
 import io.trino.plugin.jmx.JmxPlugin;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
@@ -57,7 +56,10 @@ public final class PostgreSqlQueryRunner
 
         private Builder()
         {
-            super(createSession());
+            super(testSessionBuilder()
+                    .setCatalog("postgresql")
+                    .setSchema(TPCH_SCHEMA)
+                    .build());
         }
 
         @CanIgnoreReturnValue
@@ -86,7 +88,7 @@ public final class PostgreSqlQueryRunner
                 queryRunner.installPlugin(new PostgreSqlPlugin());
                 queryRunner.createCatalog("postgresql", "postgresql", connectorProperties);
 
-                copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), initialTables);
+                copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, initialTables);
 
                 return queryRunner;
             }
@@ -95,14 +97,6 @@ public final class PostgreSqlQueryRunner
                 throw e;
             }
         }
-    }
-
-    private static Session createSession()
-    {
-        return testSessionBuilder()
-                .setCatalog("postgresql")
-                .setSchema(TPCH_SCHEMA)
-                .build();
     }
 
     public static void main(String[] args)

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlJdbcConnectionCreation.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlJdbcConnectionCreation.java
@@ -114,7 +114,7 @@ public class TestPostgreSqlJdbcConnectionCreation
                     "connection-url", server.getJdbcUrl(),
                     "connection-user", server.getUser(),
                     "connection-password", server.getPassword()));
-            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, queryRunner.getDefaultSession(), tables);
+            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, tables);
             return queryRunner;
         }
         catch (Throwable e) {

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/RedshiftQueryRunner.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/RedshiftQueryRunner.java
@@ -23,7 +23,6 @@ import io.airlift.log.Logging;
 import io.trino.Session;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.plugin.tpch.TpchPlugin;
-import io.trino.spi.security.Identity;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.MaterializedResult;
 import io.trino.testing.QueryRunner;
@@ -150,15 +149,9 @@ public final class RedshiftQueryRunner
 
     private static Session createSession()
     {
-        return createSession(GRANTED_USER);
-    }
-
-    private static Session createSession(String user)
-    {
         return testSessionBuilder()
                 .setCatalog(TEST_CATALOG)
                 .setSchema(TEST_SCHEMA)
-                .setIdentity(Identity.ofUser(user))
                 .build();
     }
 

--- a/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/SingleStoreQueryRunner.java
+++ b/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/SingleStoreQueryRunner.java
@@ -58,7 +58,7 @@ public class SingleStoreQueryRunner
             queryRunner.installPlugin(new SingleStorePlugin());
             queryRunner.createCatalog("singlestore", "singlestore", connectorProperties);
 
-            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), tables);
+            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, tables);
 
             return queryRunner;
         }

--- a/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/SnowflakeQueryRunner.java
+++ b/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/SnowflakeQueryRunner.java
@@ -60,7 +60,7 @@ public final class SnowflakeQueryRunner
             queryRunner.createCatalog("snowflake", "snowflake", connectorProperties);
 
             queryRunner.execute(createSession(), "CREATE SCHEMA IF NOT EXISTS " + TPCH_SCHEMA);
-            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), tables);
+            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, tables);
 
             return queryRunner;
         }

--- a/plugin/trino-sqlserver/pom.xml
+++ b/plugin/trino-sqlserver/pom.xml
@@ -110,6 +110,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>log-manager</artifactId>
             <scope>runtime</scope>

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerFailureRecoveryTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerFailureRecoveryTest.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static io.trino.plugin.sqlserver.SqlServerQueryRunner.createSqlServerQueryRunner;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.abort;
 
@@ -44,17 +43,16 @@ public abstract class BaseSqlServerFailureRecoveryTest
             Map<String, String> coordinatorProperties)
             throws Exception
     {
-        return createSqlServerQueryRunner(
-                closeAfterClass(new TestingSqlServer()),
-                configProperties,
-                coordinatorProperties,
-                Map.of(),
-                requiredTpchTables,
-                runner -> {
+        return SqlServerQueryRunner.builder(closeAfterClass(new TestingSqlServer()))
+                .setExtraProperties(configProperties)
+                .setCoordinatorProperties(coordinatorProperties)
+                .setInitialTables(requiredTpchTables)
+                .setAdditionalSetup(runner -> {
                     runner.installPlugin(new FileSystemExchangePlugin());
                     runner.loadExchangeManager("filesystem", ImmutableMap.of(
                             "exchange.base-directories", System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager"));
-                });
+                })
+                .build();
     }
 
     @Test

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerTransactionIsolationTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerTransactionIsolationTest.java
@@ -20,9 +20,7 @@ import io.trino.testing.sql.SqlExecutor;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Map;
 
-import static io.trino.plugin.sqlserver.SqlServerQueryRunner.createSqlServerQueryRunner;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.tpch.TpchTable.NATION;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,11 +33,9 @@ public abstract class BaseSqlServerTransactionIsolationTest
             throws Exception
     {
         TestingSqlServer sqlServer = closeAfterClass(new TestingSqlServer(this::configureDatabase));
-        return createSqlServerQueryRunner(
-                sqlServer,
-                Map.of(),
-                Map.of(),
-                List.of(NATION));
+        return SqlServerQueryRunner.builder(sqlServer)
+                .setInitialTables(List.of(NATION))
+                .build();
     }
 
     protected abstract void configureDatabase(SqlExecutor executor, String databaseName);

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/SqlServerQueryRunner.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/SqlServerQueryRunner.java
@@ -13,27 +13,30 @@
  */
 package io.trino.plugin.sqlserver;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.airlift.log.Level;
 import io.airlift.log.Logger;
 import io.airlift.log.Logging;
-import io.trino.Session;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
 import io.trino.tpch.TpchTable;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
 
 import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
 import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.util.Objects.requireNonNull;
 
 public final class SqlServerQueryRunner
 {
+    private SqlServerQueryRunner() {}
+
     static {
         Logging logging = Logging.initialize();
         logging.setLevel("com.microsoft.sqlserver.jdbc", Level.OFF);
@@ -41,66 +44,67 @@ public final class SqlServerQueryRunner
 
     private static final Logger log = Logger.get(SqlServerQueryRunner.class);
 
-    private SqlServerQueryRunner() {}
-
     public static final String CATALOG = "sqlserver";
-
     private static final String TEST_SCHEMA = "dbo";
 
-    public static QueryRunner createSqlServerQueryRunner(
-            TestingSqlServer testingSqlServer,
-            Map<String, String> extraProperties,
-            Map<String, String> connectorProperties,
-            Iterable<TpchTable<?>> tables)
-            throws Exception
+    public static Builder builder(TestingSqlServer testingSqlServer)
     {
-        return createSqlServerQueryRunner(testingSqlServer, extraProperties, Map.of(), connectorProperties, tables, runner -> {});
+        return new Builder()
+                .addConnectorProperties(Map.of(
+                        "connection-url", testingSqlServer.getJdbcUrl(),
+                        "connection-user", testingSqlServer.getUsername(),
+                        "connection-password", testingSqlServer.getPassword()));
     }
 
-    public static QueryRunner createSqlServerQueryRunner(
-            TestingSqlServer testingSqlServer,
-            Map<String, String> extraProperties,
-            Map<String, String> coordinatorProperties,
-            Map<String, String> connectorProperties,
-            Iterable<TpchTable<?>> tables,
-            Consumer<QueryRunner> moreSetup)
-            throws Exception
+    public static final class Builder
+            extends DistributedQueryRunner.Builder<Builder>
     {
-        QueryRunner queryRunner = DistributedQueryRunner.builder(createSession())
-                .setExtraProperties(extraProperties)
-                .setCoordinatorProperties(coordinatorProperties)
-                .setAdditionalSetup(moreSetup)
-                .build();
-        try {
-            queryRunner.installPlugin(new TpchPlugin());
-            queryRunner.createCatalog("tpch", "tpch");
+        private final Map<String, String> connectorProperties = new HashMap<>();
+        private List<TpchTable<?>> initialTables = ImmutableList.of();
 
-            // note: additional copy via ImmutableList so that if fails on nulls
-            connectorProperties = new HashMap<>(ImmutableMap.copyOf(connectorProperties));
-            connectorProperties.putIfAbsent("connection-url", testingSqlServer.getJdbcUrl());
-            connectorProperties.putIfAbsent("connection-user", testingSqlServer.getUsername());
-            connectorProperties.putIfAbsent("connection-password", testingSqlServer.getPassword());
-
-            queryRunner.installPlugin(new SqlServerPlugin());
-            queryRunner.createCatalog(CATALOG, "sqlserver", connectorProperties);
-            log.info("%s catalog properties: %s", CATALOG, connectorProperties);
-
-            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, tables);
-
-            return queryRunner;
+        private Builder()
+        {
+            super(testSessionBuilder()
+                    .setCatalog(CATALOG)
+                    .setSchema(TEST_SCHEMA)
+                    .build());
         }
-        catch (Throwable e) {
-            closeAllSuppress(e, queryRunner);
-            throw e;
-        }
-    }
 
-    private static Session createSession()
-    {
-        return testSessionBuilder()
-                .setCatalog(CATALOG)
-                .setSchema(TEST_SCHEMA)
-                .build();
+        @CanIgnoreReturnValue
+        public Builder addConnectorProperties(Map<String, String> connectorProperties)
+        {
+            this.connectorProperties.putAll(requireNonNull(connectorProperties, "connectorProperties is null"));
+            return this;
+        }
+
+        public Builder setInitialTables(Iterable<TpchTable<?>> initialTables)
+        {
+            this.initialTables = ImmutableList.copyOf(requireNonNull(initialTables, "initialTables is null"));
+            return this;
+        }
+
+        @Override
+        public DistributedQueryRunner build()
+                throws Exception
+        {
+            DistributedQueryRunner queryRunner = super.build();
+            try {
+                queryRunner.installPlugin(new TpchPlugin());
+                queryRunner.createCatalog("tpch", "tpch");
+
+                queryRunner.installPlugin(new SqlServerPlugin());
+                queryRunner.createCatalog(CATALOG, "sqlserver", connectorProperties);
+                log.info("%s catalog properties: %s", CATALOG, connectorProperties);
+
+                copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, initialTables);
+
+                return queryRunner;
+            }
+            catch (Throwable e) {
+                closeAllSuppress(e, queryRunner);
+                throw e;
+            }
+        }
     }
 
     public static void main(String[] args)
@@ -111,11 +115,10 @@ public final class SqlServerQueryRunner
         // SqlServer is using docker container so in case that shutdown hook is not called, developer can easily clean docker container on their own
         Runtime.getRuntime().addShutdownHook(new Thread(testingSqlServer::close));
 
-        QueryRunner queryRunner = createSqlServerQueryRunner(
-                testingSqlServer,
-                ImmutableMap.of("http-server.http.port", "8080"),
-                ImmutableMap.of(),
-                TpchTable.getTables());
+        QueryRunner queryRunner = builder(testingSqlServer)
+                .addExtraProperty("http-server.http.port", "8080")
+                .setInitialTables(TpchTable.getTables())
+                .build();
 
         Logger log = Logger.get(SqlServerQueryRunner.class);
         log.info("======== SERVER STARTED ========");

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/SqlServerQueryRunner.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/SqlServerQueryRunner.java
@@ -19,7 +19,6 @@ import io.airlift.log.Logger;
 import io.airlift.log.Logging;
 import io.trino.Session;
 import io.trino.plugin.tpch.TpchPlugin;
-import io.trino.spi.security.Identity;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
 import io.trino.tpch.TpchTable;
@@ -67,7 +66,7 @@ public final class SqlServerQueryRunner
             Consumer<QueryRunner> moreSetup)
             throws Exception
     {
-        QueryRunner queryRunner = DistributedQueryRunner.builder(createSession(testingSqlServer.getUsername()))
+        QueryRunner queryRunner = DistributedQueryRunner.builder(createSession())
                 .setExtraProperties(extraProperties)
                 .setCoordinatorProperties(coordinatorProperties)
                 .setAdditionalSetup(moreSetup)
@@ -86,7 +85,7 @@ public final class SqlServerQueryRunner
             queryRunner.createCatalog(CATALOG, "sqlserver", connectorProperties);
             log.info("%s catalog properties: %s", CATALOG, connectorProperties);
 
-            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(testingSqlServer.getUsername()), tables);
+            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), tables);
 
             return queryRunner;
         }
@@ -96,12 +95,11 @@ public final class SqlServerQueryRunner
         }
     }
 
-    private static Session createSession(String username)
+    private static Session createSession()
     {
         return testSessionBuilder()
                 .setCatalog(CATALOG)
                 .setSchema(TEST_SCHEMA)
-                .setIdentity(Identity.ofUser(username))
                 .build();
     }
 

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/SqlServerQueryRunner.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/SqlServerQueryRunner.java
@@ -85,7 +85,7 @@ public final class SqlServerQueryRunner
             queryRunner.createCatalog(CATALOG, "sqlserver", connectorProperties);
             log.info("%s catalog properties: %s", CATALOG, connectorProperties);
 
-            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), tables);
+            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, tables);
 
             return queryRunner;
         }

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerAutomaticJoinPushdown.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerAutomaticJoinPushdown.java
@@ -17,11 +17,9 @@ import io.trino.plugin.jdbc.BaseAutomaticJoinPushdownTest;
 import io.trino.testing.QueryRunner;
 
 import java.util.List;
-import java.util.Map;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Streams.stream;
-import static io.trino.plugin.sqlserver.SqlServerQueryRunner.createSqlServerQueryRunner;
 import static java.lang.String.format;
 
 public class TestSqlServerAutomaticJoinPushdown
@@ -34,7 +32,8 @@ public class TestSqlServerAutomaticJoinPushdown
             throws Exception
     {
         sqlServer = closeAfterClass(new TestingSqlServer());
-        return createSqlServerQueryRunner(sqlServer, Map.of(), Map.of(), List.of());
+        return SqlServerQueryRunner.builder(sqlServer)
+                .build();
     }
 
     @Override

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerCaseInsensitiveMapping.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerCaseInsensitiveMapping.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.sqlserver;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.jdbc.BaseCaseInsensitiveMappingTest;
 import io.trino.testing.QueryRunner;
@@ -27,7 +26,6 @@ import java.sql.Statement;
 
 import static io.trino.plugin.base.mapping.RuleBasedIdentifierMappingUtils.REFRESH_PERIOD_DURATION;
 import static io.trino.plugin.base.mapping.RuleBasedIdentifierMappingUtils.createRuleBasedIdentifierMappingFile;
-import static io.trino.plugin.sqlserver.SqlServerQueryRunner.createSqlServerQueryRunner;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -45,15 +43,13 @@ public class TestSqlServerCaseInsensitiveMapping
     {
         mappingFile = createRuleBasedIdentifierMappingFile();
         sqlServer = closeAfterClass(new TestingSqlServer());
-        return createSqlServerQueryRunner(
-                sqlServer,
-                ImmutableMap.of(),
-                ImmutableMap.<String, String>builder()
+        return SqlServerQueryRunner.builder(sqlServer)
+                .addConnectorProperties(ImmutableMap.<String, String>builder()
                         .put("case-insensitive-name-matching", "true")
                         .put("case-insensitive-name-matching.config-file", mappingFile.toFile().getAbsolutePath())
                         .put("case-insensitive-name-matching.config-file.refresh-period", REFRESH_PERIOD_DURATION.toString())
-                        .buildOrThrow(),
-                ImmutableList.of());
+                        .buildOrThrow())
+                .build();
     }
 
     @Override

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConnectorSmokeTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConnectorSmokeTest.java
@@ -13,10 +13,7 @@
  */
 package io.trino.plugin.sqlserver;
 
-import com.google.common.collect.ImmutableMap;
 import io.trino.testing.QueryRunner;
-
-import static io.trino.plugin.sqlserver.SqlServerQueryRunner.createSqlServerQueryRunner;
 
 public class TestSqlServerConnectorSmokeTest
         extends BaseSqlServerConnectorSmokeTest
@@ -26,10 +23,8 @@ public class TestSqlServerConnectorSmokeTest
             throws Exception
     {
         TestingSqlServer sqlServer = closeAfterClass(new TestingSqlServer());
-        return createSqlServerQueryRunner(
-                sqlServer,
-                ImmutableMap.of(),
-                ImmutableMap.of(),
-                REQUIRED_TPCH_TABLES);
+        return SqlServerQueryRunner.builder(sqlServer)
+                .setInitialTables(REQUIRED_TPCH_TABLES)
+                .build();
     }
 }

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConnectorTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConnectorTest.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.sqlserver;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.sql.SqlExecutor;
@@ -27,10 +26,10 @@ import org.junit.jupiter.api.Test;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Map;
 
 import static io.trino.plugin.jdbc.JdbcWriteSessionProperties.NON_TRANSACTIONAL_INSERT;
 import static io.trino.plugin.sqlserver.SqlServerQueryRunner.CATALOG;
-import static io.trino.plugin.sqlserver.SqlServerQueryRunner.createSqlServerQueryRunner;
 import static io.trino.plugin.sqlserver.SqlServerSessionProperties.BULK_COPY_FOR_WRITE;
 import static io.trino.plugin.sqlserver.SqlServerSessionProperties.BULK_COPY_FOR_WRITE_LOCK_DESTINATION_TABLE;
 import static io.trino.testing.TestingNames.randomNameSuffix;
@@ -49,11 +48,10 @@ public class TestSqlServerConnectorTest
             throws Exception
     {
         sqlServer = closeAfterClass(new TestingSqlServer());
-        return createSqlServerQueryRunner(
-                sqlServer,
-                ImmutableMap.of(),
-                ImmutableMap.of("sqlserver.experimental.stored-procedure-table-function-enabled", "true"),
-                REQUIRED_TPCH_TABLES);
+        return SqlServerQueryRunner.builder(sqlServer)
+                .addConnectorProperties(Map.of("sqlserver.experimental.stored-procedure-table-function-enabled", "true"))
+                .setInitialTables(REQUIRED_TPCH_TABLES)
+                .build();
     }
 
     @Override

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerLatestConnectorSmokeTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerLatestConnectorSmokeTest.java
@@ -13,10 +13,8 @@
  */
 package io.trino.plugin.sqlserver;
 
-import com.google.common.collect.ImmutableMap;
 import io.trino.testing.QueryRunner;
 
-import static io.trino.plugin.sqlserver.SqlServerQueryRunner.createSqlServerQueryRunner;
 import static io.trino.plugin.sqlserver.TestingSqlServer.LATEST_VERSION;
 
 public class TestSqlServerLatestConnectorSmokeTest
@@ -27,10 +25,8 @@ public class TestSqlServerLatestConnectorSmokeTest
             throws Exception
     {
         TestingSqlServer sqlServer = closeAfterClass(new TestingSqlServer(LATEST_VERSION));
-        return createSqlServerQueryRunner(
-                sqlServer,
-                ImmutableMap.of(),
-                ImmutableMap.of(),
-                REQUIRED_TPCH_TABLES);
+        return SqlServerQueryRunner.builder(sqlServer)
+                .setInitialTables(REQUIRED_TPCH_TABLES)
+                .build();
     }
 }

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerTableStatistics.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerTableStatistics.java
@@ -42,11 +42,10 @@ public class TestSqlServerTableStatistics
             throws Exception
     {
         sqlServer = closeAfterClass(new TestingSqlServer());
-        return SqlServerQueryRunner.createSqlServerQueryRunner(
-                sqlServer,
-                Map.of(),
-                Map.of("case-insensitive-name-matching", "true"),
-                List.of(ORDERS));
+        return SqlServerQueryRunner.builder(sqlServer)
+                .addConnectorProperties(Map.of("case-insensitive-name-matching", "true"))
+                .setInitialTables(List.of(ORDERS))
+                .build();
     }
 
     @Override

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerTypeMapping.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerTypeMapping.java
@@ -13,11 +13,7 @@
  */
 package io.trino.plugin.sqlserver;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.trino.testing.QueryRunner;
-
-import static io.trino.plugin.sqlserver.SqlServerQueryRunner.createSqlServerQueryRunner;
 
 public class TestSqlServerTypeMapping
         extends BaseSqlServerTypeMapping
@@ -27,10 +23,7 @@ public class TestSqlServerTypeMapping
             throws Exception
     {
         sqlServer = closeAfterClass(new TestingSqlServer());
-        return createSqlServerQueryRunner(
-                sqlServer,
-                ImmutableMap.of(),
-                ImmutableMap.of(),
-                ImmutableList.of());
+        return SqlServerQueryRunner.builder(sqlServer)
+                .build();
     }
 }

--- a/testing/trino-testing/src/main/java/io/trino/testing/QueryAssertions.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/QueryAssertions.java
@@ -496,6 +496,15 @@ public final class QueryAssertions
             QueryRunner queryRunner,
             String sourceCatalog,
             String sourceSchema,
+            Iterable<TpchTable<?>> tables)
+    {
+        copyTpchTables(queryRunner, sourceCatalog, sourceSchema, queryRunner.getDefaultSession(), tables);
+    }
+
+    public static void copyTpchTables(
+            QueryRunner queryRunner,
+            String sourceCatalog,
+            String sourceSchema,
             Session session,
             Iterable<TpchTable<?>> tables)
     {

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestQueryAssertions.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestQueryAssertions.java
@@ -87,7 +87,7 @@ public class TestQueryAssertions
             throw new RuntimeException(e);
         }
 
-        copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, queryRunner.getDefaultSession(), List.of(NATION));
+        copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, List.of(NATION));
 
         Map<String, String> jdbcWithAggregationPushdownDisabledConfigurationProperties = ImmutableMap.<String, String>builder()
                 .putAll(jdbcConfigurationProperties)


### PR DESCRIPTION
Avoid multiple overloads. Make setup easier to follow.

