### PR TITLE
Use binary search in SortedRangeSet overlaps

### DIFF
--- a/core/trino-spi/src/test/java/io/trino/spi/predicate/BenchmarkSortedRangeSet.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/predicate/BenchmarkSortedRangeSet.java
@@ -106,20 +106,26 @@ public class BenchmarkSortedRangeSet
     @Benchmark
     public List<Boolean> overlapsSmall(Data data)
     {
-        return benchmarkOverlaps(data.smallRanges);
+        return benchmarkOverlaps(data.smallRanges, data.smallRanges);
     }
 
     @Benchmark
     public List<Boolean> overlapsLarge(Data data)
     {
-        return benchmarkOverlaps(data.largeRanges);
+        return benchmarkOverlaps(data.largeRanges, data.largeRanges);
     }
 
-    private List<Boolean> benchmarkOverlaps(List<SortedRangeSet> dataRanges)
+    @Benchmark
+    public List<Boolean> overlapsSmallOnVeryLarge(Data data)
+    {
+        return benchmarkOverlaps(data.veryLargeRanges, data.smallRanges);
+    }
+
+    private List<Boolean> benchmarkOverlaps(List<SortedRangeSet> dataRanges, List<SortedRangeSet> otherDataRanges)
     {
         List<Boolean> result = new ArrayList<>(dataRanges.size() - 1);
         for (int index = 0; index < dataRanges.size() - 1; index++) {
-            result.add(dataRanges.get(index).overlaps(dataRanges.get(index + 1)));
+            result.add(dataRanges.get(index).overlaps(otherDataRanges.get(index + 1 % otherDataRanges.size())));
         }
         return result;
     }
@@ -233,6 +239,7 @@ public class BenchmarkSortedRangeSet
         public List<Range> ranges;
         public List<SortedRangeSet> smallRanges;
         public List<SortedRangeSet> largeRanges;
+        private List<SortedRangeSet> veryLargeRanges;
 
         @Setup(Level.Iteration)
         public void init()
@@ -250,6 +257,7 @@ public class BenchmarkSortedRangeSet
 
             smallRanges = generateRangeSets(500_000, 2);
             largeRanges = generateRangeSets(5_000, 300);
+            veryLargeRanges = generateRangeSets(5_000, 30_000);
         }
 
         private List<SortedRangeSet> generateRangeSets(int count, int size)
@@ -289,6 +297,7 @@ public class BenchmarkSortedRangeSet
 
         overlapsSmall(data);
         overlapsLarge(data);
+        overlapsSmallOnVeryLarge(data);
 
         intersectSmall(data);
         intersectLarge(data);

--- a/core/trino-spi/src/test/java/io/trino/spi/predicate/TestSortedRangeSet.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/predicate/TestSortedRangeSet.java
@@ -312,13 +312,21 @@ public class TestSortedRangeSet
     private void assertOverlaps(SortedRangeSet first, SortedRangeSet second)
     {
         assertThat(first.overlaps(second)).isTrue();
+        assertThat(first.linearSearchOverlaps(second)).isTrue();
+        assertThat(first.binarySearchOverlaps(second)).isTrue();
         assertThat(second.overlaps(first)).isTrue();
+        assertThat(second.linearSearchOverlaps(first)).isTrue();
+        assertThat(second.binarySearchOverlaps(first)).isTrue();
     }
 
     private void assertDoesNotOverlap(SortedRangeSet first, SortedRangeSet second)
     {
         assertThat(first.overlaps(second)).isFalse();
+        assertThat(first.linearSearchOverlaps(second)).isFalse();
+        assertThat(first.binarySearchOverlaps(second)).isFalse();
         assertThat(second.overlaps(first)).isFalse();
+        assertThat(second.linearSearchOverlaps(first)).isFalse();
+        assertThat(second.binarySearchOverlaps(first)).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## Description

Improve performance of overlaps and intersect method for common use cases.

```
// baseline
Benchmark                                          Mode  Cnt   Score   Error  Units
BenchmarkSortedRangeSet.overlapsLarge              avgt         3,580          ms/op
BenchmarkSortedRangeSet.overlapsMediumOnVeryLarge  avgt        12,021          ms/op
BenchmarkSortedRangeSet.overlapsSmall              avgt        31,873          ms/op
BenchmarkSortedRangeSet.overlapsSmallOnVeryLarge   avgt       186,582          ms/op
```

```
// bin search
Benchmark                                          Mode  Cnt   Score   Error  Units
BenchmarkSortedRangeSet.overlapsLarge              avgt        3,647          ms/op
BenchmarkSortedRangeSet.overlapsMediumOnVeryLarge  avgt        6,708          ms/op
BenchmarkSortedRangeSet.overlapsSmall              avgt       31,640          ms/op
BenchmarkSortedRangeSet.overlapsSmallOnVeryLarge   avgt        3,497          ms/op
```
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: