### PR TITLE
Define outputTimestamp for reproducible build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,8 @@
 
     <properties>
         <project.build.targetJdk>22</project.build.targetJdk>
+        <!-- for reproducible build support, updated by release plugin -->
+        <project.build.outputTimestamp>2024-04-29T23:23:14Z</project.build.outputTimestamp>
         <!-- TODO remove this property when no module overrides it -->
         <trino.error-prone.guarded-by>ERROR</trino.error-prone.guarded-by>
 


### PR DESCRIPTION
Actual value doesn't matter as it will be updated when release:prepare is called.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
