### PR TITLE
Remove unused `tests:hive` label

### DIFF
--- a/.github/config/labeler-config.yml
+++ b/.github/config/labeler-config.yml
@@ -1,8 +1,4 @@
 # Pull Request Labeler Github Action Configuration: https://github.com/marketplace/actions/labeler
-"tests:hive":
-  - changed-files:
-    - any-glob-to-any-file: ['lib/trino-orc/**', 'lib/trino-parquet/**', 'lib/trino-hive-formats/**', 'plugin/trino-hive/**', 'testing/trino-product-tests/**', 'lib/trino-filesystem/**', 'lib/trino-filesystem-*/**']
-
 jdbc:
   - changed-files:
     - any-glob-to-any-file: 'client/trino-jdbc/**'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/labeler@v5
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          # Do not sync labels as this reverts manually added "tests:hive" label.
+          # Do not sync labels as this reverts manually added labels such as "tests:all".
           # Syncing labels requires that we define "components" labels.
           sync-labels: false
           configuration-path: .github/config/labeler-config.yml


### PR DESCRIPTION
It used to drive CI jobs, but it no longer does since ceb8e1572047c7ecb8854f28ae21a5e4200c3e34.
