### PR TITLE
Make build easier to reproduce

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -7,4 +7,3 @@
 -Daether.remoteRepositoryFilter.prefixes.basedir=${session.rootDirectory}/.mvn/rrf/
 -Daether.remoteRepositoryFilter.groupId=true
 -Daether.remoteRepositoryFilter.groupId.basedir=${session.rootDirectory}/.mvn/rrf/
-

--- a/core/trino-server/pom.xml
+++ b/core/trino-server/pom.xml
@@ -81,6 +81,13 @@
                 <configuration>
                     <proc>none</proc>
                     <skip>${takari.skip}</skip>
+                    <archive>
+                        <!-- make server jar reproducible -->
+                        <ManifestEntries>
+                            <Built-By>root</Built-By>
+                            <Build-Jdk>${air.java.version}</Build-Jdk>
+                        </ManifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Even though it's possible to reproduce 446 build, it requires specific settings to TZ (America/San_Francisco), specific user (root), specific OS (Linux with inode size 4096 bytes) and specific JDK version (21.0.1). These changes are a step forward making builds more independent of these factors.