### PR TITLE
Fix reading NDV using Iceberg metadata on table with NULL partitions

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -640,7 +640,7 @@ public class IcebergMetadata
                                             partitionColumnValueStrings.get(columnId).orElse(null),
                                             column.getName());
 
-                                    return NullableValue.of(column.getType(), prestoValue);
+                                    return new NullableValue(column.getType(), prestoValue);
                                 }));
 
                 return TupleDomain.fromFixedValues(partitionValues);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -53,6 +53,7 @@ import io.trino.spi.type.TypeOperators;
 import io.trino.spi.type.UuidType;
 import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
+import jakarta.annotation.Nullable;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
@@ -531,6 +532,7 @@ public final class IcebergUtil
         }
     }
 
+    @Nullable
     public static Object deserializePartitionValue(Type type, String valueString, String name)
     {
         if (valueString == null) {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestMetadataQueryOptimization.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestMetadataQueryOptimization.java
@@ -118,6 +118,30 @@ public class TestMetadataQueryOptimization
                         values(ImmutableList.of("b", "c"), ImmutableList.of())));
     }
 
+    @Test
+    public void testOptimizationWithNullPartitions()
+    {
+        String testTable = "test_metadata_optimization_with_null_partitions";
+
+        getPlanTester().executeStatement(format(
+                "CREATE TABLE %s (a, b, c) WITH (PARTITIONING = ARRAY['b', 'c'])" +
+                        "AS VALUES (5, 6, CAST(NULL AS INTEGER)), (8, 9, CAST(NULL AS INTEGER))",
+                testTable));
+
+        Session session = Session.builder(getPlanTester().getDefaultSession())
+                .setSystemProperty("optimize_metadata_queries", "true")
+                .build();
+
+        assertPlan(
+                format("SELECT DISTINCT b, c FROM %s ORDER BY b", testTable),
+                session,
+                anyTree(values(
+                        ImmutableList.of("b", "c"),
+                        ImmutableList.of(
+                                ImmutableList.of(new Constant(INTEGER, 6L), new Constant(INTEGER, null)),
+                                ImmutableList.of(new Constant(INTEGER, 9L), new Constant(INTEGER, null))))));
+    }
+
     @AfterAll
     public void cleanup()
             throws Exception


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Use NullableValue.asNull for null values. 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Issue can be reproduced when query count distinct on partition with NULL value and optimize_metadata_queries session enabled.
```
Query 20240507_185319_10808_yp4pm failed: value is null
java.lang.NullPointerException: value is null
	at java.base/java.util.Objects.requireNonNull(Objects.java:259)
	at io.trino.spi.predicate.NullableValue.of(NullableValue.java:68)
	at io.trino.plugin.iceberg.IcebergMetadata.lambda$getTableProperties$8(IcebergMetadata.java:671)
	at com.google.common.collect.CollectCollectors.lambda$toImmutableMap$7(CollectCollectors.java:196)
```


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Fix failure when reading tables with `null` on partition columns and 
  `optimize_metadata_queries` session property is enabled. ({issue}`21844`)
```
