### PR TITLE
Update Coral to fix translation for views with EXISTS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1526,7 +1526,7 @@
             <dependency>
                 <groupId>io.trino.coral</groupId>
                 <artifactId>coral</artifactId>
-                <version>2.2.14-1</version>
+                <version>2.2.14-2</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Reference: https://github.com/trinodb/trino-coral/pull/3

## Release notes

(x) Release notes are required, with the following suggested text:

```Hive
# Section
* Fix failure when translating Hive views with `EXISTS`. ({issue}`21829`)
```
