### PR TITLE
Decrease query.low-memory-killer.delay to 30s

### DIFF
--- a/core/trino-main/src/main/java/io/trino/memory/MemoryManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/memory/MemoryManagerConfig.java
@@ -26,6 +26,7 @@ import static io.airlift.units.DataSize.succinctBytes;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 @DefunctConfig({
         "experimental.cluster-memory-manager-enabled",
@@ -47,7 +48,7 @@ public class MemoryManagerConfig
     private LowMemoryQueryKillerPolicy lowMemoryQueryKillerPolicy = LowMemoryQueryKillerPolicy.TOTAL_RESERVATION_ON_BLOCKED_NODES;
     private LowMemoryTaskKillerPolicy lowMemoryTaskKillerPolicy = LowMemoryTaskKillerPolicy.TOTAL_RESERVATION_ON_BLOCKED_NODES;
     // default value is overwritten for fault tolerant execution in {@link #applyFaultTolerantExecutionDefaults()}}
-    private Duration killOnOutOfMemoryDelay = new Duration(5, MINUTES);
+    private Duration killOnOutOfMemoryDelay = new Duration(30, SECONDS);
 
     @NotNull
     public DataSize getMaxQueryMemory()

--- a/core/trino-main/src/test/java/io/trino/memory/TestMemoryManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/memory/TestMemoryManagerConfig.java
@@ -27,7 +27,6 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDe
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
-import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class TestMemoryManagerConfig
@@ -47,7 +46,7 @@ public class TestMemoryManagerConfig
                 .setFaultTolerantExecutionEagerSpeculativeTasksNodeMemoryOvercommit(DataSize.of(20, GIGABYTE))
                 .setLowMemoryQueryKillerPolicy(LowMemoryQueryKillerPolicy.TOTAL_RESERVATION_ON_BLOCKED_NODES)
                 .setLowMemoryTaskKillerPolicy(LowMemoryTaskKillerPolicy.TOTAL_RESERVATION_ON_BLOCKED_NODES)
-                .setKillOnOutOfMemoryDelay(new Duration(5, MINUTES)));
+                .setKillOnOutOfMemoryDelay(new Duration(30, SECONDS)));
     }
 
     @Test

--- a/docs/src/main/sphinx/admin/properties-query-management.md
+++ b/docs/src/main/sphinx/admin/properties-query-management.md
@@ -112,7 +112,7 @@ Only applies for queries with task level retries enabled (`retry-policy=TASK`)
 ## `query.low-memory-killer.delay`
 
 - **Type:** {ref}`prop-type-duration`
-- **Default value:** `5m`
+- **Default value:** `30s`
 
 The amount of time a query is allowed to recover between running out of memory
 and being killed, if `query.low-memory-killer.policy` or


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Reduce delay in killing of queries when the cluster runs out of memory ({issue}`issuenumber`)
```
