### PR TITLE
Remove unsupported version changes in Cassandra

### DIFF
--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSession.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSession.java
@@ -557,7 +557,6 @@ public class CassandraSession
 
     public List<SizeEstimate> getSizeEstimates(String keyspaceName, String tableName)
     {
-        checkSizeEstimatesTableExist();
         SimpleStatement statement = selectFrom(SYSTEM, SIZE_ESTIMATES)
                 .column("partitions_count")
                 .where(Relation.column("keyspace_name").isEqualTo(literal(keyspaceName)),
@@ -572,16 +571,6 @@ public class CassandraSession
         }
 
         return estimates.build();
-    }
-
-    private void checkSizeEstimatesTableExist()
-    {
-        Optional<KeyspaceMetadata> keyspaceMetadata = executeWithSession(session -> session.getMetadata().getKeyspace(SYSTEM));
-        checkState(keyspaceMetadata.isPresent(), "system keyspace metadata must not be null");
-        Optional<TableMetadata> sizeEstimatesTableMetadata = keyspaceMetadata.flatMap(metadata -> metadata.getTable(SIZE_ESTIMATES));
-        if (sizeEstimatesTableMetadata.isEmpty()) {
-            throw new TrinoException(NOT_SUPPORTED, "Cassandra versions prior to 2.1.5 are not supported");
-        }
     }
 
     private <T> T executeWithSession(SessionCallable<T> sessionCallable)

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSessionProperties.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSessionProperties.java
@@ -35,7 +35,7 @@ public final class CassandraSessionProperties
         sessionProperties = ImmutableList.of(
                 longProperty(
                         SPLITS_PER_NODE,
-                        "Number of splits per node. By default, the values from the system.size_estimates table are used. Only override when connecting to Cassandra versions < 2.1.5.",
+                        "Number of splits per node. By default, the values from the system.size_estimates table are used.",
                         cassandraClientConfig.getSplitsPerNode().orElse(null),
                         false));
     }

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/util/TestCassandraClusteringPredicatesExtractor.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/util/TestCassandraClusteringPredicatesExtractor.java
@@ -48,7 +48,7 @@ public class TestCassandraClusteringPredicatesExtractor
         cassandraTable = new CassandraTable(
                 new CassandraNamedRelationHandle("test", "records"), ImmutableList.of(col1, col2, col3, col4));
 
-        cassandraVersion = Version.parse("2.1.5");
+        cassandraVersion = Version.parse("3.0");
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

As per https://trino.io/docs/current/connector/cassandra.html#requirements, Cassandra connector supports version starting from 3.0. PR tends to remove traces of unsupported version.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
