### PR TITLE
Leave comment why testSelectInformationSchemaColumns is isolated in Cassandra

### DIFF
--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
@@ -223,7 +223,7 @@ public class TestCassandraConnectorTest
     }
 
     @Test
-    @Override
+    @Override // Override because some tests (e.g. testKeyspaceNameAmbiguity, testNativeQueryCaseSensitivity) cause column listing failure
     public void testSelectInformationSchemaColumns()
     {
         executeExclusively(super::testSelectInformationSchemaColumns);


### PR DESCRIPTION
## Description

Leave comment why testSelectInformationSchemaColumns is isolated in Cassandra

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
