### PR TITLE
Increase margin in MariaDB testNullsFraction

### DIFF
--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/BaseMariaDbTableStatisticsTest.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/BaseMariaDbTableStatisticsTest.java
@@ -221,7 +221,7 @@ public abstract class BaseMariaDbTableStatisticsTest
                             .put("custkey", nullFractionToExpected.apply(1.0 / 3))
                             .put("orderpriority", nullFractionToExpected.apply(1.0 / 5))
                             .build());
-            assertThat(getTableCardinalityFromStats(statsResult)).isCloseTo(15000, withinPercentage(20));
+            assertThat(getTableCardinalityFromStats(statsResult)).isCloseTo(15000, withinPercentage(25));
         }
         finally {
             assertUpdate("DROP TABLE " + tableName);


### PR DESCRIPTION
## Description

We found the test failure:
```
Error:    TestMariaDbTableIndexStatisticsLatest>BaseMariaDbTableStatisticsTest.testNullsFraction:224 
Expecting actual:
  11659.0
to be close to:
  15000.0
by less than 20% but difference was 22.273333333333333%.
(a difference of exactly 20% being considered valid)
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
