### PR TITLE
Avoid over retaining memory for strings in parquet writer

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/BinaryValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/BinaryValueWriter.java
@@ -41,7 +41,9 @@ public class BinaryValueWriter
         for (int i = 0; i < block.getPositionCount(); i++) {
             if (!block.isNull(i)) {
                 Slice slice = type.getSlice(block, i);
-                Binary binary = Binary.fromConstantByteBuffer(slice.toByteBuffer());
+                // fromReusedByteBuffer must be used instead of fromConstantByteBuffer to avoid retaining entire
+                // base byte array of the Slice in DictionaryValuesWriter.PlainBinaryDictionaryValuesWriter
+                Binary binary = Binary.fromReusedByteBuffer(slice.toByteBuffer());
                 valuesWriter.writeBytes(binary);
                 getStatistics().updateStats(binary);
             }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Used Binary.fromReusedByteBuffer to ensure that DictionaryValuesWriter.PlainBinaryDictionaryValuesWriter copies specific positions rather than retaining entire underlying byte array from the Block


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes https://github.com/trinodb/trino/issues/21745


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Hudi, Delta Lake, Iceberg 
* Fix under accounting of memory usage for writing strings in parquet. ({issue}`21745`)
```
