### PR TITLE
Fix no suitable driver found in MySQL event listener

### DIFF
--- a/plugin/trino-mysql-event-listener/pom.xml
+++ b/plugin/trino-mysql-event-listener/pom.xml
@@ -29,6 +29,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>bootstrap</artifactId>
         </dependency>
@@ -102,12 +107,6 @@
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.mysql</groupId>
-            <artifactId>mysql-connector-j</artifactId>
-            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/MysqlEventListenerFactory.java
+++ b/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/MysqlEventListenerFactory.java
@@ -22,6 +22,7 @@ import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import com.google.inject.TypeLiteral;
+import com.mysql.cj.jdbc.Driver;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
 import io.trino.spi.TrinoWarning;
@@ -33,8 +34,8 @@ import org.jdbi.v3.core.ConnectionFactory;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 
-import java.sql.DriverManager;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
@@ -86,7 +87,7 @@ public class MysqlEventListenerFactory
         @Provides
         public ConnectionFactory createConnectionFactory(MysqlEventListenerConfig config)
         {
-            return () -> DriverManager.getConnection(config.getUrl());
+            return () -> new Driver().connect(config.getUrl(), new Properties());
         }
 
         @Singleton


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
mysql-jdbc-driver is not registered in mysql-event-listener plugin, resulting in the following error:
```
Unable to create injector, see the following errors:
1) Error notifying ProvisionListener LifeCycleModule$$Lambda$4541/0x0000000803c86238 of MysqlEventListener.
 Reason: LifeCycleStartException: Exception in PostConstruct method MysqlEventListener::createTable()
  at MysqlEventListenerFactory.lambda$create$0(MysqlEventListenerFactory.java:65)
  while locating MysqlEventListener
...
Caused by: java.sql.SQLException: No suitable driver found for jdbc:[mysql://]...
```


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
