### PR TITLE
Retry queries on Databricks when dealing with a communication failure

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/util/DeltaLakeTestUtils.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/util/DeltaLakeTestUtils.java
@@ -27,10 +27,12 @@ import io.trino.tempto.query.QueryResult;
 import org.intellij.lang.annotations.Language;
 import org.testng.SkipException;
 
+import java.sql.SQLException;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
@@ -50,10 +52,17 @@ public final class DeltaLakeTestUtils
     @Language("RegExp")
     public static final String DATABRICKS_COMMUNICATION_FAILURE_MATCH =
             "\\Q[Databricks][\\E(DatabricksJDBCDriver|JDBCDriver)\\Q](500593) Communication link failure. Failed to connect to server. Reason: \\E" +
-            "(" +
-            "(HTTP retry after response received with no Retry-After header, error: HTTP Response code: 503|HTTP Response code: 504), Error message: Unknown." +
-            "|java.net.SocketTimeoutException: Read timed out." +
-            ")";
+                    "(" +
+                    "(HTTP retry after response received with no Retry-After header, error: HTTP Response code: 503|HTTP Response code: 504), Error message: Unknown." +
+                    "|java.net.SocketTimeoutException: Read timed out." +
+                    ")";
+    private static final RetryPolicy<QueryResult> DATABRICKS_COMMUNICATION_FAILURE_RETRY_POLICY = RetryPolicy.<QueryResult>builder()
+            .handleIf(throwable -> Throwables.getRootCause(throwable) instanceof SQLException)
+            .handleIf(throwable -> Pattern.compile(DATABRICKS_COMMUNICATION_FAILURE_MATCH).matcher(Throwables.getRootCause(throwable).getMessage()).find())
+            .withBackoff(1, 10, ChronoUnit.SECONDS)
+            .withMaxRetries(3)
+            .onRetry(event -> log.warn(event.getLastException(), "Query failed on attempt %d, will retry.", event.getAttemptCount()))
+            .build();
     private static final RetryPolicy<QueryResult> CONCURRENT_MODIFICATION_EXCEPTION_RETRY_POLICY = RetryPolicy.<QueryResult>builder()
             .handleIf(throwable -> Throwables.getRootCause(throwable) instanceof ConcurrentModificationException)
             .handleIf(throwable -> throwable.getMessage() != null && throwable.getMessage().contains("Table being modified concurrently"))
@@ -66,7 +75,10 @@ public final class DeltaLakeTestUtils
 
     public static Optional<DatabricksVersion> getDatabricksRuntimeVersion()
     {
-        String version = (String) onDelta().executeQuery("SELECT java_method('java.lang.System', 'getenv', 'DATABRICKS_RUNTIME_VERSION')").getOnlyValue();
+        String version = (String) Failsafe.with(DATABRICKS_COMMUNICATION_FAILURE_RETRY_POLICY)
+                .get(() -> onDelta().executeQuery("SELECT java_method('java.lang.System', 'getenv', 'DATABRICKS_RUNTIME_VERSION')"))
+                .getOnlyValue();
+
         // OSS Spark returns null
         if (version.equals("null")) {
             return Optional.empty();
@@ -91,7 +103,8 @@ public final class DeltaLakeTestUtils
 
     public static List<String> getColumnNamesOnDelta(String schemaName, String tableName)
     {
-        QueryResult result = onDelta().executeQuery("SHOW COLUMNS IN " + schemaName + "." + tableName);
+        QueryResult result = Failsafe.with(DATABRICKS_COMMUNICATION_FAILURE_RETRY_POLICY)
+                .get(() -> onDelta().executeQuery("SHOW COLUMNS IN " + schemaName + "." + tableName));
         return result.column(1);
     }
 
@@ -104,7 +117,8 @@ public final class DeltaLakeTestUtils
 
     public static String getColumnCommentOnDelta(String schemaName, String tableName, String columnName)
     {
-        QueryResult result = onDelta().executeQuery(format("DESCRIBE %s.%s %s", schemaName, tableName, columnName));
+        QueryResult result = Failsafe.with(DATABRICKS_COMMUNICATION_FAILURE_RETRY_POLICY)
+                .get(() -> onDelta().executeQuery(format("DESCRIBE %s.%s %s", schemaName, tableName, columnName)));
         return (String) result.row(2).get(1);
     }
 
@@ -116,7 +130,8 @@ public final class DeltaLakeTestUtils
 
     public static String getTableCommentOnDelta(String schemaName, String tableName)
     {
-        QueryResult result = onDelta().executeQuery(format("DESCRIBE EXTENDED %s.%s", schemaName, tableName));
+        QueryResult result = Failsafe.with(DATABRICKS_COMMUNICATION_FAILURE_RETRY_POLICY)
+                .get(() -> onDelta().executeQuery(format("DESCRIBE EXTENDED %s.%s", schemaName, tableName)));
         return (String) result.rows().stream()
                 .filter(row -> row.get(0).equals("Comment"))
                 .map(row -> row.get(1))
@@ -125,7 +140,8 @@ public final class DeltaLakeTestUtils
 
     public static Map<String, String> getTablePropertiesOnDelta(String schemaName, String tableName)
     {
-        QueryResult result = onDelta().executeQuery("SHOW TBLPROPERTIES %s.%s".formatted(schemaName, tableName));
+        QueryResult result = Failsafe.with(DATABRICKS_COMMUNICATION_FAILURE_RETRY_POLICY)
+                .get(() -> onDelta().executeQuery("SHOW TBLPROPERTIES %s.%s".formatted(schemaName, tableName)));
         return result.rows().stream()
                 .map(column -> Map.entry((String) column.get(0), (String) column.get(1)))
                 .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
@@ -133,7 +149,8 @@ public final class DeltaLakeTestUtils
 
     public static String getTablePropertyOnDelta(String schemaName, String tableName, String propertyName)
     {
-        QueryResult result = onDelta().executeQuery("SHOW TBLPROPERTIES %s.%s(%s)".formatted(schemaName, tableName, propertyName));
+        QueryResult result = Failsafe.with(DATABRICKS_COMMUNICATION_FAILURE_RETRY_POLICY)
+                .get(() -> onDelta().executeQuery("SHOW TBLPROPERTIES %s.%s(%s)".formatted(schemaName, tableName, propertyName)));
         return (String) getOnlyElement(result.rows()).get(1);
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

In the commit 06633b96 there has been removed a source of flakiness in the tests involving Databricks infrastructure by empowering `FlakyTestRetryAnalyzer` to take care of them:

```
@Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
```

However, in the `setup()` methods there may be also made calls to Databricks (see `io.trino.tests.product.deltalake.TestDeltaLakeCheckpointsCompatibility#setup`).
This PR is wrapping with a failsafe retry policy the calls to Databricks.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Follow-up from 06633b96

There has been taken into consideration changing `io.trino.tests.product.utils.QueryExecutors#onDelta` to contain a retry policy for communication failures. However this option has been discarded because we may have unexpected outcomes when retrying write operations.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
