### PR TITLE
Add information about current open writers to Iceberg max open writers error message

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
@@ -380,7 +380,7 @@ public class IcebergPageSink
         verify(writers.size() == pagePartitioner.getMaxIndex() + 1);
 
         if (currentOpenWriters > maxOpenWriters) {
-            throw new TrinoException(ICEBERG_TOO_MANY_OPEN_PARTITIONS, format("Exceeded limit of %s open writers for partitions", maxOpenWriters));
+            throw new TrinoException(ICEBERG_TOO_MANY_OPEN_PARTITIONS, format("Exceeded limit of %s open writers for partitions: %s", maxOpenWriters, currentOpenWriters));
         }
 
         return writerIndexes;


### PR DESCRIPTION
Having this additional piece of information about open writers would make tuning easier for users. 