### PR TITLE
Nullify DriverFactory#operatorFactories on noMoreDrivers

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/DriverFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DriverFactory.java
@@ -16,6 +16,7 @@ package io.trino.operator;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.trino.sql.planner.plan.PlanNodeId;
+import jakarta.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,13 +33,13 @@ public class DriverFactory
     private final int pipelineId;
     private final boolean inputDriver;
     private final boolean outputDriver;
-    private final List<OperatorFactory> operatorFactories;
     private final Optional<PlanNodeId> sourceId;
     private final OptionalInt driverInstances;
 
     // must synchronize between createDriver() and noMoreDrivers(), but isNoMoreDrivers() is safe without synchronizing
     @GuardedBy("this")
     private volatile boolean noMoreDrivers;
+    private volatile List<OperatorFactory> operatorFactories;
 
     public DriverFactory(int pipelineId, boolean inputDriver, boolean outputDriver, List<OperatorFactory> operatorFactories, OptionalInt driverInstances)
     {
@@ -88,6 +89,7 @@ public class DriverFactory
         return driverInstances;
     }
 
+    @Nullable
     public List<OperatorFactory> getOperatorFactories()
     {
         return operatorFactories;
@@ -143,6 +145,7 @@ public class DriverFactory
         for (OperatorFactory operatorFactory : operatorFactories) {
             operatorFactory.noMoreOperators();
         }
+        operatorFactories = null;
         noMoreDrivers = true;
     }
 


### PR DESCRIPTION
## Description
It can happen that operator factories live longer than operators what can cause that considerable amount of memory is not freed. Specifically, `PartitionedLookupSourceFactory` (that retained size can be very big) is kept by chain of reference `JoinBridgeManager <- HashBuilderOperator <- operatorFactories <- driverFactory` even if operators are finished.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```