### PR TITLE
Fix incorrect result with deletion vector on Delta partitioned table

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSourceProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSourceProvider.java
@@ -266,8 +266,8 @@ public class DeltaLakePageSourceProvider
                 return Optional.empty();
             }
 
-            List<DeltaLakeColumnHandle> requiredColumns = ImmutableList.<DeltaLakeColumnHandle>builderWithExpectedSize(deltaLakeColumns.size() + 1)
-                    .addAll(deltaLakeColumns)
+            List<DeltaLakeColumnHandle> requiredColumns = ImmutableList.<DeltaLakeColumnHandle>builderWithExpectedSize(regularColumns.size() + 1)
+                    .addAll(regularColumns)
                     .add(rowPositionColumnHandle())
                     .build();
             PositionDeleteFilter deleteFilter = readDeletes(fileSystem, Location.of(table.location()), split.getDeletionVector().get());


### PR DESCRIPTION
## Description

Fixes #21737

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Delta Lake
* Fix incorrect result with deletion vector on partitioned tables. ({issue}`21737`)
```
