### PR TITLE
Use binary search in SortedRangeSet intersect

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
@@ -20,6 +20,7 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.spi.block.ValueBlock;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.type.Type;
 
@@ -513,7 +514,21 @@ public final class SortedRangeSet
         if (that.isNone()) {
             return that;
         }
+        int thisRangeCount = this.getRangeCount();
+        int thatRangeCount = that.getRangeCount();
 
+        if (max(thisRangeCount, thatRangeCount) * 0.02 < min(thisRangeCount, thatRangeCount)) {
+            return linearSearchIntersect(that);
+        }
+        else {
+            // Binary search is better than linear search for sets with large size difference
+            return binarySearchIntersect(that);
+        }
+    }
+
+    // visible for testing
+    SortedRangeSet linearSearchIntersect(SortedRangeSet that)
+    {
         int thisRangeCount = this.getRangeCount();
         int thatRangeCount = that.getRangeCount();
 
@@ -551,6 +566,128 @@ public final class SortedRangeSet
         }
 
         return new SortedRangeSet(type, inclusive, blockBuilder.build());
+    }
+
+    // visible for testing
+    SortedRangeSet binarySearchIntersect(SortedRangeSet that)
+    {
+        SortedRangeSet testRangeSet;
+        SortedRangeSet probeRangeSet;
+        if (this.getRangeCount() > that.getRangeCount()) {
+            testRangeSet = that;
+            probeRangeSet = this;
+        }
+        else {
+            testRangeSet = this;
+            probeRangeSet = that;
+        }
+        int testEnd = testRangeSet.getRangeCount();
+        int probeEnd = probeRangeSet.getRangeCount();
+        int resultIndex = 0;
+
+        // postponed allocation
+        boolean[] inclusive = null;
+        BlockBuilder blockBuilder = null;
+
+        for (int testIndex = 0; testIndex < testEnd; testIndex++) {
+            RangeView current = testRangeSet.getRangeView(testIndex);
+            int insertionStartIndex = 0;
+            if (!current.isLowUnbounded()) {
+                insertionStartIndex = findRangeInsertionPoint(probeRangeSet, 0, probeEnd, current.lowBound());
+                if (insertionStartIndex < 0) {
+                    insertionStartIndex = ~insertionStartIndex;
+                }
+            }
+            int intersectionEndIndex = probeEnd;
+            if (!current.isHighUnbounded()) {
+                intersectionEndIndex = findRangeInsertionPoint(probeRangeSet, 0, probeEnd, current.highBound());
+                if (intersectionEndIndex < 0) {
+                    intersectionEndIndex = ~intersectionEndIndex;
+                }
+                else {
+                    // The intersectionEndIndex is an exclusive index that needs to be increased when an overlapping RangeSet was found
+                    intersectionEndIndex++;
+                }
+            }
+            // test if testRange covers whole probeSet
+            if (insertionStartIndex == 0 && intersectionEndIndex >= probeEnd) {
+                RangeView startRange = probeRangeSet.getRangeView(0);
+                RangeView endRange = probeRangeSet.getRangeView(probeEnd - 1);
+
+                Optional<RangeView> startRangeIntersection = startRange.tryIntersect(current);
+                Optional<RangeView> endRangeIntersection = endRange.tryIntersect(current);
+                if (startRangeIntersection.isPresent() && endRangeIntersection.isPresent() &&
+                        startRangeIntersection.get().compareTo(startRange) == 0 && endRangeIntersection.get().compareTo(endRange) == 0) {
+                    return probeRangeSet;
+                }
+            }
+            if (blockBuilder == null) {
+                blockBuilder = type.createBlockBuilder(null, 2 * (testEnd + probeEnd));
+                inclusive = new boolean[2 * (testEnd + probeEnd)];
+            }
+            int probeIndex = insertionStartIndex;
+            while (probeIndex < intersectionEndIndex) {
+                RangeView probeRange = probeRangeSet.getRangeView(probeIndex);
+                // intersection at edges as [1, 9], [12, 18] intersected with [7, 15], [17, 21] should end up as [7, 9], [12, 15], [17, 18]
+                if (probeIndex == insertionStartIndex || probeIndex + 1 >= intersectionEndIndex) {
+                    Optional<RangeView> intersect = probeRange.tryIntersect(current);
+                    if (intersect.isPresent()) {
+                        writeRange(type, blockBuilder, inclusive, resultIndex, intersect.get());
+                        resultIndex++;
+                    }
+                    probeIndex++;
+                }
+                else {
+                    Block block = probeRangeSet.getSortedRanges();
+                    if (block instanceof DictionaryBlock || block instanceof ValueBlock) {
+                        int size = intersectionEndIndex - probeIndex - 1;
+                        int offset = probeIndex * 2;
+                        if (block instanceof DictionaryBlock) {
+                            copyDictionaryBlock(blockBuilder, inclusive, probeRangeSet, offset, resultIndex, size);
+                        }
+                        else {
+                            copyValueBlock(blockBuilder, inclusive, probeRangeSet, offset, resultIndex, size);
+                        }
+                        probeIndex += size;
+                        resultIndex += size;
+                    }
+                    else {
+                        // RLE
+                        writeRange(type, blockBuilder, inclusive, resultIndex, probeRange);
+                        resultIndex++;
+                        probeIndex++;
+                    }
+                }
+            }
+        }
+
+        if (blockBuilder == null) {
+            blockBuilder = type.createBlockBuilder(null, 0);
+            inclusive = new boolean[0];
+        }
+        if (resultIndex * 2 < inclusive.length) {
+            inclusive = Arrays.copyOf(inclusive, resultIndex * 2);
+        }
+
+        return new SortedRangeSet(type, inclusive, blockBuilder.build());
+    }
+
+    private static void copyValueBlock(BlockBuilder blockBuilder, boolean[] inclusive, SortedRangeSet source, int sourceOffset, int destinationOffset, int size)
+    {
+        ValueBlock valueBlock = (ValueBlock) source.getSortedRanges();
+        System.arraycopy(source.getInclusive(), sourceOffset, inclusive, destinationOffset * 2, size * 2);
+        blockBuilder.appendRange(valueBlock.getUnderlyingValueBlock(), sourceOffset, size * 2);
+    }
+
+    private static void copyDictionaryBlock(BlockBuilder blockBuilder, boolean[] inclusive, SortedRangeSet source, int sourceOffset, int destinationOffset, int size)
+    {
+        DictionaryBlock dictionaryBlock = (DictionaryBlock) source.getSortedRanges();
+        int[] positions = new int[size * 2];
+        for (int position = 0; position < size * 2; position++) {
+            positions[position] = dictionaryBlock.getUnderlyingValuePosition(position + sourceOffset);
+        }
+        System.arraycopy(source.getInclusive(), sourceOffset, inclusive, destinationOffset * 2, positions.length);
+        blockBuilder.appendPositions(dictionaryBlock.getUnderlyingValueBlock(), positions, 0, positions.length);
     }
 
     @Override
@@ -1434,6 +1571,34 @@ public final class SortedRangeSet
                     lowValue,
                     highValue,
                     highInclusive ? "]" : ")");
+        }
+
+        public RangeView highBound()
+        {
+            return new RangeView(
+                    type,
+                    comparisonOperator,
+                    rangeComparisonOperator,
+                    true,
+                    this.highValueBlock,
+                    this.highValuePosition,
+                    true,
+                    this.highValueBlock,
+                    this.highValuePosition);
+        }
+
+        public RangeView lowBound()
+        {
+            return new RangeView(
+                    type,
+                    comparisonOperator,
+                    rangeComparisonOperator,
+                    true,
+                    this.lowValueBlock,
+                    this.lowValuePosition,
+                    true,
+                    this.lowValueBlock,
+                    this.lowValuePosition);
         }
     }
 }

--- a/core/trino-spi/src/test/java/io/trino/spi/predicate/BenchmarkSortedRangeSet.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/predicate/BenchmarkSortedRangeSet.java
@@ -31,6 +31,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.stream.LongStream;
 
 import static io.trino.jmh.Benchmarks.benchmark;
 import static io.trino.spi.predicate.Range.range;
@@ -131,22 +133,80 @@ public class BenchmarkSortedRangeSet
     }
 
     @Benchmark
-    public List<ValueSet> intersectSmall(Data data)
+    public List<ValueSet> linearIntersectSmall(Data data)
     {
-        return benchmarkIntersect(data.smallRanges);
+        return benchmarkIntersect(data.smallRanges, data.smallRanges, SortedRangeSet::linearSearchIntersect);
     }
 
     @Benchmark
-    public List<ValueSet> intersectLarge(Data data)
+    public List<ValueSet> binaryIntersectSmall(Data data)
     {
-        return benchmarkIntersect(data.largeRanges);
+        return benchmarkIntersect(data.smallRanges, data.smallRanges, SortedRangeSet::binarySearchIntersect);
     }
 
-    private List<ValueSet> benchmarkIntersect(List<SortedRangeSet> dataRanges)
+    @Benchmark
+    public List<ValueSet> linearIntersectLarge(Data data)
+    {
+        return benchmarkIntersect(data.largeRanges, data.largeRanges, SortedRangeSet::linearSearchIntersect);
+    }
+
+    @Benchmark
+    public List<ValueSet> binaryIntersectLarge(Data data)
+    {
+        return benchmarkIntersect(data.largeRanges, data.largeRanges, SortedRangeSet::binarySearchIntersect);
+    }
+
+    @Benchmark
+    public List<ValueSet> linearIntersectSmallOnVeryLarge(Data data)
+    {
+        return benchmarkIntersect(data.largeRanges, data.smallRanges, SortedRangeSet::linearSearchIntersect);
+    }
+
+    @Benchmark
+    public List<ValueSet> binaryIntersectSmallOnVeryLarge(Data data)
+    {
+        return benchmarkIntersect(data.largeRanges, data.smallRanges, SortedRangeSet::binarySearchIntersect);
+    }
+
+    @Benchmark
+    public List<ValueSet> linearIntersectDiscreteOnLarge(Data data)
+    {
+        return benchmarkIntersectionSingle(data.largeDiscreteSortedRangeSet, SortedRangeSet::linearSearchIntersect);
+    }
+
+    @Benchmark
+    public List<ValueSet> binaryIntersectRangeOnLarge(Data data)
+    {
+        return benchmarkIntersectionSingle(data.largeRangeSortedRangeSet, SortedRangeSet::binarySearchIntersect);
+    }
+
+    @Benchmark
+    public List<ValueSet> linearIntersectRangeOnLarge(Data data)
+    {
+        return benchmarkIntersectionSingle(data.largeRangeSortedRangeSet, SortedRangeSet::linearSearchIntersect);
+    }
+
+    @Benchmark
+    public List<ValueSet> binaryIntersectDiscreteOnLarge(Data data)
+    {
+        return benchmarkIntersectionSingle(data.largeDiscreteSortedRangeSet, SortedRangeSet::binarySearchIntersect);
+    }
+
+    public List<ValueSet> benchmarkIntersectionSingle(SortedRangeSet target, BiFunction<SortedRangeSet, SortedRangeSet, SortedRangeSet> intersection)
+    {
+        List<ValueSet> result = new ArrayList<>(10);
+        for (int i = 0; i < 10; i++) {
+            SortedRangeSet test = SortedRangeSet.of(range(BIGINT, ThreadLocalRandom.current().nextLong(0, 100), i % 2 == 0, ThreadLocalRandom.current().nextLong(99950, 100_000), i % 2 == 1));
+            result.add(intersection.apply(target, test));
+        }
+        return result;
+    }
+
+    private List<ValueSet> benchmarkIntersect(List<SortedRangeSet> dataRanges, List<SortedRangeSet> testRanges, BiFunction<SortedRangeSet, SortedRangeSet, SortedRangeSet> intersection)
     {
         List<ValueSet> result = new ArrayList<>(dataRanges.size() - 1);
         for (int index = 0; index < dataRanges.size() - 1; index++) {
-            result.add(dataRanges.get(index).intersect(dataRanges.get(index + 1)));
+            result.add(intersection.apply(dataRanges.get(index), testRanges.get(index + 1 % testRanges.size())));
         }
         return result;
     }
@@ -240,6 +300,9 @@ public class BenchmarkSortedRangeSet
         public List<SortedRangeSet> smallRanges;
         public List<SortedRangeSet> largeRanges;
         private List<SortedRangeSet> veryLargeRanges;
+        public SortedRangeSet largeDiscreteSortedRangeSet = SortedRangeSet.of(BIGINT, 0L, LongStream.range(1, 100_000).boxed().toList().toArray());
+        public SortedRangeSet largeRangeSortedRangeSet = SortedRangeSet.of(Range.range(BIGINT, 0L, true, 9L, true),
+                LongStream.rangeClosed(1L, 100_000L).mapToObj(l -> Range.range(BIGINT, l * 10, l % 2 == 1, (l + 1) * 10 - 1, l % 2 == 0)).toList().toArray(Range[]::new));
 
         @Setup(Level.Iteration)
         public void init()
@@ -255,7 +318,7 @@ public class BenchmarkSortedRangeSet
                 ranges.add(range(BIGINT, from, false, to, false));
             }
 
-            smallRanges = generateRangeSets(500_000, 2);
+            smallRanges = generateRangeSets(50_000, 2);
             largeRanges = generateRangeSets(5_000, 300);
             veryLargeRanges = generateRangeSets(5_000, 30_000);
         }
@@ -299,8 +362,18 @@ public class BenchmarkSortedRangeSet
         overlapsLarge(data);
         overlapsSmallOnVeryLarge(data);
 
-        intersectSmall(data);
-        intersectLarge(data);
+        linearIntersectSmall(data);
+        linearIntersectLarge(data);
+        linearIntersectLarge(data);
+        linearIntersectSmallOnVeryLarge(data);
+        linearIntersectRangeOnLarge(data);
+        linearIntersectDiscreteOnLarge(data);
+        binaryIntersectSmall(data);
+        binaryIntersectLarge(data);
+        binaryIntersectLarge(data);
+        binaryIntersectSmallOnVeryLarge(data);
+        binaryIntersectRangeOnLarge(data);
+        binaryIntersectDiscreteOnLarge(data);
 
         containsValueSmall(data);
         containsValueLarge(data);

--- a/core/trino-spi/src/test/java/io/trino/spi/predicate/TestSortedRangeSet.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/predicate/TestSortedRangeSet.java
@@ -17,6 +17,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.common.collect.ImmutableList;
 import io.airlift.json.ObjectMapperProvider;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.TestingBlockEncodingSerde;
 import io.trino.spi.block.TestingBlockJsonSerde;
@@ -29,7 +31,9 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.IntStream;
 import java.util.stream.LongStream;
+import java.util.stream.Stream;
 
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -462,29 +466,152 @@ public class TestSortedRangeSet
     @Test
     public void testIntersect()
     {
-        assertThat(SortedRangeSet.none(BIGINT).intersect(
-                SortedRangeSet.none(BIGINT))).isEqualTo(SortedRangeSet.none(BIGINT));
+        assertIntersect(
+                SortedRangeSet.none(BIGINT),
+                SortedRangeSet.none(BIGINT),
+                SortedRangeSet.none(BIGINT));
 
-        assertThat(SortedRangeSet.all(BIGINT).intersect(
-                SortedRangeSet.all(BIGINT))).isEqualTo(SortedRangeSet.all(BIGINT));
+        assertIntersect(
+                SortedRangeSet.all(BIGINT),
+                SortedRangeSet.all(BIGINT),
+                SortedRangeSet.all(BIGINT));
 
-        assertThat(SortedRangeSet.none(BIGINT).intersect(
-                SortedRangeSet.all(BIGINT))).isEqualTo(SortedRangeSet.none(BIGINT));
+        assertIntersect(
+                SortedRangeSet.none(BIGINT),
+                SortedRangeSet.all(BIGINT),
+                SortedRangeSet.none(BIGINT));
 
-        assertThat(SortedRangeSet.of(Range.equal(BIGINT, 1L), Range.equal(BIGINT, 2L), Range.equal(BIGINT, 3L)).intersect(
-                SortedRangeSet.of(Range.equal(BIGINT, 2L), Range.equal(BIGINT, 4L)))).isEqualTo(SortedRangeSet.of(Range.equal(BIGINT, 2L)));
+        assertIntersect(
+                SortedRangeSet.of(Range.equal(BIGINT, 1L), Range.equal(BIGINT, 2L), Range.equal(BIGINT, 3L)),
+                SortedRangeSet.of(Range.equal(BIGINT, 2L), Range.equal(BIGINT, 4L)),
+                SortedRangeSet.of(Range.equal(BIGINT, 2L)));
 
-        assertThat(SortedRangeSet.all(BIGINT).intersect(
-                SortedRangeSet.of(Range.equal(BIGINT, 2L), Range.equal(BIGINT, 4L)))).isEqualTo(SortedRangeSet.of(Range.equal(BIGINT, 2L), Range.equal(BIGINT, 4L)));
+        assertIntersect(
+                SortedRangeSet.all(BIGINT),
+                SortedRangeSet.of(Range.equal(BIGINT, 2L), Range.equal(BIGINT, 4L)),
+                SortedRangeSet.of(Range.equal(BIGINT, 2L), Range.equal(BIGINT, 4L)));
 
-        assertThat(SortedRangeSet.of(Range.range(BIGINT, 0L, true, 4L, false)).intersect(
-                SortedRangeSet.of(Range.equal(BIGINT, 2L), Range.greaterThan(BIGINT, 3L)))).isEqualTo(SortedRangeSet.of(Range.equal(BIGINT, 2L), Range.range(BIGINT, 3L, false, 4L, false)));
+        assertIntersect(
+                SortedRangeSet.of(Range.range(BIGINT, 0L, true, 4L, false)),
+                SortedRangeSet.of(Range.equal(BIGINT, 2L), Range.greaterThan(BIGINT, 3L)),
+                SortedRangeSet.of(Range.equal(BIGINT, 2L), Range.range(BIGINT, 3L, false, 4L, false)));
 
-        assertThat(SortedRangeSet.of(Range.greaterThanOrEqual(BIGINT, 0L)).intersect(
-                SortedRangeSet.of(Range.lessThanOrEqual(BIGINT, 0L)))).isEqualTo(SortedRangeSet.of(Range.equal(BIGINT, 0L)));
+        assertIntersect(
+                SortedRangeSet.of(Range.greaterThanOrEqual(BIGINT, 0L)),
+                SortedRangeSet.of(Range.lessThanOrEqual(BIGINT, 0L)),
+                SortedRangeSet.of(Range.equal(BIGINT, 0L)));
 
-        assertThat(SortedRangeSet.of(Range.greaterThanOrEqual(BIGINT, -1L)).intersect(
-                SortedRangeSet.of(Range.lessThanOrEqual(BIGINT, 1L)))).isEqualTo(SortedRangeSet.of(Range.range(BIGINT, -1L, true, 1L, true)));
+        assertIntersect(
+                SortedRangeSet.of(Range.greaterThanOrEqual(BIGINT, -1L)),
+                SortedRangeSet.of(Range.lessThanOrEqual(BIGINT, 1L)),
+                SortedRangeSet.of(Range.range(BIGINT, -1L, true, 1L, true)));
+
+        assertIntersect(
+                SortedRangeSet.of(Range.range(BIGINT, 1L, true, 9L, true), Range.range(BIGINT, 12L, true, 18L, true)),
+                SortedRangeSet.of(Range.range(BIGINT, 7L, true, 15L, true), Range.range(BIGINT, 17L, true, 21L, true)),
+                SortedRangeSet.of(
+                        Range.range(BIGINT, 7L, true, 9L, true),
+                        Range.range(BIGINT, 12L, true, 15L, true),
+                        Range.range(BIGINT, 17L, true, 18L, true)));
+
+        assertIntersect(
+                SortedRangeSet.of(Range.range(BIGINT, 1L, true, 9L, true), Range.range(BIGINT, 12L, true, 18L, true)),
+                SortedRangeSet.of(BIGINT, 0L, LongStream.rangeClosed(1L, 25L).boxed().toArray()),
+                SortedRangeSet.of(BIGINT, 1L, Stream.concat(LongStream.rangeClosed(2, 9).boxed(), LongStream.rangeClosed(12, 18).boxed()).toArray()));
+
+        assertIntersect(
+                SortedRangeSet.of(Range.range(BIGINT, 2L, false, 9L, false), Range.range(BIGINT, 12L, false, 18L, false)),
+                SortedRangeSet.of(BIGINT, 0L, LongStream.rangeClosed(1L, 25L).boxed().toArray()),
+                SortedRangeSet.of(BIGINT, 3L, Stream.concat(LongStream.rangeClosed(4, 8).boxed(), LongStream.rangeClosed(13, 17).boxed()).toArray()));
+
+        assertIntersect(
+                SortedRangeSet.of(Range.range(BIGINT, 0L, true, 50L, true)),
+                SortedRangeSet.of(
+                        Range.range(BIGINT, 50L, false, 100L, true),
+                        Range.range(BIGINT, 150L, true, 200L, true)),
+                SortedRangeSet.none(BIGINT));
+
+        assertIntersect(
+                SortedRangeSet.of(Range.range(BIGINT, 50L, true, 100L, true)),
+                SortedRangeSet.of(
+                        Range.range(BIGINT, 0L, true, 50L, false),
+                        Range.range(BIGINT, 150L, true, 200L, true)),
+                SortedRangeSet.none(BIGINT));
+
+        assertIntersect(
+                SortedRangeSet.of(Range.range(BIGINT, 200L, true, 300L, true)),
+                SortedRangeSet.of(
+                        Range.range(BIGINT, 0L, true, 50L, true),
+                        Range.range(BIGINT, 150L, true, 200L, false)),
+                SortedRangeSet.none(BIGINT));
+
+        assertIntersect(
+                SortedRangeSet.of(Range.range(BIGINT, 10L, true, 20L, true)),
+                SortedRangeSet.of(
+                        Range.range(BIGINT, 8L, true, 12L, true),
+                        Range.range(BIGINT, 18L, true, 22L, true)),
+                SortedRangeSet.of(
+                        Range.range(BIGINT, 10L, true, 12L, true),
+                        Range.range(BIGINT, 18L, true, 20L, true)));
+
+        assertIntersect(
+                SortedRangeSet.of(Range.range(BIGINT, 10L, true, 20L, true)),
+                SortedRangeSet.of(
+                        Range.range(BIGINT, 12L, true, 18L, true)),
+                SortedRangeSet.of(
+                        Range.range(BIGINT, 12L, true, 18L, true)));
+
+        assertIntersect(
+                SortedRangeSet.of(Range.range(BIGINT, 10L, true, 20L, true)),
+                SortedRangeSet.of(
+                        Range.range(BIGINT, 12L, true, 14L, true),
+                        Range.range(BIGINT, 16L, true, 18L, true),
+                        Range.range(BIGINT, 22L, true, 24L, true)),
+                SortedRangeSet.of(
+                        Range.range(BIGINT, 12L, true, 14L, true),
+                        Range.range(BIGINT, 16L, true, 18L, true)));
+
+        assertIntersect(
+                SortedRangeSet.of(
+                        Range.equal(BIGINT, 1L),
+                        LongStream.range(1L, 5L).mapToObj(l -> Range.range(BIGINT, l * 10, l % 2 == 0, (l + 1) * 10 - 1, l % 2 == 1)).toList().toArray(Range[]::new)),
+                SortedRangeSet.of(
+                        Range.range(BIGINT, 9L, true, 30L, true),
+                        LongStream.rangeClosed(4L, 10L).mapToObj(l -> Range.range(BIGINT, l * 10, l % 2 == 1, (l + 1) * 10 - 1, l % 2 == 0)).toList().toArray(Range[]::new)),
+                SortedRangeSet.of(
+                        Range.range(BIGINT, 10L, false, 19L, true),
+                        Range.range(BIGINT, 20L, true, 29L, false),
+                        Range.range(BIGINT, 40L, false, 49L, false)));
+
+        // ValueBlock
+        List<Slice> slices = IntStream.rangeClosed(0, 500)
+                .mapToObj(String::valueOf)
+                .map(Slices::utf8Slice)
+                .sorted()
+                .toList();
+        assertIntersect(
+                SortedRangeSet.copyOf(VARCHAR,
+                        Stream.concat(
+                                IntStream.range(0, 2).mapToObj(l -> Range.range(VARCHAR, slices.get(l * 50), l % 2 == 0, slices.get((l + 1) * 50 - 1), l % 2 == 1)),
+                                IntStream.range(3, 5).mapToObj(l -> Range.range(VARCHAR, slices.get(l * 50), l % 2 == 0, slices.get((l + 1) * 50 - 1), l % 2 == 1))).toList()),
+                SortedRangeSet.copyOf(
+                        VARCHAR,
+                        IntStream.rangeClosed(1, 50).mapToObj(l -> Range.range(VARCHAR, slices.get(l * 5), l % 2 == 1, slices.get((l + 1) * 5 - 1), l % 2 == 0)).toList()),
+                SortedRangeSet.copyOf(
+                        VARCHAR,
+                        Stream.concat(
+                                IntStream.rangeClosed(1, 19).mapToObj(l -> Range.range(VARCHAR, slices.get(l * 5), l % 2 == 1, slices.get((l + 1) * 5 - 1), l % 2 == 0)),
+                                IntStream.rangeClosed(30, 49).mapToObj(l -> Range.range(VARCHAR, slices.get(l * 5), l % 2 == 1, slices.get((l + 1) * 5 - 1), l % 2 == 0))).toList()));
+    }
+
+    private void assertIntersect(SortedRangeSet first, SortedRangeSet second, SortedRangeSet result)
+    {
+        assertThat(first.intersect(second)).isEqualTo(result);
+        assertThat(first.linearSearchIntersect(second)).isEqualTo(result);
+        assertThat(first.binarySearchIntersect(second)).isEqualTo(result);
+        assertThat(second.intersect(first)).isEqualTo(result);
+        assertThat(second.linearSearchIntersect(first)).isEqualTo(result);
+        assertThat(second.binarySearchIntersect(first)).isEqualTo(result);
     }
 
     @Test


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Improve performance of SortedRangeSet intersect for common usage patterns.

```
Benchmark                                                Mode  Cnt    Score     Error  Units
BenchmarkSortedRangeSet.binaryIntersectDiscreteOnLarge   avgt    3    2,291 ±   0,098  ms/op
BenchmarkSortedRangeSet.binaryIntersectLarge             avgt    3  368,274 ±  40,854  ms/op
BenchmarkSortedRangeSet.binaryIntersectRangeOnLarge      avgt    3    0,205 ±   0,018  ms/op
BenchmarkSortedRangeSet.binaryIntersectSmall             avgt    3   18,781 ±   0,846  ms/op
BenchmarkSortedRangeSet.binaryIntersectSmallOnVeryLarge  avgt    3    4,437 ±   0,299  ms/op
BenchmarkSortedRangeSet.linearIntersectDiscreteOnLarge   avgt    3  115,397 ± 239,691  ms/op
BenchmarkSortedRangeSet.linearIntersectLarge             avgt    3   96,535 ±   5,318  ms/op
BenchmarkSortedRangeSet.linearIntersectRangeOnLarge      avgt    3    6,387 ±   1,008  ms/op
BenchmarkSortedRangeSet.linearIntersectSmall             avgt    3   13,888 ±   0,851  ms/op
BenchmarkSortedRangeSet.linearIntersectSmallOnVeryLarge  avgt    3   24,626 ±   3,915  ms/op
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
