### PR TITLE
Improve planning for table function without partitioning

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddLocalExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddLocalExchanges.java
@@ -514,20 +514,15 @@ public class AddLocalExchanges
             PlanWithProperties child = planAndEnforce(node.getSource().orElseThrow(), childRequirements, childRequirements);
 
             List<LocalProperty<Symbol>> desiredProperties = new ArrayList<>();
-            if (!partitionBy.isEmpty()) {
-                desiredProperties.add(new GroupingProperty<>(partitionBy));
-            }
+            desiredProperties.add(new GroupingProperty<>(partitionBy));
             node.getSpecification().flatMap(DataOrganizationSpecification::orderingScheme).ifPresent(orderingScheme -> desiredProperties.addAll(orderingScheme.toLocalProperties()));
             Iterator<Optional<LocalProperty<Symbol>>> matchIterator = LocalProperties.match(child.getProperties().getLocalProperties(), desiredProperties).iterator();
 
-            Set<Symbol> prePartitionedInputs = ImmutableSet.of();
-            if (!partitionBy.isEmpty()) {
-                Optional<LocalProperty<Symbol>> groupingRequirement = matchIterator.next();
-                Set<Symbol> unPartitionedInputs = groupingRequirement.map(LocalProperty::getColumns).orElse(ImmutableSet.of());
-                prePartitionedInputs = partitionBy.stream()
-                        .filter(symbol -> !unPartitionedInputs.contains(symbol))
-                        .collect(toImmutableSet());
-            }
+            Optional<LocalProperty<Symbol>> groupingRequirement = matchIterator.next();
+            Set<Symbol> unPartitionedInputs = groupingRequirement.map(LocalProperty::getColumns).orElse(ImmutableSet.of());
+            Set<Symbol> prePartitionedInputs = partitionBy.stream()
+                    .filter(symbol -> !unPartitionedInputs.contains(symbol))
+                    .collect(toImmutableSet());
 
             int preSortedOrderPrefix = 0;
             if (prePartitionedInputs.equals(ImmutableSet.copyOf(partitionBy))) {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
@@ -43,7 +43,6 @@ import io.trino.sql.planner.plan.AggregationNode;
 import io.trino.sql.planner.plan.ApplyNode;
 import io.trino.sql.planner.plan.AssignUniqueId;
 import io.trino.sql.planner.plan.CorrelatedJoinNode;
-import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.planner.plan.DistinctLimitNode;
 import io.trino.sql.planner.plan.DynamicFilterSourceNode;
 import io.trino.sql.planner.plan.EnforceSingleRowNode;
@@ -359,11 +358,8 @@ public final class PropertyDerivations
                 }
             }
 
-            List<Symbol> partitionBy = node.getSpecification()
-                    .map(DataOrganizationSpecification::partitionBy)
-                    .orElse(ImmutableList.of());
-            if (!partitionBy.isEmpty()) {
-                localProperties.add(new GroupingProperty<>(partitionBy));
+            if (node.getSpecification().isPresent()) {
+                localProperties.add(new GroupingProperty<>(node.getSpecification().orElseThrow().partitionBy()));
             }
 
             // TODO add global single stream property when there's Specification present with no partitioning columns

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/DataOrganizationSpecification.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/DataOrganizationSpecification.java
@@ -20,6 +20,7 @@ import io.trino.sql.planner.Symbol;
 import java.util.List;
 import java.util.Optional;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 public record DataOrganizationSpecification(
@@ -30,5 +31,14 @@ public record DataOrganizationSpecification(
     {
         partitionBy = ImmutableList.copyOf(partitionBy);
         requireNonNull(orderingScheme, "orderingScheme is null");
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("partitionBy", partitionBy)
+                .add("orderingScheme", orderingScheme)
+                .toString();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableFunctionProcessorNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableFunctionProcessorNode.java
@@ -110,7 +110,9 @@ public class TableFunctionProcessorNode
                         .map(OrderingScheme::orderBy)
                         .map(List::size)
                         .orElse(0) >= preSorted,
-                "the number of pre-sorted symbols cannot be greater than the number of all ordering symbols");
+                "the number of pre-sorted symbols %s cannot be greater than the number of all ordering symbols from specification %s",
+                preSorted,
+                specification);
         checkArgument(preSorted == 0 || partitionBy.equals(prePartitioned), "to specify pre-sorted symbols, it is required that all partitioning symbols are pre-partitioned");
         this.hashSymbol = requireNonNull(hashSymbol, "hashSymbol is null");
         this.handle = requireNonNull(handle, "handle is null");


### PR DESCRIPTION
Before the change planner would insert a gather exchange below such a table function, preventing distributed execution.

- Extracted from https://github.com/trinodb/trino/pull/21558 / https://github.com/trinodb/trino/pull/21378