### PR TITLE
Log a message if file system caching is disabled on coordinator

### DIFF
--- a/lib/trino-filesystem-cache-alluxio/pom.xml
+++ b/lib/trino-filesystem-cache-alluxio/pom.xml
@@ -46,6 +46,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>stats</artifactId>
         </dependency>
 

--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioCoordinatorFileSystemCache.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioCoordinatorFileSystemCache.java
@@ -17,6 +17,7 @@ import alluxio.client.file.cache.CacheManager;
 import alluxio.conf.AlluxioProperties;
 import alluxio.conf.InstancedConfiguration;
 import com.google.inject.Inject;
+import io.airlift.log.Logger;
 import io.opentelemetry.api.trace.Tracer;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoInput;
@@ -35,6 +36,8 @@ import java.util.Optional;
 public class AlluxioCoordinatorFileSystemCache
         implements TrinoFileSystemCache
 {
+    private static final Logger log = Logger.get(AlluxioCoordinatorFileSystemCache.class);
+
     private final Optional<AlluxioFileSystemCache> alluxioFileSystemCache;
 
     @Inject
@@ -49,6 +52,7 @@ public class AlluxioCoordinatorFileSystemCache
             alluxioFileSystemCache = Optional.of(new AlluxioFileSystemCache(tracer, config, statistics));
         }
         else {
+            log.debug("File system cache is disabled on a coordinator");
             alluxioFileSystemCache = Optional.empty();
             try {
                 CacheManager cacheManager = CacheManager.Factory.create(new InstancedConfiguration(new AlluxioProperties()));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
If a connector does not support caching on a Coordinator, Trino instantiates Alluxio JMX statistics but quietly disables caching.  As a result, it appears that caching is instantiated and is operating.  Consequently, it's really confusing when caching doesn't work but there is no indication why.

This PR will issue a warning on startup to let the user know that caching has been disabled for the Coordinator.

Considering this is a trivial PR, I didn't create a ticket.  But if that is appropriate, I will open an issue.   


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
N/A


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is just a logging message, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

