### PR TITLE
Push join into TableScan through Project

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -877,7 +877,7 @@ public class PlanOptimizers
                             .addAll(pushIntoTableScanRulesExceptJoins)
                             // PushJoinIntoTableScan must run after ReorderJoins (and DetermineJoinDistributionType)
                             // otherwise too early pushdown could prevent optimal plan from being selected.
-                            .add(new PushJoinIntoTableScan(plannerContext))
+                            .addAll(PushJoinIntoTableScan.rules(plannerContext))
                             // DetermineTableScanNodePartitioning is needed to needs to ensure all table handles have proper partitioning determined
                             // Must run before AddExchanges
                             .add(new DetermineTableScanNodePartitioning(metadata, nodePartitioningManager, taskCountEstimator))

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushJoinIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushJoinIntoTableScan.java
@@ -15,6 +15,7 @@ package io.trino.sql.planner.iterative.rule;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
 import io.trino.cost.PlanNodeStatsEstimate;
 import io.trino.matching.Capture;
@@ -25,11 +26,12 @@ import io.trino.spi.connector.BasicRelationStatistics;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.JoinApplicationResult;
 import io.trino.spi.connector.JoinStatistics;
-import io.trino.spi.connector.JoinType;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.ir.Booleans;
+import io.trino.sql.ir.Comparison;
+import io.trino.sql.ir.Comparison.Operator;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.planner.ConnectorExpressionTranslator;
 import io.trino.sql.planner.ConnectorExpressionTranslator.ConnectorExpressionTranslation;
@@ -37,6 +39,8 @@ import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.plan.Assignments;
 import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.JoinNode.EquiJoinClause;
+import io.trino.sql.planner.plan.JoinType;
 import io.trino.sql.planner.plan.Patterns;
 import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.ProjectNode;
@@ -44,9 +48,10 @@ import io.trino.sql.planner.plan.TableScanNode;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Set;
 
-import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.SystemSessionProperties.isAllowPushdownIntoConnectors;
@@ -59,6 +64,8 @@ import static io.trino.sql.planner.plan.JoinType.LEFT;
 import static io.trino.sql.planner.plan.JoinType.RIGHT;
 import static io.trino.sql.planner.plan.Patterns.Join.left;
 import static io.trino.sql.planner.plan.Patterns.Join.right;
+import static io.trino.sql.planner.plan.Patterns.project;
+import static io.trino.sql.planner.plan.Patterns.source;
 import static io.trino.sql.planner.plan.Patterns.tableScan;
 import static java.lang.Double.isNaN;
 import static java.util.Objects.requireNonNull;
@@ -68,131 +75,145 @@ public class PushJoinIntoTableScan
 {
     private static final Capture<TableScanNode> LEFT_TABLE_SCAN = newCapture();
     private static final Capture<TableScanNode> RIGHT_TABLE_SCAN = newCapture();
+    private static final Capture<ProjectNode> LEFT_PROJECT = newCapture();
+    private static final Capture<ProjectNode> RIGHT_PROJECT = newCapture();
+    private final PlannerContext plannerContext;
+    private final ProjectSide projectSide;
+    private final Pattern<JoinNode> pattern;
 
-    private static final Pattern<JoinNode> PATTERN =
-            Patterns.join()
+    public static Set<Rule<?>> rules(PlannerContext plannerContext)
+    {
+        return ImmutableSet.of(
+                new PushJoinIntoTableScan(plannerContext, ProjectSide.LEFT),
+                new PushJoinIntoTableScan(plannerContext, ProjectSide.RIGHT),
+                new PushJoinIntoTableScan(plannerContext, ProjectSide.BOTH),
+                new PushJoinIntoTableScan(plannerContext, ProjectSide.NONE));
+    }
+
+    PushJoinIntoTableScan(PlannerContext plannerContext, ProjectSide projectSide)
+    {
+        this.projectSide = requireNonNull(projectSide, "projectSide is null");
+        this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
+        this.pattern = switch (projectSide) {
+            case LEFT -> Patterns.join()
+                    .with(left().matching(project().capturedAs(LEFT_PROJECT).with(source().matching(tableScan().capturedAs(LEFT_TABLE_SCAN)))))
+                    .with(right().matching(tableScan().capturedAs(RIGHT_TABLE_SCAN)));
+            case RIGHT -> Patterns.join()
+                    .with(left().matching(tableScan().capturedAs(LEFT_TABLE_SCAN)))
+                    .with(right().matching(project().capturedAs(RIGHT_PROJECT).with(source().matching(tableScan().capturedAs(RIGHT_TABLE_SCAN)))));
+            case BOTH -> Patterns.join()
+                    .with(left().matching(project().capturedAs(LEFT_PROJECT).with(source().matching(tableScan().capturedAs(LEFT_TABLE_SCAN)))))
+                    .with(right().matching(project().capturedAs(RIGHT_PROJECT).with(source().matching(tableScan().capturedAs(RIGHT_TABLE_SCAN)))));
+            case NONE -> Patterns.join()
                     .with(left().matching(tableScan().capturedAs(LEFT_TABLE_SCAN)))
                     .with(right().matching(tableScan().capturedAs(RIGHT_TABLE_SCAN)));
-
-    private final PlannerContext plannerContext;
-
-    public PushJoinIntoTableScan(PlannerContext plannerContext)
-    {
-        this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
+        };
     }
 
     @Override
     public Pattern<JoinNode> getPattern()
     {
-        return PATTERN;
-    }
-
-    @Override
-    public boolean isEnabled(Session session)
-    {
-        return isAllowPushdownIntoConnectors(session);
+        return pattern;
     }
 
     @Override
     public Result apply(JoinNode joinNode, Captures captures, Context context)
     {
-        if (joinNode.isCrossJoin()) {
+        PlanNodes nodes = PlanNodes.create(captures, joinNode, projectSide);
+
+        if (nodes.join().isCrossJoin()) {
             return Result.empty();
         }
 
-        TableScanNode left = captures.get(LEFT_TABLE_SCAN);
-        TableScanNode right = captures.get(RIGHT_TABLE_SCAN);
+        if (nodes.leftScan().isUpdateTarget() || nodes.rightScan().isUpdateTarget()) {
+            // unexpected Join over for-update table scan
+            return Result.empty();
+        }
 
-        verify(!left.isUpdateTarget() && !right.isUpdateTarget(), "Unexpected Join over for-update table scan");
-
-        Expression effectiveFilter = getEffectiveFilter(joinNode);
+        Expression effectiveFilter = getJoinNodeEffectiveFilter(nodes.join(), nodes.leftProject(), nodes.rightProject());
         ConnectorExpressionTranslation translation = ConnectorExpressionTranslator.translateConjuncts(
                 context.getSession(),
                 effectiveFilter);
 
         if (!translation.remainingExpression().equals(Booleans.TRUE)) {
-            // TODO add extra filter node above join
             return Result.empty();
         }
 
-        if (left.getEnforcedConstraint().isNone() || right.getEnforcedConstraint().isNone()) {
+        if (nodes.leftScan().getEnforcedConstraint().isNone() || nodes.rightScan().getEnforcedConstraint().isNone()) {
             // bailing out on one of the tables empty; this is not interesting case which makes handling
             // enforced constraint harder below.
             return Result.empty();
         }
 
-        Map<String, ColumnHandle> leftAssignments = left.getAssignments().entrySet().stream()
-                .collect(toImmutableMap(entry -> entry.getKey().name(), Map.Entry::getValue));
+        Map<String, ColumnHandle> leftScanAssignments = nodes.leftScan().getAssignments().entrySet().stream()
+                .collect(toImmutableMap(entry -> entry.getKey().name(), Entry::getValue));
 
-        Map<String, ColumnHandle> rightAssignments = right.getAssignments().entrySet().stream()
-                .collect(toImmutableMap(entry -> entry.getKey().name(), Map.Entry::getValue));
+        Map<String, ColumnHandle> rightScanAssignments = nodes.rightScan().getAssignments().entrySet().stream()
+                .collect(toImmutableMap(entry -> entry.getKey().name(), Entry::getValue));
 
         /*
          * We are (lazily) computing estimated statistics for join node and left and right table
          * and passing those to connector via applyJoin.
          *
-         * There are a couple reasons for this approach:
+         * There are couple reasons for this approach:
          * - the engine knows how to estimate join and connector may not
          * - the engine may have cached stats for the table scans (within context.getStatsProvider()), so can be able to provide information more inexpensively
          * - in the future, the engine may be able to provide stats for table scan even in case when connector no longer can (see https://github.com/trinodb/trino/issues/6998)
          * - the pushdown feasibility assessment logic may be different (or configured differently) for different connectors/catalogs.
          */
-        JoinStatistics joinStatistics = getJoinStatistics(joinNode, left, right, context);
+        JoinStatistics joinStatistics = getJoinStatistics(nodes.join(), nodes.leftScan(), nodes.rightScan(), context);
 
         Optional<JoinApplicationResult<TableHandle>> joinApplicationResult = plannerContext.getMetadata().applyJoin(
                 context.getSession(),
-                getJoinType(joinNode),
-                left.getTable(),
-                right.getTable(),
+                getJoinType(nodes.join()),
+                nodes.leftScan().getTable(),
+                nodes.rightScan().getTable(),
                 translation.connectorExpression(),
-                // TODO we could pass only subset of assignments here, those which are needed to resolve translation.getPushableConditions
-                leftAssignments,
-                rightAssignments,
+                leftScanAssignments,
+                rightScanAssignments,
                 joinStatistics);
 
         if (joinApplicationResult.isEmpty()) {
             return Result.empty();
         }
 
-        TableHandle handle = joinApplicationResult.get().getTableHandle();
+        JoinApplicationResult<TableHandle> applyJoinResult = joinApplicationResult.get();
 
-        Map<ColumnHandle, ColumnHandle> leftColumnHandlesMapping = joinApplicationResult.get().getLeftColumnHandles();
-        Map<ColumnHandle, ColumnHandle> rightColumnHandlesMapping = joinApplicationResult.get().getRightColumnHandles();
-
+        Map<ColumnHandle, ColumnHandle> leftColumnHandlesMapping = applyJoinResult.getLeftColumnHandles();
+        Map<ColumnHandle, ColumnHandle> rightColumnHandlesMapping = applyJoinResult.getRightColumnHandles();
         ImmutableMap.Builder<Symbol, ColumnHandle> assignmentsBuilder = ImmutableMap.builder();
-        assignmentsBuilder.putAll(left.getAssignments().entrySet().stream().collect(toImmutableMap(
-                Map.Entry::getKey,
+        assignmentsBuilder.putAll(nodes.leftScan().getAssignments().entrySet().stream().collect(toImmutableMap(
+                Entry::getKey,
                 entry -> leftColumnHandlesMapping.get(entry.getValue()))));
-        assignmentsBuilder.putAll(right.getAssignments().entrySet().stream().collect(toImmutableMap(
-                Map.Entry::getKey,
+        assignmentsBuilder.putAll(nodes.rightScan().getAssignments().entrySet().stream().collect(toImmutableMap(
+                Entry::getKey,
                 entry -> rightColumnHandlesMapping.get(entry.getValue()))));
-        Map<Symbol, ColumnHandle> assignments = assignmentsBuilder.buildOrThrow();
+        Map<Symbol, ColumnHandle> tableScanAssignments = assignmentsBuilder.buildOrThrow();
 
-        // convert enforced constraint
-        io.trino.sql.planner.plan.JoinType joinType = joinNode.getType();
-        TupleDomain<ColumnHandle> leftConstraint = deriveConstraint(left.getEnforcedConstraint(), leftColumnHandlesMapping, joinType == RIGHT || joinType == FULL);
-        TupleDomain<ColumnHandle> rightConstraint = deriveConstraint(right.getEnforcedConstraint(), rightColumnHandlesMapping, joinType == LEFT || joinType == FULL);
+        TupleDomain<ColumnHandle> newEnforcedConstraint = calculateConstraint(
+                nodes,
+                leftColumnHandlesMapping,
+                rightColumnHandlesMapping);
 
-        TupleDomain<ColumnHandle> newEnforcedConstraint = TupleDomain.withColumnDomains(
-                ImmutableMap.<ColumnHandle, Domain>builder()
-                        // we are sure that domains map is present as we bailed out on isNone above
-                        .putAll(leftConstraint.getDomains().orElseThrow())
-                        .putAll(rightConstraint.getDomains().orElseThrow())
-                        .buildOrThrow());
+        Assignments projectAssignments = calculateProjectAssignments(nodes, tableScanAssignments);
 
         return Result.ofPlanNode(
                 new ProjectNode(
                         context.getIdAllocator().getNextId(),
                         new TableScanNode(
-                                joinNode.getId(),
-                                handle,
-                                ImmutableList.copyOf(assignments.keySet()),
-                                assignments,
+                                nodes.join().getId(),
+                                applyJoinResult.getTableHandle(),
+                                ImmutableList.copyOf(tableScanAssignments.keySet()),
+                                tableScanAssignments,
                                 newEnforcedConstraint,
-                                deriveTableStatisticsForPushdown(context.getStatsProvider(), context.getSession(), joinApplicationResult.get().isPrecalculateStatistics(), joinNode),
+                                deriveTableStatisticsForPushdown(
+                                        context.getStatsProvider(),
+                                        context.getSession(),
+                                        applyJoinResult.isPrecalculateStatistics(),
+                                        nodes.join()),
                                 false,
                                 Optional.empty()),
-                        Assignments.identity(joinNode.getOutputSymbols())));
+                        projectAssignments));
     }
 
     private JoinStatistics getJoinStatistics(JoinNode join, TableScanNode left, TableScanNode right, Context context)
@@ -230,7 +251,64 @@ public class PushJoinIntoTableScan
         };
     }
 
-    private TupleDomain<ColumnHandle> deriveConstraint(TupleDomain<ColumnHandle> constraint, Map<ColumnHandle, ColumnHandle> columnMapping, boolean nullable)
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isAllowPushdownIntoConnectors(session);
+    }
+
+    private record PlanNodes(JoinNode join, TableScanNode leftScan, TableScanNode rightScan, Optional<ProjectNode> leftProject, Optional<ProjectNode> rightProject)
+    {
+        public static PlanNodes create(Captures captures, JoinNode joinNode, ProjectSide projectSide)
+        {
+            return new PlanNodes(
+                    joinNode,
+                    captures.get(LEFT_TABLE_SCAN),
+                    captures.get(RIGHT_TABLE_SCAN),
+                    projectSide == ProjectSide.LEFT || projectSide == ProjectSide.BOTH ? Optional.of(captures.get(LEFT_PROJECT)) : Optional.empty(),
+                    projectSide == ProjectSide.RIGHT || projectSide == ProjectSide.BOTH ? Optional.of(captures.get(RIGHT_PROJECT)) : Optional.empty());
+        }
+    }
+
+    private static TupleDomain<ColumnHandle> calculateConstraint(
+            PlanNodes nodes,
+            Map<ColumnHandle, ColumnHandle> leftColumnHandlesMapping,
+            Map<ColumnHandle, ColumnHandle> rightColumnHandlesMapping)
+    {
+        JoinType joinType = nodes.join().getType();
+        TupleDomain<ColumnHandle> leftConstraint = deriveConstraint(nodes.leftScan().getEnforcedConstraint(), leftColumnHandlesMapping, joinType == RIGHT || joinType == FULL);
+        TupleDomain<ColumnHandle> rightConstraint = deriveConstraint(nodes.rightScan().getEnforcedConstraint(), rightColumnHandlesMapping, joinType == LEFT || joinType == FULL);
+        return TupleDomain.withColumnDomains(
+                ImmutableMap.<ColumnHandle, Domain>builder()
+                        .putAll(leftConstraint.getDomains().orElseThrow())
+                        .putAll(rightConstraint.getDomains().orElseThrow())
+                        .buildOrThrow());
+    }
+
+    private static Assignments calculateProjectAssignments(PlanNodes nodes, Map<Symbol, ColumnHandle> assignments)
+    {
+        Assignments.Builder builder = Assignments.builder();
+        nodes.join().getOutputSymbols().forEach(output -> {
+            if (assignments.containsKey(output)) {
+                builder.putIdentity(output);
+            }
+            else {
+                // look for missing output assignment in projections
+                Expression expression = findAssignment(output, nodes.leftProject())
+                        .or(() -> findAssignment(output, nodes.rightProject()))
+                        .orElseThrow(() -> new IllegalStateException("Output %s not found".formatted(output)));
+                builder.put(output, expression);
+            }
+        });
+        return builder.build();
+    }
+
+    private static Optional<Expression> findAssignment(Symbol output, Optional<ProjectNode> projectNode)
+    {
+        return projectNode.flatMap(node -> Optional.ofNullable(node.getAssignments().get(output)));
+    }
+
+    private static TupleDomain<ColumnHandle> deriveConstraint(TupleDomain<ColumnHandle> constraint, Map<ColumnHandle, ColumnHandle> columnMapping, boolean nullable)
     {
         if (nullable) {
             constraint = constraint.transformDomains((columnHandle, domain) -> domain.union(onlyNull(domain.getType())));
@@ -238,22 +316,41 @@ public class PushJoinIntoTableScan
         return constraint.transformKeys(columnMapping::get);
     }
 
-    public Expression getEffectiveFilter(JoinNode node)
+    private static Expression getJoinNodeEffectiveFilter(JoinNode node, Optional<ProjectNode> leftProject, Optional<ProjectNode> rightProject)
     {
-        Expression effectiveFilter = and(node.getCriteria().stream().map(JoinNode.EquiJoinClause::toExpression).collect(toImmutableList()));
+        List<Expression> equiJoinClausesExpressions = node.getCriteria().stream()
+                .map(equiJoinClause -> getExpression(equiJoinClause, leftProject, rightProject))
+                .collect(toImmutableList());
+
+        Expression joinCriteriaEffectiveFilter = and(equiJoinClausesExpressions);
         if (node.getFilter().isPresent()) {
-            effectiveFilter = and(effectiveFilter, node.getFilter().get());
+            return and(joinCriteriaEffectiveFilter, node.getFilter().get());
         }
-        return effectiveFilter;
+        return joinCriteriaEffectiveFilter;
     }
 
-    private JoinType getJoinType(JoinNode joinNode)
+    private static Expression getExpression(EquiJoinClause equiJoinClause, Optional<ProjectNode> leftProjectNode, Optional<ProjectNode> rightProjectNode)
+    {
+        Expression leftExpression = leftProjectNode.map(assignments -> assignments.getAssignments().get(Symbol.from(equiJoinClause.getLeft().toSymbolReference())))
+                .orElse(equiJoinClause.getLeft().toSymbolReference());
+        Expression rightExpression = rightProjectNode.map(assignments -> assignments.getAssignments().get(Symbol.from(equiJoinClause.getRight().toSymbolReference())))
+                .orElse(equiJoinClause.getRight().toSymbolReference());
+
+        return new Comparison(Operator.EQUAL, leftExpression, rightExpression);
+    }
+
+    private io.trino.spi.connector.JoinType getJoinType(JoinNode joinNode)
     {
         return switch (joinNode.getType()) {
-            case INNER -> JoinType.INNER;
-            case LEFT -> JoinType.LEFT_OUTER;
-            case RIGHT -> JoinType.RIGHT_OUTER;
-            case FULL -> JoinType.FULL_OUTER;
+            case INNER -> io.trino.spi.connector.JoinType.INNER;
+            case LEFT -> io.trino.spi.connector.JoinType.LEFT_OUTER;
+            case RIGHT -> io.trino.spi.connector.JoinType.RIGHT_OUTER;
+            case FULL -> io.trino.spi.connector.JoinType.FULL_OUTER;
         };
+    }
+
+    enum ProjectSide
+    {
+        LEFT, RIGHT, BOTH, NONE
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushJoinIntoTableScan.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushJoinIntoTableScan.java
@@ -18,7 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.connector.MockConnectorColumnHandle;
 import io.trino.connector.MockConnectorFactory;
-import io.trino.connector.MockConnectorFactory.ApplyJoinLegacy;
+import io.trino.connector.MockConnectorFactory.ApplyJoin;
 import io.trino.connector.MockConnectorTableHandle;
 import io.trino.metadata.ResolvedFunction;
 import io.trino.metadata.TableHandle;
@@ -29,20 +29,27 @@ import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.JoinApplicationResult;
-import io.trino.spi.connector.JoinCondition;
-import io.trino.spi.connector.JoinType;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.expression.Call;
+import io.trino.spi.expression.FunctionName;
 import io.trino.spi.expression.Variable;
-import io.trino.spi.function.OperatorType;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.NullableValue;
 import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.BooleanType;
+import io.trino.spi.type.VarcharType;
 import io.trino.sql.ir.Comparison;
-import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Comparison.Operator;
+import io.trino.sql.ir.Expression;
 import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.rule.PushJoinIntoTableScan.ProjectSide;
+import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
 import io.trino.sql.planner.iterative.rule.test.RuleTester;
+import io.trino.sql.planner.plan.Assignments;
 import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.JoinNode.EquiJoinClause;
+import io.trino.sql.planner.plan.JoinType;
+import io.trino.sql.planner.plan.ProjectNode;
 import io.trino.sql.planner.plan.TableScanNode;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -57,9 +64,11 @@ import java.util.stream.Stream;
 
 import static com.google.common.base.Predicates.equalTo;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.trino.spi.expression.StandardFunctions.MULTIPLY_FUNCTION_NAME;
+import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.predicate.Domain.onlyNull;
-import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static io.trino.sql.ir.Comparison.Operator.EQUAL;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
@@ -67,7 +76,6 @@ import static io.trino.sql.planner.plan.JoinType.FULL;
 import static io.trino.sql.planner.plan.JoinType.INNER;
 import static io.trino.sql.planner.plan.JoinType.LEFT;
 import static io.trino.sql.planner.plan.JoinType.RIGHT;
-import static io.trino.testing.TestingHandles.TEST_CATALOG_HANDLE;
 import static io.trino.testing.TestingHandles.TEST_CATALOG_NAME;
 import static io.trino.testing.TestingHandles.createTestCatalogHandle;
 import static io.trino.testing.TestingSession.testSessionBuilder;
@@ -76,35 +84,41 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestPushJoinIntoTableScan
 {
-    private static final TestingFunctionResolution FUNCTIONS = new TestingFunctionResolution();
-    private static final ResolvedFunction MULTIPLY_BIGINT = FUNCTIONS.resolveOperator(OperatorType.MULTIPLY, ImmutableList.of(BIGINT, BIGINT));
-
+    private static final VarcharType VARCHAR = createVarcharType(5);
     private static final String SCHEMA = "test_schema";
     private static final String TABLE_A = "test_table_a";
     private static final String TABLE_B = "test_table_b";
     private static final SchemaTableName TABLE_A_SCHEMA_TABLE_NAME = new SchemaTableName(SCHEMA, TABLE_A);
     private static final SchemaTableName TABLE_B_SCHEMA_TABLE_NAME = new SchemaTableName(SCHEMA, TABLE_B);
 
+    private static final TestingFunctionResolution FUNCTIONS = new TestingFunctionResolution();
+    private static final ResolvedFunction UPPER_VARCHAR = FUNCTIONS.resolveFunction("upper", fromTypes(VARCHAR));
+
     private static final Session MOCK_SESSION = testSessionBuilder()
             .setCatalog(TEST_CATALOG_NAME)
             .setSchema(SCHEMA)
             .build();
 
+    private static final String CALL_1 = "upper";
+    private static final String CALL_2 = "upper_0";
     private static final String COLUMN_A1 = "columna1";
-    public static final Variable COLUMN_A1_VARIABLE = new Variable(COLUMN_A1, BIGINT);
-    private static final ColumnHandle COLUMN_A1_HANDLE = new MockConnectorColumnHandle(COLUMN_A1, BIGINT);
+    public static final Variable COLUMN_A1_VARIABLE = new Variable(COLUMN_A1, VARCHAR);
+    private static final ColumnHandle COLUMN_A1_HANDLE = new MockConnectorColumnHandle(COLUMN_A1, VARCHAR);
     private static final String COLUMN_A2 = "columna2";
-    private static final ColumnHandle COLUMN_A2_HANDLE = new MockConnectorColumnHandle(COLUMN_A2, BIGINT);
+    private static final ColumnHandle COLUMN_A2_HANDLE = new MockConnectorColumnHandle(COLUMN_A2, VARCHAR);
     private static final String COLUMN_B1 = "columnb1";
-    public static final Variable COLUMN_B1_VARIABLE = new Variable(COLUMN_B1, BIGINT);
-    private static final ColumnHandle COLUMN_B1_HANDLE = new MockConnectorColumnHandle(COLUMN_B1, BIGINT);
+    public static final Variable COLUMN_B1_VARIABLE = new Variable(COLUMN_B1, VARCHAR);
+    private static final ColumnHandle COLUMN_B1_HANDLE = new MockConnectorColumnHandle(COLUMN_B1, VARCHAR);
+    private static final String COLUMN_B2 = "columnb2";
+    private static final ColumnHandle COLUMN_B2_HANDLE = new MockConnectorColumnHandle(COLUMN_B2, VARCHAR);
 
     private static final Map<String, ColumnHandle> TABLE_A_ASSIGNMENTS = ImmutableMap.of(
             COLUMN_A1, COLUMN_A1_HANDLE,
             COLUMN_A2, COLUMN_A2_HANDLE);
 
     private static final Map<String, ColumnHandle> TABLE_B_ASSIGNMENTS = ImmutableMap.of(
-            COLUMN_B1, COLUMN_B1_HANDLE);
+            COLUMN_B1, COLUMN_B1_HANDLE,
+            COLUMN_B2, COLUMN_B2_HANDLE);
 
     private static final List<ColumnMetadata> TABLE_A_COLUMN_METADATA = TABLE_A_ASSIGNMENTS.entrySet().stream()
             .map(entry -> new ColumnMetadata(entry.getKey(), ((MockConnectorColumnHandle) entry.getValue()).getType()))
@@ -116,34 +130,98 @@ public class TestPushJoinIntoTableScan
 
     public static final SchemaTableName JOIN_PUSHDOWN_SCHEMA_TABLE_NAME = new SchemaTableName(SCHEMA, "TABLE_A_JOINED_WITH_B");
 
-    public static final ColumnHandle JOIN_COLUMN_A1_HANDLE = new MockConnectorColumnHandle("join_" + COLUMN_A1, BIGINT);
-    public static final ColumnHandle JOIN_COLUMN_A2_HANDLE = new MockConnectorColumnHandle("join_" + COLUMN_A2, BIGINT);
-    public static final ColumnHandle JOIN_COLUMN_B1_HANDLE = new MockConnectorColumnHandle("join_" + COLUMN_B1, BIGINT);
+    public static final ColumnHandle JOIN_COLUMN_A1_HANDLE = new MockConnectorColumnHandle("join_" + COLUMN_A1, VARCHAR);
+    public static final ColumnHandle JOIN_COLUMN_A2_HANDLE = new MockConnectorColumnHandle("join_" + COLUMN_A2, VARCHAR);
+    public static final ColumnHandle JOIN_COLUMN_B1_HANDLE = new MockConnectorColumnHandle("join_" + COLUMN_B1, VARCHAR);
+    public static final ColumnHandle JOIN_COLUMN_B2_HANDLE = new MockConnectorColumnHandle("join_" + COLUMN_B2, VARCHAR);
 
     public static final MockConnectorTableHandle JOIN_CONNECTOR_TABLE_HANDLE = new MockConnectorTableHandle(
-            JOIN_PUSHDOWN_SCHEMA_TABLE_NAME, TupleDomain.none(), Optional.of(ImmutableList.of(JOIN_COLUMN_A1_HANDLE, JOIN_COLUMN_A2_HANDLE, JOIN_COLUMN_B1_HANDLE)));
+            JOIN_PUSHDOWN_SCHEMA_TABLE_NAME,
+            TupleDomain.none(),
+            Optional.of(ImmutableList.of(JOIN_COLUMN_A1_HANDLE, JOIN_COLUMN_A2_HANDLE, JOIN_COLUMN_B1_HANDLE, JOIN_COLUMN_B2_HANDLE)));
 
     public static final Map<ColumnHandle, ColumnHandle> JOIN_TABLE_A_COLUMN_MAPPING = ImmutableMap.of(
             COLUMN_A1_HANDLE, JOIN_COLUMN_A1_HANDLE,
             COLUMN_A2_HANDLE, JOIN_COLUMN_A2_HANDLE);
     public static final Map<ColumnHandle, ColumnHandle> JOIN_TABLE_B_COLUMN_MAPPING = ImmutableMap.of(
-            COLUMN_B1_HANDLE, JOIN_COLUMN_B1_HANDLE);
+            COLUMN_B1_HANDLE, JOIN_COLUMN_B1_HANDLE,
+            COLUMN_B2_HANDLE, JOIN_COLUMN_B2_HANDLE);
 
-    public static final List<ColumnMetadata> JOIN_TABLE_COLUMN_METADATA = JOIN_TABLE_A_COLUMN_MAPPING.entrySet().stream()
-            .map(entry -> new ColumnMetadata(((MockConnectorColumnHandle) entry.getValue()).getName(), ((MockConnectorColumnHandle) entry.getValue()).getType()))
+    public static final List<ColumnMetadata> JOIN_TABLE_COLUMN_METADATA = JOIN_TABLE_A_COLUMN_MAPPING.values().stream()
+            .map(columnHandle -> new ColumnMetadata(((MockConnectorColumnHandle) columnHandle).getName(), ((MockConnectorColumnHandle) columnHandle).getType()))
             .collect(toImmutableList());
 
     @ParameterizedTest
     @MethodSource("testPushJoinIntoTableScanParams")
-    public void testPushJoinIntoTableScan(io.trino.sql.planner.plan.JoinType joinType, Optional<Comparison.Operator> filterComparisonOperator)
+    public void testPushJoinIntoTableScanThroughProject(JoinType joinType, Optional<Operator> filterComparisonOperator, ProjectSide projectSide)
     {
         MockConnectorFactory connectorFactory = createMockConnectorFactory((session, applyJoinType, left, right, joinConditions, leftAssignments, rightAssignments) -> {
             assertThat(((MockConnectorTableHandle) left).getTableName()).isEqualTo(TABLE_A_SCHEMA_TABLE_NAME);
             assertThat(((MockConnectorTableHandle) right).getTableName()).isEqualTo(TABLE_B_SCHEMA_TABLE_NAME);
             assertThat(applyJoinType).isEqualTo(toSpiJoinType(joinType));
-            JoinCondition.Operator expectedOperator = filterComparisonOperator.map(this::getConditionOperator).orElse(JoinCondition.Operator.EQUAL);
-            assertThat(joinConditions).containsExactly(new JoinCondition(expectedOperator, COLUMN_A1_VARIABLE, COLUMN_B1_VARIABLE));
-
+            if (filterComparisonOperator.isEmpty()) {
+                assertThat(joinConditions).isEqualTo(new Call(
+                        BooleanType.BOOLEAN,
+                        new FunctionName("$equal"),
+                        switch (projectSide) {
+                            case LEFT -> ImmutableList.of(
+                                    new Call(VARCHAR, new FunctionName(CALL_1), ImmutableList.of(COLUMN_A1_VARIABLE)),
+                                    COLUMN_B1_VARIABLE);
+                            case RIGHT -> ImmutableList.of(
+                                    COLUMN_A1_VARIABLE,
+                                    new Call(VARCHAR, new FunctionName(CALL_1), ImmutableList.of(COLUMN_B1_VARIABLE)));
+                            case BOTH -> ImmutableList.of(
+                                    new Call(VARCHAR, new FunctionName(CALL_1), ImmutableList.of(COLUMN_A1_VARIABLE)),
+                                    new Call(VARCHAR, new FunctionName(CALL_1), ImmutableList.of(COLUMN_B1_VARIABLE)));
+                            case NONE -> ImmutableList.of(
+                                    COLUMN_A1_VARIABLE,
+                                    COLUMN_B1_VARIABLE);
+                        }));
+            }
+            else {
+                assertThat(joinConditions).isEqualTo(new Call(
+                        BooleanType.BOOLEAN,
+                        new FunctionName("$and"),
+                        ImmutableList.of(
+                                new Call(
+                                        BooleanType.BOOLEAN,
+                                        new FunctionName("$equal"),
+                                        switch (projectSide) {
+                                            case LEFT -> ImmutableList.of(
+                                                    new Call(
+                                                            VARCHAR,
+                                                            new FunctionName("upper"),
+                                                            ImmutableList.of(COLUMN_A1_VARIABLE)),
+                                                    COLUMN_B1_VARIABLE);
+                                            case RIGHT -> ImmutableList.of(
+                                                    COLUMN_A1_VARIABLE,
+                                                    new Call(
+                                                            VARCHAR,
+                                                            new FunctionName("upper"),
+                                                            ImmutableList.of(COLUMN_B1_VARIABLE)));
+                                            case BOTH -> ImmutableList.of(
+                                                    new Call(
+                                                            VARCHAR,
+                                                            new FunctionName("upper"),
+                                                            ImmutableList.of(COLUMN_A1_VARIABLE)),
+                                                    new Call(
+                                                            VARCHAR,
+                                                            new FunctionName("upper"),
+                                                            ImmutableList.of(COLUMN_B1_VARIABLE)));
+                                            case NONE -> ImmutableList.of(
+                                                    COLUMN_A1_VARIABLE,
+                                                    COLUMN_B1_VARIABLE);
+                                        }),
+                                new Call(
+                                        BooleanType.BOOLEAN,
+                                        filterComparisonOperator.map(this::toSpiFunctionName).orElse(new FunctionName("$equal")),
+                                        switch (projectSide) {
+                                            case LEFT -> ImmutableList.of(new Variable(CALL_1, VARCHAR), COLUMN_B1_VARIABLE);
+                                            case RIGHT -> ImmutableList.of(COLUMN_A1_VARIABLE, new Variable(CALL_1, VARCHAR));
+                                            case BOTH -> ImmutableList.of(new Variable(CALL_1, VARCHAR), new Variable(CALL_2, VARCHAR));
+                                            case NONE -> ImmutableList.of(COLUMN_A1_VARIABLE, COLUMN_B1_VARIABLE);
+                                        }))));
+            }
             return Optional.of(new JoinApplicationResult<>(
                     JOIN_CONNECTOR_TABLE_HANDLE,
                     JOIN_TABLE_A_COLUMN_MAPPING,
@@ -151,142 +229,274 @@ public class TestPushJoinIntoTableScan
                     false));
         });
         try (RuleTester ruleTester = RuleTester.builder().withDefaultCatalogConnectorFactory(connectorFactory).build()) {
-            ruleTester.assertThat(new PushJoinIntoTableScan(ruleTester.getPlannerContext()))
+            ruleTester.assertThat(new PushJoinIntoTableScan(ruleTester.getPlannerContext(), projectSide))
                     .withSession(MOCK_SESSION)
                     .on(p -> {
-                        Symbol columnA1Symbol = p.symbol(COLUMN_A1);
-                        Symbol columnA2Symbol = p.symbol(COLUMN_A2);
-                        Symbol columnB1Symbol = p.symbol(COLUMN_B1);
-                        TableScanNode left = p.tableScan(
+                        Symbol columnA1Symbol = p.symbol(COLUMN_A1, VARCHAR);
+                        Symbol columnA2Symbol = p.symbol(COLUMN_A2, VARCHAR);
+                        Symbol columnB1Symbol = p.symbol(COLUMN_B1, VARCHAR);
+                        Symbol columnB2Symbol = p.symbol(COLUMN_B2, VARCHAR);
+                        Symbol callSymbolA = p.symbol(CALL_1, VARCHAR);
+                        Symbol callSymbolB = p.symbol(projectSide.equals(ProjectSide.BOTH) ? CALL_2 : CALL_1, VARCHAR);
+                        TableScanNode leftScan = p.tableScan(
                                 ruleTester.getCurrentCatalogTableHandle(SCHEMA, TABLE_A),
                                 ImmutableList.of(columnA1Symbol, columnA2Symbol),
                                 ImmutableMap.of(
                                         columnA1Symbol, COLUMN_A1_HANDLE,
                                         columnA2Symbol, COLUMN_A2_HANDLE));
-                        TableScanNode right = p.tableScan(
+                        TableScanNode rightScan = p.tableScan(
                                 ruleTester.getCurrentCatalogTableHandle(SCHEMA, TABLE_B),
-                                ImmutableList.of(columnB1Symbol),
-                                ImmutableMap.of(columnB1Symbol, COLUMN_B1_HANDLE));
+                                ImmutableList.of(columnB1Symbol, columnB2Symbol),
+                                ImmutableMap.of(
+                                        columnB1Symbol, COLUMN_B1_HANDLE,
+                                        columnB2Symbol, COLUMN_B2_HANDLE));
+                        ProjectNode leftProject = p.project(
+                                Assignments.builder()
+                                        .putIdentity(columnA1Symbol)
+                                        .putIdentity(columnA2Symbol)
+                                        .put(callSymbolA, upperCall(ImmutableList.of(columnA1Symbol.toSymbolReference())))
+                                        .build(),
+                                leftScan);
+                        ProjectNode rightProject = p.project(
+                                Assignments.builder()
+                                        .putIdentity(columnB1Symbol)
+                                        .putIdentity(columnB2Symbol)
+                                        .put(callSymbolB, upperCall(ImmutableList.of(columnB1Symbol.toSymbolReference())))
+                                        .build(),
+                                rightScan);
 
                         if (filterComparisonOperator.isEmpty()) {
-                            return p.join(
-                                    joinType,
-                                    left,
-                                    right,
-                                    new JoinNode.EquiJoinClause(columnA1Symbol, columnB1Symbol));
+                            return switch (projectSide) {
+                                case LEFT -> p.join(
+                                        joinType,
+                                        leftProject,
+                                        rightScan,
+                                        ImmutableList.of(new EquiJoinClause(callSymbolA, columnB1Symbol)),
+                                        ImmutableList.of(columnA1Symbol, columnA2Symbol),
+                                        ImmutableList.of(columnB1Symbol, columnB2Symbol),
+                                        Optional.empty());
+                                case RIGHT -> p.join(
+                                        joinType,
+                                        leftScan,
+                                        rightProject,
+                                        ImmutableList.of(new EquiJoinClause(columnA1Symbol, callSymbolB)),
+                                        ImmutableList.of(columnA1Symbol, columnA2Symbol),
+                                        ImmutableList.of(columnB1Symbol, columnB2Symbol),
+                                        Optional.empty());
+                                case BOTH -> p.join(
+                                        joinType,
+                                        leftProject,
+                                        rightProject,
+                                        ImmutableList.of(new EquiJoinClause(callSymbolA, callSymbolB)),
+                                        ImmutableList.of(columnA1Symbol, columnA2Symbol),
+                                        ImmutableList.of(columnB1Symbol, columnB2Symbol),
+                                        Optional.empty());
+                                case NONE -> p.join(
+                                        joinType,
+                                        leftScan,
+                                        rightScan,
+                                        ImmutableList.of(new EquiJoinClause(columnA1Symbol, columnB1Symbol)),
+                                        ImmutableList.of(columnA1Symbol, columnA2Symbol),
+                                        ImmutableList.of(columnB1Symbol, columnB2Symbol),
+                                        Optional.empty());
+                            };
                         }
-                        return p.join(
-                                joinType,
-                                left,
-                                right,
-                                new Comparison(filterComparisonOperator.get(), columnA1Symbol.toSymbolReference(), columnB1Symbol.toSymbolReference()));
+                        return switch (projectSide) {
+                            case LEFT -> p.join(
+                                    joinType,
+                                    leftProject,
+                                    rightScan,
+                                    ImmutableList.of(new EquiJoinClause(callSymbolA, columnB1Symbol)),
+                                    ImmutableList.of(columnA1Symbol, columnA2Symbol),
+                                    ImmutableList.of(columnB1Symbol, columnB2Symbol),
+                                    Optional.of(new Comparison(filterComparisonOperator.get(), callSymbolA.toSymbolReference(), columnB1Symbol.toSymbolReference())));
+                            case RIGHT -> p.join(
+                                    joinType,
+                                    leftScan,
+                                    rightProject,
+                                    ImmutableList.of(new EquiJoinClause(columnA1Symbol, callSymbolB)),
+                                    ImmutableList.of(columnA1Symbol, columnA2Symbol),
+                                    ImmutableList.of(columnB1Symbol, columnB2Symbol),
+                                    Optional.of(new Comparison(filterComparisonOperator.get(), columnA1Symbol.toSymbolReference(), callSymbolB.toSymbolReference())));
+                            case BOTH -> p.join(
+                                    joinType,
+                                    leftProject,
+                                    rightProject,
+                                    ImmutableList.of(new EquiJoinClause(callSymbolA, callSymbolB)),
+                                    ImmutableList.of(columnA1Symbol, columnA2Symbol),
+                                    ImmutableList.of(columnB1Symbol, columnB2Symbol),
+                                    Optional.of(new Comparison(filterComparisonOperator.get(), callSymbolA.toSymbolReference(), callSymbolB.toSymbolReference())));
+                            case NONE -> p.join(
+                                    joinType,
+                                    leftScan,
+                                    rightScan,
+                                    ImmutableList.of(new EquiJoinClause(columnA1Symbol, columnB1Symbol)),
+                                    ImmutableList.of(columnA1Symbol, columnA2Symbol),
+                                    ImmutableList.of(columnB1Symbol, columnB2Symbol),
+                                    Optional.of(new Comparison(filterComparisonOperator.get(), columnA1Symbol.toSymbolReference(), columnB1Symbol.toSymbolReference())));
+                        };
                     })
                     .matches(
                             project(
                                     tableScan(JOIN_PUSHDOWN_SCHEMA_TABLE_NAME.getTableName())));
         }
+    }
+
+    private static io.trino.sql.ir.Call upperCall(ImmutableList<Expression> arguments)
+    {
+        return new io.trino.sql.ir.Call(UPPER_VARCHAR, arguments);
     }
 
     public static Stream<Arguments> testPushJoinIntoTableScanParams()
     {
         return Stream.of(
-                Arguments.of(INNER, Optional.empty()),
-                Arguments.of(INNER, Optional.of(Comparison.Operator.EQUAL)),
-                Arguments.of(INNER, Optional.of(Comparison.Operator.LESS_THAN)),
-                Arguments.of(INNER, Optional.of(Comparison.Operator.LESS_THAN_OR_EQUAL)),
-                Arguments.of(INNER, Optional.of(Comparison.Operator.GREATER_THAN)),
-                Arguments.of(INNER, Optional.of(Comparison.Operator.GREATER_THAN_OR_EQUAL)),
-                Arguments.of(INNER, Optional.of(Comparison.Operator.NOT_EQUAL)),
-                Arguments.of(INNER, Optional.of(Comparison.Operator.IDENTICAL)),
+                Arguments.of(INNER, Optional.empty(), ProjectSide.LEFT),
+                Arguments.of(INNER, Optional.of(EQUAL), ProjectSide.LEFT),
+                Arguments.of(INNER, Optional.of(Operator.LESS_THAN), ProjectSide.LEFT),
+                Arguments.of(INNER, Optional.of(Operator.LESS_THAN_OR_EQUAL), ProjectSide.LEFT),
+                Arguments.of(INNER, Optional.of(Operator.GREATER_THAN), ProjectSide.LEFT),
+                Arguments.of(INNER, Optional.of(Operator.GREATER_THAN_OR_EQUAL), ProjectSide.LEFT),
+                Arguments.of(INNER, Optional.of(Operator.NOT_EQUAL), ProjectSide.LEFT),
+                Arguments.of(INNER, Optional.of(Operator.IDENTICAL), ProjectSide.LEFT),
 
-                Arguments.of(io.trino.sql.planner.plan.JoinType.LEFT, Optional.empty()),
-                Arguments.of(io.trino.sql.planner.plan.JoinType.LEFT, Optional.of(Comparison.Operator.EQUAL)),
-                Arguments.of(io.trino.sql.planner.plan.JoinType.LEFT, Optional.of(Comparison.Operator.LESS_THAN)),
-                Arguments.of(io.trino.sql.planner.plan.JoinType.LEFT, Optional.of(Comparison.Operator.LESS_THAN_OR_EQUAL)),
-                Arguments.of(io.trino.sql.planner.plan.JoinType.LEFT, Optional.of(Comparison.Operator.GREATER_THAN)),
-                Arguments.of(io.trino.sql.planner.plan.JoinType.LEFT, Optional.of(Comparison.Operator.GREATER_THAN_OR_EQUAL)),
-                Arguments.of(io.trino.sql.planner.plan.JoinType.LEFT, Optional.of(Comparison.Operator.NOT_EQUAL)),
-                Arguments.of(io.trino.sql.planner.plan.JoinType.LEFT, Optional.of(Comparison.Operator.IDENTICAL)),
+                Arguments.of(LEFT, Optional.empty(), ProjectSide.LEFT),
+                Arguments.of(LEFT, Optional.of(EQUAL), ProjectSide.LEFT),
+                Arguments.of(LEFT, Optional.of(Operator.LESS_THAN), ProjectSide.LEFT),
+                Arguments.of(LEFT, Optional.of(Operator.LESS_THAN_OR_EQUAL), ProjectSide.LEFT),
+                Arguments.of(LEFT, Optional.of(Operator.GREATER_THAN), ProjectSide.LEFT),
+                Arguments.of(LEFT, Optional.of(Operator.GREATER_THAN_OR_EQUAL), ProjectSide.LEFT),
+                Arguments.of(LEFT, Optional.of(Operator.NOT_EQUAL), ProjectSide.LEFT),
+                Arguments.of(LEFT, Optional.of(Operator.IDENTICAL), ProjectSide.LEFT),
 
-                Arguments.of(io.trino.sql.planner.plan.JoinType.RIGHT, Optional.empty()),
-                Arguments.of(io.trino.sql.planner.plan.JoinType.RIGHT, Optional.of(Comparison.Operator.EQUAL)),
-                Arguments.of(io.trino.sql.planner.plan.JoinType.RIGHT, Optional.of(Comparison.Operator.LESS_THAN)),
-                Arguments.of(io.trino.sql.planner.plan.JoinType.RIGHT, Optional.of(Comparison.Operator.LESS_THAN_OR_EQUAL)),
-                Arguments.of(io.trino.sql.planner.plan.JoinType.RIGHT, Optional.of(Comparison.Operator.GREATER_THAN)),
-                Arguments.of(io.trino.sql.planner.plan.JoinType.RIGHT, Optional.of(Comparison.Operator.GREATER_THAN_OR_EQUAL)),
-                Arguments.of(io.trino.sql.planner.plan.JoinType.RIGHT, Optional.of(Comparison.Operator.NOT_EQUAL)),
-                Arguments.of(io.trino.sql.planner.plan.JoinType.RIGHT, Optional.of(Comparison.Operator.IDENTICAL)),
+                Arguments.of(RIGHT, Optional.empty(), ProjectSide.LEFT),
+                Arguments.of(RIGHT, Optional.of(EQUAL), ProjectSide.LEFT),
+                Arguments.of(RIGHT, Optional.of(Operator.LESS_THAN), ProjectSide.LEFT),
+                Arguments.of(RIGHT, Optional.of(Operator.LESS_THAN_OR_EQUAL), ProjectSide.LEFT),
+                Arguments.of(RIGHT, Optional.of(Operator.GREATER_THAN), ProjectSide.LEFT),
+                Arguments.of(RIGHT, Optional.of(Operator.GREATER_THAN_OR_EQUAL), ProjectSide.LEFT),
+                Arguments.of(RIGHT, Optional.of(Operator.NOT_EQUAL), ProjectSide.LEFT),
+                Arguments.of(RIGHT, Optional.of(Operator.IDENTICAL), ProjectSide.LEFT),
 
-                Arguments.of(io.trino.sql.planner.plan.JoinType.FULL, Optional.empty()),
-                Arguments.of(io.trino.sql.planner.plan.JoinType.FULL, Optional.of(Comparison.Operator.EQUAL)),
-                Arguments.of(io.trino.sql.planner.plan.JoinType.FULL, Optional.of(Comparison.Operator.LESS_THAN)),
-                Arguments.of(io.trino.sql.planner.plan.JoinType.FULL, Optional.of(Comparison.Operator.LESS_THAN_OR_EQUAL)),
-                Arguments.of(io.trino.sql.planner.plan.JoinType.FULL, Optional.of(Comparison.Operator.GREATER_THAN)),
-                Arguments.of(io.trino.sql.planner.plan.JoinType.FULL, Optional.of(Comparison.Operator.GREATER_THAN_OR_EQUAL)),
-                Arguments.of(io.trino.sql.planner.plan.JoinType.FULL, Optional.of(Comparison.Operator.NOT_EQUAL)),
-                Arguments.of(io.trino.sql.planner.plan.JoinType.FULL, Optional.of(Comparison.Operator.IDENTICAL)));
+                Arguments.of(FULL, Optional.empty(), ProjectSide.LEFT),
+                Arguments.of(FULL, Optional.of(EQUAL), ProjectSide.LEFT),
+                Arguments.of(FULL, Optional.of(Operator.LESS_THAN), ProjectSide.LEFT),
+                Arguments.of(FULL, Optional.of(Operator.LESS_THAN_OR_EQUAL), ProjectSide.LEFT),
+                Arguments.of(FULL, Optional.of(Operator.GREATER_THAN), ProjectSide.LEFT),
+                Arguments.of(FULL, Optional.of(Operator.GREATER_THAN_OR_EQUAL), ProjectSide.LEFT),
+                Arguments.of(FULL, Optional.of(Operator.NOT_EQUAL), ProjectSide.LEFT),
+                Arguments.of(FULL, Optional.of(Operator.IDENTICAL), ProjectSide.LEFT),
+
+                Arguments.of(INNER, Optional.empty(), ProjectSide.RIGHT),
+                Arguments.of(INNER, Optional.of(EQUAL), ProjectSide.RIGHT),
+                Arguments.of(INNER, Optional.of(Operator.LESS_THAN), ProjectSide.RIGHT),
+                Arguments.of(INNER, Optional.of(Operator.LESS_THAN_OR_EQUAL), ProjectSide.RIGHT),
+                Arguments.of(INNER, Optional.of(Operator.GREATER_THAN), ProjectSide.RIGHT),
+                Arguments.of(INNER, Optional.of(Operator.GREATER_THAN_OR_EQUAL), ProjectSide.RIGHT),
+                Arguments.of(INNER, Optional.of(Operator.NOT_EQUAL), ProjectSide.RIGHT),
+                Arguments.of(INNER, Optional.of(Operator.IDENTICAL), ProjectSide.RIGHT),
+
+                Arguments.of(LEFT, Optional.empty(), ProjectSide.RIGHT),
+                Arguments.of(LEFT, Optional.of(EQUAL), ProjectSide.RIGHT),
+                Arguments.of(LEFT, Optional.of(Operator.LESS_THAN), ProjectSide.RIGHT),
+                Arguments.of(LEFT, Optional.of(Operator.LESS_THAN_OR_EQUAL), ProjectSide.RIGHT),
+                Arguments.of(LEFT, Optional.of(Operator.GREATER_THAN), ProjectSide.RIGHT),
+                Arguments.of(LEFT, Optional.of(Operator.GREATER_THAN_OR_EQUAL), ProjectSide.RIGHT),
+                Arguments.of(LEFT, Optional.of(Operator.NOT_EQUAL), ProjectSide.RIGHT),
+                Arguments.of(LEFT, Optional.of(Operator.IDENTICAL), ProjectSide.RIGHT),
+
+                Arguments.of(RIGHT, Optional.empty(), ProjectSide.RIGHT),
+                Arguments.of(RIGHT, Optional.of(EQUAL), ProjectSide.RIGHT),
+                Arguments.of(RIGHT, Optional.of(Operator.LESS_THAN), ProjectSide.RIGHT),
+                Arguments.of(RIGHT, Optional.of(Operator.LESS_THAN_OR_EQUAL), ProjectSide.RIGHT),
+                Arguments.of(RIGHT, Optional.of(Operator.GREATER_THAN), ProjectSide.RIGHT),
+                Arguments.of(RIGHT, Optional.of(Operator.GREATER_THAN_OR_EQUAL), ProjectSide.RIGHT),
+                Arguments.of(RIGHT, Optional.of(Operator.NOT_EQUAL), ProjectSide.RIGHT),
+                Arguments.of(RIGHT, Optional.of(Operator.IDENTICAL), ProjectSide.RIGHT),
+
+                Arguments.of(FULL, Optional.empty(), ProjectSide.RIGHT),
+                Arguments.of(FULL, Optional.of(EQUAL), ProjectSide.RIGHT),
+                Arguments.of(FULL, Optional.of(Operator.LESS_THAN), ProjectSide.RIGHT),
+                Arguments.of(FULL, Optional.of(Operator.LESS_THAN_OR_EQUAL), ProjectSide.RIGHT),
+                Arguments.of(FULL, Optional.of(Operator.GREATER_THAN), ProjectSide.RIGHT),
+                Arguments.of(FULL, Optional.of(Operator.GREATER_THAN_OR_EQUAL), ProjectSide.RIGHT),
+                Arguments.of(FULL, Optional.of(Operator.NOT_EQUAL), ProjectSide.RIGHT),
+                Arguments.of(FULL, Optional.of(Operator.IDENTICAL), ProjectSide.RIGHT),
+
+                Arguments.of(INNER, Optional.empty(), ProjectSide.BOTH),
+                Arguments.of(INNER, Optional.of(EQUAL), ProjectSide.BOTH),
+                Arguments.of(INNER, Optional.of(Operator.LESS_THAN), ProjectSide.BOTH),
+                Arguments.of(INNER, Optional.of(Operator.LESS_THAN_OR_EQUAL), ProjectSide.BOTH),
+                Arguments.of(INNER, Optional.of(Operator.GREATER_THAN), ProjectSide.BOTH),
+                Arguments.of(INNER, Optional.of(Operator.GREATER_THAN_OR_EQUAL), ProjectSide.BOTH),
+                Arguments.of(INNER, Optional.of(Operator.NOT_EQUAL), ProjectSide.BOTH),
+                Arguments.of(INNER, Optional.of(Operator.IDENTICAL), ProjectSide.BOTH),
+
+                Arguments.of(LEFT, Optional.empty(), ProjectSide.BOTH),
+                Arguments.of(LEFT, Optional.of(EQUAL), ProjectSide.BOTH),
+                Arguments.of(LEFT, Optional.of(Operator.LESS_THAN), ProjectSide.BOTH),
+                Arguments.of(LEFT, Optional.of(Operator.LESS_THAN_OR_EQUAL), ProjectSide.BOTH),
+                Arguments.of(LEFT, Optional.of(Operator.GREATER_THAN), ProjectSide.BOTH),
+                Arguments.of(LEFT, Optional.of(Operator.GREATER_THAN_OR_EQUAL), ProjectSide.BOTH),
+                Arguments.of(LEFT, Optional.of(Operator.NOT_EQUAL), ProjectSide.BOTH),
+                Arguments.of(LEFT, Optional.of(Operator.IDENTICAL), ProjectSide.BOTH),
+
+                Arguments.of(RIGHT, Optional.empty(), ProjectSide.BOTH),
+                Arguments.of(RIGHT, Optional.of(EQUAL), ProjectSide.BOTH),
+                Arguments.of(RIGHT, Optional.of(Operator.LESS_THAN), ProjectSide.BOTH),
+                Arguments.of(RIGHT, Optional.of(Operator.LESS_THAN_OR_EQUAL), ProjectSide.BOTH),
+                Arguments.of(RIGHT, Optional.of(Operator.GREATER_THAN), ProjectSide.BOTH),
+                Arguments.of(RIGHT, Optional.of(Operator.GREATER_THAN_OR_EQUAL), ProjectSide.BOTH),
+                Arguments.of(RIGHT, Optional.of(Operator.NOT_EQUAL), ProjectSide.BOTH),
+                Arguments.of(RIGHT, Optional.of(Operator.IDENTICAL), ProjectSide.BOTH),
+
+                Arguments.of(FULL, Optional.empty(), ProjectSide.BOTH),
+                Arguments.of(FULL, Optional.of(EQUAL), ProjectSide.BOTH),
+                Arguments.of(FULL, Optional.of(Operator.LESS_THAN), ProjectSide.BOTH),
+                Arguments.of(FULL, Optional.of(Operator.LESS_THAN_OR_EQUAL), ProjectSide.BOTH),
+                Arguments.of(FULL, Optional.of(Operator.GREATER_THAN), ProjectSide.BOTH),
+                Arguments.of(FULL, Optional.of(Operator.GREATER_THAN_OR_EQUAL), ProjectSide.BOTH),
+                Arguments.of(FULL, Optional.of(Operator.NOT_EQUAL), ProjectSide.BOTH),
+                Arguments.of(FULL, Optional.of(Operator.IDENTICAL), ProjectSide.BOTH),
+
+                Arguments.of(INNER, Optional.empty(), ProjectSide.NONE),
+                Arguments.of(INNER, Optional.of(EQUAL), ProjectSide.NONE),
+                Arguments.of(INNER, Optional.of(Operator.LESS_THAN), ProjectSide.NONE),
+                Arguments.of(INNER, Optional.of(Operator.LESS_THAN_OR_EQUAL), ProjectSide.NONE),
+                Arguments.of(INNER, Optional.of(Operator.GREATER_THAN), ProjectSide.NONE),
+                Arguments.of(INNER, Optional.of(Operator.GREATER_THAN_OR_EQUAL), ProjectSide.NONE),
+                Arguments.of(INNER, Optional.of(Operator.NOT_EQUAL), ProjectSide.NONE),
+                Arguments.of(INNER, Optional.of(Operator.IDENTICAL), ProjectSide.NONE),
+
+                Arguments.of(LEFT, Optional.empty(), ProjectSide.NONE),
+                Arguments.of(LEFT, Optional.of(EQUAL), ProjectSide.NONE),
+                Arguments.of(LEFT, Optional.of(Operator.LESS_THAN), ProjectSide.NONE),
+                Arguments.of(LEFT, Optional.of(Operator.LESS_THAN_OR_EQUAL), ProjectSide.NONE),
+                Arguments.of(LEFT, Optional.of(Operator.GREATER_THAN), ProjectSide.NONE),
+                Arguments.of(LEFT, Optional.of(Operator.GREATER_THAN_OR_EQUAL), ProjectSide.NONE),
+                Arguments.of(LEFT, Optional.of(Operator.NOT_EQUAL), ProjectSide.NONE),
+                Arguments.of(LEFT, Optional.of(Operator.IDENTICAL), ProjectSide.NONE),
+
+                Arguments.of(RIGHT, Optional.empty(), ProjectSide.NONE),
+                Arguments.of(RIGHT, Optional.of(EQUAL), ProjectSide.NONE),
+                Arguments.of(RIGHT, Optional.of(Operator.LESS_THAN), ProjectSide.NONE),
+                Arguments.of(RIGHT, Optional.of(Operator.LESS_THAN_OR_EQUAL), ProjectSide.NONE),
+                Arguments.of(RIGHT, Optional.of(Operator.GREATER_THAN), ProjectSide.NONE),
+                Arguments.of(RIGHT, Optional.of(Operator.GREATER_THAN_OR_EQUAL), ProjectSide.NONE),
+                Arguments.of(RIGHT, Optional.of(Operator.NOT_EQUAL), ProjectSide.NONE),
+                Arguments.of(RIGHT, Optional.of(Operator.IDENTICAL), ProjectSide.NONE),
+
+                Arguments.of(FULL, Optional.empty(), ProjectSide.NONE),
+                Arguments.of(FULL, Optional.of(EQUAL), ProjectSide.NONE),
+                Arguments.of(FULL, Optional.of(Operator.LESS_THAN), ProjectSide.NONE),
+                Arguments.of(FULL, Optional.of(Operator.LESS_THAN_OR_EQUAL), ProjectSide.NONE),
+                Arguments.of(FULL, Optional.of(Operator.GREATER_THAN), ProjectSide.NONE),
+                Arguments.of(FULL, Optional.of(Operator.GREATER_THAN_OR_EQUAL), ProjectSide.NONE),
+                Arguments.of(FULL, Optional.of(Operator.NOT_EQUAL), ProjectSide.NONE),
+                Arguments.of(FULL, Optional.of(Operator.IDENTICAL), ProjectSide.NONE));
     }
 
-    /**
-     * Test a scenario where join condition cannot be represented with simple comparisons.
-     */
     @Test
-    public void testPushJoinIntoTableScanWithComplexFilter()
-    {
-        MockConnectorFactory connectorFactory = createMockConnectorFactory(
-                (session, applyJoinType, left, right, joinConditions, leftAssignments, rightAssignments) -> {
-                    assertThat(joinConditions).as("joinConditions")
-                            .isEqualTo(List.of(
-                                    new JoinCondition(
-                                            JoinCondition.Operator.GREATER_THAN,
-                                            new Call(
-                                                    BIGINT,
-                                                    MULTIPLY_FUNCTION_NAME,
-                                                    List.of(
-                                                            new io.trino.spi.expression.Constant(44L, BIGINT),
-                                                            new Variable("columna1", BIGINT))),
-                                            new Variable("columnb1", BIGINT))));
-                    return Optional.of(new JoinApplicationResult<>(
-                            JOIN_CONNECTOR_TABLE_HANDLE,
-                            JOIN_TABLE_A_COLUMN_MAPPING,
-                            JOIN_TABLE_B_COLUMN_MAPPING,
-                            false));
-                });
-        try (RuleTester ruleTester = RuleTester.builder().withDefaultCatalogConnectorFactory(connectorFactory).build()) {
-            ruleTester.assertThat(new PushJoinIntoTableScan(ruleTester.getPlannerContext()))
-                    .withSession(MOCK_SESSION)
-                    .on(p -> {
-                        Symbol columnA1Symbol = p.symbol(COLUMN_A1);
-                        Symbol columnA2Symbol = p.symbol(COLUMN_A2);
-                        Symbol columnB1Symbol = p.symbol(COLUMN_B1);
-                        TableScanNode left = p.tableScan(
-                                ruleTester.getCurrentCatalogTableHandle(SCHEMA, TABLE_A),
-                                ImmutableList.of(columnA1Symbol, columnA2Symbol),
-                                ImmutableMap.of(
-                                        columnA1Symbol, COLUMN_A1_HANDLE,
-                                        columnA2Symbol, COLUMN_A2_HANDLE));
-                        TableScanNode right = p.tableScan(
-                                ruleTester.getCurrentCatalogTableHandle(SCHEMA, TABLE_B),
-                                ImmutableList.of(columnB1Symbol),
-                                ImmutableMap.of(columnB1Symbol, COLUMN_B1_HANDLE));
-
-                        return p.join(
-                                INNER,
-                                left,
-                                right,
-                                new Comparison(
-                                        Comparison.Operator.GREATER_THAN,
-                                        new io.trino.sql.ir.Call(MULTIPLY_BIGINT, ImmutableList.of(new Constant(BIGINT, 44L), columnA1Symbol.toSymbolReference())),
-                                        columnB1Symbol.toSymbolReference()));
-                    })
-                    .matches(
-                            project(
-                                    tableScan(JOIN_PUSHDOWN_SCHEMA_TABLE_NAME.getTableName())));
-        }
-    }
-
-    @Test
-    public void testPushJoinIntoTableScanDoesNotFireForDifferentCatalogs()
+    public void testDoesNotFireForDifferentCatalogs()
     {
         MockConnectorFactory connectorFactory = createMockConnectorFactory(
                 (session, applyJoinType, left, right, joinConditions, leftAssignments, rightAssignments) -> {
@@ -294,37 +504,48 @@ public class TestPushJoinIntoTableScan
                 });
         try (RuleTester ruleTester = RuleTester.builder().withDefaultCatalogConnectorFactory(connectorFactory).build()) {
             ruleTester.getPlanTester().createCatalog("another_catalog", "mock", ImmutableMap.of());
-            TableHandle tableBHandleAnotherCatalog = createTableHandle(new MockConnectorTableHandle(new SchemaTableName(SCHEMA, TABLE_B)), createTestCatalogHandle("another_catalog"));
+            TableHandle tableBHandleAnotherCatalog = createTableHandle(
+                    new MockConnectorTableHandle(new SchemaTableName(SCHEMA, TABLE_B)),
+                    createTestCatalogHandle("another_catalog"));
 
-            ruleTester.assertThat(new PushJoinIntoTableScan(ruleTester.getPlannerContext()))
+            ruleTester.assertThat(new PushJoinIntoTableScan(ruleTester.getPlannerContext(), ProjectSide.LEFT))
                     .withSession(MOCK_SESSION)
                     .on(p -> {
-                        Symbol columnA1Symbol = p.symbol(COLUMN_A1);
-                        Symbol columnA2Symbol = p.symbol(COLUMN_A2);
-                        Symbol columnB1Symbol = p.symbol(COLUMN_B1);
-                        TableScanNode left = p.tableScan(
+                        Symbol columnA1Symbol = p.symbol(COLUMN_A1, VARCHAR);
+                        Symbol columnA2Symbol = p.symbol(COLUMN_A2, VARCHAR);
+                        Symbol columnB1Symbol = p.symbol(COLUMN_B1, VARCHAR);
+                        Symbol callSymbolA = p.symbol(CALL_1, VARCHAR);
+
+                        TableScanNode leftScan = p.tableScan(
                                 ruleTester.getCurrentCatalogTableHandle(SCHEMA, TABLE_A),
                                 ImmutableList.of(columnA1Symbol, columnA2Symbol),
                                 ImmutableMap.of(
                                         columnA1Symbol, COLUMN_A1_HANDLE,
                                         columnA2Symbol, COLUMN_A2_HANDLE));
-                        TableScanNode right = p.tableScan(
+                        TableScanNode rightScan = p.tableScan(
                                 tableBHandleAnotherCatalog,
                                 ImmutableList.of(columnB1Symbol),
                                 ImmutableMap.of(columnB1Symbol, COLUMN_B1_HANDLE));
 
+                        ProjectNode leftProject = p.project(
+                                Assignments.builder()
+                                        .putIdentity(columnB1Symbol)
+                                        .put(callSymbolA, upperCall(ImmutableList.of(columnA1Symbol.toSymbolReference())))
+                                        .build(),
+                                leftScan);
+
                         return p.join(
                                 INNER,
-                                left,
-                                right,
-                                new JoinNode.EquiJoinClause(columnA1Symbol, columnB1Symbol));
+                                leftProject,
+                                rightScan,
+                                new EquiJoinClause(callSymbolA, columnB1Symbol));
                     })
                     .doesNotFire();
         }
     }
 
     @Test
-    public void testPushJoinIntoTableScanDoesNotFireWhenDisabled()
+    public void testDoesNotFireWhenDisabled()
     {
         Session joinPushDownDisabledSession = Session.builder(MOCK_SESSION)
                 .setSystemProperty("allow_pushdown_into_connectors", "false")
@@ -335,35 +556,58 @@ public class TestPushJoinIntoTableScan
                     throw new IllegalStateException("applyJoin should not be called!");
                 });
         try (RuleTester ruleTester = RuleTester.builder().withDefaultCatalogConnectorFactory(connectorFactory).build()) {
-            ruleTester.assertThat(new PushJoinIntoTableScan(ruleTester.getPlannerContext()))
+            ruleTester.assertThat(new PushJoinIntoTableScan(ruleTester.getPlannerContext(), ProjectSide.LEFT))
                     .withSession(joinPushDownDisabledSession)
-                    .on(p -> {
-                        Symbol columnA1Symbol = p.symbol(COLUMN_A1);
-                        Symbol columnA2Symbol = p.symbol(COLUMN_A2);
-                        Symbol columnB1Symbol = p.symbol(COLUMN_B1);
-                        TableScanNode left = p.tableScan(
-                                ruleTester.getCurrentCatalogTableHandle(SCHEMA, TABLE_A),
-                                ImmutableList.of(columnA1Symbol, columnA2Symbol),
-                                ImmutableMap.of(
-                                        columnA1Symbol, COLUMN_A1_HANDLE,
-                                        columnA2Symbol, COLUMN_A2_HANDLE));
-                        TableScanNode right = p.tableScan(
-                                ruleTester.getCurrentCatalogTableHandle(SCHEMA, TABLE_B),
-                                ImmutableList.of(columnB1Symbol),
-                                ImmutableMap.of(columnB1Symbol, COLUMN_B1_HANDLE));
-
-                        return p.join(
-                                INNER,
-                                left,
-                                right,
-                                new JoinNode.EquiJoinClause(columnA1Symbol, columnB1Symbol));
-                    })
+                    .on(p -> genericJoinLeftProject(p, ruleTester))
                     .doesNotFire();
         }
     }
 
+    private static JoinNode genericJoinLeftProject(PlanBuilder planBuilder, RuleTester ruleTester)
+    {
+        return genericJoinLeftProject(planBuilder, ruleTester, INNER, TupleDomain.all(), TupleDomain.all());
+    }
+
+    private static JoinNode genericJoinLeftProject(
+            PlanBuilder planBuilder,
+            RuleTester ruleTester,
+            JoinType joinType,
+            TupleDomain<ColumnHandle> leftConstraint,
+            TupleDomain<ColumnHandle> rightConstraint)
+    {
+        Symbol columnA1Symbol = planBuilder.symbol(COLUMN_A1, VARCHAR);
+        Symbol columnA2Symbol = planBuilder.symbol(COLUMN_A2, VARCHAR);
+        Symbol columnB1Symbol = planBuilder.symbol(COLUMN_B1, VARCHAR);
+        Symbol callSymbolA = planBuilder.symbol(CALL_1, VARCHAR);
+
+        TableScanNode leftScan = planBuilder.tableScan(
+                ruleTester.getCurrentCatalogTableHandle(SCHEMA, TABLE_A),
+                ImmutableList.of(columnA1Symbol, columnA2Symbol),
+                ImmutableMap.of(
+                        columnA1Symbol, COLUMN_A1_HANDLE,
+                        columnA2Symbol, COLUMN_A2_HANDLE),
+                leftConstraint);
+        TableScanNode rightScan = planBuilder.tableScan(
+                ruleTester.getCurrentCatalogTableHandle(SCHEMA, TABLE_B),
+                ImmutableList.of(columnB1Symbol),
+                ImmutableMap.of(columnB1Symbol, COLUMN_B1_HANDLE),
+                rightConstraint);
+        ProjectNode leftProject = planBuilder.project(
+                Assignments.builder()
+                        .putIdentity(columnB1Symbol)
+                        .put(callSymbolA, upperCall(ImmutableList.of(columnA1Symbol.toSymbolReference())))
+                        .build(),
+                leftScan);
+
+        return planBuilder.join(
+                joinType,
+                leftProject,
+                rightScan,
+                new EquiJoinClause(callSymbolA, columnB1Symbol));
+    }
+
     @Test
-    public void testPushJoinIntoTableScanDoesNotFireWhenAllPushdownsDisabled()
+    public void testDoesNotFireWhenAllPushdownsDisabled()
     {
         Session allPushdownsDisabledSession = Session.builder(MOCK_SESSION)
                 .setSystemProperty("allow_pushdown_into_connectors", "false")
@@ -374,69 +618,31 @@ public class TestPushJoinIntoTableScan
                     throw new IllegalStateException("applyJoin should not be called!");
                 });
         try (RuleTester ruleTester = RuleTester.builder().withDefaultCatalogConnectorFactory(connectorFactory).build()) {
-            ruleTester.assertThat(new PushJoinIntoTableScan(ruleTester.getPlannerContext()))
+            ruleTester.assertThat(new PushJoinIntoTableScan(ruleTester.getPlannerContext(), ProjectSide.LEFT))
                     .withSession(allPushdownsDisabledSession)
-                    .on(p -> {
-                        Symbol columnA1Symbol = p.symbol(COLUMN_A1);
-                        Symbol columnA2Symbol = p.symbol(COLUMN_A2);
-                        Symbol columnB1Symbol = p.symbol(COLUMN_B1);
-                        TableScanNode left = p.tableScan(
-                                ruleTester.getCurrentCatalogTableHandle(SCHEMA, TABLE_A),
-                                ImmutableList.of(columnA1Symbol, columnA2Symbol),
-                                ImmutableMap.of(
-                                        columnA1Symbol, COLUMN_A1_HANDLE,
-                                        columnA2Symbol, COLUMN_A2_HANDLE));
-                        TableScanNode right = p.tableScan(
-                                ruleTester.getCurrentCatalogTableHandle(SCHEMA, TABLE_B),
-                                ImmutableList.of(columnB1Symbol),
-                                ImmutableMap.of(columnB1Symbol, COLUMN_B1_HANDLE));
-
-                        return p.join(
-                                INNER,
-                                left,
-                                right,
-                                new JoinNode.EquiJoinClause(columnA1Symbol, columnB1Symbol));
-                    })
+                    .on(p -> genericJoinLeftProject(p, ruleTester))
                     .doesNotFire();
         }
     }
 
     @ParameterizedTest
-    @MethodSource("testPushJoinIntoTableScanPreservesEnforcedConstraintParams")
-    public void testPushJoinIntoTableScanPreservesEnforcedConstraint(io.trino.sql.planner.plan.JoinType joinType, TupleDomain<ColumnHandle> leftConstraint, TupleDomain<ColumnHandle> rightConstraint, TupleDomain<Predicate<ColumnHandle>> expectedConstraint)
+    @MethodSource("testPreservesEnforcedConstraintParams")
+    public void testPreservesEnforcedConstraint(
+            JoinType joinType,
+            TupleDomain<ColumnHandle> leftConstraint,
+            TupleDomain<ColumnHandle> rightConstraint,
+            TupleDomain<Predicate<ColumnHandle>> expectedConstraint)
     {
-        MockConnectorFactory connectorFactory = createMockConnectorFactory((session, applyJoinType, left, right, joinConditions, leftAssignments, rightAssignments) -> Optional.of(new JoinApplicationResult<>(
-                JOIN_CONNECTOR_TABLE_HANDLE,
-                JOIN_TABLE_A_COLUMN_MAPPING,
-                JOIN_TABLE_B_COLUMN_MAPPING,
-                false)));
+        MockConnectorFactory connectorFactory = createMockConnectorFactory((session, applyJoinType, left, right, joinConditions, leftAssignments, rightAssignments) -> Optional.of(
+                new JoinApplicationResult<>(
+                        JOIN_CONNECTOR_TABLE_HANDLE,
+                        JOIN_TABLE_A_COLUMN_MAPPING,
+                        JOIN_TABLE_B_COLUMN_MAPPING,
+                        false)));
         try (RuleTester ruleTester = RuleTester.builder().withDefaultCatalogConnectorFactory(connectorFactory).build()) {
-            ruleTester.assertThat(new PushJoinIntoTableScan(ruleTester.getPlannerContext()))
+            ruleTester.assertThat(new PushJoinIntoTableScan(ruleTester.getPlannerContext(), ProjectSide.LEFT))
                     .withSession(MOCK_SESSION)
-                    .on(p -> {
-                        Symbol columnA1Symbol = p.symbol(COLUMN_A1);
-                        Symbol columnA2Symbol = p.symbol(COLUMN_A2);
-                        Symbol columnB1Symbol = p.symbol(COLUMN_B1);
-
-                        TableScanNode left = p.tableScan(
-                                ruleTester.getCurrentCatalogTableHandle(SCHEMA, TABLE_A),
-                                ImmutableList.of(columnA1Symbol, columnA2Symbol),
-                                ImmutableMap.of(
-                                        columnA1Symbol, COLUMN_A1_HANDLE,
-                                        columnA2Symbol, COLUMN_A2_HANDLE),
-                                leftConstraint);
-                        TableScanNode right = p.tableScan(
-                                ruleTester.getCurrentCatalogTableHandle(SCHEMA, TABLE_B),
-                                ImmutableList.of(columnB1Symbol),
-                                ImmutableMap.of(columnB1Symbol, COLUMN_B1_HANDLE),
-                                rightConstraint);
-
-                        return p.join(
-                                joinType,
-                                left,
-                                right,
-                                new JoinNode.EquiJoinClause(columnA1Symbol, columnB1Symbol));
-                    })
+                    .on(p -> genericJoinLeftProject(p, ruleTester, joinType, leftConstraint, rightConstraint))
                     .matches(
                             project(
                                     tableScan(
@@ -446,11 +652,11 @@ public class TestPushJoinIntoTableScan
         }
     }
 
-    public static Stream<Arguments> testPushJoinIntoTableScanPreservesEnforcedConstraintParams()
+    public static Stream<Arguments> testPreservesEnforcedConstraintParams()
     {
-        Domain columnA1Domain = Domain.multipleValues(BIGINT, List.of(3L));
-        Domain columnA2Domain = Domain.multipleValues(BIGINT, List.of(10L, 20L));
-        Domain columnB1Domain = Domain.multipleValues(BIGINT, List.of(30L, 40L));
+        Domain columnA1Domain = Domain.multipleValues(VARCHAR, List.of(utf8Slice("3L")));
+        Domain columnA2Domain = Domain.multipleValues(VARCHAR, List.of(utf8Slice("10L"), utf8Slice("20L")));
+        Domain columnB1Domain = Domain.multipleValues(VARCHAR, List.of(utf8Slice("30L"), utf8Slice("40L")));
         return Stream.of(
                 Arguments.of(
                         INNER,
@@ -471,8 +677,8 @@ public class TestPushJoinIntoTableScan
                         TupleDomain.withColumnDomains(Map.of(
                                 COLUMN_B1_HANDLE, columnB1Domain)),
                         TupleDomain.withColumnDomains(Map.of(
-                                equalTo(JOIN_COLUMN_A1_HANDLE), columnA1Domain.union(onlyNull(BIGINT)),
-                                equalTo(JOIN_COLUMN_A2_HANDLE), columnA2Domain.union(onlyNull(BIGINT)),
+                                equalTo(JOIN_COLUMN_A1_HANDLE), columnA1Domain.union(onlyNull(VARCHAR)),
+                                equalTo(JOIN_COLUMN_A2_HANDLE), columnA2Domain.union(onlyNull(VARCHAR)),
                                 equalTo(JOIN_COLUMN_B1_HANDLE), columnB1Domain))),
                 Arguments.of(
                         LEFT,
@@ -484,7 +690,7 @@ public class TestPushJoinIntoTableScan
                         TupleDomain.withColumnDomains(Map.of(
                                 equalTo(JOIN_COLUMN_A1_HANDLE), columnA1Domain,
                                 equalTo(JOIN_COLUMN_A2_HANDLE), columnA2Domain,
-                                equalTo(JOIN_COLUMN_B1_HANDLE), columnB1Domain.union(onlyNull(BIGINT))))),
+                                equalTo(JOIN_COLUMN_B1_HANDLE), columnB1Domain.union(onlyNull(VARCHAR))))),
                 Arguments.of(
                         FULL,
                         TupleDomain.withColumnDomains(Map.of(
@@ -493,99 +699,77 @@ public class TestPushJoinIntoTableScan
                         TupleDomain.withColumnDomains(Map.of(
                                 COLUMN_B1_HANDLE, columnB1Domain)),
                         TupleDomain.withColumnDomains(Map.of(
-                                equalTo(JOIN_COLUMN_A1_HANDLE), columnA1Domain.union(onlyNull(BIGINT)),
-                                equalTo(JOIN_COLUMN_A2_HANDLE), columnA2Domain.union(onlyNull(BIGINT)),
-                                equalTo(JOIN_COLUMN_B1_HANDLE), columnB1Domain.union(onlyNull(BIGINT))))));
+                                equalTo(JOIN_COLUMN_A1_HANDLE), columnA1Domain.union(onlyNull(VARCHAR)),
+                                equalTo(JOIN_COLUMN_A2_HANDLE), columnA2Domain.union(onlyNull(VARCHAR)),
+                                equalTo(JOIN_COLUMN_B1_HANDLE), columnB1Domain.union(onlyNull(VARCHAR))))));
     }
 
     @Test
-    public void testPushJoinIntoTableDoesNotFireForCrossJoin()
+    public void testDoesNotFireForCrossJoin()
     {
         MockConnectorFactory connectorFactory = createMockConnectorFactory(
                 (session, applyJoinType, left, right, joinConditions, leftAssignments, rightAssignments) -> {
                     throw new IllegalStateException("applyJoin should not be called!");
                 });
         try (RuleTester ruleTester = RuleTester.builder().withDefaultCatalogConnectorFactory(connectorFactory).build()) {
-            ruleTester.assertThat(new PushJoinIntoTableScan(ruleTester.getPlannerContext()))
+            ruleTester.assertThat(new PushJoinIntoTableScan(ruleTester.getPlannerContext(), ProjectSide.LEFT))
                     .withSession(MOCK_SESSION)
                     .on(p -> {
-                        Symbol columnA1Symbol = p.symbol(COLUMN_A1);
-                        Symbol columnA2Symbol = p.symbol(COLUMN_A2);
-                        Symbol columnB1Symbol = p.symbol(COLUMN_B1);
+                        Symbol columnA1Symbol = p.symbol(COLUMN_A1, VARCHAR);
+                        Symbol columnA2Symbol = p.symbol(COLUMN_A2, VARCHAR);
+                        Symbol columnB1Symbol = p.symbol(COLUMN_B1, VARCHAR);
+                        Symbol callSymbolA = p.symbol(CALL_1, VARCHAR);
 
-                        TableScanNode left = p.tableScan(
+                        TableScanNode leftScan = p.tableScan(
                                 ruleTester.getCurrentCatalogTableHandle(SCHEMA, TABLE_A),
                                 ImmutableList.of(columnA1Symbol, columnA2Symbol),
                                 ImmutableMap.of(
                                         columnA1Symbol, COLUMN_A1_HANDLE,
                                         columnA2Symbol, COLUMN_A2_HANDLE));
-                        TableScanNode right = p.tableScan(
+                        TableScanNode rightScan = p.tableScan(
                                 ruleTester.getCurrentCatalogTableHandle(SCHEMA, TABLE_B),
                                 ImmutableList.of(columnB1Symbol),
                                 ImmutableMap.of(columnB1Symbol, COLUMN_B1_HANDLE));
+                        ProjectNode leftProject = p.project(
+                                Assignments.builder()
+                                        .putIdentity(columnB1Symbol)
+                                        .put(callSymbolA, upperCall(ImmutableList.of(columnA1Symbol.toSymbolReference())))
+                                        .build(),
+                                leftScan);
 
                         // cross-join - no criteria
                         return p.join(
                                 INNER,
-                                left,
-                                right);
+                                leftProject,
+                                rightScan);
                     })
                     .doesNotFire();
         }
     }
 
     @Test
-    public void testPushJoinIntoTableRequiresFullColumnHandleMappingInResult()
+    public void testRequiresFullColumnHandleMappingInResult()
     {
-        MockConnectorFactory connectorFactory = createMockConnectorFactory((session, applyJoinType, left, right, joinConditions, leftAssignments, rightAssignments) -> Optional.of(new JoinApplicationResult<>(
-                JOIN_CONNECTOR_TABLE_HANDLE,
-                ImmutableMap.of(COLUMN_A1_HANDLE, JOIN_COLUMN_A1_HANDLE, COLUMN_A2_HANDLE, JOIN_COLUMN_A2_HANDLE),
-                // mapping for COLUMN_B1_HANDLE is missing
-                ImmutableMap.of(),
-                false)));
+        MockConnectorFactory connectorFactory = createMockConnectorFactory((session, applyJoinType, left, right, joinConditions, leftAssignments, rightAssignments) -> Optional.of(
+                new JoinApplicationResult<>(
+                        JOIN_CONNECTOR_TABLE_HANDLE,
+                        ImmutableMap.of(COLUMN_A1_HANDLE, JOIN_COLUMN_A1_HANDLE, COLUMN_A2_HANDLE, JOIN_COLUMN_A2_HANDLE),
+                        // mapping for COLUMN_B1_HANDLE is missing
+                        ImmutableMap.of(),
+                        false)));
         try (RuleTester ruleTester = RuleTester.builder().withDefaultCatalogConnectorFactory(connectorFactory).build()) {
-            assertThatThrownBy(() -> {
-                ruleTester.assertThat(new PushJoinIntoTableScan(ruleTester.getPlannerContext()))
-                        .withSession(MOCK_SESSION)
-                        .on(p -> {
-                            Symbol columnA1Symbol = p.symbol(COLUMN_A1);
-                            Symbol columnA2Symbol = p.symbol(COLUMN_A2);
-                            Symbol columnB1Symbol = p.symbol(COLUMN_B1);
-
-                            TupleDomain<ColumnHandle> leftConstraint =
-                                    TupleDomain.fromFixedValues(ImmutableMap.of(COLUMN_A2_HANDLE, NullableValue.of(BIGINT, 44L)));
-                            TupleDomain<ColumnHandle> rightConstraint =
-                                    TupleDomain.fromFixedValues(ImmutableMap.of(COLUMN_B1_HANDLE, NullableValue.of(BIGINT, 45L)));
-
-                            TableScanNode left = p.tableScan(
-                                    ruleTester.getCurrentCatalogTableHandle(SCHEMA, TABLE_A),
-                                    ImmutableList.of(columnA1Symbol, columnA2Symbol),
-                                    ImmutableMap.of(
-                                            columnA1Symbol, COLUMN_A1_HANDLE,
-                                            columnA2Symbol, COLUMN_A2_HANDLE),
-                                    leftConstraint);
-                            TableScanNode right = p.tableScan(
-                                    ruleTester.getCurrentCatalogTableHandle(SCHEMA, TABLE_B),
-                                    ImmutableList.of(columnB1Symbol),
-                                    ImmutableMap.of(columnB1Symbol, COLUMN_B1_HANDLE),
-                                    rightConstraint);
-
-                            return p.join(
-                                    INNER,
-                                    left,
-                                    right,
-                                    new JoinNode.EquiJoinClause(columnA1Symbol, columnB1Symbol));
-                        })
-                        .matches(anyTree());
-            })
+            assertThatThrownBy(() -> ruleTester.assertThat(new PushJoinIntoTableScan(ruleTester.getPlannerContext(), ProjectSide.LEFT))
+                    .withSession(MOCK_SESSION)
+                    .on(p -> genericJoinLeftProject(
+                            p,
+                            ruleTester,
+                            INNER,
+                            TupleDomain.fromFixedValues(ImmutableMap.of(COLUMN_A2_HANDLE, NullableValue.of(VARCHAR, utf8Slice("44L")))),
+                            TupleDomain.fromFixedValues(ImmutableMap.of(COLUMN_B1_HANDLE, NullableValue.of(VARCHAR, utf8Slice("45L"))))))
+                    .matches(anyTree()))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessageContaining("Column handle mappings do not match old column handles");
         }
-    }
-
-    private static TableHandle createTableHandle(ConnectorTableHandle tableHandle)
-    {
-        return createTableHandle(tableHandle, TEST_CATALOG_HANDLE);
     }
 
     private static TableHandle createTableHandle(ConnectorTableHandle tableHandle, CatalogHandle catalogHandle)
@@ -596,11 +780,13 @@ public class TestPushJoinIntoTableScan
                 new ConnectorTransactionHandle() {});
     }
 
-    private MockConnectorFactory createMockConnectorFactory(ApplyJoinLegacy applyJoin)
+    private MockConnectorFactory createMockConnectorFactory(ApplyJoin applyJoin)
     {
         return MockConnectorFactory.builder()
                 .withListSchemaNames(connectorSession -> ImmutableList.of(SCHEMA))
-                .withListTables((connectorSession, schema) -> SCHEMA.equals(schema) ? ImmutableList.of(TABLE_A_SCHEMA_TABLE_NAME.getTableName(), TABLE_B_SCHEMA_TABLE_NAME.getTableName()) : ImmutableList.of())
+                .withListTables((connectorSession, schema) -> SCHEMA.equals(schema) ? ImmutableList.of(
+                        TABLE_A_SCHEMA_TABLE_NAME.getTableName(),
+                        TABLE_B_SCHEMA_TABLE_NAME.getTableName()) : ImmutableList.of())
                 .withApplyJoin(applyJoin)
                 .withGetColumns(schemaTableName -> {
                     if (schemaTableName.equals(TABLE_A_SCHEMA_TABLE_NAME)) {
@@ -617,34 +803,26 @@ public class TestPushJoinIntoTableScan
                 .build();
     }
 
-    private JoinType toSpiJoinType(io.trino.sql.planner.plan.JoinType joinType)
+    private io.trino.spi.connector.JoinType toSpiJoinType(JoinType joinType)
     {
         return switch (joinType) {
-            case INNER -> JoinType.INNER;
-            case LEFT -> JoinType.LEFT_OUTER;
-            case RIGHT -> JoinType.RIGHT_OUTER;
-            case FULL -> JoinType.FULL_OUTER;
+            case INNER -> io.trino.spi.connector.JoinType.INNER;
+            case LEFT -> io.trino.spi.connector.JoinType.LEFT_OUTER;
+            case RIGHT -> io.trino.spi.connector.JoinType.RIGHT_OUTER;
+            case FULL -> io.trino.spi.connector.JoinType.FULL_OUTER;
         };
     }
 
-    private JoinCondition.Operator getConditionOperator(Comparison.Operator operator)
+    private FunctionName toSpiFunctionName(Operator operator)
     {
-        switch (operator) {
-            case EQUAL:
-                return JoinCondition.Operator.EQUAL;
-            case NOT_EQUAL:
-                return JoinCondition.Operator.NOT_EQUAL;
-            case LESS_THAN:
-                return JoinCondition.Operator.LESS_THAN;
-            case LESS_THAN_OR_EQUAL:
-                return JoinCondition.Operator.LESS_THAN_OR_EQUAL;
-            case GREATER_THAN:
-                return JoinCondition.Operator.GREATER_THAN;
-            case GREATER_THAN_OR_EQUAL:
-                return JoinCondition.Operator.GREATER_THAN_OR_EQUAL;
-            case IDENTICAL:
-                return JoinCondition.Operator.IDENTICAL;
-        }
-        throw new IllegalArgumentException("Unknown operator: " + operator);
+        return switch (operator) {
+            case EQUAL -> new FunctionName("$equal");
+            case NOT_EQUAL -> new FunctionName("$not_equal");
+            case LESS_THAN -> new FunctionName("$less_than");
+            case LESS_THAN_OR_EQUAL -> new FunctionName("$less_than_or_equal");
+            case GREATER_THAN -> new FunctionName("$greater_than");
+            case GREATER_THAN_OR_EQUAL -> new FunctionName("$greater_than_or_equal");
+            case IDENTICAL -> new FunctionName("$identical");
+        };
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushJoinIntoTableScan.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushJoinIntoTableScan.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.connector.MockConnectorColumnHandle;
 import io.trino.connector.MockConnectorFactory;
+import io.trino.connector.MockConnectorFactory.ApplyJoinLegacy;
 import io.trino.connector.MockConnectorTableHandle;
 import io.trino.metadata.ResolvedFunction;
 import io.trino.metadata.TableHandle;
@@ -595,7 +596,7 @@ public class TestPushJoinIntoTableScan
                 new ConnectorTransactionHandle() {});
     }
 
-    private MockConnectorFactory createMockConnectorFactory(MockConnectorFactory.ApplyJoin applyJoin)
+    private MockConnectorFactory createMockConnectorFactory(ApplyJoinLegacy applyJoin)
     {
         return MockConnectorFactory.builder()
                 .withListSchemaNames(connectorSession -> ImmutableList.of(SCHEMA))

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/BaseMariaDbFailureRecoveryTest.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/BaseMariaDbFailureRecoveryTest.java
@@ -25,9 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assumptions.abort;
-
 public abstract class BaseMariaDbFailureRecoveryTest
         extends BaseJdbcFailureRecoveryTest
 {
@@ -51,14 +48,6 @@ public abstract class BaseMariaDbFailureRecoveryTest
                             "exchange.base-directories", System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager"));
                 })
                 .build();
-    }
-
-    @Test
-    @Override
-    protected void testUpdateWithSubquery()
-    {
-        assertThatThrownBy(super::testUpdateWithSubquery).hasMessageContaining("Unexpected Join over for-update table scan");
-        abort("skipped");
     }
 
     @Test

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlFailureRecoveryTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlFailureRecoveryTest.java
@@ -25,9 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assumptions.abort;
-
 public abstract class BaseMySqlFailureRecoveryTest
         extends BaseJdbcFailureRecoveryTest
 {
@@ -53,14 +50,6 @@ public abstract class BaseMySqlFailureRecoveryTest
                 })
                 .setInitialTables(requiredTpchTables)
                 .build();
-    }
-
-    @Test
-    @Override
-    protected void testUpdateWithSubquery()
-    {
-        assertThatThrownBy(super::testUpdateWithSubquery).hasMessageContaining("Unexpected Join over for-update table scan");
-        abort("skipped");
     }
 
     @Test

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleFailureRecoveryTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleFailureRecoveryTest.java
@@ -25,9 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assumptions.abort;
-
 public abstract class BaseOracleFailureRecoveryTest
         extends BaseJdbcFailureRecoveryTest
 {
@@ -54,14 +51,6 @@ public abstract class BaseOracleFailureRecoveryTest
                 })
                 .setInitialTables(requiredTpchTables)
                 .build();
-    }
-
-    @Test
-    @Override
-    protected void testUpdateWithSubquery()
-    {
-        assertThatThrownBy(super::testUpdateWithSubquery).hasMessageContaining("Unexpected Join over for-update table scan");
-        abort("skipped");
     }
 
     @Test

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -310,6 +310,8 @@ public class PostgreSqlClient
                 .add(new RewriteIn())
                 .withTypeClass("integer_type", ImmutableSet.of("tinyint", "smallint", "integer", "bigint"))
                 .withTypeClass("numeric_type", ImmutableSet.of("tinyint", "smallint", "integer", "bigint", "decimal", "real", "double"))
+                .withTypeClass("string_type", ImmutableSet.of("char", "varchar"))
+                .map("reverse(value: string_type)").to("REVERSE(value)")
                 .map("$equal(left, right)").to("left = right")
                 .map("$not_equal(left, right)").to("left <> right")
                 .map("$identical(left, right)").to("left IS NOT DISTINCT FROM right")

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/BasePostgresFailureRecoveryTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/BasePostgresFailureRecoveryTest.java
@@ -25,9 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assumptions.abort;
-
 public abstract class BasePostgresFailureRecoveryTest
         extends BaseJdbcFailureRecoveryTest
 {
@@ -53,14 +50,6 @@ public abstract class BasePostgresFailureRecoveryTest
                 })
                 .setInitialTables(requiredTpchTables)
                 .build();
-    }
-
-    @Test
-    @Override
-    protected void testUpdateWithSubquery()
-    {
-        assertThatThrownBy(super::testUpdateWithSubquery).hasMessageContaining("Unexpected Join over for-update table scan");
-        abort("skipped");
     }
 
     @Test

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/BaseRedshiftFailureRecoveryTest.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/BaseRedshiftFailureRecoveryTest.java
@@ -25,9 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assumptions.abort;
-
 public abstract class BaseRedshiftFailureRecoveryTest
         extends BaseJdbcFailureRecoveryTest
 {
@@ -53,14 +50,6 @@ public abstract class BaseRedshiftFailureRecoveryTest
                 })
                 .setInitialTables(requiredTpchTables)
                 .build();
-    }
-
-    @Test
-    @Override
-    protected void testUpdateWithSubquery()
-    {
-        assertThatThrownBy(super::testUpdateWithSubquery).hasMessageContaining("Unexpected Join over for-update table scan");
-        abort("skipped");
     }
 
     @Test

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerFailureRecoveryTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerFailureRecoveryTest.java
@@ -25,9 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assumptions.abort;
-
 public abstract class BaseSqlServerFailureRecoveryTest
         extends BaseJdbcFailureRecoveryTest
 {
@@ -53,14 +50,6 @@ public abstract class BaseSqlServerFailureRecoveryTest
                 })
                 .setInitialTables(requiredTpchTables)
                 .build();
-    }
-
-    @Test
-    @Override
-    protected void testUpdateWithSubquery()
-    {
-        assertThatThrownBy(super::testUpdateWithSubquery).hasMessageContaining("Unexpected Join over for-update table scan");
-        abort("skipped");
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Add a ruleset to push join into TableScan through Project.

**Draft todos:**
 - [x] decide whether to merge with `PushJoinIntoTableScan` - extend `PushJoinIntoTableScan` with new behavior
 - [x] Result correctness  - PostgreSQL reference methods: account for collation - `UPPER/LOWER COLLATE C` as well as other [standard collations](https://www.postgresql.org/docs/current/collation.html#COLLATION-MANAGING-STANDARD) are not producing results consistent with Trino:

PostgreSQL:
```
SELECT UPPER('ślad');

C_Collation        PL_Collation
--------------------------------------
śLAD                  ŚLAD
```

Trino:
```
SELECT UPPER('ślad');

--------------------------------------
ŚLAD
```

Therefore the test use `REVERSE` as a reference function call which does not exhibit inconsistent behavior.
 
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

**Why push though projection is needed?**
To enable pushdown of joins with function calls in join conditions (UPPER/LOWER/CASTS etc.)

**Why projection is not consumed by connector?** 
It is currently unsupported for JDBC connectors. There was an attempt https://github.com/trinodb/trino/pull/19740, but it didn't make it due to reasons (edge cases, fact that it needs JDBC type to be derived from Trino type when mapping).

**What if there is filter below projection?**
This rule will not work.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
