### PR TITLE
Fix flakiness in TestIcebergNessieCatalogConnectorSmokeTest

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestIcebergNessieCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestIcebergNessieCatalogConnectorSmokeTest.java
@@ -27,6 +27,7 @@ import io.trino.tpch.TpchTable;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -42,8 +43,10 @@ import static org.apache.iceberg.FileFormat.PARQUET;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.abort;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
 @TestInstance(PER_CLASS)
+@Execution(SAME_THREAD)
 public class TestIcebergNessieCatalogConnectorSmokeTest
         extends BaseIcebergConnectorSmokeTest
 {


### PR DESCRIPTION
## Description

When multiple commits occur concurrently on the same branch, the Nessie backend will throw a `NessieReferenceConflictException` for the current commit. Subsequently, from Trino, 
`IcebergNessieTableOperations` will throw a `CommitFailedException`. Iceberg will then retry the commit from 
`BaseTransaction.commitSimpleTransaction` with the latest hash, and it should succeed if no other concurrent commits occurred.

Due to concurrent commits, the default retry count (4) may not be sufficient for the commits to succeed.
The `TestIcebergNessieCatalogConnectorSmokeTest`, inheriting concurrent execution mode from `AbstractTestQueryFramework` is the root cause of the problem. This was addressed by overriding
 it to execute in a single thread.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes https://github.com/trinodb/trino/issues/20323


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

