### PR TITLE
Revert "Convert Split to record"

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/SqlTaskExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTaskExecution.java
@@ -912,7 +912,7 @@ public class SqlTaskExecution
 
         private static String formatSplitInfo(Split split)
         {
-            return split.connectorSplit().getClass().getSimpleName() + "{" + JOINER.join(split.getInfo()) + "}";
+            return split.getConnectorSplit().getClass().getSimpleName() + "{" + JOINER.join(split.getInfo()) + "}";
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/DynamicSplitPlacementPolicy.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/DynamicSplitPlacementPolicy.java
@@ -18,6 +18,7 @@ import io.trino.metadata.InternalNode;
 import io.trino.metadata.Split;
 
 import java.util.List;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
@@ -35,7 +36,7 @@ public class DynamicSplitPlacementPolicy
     }
 
     @Override
-    public SplitPlacementResult computeAssignments(List<Split> splits)
+    public SplitPlacementResult computeAssignments(Set<Split> splits)
     {
         return nodeSelector.computeAssignments(splits, remoteTasks.get());
     }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/FixedSourcePartitionedScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/FixedSourcePartitionedScheduler.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -186,7 +187,7 @@ public class FixedSourcePartitionedScheduler
         }
 
         @Override
-        public SplitPlacementResult computeAssignments(List<Split> splits)
+        public SplitPlacementResult computeAssignments(Set<Split> splits)
         {
             return nodeSelector.computeAssignments(splits, remoteTasks.get(), bucketNodeMap);
         }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeScheduler.java
@@ -158,7 +158,7 @@ public class NodeScheduler
             long maxSplitsWeightPerNode,
             long minPendingSplitsWeightPerTask,
             int maxUnacknowledgedSplitsPerTask,
-            List<Split> splits,
+            Set<Split> splits,
             List<RemoteTask> existingTasks,
             BucketNodeMap bucketNodeMap)
     {

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeSelector.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeSelector.java
@@ -44,7 +44,7 @@ public interface NodeSelector
      * If we cannot find an assignment for a split, it is not included in the map. Also returns a future indicating when
      * to reattempt scheduling of this batch of splits, if some of them could not be scheduled.
      */
-    SplitPlacementResult computeAssignments(List<Split> splits, List<RemoteTask> existingTasks);
+    SplitPlacementResult computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks);
 
     /**
      * Identifies the nodes for running the specified splits based on a precomputed fixed partitioning.
@@ -54,5 +54,5 @@ public interface NodeSelector
      * If we cannot find an assignment for a split, it is not included in the map. Also returns a future indicating when
      * to reattempt scheduling of this batch of splits, if some of them could not be scheduled.
      */
-    SplitPlacementResult computeAssignments(List<Split> splits, List<RemoteTask> existingTasks, BucketNodeMap bucketNodeMap);
+    SplitPlacementResult computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks, BucketNodeMap bucketNodeMap);
 }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/SourcePartitionedScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/SourcePartitionedScheduler.java
@@ -30,8 +30,8 @@ import io.trino.split.SplitSource;
 import io.trino.split.SplitSource.SplitBatch;
 import io.trino.sql.planner.plan.PlanNodeId;
 
-import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -92,7 +92,7 @@ public class SourcePartitionedScheduler
     private final BooleanSupplier anySourceTaskBlocked;
     private final PartitionIdAllocator partitionIdAllocator;
     private final Map<InternalNode, RemoteTask> scheduledTasks;
-    private final List<Split> pendingSplits = new ArrayList<>();
+    private final Set<Split> pendingSplits = new HashSet<>();
 
     private ListenableFuture<SplitBatch> nextSplitBatchFuture;
     private ListenableFuture<Void> placementFuture = immediateVoidFuture();

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/SplitPlacementPolicy.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/SplitPlacementPolicy.java
@@ -17,10 +17,11 @@ import io.trino.metadata.InternalNode;
 import io.trino.metadata.Split;
 
 import java.util.List;
+import java.util.Set;
 
 public interface SplitPlacementPolicy
 {
-    SplitPlacementResult computeAssignments(List<Split> splits);
+    SplitPlacementResult computeAssignments(Set<Split> splits);
 
     void lockDownNodes();
 

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/TopologyAwareNodeSelector.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/TopologyAwareNodeSelector.java
@@ -116,7 +116,7 @@ public class TopologyAwareNodeSelector
     }
 
     @Override
-    public SplitPlacementResult computeAssignments(List<Split> splits, List<RemoteTask> existingTasks)
+    public SplitPlacementResult computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks)
     {
         NodeMap nodeMap = this.nodeMap.get().get();
         Multimap<InternalNode, Split> assignment = HashMultimap.create();
@@ -222,7 +222,7 @@ public class TopologyAwareNodeSelector
     }
 
     @Override
-    public SplitPlacementResult computeAssignments(List<Split> splits, List<RemoteTask> existingTasks, BucketNodeMap bucketNodeMap)
+    public SplitPlacementResult computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks, BucketNodeMap bucketNodeMap)
     {
         return selectDistributionNodes(nodeMap.get().get(), nodeTaskMap, maxSplitsWeightPerNode, maxPendingSplitsWeightPerTask, maxUnacknowledgedSplitsPerTask, splits, existingTasks, bucketNodeMap);
     }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/UniformNodeSelector.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/UniformNodeSelector.java
@@ -37,7 +37,6 @@ import jakarta.annotation.Nullable;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -161,7 +160,7 @@ public class UniformNodeSelector
     }
 
     @Override
-    public SplitPlacementResult computeAssignments(List<Split> splits, List<RemoteTask> existingTasks)
+    public SplitPlacementResult computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks)
     {
         Multimap<InternalNode, Split> assignment = HashMultimap.create();
         NodeMap nodeMap = this.nodeMap.get().get();
@@ -171,7 +170,7 @@ public class UniformNodeSelector
         boolean splitWaitingForAnyNode = false;
         // splitsToBeRedistributed becomes true only when splits go through locality-based assignment
         boolean splitsToBeRedistributed = false;
-        List<Split> remainingSplits = new ArrayList<>(splits.size());
+        Set<Split> remainingSplits = new HashSet<>(splits.size());
 
         List<InternalNode> filteredNodes = filterNodes(nodeMap, includeCoordinator, ImmutableSet.of());
         ResettableRandomizedIterator<InternalNode> randomCandidates = new ResettableRandomizedIterator<>(filteredNodes);
@@ -269,7 +268,7 @@ public class UniformNodeSelector
     }
 
     @Override
-    public SplitPlacementResult computeAssignments(List<Split> splits, List<RemoteTask> existingTasks, BucketNodeMap bucketNodeMap)
+    public SplitPlacementResult computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks, BucketNodeMap bucketNodeMap)
     {
         // TODO: Implement split assignment adjustment based on how quick node is able to process splits. More information https://github.com/trinodb/trino/pull/15168
         return selectDistributionNodes(nodeMap.get().get(), nodeTaskMap, maxSplitsWeightPerNode, minPendingSplitsWeightPerTask, maxUnacknowledgedSplitsPerTask, splits, existingTasks, bucketNodeMap);

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/ArbitraryDistributionSplitAssigner.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/ArbitraryDistributionSplitAssigner.java
@@ -104,7 +104,7 @@ class ArbitraryDistributionSplitAssigner
     public AssignmentResult assign(PlanNodeId planNodeId, ListMultimap<Integer, Split> splits, boolean noMoreSplits)
     {
         for (Split split : splits.values()) {
-            Optional<CatalogHandle> splitCatalogRequirement = Optional.of(split.catalogHandle())
+            Optional<CatalogHandle> splitCatalogRequirement = Optional.of(split.getCatalogHandle())
                     .filter(catalog -> !catalog.getType().isInternal() && !catalog.equals(REMOTE_CATALOG_HANDLE));
             checkArgument(
                     catalogRequirement.isEmpty() || catalogRequirement.equals(splitCatalogRequirement),
@@ -343,7 +343,7 @@ class ArbitraryDistributionSplitAssigner
 
     private Optional<HostAddress> getHostRequirement(Split split)
     {
-        if (split.connectorSplit().isRemotelyAccessible()) {
+        if (split.getConnectorSplit().isRemotelyAccessible()) {
             return Optional.empty();
         }
         List<HostAddress> addresses = split.getAddresses();
@@ -369,8 +369,8 @@ class ArbitraryDistributionSplitAssigner
 
     private long getSplitSizeInBytes(Split split)
     {
-        if (split.catalogHandle().equals(REMOTE_CATALOG_HANDLE)) {
-            RemoteSplit remoteSplit = (RemoteSplit) split.connectorSplit();
+        if (split.getCatalogHandle().equals(REMOTE_CATALOG_HANDLE)) {
+            RemoteSplit remoteSplit = (RemoteSplit) split.getConnectorSplit();
             SpoolingExchangeInput exchangeInput = (SpoolingExchangeInput) remoteSplit.getExchangeInput();
             long size = 0;
             for (ExchangeSourceHandle handle : exchangeInput.getExchangeSourceHandles()) {

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenTaskSource.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenTaskSource.java
@@ -207,7 +207,7 @@ class EventDrivenTaskSource
 
     private int getSplitPartition(Split split)
     {
-        if (split.connectorSplit() instanceof RemoteSplit remoteSplit) {
+        if (split.getConnectorSplit() instanceof RemoteSplit remoteSplit) {
             SpoolingExchangeInput exchangeInput = (SpoolingExchangeInput) remoteSplit.getExchangeInput();
             List<ExchangeSourceHandle> handles = exchangeInput.getExchangeSourceHandles();
             return handles.get(0).getPartitionId();

--- a/core/trino-main/src/main/java/io/trino/metadata/Split.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Split.java
@@ -13,7 +13,9 @@
  */
 package io.trino.metadata;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 import io.trino.spi.HostAddress;
 import io.trino.spi.SplitWeight;
@@ -24,17 +26,36 @@ import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
-public record Split(CatalogHandle catalogHandle, ConnectorSplit connectorSplit)
+public final class Split
 {
     private static final int INSTANCE_SIZE = instanceSize(Split.class);
 
-    public Split
+    private final CatalogHandle catalogHandle;
+    private final ConnectorSplit connectorSplit;
+
+    @JsonCreator
+    public Split(
+            @JsonProperty("catalogHandle") CatalogHandle catalogHandle,
+            @JsonProperty("connectorSplit") ConnectorSplit connectorSplit)
     {
-        requireNonNull(catalogHandle, "catalogHandle is null");
-        requireNonNull(connectorSplit, "connectorSplit is null");
+        this.catalogHandle = requireNonNull(catalogHandle, "catalogHandle is null");
+        this.connectorSplit = requireNonNull(connectorSplit, "connectorSplit is null");
+    }
+
+    @JsonProperty
+    public CatalogHandle getCatalogHandle()
+    {
+        return catalogHandle;
+    }
+
+    @JsonProperty
+    public ConnectorSplit getConnectorSplit()
+    {
+        return connectorSplit;
     }
 
     @JsonIgnore
@@ -43,22 +64,28 @@ public record Split(CatalogHandle catalogHandle, ConnectorSplit connectorSplit)
         return firstNonNull(connectorSplit.getSplitInfo(), ImmutableMap.of());
     }
 
-    @JsonIgnore
     public List<HostAddress> getAddresses()
     {
         return connectorSplit.getAddresses();
     }
 
-    @JsonIgnore
     public boolean isRemotelyAccessible()
     {
         return connectorSplit.isRemotelyAccessible();
     }
 
-    @JsonIgnore
     public SplitWeight getSplitWeight()
     {
         return connectorSplit.getSplitWeight();
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("catalogHandle", catalogHandle)
+                .add("connectorSplit", connectorSplit)
+                .toString();
     }
 
     public long getRetainedSizeInBytes()

--- a/core/trino-main/src/main/java/io/trino/operator/ExchangeOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ExchangeOperator.java
@@ -172,9 +172,9 @@ public class ExchangeOperator
     public void addSplit(Split split)
     {
         requireNonNull(split, "split is null");
-        checkArgument(split.catalogHandle().equals(REMOTE_CATALOG_HANDLE), "split is not a remote split");
+        checkArgument(split.getCatalogHandle().equals(REMOTE_CATALOG_HANDLE), "split is not a remote split");
 
-        RemoteSplit remoteSplit = (RemoteSplit) split.connectorSplit();
+        RemoteSplit remoteSplit = (RemoteSplit) split.getConnectorSplit();
         exchangeDataSource.addInput(remoteSplit.getExchangeInput());
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/LeafTableFunctionOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/LeafTableFunctionOperator.java
@@ -148,7 +148,7 @@ public class LeafTableFunctionOperator
     public void addSplit(Split split)
     {
         checkState(!noMoreSplits, "no more splits expected");
-        pendingSplits.add(split.connectorSplit());
+        pendingSplits.add(split.getConnectorSplit());
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/MergeOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/MergeOperator.java
@@ -162,7 +162,7 @@ public class MergeOperator
     public void addSplit(Split split)
     {
         requireNonNull(split, "split is null");
-        checkArgument(split.connectorSplit() instanceof RemoteSplit, "split is not a remote split");
+        checkArgument(split.getConnectorSplit() instanceof RemoteSplit, "split is not a remote split");
         checkState(!blockedOnSplits.isDone(), "noMoreSplits has been called already");
 
         TaskContext taskContext = operatorContext.getDriverContext().getPipelineContext().getTaskContext();
@@ -173,7 +173,7 @@ public class MergeOperator
                 operatorContext.localUserMemoryContext(),
                 taskContext::sourceTaskFailed,
                 RetryPolicy.NONE));
-        RemoteSplit remoteSplit = (RemoteSplit) split.connectorSplit();
+        RemoteSplit remoteSplit = (RemoteSplit) split.getConnectorSplit();
         // Only fault tolerant execution mode is expected to execute external exchanges.
         // MergeOperator is used for distributed sort only and it is not compatible (and disabled) with fault tolerant execution mode.
         DirectExchangeInput exchangeInput = (DirectExchangeInput) remoteSplit.getExchangeInput();

--- a/core/trino-main/src/main/java/io/trino/operator/ScanFilterAndProjectOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ScanFilterAndProjectOperator.java
@@ -252,7 +252,7 @@ public class ScanFilterAndProjectOperator
             }
 
             ConnectorPageSource source;
-            if (split.connectorSplit() instanceof EmptySplit) {
+            if (split.getConnectorSplit() instanceof EmptySplit) {
                 source = new EmptyPageSource();
             }
             else {

--- a/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
@@ -165,12 +165,12 @@ public class TableScanOperator
 
         Map<String, String> splitInfo = split.getInfo();
         if (!splitInfo.isEmpty()) {
-            operatorContext.setInfoSupplier(Suppliers.ofInstance(new SplitOperatorInfo(split.catalogHandle(), splitInfo)));
+            operatorContext.setInfoSupplier(Suppliers.ofInstance(new SplitOperatorInfo(split.getCatalogHandle(), splitInfo)));
         }
 
         blocked.set(null);
 
-        if (split.connectorSplit() instanceof EmptySplit) {
+        if (split.getConnectorSplit() instanceof EmptySplit) {
             source = new EmptyPageSource();
         }
     }

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorSourceOperatorAdapter.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorSourceOperatorAdapter.java
@@ -87,7 +87,7 @@ public class WorkProcessorSourceOperatorAdapter
 
         Map<String, String> splitInfo = split.getInfo();
         if (!splitInfo.isEmpty()) {
-            operatorContext.setInfoSupplier(Suppliers.ofInstance(new SplitOperatorInfo(split.catalogHandle(), splitInfo)));
+            operatorContext.setInfoSupplier(Suppliers.ofInstance(new SplitOperatorInfo(split.getCatalogHandle(), splitInfo)));
         }
 
         splitBuffer.add(split);

--- a/core/trino-main/src/main/java/io/trino/operator/index/IndexSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/index/IndexSourceOperator.java
@@ -121,7 +121,7 @@ public class IndexSourceOperator
         requireNonNull(split, "split is null");
         checkState(source == null, "Index source split already set");
 
-        IndexSplit indexSplit = (IndexSplit) split.connectorSplit();
+        IndexSplit indexSplit = (IndexSplit) split.getConnectorSplit();
 
         // Normalize the incoming RecordSet to something that can be consumed by the index
         RecordSet normalizedRecordSet = probeKeyNormalizer.apply(indexSplit.getKeyRecordSet());
@@ -130,7 +130,7 @@ public class IndexSourceOperator
 
         Map<String, String> splitInfo = split.getInfo();
         if (!splitInfo.isEmpty()) {
-            operatorContext.setInfoSupplier(Suppliers.ofInstance(new SplitOperatorInfo(split.catalogHandle(), splitInfo)));
+            operatorContext.setInfoSupplier(Suppliers.ofInstance(new SplitOperatorInfo(split.getCatalogHandle(), splitInfo)));
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/split/PageSourceManager.java
+++ b/core/trino-main/src/main/java/io/trino/split/PageSourceManager.java
@@ -47,8 +47,8 @@ public class PageSourceManager
     public ConnectorPageSource createPageSource(Session session, Split split, TableHandle table, List<ColumnHandle> columns, DynamicFilter dynamicFilter)
     {
         requireNonNull(columns, "columns is null");
-        checkArgument(split.catalogHandle().equals(table.catalogHandle()), "mismatched split and table");
-        CatalogHandle catalogHandle = split.catalogHandle();
+        checkArgument(split.getCatalogHandle().equals(table.catalogHandle()), "mismatched split and table");
+        CatalogHandle catalogHandle = split.getCatalogHandle();
 
         ConnectorPageSourceProvider provider = pageSourceProvider.getService(catalogHandle);
         TupleDomain<ColumnHandle> constraint = dynamicFilter.getCurrentPredicate();
@@ -61,7 +61,7 @@ public class PageSourceManager
         return provider.createPageSource(
                 table.transaction(),
                 session.toConnectorSession(catalogHandle),
-                split.connectorSplit(),
+                split.getConnectorSplit(),
                 table.connectorHandle(),
                 columns,
                 dynamicFilter);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/NodePartitioningManager.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/NodePartitioningManager.java
@@ -290,11 +290,11 @@ public class NodePartitioningManager
 
         return split -> {
             int bucket;
-            if (split.connectorSplit() instanceof EmptySplit) {
+            if (split.getConnectorSplit() instanceof EmptySplit) {
                 bucket = 0;
             }
             else {
-                bucket = splitBucketFunction.applyAsInt(split.connectorSplit());
+                bucket = splitBucketFunction.applyAsInt(split.getConnectorSplit());
             }
             return bucket;
         };

--- a/core/trino-main/src/test/java/io/trino/execution/BenchmarkNodeScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/BenchmarkNodeScheduler.java
@@ -59,10 +59,12 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
@@ -99,7 +101,7 @@ public class BenchmarkNodeScheduler
         List<RemoteTask> remoteTasks = ImmutableList.copyOf(data.getTaskMap().values());
         Iterator<MockRemoteTaskFactory.MockRemoteTask> finishingTask = Iterators.cycle(data.getTaskMap().values());
         Iterator<Split> splits = data.getSplits().iterator();
-        List<Split> batch = new ArrayList<>();
+        Set<Split> batch = new HashSet<>();
         while (splits.hasNext() || !batch.isEmpty()) {
             Multimap<InternalNode, Split> assignments = data.getNodeSelector().computeAssignments(batch, remoteTasks).getAssignments();
             for (InternalNode node : assignments.keySet()) {

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskExecution.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskExecution.java
@@ -435,7 +435,7 @@ public class TestSqlTaskExecution
                     return;
                 }
 
-                this.split = (TestingSplit) split.connectorSplit();
+                this.split = (TestingSplit) split.getConnectorSplit();
                 blocked.set(null);
             }
 

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestUniformNodeSelector.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestUniformNodeSelector.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
 import io.airlift.testing.TestingTicker;
 import io.trino.Session;
 import io.trino.client.NodeVersion;
@@ -42,9 +43,9 @@ import org.junit.jupiter.api.TestInstance;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -65,7 +66,7 @@ public class TestUniformNodeSelector
 {
     private static final InternalNode node1 = new InternalNode("node1", URI.create("http://10.0.0.1:13"), NodeVersion.UNKNOWN, false);
     private static final InternalNode node2 = new InternalNode("node2", URI.create("http://10.0.0.1:12"), NodeVersion.UNKNOWN, false);
-    private final List<Split> splits = new ArrayList<>();
+    private final Set<Split> splits = new LinkedHashSet<>();
     private FinalizerService finalizerService;
     private NodeTaskMap nodeTaskMap;
     private InMemoryNodeManager nodeManager;
@@ -153,7 +154,7 @@ public class TestUniformNodeSelector
             nodeTaskMap.addTask(node, remoteTask);
             taskMap.put(node, remoteTask);
         }
-        List<Split> unassignedSplits = difference(splits, ImmutableList.copyOf(assignments1.values()));
+        Set<Split> unassignedSplits = Sets.difference(splits, new HashSet<>(assignments1.values()));
         assertThat(unassignedSplits.size()).isEqualTo(18);
         // It's possible to add new assignments because split queue was upscaled
         Multimap<InternalNode, Split> assignments2 = nodeSelector.computeAssignments(unassignedSplits, ImmutableList.copyOf(taskMap.values())).getAssignments();
@@ -201,7 +202,7 @@ public class TestUniformNodeSelector
             nodeTaskMap.addTask(node, remoteTask);
             taskMap.put(node, remoteTask);
         }
-        List<Split> unassignedSplits = difference(splits, ImmutableList.copyOf(assignments1.values()));
+        Set<Split> unassignedSplits = Sets.difference(splits, new HashSet<>(assignments1.values()));
         assertThat(unassignedSplits.size()).isEqualTo(140);
 
         // assign splits, mark all splits running to trigger adjustment
@@ -213,7 +214,7 @@ public class TestUniformNodeSelector
                     .build());
             remoteTask.startSplits(remoteTask.getPartitionedSplitsInfo().getCount()); // mark all task running
         }
-        unassignedSplits = difference(unassignedSplits, ImmutableList.copyOf(assignments2.values()));
+        unassignedSplits = Sets.difference(unassignedSplits, new HashSet<>(assignments2.values()));
         assertThat(unassignedSplits.size()).isEqualTo(100); // 140 (unassigned splits) - (2 (queue size adjustment) * 10 (minPendingSplitsPerTask)) * 2 (nodes)
 
         // assign splits without setting all splits running
@@ -224,12 +225,12 @@ public class TestUniformNodeSelector
                     .putAll(new PlanNodeId("sourceId"), assignments3.get(node))
                     .build());
         }
-        unassignedSplits = difference(unassignedSplits, ImmutableList.copyOf(assignments3.values()));
+        unassignedSplits = Sets.difference(unassignedSplits, new HashSet<>(assignments3.values()));
         assertThat(unassignedSplits.size()).isEqualTo(20); // 100 (unassigned splits) - (4 (queue size adjustment) * 10 (minPendingSplitsPerTask)) * 2 (nodes)
 
         // compute assignments with exhausted nodes
         Multimap<InternalNode, Split> assignments4 = nodeSelector.computeAssignments(unassignedSplits, ImmutableList.copyOf(taskMap.values())).getAssignments();
-        unassignedSplits = difference(unassignedSplits, ImmutableList.copyOf(assignments4.values()));
+        unassignedSplits = Sets.difference(unassignedSplits, new HashSet<>(assignments4.values()));
         assertThat(unassignedSplits.size()).isEqualTo(20); // no new split assignments, queued are more than 0
     }
 
@@ -255,7 +256,7 @@ public class TestUniformNodeSelector
             nodeTaskMap.addTask(node, remoteTask);
             taskMap.put(node, remoteTask);
         }
-        List<Split> unassignedSplits = difference(splits, ImmutableList.copyOf(assignments1.values()));
+        Set<Split> unassignedSplits = Sets.difference(splits, new HashSet<>(assignments1.values()));
         assertThat(unassignedSplits.size()).isEqualTo(140);
 
         // assign splits, mark all splits for node1 running to trigger adjustment
@@ -269,7 +270,7 @@ public class TestUniformNodeSelector
                 remoteTask.startSplits(remoteTask.getPartitionedSplitsInfo().getCount());
             }
         }
-        unassignedSplits = difference(unassignedSplits, ImmutableList.copyOf(assignments2.values()));
+        unassignedSplits = Sets.difference(unassignedSplits, new HashSet<>(assignments2.values()));
         assertThat(unassignedSplits.size()).isEqualTo(120);
         assertThat(assignments2.get(node1).size()).isEqualTo(20); // 2x max pending
         assertThat(assignments2.containsKey(node2)).isFalse();
@@ -285,7 +286,7 @@ public class TestUniformNodeSelector
                 remoteTask.startSplits(remoteTask.getPartitionedSplitsInfo().getCount());
             }
         }
-        unassignedSplits = difference(unassignedSplits, ImmutableList.copyOf(assignments3.values()));
+        unassignedSplits = Sets.difference(unassignedSplits, new HashSet<>(assignments3.values()));
         assertThat(unassignedSplits.size()).isEqualTo(80);
         assertThat(assignments3.get(node1).size()).isEqualTo(40); // 4x max pending
         assertThat(assignments2.containsKey(node2)).isFalse();
@@ -312,12 +313,5 @@ public class TestUniformNodeSelector
         }
 
         return new NodeMap(byHostAndPort.build(), byHost.build(), ImmutableSetMultimap.of(), coordinatorNodeIds);
-    }
-
-    private static <T> List<T> difference(List<T> left, List<T> right)
-    {
-        List<T> retVal = new ArrayList<>(left);
-        retVal.removeAll(right);
-        return retVal;
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestingNodeSelectorFactory.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestingNodeSelectorFactory.java
@@ -139,13 +139,13 @@ public class TestingNodeSelectorFactory
         }
 
         @Override
-        public SplitPlacementResult computeAssignments(List<Split> splits, List<RemoteTask> existingTasks)
+        public SplitPlacementResult computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks)
         {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public SplitPlacementResult computeAssignments(List<Split> splits, List<RemoteTask> existingTasks, BucketNodeMap bucketNodeMap)
+        public SplitPlacementResult computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks, BucketNodeMap bucketNodeMap)
         {
             throw new UnsupportedOperationException();
         }

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/SplitAssignerTester.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/SplitAssignerTester.java
@@ -73,7 +73,7 @@ class SplitAssignerTester
         SplitsMapping taskPartitionSplits = splits.getOrDefault(taskPartition, SplitsMapping.EMPTY);
         List<Split> splitsFlat = taskPartitionSplits.getSplitsFlat(planNodeId);
         return splitsFlat.stream()
-                .map(split -> (TestingConnectorSplit) split.connectorSplit())
+                .map(split -> (TestingConnectorSplit) split.getConnectorSplit())
                 .map(TestingConnectorSplit::getId)
                 .collect(toImmutableSet());
     }

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestArbitraryDistributionSplitAssigner.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestArbitraryDistributionSplitAssigner.java
@@ -677,7 +677,7 @@ public class TestArbitraryDistributionSplitAssigner
                     Optional<HostAddress> hostRequirement = Optional.empty();
                     if (!split.isRemotelyAccessible()) {
                         int splitCount = Integer.MAX_VALUE;
-                        for (HostAddress hostAddress : split.connectorSplit().getAddresses()) {
+                        for (HostAddress hostAddress : split.getConnectorSplit().getAddresses()) {
                             PartitionAssignment currentAssignment = currentSplitAssignments.get(Optional.of(hostAddress));
                             if (currentAssignment == null) {
                                 hostRequirement = Optional.of(hostAddress);

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestEventDrivenTaskSource.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestEventDrivenTaskSource.java
@@ -364,8 +364,8 @@ public class TestEventDrivenTaskSource
         for (TaskDescriptor taskDescriptor : taskDescriptors) {
             int partitionId = taskDescriptor.getPartitionId();
             for (Map.Entry<PlanNodeId, Split> entry : taskDescriptor.getSplits().getSplitsFlat().entries()) {
-                if (entry.getValue().catalogHandle().equals(REMOTE_CATALOG_HANDLE)) {
-                    RemoteSplit remoteSplit = (RemoteSplit) entry.getValue().connectorSplit();
+                if (entry.getValue().getCatalogHandle().equals(REMOTE_CATALOG_HANDLE)) {
+                    RemoteSplit remoteSplit = (RemoteSplit) entry.getValue().getConnectorSplit();
                     SpoolingExchangeInput input = (SpoolingExchangeInput) remoteSplit.getExchangeInput();
                     for (ExchangeSourceHandle handle : input.getExchangeSourceHandles()) {
                         assertThat(handle.getPartitionId()).isEqualTo(partitionId);
@@ -373,7 +373,7 @@ public class TestEventDrivenTaskSource
                     }
                 }
                 else {
-                    TestingConnectorSplit split = (TestingConnectorSplit) entry.getValue().connectorSplit();
+                    TestingConnectorSplit split = (TestingConnectorSplit) entry.getValue().getConnectorSplit();
                     assertThat(split.getBucket().orElseThrow()).isEqualTo(partitionId);
                     actualSplits.computeIfAbsent(partitionId, key -> HashMultimap.create()).put(entry.getKey(), split);
                 }
@@ -389,7 +389,7 @@ public class TestEventDrivenTaskSource
         return new FaultTolerantPartitioningScheme(
                 partitionCount,
                 Optional.of(IntStream.range(0, partitionCount).toArray()),
-                Optional.of(split -> ((TestingConnectorSplit) split.connectorSplit()).getBucket().orElseThrow()),
+                Optional.of(split -> ((TestingConnectorSplit) split.getConnectorSplit()).getBucket().orElseThrow()),
                 Optional.empty());
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestHashDistributionSplitAssigner.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestHashDistributionSplitAssigner.java
@@ -575,7 +575,7 @@ public class TestHashDistributionSplitAssigner
     private static ListMultimap<Integer, Split> createSplitMap(Split... splits)
     {
         return Arrays.stream(splits)
-                .collect(toImmutableListMultimap(split -> ((TestingConnectorSplit) split.connectorSplit()).getBucket().orElseThrow(), Function.identity()));
+                .collect(toImmutableListMultimap(split -> ((TestingConnectorSplit) split.getConnectorSplit()).getBucket().orElseThrow(), Function.identity()));
     }
 
     private static FaultTolerantPartitioningScheme createPartitioningScheme(int partitionCount, Optional<List<InternalNode>> partitionToNodeMap)
@@ -583,7 +583,7 @@ public class TestHashDistributionSplitAssigner
         return new FaultTolerantPartitioningScheme(
                 partitionCount,
                 Optional.of(IntStream.range(0, partitionCount).toArray()),
-                Optional.of(split -> ((TestingConnectorSplit) split.connectorSplit()).getBucket().orElseThrow()),
+                Optional.of(split -> ((TestingConnectorSplit) split.getConnectorSplit()).getBucket().orElseThrow()),
                 partitionToNodeMap);
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestSplitsMapping.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestSplitsMapping.java
@@ -119,7 +119,7 @@ public class TestSplitsMapping
         return splitsMapping.getSplits(new PlanNodeId(planNodeId)).entries().stream()
                 .collect(ImmutableListMultimap.toImmutableListMultimap(
                         Map.Entry::getKey,
-                        entry -> ((TestingConnectorSplit) entry.getValue().connectorSplit()).getId()));
+                        entry -> ((TestingConnectorSplit) entry.getValue().getConnectorSplit()).getId()));
     }
 
     private static Split createSplit(int id)

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestingConnectorSplit.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestingConnectorSplit.java
@@ -113,6 +113,6 @@ class TestingConnectorSplit
 
     public static int getSplitId(Split split)
     {
-        return ((TestingConnectorSplit) split.connectorSplit()).getId();
+        return ((TestingConnectorSplit) split.getConnectorSplit()).getId();
     }
 }


### PR DESCRIPTION
This reverts commit 12b8e5f469edfa27418c66dcec4f7ae54be9716d. The commit introduced some bug to execution engine which could be reproduced by running
`TestDistributedEngineOnlyQueries.testAssignUniqueId` with `@RepeatedTest(1000)`. The fact that tests execute in concurrency could be a factor in reproducing the problem.

Fixes https://github.com/trinodb/trino/issues/21630
This also fixes probable performance issue -- https://github.com/trinodb/trino/pull/21583/files#r1572265677 