### PR TITLE
Suppress single view errors during metadata listing. 

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -1401,9 +1401,16 @@ public final class MetadataManager
 
                 Map<SchemaTableName, ConnectorViewDefinition> viewMap;
                 if (tablePrefix.getTable().isPresent()) {
-                    viewMap = metadata.getView(connectorSession, tablePrefix.toSchemaTableName())
-                            .map(view -> ImmutableMap.of(tablePrefix.toSchemaTableName(), view))
-                            .orElse(ImmutableMap.of());
+                    try {
+                        viewMap = metadata.getView(connectorSession, tablePrefix.toSchemaTableName())
+                                .map(view -> ImmutableMap.of(tablePrefix.toSchemaTableName(), view))
+                                .orElse(ImmutableMap.of());
+                    }
+                    catch (RuntimeException e) {
+                        handleListingError(e, prefix);
+                        // Empty in case of metadata error.
+                        viewMap = ImmutableMap.of();
+                    }
                 }
                 else {
                     viewMap = metadata.getViews(connectorSession, tablePrefix.getSchema());

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveViews.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveViews.java
@@ -92,8 +92,8 @@ public class TestHiveViews
                         row("correct_view", "n_comment"),
                         row("failing_view", "col0"));
 
-        assertThatThrownBy(() -> onTrino().executeQuery("SELECT * FROM information_schema.columns WHERE table_schema = 'test_list_failing_views' AND table_name = 'failing_view'"))
-                .hasMessageContaining("Failed to translate Hive view 'test_list_failing_views.failing_view'");
+        assertThat(onTrino().executeQuery("SELECT * FROM information_schema.columns WHERE table_schema = 'test_list_failing_views' AND table_name = 'failing_view'"))
+                .hasNoRows();
     }
 
     private void testFailingHiveViewsWithSystemJdbc()
@@ -136,8 +136,8 @@ public class TestHiveViews
                         row("correct_view", "n_comment"),
                         row("failing_view", "col0"));
 
-        assertThatThrownBy(() -> onTrino().executeQuery("SELECT * FROM system.jdbc.columns WHERE table_cat = 'hive' AND table_schem = 'test_list_failing_views' AND table_name = 'failing_view'"))
-                .hasMessageContaining("Failed to translate Hive view 'test_list_failing_views.failing_view'");
+        assertThat(onTrino().executeQuery("SELECT * FROM system.jdbc.columns WHERE table_cat = 'hive' AND table_schem = 'test_list_failing_views' AND table_name = 'failing_view'"))
+                .hasNoRows();
     }
 
     private static void setupBrokenView()


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

In case of single view error (e.g Hive views are not supported) listing is failing.
This change filter outs views causing errors from lists returned when listing views or comments.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Metadata
* Suppress not supported view errors during metadata listing
```
