### PR TITLE
Remove default insert layout inferred from table properties

### DIFF
--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsMetadata.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsMetadata.java
@@ -26,7 +26,6 @@ import io.trino.spi.connector.ConnectorOutputMetadata;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTableMetadata;
-import io.trino.spi.connector.ConnectorTableProperties;
 import io.trino.spi.connector.RetryMode;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
@@ -140,12 +139,6 @@ public class SheetsMetadata
             return Optional.of(new ConnectorTableMetadata(tableName, table.get().getColumnsMetadata()));
         }
         return Optional.empty();
-    }
-
-    @Override
-    public ConnectorTableProperties getTableProperties(ConnectorSession session, ConnectorTableHandle table)
-    {
-        return new ConnectorTableProperties();
     }
 
     @Override

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduMetadata.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduMetadata.java
@@ -32,12 +32,10 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTableLayout;
 import io.trino.spi.connector.ConnectorTableMetadata;
-import io.trino.spi.connector.ConnectorTablePartitioning;
 import io.trino.spi.connector.ConnectorTableProperties;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.ConstraintApplicationResult;
 import io.trino.spi.connector.LimitApplicationResult;
-import io.trino.spi.connector.LocalProperty;
 import io.trino.spi.connector.NotFoundException;
 import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.connector.RetryMode;
@@ -438,14 +436,11 @@ public class KuduMetadata
     {
         KuduTableHandle handle = (KuduTableHandle) table;
 
-        Optional<ConnectorTablePartitioning> tablePartitioning = Optional.empty();
-        List<LocalProperty<ColumnHandle>> localProperties = ImmutableList.of();
-
         return new ConnectorTableProperties(
                 handle.getConstraint(),
-                tablePartitioning,
                 Optional.empty(),
-                localProperties);
+                Optional.empty(),
+                ImmutableList.of());
     }
 
     @Override

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorMetadata.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorMetadata.java
@@ -82,6 +82,7 @@ import java.util.function.LongConsumer;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.MoreCollectors.toOptional;
 import static io.airlift.json.JsonCodec.jsonCodec;
@@ -714,6 +715,20 @@ public class RaptorMetadata
         clearRollback();
 
         return Optional.empty();
+    }
+
+    @Override
+    public Optional<ConnectorTableLayout> getInsertLayout(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        RaptorTableHandle table = (RaptorTableHandle) tableHandle;
+        if (table.getPartitioningHandle().isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(new ConnectorTableLayout(
+                table.getPartitioningHandle().get(),
+                getBucketColumnHandles(table.getTableId()).stream()
+                        .map(RaptorColumnHandle::getColumnName)
+                        .collect(toImmutableList())));
     }
 
     @Override

--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchMetadata.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchMetadata.java
@@ -33,6 +33,7 @@ import io.trino.spi.connector.ConnectorAnalyzeMetadata;
 import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTableLayout;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTablePartitioning;
 import io.trino.spi.connector.ConnectorTableProperties;
@@ -467,6 +468,12 @@ public class TpchMetadata
                 tablePartitioning,
                 Optional.empty(),
                 localProperties);
+    }
+
+    @Override
+    public Optional<ConnectorTableLayout> getInsertLayout(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        return Optional.empty();
     }
 
     @Override


### PR DESCRIPTION
Picking write layout based on read partitioning is a heuristic, but it's better to leave the responsibility to the connector. We don't have such heuristic for updates or execute and also connector still needs to pick the layout for new tables anyway.
