### PR TITLE
Fix compilation of SQL functions with labels

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutineCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutineCompiler.java
@@ -72,7 +72,7 @@ import io.trino.util.Reflection;
 import java.lang.invoke.MethodHandle;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.IdentityHashMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -287,8 +287,8 @@ public final class SqlRoutineCompiler
         private final Map<LambdaDefinitionExpression, CompiledLambda> compiledLambdaMap;
         private final Map<IrVariable, Variable> variables;
 
-        private final Map<IrLabel, LabelNode> continueLabels = new IdentityHashMap<>();
-        private final Map<IrLabel, LabelNode> breakLabels = new IdentityHashMap<>();
+        private final Map<IrLabel, LabelNode> continueLabels = new HashMap<>();
+        private final Map<IrLabel, LabelNode> breakLabels = new HashMap<>();
 
         public BytecodeVisitor(
                 CachedInstanceBinder cachedInstanceBinder,

--- a/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutineCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutineCompiler.java
@@ -333,11 +333,11 @@ public final class SqlRoutineCompiler
             LabelNode continueLabel = new LabelNode("continue");
             LabelNode breakLabel = new LabelNode("break");
 
-            if (node.label().isPresent()) {
-                continueLabels.put(node.label().get(), continueLabel);
-                breakLabels.put(node.label().get(), breakLabel);
+            node.label().ifPresent(label -> {
+                verify(continueLabels.putIfAbsent(label, continueLabel) == null, "continue label for loop label %s already exists", label);
+                verify(breakLabels.putIfAbsent(label, breakLabel) == null, "break label for loop label %s already exists", label);
                 block.visitLabel(continueLabel);
-            }
+            });
 
             for (IrStatement statement : node.statements()) {
                 block.append(process(statement, scope));
@@ -439,8 +439,8 @@ public final class SqlRoutineCompiler
             LabelNode breakLabel = new LabelNode("break");
 
             if (label.isPresent()) {
-                continueLabels.put(label.get(), continueLabel);
-                breakLabels.put(label.get(), breakLabel);
+                verify(continueLabels.putIfAbsent(label.get(), continueLabel) == null, "continue label for loop label %s already exists", label.get());
+                verify(breakLabels.putIfAbsent(label.get(), breakLabel) == null, "break label for loop label %s already exists", label.get());
                 block.visitLabel(continueLabel);
             }
 

--- a/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutinePlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutinePlanner.java
@@ -75,6 +75,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
@@ -122,6 +123,8 @@ public final class SqlRoutinePlanner
         private final List<IrVariable> allVariables;
         private final Analysis analysis;
         private final StandardFunctionResolution resolution;
+
+        private final AtomicInteger labelCounter = new AtomicInteger();
 
         public StatementVisitor(
                 Session session,
@@ -283,10 +286,10 @@ public final class SqlRoutinePlanner
             return new IrBreak(label(context, node.getLabel()));
         }
 
-        private static Optional<IrLabel> getSqlLabel(Context context, Optional<Identifier> labelName)
+        private Optional<IrLabel> getSqlLabel(Context context, Optional<Identifier> labelName)
         {
             return labelName.map(name -> {
-                IrLabel label = new IrLabel(identifierValue(name));
+                IrLabel label = new IrLabel(identifierValue(name) + "_" + labelCounter.getAndIncrement());
                 verify(context.labels().put(identifierValue(name), label) == null, "Label already declared in this scope: %s", name);
                 return label;
             });

--- a/core/trino-main/src/test/java/io/trino/sql/routine/TestSqlFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/routine/TestSqlFunctions.java
@@ -340,6 +340,30 @@ class TestSqlFunctions
     }
 
     @Test
+    void testLoop()
+    {
+        @Language("SQL") String sql = """
+                FUNCTION test()
+                RETURNS bigint
+                BEGIN
+                  DECLARE a, b int DEFAULT 0;
+                  top: LOOP
+                    SET a = a + 1;
+                    IF a < 3 THEN
+                      ITERATE top;
+                    END IF;
+                    SET b = b + 1;
+                    IF a > 6 THEN
+                      LEAVE top;
+                    END IF;
+                  END LOOP;
+                  RETURN b;
+                END
+                """;
+        assertFunction(sql, handle -> assertThat(handle.invoke()).isEqualTo(5L));
+    }
+
+    @Test
     void testReuseLabels()
     {
         @Language("SQL") String sql = """

--- a/core/trino-main/src/test/java/io/trino/sql/routine/TestSqlFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/routine/TestSqlFunctions.java
@@ -14,28 +14,37 @@
 package io.trino.sql.routine;
 
 import com.google.common.hash.Hashing;
+import io.airlift.json.JsonCodec;
+import io.airlift.json.JsonCodecFactory;
+import io.airlift.json.ObjectMapperProvider;
 import io.airlift.slice.Slice;
 import io.trino.Session;
+import io.trino.block.BlockJsonSerde;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.operator.scalar.SpecializedSqlScalarFunction;
 import io.trino.security.AllowAllAccessControl;
+import io.trino.spi.block.Block;
 import io.trino.spi.block.TestingBlockEncodingSerde;
 import io.trino.spi.function.FunctionId;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.InvocationConvention;
 import io.trino.spi.function.ScalarFunctionImplementation;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeSignature;
 import io.trino.spi.type.VarcharType;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.parser.SqlParser;
 import io.trino.sql.routine.ir.IrRoutine;
 import io.trino.sql.tree.FunctionSpecification;
 import io.trino.transaction.TransactionManager;
+import io.trino.type.TypeDeserializer;
+import io.trino.type.TypeSignatureKeyDeserializer;
 import org.assertj.core.api.ThrowingConsumer;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 
 import java.lang.invoke.MethodHandle;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.google.common.base.Throwables.throwIfUnchecked;
@@ -67,6 +76,19 @@ class TestSqlFunctions
             .withTransactionManager(TRANSACTION_MANAGER)
             .build();
     private static final Session SESSION = testSessionBuilder().build();
+    private static final JsonCodec<IrRoutine> IR_ROUTINE_CODEC;
+
+    static {
+        ObjectMapperProvider provider = new ObjectMapperProvider();
+        provider.setJsonSerializers(Map.of(
+                Block.class, new BlockJsonSerde.Serializer(PLANNER_CONTEXT.getBlockEncodingSerde())));
+        provider.setJsonDeserializers(Map.of(
+                Type.class, new TypeDeserializer(PLANNER_CONTEXT.getTypeManager()),
+                Block.class, new BlockJsonSerde.Deserializer(PLANNER_CONTEXT.getBlockEncodingSerde())));
+        provider.setKeyDeserializers(Map.of(
+                TypeSignature.class, new TypeSignatureKeyDeserializer()));
+        IR_ROUTINE_CODEC = new JsonCodecFactory(provider).jsonCodec(IrRoutine.class);
+    }
 
     @Test
     void testConstantReturn()
@@ -528,7 +550,17 @@ class TestSqlFunctions
         transaction(TRANSACTION_MANAGER, PLANNER_CONTEXT.getMetadata(), new AllowAllAccessControl())
                 .singleStatement()
                 .execute(SESSION, session -> {
-                    ScalarFunctionImplementation implementation = compileFunction(sql, session);
+                    ScalarFunctionImplementation implementation = compileFunction(sql, session, false);
+                    MethodHandle handle = implementation.getMethodHandle()
+                            .bindTo(getInstance(implementation))
+                            .bindTo(session.toConnectorSession());
+                    consumer.accept(handle);
+                });
+
+        transaction(TRANSACTION_MANAGER, PLANNER_CONTEXT.getMetadata(), new AllowAllAccessControl())
+                .singleStatement()
+                .execute(SESSION, session -> {
+                    ScalarFunctionImplementation implementation = compileFunction(sql, session, true);
                     MethodHandle handle = implementation.getMethodHandle()
                             .bindTo(getInstance(implementation))
                             .bindTo(session.toConnectorSession());
@@ -547,7 +579,7 @@ class TestSqlFunctions
         }
     }
 
-    private static ScalarFunctionImplementation compileFunction(@Language("SQL") String sql, Session session)
+    private static ScalarFunctionImplementation compileFunction(@Language("SQL") String sql, Session session, boolean serialize)
     {
         FunctionSpecification function = SQL_PARSER.createFunctionSpecification(sql);
 
@@ -558,6 +590,11 @@ class TestSqlFunctions
 
         SqlRoutinePlanner planner = new SqlRoutinePlanner(PLANNER_CONTEXT);
         IrRoutine routine = planner.planSqlFunction(session, function, analysis);
+
+        if (serialize) {
+            // Simulate worker communication
+            routine = IR_ROUTINE_CODEC.fromJson(IR_ROUTINE_CODEC.toJson(routine));
+        }
 
         // verify routine hash does not fail
         SqlRoutineHash.hash(routine, Hashing.sha256().newHasher(), new TestingBlockEncodingSerde());


### PR DESCRIPTION
The labels are used for LEAVE, ITERATE inside LOOP, REPEAT or WHILE.
When generating function bytecode, the `SqlRoutineCompiler` relied on
identity of `IrLabel` objects, which is maintained by the
`SqlRoutinePlanner`. However, if the function IR is transferred to a
worker, the identity is lost which was resulting in function compilation
error. This commit fixes this by generating unique labels names in the
function planner and identifying IR labels by value in the function
compiler.

Fixes https://github.com/trinodb/trino/issues/21682