### PR TITLE
Remove legacy column mapping from Redshift

### DIFF
--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftConfig.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftConfig.java
@@ -13,23 +13,12 @@
  */
 package io.trino.plugin.redshift;
 
-import io.airlift.configuration.Config;
 import io.airlift.configuration.DefunctConfig;
 
-@DefunctConfig("redshift.disable-automatic-fetch-size")
+@DefunctConfig({
+        "redshift.disable-automatic-fetch-size",
+        "redshift.use-legacy-type-mapping",
+})
 public class RedshiftConfig
 {
-    private boolean legacyTypeMapping;
-
-    public boolean isLegacyTypeMapping()
-    {
-        return legacyTypeMapping;
-    }
-
-    @Config("redshift.use-legacy-type-mapping")
-    public RedshiftConfig setLegacyTypeMapping(boolean legacyTypeMapping)
-    {
-        this.legacyTypeMapping = legacyTypeMapping;
-        return this;
-    }
 }

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConfig.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConfig.java
@@ -27,19 +27,16 @@ public class TestRedshiftConfig
     @Test
     public void testDefaults()
     {
-        assertRecordedDefaults(recordDefaults(RedshiftConfig.class)
-                .setLegacyTypeMapping(false));
+        assertRecordedDefaults(recordDefaults(RedshiftConfig.class));
     }
 
     @Test
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
-                .put("redshift.use-legacy-type-mapping", "true")
                 .buildOrThrow();
 
-        RedshiftConfig expected = new RedshiftConfig()
-                .setLegacyTypeMapping(true);
+        RedshiftConfig expected = new RedshiftConfig();
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description

It has been deprecated since 2022 Dec.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Redshift
* Remove deprecated legacy column mapping. ({issue}`issuenumber`)
```
