### PR TITLE
Avoid using JwtBuilder's deprecated methods

### DIFF
--- a/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
@@ -27,7 +27,6 @@ import io.airlift.http.server.HttpServerInfo;
 import io.airlift.http.server.testing.TestingHttpServer;
 import io.airlift.node.NodeInfo;
 import io.airlift.security.pem.PemReader;
-import io.jsonwebtoken.JwsHeader;
 import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.JwtParser;
 import io.trino.plugin.base.security.AllowAllSystemAccessControl;
@@ -534,9 +533,9 @@ public class TestResourceSecurity
 
             String token = newJwtBuilder()
                     .signWith(JWK_PRIVATE_KEY)
-                    .setHeaderParam(JwsHeader.KEY_ID, JWK_KEY_ID)
-                    .setSubject("test-user")
-                    .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()))
+                    .header().keyId(JWK_KEY_ID).and()
+                    .subject("test-user")
+                    .expiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()))
                     .compact();
 
             OkHttpClient clientWithJwt = client.newBuilder()
@@ -910,9 +909,9 @@ public class TestResourceSecurity
 
             String token = newJwtBuilder()
                     .signWith(JWK_PRIVATE_KEY)
-                    .setHeaderParam(JwsHeader.KEY_ID, JWK_KEY_ID)
-                    .setSubject("test-user")
-                    .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()))
+                    .header().keyId(JWK_KEY_ID).and()
+                    .subject("test-user")
+                    .expiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()))
                     .compact();
 
             OkHttpClient clientWithJwt = client.newBuilder()
@@ -952,9 +951,9 @@ public class TestResourceSecurity
 
             String token = newJwtBuilder()
                     .signWith(JWK_PRIVATE_KEY)
-                    .setHeaderParam(JwsHeader.KEY_ID, JWK_KEY_ID)
-                    .setSubject("test-user")
-                    .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()))
+                    .header().keyId(JWK_KEY_ID).and()
+                    .subject("test-user")
+                    .expiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()))
                     .compact();
 
             OkHttpClient clientWithJwt = client.newBuilder()
@@ -1141,15 +1140,15 @@ public class TestResourceSecurity
         {
             JwtBuilder accessToken = newJwtBuilder()
                     .signWith(JWK_PRIVATE_KEY)
-                    .setHeaderParam(JwsHeader.KEY_ID, JWK_KEY_ID)
-                    .setIssuer(issuer)
-                    .setAudience(clientId)
-                    .setExpiration(tokenExpiration);
+                    .header().keyId(JWK_KEY_ID).and()
+                    .issuer(issuer)
+                    .audience().add(clientId).and()
+                    .expiration(tokenExpiration);
             if (principalField.isPresent()) {
                 accessToken.claim(principalField.get(), TEST_USER);
             }
             else {
-                accessToken.setSubject(TEST_USER);
+                accessToken.subject(TEST_USER);
             }
             groups.ifPresent(groupsClaim -> accessToken.claim(GROUPS_CLAIM, groupsClaim));
             return accessToken.compact();
@@ -1159,15 +1158,15 @@ public class TestResourceSecurity
         {
             JwtBuilder idToken = newJwtBuilder()
                     .signWith(JWK_PRIVATE_KEY)
-                    .setHeaderParam(JwsHeader.KEY_ID, JWK_KEY_ID)
-                    .setIssuer(issuer)
-                    .setAudience(clientId)
-                    .setExpiration(tokenExpiration);
+                    .header().keyId(JWK_KEY_ID).and()
+                    .issuer(issuer)
+                    .audience().add(clientId).and()
+                    .expiration(tokenExpiration);
             if (principalField.isPresent()) {
                 idToken.claim(principalField.get(), TEST_USER);
             }
             else {
-                idToken.setSubject(TEST_USER);
+                idToken.subject(TEST_USER);
             }
             nonceHash.ifPresent(nonce -> idToken.claim(NONCE, nonce));
             return idToken.compact();

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -498,11 +498,11 @@ public class TrinoRestCatalog
                         .buildOrThrow();
 
                 String subjectJwt = new DefaultJwtBuilder()
-                        .setSubject(session.getUser())
-                        .setIssuer(trinoVersion)
-                        .setIssuedAt(new Date())
-                        .addClaims(claims)
-                        .serializeToJsonWith(new JacksonSerializer<>())
+                        .subject(session.getUser())
+                        .issuer(trinoVersion)
+                        .issuedAt(new Date())
+                        .claims(claims)
+                        .json(new JacksonSerializer<>())
                         .compact();
 
                 Map<String, String> credentials = ImmutableMap.<String, String>builder()

--- a/service/trino-proxy/src/main/java/io/trino/proxy/JsonWebTokenHandler.java
+++ b/service/trino-proxy/src/main/java/io/trino/proxy/JsonWebTokenHandler.java
@@ -33,7 +33,6 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 import static com.google.common.base.Preconditions.checkState;
-import static io.jsonwebtoken.JwsHeader.KEY_ID;
 import static java.nio.file.Files.readAllBytes;
 
 public class JsonWebTokenHandler
@@ -62,14 +61,14 @@ public class JsonWebTokenHandler
         checkState(jwtSigner.isPresent(), "not configured");
 
         JwtBuilder jwt = new DefaultJwtBuilder()
-                .serializeToJsonWith(new JacksonSerializer<>())
-                .setSubject(subject)
-                .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()));
+                .json(new JacksonSerializer<>())
+                .subject(subject)
+                .expiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()));
 
         jwtSigner.get().accept(jwt);
-        jwtKeyId.ifPresent(keyId -> jwt.setHeaderParam(KEY_ID, keyId));
-        jwtIssuer.ifPresent(jwt::setIssuer);
-        jwtAudience.ifPresent(jwt::setAudience);
+        jwtKeyId.ifPresent(keyId -> jwt.header().keyId(keyId));
+        jwtIssuer.ifPresent(jwt::issuer);
+        jwtAudience.ifPresent(audience -> jwt.audience().add(audience));
 
         return jwt.compact();
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
`JwtBuilder`'s setter methods have been deprecated and now recommended to use builder-style methods.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
- https://github.com/jwtk/jjwt/pull/794
- https://github.com/jwtk/jjwt/pull/841


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
