### PR TITLE
Update to Hadoop 3.3.5-2

### DIFF
--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/sequence/TestSequenceFileReaderWriter.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/sequence/TestSequenceFileReaderWriter.java
@@ -53,6 +53,7 @@ import static io.trino.hive.formats.FormatTestUtils.COMPRESSION;
 import static io.trino.hive.formats.FormatTestUtils.configureCompressionCodecs;
 import static io.trino.hive.formats.ReadWriteUtils.findFirstSyncPosition;
 import static io.trino.hive.formats.compression.CompressionKind.LZOP;
+import static io.trino.hive.formats.compression.CompressionKind.ZSTD;
 import static io.trino.hive.formats.line.sequence.SequenceFileWriter.TRINO_SEQUENCE_FILE_WRITER_VERSION;
 import static io.trino.hive.formats.line.sequence.SequenceFileWriter.TRINO_SEQUENCE_FILE_WRITER_VERSION_METADATA_KEY;
 import static java.lang.Math.toIntExact;
@@ -88,7 +89,7 @@ public class TestSequenceFileReaderWriter
             throws Exception
     {
         for (Optional<CompressionKind> compressionKind : COMPRESSION) {
-            if (compressionKind.equals(Optional.of(LZOP))) {
+            if (compressionKind.equals(Optional.of(LZOP)) || compressionKind.equals(Optional.of(ZSTD))) {
                 continue;
             }
             for (boolean blockCompressed : ImmutableList.of(true)) {

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/text/TestTextLineReaderWriter.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/text/TestTextLineReaderWriter.java
@@ -44,6 +44,7 @@ import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.trino.hive.formats.FormatTestUtils.COMPRESSION;
 import static io.trino.hive.formats.FormatTestUtils.configureCompressionCodecs;
+import static io.trino.hive.formats.compression.CompressionKind.ZSTD;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.createTempDirectory;
 import static org.apache.hadoop.mapreduce.lib.output.FileOutputFormat.COMPRESS_CODEC;
@@ -57,6 +58,10 @@ public class TestTextLineReaderWriter
             throws Exception
     {
         for (Optional<CompressionKind> compressionKind : COMPRESSION) {
+            if (compressionKind.equals(Optional.of(ZSTD))) {
+                continue;
+            }
+
             // write old, read new and ol
             try (TempFileWithExtension tempFile = new TempFileWithExtension(compressionKind.map(CompressionKind::getFileExtension).orElse(""))) {
                 writeOld(tempFile.file(), compressionKind, values);

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/rcfile/RcFileTester.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/rcfile/RcFileTester.java
@@ -94,6 +94,7 @@ import static io.trino.hive.formats.FormatTestUtils.toHiveWriteValue;
 import static io.trino.hive.formats.FormatTestUtils.writeTrinoValue;
 import static io.trino.hive.formats.ReadWriteUtils.findFirstSyncPosition;
 import static io.trino.hive.formats.compression.CompressionKind.LZOP;
+import static io.trino.hive.formats.compression.CompressionKind.ZSTD;
 import static io.trino.hive.formats.rcfile.RcFileWriter.TRINO_RCFILE_WRITER_VERSION;
 import static io.trino.hive.formats.rcfile.RcFileWriter.TRINO_RCFILE_WRITER_VERSION_METADATA_KEY;
 import static io.trino.spi.type.StandardTypes.MAP;
@@ -181,7 +182,7 @@ public class RcFileTester
         rcFileTester.listTestsEnabled = true;
         rcFileTester.complexStructuralTestsEnabled = false;
         rcFileTester.readLastBatchOnlyEnabled = false;
-        rcFileTester.compressions = ImmutableList.of(Optional.empty(), Optional.of(CompressionKind.ZSTD));
+        rcFileTester.compressions = ImmutableList.of(Optional.empty(), Optional.of(ZSTD));
         return rcFileTester;
     }
 
@@ -322,9 +323,10 @@ public class RcFileTester
 
         for (Format format : formats) {
             for (Optional<CompressionKind> compression : compressions) {
-                if (compression.equals(Optional.of(LZOP))) {
+                if (compression.equals(Optional.of(LZOP)) || compression.equals(Optional.of(ZSTD))) {
                     continue;
                 }
+
                 // write old, read new
                 try (TempFile tempFile = new TempFile()) {
                     writeRcFileColumnOld(tempFile.file(), format, compression, type, finalValues.iterator());

--- a/pom.xml
+++ b/pom.xml
@@ -1536,7 +1536,7 @@
             <dependency>
                 <groupId>io.trino.hadoop</groupId>
                 <artifactId>hadoop-apache</artifactId>
-                <version>3.3.5-1</version>
+                <version>3.3.5-2</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
