### PR TITLE
Optimize join filters after ReorderJoins

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -788,7 +788,9 @@ public class PlanOptimizers
                         ruleStats,
                         statsCalculator,
                         costCalculator,
-                        ImmutableSet.of(new ReorderJoins(plannerContext, costComparator))));
+                        ImmutableSet.of(new ReorderJoins(plannerContext, costComparator))),
+                // ReorderJoins may produce filters above joins that could (and should be) pushed back down
+                new StatsRecordingPlanOptimizer(optimizerStats, new PredicatePushDown(plannerContext, true, false)));
 
         builder.add(new OptimizeMixedDistinctAggregations(metadata));
         builder.add(new IterativeOptimizer(

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConnectorTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConnectorTest.java
@@ -20,7 +20,6 @@ import io.trino.testing.sql.SqlExecutor;
 import io.trino.testing.sql.TestTable;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
@@ -292,30 +291,5 @@ public class TestSqlServerConnectorTest
     {
         // Isolate this test to avoid problem described in https://github.com/trinodb/trino/issues/10846
         executeExclusively(super::testSelectInformationSchemaColumns);
-    }
-
-    @Override
-    @Test
-    @Disabled
-    public void testComplexJoinPushdown()
-    {
-        // Join pushdown in SQL server produces different behavior depending
-        // on whether the plan contains an inner join node with a filter vs
-        // the filter on top of the join.
-        //
-        // The connector is producing column stats inconsistently, based on timing.
-        // This causes join reordering to sometimes fire before join pushdown happens.
-        // When it fires, it produces a slightly different plan that the connector
-        // accepts for pushdown, which causes the assertions to fail.
-
-        // TODO: fix join pushdown in SQL server connector by making filter(<f>, innerjoin(l, r, true)) work the same as innerjoin(l, r, <f>)
-    }
-
-    @Override
-    @Test
-    public void testJoinPushdown()
-    {
-        // TODO: fix join pushdown in SQL server connector
-        // See testComplexJoinPushdown() for explanation
     }
 }


### PR DESCRIPTION
`ReorderJoins` can produce a suboptimal plan with residual conditions added on top of joins being reordered in a form of separate `FilterNode`. This may result in suboptimal join pushdown decisions, since only part of join condition is offered to the connector.

Fixes https://github.com/trinodb/trino/issues/21637
Fixes https://github.com/trinodb/trino/issues/21621