### PR TITLE
Include addresses in retainedSize of IcebergSplit

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplit.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplit.java
@@ -220,7 +220,8 @@ public class IcebergSplit
                 + estimatedSizeOf(deletes, DeleteFile::getRetainedSizeInBytes)
                 + splitWeight.getRetainedSizeInBytes()
                 + fileStatisticsDomain.getRetainedSizeInBytes(IcebergColumnHandle::getRetainedSizeInBytes)
-                + estimatedSizeOf(fileIoProperties, SizeOf::estimatedSizeOf, SizeOf::estimatedSizeOf);
+                + estimatedSizeOf(fileIoProperties, SizeOf::estimatedSizeOf, SizeOf::estimatedSizeOf)
+                + estimatedSizeOf(addresses, HostAddress::getRetainedSizeInBytes);
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
In `IcebergSplit`, `addresses` was once removed in https://github.com/trinodb/trino/commit/037118255a08b45b7a061991cd22628ff3ce01d4 and resurrected in https://github.com/trinodb/trino/commit/102ce9df60c8df086a186aef41c8546a1c96d359 but without fixing `getRetainedSizeInBytes()`.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
- https://github.com/trinodb/trino/pull/18006
- https://github.com/trinodb/trino/pull/20602

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
