### PR TITLE
Avoid non-actionable warnings logged in Delta writer stats

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeParquetStatisticsUtils.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeParquetStatisticsUtils.java
@@ -349,7 +349,7 @@ public class DeltaLakeParquetStatisticsUtils
             return Optional.empty();
         }
 
-        LOG.warn("Accumulating Parquet statistics with Trino type: %s and Parquet statistics of type: %s is not supported", type, statistics);
+        LOG.debug("Accumulating Parquet statistics with Trino type: %s and Parquet statistics of type: %s is not supported", type, statistics);
         return Optional.empty();
     }
 
@@ -429,7 +429,7 @@ public class DeltaLakeParquetStatisticsUtils
             return Optional.empty();
         }
 
-        LOG.warn("Accumulating Parquet statistics with Trino type: %s and Parquet statistics of type: %s is not supported", type, statistics);
+        LOG.debug("Accumulating Parquet statistics with Trino type: %s and Parquet statistics of type: %s is not supported", type, statistics);
         return Optional.empty();
     }
 }


### PR DESCRIPTION
If the code does not support stats for given type, there is nothing a Trino operator can do about this, so logging a warning is not helpful.
