### PR TITLE
Allow writing into Delta tables using deletion vectors

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeSchemaSupport.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeSchemaSupport.java
@@ -119,6 +119,7 @@ public final class DeltaLakeSchemaSupport
             .add(CHANGE_DATA_FEED_FEATURE_NAME)
             .add(COLUMN_MAPPING_FEATURE_NAME)
             .add(TIMESTAMP_NTZ_FEATURE_NAME)
+            .add(DELETION_VECTORS_FEATURE_NAME)
             .build();
 
     public enum ColumnMappingMode

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDeleteCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDeleteCompatibility.java
@@ -261,15 +261,16 @@ public class TestDeltaLakeDeleteCompatibility
                     .contains(row("a", "integer", "", ""), row("b", "integer", "", ""));
 
             // TODO https://github.com/trinodb/trino/issues/17063 Use Delta Deletion Vectors for row-level deletes
-            assertQueryFailure(() -> onTrino().executeQuery("INSERT INTO delta.default." + tableName + " VALUES (3, 33)"))
-                    .hasMessageContaining("Unsupported writer features: [deletionVectors]");
-            assertQueryFailure(() -> onTrino().executeQuery("DELETE FROM delta.default." + tableName))
-                    .hasMessageContaining("Unsupported writer features: [deletionVectors]");
-            assertQueryFailure(() -> onTrino().executeQuery("UPDATE delta.default." + tableName + " SET a = 3"))
-                    .hasMessageContaining("Unsupported writer features: [deletionVectors]");
-            assertQueryFailure(() -> onTrino().executeQuery("MERGE INTO delta.default." + tableName + " t USING delta.default." + tableName + " s " +
-                    "ON (t.a = s.a) WHEN MATCHED THEN UPDATE SET b = -1"))
-                    .hasMessageContaining("Unsupported writer features: [deletionVectors]");
+            onTrino().executeQuery("INSERT INTO delta.default." + tableName + " VALUES (3, 33)");
+            onTrino().executeQuery("DELETE FROM delta.default." + tableName + " WHERE a = 1");
+            onTrino().executeQuery("UPDATE delta.default." + tableName + " SET a = 30 WHERE b = 33");
+            onTrino().executeQuery("MERGE INTO delta.default." + tableName + " t USING delta.default." + tableName + " s " +
+                    "ON (t.a = s.a) WHEN MATCHED THEN UPDATE SET b = -1");
+
+            assertThat(onDelta().executeQuery("SELECT * FROM default." + tableName))
+                    .containsOnly(row(2, -1), row(30, -1));
+            assertThat(onTrino().executeQuery("SELECT * FROM delta.default." + tableName))
+                    .containsOnly(row(2, -1), row(30, -1));
         }
         finally {
             dropDeltaTableWithRetry("default." + tableName);

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeWriteDatabricksCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeWriteDatabricksCompatibility.java
@@ -421,10 +421,10 @@ public class TestDeltaLakeWriteDatabricksCompatibility
                 "(a INT)" +
                 "USING DELTA " +
                 "LOCATION '" + ("s3://" + bucketName + "/" + directoryName) + "'" +
-                "TBLPROPERTIES ('delta.enableDeletionVectors' = true)");
+                "TBLPROPERTIES ('delta.enableRowTracking' = true)");
         try {
             assertThatThrownBy(() -> onTrino().executeQuery("CALL delta.system.vacuum('default', '" + tableName + "', '7d')"))
-                    .hasMessageContaining("Cannot execute vacuum procedure with [deletionVectors] writer features");
+                    .hasMessageContaining("Cannot execute vacuum procedure with [rowTracking] writer features");
         }
         finally {
             dropDeltaTableWithRetry("default." + tableName);


### PR DESCRIPTION
## Description

This PR doesn't writing deletion vectors. Still rewriting whole files. 
Relates to https://github.com/trinodb/trino/issues/17063

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Delta Lake
* TBD. ({issue}`issuenumber`)
```
