### PR TITLE
Replace uses of newParameterizedType

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/Server.java
+++ b/core/trino-main/src/main/java/io/trino/server/Server.java
@@ -20,7 +20,6 @@ import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.TypeLiteral;
-import com.google.inject.util.Types;
 import io.airlift.bootstrap.ApplicationConfigurationException;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.discovery.client.Announcer;
@@ -148,7 +147,7 @@ public class Server
 
             injector.getInstance(PluginInstaller.class).loadPlugins();
 
-            var catalogStoreManager = injector.getInstance(optionalKey(CatalogStoreManager.class));
+            var catalogStoreManager = injector.getInstance(Key.get(new TypeLiteral<Optional<CatalogStoreManager>>() {}));
             if (catalogStoreManager.isPresent()) {
                 catalogStoreManager.get().loadConfiguredCatalogStore();
             }
@@ -173,16 +172,17 @@ public class Server
             injector.getInstance(SessionPropertyDefaults.class).loadConfigurationManager();
             injector.getInstance(ResourceGroupManager.class).loadConfigurationManager();
             injector.getInstance(AccessControlManager.class).loadSystemAccessControl();
-            injector.getInstance(optionalKey(PasswordAuthenticatorManager.class))
+            injector.getInstance(Key.get(new TypeLiteral<Optional<PasswordAuthenticatorManager>>() {}))
                     .ifPresent(PasswordAuthenticatorManager::loadPasswordAuthenticator);
             injector.getInstance(EventListenerManager.class).loadEventListeners();
             injector.getInstance(GroupProviderManager.class).loadConfiguredGroupProvider();
             injector.getInstance(ExchangeManagerRegistry.class).loadExchangeManager();
             injector.getInstance(CertificateAuthenticatorManager.class).loadCertificateAuthenticator();
-            injector.getInstance(optionalKey(HeaderAuthenticatorManager.class))
+            injector.getInstance(Key.get(new TypeLiteral<Optional<HeaderAuthenticatorManager>>() {}))
                     .ifPresent(HeaderAuthenticatorManager::loadHeaderAuthenticator);
 
-            injector.getInstance(optionalKey(OAuth2Client.class)).ifPresent(OAuth2Client::load);
+            injector.getInstance(Key.get(new TypeLiteral<Optional<OAuth2Client>>() {}))
+                    .ifPresent(OAuth2Client::load);
 
             injector.getInstance(Announcer.class).start();
 
@@ -223,12 +223,6 @@ public class Server
                 .map(ConnectorServices::getEventListeners)
                 .flatMap(Collection::stream)
                 .forEach(eventListenerManager::addEventListener);
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <T> Key<Optional<T>> optionalKey(Class<T> type)
-    {
-        return Key.get((TypeLiteral<Optional<T>>) TypeLiteral.get(Types.newParameterizedType(Optional.class, type)));
     }
 
     private static void addMessages(StringBuilder output, String type, List<Object> messages)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This uses the "well known" trick, used already elsewhere in the code, to use the anonymous inner class to force reification of type parameters, so that `Key` can get the exact type parameter information via reflection. This saves us a utility method and an unchecked cast.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

-

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
