### PR TITLE
Enable full predicate pushdown for decimal type in ClickHouse connector

### DIFF
--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseLatestTypeMapping.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseLatestTypeMapping.java
@@ -14,9 +14,16 @@
 package io.trino.plugin.clickhouse;
 
 import io.trino.testing.QueryRunner;
+import io.trino.testing.sql.JdbcSqlExecutor;
+import io.trino.testing.sql.TestTable;
+import org.junit.jupiter.api.Test;
 
 import static io.trino.plugin.clickhouse.ClickHouseQueryRunner.createClickHouseQueryRunner;
 import static io.trino.plugin.clickhouse.TestingClickHouseServer.CLICKHOUSE_LATEST_IMAGE;
+import static java.lang.String.format;
+import static java.math.RoundingMode.HALF_UP;
+import static java.math.RoundingMode.UNNECESSARY;
+import static java.util.Arrays.asList;
 
 public class TestClickHouseLatestTypeMapping
         extends BaseClickHouseTypeMapping
@@ -27,5 +34,64 @@ public class TestClickHouseLatestTypeMapping
     {
         clickhouseServer = closeAfterClass(new TestingClickHouseServer(CLICKHOUSE_LATEST_IMAGE));
         return createClickHouseQueryRunner(clickhouseServer);
+    }
+
+    @Test
+    public void testDecimalUnspecifiedPrecisionWithValues()
+    {
+        JdbcSqlExecutor jse = new JdbcSqlExecutor(clickhouseServer.getJdbcUrl());
+
+        // https://github.com/clickhouse/ClickHouse/pull/53328 restores the support of
+        // Decimal with unspecified precision and scale.
+        try (TestTable testTable = new TestTable(
+                jse,
+                "tpch.test_var_decimal",
+                "(d_col decimal) Engine=Log",
+                asList("1.12", "123456.789", "-1.12", "-123456.789"))) {
+            assertQuery(
+                    sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 0),
+                    format("SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'tpch' AND table_name = '%s'", omitDatabasePrefix(testTable.getName())),
+                    "VALUES ('d_col','decimal(10,0)')");
+
+            // Excessive digits in a fraction are discarded (not rounded). Excessive digits in integer part will lead to an exception.
+            // Danger: Overflow check is not implemented for Decimal128 and Decimal256. In case of overflow incorrect result is returned, no exception is thrown.
+            assertQuery(
+                    sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 0),
+                    "SELECT d_col FROM " + testTable.getName(),
+                    "VALUES (1), (123456), (-1), (-123456)");
+            assertQuery(
+                    sessionWithDecimalMappingAllowOverflow(HALF_UP, 0),
+                    "SELECT d_col FROM " + testTable.getName(),
+                    "VALUES (1), (123456), (-1), (-123456)");
+            assertQuery(
+                    sessionWithDecimalMappingAllowOverflow(HALF_UP, 1),
+                    format("SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'tpch' AND table_name = '%s'", omitDatabasePrefix(testTable.getName())),
+                    "VALUES ('d_col','decimal(10,0)')");
+            assertQuery(
+                    sessionWithDecimalMappingAllowOverflow(HALF_UP, 1),
+                    "SELECT d_col FROM " + testTable.getName(),
+                    "VALUES (1), (123456), (-1), (-123456)");
+            assertQuery(
+                    sessionWithDecimalMappingAllowOverflow(HALF_UP, 2),
+                    "SELECT d_col FROM " + testTable.getName(),
+                    "VALUES (1), (123456), (-1), (-123456)");
+            assertQuery(
+                    sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 3),
+                    format("SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'tpch' AND table_name = '%s'", omitDatabasePrefix(testTable.getName())),
+                    "VALUES ('d_col','decimal(10,0)')");
+            assertQuery(
+                    sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 3),
+                    "SELECT d_col FROM " + testTable.getName(),
+                    "VALUES (1), (123456), (-1), (-123456)");
+
+            // Check that integer part overflow leads to an exception
+            assertQuerySucceeds(
+                    sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 2),
+                    "INSERT INTO " + testTable.getName() + " VALUES (1234567890)");
+            assertQueryFails(
+                    sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 2),
+                    "INSERT INTO " + testTable.getName() + " VALUES (12345678901)",
+                    "Cannot cast.*");
+        }
     }
 }


### PR DESCRIPTION
## Description
Partially resolves #7100.

This PR reworks `decimal` type support by ClickHouse connector and makes implementation similar to the one by e.g. MySQL or Postgres connectors. As the result it enables full predicate pushdown.

Changes:
 - Columns are ignored (unless it's configured to treat it as varchar) if precision exceeds maximum value (38).
 - ClickHouse doesn't support negative scale, however it's coded nonetheless.

It's worth noting that ClickHouse implements Decimal in a slightly nuanced way ([link](https://clickhouse.com/docs/en/sql-reference/data-types/decimal)):
1. Excessive digits in a fraction are discarded (not rounded). Excessive digits in integer part will lead to an exception. There's a unit test for that.
2. Overflow check is not implemented for Decimal128 and Decimal256. In case of overflow incorrect result is returned, no exception is thrown. Trino supports precision up to 38 digits which is therefore implemented by Decimal128.

## Additional context and related issues
Please review previous PRs related to ClickHouse connector as the number of changes keep accumulating.

Next I'm going to focus predicate pushdown for time types and on aggregate functions.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( x) Release notes are required, with the following suggested text:

```markdown
# Section
* Enable decimal full predicate pushdown for ClickHouse connector. ({issue}`7100`)
```
