### PR TITLE
fix file-system-access-control permission table

### DIFF
--- a/docs/src/main/sphinx/security/file-system-access-control.md
+++ b/docs/src/main/sphinx/security/file-system-access-control.md
@@ -119,7 +119,7 @@ The following table summarizes the permissions required for each SQL command:
 | ALTER TABLE ... ADD COLUMN         | all       |         | owner                |                                                                   |
 | ALTER TABLE ... DROP COLUMN        | all       |         | owner                |                                                                   |
 | ALTER TABLE ... RENAME COLUMN      | all       |         | owner                |                                                                   |
-| SHOW COLUMNS                       | all       |         | any                  |                                                                   |
+| SHOW COLUMNS                       | read-only |         | any                  |                                                                   |
 | SELECT FROM table                  | read-only |         | select               |                                                                   |
 | SELECT FROM view                   | read-only |         | select, grant_select |                                                                   |
 | INSERT INTO                        | all       |         | insert               |                                                                   |


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
"SHOW COLUMNS" work just with "read-only" permission per schema


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
