### PR TITLE
Handle exception when OTEL is not fully available to Trino JDBC

### DIFF
--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/NonRegisteringTrinoDriver.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/NonRegisteringTrinoDriver.java
@@ -68,8 +68,8 @@ public class NonRegisteringTrinoDriver
             OpenTelemetry openTelemetry = GlobalOpenTelemetry.get();
             return OkHttpTelemetry.builder(openTelemetry).build().newCallFactory(client);
         }
-        catch (NoClassDefFoundError ignored) {
-            // assume OTEL is not available and return the original client
+        catch (NoClassDefFoundError | NoSuchMethodError ignored) {
+            // assume OTEL is not (fully) available and return the original client
             return (Call.Factory) client;
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

If an incomplete or wrongly versioned set of OpenTelemetry classes are available at runtime initialization of Trino JDBC connections can fail with `NoSuchMethodError`. We should catch and fall back to the non-instrumeted client on these errors.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
