### PR TITLE
Fixed documentation for hive connector

### DIFF
--- a/docs/src/main/sphinx/connector/hive.md
+++ b/docs/src/main/sphinx/connector/hive.md
@@ -51,7 +51,7 @@ configured using file format configuration properties per catalog:
 ## General configuration
 
 To configure the Hive connector, create a catalog properties file
-`etc/catalog/example.properties` that references the `hive`
+`/etc/trino/catalog/example.properties` that references the `hive`
 connector and defines a metastore. You must configure a metastore for table
 metadata. If you are using a {ref}`Hive metastore <hive-thrift-metastore>`,
 `hive.metastore.uri` must be configured:
@@ -75,7 +75,7 @@ Each metastore type has specific configuration properties along with
 ### Multiple Hive clusters
 
 You can have as many catalogs as you need, so if you have additional
-Hive clusters, simply add another properties file to `etc/catalog`
+Hive clusters, simply add another properties file to `/etc/trino/catalog`
 with a different name, making sure it ends in `.properties`. For
 example, if you name the property file `sales.properties`, Trino
 creates a catalog named `sales` using the configured connector.


### PR DESCRIPTION
Fixed location to catalog in documentation

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Looks like the documentation for Hive connector contains invalid location for catalog file. Fixed it


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
