### PR TITLE
Use getSizeInBytes rather than getRetainedSizeInBytes

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/exchange/ScaleWriterPartitioningExchanger.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/ScaleWriterPartitioningExchanger.java
@@ -171,6 +171,6 @@ public class ScaleWriterPartitioningExchanger
         long retainedSizeInBytes = pageSplit.getRetainedSizeInBytes();
         memoryManager.updateMemoryUsage(retainedSizeInBytes);
         buffer.accept(pageSplit);
-        return retainedSizeInBytes;
+        return pageSplit.getSizeInBytes();
     }
 }


### PR DESCRIPTION
For processed data getSizeInBytes should be used

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
