### PR TITLE
Add builders for Redshift query runner

### DIFF
--- a/plugin/trino-redshift/pom.xml
+++ b/plugin/trino-redshift/pom.xml
@@ -96,6 +96,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>dev.failsafe</groupId>
             <artifactId>failsafe</artifactId>
             <scope>runtime</scope>

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/BaseRedshiftFailureRecoveryTest.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/BaseRedshiftFailureRecoveryTest.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static io.trino.plugin.redshift.RedshiftQueryRunner.createRedshiftQueryRunner;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.abort;
 
@@ -44,16 +43,16 @@ public abstract class BaseRedshiftFailureRecoveryTest
             Map<String, String> coordinatorProperties)
             throws Exception
     {
-        return createRedshiftQueryRunner(
-                configProperties,
-                coordinatorProperties,
-                Map.of(),
-                requiredTpchTables,
-                runner -> {
+        return RedshiftQueryRunner.builder()
+                .setExtraProperties(configProperties)
+                .setCoordinatorProperties(coordinatorProperties)
+                .setAdditionalSetup(runner -> {
                     runner.installPlugin(new FileSystemExchangePlugin());
                     runner.loadExchangeManager("filesystem", ImmutableMap.of(
                             "exchange.base-directories", System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager"));
-                });
+                })
+                .setInitialTables(requiredTpchTables)
+                .build();
     }
 
     @Test

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/RedshiftQueryRunner.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/RedshiftQueryRunner.java
@@ -39,7 +39,6 @@ import java.util.function.Consumer;
 
 import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
-import static io.trino.testing.QueryAssertions.copyTable;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
@@ -229,14 +228,6 @@ public final class RedshiftQueryRunner
                 " IAM_ROLE '" + IAM_ROLE + "'" +
                 " FORMAT PARQUET";
         executeInRedshiftWithRetry(copySql);
-    }
-
-    private static void copyFromTpchCatalog(QueryRunner queryRunner, Session session, String name)
-    {
-        // This function exists in case we need to copy data from the TPCH catalog rather than S3,
-        // such as moving to a new AWS account or if the schema changes. We can swap this method out for
-        // copyFromS3 in provisionTables and then export the data again to S3.
-        copyTable(queryRunner, TPCH_CATALOG, TINY_SCHEMA_NAME, name, session);
     }
 
     private static void verifyLoadedDataHasSameSchema(Session session, QueryRunner queryRunner, TpchTable<?> tpchTable)

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/RedshiftQueryRunner.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/RedshiftQueryRunner.java
@@ -135,7 +135,7 @@ public final class RedshiftQueryRunner
             executeInRedshiftWithRetry(format("GRANT ALL PRIVILEGES ON DATABASE %s TO %s", TEST_DATABASE, GRANTED_USER));
             executeInRedshiftWithRetry(format("GRANT ALL PRIVILEGES ON SCHEMA %s TO %s", TEST_SCHEMA, GRANTED_USER));
 
-            provisionTables(session, runner, tables);
+            provisionTables(runner, tables);
 
             // This step is necessary for product tests
             executeInRedshiftWithRetry(format("GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA %s TO %s", TEST_SCHEMA, GRANTED_USER));
@@ -195,8 +195,9 @@ public final class RedshiftQueryRunner
         return Jdbi.create(JDBC_URL, JDBC_USER, JDBC_PASSWORD).withHandle(callback);
     }
 
-    private static synchronized void provisionTables(Session session, QueryRunner queryRunner, Iterable<TpchTable<?>> tables)
+    private static synchronized void provisionTables(QueryRunner queryRunner, Iterable<TpchTable<?>> tables)
     {
+        Session session = queryRunner.getDefaultSession();
         Set<String> existingTables = queryRunner.listTables(session, session.getCatalog().orElseThrow(), session.getSchema().orElseThrow())
                 .stream()
                 .map(QualifiedObjectName::objectName)

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftAutomaticJoinPushdown.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftAutomaticJoinPushdown.java
@@ -13,15 +13,12 @@
  */
 package io.trino.plugin.redshift;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.jdbc.BaseAutomaticJoinPushdownTest;
 import io.trino.testing.QueryRunner;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static io.trino.plugin.redshift.RedshiftQueryRunner.TEST_SCHEMA;
-import static io.trino.plugin.redshift.RedshiftQueryRunner.createRedshiftQueryRunner;
 import static io.trino.plugin.redshift.RedshiftQueryRunner.executeInRedshift;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
@@ -33,10 +30,8 @@ public class TestRedshiftAutomaticJoinPushdown
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createRedshiftQueryRunner(
-                ImmutableMap.of(),
-                ImmutableMap.of(),
-                ImmutableList.of());
+        return RedshiftQueryRunner.builder()
+                .build();
     }
 
     @Test

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConnectorSmokeTest.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConnectorSmokeTest.java
@@ -13,12 +13,9 @@
  */
 package io.trino.plugin.redshift;
 
-import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.jdbc.BaseJdbcConnectorSmokeTest;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
-
-import static io.trino.plugin.redshift.RedshiftQueryRunner.createRedshiftQueryRunner;
 
 public class TestRedshiftConnectorSmokeTest
         extends BaseJdbcConnectorSmokeTest
@@ -36,9 +33,8 @@ public class TestRedshiftConnectorSmokeTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createRedshiftQueryRunner(
-                ImmutableMap.of(),
-                ImmutableMap.of(),
-                REQUIRED_TPCH_TABLES);
+        return RedshiftQueryRunner.builder()
+                .setInitialTables(REQUIRED_TPCH_TABLES)
+                .build();
     }
 }

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConnectorTest.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConnectorTest.java
@@ -21,7 +21,6 @@ import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
 import io.trino.testing.sql.SqlExecutor;
 import io.trino.testing.sql.TestTable;
-import io.trino.tpch.TpchTable;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -57,7 +56,7 @@ public class TestRedshiftConnectorTest
                 ImmutableMap.of(),
                 // NOTE this can cause tests to time-out if larger tables like
                 //  lineitem and orders need to be re-created.
-                TpchTable.getTables());
+                REQUIRED_TPCH_TABLES);
     }
 
     @Override

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConnectorTest.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConnectorTest.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.redshift;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.plugin.jdbc.BaseJdbcConnectorTest;
 import io.trino.testing.QueryRunner;
@@ -34,7 +33,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.jdbc.TypeHandlingJdbcSessionProperties.UNSUPPORTED_TYPE_HANDLING;
 import static io.trino.plugin.jdbc.UnsupportedTypeHandling.CONVERT_TO_VARCHAR;
 import static io.trino.plugin.redshift.RedshiftQueryRunner.TEST_SCHEMA;
-import static io.trino.plugin.redshift.RedshiftQueryRunner.createRedshiftQueryRunner;
 import static io.trino.plugin.redshift.RedshiftQueryRunner.executeInRedshift;
 import static io.trino.plugin.redshift.RedshiftQueryRunner.executeWithRedshift;
 import static io.trino.testing.TestingNames.randomNameSuffix;
@@ -51,12 +49,11 @@ public class TestRedshiftConnectorTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createRedshiftQueryRunner(
-                ImmutableMap.of(),
-                ImmutableMap.of(),
+        return RedshiftQueryRunner.builder()
                 // NOTE this can cause tests to time-out if larger tables like
                 //  lineitem and orders need to be re-created.
-                REQUIRED_TPCH_TABLES);
+                .setInitialTables(REQUIRED_TPCH_TABLES)
+                .build();
     }
 
     @Override

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftTableStatisticsReader.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftTableStatisticsReader.java
@@ -37,7 +37,6 @@ import org.junit.jupiter.api.Test;
 
 import java.sql.Types;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -45,7 +44,6 @@ import static io.trino.plugin.redshift.RedshiftQueryRunner.JDBC_PASSWORD;
 import static io.trino.plugin.redshift.RedshiftQueryRunner.JDBC_URL;
 import static io.trino.plugin.redshift.RedshiftQueryRunner.JDBC_USER;
 import static io.trino.plugin.redshift.RedshiftQueryRunner.TEST_SCHEMA;
-import static io.trino.plugin.redshift.RedshiftQueryRunner.createRedshiftQueryRunner;
 import static io.trino.plugin.redshift.RedshiftQueryRunner.executeInRedshift;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DoubleType.DOUBLE;
@@ -82,7 +80,9 @@ public class TestRedshiftTableStatisticsReader
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createRedshiftQueryRunner(Map.of(), Map.of(), ImmutableList.of(CUSTOMER));
+        return RedshiftQueryRunner.builder()
+                .setInitialTables(List.of(CUSTOMER))
+                .build();
     }
 
     @Test

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftTypeMapping.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftTypeMapping.java
@@ -49,7 +49,6 @@ import static io.trino.plugin.redshift.RedshiftQueryRunner.JDBC_PASSWORD;
 import static io.trino.plugin.redshift.RedshiftQueryRunner.JDBC_URL;
 import static io.trino.plugin.redshift.RedshiftQueryRunner.JDBC_USER;
 import static io.trino.plugin.redshift.RedshiftQueryRunner.TEST_SCHEMA;
-import static io.trino.plugin.redshift.RedshiftQueryRunner.createRedshiftQueryRunner;
 import static io.trino.plugin.redshift.RedshiftQueryRunner.executeInRedshift;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -123,7 +122,8 @@ public class TestRedshiftTypeMapping
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createRedshiftQueryRunner(Map.of(), Map.of(), List.of());
+        return RedshiftQueryRunner.builder()
+                .build();
     }
 
     @Test


### PR DESCRIPTION
Avoid multiple overloads. Make setup easier to follow.

