### PR TITLE
Relax condition for allowing writer tasks splitting

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/HashDistributionSplitAssigner.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/HashDistributionSplitAssigner.java
@@ -48,7 +48,6 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static io.trino.sql.planner.SystemPartitioningHandle.SCALED_WRITER_HASH_DISTRIBUTION;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
@@ -79,9 +78,9 @@ class HashDistributionSplitAssigner
             int targetMinTaskCount,
             int targetMaxTaskCount)
     {
-        if (fragment.getPartitioning().equals(SCALED_WRITER_HASH_DISTRIBUTION)) {
+        if (fragment.getPartitioning().isScaleWriters()) {
             verify(fragment.getPartitionedSources().isEmpty() && fragment.getRemoteSourceNodes().size() == 1,
-                    "SCALED_WRITER_HASH_DISTRIBUTION fragments are expected to have exactly one remote source and no table scans");
+                    "fragments using scale-writers partitioning are expected to have exactly one remote source and no table scans");
         }
         return new HashDistributionSplitAssigner(
                 catalogRequirement,
@@ -95,7 +94,7 @@ class HashDistributionSplitAssigner
                         targetPartitionSizeInBytes,
                         targetMinTaskCount,
                         targetMaxTaskCount,
-                        sourceId -> fragment.getPartitioning().equals(SCALED_WRITER_HASH_DISTRIBUTION),
+                        sourceId -> fragment.getPartitioning().isScaleWriters(),
                         // never merge partitions for table write to avoid running into the maximum writers limit per task
                         !isWriteFragment(fragment)));
     }


### PR DESCRIPTION
Current condition which governed if given partition can be split between multiple writer tasks allowed only SCALED_WRITER_HASH_DISTRIBUTION. This effectively disabled writing single partition from multiple writer tasks if connector based partitioning was used, like e.g. Icebergs
  day(some_timestamp_column)

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
