### PR TITLE
Improve speed when listing columns in BigQuery

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/type/ArrayTypeInfo.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/type/ArrayTypeInfo.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery.type;
+
+import static com.google.cloud.bigquery.StandardSQLTypeName.ARRAY;
+import static java.util.Objects.requireNonNull;
+
+public final class ArrayTypeInfo
+        extends TypeInfo
+{
+    private final TypeInfo elementTypeInfo;
+
+    ArrayTypeInfo(TypeInfo elementTypeInfo)
+    {
+        this.elementTypeInfo = requireNonNull(elementTypeInfo, "elementTypeInfo is null");
+    }
+
+    @Override
+    public String getTypeName()
+    {
+        return ARRAY + "<" + elementTypeInfo.getTypeName() + ">";
+    }
+
+    @Override
+    public Category getCategory()
+    {
+        return Category.ARRAY;
+    }
+
+    public TypeInfo getListElementTypeInfo()
+    {
+        return elementTypeInfo;
+    }
+
+    @Override
+    public boolean equals(Object other)
+    {
+        return (other instanceof ArrayTypeInfo o) &&
+                elementTypeInfo.equals(o.elementTypeInfo);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return elementTypeInfo.hashCode();
+    }
+}

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/type/Category.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/type/Category.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery.type;
+
+public enum Category
+{
+    PRIMITIVE,
+    ARRAY,
+    STRUCT,
+    /**/
+}

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/type/DecimalTypeInfo.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/type/DecimalTypeInfo.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery.type;
+
+import java.util.Objects;
+
+import static com.google.cloud.bigquery.StandardSQLTypeName.NUMERIC;
+import static com.google.common.base.Preconditions.checkArgument;
+
+public final class DecimalTypeInfo
+        extends PrimitiveTypeInfo
+{
+    private static final int MAX_PRECISION = 38;
+    private static final int MAX_SCALE = 38;
+
+    private final int precision;
+    private final int scale;
+
+    public DecimalTypeInfo(int precision, int scale)
+    {
+        super(NUMERIC.name());
+        this.precision = precision;
+        this.scale = scale;
+        checkArgument(precision >= 1 && precision <= MAX_PRECISION, "invalid decimal precision: %s", precision);
+        checkArgument(scale >= 0 && scale <= MAX_SCALE, "invalid decimal scale: %s", scale);
+        checkArgument(scale <= precision, "decimal precision (%s) is greater than scale (%s)", precision, scale);
+    }
+
+    @Override
+    public String getTypeName()
+    {
+        return decimalTypeName(precision, scale);
+    }
+
+    @Override
+    public boolean equals(Object other)
+    {
+        return (other instanceof DecimalTypeInfo o) &&
+                (precision == o.precision) &&
+                (scale == o.scale);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(precision, scale);
+    }
+
+    public int precision()
+    {
+        return precision;
+    }
+
+    public int scale()
+    {
+        return scale;
+    }
+
+    public static String decimalTypeName(int precision, int scale)
+    {
+        return NUMERIC.name() + "(" + precision + ", " + scale + ")";
+    }
+}

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/type/PrimitiveTypeInfo.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/type/PrimitiveTypeInfo.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery.type;
+
+import com.google.cloud.bigquery.StandardSQLTypeName;
+
+import static io.trino.plugin.bigquery.type.TypeInfoUtils.getStandardSqlTypeNameFromTypeName;
+import static java.util.Objects.requireNonNull;
+
+public sealed class PrimitiveTypeInfo
+        extends TypeInfo
+        permits DecimalTypeInfo
+{
+    protected final String typeName;
+    private final StandardSQLTypeName standardSqlTypeName;
+
+    PrimitiveTypeInfo(String typeName)
+    {
+        this.typeName = requireNonNull(typeName, "typeName is null");
+        this.standardSqlTypeName = getStandardSqlTypeNameFromTypeName(typeName);
+    }
+
+    @Override
+    public Category getCategory()
+    {
+        return Category.PRIMITIVE;
+    }
+
+    public StandardSQLTypeName getStandardSqlTypeName()
+    {
+        return standardSqlTypeName;
+    }
+
+    @Override
+    public String getTypeName()
+    {
+        return typeName;
+    }
+
+    @Override
+    public boolean equals(Object other)
+    {
+        return (other instanceof PrimitiveTypeInfo o)
+                && typeName.equals(o.typeName);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return typeName.hashCode();
+    }
+}

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/type/StructTypeInfo.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/type/StructTypeInfo.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery.type;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+import static com.google.cloud.bigquery.StandardSQLTypeName.STRUCT;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public final class StructTypeInfo
+        extends TypeInfo
+{
+    private final List<String> names;
+    private final List<TypeInfo> typeInfos;
+
+    StructTypeInfo(List<String> names, List<TypeInfo> typeInfos)
+    {
+        this.names = ImmutableList.copyOf(requireNonNull(names, "names is null"));
+        this.typeInfos = ImmutableList.copyOf(requireNonNull(typeInfos, "typeInfos is null"));
+        checkArgument(names.size() == typeInfos.size(), "mismatched sizes");
+    }
+
+    @Override
+    public String getTypeName()
+    {
+        StringJoiner joiner = new StringJoiner(", ", STRUCT.name() + "<", ">");
+        for (int i = 0; i < names.size(); i++) {
+            joiner.add(names.get(i) + " " + typeInfos.get(i).getTypeName());
+        }
+        return joiner.toString();
+    }
+
+    @Override
+    public Category getCategory()
+    {
+        return Category.STRUCT;
+    }
+
+    public List<String> getAllStructFieldNames()
+    {
+        return names;
+    }
+
+    public List<TypeInfo> getAllStructFieldTypeInfos()
+    {
+        return typeInfos;
+    }
+
+    @Override
+    public boolean equals(Object other)
+    {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof StructTypeInfo o)) {
+            return false;
+        }
+        Iterator<String> namesIterator = getAllStructFieldNames().iterator();
+        Iterator<String> otherNamesIterator = o.getAllStructFieldNames().iterator();
+
+        // Compare the field names using ignore-case semantics
+        while (namesIterator.hasNext() && otherNamesIterator.hasNext()) {
+            if (!namesIterator.next().equalsIgnoreCase(otherNamesIterator.next())) {
+                return false;
+            }
+        }
+
+        // Different number of field names
+        if (namesIterator.hasNext() || otherNamesIterator.hasNext()) {
+            return false;
+        }
+
+        // Compare the field types
+        return o.getAllStructFieldTypeInfos().equals(getAllStructFieldTypeInfos());
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(names, typeInfos);
+    }
+}

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/type/TypeInfo.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/type/TypeInfo.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery.type;
+
+public abstract sealed class TypeInfo
+        permits PrimitiveTypeInfo, ArrayTypeInfo, StructTypeInfo
+{
+    protected TypeInfo() {}
+
+    public abstract Category getCategory();
+
+    public abstract String getTypeName();
+
+    @Override
+    public final String toString()
+    {
+        return getTypeName();
+    }
+
+    @Override
+    public abstract boolean equals(Object o);
+
+    @Override
+    public abstract int hashCode();
+}

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/type/TypeInfoFactory.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/type/TypeInfoFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery.type;
+
+import com.google.cloud.bigquery.StandardSQLTypeName;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.plugin.bigquery.type.DecimalTypeInfo.decimalTypeName;
+import static io.trino.plugin.bigquery.type.TypeInfoUtils.getBaseName;
+import static io.trino.plugin.bigquery.type.TypeInfoUtils.getStandardSqlTypeNameFromTypeName;
+import static io.trino.plugin.bigquery.type.TypeInfoUtils.parsePrimitiveParts;
+import static java.lang.Integer.parseInt;
+
+public final class TypeInfoFactory
+{
+    private TypeInfoFactory() {}
+
+    public static PrimitiveTypeInfo getPrimitiveTypeInfo(String typeName)
+    {
+        String baseName = getBaseName(typeName);
+        StandardSQLTypeName typeEntry = getStandardSqlTypeNameFromTypeName(baseName);
+        checkArgument(typeEntry != null, "Unknown type: %s", typeName);
+
+        return switch (typeEntry) {
+            case NUMERIC, BIGNUMERIC -> {
+                TypeInfoUtils.PrimitiveParts parts = parsePrimitiveParts(typeName);
+                checkArgument(parts.typeParams().length == 2);
+                yield new DecimalTypeInfo(parseInt(parts.typeParams()[0]), parseInt(parts.typeParams()[1]));
+            }
+            default -> new PrimitiveTypeInfo(typeName);
+        };
+    }
+
+    public static DecimalTypeInfo getDecimalTypeInfo(int precision, int scale)
+    {
+        return (DecimalTypeInfo) getPrimitiveTypeInfo(decimalTypeName(precision, scale));
+    }
+
+    public static TypeInfo getStructTypeInfo(List<String> names, List<TypeInfo> typeInfos)
+    {
+        return new StructTypeInfo(names, typeInfos);
+    }
+
+    public static TypeInfo getListTypeInfo(TypeInfo elementTypeInfo)
+    {
+        return new ArrayTypeInfo(elementTypeInfo);
+    }
+}

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/type/TypeInfoUtils.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/type/TypeInfoUtils.java
@@ -1,0 +1,326 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery.type;
+
+import com.google.cloud.bigquery.StandardSQLTypeName;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.cloud.bigquery.StandardSQLTypeName.ARRAY;
+import static com.google.cloud.bigquery.StandardSQLTypeName.STRUCT;
+import static io.trino.plugin.bigquery.type.TypeInfoFactory.getDecimalTypeInfo;
+import static io.trino.plugin.bigquery.type.TypeInfoFactory.getListTypeInfo;
+import static io.trino.plugin.bigquery.type.TypeInfoFactory.getPrimitiveTypeInfo;
+import static io.trino.plugin.bigquery.type.TypeInfoFactory.getStructTypeInfo;
+import static java.lang.Character.isLetterOrDigit;
+import static java.lang.Integer.parseInt;
+import static java.util.Objects.requireNonNull;
+
+public final class TypeInfoUtils
+{
+    private static final Map<String, StandardSQLTypeName> TYPES = new HashMap<>();
+
+    private TypeInfoUtils() {}
+
+    static {
+        registerType(StandardSQLTypeName.BYTES);
+        registerType(StandardSQLTypeName.STRING);
+        registerType(StandardSQLTypeName.BOOL);
+        registerType(StandardSQLTypeName.INT64);
+        registerType(StandardSQLTypeName.FLOAT64);
+        registerType(StandardSQLTypeName.DATE);
+        registerType(StandardSQLTypeName.DATETIME);
+        registerType(StandardSQLTypeName.TIME);
+        registerType(StandardSQLTypeName.TIMESTAMP);
+        registerType(StandardSQLTypeName.GEOGRAPHY);
+        registerType(StandardSQLTypeName.NUMERIC);
+        registerType(StandardSQLTypeName.BIGNUMERIC);
+        registerType(StandardSQLTypeName.JSON);
+    }
+
+    private static void registerType(StandardSQLTypeName entry)
+    {
+        TYPES.put(entry.name(), entry);
+    }
+
+    public static StandardSQLTypeName getStandardSqlTypeNameFromTypeName(String typeName)
+    {
+        return TYPES.get(typeName);
+    }
+
+    public static String getBaseName(String typeName)
+    {
+        int index = typeName.indexOf('(');
+        if (index == -1) {
+            return typeName;
+        }
+        return typeName.substring(0, index);
+    }
+
+    private static class TypeInfoParser
+    {
+        public record Token(int position, String text, boolean type)
+        {
+            public Token
+            {
+                requireNonNull(text, "text is null");
+            }
+
+            @Override
+            public String toString()
+            {
+                return "%s:%s".formatted(position, text);
+            }
+        }
+
+        private static boolean isTypeChar(char c)
+        {
+            return isLetterOrDigit(c) || c == '_' || c == '.' || c == '$';
+        }
+
+        private static boolean isDigit(String string)
+        {
+            return string.chars().allMatch(Character::isDigit);
+        }
+
+        private static List<Token> tokenize(String typeInfoString)
+        {
+            List<Token> tokens = new ArrayList<>();
+            int begin = 0;
+            int end = 1;
+            while (end <= typeInfoString.length()) {
+                if ((begin > 0) && (typeInfoString.charAt(begin - 1) == '(') && (typeInfoString.charAt(begin) == '\'')) {
+                    begin++;
+                    do {
+                        end++;
+                    }
+                    while (typeInfoString.charAt(end) != '\'');
+                }
+                else if ((typeInfoString.charAt(begin) == '\'') && (typeInfoString.charAt(begin + 1) == ')')) {
+                    begin++;
+                    end++;
+                }
+                if (end == typeInfoString.length() ||
+                        !isTypeChar(typeInfoString.charAt(end - 1)) ||
+                        !isTypeChar(typeInfoString.charAt(end))) {
+                    Token token = new Token(
+                            begin,
+                            typeInfoString.substring(begin, end),
+                            isTypeChar(typeInfoString.charAt(begin)));
+                    tokens.add(token);
+                    begin = end;
+                }
+                end++;
+            }
+            return tokens;
+        }
+
+        public TypeInfoParser(String typeInfoString)
+        {
+            this.typeInfoString = typeInfoString;
+            typeInfoTokens = tokenize(typeInfoString);
+        }
+
+        private final String typeInfoString;
+        private final List<Token> typeInfoTokens;
+        private int index;
+
+        public List<TypeInfo> parseTypeInfos()
+        {
+            List<TypeInfo> typeInfos = new ArrayList<>();
+            index = 0;
+            while (index < typeInfoTokens.size()) {
+                typeInfos.add(parseType());
+                if (index < typeInfoTokens.size()) {
+                    Token separator = typeInfoTokens.get(index);
+                    switch (separator.text()) {
+                        case ",", " " -> index++;
+                        default -> throw new IllegalArgumentException("Error: ',' or ' ' expected at position %s from '%s' %s".formatted(separator.position(), typeInfoString, typeInfoTokens));
+                    }
+                }
+            }
+            return typeInfos;
+        }
+
+        private Token peek()
+        {
+            if (index < typeInfoTokens.size()) {
+                return typeInfoTokens.get(index);
+            }
+            return null;
+        }
+
+        private Token expect(String item)
+        {
+            return expect(item, null);
+        }
+
+        private Token expect(String item, String alternative)
+        {
+            if (index >= typeInfoTokens.size()) {
+                throw new IllegalArgumentException("Error: %s expected at the end of '%s'".formatted(item, typeInfoString));
+            }
+            Token token = typeInfoTokens.get(index);
+
+            if (item.equals("type")) {
+                if (!ARRAY.name().equals(token.text()) &&
+                        !STRUCT.name().equals(token.text()) &&
+                        (getStandardSqlTypeNameFromTypeName(token.text()) == null) &&
+                        !token.text().equals(alternative)) {
+                    throw new IllegalArgumentException("Error: '%s' expected at the position %s of '%s' but '%s' is found.".formatted(item, token.position(), typeInfoString, token.text()));
+                }
+            }
+            else if (item.equals("name")) {
+                if (!token.type() && !token.text().equals(alternative)) {
+                    throw new IllegalArgumentException("Error: '%s' expected at the position %s of '%s' but '%s' is found.".formatted(item, token.position(), typeInfoString, token.text()));
+                }
+            }
+            else if (!item.equals(token.text()) && !token.text().equals(alternative)) {
+                throw new IllegalArgumentException("Error: '%s' expected at the position %s of '%s' but '%s' is found.".formatted(item, token.position(), typeInfoString, token.text()));
+            }
+
+            index++;
+            return token;
+        }
+
+        private String[] parseParams()
+        {
+            List<String> params = new LinkedList<>();
+
+            Token token = peek();
+            if ((token != null) && token.text().equals("(")) {
+                expect("(");
+                token = peek();
+                while ((token == null) || !token.text().equals(")")) {
+                    Token name = typeInfoTokens.get(index);
+                    if (isDigit(name.text())) {
+                        params.add(name.text());
+                    }
+                    token = name;
+                    index++;
+                }
+                if (params.isEmpty()) {
+                    throw new IllegalArgumentException("type parameters expected for type string " + typeInfoString);
+                }
+            }
+
+            return params.toArray(new String[0]);
+        }
+
+        private TypeInfo parseType()
+        {
+            Token token = expect("type");
+
+            StandardSQLTypeName typeEntry = getStandardSqlTypeNameFromTypeName(token.text());
+            if (typeEntry != null) {
+                String[] params = parseParams();
+                switch (typeEntry) {
+                    case STRING -> {
+                        if (params.length != 0 && params.length != 1) {
+                            throw new IllegalArgumentException("%s type is specified without length: %s".formatted(typeEntry.name(), typeInfoString));
+                        }
+                        return getPrimitiveTypeInfo("STRING");
+                    }
+                    case NUMERIC, BIGNUMERIC -> {
+                        if (params.length == 0) {
+                            return getDecimalTypeInfo(10, 0);
+                        }
+                        if (params.length == 1) {
+                            return getDecimalTypeInfo(parseInt(params[0]), 0);
+                        }
+                        if (params.length == 2) {
+                            return getDecimalTypeInfo(parseInt(params[0]), parseInt(params[1]));
+                        }
+                        throw new IllegalArgumentException("Type decimal only takes two parameter, but %s is seen".formatted(params.length));
+                    }
+                    default -> {
+                        return getPrimitiveTypeInfo(typeEntry.name());
+                    }
+                }
+            }
+
+            if (ARRAY.name().equals(token.text())) {
+                expect("<");
+                TypeInfo listElementType = parseType();
+                expect(">");
+                return getListTypeInfo(listElementType);
+            }
+
+            if (STRUCT.name().equals(token.text())) {
+                List<String> fieldNames = new ArrayList<>();
+                List<TypeInfo> fieldTypeInfos = new ArrayList<>();
+                boolean first = true;
+                do {
+                    if (first) {
+                        expect("<");
+                        first = false;
+                    }
+                    else {
+                        Token separator = expect(">", ",");
+                        if (separator.text().equals(">")) {
+                            break;
+                        }
+                        expect(" ");
+                    }
+                    Token name = expect("name", ">");
+                    if (name.text().equals(">")) {
+                        break;
+                    }
+                    fieldNames.add(name.text());
+                    expect(" ");
+                    fieldTypeInfos.add(parseType());
+                }
+                while (true);
+
+                return getStructTypeInfo(fieldNames, fieldTypeInfos);
+            }
+
+            throw new RuntimeException("Internal error parsing position %s of '%s'".formatted(token.position(), typeInfoString));
+        }
+
+        public PrimitiveParts parsePrimitiveParts()
+        {
+            Token token = expect("type");
+            return new PrimitiveParts(token.text(), parseParams());
+        }
+    }
+
+    public record PrimitiveParts(String typeName, String[] typeParams)
+    {
+        public PrimitiveParts
+        {
+            requireNonNull(typeName, "typeName is null");
+            requireNonNull(typeParams, "typeParams is null");
+        }
+    }
+
+    public static PrimitiveParts parsePrimitiveParts(String typeInfoString)
+    {
+        return new TypeInfoParser(typeInfoString).parsePrimitiveParts();
+    }
+
+    public static List<TypeInfo> getTypeInfosFromTypeString(String typeString)
+    {
+        return new TypeInfoParser(typeString).parseTypeInfos();
+    }
+
+    public static TypeInfo getTypeInfoFromTypeString(String typeString)
+    {
+        return getTypeInfosFromTypeString(typeString).get(0);
+    }
+}

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/type/TestTypeInfoUtils.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/type/TestTypeInfoUtils.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery.type;
+
+import org.assertj.core.api.ObjectAssert;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.trino.plugin.bigquery.type.TypeInfoFactory.getDecimalTypeInfo;
+import static io.trino.plugin.bigquery.type.TypeInfoFactory.getListTypeInfo;
+import static io.trino.plugin.bigquery.type.TypeInfoFactory.getPrimitiveTypeInfo;
+import static io.trino.plugin.bigquery.type.TypeInfoFactory.getStructTypeInfo;
+import static io.trino.plugin.bigquery.type.TypeInfoUtils.getTypeInfoFromTypeString;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestTypeInfoUtils
+{
+    @Test
+    public void testBasicPrimitive()
+    {
+        assertTypeInfo("BOOL").isEqualTo(getPrimitiveTypeInfo("BOOL"));
+        assertTypeInfo("INT64").isEqualTo(getPrimitiveTypeInfo("INT64"));
+        assertTypeInfo("FLOAT64").isEqualTo(getPrimitiveTypeInfo("FLOAT64"));
+        assertTypeInfo("STRING").isEqualTo(getPrimitiveTypeInfo("STRING"));
+        assertTypeInfo("STRING(10)", "STRING").isEqualTo(getPrimitiveTypeInfo("STRING"));
+        assertTypeInfo("BYTES").isEqualTo(getPrimitiveTypeInfo("BYTES"));
+        assertTypeInfo("DATE").isEqualTo(getPrimitiveTypeInfo("DATE"));
+        assertTypeInfo("TIME").isEqualTo(getPrimitiveTypeInfo("TIME"));
+        assertTypeInfo("DATETIME").isEqualTo(getPrimitiveTypeInfo("DATETIME"));
+        assertTypeInfo("TIMESTAMP").isEqualTo(getPrimitiveTypeInfo("TIMESTAMP"));
+        assertTypeInfo("GEOGRAPHY").isEqualTo(getPrimitiveTypeInfo("GEOGRAPHY"));
+        assertTypeInfo("JSON").isEqualTo(getPrimitiveTypeInfo("JSON"));
+    }
+
+    @Test
+    public void testNumeric()
+    {
+        testNumeric("NUMERIC");
+    }
+
+    @Test
+    public void testBignumeric()
+    {
+        testNumeric("BIGNUMERIC");
+    }
+
+    private void testNumeric(String typeName)
+    {
+        assertTypeInfo(typeName, "NUMERIC(10, 0)").isEqualTo(getDecimalTypeInfo(10, 0));
+        assertTypeInfo(typeName + "(1)", "NUMERIC(1, 0)").isEqualTo(getDecimalTypeInfo(1, 0));
+        assertTypeInfo(typeName + "(5)", "NUMERIC(5, 0)").isEqualTo(getDecimalTypeInfo(5, 0));
+        assertTypeInfo(typeName + "(38)", "NUMERIC(38, 0)").isEqualTo(getDecimalTypeInfo(38, 0));
+        assertTypeInfo(typeName + "(1, 1)", "NUMERIC(1, 1)").isEqualTo(getDecimalTypeInfo(1, 1));
+        assertTypeInfo(typeName + "(10, 5)", "NUMERIC(10, 5)").isEqualTo(getDecimalTypeInfo(10, 5));
+        assertTypeInfo(typeName + "(38, 38)", "NUMERIC(38, 38)").isEqualTo(getDecimalTypeInfo(38, 38));
+
+        assertThatThrownBy(() -> getTypeInfoFromTypeString(typeName + "(0)"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("invalid decimal precision: 0");
+
+        assertThatThrownBy(() -> getTypeInfoFromTypeString(typeName + "(39)"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("invalid decimal precision: 39");
+
+        assertThatThrownBy(() -> getTypeInfoFromTypeString(typeName + "(38,39)"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("invalid decimal scale: 39");
+
+        assertThatThrownBy(() -> getTypeInfoFromTypeString(typeName + "(4,5)"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("decimal precision (4) is greater than scale (5)");
+    }
+
+    @Test
+    public void testArray()
+    {
+        assertTypeInfo("ARRAY<INT64>")
+                .isEqualTo(getListTypeInfo(getPrimitiveTypeInfo("INT64")));
+    }
+
+    @Test
+    public void testStruct()
+    {
+        assertTypeInfo("STRUCT<x INT64, y STRING>")
+                .isEqualTo(getStructTypeInfo(
+                        List.of("x", "y"),
+                        List.of(getPrimitiveTypeInfo("INT64"),
+                                getPrimitiveTypeInfo("STRING"))));
+
+        assertTypeInfo("STRUCT<x INT64, y ARRAY<STRING>>")
+                .isEqualTo(getStructTypeInfo(
+                        List.of("x", "y"),
+                        List.of(getPrimitiveTypeInfo("INT64"),
+                                getListTypeInfo(getPrimitiveTypeInfo("STRING")))));
+    }
+
+    private static ObjectAssert<TypeInfo> assertTypeInfo(String typeString)
+    {
+        assertThat(getBigQueryTypeInfo(typeString))
+                .hasToString(typeString);
+
+        return assertThat(getTypeInfoFromTypeString(typeString))
+                .hasToString(typeString);
+    }
+
+    private static ObjectAssert<TypeInfo> assertTypeInfo(String typeString, String toString)
+    {
+        assertThat(getBigQueryTypeInfo(typeString))
+                .hasToString(toString);
+
+        return assertThat(getTypeInfoFromTypeString(typeString))
+                .hasToString(toString);
+    }
+
+    private static TypeInfo getBigQueryTypeInfo(String typeString)
+    {
+        return TypeInfoUtils.getTypeInfoFromTypeString(typeString);
+    }
+}


### PR DESCRIPTION
## Description

Using mini parser because BigQuery Java SDK doesn't support translating string to BigQuery type as far as I asked Google engineers. 

This PR improves listing columns. Test with 169 tables is improved from 22s to 1.5s. 

```sql
SELECT * FROM bigquery.information_schema.columns WHERE table_schema = 'test';
```

- [ ] Add tests for special column names
- [ ] Add tests for unsupported column types and fields

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# BigQuery
* TBD. ({issue}`issuenumber`)
```
