### PR TITLE
Write checkpoint if necessary for CREATE OR REPLACE statements

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -1059,6 +1059,10 @@ public class DeltaLakeMetadata
                         protocolEntry);
 
                 transactionLogWriter.flush();
+
+                if (replaceExistingTable) {
+                    writeCheckpointIfNeeded(session, schemaTableName, location, tableHandle.getReadVersion(), checkpointInterval, commitVersion);
+                }
             }
         }
         catch (IOException e) {
@@ -1425,6 +1429,10 @@ public class DeltaLakeMetadata
             }
             transactionLogWriter.flush();
             writeCommitted = true;
+
+            if (handle.replace() && handle.readVersion().isPresent()) {
+                writeCheckpointIfNeeded(session, schemaTableName, handle.location(), handle.readVersion().getAsLong(), handle.checkpointInterval(), commitVersion);
+            }
 
             if (isCollectExtendedStatisticsColumnStatisticsOnWrite(session) && !computedStatistics.isEmpty()) {
                 Optional<Instant> maxFileModificationTime = dataFileInfos.stream()


### PR DESCRIPTION
## Description
When running `CREATE [OR REPLACE] TABLE` statements for an existing table, the `finishCreate` method is currently not writing a checkpoint to the Delta Log. This PR makes it possible to write those checkpoints. It results in faster analysis times for queries that read from those tables.

## Additional context and related issues
We have noticed that tables recreated through this flow (`CREATE [OR REPLACE] TABLE`) have more than 2000 commits and no checkpoint, which leads to a very bad analysis time


## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
