### PR TITLE
Upgrade to Iceberg 1.5.1

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/fileio/ForwardingFileIo.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/fileio/ForwardingFileIo.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
@@ -104,35 +103,22 @@ public class ForwardingFileIo
         partitions.forEach(this::deleteBatch);
     }
 
-    // TODO: remove below workarounds after https://github.com/apache/iceberg/pull/9953
     @Override
     public InputFile newInputFile(ManifestFile manifest)
     {
-        checkArgument(
-                manifest.keyMetadata() == null,
-                "Cannot decrypt manifest: %s (use EncryptingFileIO)",
-                manifest.path());
-        return newInputFile(manifest.path(), manifest.length());
+        return SupportsBulkOperations.super.newInputFile(manifest);
     }
 
     @Override
     public InputFile newInputFile(DataFile file)
     {
-        checkArgument(
-                file.keyMetadata() == null,
-                "Cannot decrypt data file: %s (use EncryptingFileIO)",
-                file.path());
-        return newInputFile(file.path().toString(), file.fileSizeInBytes());
+        return SupportsBulkOperations.super.newInputFile(file);
     }
 
     @Override
     public InputFile newInputFile(DeleteFile file)
     {
-        checkArgument(
-                file.keyMetadata() == null,
-                "Cannot decrypt delete file: %s (use EncryptingFileIO)",
-                file.path());
-        return newInputFile(file.path().toString(), file.fileSizeInBytes());
+        return SupportsBulkOperations.super.newInputFile(file);
     }
 
     private void deleteBatch(List<String> filesToDelete)

--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
         <dep.errorprone.version>2.26.1</dep.errorprone.version>
         <dep.flyway.version>10.11.1</dep.flyway.version>
         <dep.google.http.client.version>1.44.1</dep.google.http.client.version>
-        <dep.iceberg.version>1.5.0</dep.iceberg.version>
+        <dep.iceberg.version>1.5.1</dep.iceberg.version>
         <dep.jna.version>5.14.0</dep.jna.version>
         <dep.joda.version>2.12.7</dep.joda.version>
         <dep.jsonwebtoken.version>0.12.5</dep.jsonwebtoken.version>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This change upgrades Iceberg to 1.5.1 in the project. 1.5.1 fixes the regression in the default FileIO implementation to do an extra head request for manifest reads. Trino was not impacted by this regression since we overrode the ForwardingFileIO implementation to avoid it. Now since 1.5.1 addresses this, we can simplify the implemenation.

There are other fixes in 1.5.1 as well. For more details see https://github.com/apache/iceberg/milestone/45



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
