### PR TITLE
Allow complex expression rewrites with double and real constant

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/RewriteExactNumericConstant.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/RewriteExactNumericConstant.java
@@ -27,7 +27,9 @@ import java.util.Optional;
 import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.constant;
 import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
 
@@ -35,7 +37,8 @@ public class RewriteExactNumericConstant
         implements ConnectorExpressionRule<Constant, ParameterizedExpression>
 {
     private static final Pattern<Constant> PATTERN = constant().with(type().matching(type ->
-            type == TINYINT || type == SMALLINT || type == INTEGER || type == BIGINT || type instanceof DecimalType));
+            type == TINYINT || type == SMALLINT || type == INTEGER || type == BIGINT
+                    || type == REAL || type == DOUBLE || type instanceof DecimalType));
 
     @Override
     public Pattern<Constant> getPattern()
@@ -52,7 +55,7 @@ public class RewriteExactNumericConstant
             // TODO we could handle NULL values too
             return Optional.empty();
         }
-        if (type == TINYINT || type == SMALLINT || type == INTEGER || type == BIGINT || type instanceof DecimalType) {
+        if (type == TINYINT || type == SMALLINT || type == INTEGER || type == BIGINT || type == REAL || type == DOUBLE || type instanceof DecimalType) {
             return Optional.of(new ParameterizedExpression("?", ImmutableList.of(new QueryParameter(type, Optional.of(value)))));
         }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Currently `RewriteExactNumericConstant` doesn't support rewriting expressions if they are of `DOUBLE` or `REAL` type. 



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

This would affect the JDBC connectors in general so should implement it for each of them or do we have a generic options for JDBC ?
```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
