### PR TITLE
Remove reliance on split equality or identity

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/DynamicSplitPlacementPolicy.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/DynamicSplitPlacementPolicy.java
@@ -18,6 +18,7 @@ import io.trino.metadata.InternalNode;
 import io.trino.metadata.Split;
 
 import java.util.List;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
@@ -35,7 +36,7 @@ public class DynamicSplitPlacementPolicy
     }
 
     @Override
-    public SplitPlacementResult computeAssignments(List<Split> splits)
+    public SplitPlacementResult computeAssignments(Set<Split> splits)
     {
         return nodeSelector.computeAssignments(splits, remoteTasks.get());
     }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/FixedSourcePartitionedScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/FixedSourcePartitionedScheduler.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -186,7 +187,7 @@ public class FixedSourcePartitionedScheduler
         }
 
         @Override
-        public SplitPlacementResult computeAssignments(List<Split> splits)
+        public SplitPlacementResult computeAssignments(Set<Split> splits)
         {
             return nodeSelector.computeAssignments(splits, remoteTasks.get(), bucketNodeMap);
         }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeScheduler.java
@@ -158,7 +158,7 @@ public class NodeScheduler
             long maxSplitsWeightPerNode,
             long minPendingSplitsWeightPerTask,
             int maxUnacknowledgedSplitsPerTask,
-            List<Split> splits,
+            Set<Split> splits,
             List<RemoteTask> existingTasks,
             BucketNodeMap bucketNodeMap)
     {

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeSelector.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeSelector.java
@@ -44,7 +44,7 @@ public interface NodeSelector
      * If we cannot find an assignment for a split, it is not included in the map. Also returns a future indicating when
      * to reattempt scheduling of this batch of splits, if some of them could not be scheduled.
      */
-    SplitPlacementResult computeAssignments(List<Split> splits, List<RemoteTask> existingTasks);
+    SplitPlacementResult computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks);
 
     /**
      * Identifies the nodes for running the specified splits based on a precomputed fixed partitioning.
@@ -54,5 +54,5 @@ public interface NodeSelector
      * If we cannot find an assignment for a split, it is not included in the map. Also returns a future indicating when
      * to reattempt scheduling of this batch of splits, if some of them could not be scheduled.
      */
-    SplitPlacementResult computeAssignments(List<Split> splits, List<RemoteTask> existingTasks, BucketNodeMap bucketNodeMap);
+    SplitPlacementResult computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks, BucketNodeMap bucketNodeMap);
 }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/SourcePartitionedScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/SourcePartitionedScheduler.java
@@ -30,8 +30,8 @@ import io.trino.split.SplitSource;
 import io.trino.split.SplitSource.SplitBatch;
 import io.trino.sql.planner.plan.PlanNodeId;
 
-import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -92,7 +92,7 @@ public class SourcePartitionedScheduler
     private final BooleanSupplier anySourceTaskBlocked;
     private final PartitionIdAllocator partitionIdAllocator;
     private final Map<InternalNode, RemoteTask> scheduledTasks;
-    private final List<Split> pendingSplits = new ArrayList<>();
+    private final Set<Split> pendingSplits = new HashSet<>();
 
     private ListenableFuture<SplitBatch> nextSplitBatchFuture;
     private ListenableFuture<Void> placementFuture = immediateVoidFuture();

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/SplitPlacementPolicy.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/SplitPlacementPolicy.java
@@ -17,10 +17,11 @@ import io.trino.metadata.InternalNode;
 import io.trino.metadata.Split;
 
 import java.util.List;
+import java.util.Set;
 
 public interface SplitPlacementPolicy
 {
-    SplitPlacementResult computeAssignments(List<Split> splits);
+    SplitPlacementResult computeAssignments(Set<Split> splits);
 
     void lockDownNodes();
 

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/TopologyAwareNodeSelector.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/TopologyAwareNodeSelector.java
@@ -116,7 +116,7 @@ public class TopologyAwareNodeSelector
     }
 
     @Override
-    public SplitPlacementResult computeAssignments(List<Split> splits, List<RemoteTask> existingTasks)
+    public SplitPlacementResult computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks)
     {
         NodeMap nodeMap = this.nodeMap.get().get();
         Multimap<InternalNode, Split> assignment = HashMultimap.create();
@@ -222,7 +222,7 @@ public class TopologyAwareNodeSelector
     }
 
     @Override
-    public SplitPlacementResult computeAssignments(List<Split> splits, List<RemoteTask> existingTasks, BucketNodeMap bucketNodeMap)
+    public SplitPlacementResult computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks, BucketNodeMap bucketNodeMap)
     {
         return selectDistributionNodes(nodeMap.get().get(), nodeTaskMap, maxSplitsWeightPerNode, maxPendingSplitsWeightPerTask, maxUnacknowledgedSplitsPerTask, splits, existingTasks, bucketNodeMap);
     }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/UniformNodeSelector.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/UniformNodeSelector.java
@@ -37,7 +37,6 @@ import jakarta.annotation.Nullable;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -161,7 +160,7 @@ public class UniformNodeSelector
     }
 
     @Override
-    public SplitPlacementResult computeAssignments(List<Split> splits, List<RemoteTask> existingTasks)
+    public SplitPlacementResult computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks)
     {
         Multimap<InternalNode, Split> assignment = HashMultimap.create();
         NodeMap nodeMap = this.nodeMap.get().get();
@@ -171,7 +170,7 @@ public class UniformNodeSelector
         boolean splitWaitingForAnyNode = false;
         // splitsToBeRedistributed becomes true only when splits go through locality-based assignment
         boolean splitsToBeRedistributed = false;
-        List<Split> remainingSplits = new ArrayList<>(splits.size());
+        Set<Split> remainingSplits = new HashSet<>(splits.size());
 
         List<InternalNode> filteredNodes = filterNodes(nodeMap, includeCoordinator, ImmutableSet.of());
         ResettableRandomizedIterator<InternalNode> randomCandidates = new ResettableRandomizedIterator<>(filteredNodes);
@@ -269,7 +268,7 @@ public class UniformNodeSelector
     }
 
     @Override
-    public SplitPlacementResult computeAssignments(List<Split> splits, List<RemoteTask> existingTasks, BucketNodeMap bucketNodeMap)
+    public SplitPlacementResult computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks, BucketNodeMap bucketNodeMap)
     {
         // TODO: Implement split assignment adjustment based on how quick node is able to process splits. More information https://github.com/trinodb/trino/pull/15168
         return selectDistributionNodes(nodeMap.get().get(), nodeTaskMap, maxSplitsWeightPerNode, minPendingSplitsWeightPerTask, maxUnacknowledgedSplitsPerTask, splits, existingTasks, bucketNodeMap);

--- a/core/trino-main/src/main/java/io/trino/metadata/Split.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Split.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static io.airlift.slice.SizeOf.instanceSize;
+import static java.lang.System.identityHashCode;
 import static java.util.Objects.requireNonNull;
 
 public record Split(CatalogHandle catalogHandle, ConnectorSplit connectorSplit)
@@ -66,5 +67,21 @@ public record Split(CatalogHandle catalogHandle, ConnectorSplit connectorSplit)
         return INSTANCE_SIZE
                 + catalogHandle.getRetainedSizeInBytes()
                 + connectorSplit.getRetainedSizeInBytes();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        // There is no equality contract for ConnectorSplit and there is no requirement for
+        // ConnectorSplits returned from ConnectorSplitSource to be different. For example,
+        // a ConnectorSplitSource could return 10 times same "produce a row" split instance,
+        // so that the table has effectively 10 rows. The blackhole connector does that.
+        return this == o;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return identityHashCode(this);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/Split.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Split.java
@@ -38,30 +38,31 @@ public record Split(CatalogHandle catalogHandle, ConnectorSplit connectorSplit)
         requireNonNull(connectorSplit, "connectorSplit is null");
     }
 
-    @JsonIgnore
+    @JsonIgnore // TODO remove after https://github.com/airlift/airlift/pull/1141
     public Map<String, String> getInfo()
     {
         return firstNonNull(connectorSplit.getSplitInfo(), ImmutableMap.of());
     }
 
-    @JsonIgnore
+    @JsonIgnore // TODO remove after https://github.com/airlift/airlift/pull/1141
     public List<HostAddress> getAddresses()
     {
         return connectorSplit.getAddresses();
     }
 
-    @JsonIgnore
+    @JsonIgnore // TODO remove after https://github.com/airlift/airlift/pull/1141
     public boolean isRemotelyAccessible()
     {
         return connectorSplit.isRemotelyAccessible();
     }
 
-    @JsonIgnore
+    @JsonIgnore // TODO remove after https://github.com/airlift/airlift/pull/1141
     public SplitWeight getSplitWeight()
     {
         return connectorSplit.getSplitWeight();
     }
 
+    @JsonIgnore // TODO remove after https://github.com/airlift/airlift/pull/1141
     public long getRetainedSizeInBytes()
     {
         return INSTANCE_SIZE

--- a/core/trino-main/src/test/java/io/trino/execution/BenchmarkNodeScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/BenchmarkNodeScheduler.java
@@ -59,10 +59,12 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
@@ -99,7 +101,7 @@ public class BenchmarkNodeScheduler
         List<RemoteTask> remoteTasks = ImmutableList.copyOf(data.getTaskMap().values());
         Iterator<MockRemoteTaskFactory.MockRemoteTask> finishingTask = Iterators.cycle(data.getTaskMap().values());
         Iterator<Split> splits = data.getSplits().iterator();
-        List<Split> batch = new ArrayList<>();
+        Set<Split> batch = new HashSet<>();
         while (splits.hasNext() || !batch.isEmpty()) {
             Multimap<InternalNode, Split> assignments = data.getNodeSelector().computeAssignments(batch, remoteTasks).getAssignments();
             for (InternalNode node : assignments.keySet()) {

--- a/core/trino-main/src/test/java/io/trino/execution/TestNodeScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestNodeScheduler.java
@@ -18,6 +18,7 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
@@ -157,7 +158,7 @@ public class TestNodeScheduler
     @Test
     public void testAssignmentWhenNoNodes()
     {
-        List<Split> splits = new ArrayList<>();
+        Set<Split> splits = new HashSet<>();
         splits.add(new Split(TEST_CATALOG_HANDLE, new TestSplitRemote()));
 
         assertTrinoExceptionThrownBy(() -> nodeSelector.computeAssignments(splits, ImmutableList.copyOf(taskMap.values())))
@@ -170,7 +171,7 @@ public class TestNodeScheduler
     {
         setUpNodes();
         Split split = new Split(TEST_CATALOG_HANDLE, new TestSplitLocallyAccessible());
-        List<Split> splits = ImmutableList.of(split);
+        Set<Split> splits = ImmutableSet.of(split);
 
         Map.Entry<InternalNode, Split> assignment = getOnlyElement(nodeSelector.computeAssignments(splits, ImmutableList.copyOf(taskMap.values())).getAssignments().entries());
         assertThat(assignment.getKey().getHostAndPort()).isEqualTo(split.getAddresses().get(0));
@@ -200,11 +201,11 @@ public class TestNodeScheduler
         NodeSelector nodeSelector = nodeScheduler.createNodeSelector(session, Optional.of(TEST_CATALOG_HANDLE));
 
         // Fill up the nodes with non-local data
-        ImmutableList.Builder<Split> nonRackLocalBuilder = ImmutableList.builder();
+        ImmutableSet.Builder<Split> nonRackLocalBuilder = ImmutableSet.builder();
         for (int i = 0; i < (25 + 11) * 3; i++) {
             nonRackLocalBuilder.add(new Split(TEST_CATALOG_HANDLE, new TestSplitRemote(HostAddress.fromParts("data.other_rack", 1))));
         }
-        List<Split> nonRackLocalSplits = nonRackLocalBuilder.build();
+        Set<Split> nonRackLocalSplits = nonRackLocalBuilder.build();
         Multimap<InternalNode, Split> assignments = nodeSelector.computeAssignments(nonRackLocalSplits, ImmutableList.copyOf(taskMap.values())).getAssignments();
         MockRemoteTaskFactory remoteTaskFactory = new MockRemoteTaskFactory(remoteTaskExecutor, remoteTaskScheduledExecutor);
         int task = 0;
@@ -217,7 +218,7 @@ public class TestNodeScheduler
             taskMap.put(node, remoteTask);
         }
         // Continue assigning to fill up part of the queue
-        nonRackLocalSplits = difference(nonRackLocalSplits, ImmutableList.copyOf(assignments.values()));
+        nonRackLocalSplits = Sets.difference(nonRackLocalSplits, new HashSet<>(assignments.values()));
         assignments = nodeSelector.computeAssignments(nonRackLocalSplits, ImmutableList.copyOf(taskMap.values())).getAssignments();
         for (InternalNode node : assignments.keySet()) {
             RemoteTask remoteTask = taskMap.get(node);
@@ -225,12 +226,12 @@ public class TestNodeScheduler
                     .putAll(new PlanNodeId("sourceId"), assignments.get(node))
                     .build());
         }
-        nonRackLocalSplits = difference(nonRackLocalSplits, ImmutableList.copyOf(assignments.values()));
+        nonRackLocalSplits = Sets.difference(nonRackLocalSplits, new HashSet<>(assignments.values()));
         // Check that 3 of the splits were rejected, since they're non-local
         assertThat(nonRackLocalSplits.size()).isEqualTo(3);
 
         // Assign rack-local splits
-        ImmutableList.Builder<Split> rackLocalSplits = ImmutableList.builder();
+        ImmutableSet.Builder<Split> rackLocalSplits = ImmutableSet.builder();
         HostAddress dataHost1 = HostAddress.fromParts("data.rack1", 1);
         HostAddress dataHost2 = HostAddress.fromParts("data.rack2", 1);
         for (int i = 0; i < 6 * 2; i++) {
@@ -246,7 +247,7 @@ public class TestNodeScheduler
                     .putAll(new PlanNodeId("sourceId"), assignments.get(node))
                     .build());
         }
-        List<Split> unassigned = difference(rackLocalSplits.build(), ImmutableList.copyOf(assignments.values()));
+        Set<Split> unassigned = Sets.difference(rackLocalSplits.build(), new HashSet<>(assignments.values()));
         // Compute the assignments a second time to account for the fact that some splits may not have been assigned due to asynchronous
         // loading of the NetworkLocationCache
         assignments = nodeSelector.computeAssignments(unassigned, ImmutableList.copyOf(taskMap.values())).getAssignments();
@@ -256,7 +257,7 @@ public class TestNodeScheduler
                     .putAll(new PlanNodeId("sourceId"), assignments.get(node))
                     .build());
         }
-        unassigned = difference(unassigned, ImmutableList.copyOf(assignments.values()));
+        unassigned = Sets.difference(unassigned, new HashSet<>(assignments.values()));
         assertThat(unassigned.size()).isEqualTo(3);
         int rack1 = 0;
         int rack2 = 0;
@@ -277,7 +278,7 @@ public class TestNodeScheduler
         assertThat(rack2).isEqualTo(1);
 
         // Assign local splits
-        ImmutableList.Builder<Split> localSplits = ImmutableList.builder();
+        ImmutableSet.Builder<Split> localSplits = ImmutableSet.builder();
         localSplits.add(new Split(TEST_CATALOG_HANDLE, new TestSplitRemote(HostAddress.fromParts("host1.rack1", 1))));
         localSplits.add(new Split(TEST_CATALOG_HANDLE, new TestSplitRemote(HostAddress.fromParts("host2.rack1", 1))));
         localSplits.add(new Split(TEST_CATALOG_HANDLE, new TestSplitRemote(HostAddress.fromParts("host3.rack2", 1))));
@@ -290,7 +291,8 @@ public class TestNodeScheduler
     public void testScheduleRemote()
     {
         setUpNodes();
-        List<Split> splits = ImmutableList.of(new Split(TEST_CATALOG_HANDLE, new TestSplitRemote()));
+        Set<Split> splits = new HashSet<>();
+        splits.add(new Split(TEST_CATALOG_HANDLE, new TestSplitRemote()));
         Multimap<InternalNode, Split> assignments = nodeSelector.computeAssignments(splits, ImmutableList.copyOf(taskMap.values())).getAssignments();
         assertThat(assignments.size()).isEqualTo(1);
     }
@@ -304,7 +306,7 @@ public class TestNodeScheduler
                 .collect(toImmutableSet());
 
         // One split for each node
-        List<Split> splits = new ArrayList<>();
+        Set<Split> splits = new HashSet<>();
         for (int i = 0; i < activeCatalogNodes.size(); i++) {
             splits.add(new Split(TEST_CATALOG_HANDLE, new TestSplitRemote()));
         }
@@ -337,7 +339,7 @@ public class TestNodeScheduler
         RemoteTask remoteTask2 = remoteTaskFactory.createTableScanTask(taskId2, newNode, initialSplits.build(), nodeTaskMap.createPartitionedSplitCountTracker(newNode, taskId2));
         nodeTaskMap.addTask(newNode, remoteTask2);
 
-        List<Split> splits = new ArrayList<>();
+        Set<Split> splits = new HashSet<>();
         for (int i = 0; i < 5; i++) {
             splits.add(new Split(TEST_CATALOG_HANDLE, new TestSplitRemote()));
         }
@@ -363,7 +365,7 @@ public class TestNodeScheduler
                 .filter(node -> !node.isCoordinator())
                 .collect(toImmutableSet());
         int splitCount = activeCatalogNodes.size() + 1;
-        List<Split> splits = new ArrayList<>();
+        Set<Split> splits = new HashSet<>();
         for (int i = 0; i < splitCount; i++) {
             splits.add(new Split(TEST_CATALOG_HANDLE, new TestSplitRemote()));
         }
@@ -403,7 +405,7 @@ public class TestNodeScheduler
         nodeTaskMap.addTask(newNode, newRemoteTask);
         tasks.add(newRemoteTask);
 
-        List<Split> splits = new ArrayList<>();
+        Set<Split> splits = new HashSet<>();
         for (int i = 0; i < 5; i++) {
             splits.add(new Split(TEST_CATALOG_HANDLE, new TestSplitRemote()));
         }
@@ -482,7 +484,7 @@ public class TestNodeScheduler
         nodeManager.addNodes(node);
 
         // Check for Split assignments till maxSplitsPerNode (20)
-        List<Split> splits = new ArrayList<>();
+        Set<Split> splits = new LinkedHashSet<>();
         // 20 splits with node1 as a non-local node to be assigned in the second iteration of computeAssignments
         for (int i = 0; i < 20; i++) {
             splits.add(new Split(TEST_CATALOG_HANDLE, new TestSplitRemote()));
@@ -521,7 +523,7 @@ public class TestNodeScheduler
         nodeManager.addNodes(node);
 
         // Check for Split assignments till maxSplitsPerNode (20)
-        List<Split> splits = new ArrayList<>();
+        Set<Split> splits = new LinkedHashSet<>();
         // 10 splits with node1 as local node to be assigned in the first iteration of computeAssignments
         for (int i = 0; i < 10; i++) {
             splits.add(new Split(TEST_CATALOG_HANDLE, new TestSplitLocal()));
@@ -565,7 +567,7 @@ public class TestNodeScheduler
         InternalNode node2 = new InternalNode("node2", URI.create("http://10.0.0.1:12"), NodeVersion.UNKNOWN, false);
         nodeManager.addNodes(node2);
 
-        List<Split> splits = new ArrayList<>();
+        Set<Split> splits = new LinkedHashSet<>();
         // 20 splits with node1 as local node to be assigned in the first iteration of computeAssignments
         for (int i = 0; i < 20; i++) {
             splits.add(new Split(TEST_CATALOG_HANDLE, new TestSplitLocal()));
@@ -641,7 +643,7 @@ public class TestNodeScheduler
         InternalNode node4 = new InternalNode("node4", URI.create("http://10.0.0.1:14"), NodeVersion.UNKNOWN, false);
         nodeManager.addNodes(node4);
 
-        List<Split> splits = new ArrayList<>();
+        Set<Split> splits = new LinkedHashSet<>();
         // 20 splits with node1 as local node to be assigned in the first iteration of computeAssignments
         for (int i = 0; i < 20; i++) {
             splits.add(new Split(TEST_CATALOG_HANDLE, new TestSplitLocal()));
@@ -685,7 +687,7 @@ public class TestNodeScheduler
         }
         List<InternalNode> nodes = nodesBuilder.build();
 
-        List<Split> splits = new ArrayList<>();
+        Set<Split> splits = new LinkedHashSet<>();
         Random random = new Random(0);
         ImmutableSetMultimap.Builder<InternalNode, Split> originalAssignmentBuilder = ImmutableSetMultimap.builder();
         // assign splits randomly according to consistent hashing
@@ -772,7 +774,7 @@ public class TestNodeScheduler
         InternalNode node2 = new InternalNode("node2", URI.create("http://10.0.0.1:12"), NodeVersion.UNKNOWN, false);
         nodeManager.addNodes(node2);
 
-        List<Split> splits = new ArrayList<>();
+        Set<Split> splits = new LinkedHashSet<>();
         // 20 splits with node1 as local node to be assigned in the first iteration of computeAssignments
         for (int i = 0; i < (20 + 10 + 5) * 2; i++) {
             splits.add(new Split(TEST_CATALOG_HANDLE, new TestSplitLocal()));
@@ -793,7 +795,7 @@ public class TestNodeScheduler
             nodeTaskMap.addTask(node, remoteTask);
             taskMap.put(node, remoteTask);
         }
-        List<Split> unassignedSplits = difference(splits, ImmutableList.copyOf(assignments1.values()));
+        Set<Split> unassignedSplits = Sets.difference(splits, new HashSet<>(assignments1.values()));
         assertThat(unassignedSplits.size()).isEqualTo(30);
 
         Multimap<InternalNode, Split> assignments2 = nodeSelector.computeAssignments(unassignedSplits, ImmutableList.copyOf(taskMap.values())).getAssignments();
@@ -803,7 +805,7 @@ public class TestNodeScheduler
                     .putAll(new PlanNodeId("sourceId"), assignments2.get(node))
                     .build());
         }
-        unassignedSplits = difference(unassignedSplits, ImmutableList.copyOf(assignments2.values()));
+        unassignedSplits = Sets.difference(unassignedSplits, new HashSet<>(assignments2.values()));
         assertThat(unassignedSplits.size()).isEqualTo(20); // 30 (unassignedSplits) - (10 (maxPendingSplitsPerTask) - 5(queued)) * 2 (nodes))
 
         Multimap<InternalNode, Split> assignments3 = nodeSelector.computeAssignments(unassignedSplits, ImmutableList.copyOf(taskMap.values())).getAssignments();
@@ -839,7 +841,7 @@ public class TestNodeScheduler
         }
 
         // One split per node
-        List<Split> splits = new ArrayList<>();
+        Set<Split> splits = new HashSet<>();
         for (int i = 0; i < nodes.size(); i++) {
             splits.add(new Split(TEST_CATALOG_HANDLE, new TestSplitRemote()));
         }
@@ -1040,12 +1042,5 @@ public class TestNodeScheduler
     {
         return new TopologyAwareNodeSelectorConfig()
                 .setLocationSegmentNames(ImmutableList.of("rack", "machine"));
-    }
-
-    private static <T> List<T> difference(List<T> left, List<T> right)
-    {
-        List<T> retVal = new ArrayList<>(left);
-        retVal.removeAll(right);
-        return retVal;
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestUniformNodeSelector.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestUniformNodeSelector.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
 import io.airlift.testing.TestingTicker;
 import io.trino.Session;
 import io.trino.client.NodeVersion;
@@ -42,9 +43,9 @@ import org.junit.jupiter.api.TestInstance;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -65,7 +66,7 @@ public class TestUniformNodeSelector
 {
     private static final InternalNode node1 = new InternalNode("node1", URI.create("http://10.0.0.1:13"), NodeVersion.UNKNOWN, false);
     private static final InternalNode node2 = new InternalNode("node2", URI.create("http://10.0.0.1:12"), NodeVersion.UNKNOWN, false);
-    private final List<Split> splits = new ArrayList<>();
+    private final Set<Split> splits = new LinkedHashSet<>();
     private FinalizerService finalizerService;
     private NodeTaskMap nodeTaskMap;
     private InMemoryNodeManager nodeManager;
@@ -153,7 +154,7 @@ public class TestUniformNodeSelector
             nodeTaskMap.addTask(node, remoteTask);
             taskMap.put(node, remoteTask);
         }
-        List<Split> unassignedSplits = difference(splits, ImmutableList.copyOf(assignments1.values()));
+        Set<Split> unassignedSplits = Sets.difference(splits, new HashSet<>(assignments1.values()));
         assertThat(unassignedSplits.size()).isEqualTo(18);
         // It's possible to add new assignments because split queue was upscaled
         Multimap<InternalNode, Split> assignments2 = nodeSelector.computeAssignments(unassignedSplits, ImmutableList.copyOf(taskMap.values())).getAssignments();
@@ -201,7 +202,7 @@ public class TestUniformNodeSelector
             nodeTaskMap.addTask(node, remoteTask);
             taskMap.put(node, remoteTask);
         }
-        List<Split> unassignedSplits = difference(splits, ImmutableList.copyOf(assignments1.values()));
+        Set<Split> unassignedSplits = Sets.difference(splits, new HashSet<>(assignments1.values()));
         assertThat(unassignedSplits.size()).isEqualTo(140);
 
         // assign splits, mark all splits running to trigger adjustment
@@ -213,7 +214,7 @@ public class TestUniformNodeSelector
                     .build());
             remoteTask.startSplits(remoteTask.getPartitionedSplitsInfo().getCount()); // mark all task running
         }
-        unassignedSplits = difference(unassignedSplits, ImmutableList.copyOf(assignments2.values()));
+        unassignedSplits = Sets.difference(unassignedSplits, new HashSet<>(assignments2.values()));
         assertThat(unassignedSplits.size()).isEqualTo(100); // 140 (unassigned splits) - (2 (queue size adjustment) * 10 (minPendingSplitsPerTask)) * 2 (nodes)
 
         // assign splits without setting all splits running
@@ -224,12 +225,12 @@ public class TestUniformNodeSelector
                     .putAll(new PlanNodeId("sourceId"), assignments3.get(node))
                     .build());
         }
-        unassignedSplits = difference(unassignedSplits, ImmutableList.copyOf(assignments3.values()));
+        unassignedSplits = Sets.difference(unassignedSplits, new HashSet<>(assignments3.values()));
         assertThat(unassignedSplits.size()).isEqualTo(20); // 100 (unassigned splits) - (4 (queue size adjustment) * 10 (minPendingSplitsPerTask)) * 2 (nodes)
 
         // compute assignments with exhausted nodes
         Multimap<InternalNode, Split> assignments4 = nodeSelector.computeAssignments(unassignedSplits, ImmutableList.copyOf(taskMap.values())).getAssignments();
-        unassignedSplits = difference(unassignedSplits, ImmutableList.copyOf(assignments4.values()));
+        unassignedSplits = Sets.difference(unassignedSplits, new HashSet<>(assignments4.values()));
         assertThat(unassignedSplits.size()).isEqualTo(20); // no new split assignments, queued are more than 0
     }
 
@@ -255,7 +256,7 @@ public class TestUniformNodeSelector
             nodeTaskMap.addTask(node, remoteTask);
             taskMap.put(node, remoteTask);
         }
-        List<Split> unassignedSplits = difference(splits, ImmutableList.copyOf(assignments1.values()));
+        Set<Split> unassignedSplits = Sets.difference(splits, new HashSet<>(assignments1.values()));
         assertThat(unassignedSplits.size()).isEqualTo(140);
 
         // assign splits, mark all splits for node1 running to trigger adjustment
@@ -269,7 +270,7 @@ public class TestUniformNodeSelector
                 remoteTask.startSplits(remoteTask.getPartitionedSplitsInfo().getCount());
             }
         }
-        unassignedSplits = difference(unassignedSplits, ImmutableList.copyOf(assignments2.values()));
+        unassignedSplits = Sets.difference(unassignedSplits, new HashSet<>(assignments2.values()));
         assertThat(unassignedSplits.size()).isEqualTo(120);
         assertThat(assignments2.get(node1).size()).isEqualTo(20); // 2x max pending
         assertThat(assignments2.containsKey(node2)).isFalse();
@@ -285,7 +286,7 @@ public class TestUniformNodeSelector
                 remoteTask.startSplits(remoteTask.getPartitionedSplitsInfo().getCount());
             }
         }
-        unassignedSplits = difference(unassignedSplits, ImmutableList.copyOf(assignments3.values()));
+        unassignedSplits = Sets.difference(unassignedSplits, new HashSet<>(assignments3.values()));
         assertThat(unassignedSplits.size()).isEqualTo(80);
         assertThat(assignments3.get(node1).size()).isEqualTo(40); // 4x max pending
         assertThat(assignments2.containsKey(node2)).isFalse();
@@ -312,12 +313,5 @@ public class TestUniformNodeSelector
         }
 
         return new NodeMap(byHostAndPort.build(), byHost.build(), ImmutableSetMultimap.of(), coordinatorNodeIds);
-    }
-
-    private static <T> List<T> difference(List<T> left, List<T> right)
-    {
-        List<T> retVal = new ArrayList<>(left);
-        retVal.removeAll(right);
-        return retVal;
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestingNodeSelectorFactory.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestingNodeSelectorFactory.java
@@ -139,13 +139,13 @@ public class TestingNodeSelectorFactory
         }
 
         @Override
-        public SplitPlacementResult computeAssignments(List<Split> splits, List<RemoteTask> existingTasks)
+        public SplitPlacementResult computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks)
         {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public SplitPlacementResult computeAssignments(List<Split> splits, List<RemoteTask> existingTasks, BucketNodeMap bucketNodeMap)
+        public SplitPlacementResult computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks, BucketNodeMap bucketNodeMap)
         {
             throw new UnsupportedOperationException();
         }

--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemorySplit.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemorySplit.java
@@ -127,33 +127,39 @@ public class MemorySplit
     }
 
     @Override
-    public boolean equals(Object obj)
+    public boolean equals(Object o)
     {
-        if (this == obj) {
+        if (this == o) {
             return true;
         }
-        if ((obj == null) || (getClass() != obj.getClass())) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        MemorySplit other = (MemorySplit) obj;
-        return Objects.equals(this.table, other.table) &&
-                Objects.equals(this.totalPartsPerWorker, other.totalPartsPerWorker) &&
-                Objects.equals(this.partNumber, other.partNumber);
+        MemorySplit that = (MemorySplit) o;
+        return table == that.table &&
+                totalPartsPerWorker == that.totalPartsPerWorker &&
+                partNumber == that.partNumber &&
+                expectedRows == that.expectedRows &&
+                Objects.equals(address, that.address) &&
+                Objects.equals(limit, that.limit);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(table, totalPartsPerWorker, partNumber);
+        return Objects.hash(table, totalPartsPerWorker, partNumber, address, expectedRows, limit);
     }
 
     @Override
     public String toString()
     {
         return toStringHelper(this)
-                .add("tableHandle", table)
-                .add("partNumber", partNumber)
+                .add("table", table)
                 .add("totalPartsPerWorker", totalPartsPerWorker)
+                .add("partNumber", partNumber)
+                .add("address", address)
+                .add("expectedRows", expectedRows)
+                .add("limit", limit)
                 .toString();
     }
 }

--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchSplit.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchSplit.java
@@ -22,7 +22,6 @@ import io.trino.spi.connector.ConnectorSplit;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
@@ -93,21 +92,15 @@ public class TpchSplit
     @Override
     public boolean equals(Object obj)
     {
-        if (this == obj) {
-            return true;
-        }
-        if ((obj == null) || (getClass() != obj.getClass())) {
-            return false;
-        }
-        TpchSplit other = (TpchSplit) obj;
-        return Objects.equals(this.totalParts, other.totalParts) &&
-                Objects.equals(this.partNumber, other.partNumber);
+        //  There is no equality contract for ConnectorSplit and engine should not call this method.
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(totalParts, partNumber);
+        //  There is no equality contract for ConnectorSplit and engine should not call this method.
+        throw new UnsupportedOperationException();
     }
 
     @Override


### PR DESCRIPTION
There is no equality contract for `ConnectorSplit` and there is no
    requirement for connector splits  returned from `ConnectorSplitSource`
    to be different, regardless whether comparing them by value or by
    reference. For example, a ConnectorSplitSource could return 10 times
    same "produce a row" split instance, so that the table has effectively
    10 rows. In fact, the blackhole connector does that.

Fixes https://github.com/trinodb/trino/issues/21630