### PR TITLE
Increase lock timeout from 1s to 5s in H2

### DIFF
--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingH2JdbcModule.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingH2JdbcModule.java
@@ -78,7 +78,7 @@ public class TestingH2JdbcModule
 
     public static String createH2ConnectionUrl()
     {
-        return format("jdbc:h2:mem:test%s;DB_CLOSE_DELAY=-1", System.nanoTime() + ThreadLocalRandom.current().nextLong());
+        return format("jdbc:h2:mem:test%s;DB_CLOSE_DELAY=-1;DEFAULT_LOCK_TIMEOUT=5000", System.nanoTime() + ThreadLocalRandom.current().nextLong());
     }
 
     public interface TestingH2JdbcClientFactory


### PR DESCRIPTION
## Description

Example failure: https://github.com/trinodb/trino/actions/runs/8841476507/job/24278659109
```
Error:    TestJdbcCachingConnectorSmokeTest>BaseConnectorSmokeTest.testRenameSchema:418->AbstractTestQueryFramework.assertUpdate:405->AbstractTestQueryFramework.assertUpdate:410 » QueryFailed Timeout trying to lock table "SYS"; SQL statement:
DROP SCHEMA "TEST_RENAME_SCHEMA_TJNEG1VTKF_RENAMED" [50200-224]
```

H2 documentation: https://www.h2database.com/html/features.html

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
