### PR TITLE
Serialize function dependencies for SpecialForm

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/relational/SpecialForm.java
+++ b/core/trino-main/src/main/java/io/trino/sql/relational/SpecialForm.java
@@ -44,15 +44,12 @@ public final class SpecialForm
         this(form, returnType, ImmutableList.copyOf(arguments));
     }
 
-    @JsonCreator
-    public SpecialForm(
-            @JsonProperty Form form,
-            @JsonProperty Type returnType,
-            @JsonProperty List<RowExpression> arguments)
+    public SpecialForm(Form form, Type returnType, List<RowExpression> arguments)
     {
         this(form, returnType, arguments, ImmutableList.of());
     }
 
+    @JsonCreator
     public SpecialForm(Form form, Type returnType, List<RowExpression> arguments, List<ResolvedFunction> functionDependencies)
     {
         this.form = requireNonNull(form, "form is null");
@@ -67,6 +64,7 @@ public final class SpecialForm
         return form;
     }
 
+    @JsonProperty
     public List<ResolvedFunction> getFunctionDependencies()
     {
         return functionDependencies;

--- a/core/trino-main/src/test/java/io/trino/sql/routine/TestSqlFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/routine/TestSqlFunctions.java
@@ -408,6 +408,20 @@ class TestSqlFunctions
     }
 
     @Test
+    void testSpecialForm()
+    {
+        @Language("SQL") String sql = """
+                FUNCTION test(a varchar)
+                RETURNS varchar
+                BEGIN
+                  RETURN NULLIF(a, 'test');
+                END
+                """;
+        assertFunction(sql, handle -> assertThat(handle.invoke(utf8Slice("test"))).isEqualTo(null));
+        assertFunction(sql, handle -> assertThat(handle.invoke(utf8Slice("test2"))).isEqualTo(utf8Slice("test2")));
+    }
+
+    @Test
     void testReuseVariables()
     {
         @Language("SQL") String sql = """


### PR DESCRIPTION
This is causing some queries that are executed in a distributed fashion to fail.

Fixes https://github.com/trinodb/trino/issues/19820