### PR TITLE
Fix error location markers for SQL routines

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/LanguageFunctionAnalysisException.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/LanguageFunctionAnalysisException.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.metadata;
+
+import io.trino.spi.ErrorCodeSupplier;
+import io.trino.spi.TrinoException;
+
+public class LanguageFunctionAnalysisException
+        extends TrinoException
+{
+    public LanguageFunctionAnalysisException(ErrorCodeSupplier errorCode, String message)
+    {
+        super(errorCode, message);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Multimap;
 import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.FunctionResolver;
+import io.trino.metadata.LanguageFunctionAnalysisException;
 import io.trino.metadata.OperatorNotFoundException;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.ResolvedFunction;
@@ -1365,6 +1366,11 @@ public class ExpressionAnalyzer
                 if (e.getLocation().isPresent()) {
                     // If analysis of any of the argument types (which is done lazily to deal with lambda
                     // expressions) fails, we want to report the original reason for the failure
+                    throw e;
+                }
+
+                if (e instanceof LanguageFunctionAnalysisException) {
+                    // report the original reason for language function analysis errors
                     throw e;
                 }
 

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -379,7 +379,6 @@ import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.sql.NodeUtils.getSortItemsFromOrderBy;
-import static io.trino.sql.SqlFormatter.formatSql;
 import static io.trino.sql.analyzer.AggregationAnalyzer.verifyOrderByAggregations;
 import static io.trino.sql.analyzer.AggregationAnalyzer.verifySourceAggregations;
 import static io.trino.sql.analyzer.Analyzer.verifyNoAggregateWindowOrGroupingFunctions;
@@ -1558,7 +1557,7 @@ class StatementAnalyzer
                         .ifPresent(security -> {
                             throw semanticException(NOT_SUPPORTED, security, "Security mode not supported for inline functions");
                         });
-                plannerContext.getLanguageFunctionManager().addInlineFunction(session, formatSql(function), accessControl);
+                plannerContext.getLanguageFunctionManager().addInlineFunction(session, function, accessControl);
             }
 
             Scope withScope = analyzeWith(node, scope);

--- a/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutineAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutineAnalyzer.java
@@ -223,7 +223,7 @@ public class SqlRoutineAnalyzer
         }
     }
 
-    private static Optional<String> getLanguage(FunctionSpecification function)
+    private static Optional<Identifier> getLanguage(FunctionSpecification function)
     {
         List<LanguageCharacteristic> language = function.getRoutineCharacteristics().stream()
                 .filter(LanguageCharacteristic.class::isInstance)
@@ -231,21 +231,21 @@ public class SqlRoutineAnalyzer
                 .collect(toImmutableList());
 
         if (language.size() > 1) {
-            throw semanticException(SYNTAX_ERROR, function, "Multiple language clauses specified");
+            throw semanticException(SYNTAX_ERROR, language.get(1), "Multiple language clauses specified");
         }
 
         return language.stream()
                 .map(LanguageCharacteristic::getLanguage)
-                .map(Identifier::getValue)
                 .findAny();
     }
 
     private static void validateLanguage(FunctionSpecification function)
     {
-        Optional<String> language = getLanguage(function);
-        if (language.isPresent() && !language.get().equalsIgnoreCase("sql")) {
-            throw semanticException(NOT_SUPPORTED, function, "Unsupported language: %s", language.get());
-        }
+        getLanguage(function).ifPresent(language -> {
+            if (!language.getValue().equalsIgnoreCase("sql")) {
+                throw semanticException(NOT_SUPPORTED, language, "Unsupported function language: %s", language.getCanonicalValue());
+            }
+        });
     }
 
     private static Optional<Boolean> getDeterministic(FunctionSpecification function)
@@ -256,7 +256,7 @@ public class SqlRoutineAnalyzer
                 .collect(toImmutableList());
 
         if (deterministic.size() > 1) {
-            throw semanticException(SYNTAX_ERROR, function, "Multiple deterministic clauses specified");
+            throw semanticException(SYNTAX_ERROR, deterministic.get(1), "Multiple deterministic clauses specified");
         }
 
         return deterministic.stream()
@@ -272,7 +272,7 @@ public class SqlRoutineAnalyzer
                 .collect(toImmutableList());
 
         if (nullInput.size() > 1) {
-            throw semanticException(SYNTAX_ERROR, function, "Multiple null-call clauses specified");
+            throw semanticException(SYNTAX_ERROR, nullInput.get(1), "Multiple null-call clauses specified");
         }
 
         return nullInput.stream()
@@ -289,7 +289,7 @@ public class SqlRoutineAnalyzer
                 .collect(toImmutableList());
 
         if (security.size() > 1) {
-            throw semanticException(SYNTAX_ERROR, function, "Multiple security clauses specified");
+            throw semanticException(SYNTAX_ERROR, security.get(1), "Multiple security clauses specified");
         }
 
         return security.stream()
@@ -312,7 +312,7 @@ public class SqlRoutineAnalyzer
                 .collect(toImmutableList());
 
         if (comment.size() > 1) {
-            throw semanticException(SYNTAX_ERROR, function, "Multiple comment clauses specified");
+            throw semanticException(SYNTAX_ERROR, comment.get(1), "Multiple comment clauses specified");
         }
 
         return comment.stream()

--- a/core/trino-main/src/test/java/io/trino/sql/routine/TestSqlRoutineAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/routine/TestSqlRoutineAnalyzer.java
@@ -59,23 +59,23 @@ class TestSqlRoutineAnalyzer
     {
         assertFails("FUNCTION test() RETURNS int CALLED ON NULL INPUT CALLED ON NULL INPUT RETURN 123")
                 .hasErrorCode(SYNTAX_ERROR)
-                .hasMessage("line 1:1: Multiple null-call clauses specified");
+                .hasMessage("line 1:50: Multiple null-call clauses specified");
 
         assertFails("FUNCTION test() RETURNS int RETURNS NULL ON NULL INPUT CALLED ON NULL INPUT RETURN 123")
                 .hasErrorCode(SYNTAX_ERROR)
-                .hasMessage("line 1:1: Multiple null-call clauses specified");
+                .hasMessage("line 1:56: Multiple null-call clauses specified");
 
         assertFails("FUNCTION test() RETURNS int COMMENT 'abc' COMMENT 'xyz' RETURN 123")
                 .hasErrorCode(SYNTAX_ERROR)
-                .hasMessage("line 1:1: Multiple comment clauses specified");
+                .hasMessage("line 1:43: Multiple comment clauses specified");
 
         assertFails("FUNCTION test() RETURNS int LANGUAGE abc LANGUAGE xyz RETURN 123")
                 .hasErrorCode(SYNTAX_ERROR)
-                .hasMessage("line 1:1: Multiple language clauses specified");
+                .hasMessage("line 1:42: Multiple language clauses specified");
 
         assertFails("FUNCTION test() RETURNS int NOT DETERMINISTIC DETERMINISTIC RETURN 123")
                 .hasErrorCode(SYNTAX_ERROR)
-                .hasMessage("line 1:1: Multiple deterministic clauses specified");
+                .hasMessage("line 1:47: Multiple deterministic clauses specified");
     }
 
     @Test
@@ -121,7 +121,7 @@ class TestSqlRoutineAnalyzer
 
         assertFails("FUNCTION test() RETURNS bigint LANGUAGE JAVASCRIPT RETURN abs(-42)")
                 .hasErrorCode(NOT_SUPPORTED)
-                .hasMessage("line 1:1: Unsupported language: JAVASCRIPT");
+                .hasMessage("line 1:41: Unsupported function language: JAVASCRIPT");
     }
 
     @Test

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -6599,7 +6599,8 @@ public abstract class BaseConnectorTest
         assertUpdate("CREATE FUNCTION " + recursive1 + "(x integer) RETURNS integer RETURN x");
         assertUpdate("CREATE FUNCTION " + recursive2 + "(x integer) RETURNS integer RETURN " + recursive1 + "(x)");
         assertUpdate("CREATE OR REPLACE FUNCTION " + recursive1 + "(x integer) RETURNS integer RETURN " + recursive2 + "(x)");
-        assertQueryFails("SELECT " + recursive1 + "(42)", "line 3:8: Recursive language functions are not supported: " + recursive1 + "\\(integer\\):integer");
+        assertQueryFails("SELECT " + recursive1 + "(42)", "Recursive language functions are not supported: " + recursive1 + "\\(integer\\):integer");
+        assertQueryFails("SELECT " + recursive2 + "(42)", "Recursive language functions are not supported: " + recursive2 + "\\(integer\\):integer");
         assertUpdate("DROP FUNCTION " + recursive1 + "(integer)");
         assertUpdate("DROP FUNCTION " + recursive2 + "(integer)");
     }


### PR DESCRIPTION
Fixes #21357

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix error location markers for SQL routines. ({issue}`21357`)
```
