### PR TITLE
Fix Thrift connector config parameter name

### DIFF
--- a/docs/src/main/sphinx/connector/thrift.md
+++ b/docs/src/main/sphinx/connector/thrift.md
@@ -45,7 +45,7 @@ The following configuration properties are available:
 | Property name                              | Description                                              |
 | ------------------------------------------ | -------------------------------------------------------- |
 | `trino.thrift.client.addresses`            | Location of Thrift servers                               |
-| `trino-thrift.max-response-size`           | Maximum size of data returned from Thrift server         |
+| `trino.thrift.client.max-response-size`    | Maximum size of data returned from Thrift server         |
 | `trino-thrift.metadata-refresh-threads`    | Number of refresh threads for metadata cache             |
 | `trino.thrift.client.max-retries`          | Maximum number of retries for failed Thrift requests     |
 | `trino.thrift.client.max-backoff-delay`    | Maximum interval between retry attempts                  |
@@ -69,7 +69,7 @@ trino.thrift.client.addresses=192.0.2.3:7777,192.0.2.4:7779
 
 This property is required; there is no default.
 
-### `trino-thrift.max-response-size`
+### `trino.thrift.client.max-response-size`
 
 Maximum size of a data response that the connector accepts. This value is sent
 by the connector to the Thrift server when requesting data, allowing it to size


### PR DESCRIPTION
correct Thrift connector configuration parameter from 'trino-thrift.max-frame-size' to 'trino.thrift.client.max-frame-size'

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
updating documentation to reflect correct configuration parameter name


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

