### PR TITLE
Add support array subscript pushdown for 1D array in Postgres connector

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/projection/ProjectFunctionRewriter.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/projection/ProjectFunctionRewriter.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.projection;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.trino.matching.Match;
+import io.trino.plugin.base.expression.ConnectorExpressionRewriter;
+import io.trino.plugin.base.projection.ProjectFunctionRule.RewriteContext;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.expression.ConnectorExpression;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public final class ProjectFunctionRewriter<ProjectionResult, ExpressionResult>
+{
+    private final ConnectorExpressionRewriter<ExpressionResult> connectorExpressionRewriter;
+    private final Set<ProjectFunctionRule<ProjectionResult, ExpressionResult>> rules;
+
+    public ProjectFunctionRewriter(ConnectorExpressionRewriter<ExpressionResult> connectorExpressionRewriter, Set<ProjectFunctionRule<ProjectionResult, ExpressionResult>> rules)
+    {
+        this.connectorExpressionRewriter = requireNonNull(connectorExpressionRewriter, "connectorExpressionRewriter is null");
+        this.rules = ImmutableSet.copyOf(requireNonNull(rules, "rules is null"));
+    }
+
+    public Map<ConnectorExpression, ProjectionResult> rewrite(ConnectorSession session, ConnectorExpression projectionExpression, Map<String, ColumnHandle> assignments)
+    {
+        requireNonNull(projectionExpression, "projectionExpression is null");
+        requireNonNull(assignments, "assignments is null");
+
+        RewriteContext<ExpressionResult> context = new RewriteContext<>()
+        {
+            @Override
+            public Map<String, ColumnHandle> getAssignments()
+            {
+                return assignments;
+            }
+
+            @Override
+            public ConnectorSession getSession()
+            {
+                return session;
+            }
+
+            @Override
+            public Optional<ExpressionResult> rewriteExpression(ConnectorExpression expression)
+            {
+                return connectorExpressionRewriter.rewrite(session, expression, assignments);
+            }
+        };
+
+        Optional<ProjectionResult> rewrittenExpression = rewriteProjectionFunction(projectionExpression, context);
+        if (rewrittenExpression.isPresent()) {
+            return ImmutableMap.of(projectionExpression, rewrittenExpression.get());
+        }
+
+        ImmutableMap.Builder<ConnectorExpression, ProjectionResult> resultBuilder = ImmutableMap.builder();
+
+        for (ConnectorExpression child : projectionExpression.getChildren()) {
+            resultBuilder.putAll(rewrite(session, child, assignments));
+        }
+
+        return resultBuilder.build();
+    }
+
+    private Optional<ProjectionResult> rewriteProjectionFunction(ConnectorExpression projectionExpression, RewriteContext context)
+    {
+        for (ProjectFunctionRule<ProjectionResult, ExpressionResult> rule : rules) {
+            Iterator<Match> matches = rule.getPattern().match(projectionExpression, context).iterator();
+            while (matches.hasNext()) {
+                Match match = matches.next();
+                Optional<ProjectionResult> rewritten = rule.rewrite(projectionExpression, match.captures(), context);
+                if (rewritten.isPresent()) {
+                    return rewritten;
+                }
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/projection/ProjectFunctionRule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/projection/ProjectFunctionRule.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.projection;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.expression.ConnectorExpression;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.base.Verify.verifyNotNull;
+import static java.util.Objects.requireNonNull;
+
+public interface ProjectFunctionRule<ProjectionResult, ExpressionResult>
+{
+    Pattern<? extends ConnectorExpression> getPattern();
+
+    Optional<ProjectionResult> rewrite(ConnectorExpression projectionExpression, Captures captures, RewriteContext<ExpressionResult> context);
+
+    interface RewriteContext<ExpressionResult>
+    {
+        default ColumnHandle getAssignment(String name)
+        {
+            requireNonNull(name, "name is null");
+            ColumnHandle columnHandle = getAssignments().get(name);
+            verifyNotNull(columnHandle, "No assignment for %s", name);
+            return columnHandle;
+        }
+
+        Map<String, ColumnHandle> getAssignments();
+
+        ConnectorSession getSession();
+
+        Optional<ExpressionResult> rewriteExpression(ConnectorExpression expression);
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -229,6 +229,12 @@ public class CachingJdbcClient
     }
 
     @Override
+    public Map<ConnectorExpression, JdbcExpression> convertProjection(ConnectorSession session, JdbcTableHandle handle, ConnectorExpression expression, Map<String, ColumnHandle> assignments)
+    {
+        return delegate.convertProjection(session, handle, expression, assignments);
+    }
+
+    @Override
     public ConnectorSplitSource getSplits(ConnectorSession session, JdbcTableHandle tableHandle)
     {
         return delegate.getSplits(session, tableHandle);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
@@ -97,6 +97,8 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.plugin.base.expression.ConnectorExpressions.and;
 import static io.trino.plugin.base.expression.ConnectorExpressions.extractConjuncts;
+import static io.trino.plugin.base.projection.ApplyProjectionUtil.extractSupportedProjectedColumns;
+import static io.trino.plugin.base.projection.ApplyProjectionUtil.replaceWithNewVariables;
 import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_NON_TRANSIENT_ERROR;
 import static io.trino.plugin.jdbc.JdbcMetadataSessionProperties.isAggregationPushdownEnabled;
 import static io.trino.plugin.jdbc.JdbcMetadataSessionProperties.isComplexExpressionPushdown;
@@ -308,11 +310,85 @@ public class DefaultJdbcMetadata
 
         JdbcTableHandle handle = (JdbcTableHandle) table;
 
-        List<JdbcColumnHandle> newColumns = assignments.values().stream()
-                .map(JdbcColumnHandle.class::cast)
+        int nextSyntheticColumnId = handle.getNextSyntheticColumnId();
+
+        Map<String, Assignment> newAssignments = new HashMap<>();
+        ImmutableMap.Builder<ConnectorExpression, Variable> newVariablesBuilder = ImmutableMap.builder();
+        ImmutableList.Builder<JdbcColumnHandle> newColumnsBuilder = ImmutableList.builder();
+        ImmutableMap.Builder<String, ParameterizedExpression> columnExpressionsBuilder = ImmutableMap.builder();
+
+        for (ConnectorExpression projection : projections) {
+            // Don't generate needless transformations for constants.
+            if (projection instanceof Constant) {
+                continue;
+            }
+            // Don't generate needless transformations for variable.
+            if (projection instanceof Variable variable) {
+                JdbcColumnHandle columnHandle = (JdbcColumnHandle) assignments.get(variable.getName());
+                newAssignments.put(variable.getName(), new Assignment(variable.getName(), columnHandle, variable.getType()));
+                newColumnsBuilder.add(columnHandle);
+                continue;
+            }
+            // Try to convert Projection
+            Map<ConnectorExpression, JdbcExpression> expression = jdbcClient.convertProjection(session, handle, projection, assignments);
+            if (isComplexExpressionPushdown(session) && !expression.isEmpty()) {
+                for (Map.Entry<ConnectorExpression, JdbcExpression> convertedExpression : expression.entrySet()) {
+                    String columnName = SYNTHETIC_COLUMN_NAME_PREFIX + nextSyntheticColumnId;
+                    JdbcColumnHandle newColumn = JdbcColumnHandle.builder()
+                            .setColumnName(columnName)
+                            .setJdbcTypeHandle(convertedExpression.getValue().getJdbcTypeHandle())
+                            .setColumnType(convertedExpression.getKey().getType())
+                            .setComment(Optional.of("synthetic"))
+                            .build();
+                    nextSyntheticColumnId++;
+                    columnExpressionsBuilder.put(columnName, new ParameterizedExpression(convertedExpression.getValue().getExpression(), convertedExpression.getValue().getParameters()));
+                    Variable newVariable = new Variable(newColumn.getColumnName(), newColumn.getColumnType());
+                    newVariablesBuilder.put(convertedExpression.getKey(), newVariable);
+                    Assignment newAssignment = new Assignment(columnName, newColumn, convertedExpression.getKey().getType());
+                    newAssignments.putIfAbsent(columnName, newAssignment);
+                    newColumnsBuilder.add(newColumn);
+                }
+            }
+            else {
+                extractSupportedProjectedColumns(projection, connectorExpression -> connectorExpression instanceof Variable).stream()
+                        .map(Variable.class::cast).map(Variable::getName)
+                        .forEach(name -> {
+                            newAssignments.put(name, new Assignment(name, assignments.get(name), ((JdbcColumnHandle) assignments.get(name)).getColumnType()));
+                            newColumnsBuilder.add((JdbcColumnHandle) assignments.get(name));
+                        });
+            }
+        }
+
+        List<JdbcColumnHandle> newColumns = newColumnsBuilder.build();
+
+        // Modify projections to refer to new variables
+        Map<ConnectorExpression, Variable> newVariables = newVariablesBuilder.buildOrThrow();
+        List<ConnectorExpression> newProjections = projections.stream()
+                .map(expression -> replaceWithNewVariables(expression, newVariables))
                 .collect(toImmutableList());
 
-        if (handle.getColumns().isPresent()) {
+        List<Assignment> outputAssignments = newAssignments.values().stream().collect(toImmutableList());
+
+        if (!columnExpressionsBuilder.buildOrThrow().isEmpty()) {
+            PreparedQuery preparedQuery = jdbcClient.prepareQuery(session, handle, Optional.empty(), newColumns, columnExpressionsBuilder.buildOrThrow());
+            return Optional.of(new ProjectionApplicationResult<>(
+                    new JdbcTableHandle(
+                            new JdbcQueryRelationHandle(preparedQuery),
+                            TupleDomain.all(),
+                            ImmutableList.of(),
+                            Optional.empty(),
+                            OptionalLong.empty(),
+                            Optional.of(newColumns),
+                            handle.getOtherReferencedTables(),
+                            nextSyntheticColumnId,
+                            handle.getAuthorization(),
+                            handle.getUpdateAssignments()),
+                    newProjections,
+                    outputAssignments,
+                    precalculateStatisticsForPushdown));
+        }
+
+        if (newVariables.isEmpty() && handle.getColumns().isPresent()) {
             Set<JdbcColumnHandle> newColumnSet = ImmutableSet.copyOf(newColumns);
             Set<JdbcColumnHandle> tableColumnSet = ImmutableSet.copyOf(handle.getColumns().get());
             if (newColumnSet.equals(tableColumnSet)) {
@@ -337,16 +413,11 @@ public class DefaultJdbcMetadata
                         handle.getLimit(),
                         Optional.of(newColumns),
                         handle.getOtherReferencedTables(),
-                        handle.getNextSyntheticColumnId(),
+                        nextSyntheticColumnId,
                         handle.getAuthorization(),
                         handle.getUpdateAssignments()),
-                projections,
-                assignments.entrySet().stream()
-                        .map(assignment -> new Assignment(
-                                assignment.getKey(),
-                                assignment.getValue(),
-                                ((JdbcColumnHandle) assignment.getValue()).getColumnType()))
-                        .collect(toImmutableList()),
+                newProjections,
+                outputAssignments,
                 precalculateStatisticsForPushdown));
     }
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
@@ -155,6 +155,12 @@ public abstract class ForwardingJdbcClient
     }
 
     @Override
+    public Map<ConnectorExpression, JdbcExpression> convertProjection(ConnectorSession session, JdbcTableHandle tableHandle, ConnectorExpression expression, Map<String, ColumnHandle> assignments)
+    {
+        return delegate().convertProjection(session, tableHandle, expression, assignments);
+    }
+
+    @Override
     public ConnectorSplitSource getSplits(ConnectorSession session, JdbcTableHandle layoutHandle)
     {
         return delegate().getSplits(session, layoutHandle);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.jdbc;
 
+import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.jdbc.JdbcProcedureHandle.ProcedureQuery;
 import io.trino.plugin.jdbc.expression.ParameterizedExpression;
 import io.trino.spi.TrinoException;
@@ -94,6 +95,11 @@ public interface JdbcClient
     default Optional<ParameterizedExpression> convertPredicate(ConnectorSession session, ConnectorExpression expression, Map<String, ColumnHandle> assignments)
     {
         return Optional.empty();
+    }
+
+    default Map<ConnectorExpression, JdbcExpression> convertProjection(ConnectorSession session, JdbcTableHandle handle, ConnectorExpression expression, Map<String, ColumnHandle> assignments)
+    {
+        return ImmutableMap.of();
     }
 
     ConnectorSplitSource getSplits(ConnectorSession session, JdbcTableHandle tableHandle);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/RewriteArraySubscript.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/RewriteArraySubscript.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc.expression;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.plugin.base.projection.ProjectFunctionRule;
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcExpression;
+import io.trino.plugin.jdbc.JdbcTypeHandle;
+import io.trino.plugin.jdbc.QueryParameter;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.expression.Variable;
+import io.trino.spi.type.ArrayType;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argument;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argumentCount;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.expression;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.variable;
+import static java.util.Objects.requireNonNull;
+
+public class RewriteArraySubscript
+{
+    private static final Capture<Variable> VALUE = newCapture();
+    private static final Capture<ConnectorExpression> INDEX = newCapture();
+    private static final Pattern<Call> PATTERN = call()
+            .with(functionName().equalTo(new FunctionName("$operator$subscript")))
+            .with(type().matching(type -> !(type instanceof ArrayType)))
+            .with(argumentCount().equalTo(2))
+            .with(argument(0).matching(variable().capturedAs(VALUE)))
+            .with(argument(1).matching(expression().capturedAs(INDEX)));
+
+    public static class RewriteArraySubscriptFilter
+            implements ConnectorExpressionRule<Call, ParameterizedExpression>
+    {
+        private final BiFunction<ConnectorSession, JdbcColumnHandle, JdbcTypeHandle> arrayElementTypeHandleProvider;
+
+        public RewriteArraySubscriptFilter(BiFunction<ConnectorSession, JdbcColumnHandle, JdbcTypeHandle> arrayElementTypeHandleProvider)
+        {
+            this.arrayElementTypeHandleProvider = requireNonNull(arrayElementTypeHandleProvider, "arrayElementTypeHandleProvider is null");
+        }
+
+        @Override
+        public Pattern<Call> getPattern()
+        {
+            return PATTERN;
+        }
+
+        @Override
+        public Optional<ParameterizedExpression> rewrite(Call call, Captures captures, RewriteContext<ParameterizedExpression> context)
+        {
+            Variable value = captures.get(VALUE);
+            JdbcColumnHandle columnHandle = (JdbcColumnHandle) context.getAssignment(value.getName());
+
+            Optional<ParameterizedExpression> index = context.defaultRewrite(captures.get(INDEX));
+            if (index.isEmpty()) {
+                return Optional.empty();
+            }
+
+            JdbcTypeHandle arrayElementTypeHandle = arrayElementTypeHandleProvider.apply(context.getSession(), columnHandle);
+            if (arrayElementTypeHandle.jdbcTypeName().isEmpty()) {
+                return Optional.empty();
+            }
+
+            return Optional.of(rewriteArraySubscriptExpression(value, index.get(), arrayElementTypeHandle));
+        }
+    }
+
+    public static class RewriteArraySubscriptProjection
+            implements ProjectFunctionRule<JdbcExpression, ParameterizedExpression>
+    {
+        private final BiFunction<ConnectorSession, JdbcColumnHandle, JdbcTypeHandle> arrayElementTypeHandleProvider;
+
+        public RewriteArraySubscriptProjection(BiFunction<ConnectorSession, JdbcColumnHandle, JdbcTypeHandle> arrayElementTypeHandleProvider)
+        {
+            this.arrayElementTypeHandleProvider = requireNonNull(arrayElementTypeHandleProvider, "arrayElementTypeHandleProvider is null");
+        }
+
+        @Override
+        public Pattern<Call> getPattern()
+        {
+            return PATTERN;
+        }
+
+        @Override
+        public Optional<JdbcExpression> rewrite(ConnectorExpression projectionExpression, Captures captures, RewriteContext<ParameterizedExpression> context)
+        {
+            context.rewriteExpression(projectionExpression);
+            Variable value = captures.get(VALUE);
+            JdbcColumnHandle columnHandle = (JdbcColumnHandle) context.getAssignment(value.getName());
+
+            Optional<ParameterizedExpression> index = context.rewriteExpression(captures.get(INDEX));
+            if (index.isEmpty()) {
+                return Optional.empty();
+            }
+
+            JdbcTypeHandle arrayElementTypeHandle = arrayElementTypeHandleProvider.apply(context.getSession(), columnHandle);
+            if (arrayElementTypeHandle.jdbcTypeName().isEmpty()) {
+                return Optional.empty();
+            }
+
+            ParameterizedExpression parameterizedExpression = rewriteArraySubscriptExpression(value, index.get(), arrayElementTypeHandle);
+            return Optional.of(new JdbcExpression(
+                    parameterizedExpression.expression(),
+                    parameterizedExpression.parameters(),
+                    arrayElementTypeHandle));
+        }
+    }
+
+    private static ParameterizedExpression rewriteArraySubscriptExpression(Variable value, ParameterizedExpression index, JdbcTypeHandle arrayElementTypeHandle)
+    {
+        return new ParameterizedExpression(
+                "(CASE WHEN (%2$s > 0 AND ARRAY_NDIMS(%1$s) = 1 AND ARRAY_LENGTH(%1$s, 1) >= %2$s) THEN %1$s ELSE ARRAY[null, ARRAY[(SELECT null)]]::%3$s[] END)[%2$s]"
+                        .formatted(value.getName(), index.expression(), arrayElementTypeHandle.jdbcTypeName().get()),
+                ImmutableList.<QueryParameter>builder()
+                        .addAll(index.parameters())
+                        .addAll(index.parameters())
+                        .addAll(index.parameters())
+                        .build());
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/JdbcClientStats.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/JdbcClientStats.java
@@ -64,6 +64,7 @@ public final class JdbcClientStats
     private final JdbcApiStats toWriteMapping = new JdbcApiStats();
     private final JdbcApiStats implementAggregation = new JdbcApiStats();
     private final JdbcApiStats convertPredicate = new JdbcApiStats();
+    private final JdbcApiStats convertProjection = new JdbcApiStats();
     private final JdbcApiStats getTableScanRedirection = new JdbcApiStats();
     private final JdbcApiStats delete = new JdbcApiStats();
     private final JdbcApiStats update = new JdbcApiStats();
@@ -389,6 +390,13 @@ public final class JdbcClientStats
     public JdbcApiStats getConvertPredicate()
     {
         return convertPredicate;
+    }
+
+    @Managed
+    @Nested
+    public JdbcApiStats getConvertProjection()
+    {
+        return convertProjection;
     }
 
     @Managed

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
@@ -176,6 +176,12 @@ public final class StatisticsAwareJdbcClient
     }
 
     @Override
+    public Map<ConnectorExpression, JdbcExpression> convertProjection(ConnectorSession session, JdbcTableHandle tableHandle, ConnectorExpression expression, Map<String, ColumnHandle> assignments)
+    {
+        return stats.getConvertProjection().wrap(() -> delegate().convertProjection(session, tableHandle, expression, assignments));
+    }
+
+    @Override
     public ConnectorSplitSource getSplits(ConnectorSession session, JdbcTableHandle layoutHandle)
     {
         return stats.getGetSplits().wrap(() -> delegate().getSplits(session, layoutHandle));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Extension of https://github.com/trinodb/trino/pull/21479. This PR attempts to pushdown both predicate/projection for array subscript operator for a 1D array. 

Test coverage are still missing - Wanted to have an early feedback for this approach. Need to extend the same for multidimensional array. 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
