### PR TITLE
Make logging about container.log to be less verbose

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/Environment.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/Environment.java
@@ -640,7 +640,7 @@ public final class Environment
         private static Consumer<OutputFrame> writeContainerLogs(DockerContainer container, Path path)
         {
             Path containerLogFile = path.resolve(container.getLogicalName() + "/container.log");
-            log.info("Writing container %s logs to %s", container, containerLogFile);
+            log.debug("Writing container %s logs to %s", container, containerLogFile);
 
             try {
                 ensurePathExists(containerLogFile.getParent());


### PR DESCRIPTION
Make logging about container.log to be less verbose

This logging entry can pollute test log sometimes that makes it more
challenging to diagnose issues.
