### PR TITLE
Include all properties in InternalNode equals

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/InternalNode.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/InternalNode.java
@@ -20,6 +20,7 @@ import io.trino.spi.Node;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
+import java.util.Objects;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -108,13 +109,16 @@ public class InternalNode
             return false;
         }
         InternalNode o = (InternalNode) obj;
-        return nodeIdentifier.equals(o.nodeIdentifier);
+        return coordinator == o.coordinator &&
+                Objects.equals(nodeIdentifier, o.nodeIdentifier) &&
+                Objects.equals(internalUri, o.internalUri) &&
+                Objects.equals(nodeVersion, o.nodeVersion);
     }
 
     @Override
     public int hashCode()
     {
-        return nodeIdentifier.hashCode();
+        return Objects.hash(nodeIdentifier, internalUri, nodeVersion, coordinator);
     }
 
     @Override
@@ -124,6 +128,7 @@ public class InternalNode
                 .add("nodeIdentifier", nodeIdentifier)
                 .add("internalUri", internalUri)
                 .add("nodeVersion", nodeVersion)
+                .add("coordinator", coordinator)
                 .toString();
     }
 }


### PR DESCRIPTION
Comparing by just subset of properties may lead `DiscoveryNodeManager` to have wrong state of the world. In
`DiscoveryNodeManager.refreshNodesInternal` we build a set of internal nodes (the `AllNodes` class instance) and then check whether it is different than what we already had.

relates to https://github.com/trinodb/trino/pull/21744