### PR TITLE
Respect HTTP port provided to TestingTrinoServer 

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
+++ b/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
@@ -131,6 +131,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.io.MoreFiles.deleteRecursively;
@@ -253,10 +254,7 @@ public class TestingTrinoServer
         this.preserveData = baseDataDir.isPresent();
 
         properties = new HashMap<>(properties);
-        String coordinatorPort = properties.remove("http-server.http.port");
-        if (coordinatorPort == null) {
-            coordinatorPort = "0";
-        }
+        int httpPort = parseInt(firstNonNull(properties.remove("http-server.http.port"), "0"));
 
         ImmutableMap.Builder<String, String> serverProperties = ImmutableMap.<String, String>builder()
                 .putAll(properties)
@@ -283,7 +281,7 @@ public class TestingTrinoServer
 
         ImmutableList.Builder<Module> modules = ImmutableList.<Module>builder()
                 .add(new TestingNodeModule(environment))
-                .add(new TestingHttpServerModule(parseInt(coordinator ? coordinatorPort : "0")))
+                .add(new TestingHttpServerModule(httpPort))
                 .add(new JsonModule())
                 .add(new JaxrsModule())
                 .add(new MBeanModule())

--- a/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/AccumuloQueryRunner.java
+++ b/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/AccumuloQueryRunner.java
@@ -53,7 +53,14 @@ public final class AccumuloQueryRunner
 
     private AccumuloQueryRunner() {}
 
-    public static synchronized QueryRunner createAccumuloQueryRunner(Map<String, String> extraProperties)
+    public static synchronized QueryRunner createAccumuloQueryRunner()
+            throws Exception
+    {
+        return createAccumuloQueryRunner(ImmutableMap.of());
+    }
+
+    // TODO convert to builder
+    private static synchronized QueryRunner createAccumuloQueryRunner(Map<String, String> extraProperties)
             throws Exception
     {
         QueryRunner queryRunner = DistributedQueryRunner.builder(createSession())

--- a/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/AccumuloQueryRunner.java
+++ b/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/AccumuloQueryRunner.java
@@ -60,11 +60,11 @@ public final class AccumuloQueryRunner
     }
 
     // TODO convert to builder
-    private static synchronized QueryRunner createAccumuloQueryRunner(Map<String, String> extraProperties)
+    private static synchronized QueryRunner createAccumuloQueryRunner(Map<String, String> coordinatorProperties)
             throws Exception
     {
         QueryRunner queryRunner = DistributedQueryRunner.builder(createSession())
-                .setExtraProperties(extraProperties)
+                .setCoordinatorProperties(coordinatorProperties)
                 .build();
 
         queryRunner.installPlugin(new TpchPlugin());

--- a/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/TestAccumuloConnectorTest.java
+++ b/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/TestAccumuloConnectorTest.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.accumulo;
 
-import com.google.common.collect.ImmutableMap;
 import io.trino.testing.BaseConnectorTest;
 import io.trino.testing.MaterializedResult;
 import io.trino.testing.QueryRunner;
@@ -51,7 +50,7 @@ public class TestAccumuloConnectorTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createAccumuloQueryRunner(ImmutableMap.of());
+        return createAccumuloQueryRunner();
     }
 
     @Override

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
@@ -222,7 +222,7 @@ public final class BigQueryQueryRunner
             throws Exception
     {
         QueryRunner queryRunner = BigQueryQueryRunner.builder()
-                .setExtraProperties(Map.of("http-server.http.port", "8080"))
+                .setCoordinatorProperties(Map.of("http-server.http.port", "8080"))
                 .setInitialTables(TpchTable.getTables())
                 .build();
         Logger log = Logger.get(BigQueryQueryRunner.class);

--- a/plugin/trino-blackhole/src/test/java/io/trino/plugin/blackhole/BlackHoleQueryRunner.java
+++ b/plugin/trino-blackhole/src/test/java/io/trino/plugin/blackhole/BlackHoleQueryRunner.java
@@ -35,7 +35,8 @@ public final class BlackHoleQueryRunner
         return createQueryRunner(ImmutableMap.of());
     }
 
-    public static QueryRunner createQueryRunner(Map<String, String> extraProperties)
+    // TODO convert to builder
+    private static QueryRunner createQueryRunner(Map<String, String> extraProperties)
             throws Exception
     {
         Session session = testSessionBuilder()

--- a/plugin/trino-blackhole/src/test/java/io/trino/plugin/blackhole/BlackHoleQueryRunner.java
+++ b/plugin/trino-blackhole/src/test/java/io/trino/plugin/blackhole/BlackHoleQueryRunner.java
@@ -36,7 +36,7 @@ public final class BlackHoleQueryRunner
     }
 
     // TODO convert to builder
-    private static QueryRunner createQueryRunner(Map<String, String> extraProperties)
+    private static QueryRunner createQueryRunner(Map<String, String> coordinatorProperties)
             throws Exception
     {
         Session session = testSessionBuilder()
@@ -45,7 +45,7 @@ public final class BlackHoleQueryRunner
                 .build();
 
         QueryRunner queryRunner = DistributedQueryRunner.builder(session)
-                .setExtraProperties(extraProperties)
+                .setCoordinatorProperties(coordinatorProperties)
                 .build();
 
         try {

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraQueryRunner.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraQueryRunner.java
@@ -115,7 +115,7 @@ public final class CassandraQueryRunner
             throws Exception
     {
         QueryRunner queryRunner = builder(new CassandraServer())
-                .addExtraProperty("http-server.http.port", "8080")
+                .addCoordinatorProperty("http-server.http.port", "8080")
                 .setInitialTables(TpchTable.getTables())
                 .build();
 

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/ScyllaQueryRunner.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/ScyllaQueryRunner.java
@@ -46,12 +46,12 @@ public final class ScyllaQueryRunner
     // TODO convert to builder
     private static QueryRunner createScyllaQueryRunner(
             TestingScyllaServer server,
-            Map<String, String> extraProperties,
+            Map<String, String> coordinatorProperties,
             Iterable<TpchTable<?>> tables)
             throws Exception
     {
         QueryRunner queryRunner = DistributedQueryRunner.builder(createSession("tpch"))
-                .setExtraProperties(extraProperties)
+                .setCoordinatorProperties(coordinatorProperties)
                 .build();
 
         try {

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/ScyllaQueryRunner.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/ScyllaQueryRunner.java
@@ -38,7 +38,6 @@ public final class ScyllaQueryRunner
     public static QueryRunner createScyllaQueryRunner(
             TestingScyllaServer server,
             Map<String, String> extraProperties,
-            Map<String, String> connectorProperties,
             Iterable<TpchTable<?>> tables)
             throws Exception
     {
@@ -51,12 +50,12 @@ public final class ScyllaQueryRunner
             queryRunner.createCatalog("tpch", "tpch");
 
             // note: additional copy via ImmutableList so that if fails on nulls
-            connectorProperties = new HashMap<>(ImmutableMap.copyOf(connectorProperties));
-            connectorProperties.putIfAbsent("cassandra.contact-points", server.getHost());
-            connectorProperties.putIfAbsent("cassandra.native-protocol-port", Integer.toString(server.getPort()));
-            connectorProperties.putIfAbsent("cassandra.allow-drop-table", "true");
-            connectorProperties.putIfAbsent("cassandra.load-policy.use-dc-aware", "true");
-            connectorProperties.putIfAbsent("cassandra.load-policy.dc-aware.local-dc", "datacenter1");
+            Map<String, String> connectorProperties = new HashMap<>();
+            connectorProperties.put("cassandra.contact-points", server.getHost());
+            connectorProperties.put("cassandra.native-protocol-port", Integer.toString(server.getPort()));
+            connectorProperties.put("cassandra.allow-drop-table", "true");
+            connectorProperties.put("cassandra.load-policy.use-dc-aware", "true");
+            connectorProperties.put("cassandra.load-policy.dc-aware.local-dc", "datacenter1");
 
             queryRunner.installPlugin(new CassandraPlugin());
             queryRunner.createCatalog("cassandra", "cassandra", connectorProperties);
@@ -90,7 +89,6 @@ public final class ScyllaQueryRunner
         QueryRunner queryRunner = createScyllaQueryRunner(
                 new TestingScyllaServer(),
                 ImmutableMap.of("http-server.http.port", "8080"),
-                ImmutableMap.of(),
                 TpchTable.getTables());
 
         Logger log = Logger.get(ScyllaQueryRunner.class);

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/ScyllaQueryRunner.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/ScyllaQueryRunner.java
@@ -37,6 +37,15 @@ public final class ScyllaQueryRunner
 
     public static QueryRunner createScyllaQueryRunner(
             TestingScyllaServer server,
+            Iterable<TpchTable<?>> tables)
+            throws Exception
+    {
+        return createScyllaQueryRunner(server, Map.of(), tables);
+    }
+
+    // TODO convert to builder
+    private static QueryRunner createScyllaQueryRunner(
+            TestingScyllaServer server,
             Map<String, String> extraProperties,
             Iterable<TpchTable<?>> tables)
             throws Exception

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestScyllaConnectorSmokeTest.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestScyllaConnectorSmokeTest.java
@@ -31,6 +31,6 @@ public class TestScyllaConnectorSmokeTest
         TestingScyllaServer server = closeAfterClass(new TestingScyllaServer());
         CassandraSession session = server.getSession();
         createTestTables(session, KEYSPACE, Timestamp.from(TIMESTAMP_VALUE.toInstant()));
-        return createScyllaQueryRunner(server, ImmutableMap.of(), ImmutableMap.of(), REQUIRED_TPCH_TABLES);
+        return createScyllaQueryRunner(server, ImmutableMap.of(), REQUIRED_TPCH_TABLES);
     }
 }

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestScyllaConnectorSmokeTest.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestScyllaConnectorSmokeTest.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.cassandra;
 
-import com.google.common.collect.ImmutableMap;
 import io.trino.testing.QueryRunner;
 
 import java.sql.Timestamp;
@@ -31,6 +30,6 @@ public class TestScyllaConnectorSmokeTest
         TestingScyllaServer server = closeAfterClass(new TestingScyllaServer());
         CassandraSession session = server.getSession();
         createTestTables(session, KEYSPACE, Timestamp.from(TIMESTAMP_VALUE.toInstant()));
-        return createScyllaQueryRunner(server, ImmutableMap.of(), REQUIRED_TPCH_TABLES);
+        return createScyllaQueryRunner(server, REQUIRED_TPCH_TABLES);
     }
 }

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/ClickHouseQueryRunner.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/ClickHouseQueryRunner.java
@@ -66,7 +66,7 @@ public final class ClickHouseQueryRunner
     // TODO convert to builder
     private static QueryRunner createClickHouseQueryRunner(
             TestingClickHouseServer server,
-            Map<String, String> extraProperties,
+            Map<String, String> coordinatorProperties,
             Map<String, String> connectorProperties,
             Iterable<TpchTable<?>> tables)
             throws Exception
@@ -74,7 +74,7 @@ public final class ClickHouseQueryRunner
         QueryRunner queryRunner = null;
         try {
             queryRunner = DistributedQueryRunner.builder(createSession())
-                    .setExtraProperties(extraProperties)
+                    .setCoordinatorProperties(coordinatorProperties)
                     .build();
 
             queryRunner.installPlugin(new TpchPlugin());

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/ClickHouseQueryRunner.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/ClickHouseQueryRunner.java
@@ -46,10 +46,25 @@ public final class ClickHouseQueryRunner
     public static QueryRunner createClickHouseQueryRunner(TestingClickHouseServer server, TpchTable<?>... tables)
             throws Exception
     {
-        return createClickHouseQueryRunner(server, ImmutableMap.of(), ImmutableMap.of(), ImmutableList.copyOf(tables));
+        return createClickHouseQueryRunner(server, ImmutableMap.of(), ImmutableList.copyOf(tables));
     }
 
+    // TODO convert to builder
     public static QueryRunner createClickHouseQueryRunner(
+            TestingClickHouseServer server,
+            Map<String, String> connectorProperties,
+            Iterable<TpchTable<?>> tables)
+            throws Exception
+    {
+        return createClickHouseQueryRunner(
+                server,
+                ImmutableMap.of(),
+                connectorProperties,
+                tables);
+    }
+
+    // TODO convert to builder
+    private static QueryRunner createClickHouseQueryRunner(
             TestingClickHouseServer server,
             Map<String, String> extraProperties,
             Map<String, String> connectorProperties,

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestAltinityConnectorSmokeTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestAltinityConnectorSmokeTest.java
@@ -28,7 +28,6 @@ public class TestAltinityConnectorSmokeTest
     {
         return createClickHouseQueryRunner(
                 closeAfterClass(new TestingClickHouseServer(ALTINITY_DEFAULT_IMAGE)),
-                ImmutableMap.of(),
                 ImmutableMap.of("clickhouse.map-string-as-varchar", "true"), // To handle string types in TPCH tables as varchar instead of varbinary
                 REQUIRED_TPCH_TABLES);
     }

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestAltinityLatestConnectorSmokeTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestAltinityLatestConnectorSmokeTest.java
@@ -28,7 +28,6 @@ public class TestAltinityLatestConnectorSmokeTest
     {
         return createClickHouseQueryRunner(
                 closeAfterClass(new TestingClickHouseServer(ALTINITY_LATEST_IMAGE)),
-                ImmutableMap.of(),
                 ImmutableMap.of("clickhouse.map-string-as-varchar", "true"), // To handle string types in TPCH tables as varchar instead of varbinary
                 REQUIRED_TPCH_TABLES);
     }

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorSmokeTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorSmokeTest.java
@@ -30,7 +30,6 @@ public class TestClickHouseConnectorSmokeTest
         clickHouseServer = closeAfterClass(new TestingClickHouseServer());
         return createClickHouseQueryRunner(
                 clickHouseServer,
-                ImmutableMap.of(),
                 ImmutableMap.of("clickhouse.map-string-as-varchar", "true"), // To handle string types in TPCH tables as varchar instead of varbinary
                 REQUIRED_TPCH_TABLES);
     }

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
@@ -89,7 +89,6 @@ public class TestClickHouseConnectorTest
         this.clickhouseServer = closeAfterClass(new TestingClickHouseServer(CLICKHOUSE_LATEST_IMAGE));
         return createClickHouseQueryRunner(
                 clickhouseServer,
-                ImmutableMap.of(),
                 ImmutableMap.of("clickhouse.map-string-as-varchar", "true"),
                 REQUIRED_TPCH_TABLES);
     }

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseLatestConnectorSmokeTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseLatestConnectorSmokeTest.java
@@ -28,7 +28,6 @@ public class TestClickHouseLatestConnectorSmokeTest
     {
         return createClickHouseQueryRunner(
                 closeAfterClass(new TestingClickHouseServer(CLICKHOUSE_LATEST_IMAGE)),
-                ImmutableMap.of(),
                 ImmutableMap.of("clickhouse.map-string-as-varchar", "true"), // To handle string types in TPCH tables as varchar instead of varbinary
                 REQUIRED_TPCH_TABLES);
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
@@ -187,7 +187,7 @@ public final class DeltaLakeQueryRunner
                 throws Exception
         {
             QueryRunner queryRunner = builder()
-                    .addExtraProperty("http-server.http.port", "8080")
+                    .addCoordinatorProperty("http-server.http.port", "8080")
                     .addDeltaProperty("delta.enable-non-concurrent-writes", "true")
                     .setInitialTables(TpchTable.getTables())
                     .build();
@@ -207,7 +207,7 @@ public final class DeltaLakeQueryRunner
         {
             // Please set Delta Lake connector properties via VM options. e.g. -Dhive.metastore=glue -D..
             QueryRunner queryRunner = builder()
-                    .addExtraProperty("http-server.http.port", "8080")
+                    .addCoordinatorProperty("http-server.http.port", "8080")
                     .build();
 
             Logger log = Logger.get(DeltaLakeExternalQueryRunnerMain.class);
@@ -229,7 +229,7 @@ public final class DeltaLakeQueryRunner
             hiveMinioDataLake.start();
 
             QueryRunner queryRunner = builder()
-                    .addExtraProperty("http-server.http.port", "8080")
+                    .addCoordinatorProperty("http-server.http.port", "8080")
                     .addMetastoreProperties(hiveMinioDataLake.getHiveHadoop())
                     .addS3Properties(hiveMinioDataLake.getMinio(), bucketName)
                     .addDeltaProperty("delta.enable-non-concurrent-writes", "true")

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/DruidQueryRunner.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/DruidQueryRunner.java
@@ -50,15 +50,29 @@ import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-public class DruidQueryRunner
+public final class DruidQueryRunner
 {
+    private DruidQueryRunner() {}
+
     private static final Logger log = Logger.get(DruidQueryRunner.class);
 
     private static final String SCHEMA = "druid";
 
-    private DruidQueryRunner() {}
-
     public static QueryRunner createDruidQueryRunnerTpch(
+            TestingDruidServer testingDruidServer,
+            Map<String, String> connectorProperties,
+            Iterable<TpchTable<?>> tables)
+            throws Exception
+    {
+        return createDruidQueryRunnerTpch(
+                testingDruidServer,
+                ImmutableMap.of(),
+                connectorProperties,
+                tables);
+    }
+
+    // TODO convert to builder
+    private static QueryRunner createDruidQueryRunnerTpch(
             TestingDruidServer testingDruidServer,
             Map<String, String> extraProperties,
             Map<String, String> connectorProperties,

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/DruidQueryRunner.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/DruidQueryRunner.java
@@ -74,7 +74,7 @@ public final class DruidQueryRunner
     // TODO convert to builder
     private static QueryRunner createDruidQueryRunnerTpch(
             TestingDruidServer testingDruidServer,
-            Map<String, String> extraProperties,
+            Map<String, String> coordinatorProperties,
             Map<String, String> connectorProperties,
             Iterable<TpchTable<?>> tables)
             throws Exception
@@ -82,7 +82,7 @@ public final class DruidQueryRunner
         QueryRunner queryRunner = null;
         try {
             queryRunner = DistributedQueryRunner.builder(createSession())
-                    .setExtraProperties(extraProperties)
+                    .setCoordinatorProperties(coordinatorProperties)
                     .build();
             queryRunner.installPlugin(new TpchPlugin());
             queryRunner.createCatalog("tpch", "tpch");

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidCaseInsensitiveMapping.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidCaseInsensitiveMapping.java
@@ -66,7 +66,6 @@ public class TestDruidCaseInsensitiveMapping
         mappingFile = createRuleBasedIdentifierMappingFile();
         QueryRunner queryRunner = createDruidQueryRunnerTpch(
                 druidServer,
-                ImmutableMap.of(),
                 ImmutableMap.of("case-insensitive-name-matching", "true",
                         "case-insensitive-name-matching.config-file", mappingFile.toFile().getAbsolutePath(),
                         "case-insensitive-name-matching.config-file.refresh-period", "1ms"), // ~always refresh

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidConnectorTest.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidConnectorTest.java
@@ -73,7 +73,6 @@ public class TestDruidConnectorTest
         return createDruidQueryRunnerTpch(
                 druidServer,
                 ImmutableMap.of(),
-                ImmutableMap.of(),
                 ImmutableList.of(ORDERS, LINE_ITEM, NATION, REGION, PART, CUSTOMER));
     }
 

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidLatestConnectorSmokeTest.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidLatestConnectorSmokeTest.java
@@ -39,7 +39,6 @@ public class TestDruidLatestConnectorSmokeTest
         return createDruidQueryRunnerTpch(
                 druidServer,
                 ImmutableMap.of(),
-                ImmutableMap.of(),
                 REQUIRED_TPCH_TABLES);
     }
 

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidTypeMapping.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidTypeMapping.java
@@ -57,7 +57,7 @@ public class TestDruidTypeMapping
             throws Exception
     {
         this.druidServer = new TestingDruidServer(DRUID_DOCKER_IMAGE);
-        return createDruidQueryRunnerTpch(druidServer, ImmutableMap.of(), ImmutableMap.of(), ImmutableList.of());
+        return createDruidQueryRunnerTpch(druidServer, ImmutableMap.of(), ImmutableList.of());
     }
 
     @AfterAll

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchQueryRunner.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchQueryRunner.java
@@ -166,7 +166,7 @@ public final class ElasticsearchQueryRunner
             throws Exception
     {
         QueryRunner queryRunner = builder(new ElasticsearchServer(ELASTICSEARCH_7_IMAGE))
-                .addExtraProperty("http-server.http.port", "8080")
+                .addCoordinatorProperty("http-server.http.port", "8080")
                 .setInitialTables(TpchTable.getTables())
                 .build();
 

--- a/plugin/trino-example-jdbc/src/test/java/io/trino/plugin/example/ExampleQueryRunner.java
+++ b/plugin/trino-example-jdbc/src/test/java/io/trino/plugin/example/ExampleQueryRunner.java
@@ -40,11 +40,11 @@ public final class ExampleQueryRunner
                 .build();
 
         // TODO static port binding should be in main() only
-        Map<String, String> extraProperties = ImmutableMap.<String, String>builder()
+        Map<String, String> coordinatorProperties = ImmutableMap.<String, String>builder()
                 .put("http-server.http.port", "8080")
                 .buildOrThrow();
         QueryRunner queryRunner = DistributedQueryRunner.builder(defaultSession)
-                .setExtraProperties(extraProperties)
+                .setCoordinatorProperties(coordinatorProperties)
                 .build();
         queryRunner.installPlugin(new ExamplePlugin());
 

--- a/plugin/trino-example-jdbc/src/test/java/io/trino/plugin/example/ExampleQueryRunner.java
+++ b/plugin/trino-example-jdbc/src/test/java/io/trino/plugin/example/ExampleQueryRunner.java
@@ -26,10 +26,11 @@ import java.util.Map;
 
 import static io.trino.testing.TestingSession.testSessionBuilder;
 
-public class ExampleQueryRunner
+public final class ExampleQueryRunner
 {
     private ExampleQueryRunner() {}
 
+    // TODO convert to builder
     public static QueryRunner createQueryRunner()
             throws Exception
     {
@@ -38,6 +39,7 @@ public class ExampleQueryRunner
                 .setSchema("default")
                 .build();
 
+        // TODO static port binding should be in main() only
         Map<String, String> extraProperties = ImmutableMap.<String, String>builder()
                 .put("http-server.http.port", "8080")
                 .buildOrThrow();

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/GeoQueryRunner.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/GeoQueryRunner.java
@@ -27,7 +27,7 @@ public final class GeoQueryRunner
             throws Exception
     {
         QueryRunner queryRunner = DistributedQueryRunner.builder(testSessionBuilder().build())
-                .addExtraProperty("http-server.http.port", "8080")
+                .addCoordinatorProperty("http-server.http.port", "8080")
                 .build();
         queryRunner.installPlugin(new GeoPlugin());
         Logger log = Logger.get(GeoQueryRunner.class);

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/GeoQueryRunner.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/GeoQueryRunner.java
@@ -13,12 +13,9 @@
  */
 package io.trino.plugin.geospatial;
 
-import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
-
-import java.util.Map;
 
 import static io.trino.testing.TestingSession.testSessionBuilder;
 
@@ -26,20 +23,13 @@ public final class GeoQueryRunner
 {
     private GeoQueryRunner() {}
 
-    private static QueryRunner createQueryRunner(Map<String, String> extraProperties)
-            throws Exception
-    {
-        QueryRunner queryRunner = DistributedQueryRunner.builder(testSessionBuilder().build())
-                .setExtraProperties(extraProperties)
-                .build();
-        queryRunner.installPlugin(new GeoPlugin());
-        return queryRunner;
-    }
-
     public static void main(String[] args)
             throws Exception
     {
-        QueryRunner queryRunner = createQueryRunner(ImmutableMap.of("http-server.http.port", "8080"));
+        QueryRunner queryRunner = DistributedQueryRunner.builder(testSessionBuilder().build())
+                .addExtraProperty("http-server.http.port", "8080")
+                .build();
+        queryRunner.installPlugin(new GeoPlugin());
         Logger log = Logger.get(GeoQueryRunner.class);
         log.info("======== SERVER STARTED ========");
         log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());

--- a/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/SheetsQueryRunner.java
+++ b/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/SheetsQueryRunner.java
@@ -29,13 +29,23 @@ import static io.trino.plugin.google.sheets.TestSheetsPlugin.TEST_METADATA_SHEET
 import static io.trino.plugin.google.sheets.TestSheetsPlugin.getTestCredentialsPath;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 
-public class SheetsQueryRunner
+public final class SheetsQueryRunner
 {
-    protected static final String GOOGLE_SHEETS = "gsheets";
-
     private SheetsQueryRunner() {}
 
+    static final String GOOGLE_SHEETS = "gsheets";
+
     public static QueryRunner createSheetsQueryRunner(
+            Map<String, String> connectorProperties)
+            throws Exception
+    {
+        return createSheetsQueryRunner(
+                ImmutableMap.of(),
+                connectorProperties);
+    }
+
+    // TODO convert to builder
+    private static QueryRunner createSheetsQueryRunner(
             Map<String, String> extraProperties,
             Map<String, String> connectorProperties)
             throws Exception

--- a/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/SheetsQueryRunner.java
+++ b/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/SheetsQueryRunner.java
@@ -46,12 +46,12 @@ public final class SheetsQueryRunner
 
     // TODO convert to builder
     private static QueryRunner createSheetsQueryRunner(
-            Map<String, String> extraProperties,
+            Map<String, String> coordinatorProperties,
             Map<String, String> connectorProperties)
             throws Exception
     {
         QueryRunner queryRunner = DistributedQueryRunner.builder(createSession())
-                .setExtraProperties(extraProperties)
+                .setCoordinatorProperties(coordinatorProperties)
                 .build();
         try {
             // note: additional copy via ImmutableList so that if fails on nulls

--- a/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestGoogleSheets.java
+++ b/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestGoogleSheets.java
@@ -58,7 +58,7 @@ public class TestGoogleSheets
     {
         sheetsService = getSheetsService();
         spreadsheetId = createSpreadsheetWithTestdata();
-        return createSheetsQueryRunner(ImmutableMap.of(), ImmutableMap.of(
+        return createSheetsQueryRunner(ImmutableMap.of(
                 "gsheets.metadata-sheet-id", spreadsheetId + "#Metadata",
                 "gsheets.connection-timeout", "1m",
                 "gsheets.read-timeout", "1m",

--- a/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestGoogleSheetsWithoutMetadataSheetId.java
+++ b/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestGoogleSheetsWithoutMetadataSheetId.java
@@ -28,7 +28,7 @@ public class TestGoogleSheetsWithoutMetadataSheetId
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createSheetsQueryRunner(ImmutableMap.of(), ImmutableMap.of("gsheets.read-timeout", "1m"));
+        return createSheetsQueryRunner(ImmutableMap.of("gsheets.read-timeout", "1m"));
     }
 
     @Test

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
@@ -380,7 +380,7 @@ public final class HiveQueryRunner
         }
 
         QueryRunner queryRunner = builder()
-                .setExtraProperties(ImmutableMap.of("http-server.http.port", "8080"))
+                .addCoordinatorProperty("http-server.http.port", "8080")
                 .setHiveProperties(ImmutableMap.of("hive.security", "allow-all"))
                 .setSkipTimezoneSetup(true)
                 .setInitialTables(TpchTable.getTables())

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/S3HiveQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/S3HiveQueryRunner.java
@@ -177,7 +177,7 @@ public final class S3HiveQueryRunner
         hiveMinioDataLake.start();
 
         QueryRunner queryRunner = S3HiveQueryRunner.builder(hiveMinioDataLake)
-                .setExtraProperties(ImmutableMap.of("http-server.http.port", "8080"))
+                .addCoordinatorProperty("http-server.http.port", "8080")
                 .setHiveProperties(ImmutableMap.of("hive.security", "allow-all"))
                 .setSkipTimezoneSetup(true)
                 .setInitialTables(TpchTable.getTables())

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/HudiQueryRunner.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/HudiQueryRunner.java
@@ -34,6 +34,8 @@ import static io.trino.testing.TestingSession.testSessionBuilder;
 
 public final class HudiQueryRunner
 {
+    private HudiQueryRunner() {}
+
     static {
         Logging logging = Logging.initialize();
         logging.setLevel("org.apache.hudi", Level.OFF);
@@ -41,9 +43,17 @@ public final class HudiQueryRunner
 
     private static final String SCHEMA_NAME = "tests";
 
-    private HudiQueryRunner() {}
-
+    // TODO convert to builder
     public static QueryRunner createHudiQueryRunner(
+            Map<String, String> connectorProperties,
+            HudiTablesInitializer dataLoader)
+            throws Exception
+    {
+        return createHudiQueryRunner(ImmutableMap.of(), connectorProperties, dataLoader);
+    }
+
+    // TODO convert to builder
+    private static QueryRunner createHudiQueryRunner(
             Map<String, String> extraProperties,
             Map<String, String> connectorProperties,
             HudiTablesInitializer dataLoader)

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/HudiQueryRunner.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/HudiQueryRunner.java
@@ -54,14 +54,14 @@ public final class HudiQueryRunner
 
     // TODO convert to builder
     private static QueryRunner createHudiQueryRunner(
-            Map<String, String> extraProperties,
+            Map<String, String> coordinatorProperties,
             Map<String, String> connectorProperties,
             HudiTablesInitializer dataLoader)
             throws Exception
     {
         QueryRunner queryRunner = DistributedQueryRunner
                 .builder(createSession())
-                .setExtraProperties(extraProperties)
+                .setCoordinatorProperties(coordinatorProperties)
                 .build();
 
         queryRunner.installPlugin(new TestingHudiPlugin(queryRunner.getCoordinator().getBaseDataDir().resolve("hudi_data")));

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/S3HudiQueryRunner.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/S3HudiQueryRunner.java
@@ -42,7 +42,22 @@ public final class S3HudiQueryRunner
 
     private S3HudiQueryRunner() {}
 
+    // TODO convert to builder, merge with HudiQueryRunner
     public static QueryRunner create(
+            Map<String, String> connectorProperties,
+            HudiTablesInitializer dataLoader,
+            HiveMinioDataLake hiveMinioDataLake)
+            throws Exception
+    {
+        return create(
+                ImmutableMap.of(),
+                connectorProperties,
+                dataLoader,
+                hiveMinioDataLake);
+    }
+
+    // TODO convert to builder, merge with HudiQueryRunner
+    private static QueryRunner create(
             Map<String, String> extraProperties,
             Map<String, String> connectorProperties,
             HudiTablesInitializer dataLoader,

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/S3HudiQueryRunner.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/S3HudiQueryRunner.java
@@ -58,14 +58,14 @@ public final class S3HudiQueryRunner
 
     // TODO convert to builder, merge with HudiQueryRunner
     private static QueryRunner create(
-            Map<String, String> extraProperties,
+            Map<String, String> coordinatorProperties,
             Map<String, String> connectorProperties,
             HudiTablesInitializer dataLoader,
             HiveMinioDataLake hiveMinioDataLake)
             throws Exception
     {
         QueryRunner queryRunner = DistributedQueryRunner.builder(createSession())
-                .setExtraProperties(extraProperties)
+                .setCoordinatorProperties(coordinatorProperties)
                 .build();
         queryRunner.installPlugin(new TestingHudiPlugin(queryRunner.getCoordinator().getBaseDataDir().resolve("hudi_data")));
         queryRunner.createCatalog(

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiConnectorParquetColumnNamesTest.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiConnectorParquetColumnNamesTest.java
@@ -26,6 +26,6 @@ public class TestHudiConnectorParquetColumnNamesTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createHudiQueryRunner(ImmutableMap.of(), ImmutableMap.of("hudi.parquet.use-column-names", "false"), new ResourceHudiTablesInitializer());
+        return createHudiQueryRunner(ImmutableMap.of("hudi.parquet.use-column-names", "false"), new ResourceHudiTablesInitializer());
     }
 }

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiConnectorTest.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiConnectorTest.java
@@ -32,7 +32,6 @@ public class TestHudiConnectorTest
             throws Exception
     {
         return createHudiQueryRunner(
-                ImmutableMap.of(),
                 ImmutableMap.of("hudi.columns-to-hide", COLUMNS_TO_HIDE),
                 new TpchHudiTablesInitializer(REQUIRED_TPCH_TABLES));
     }

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiCopyOnWriteMinioConnectorSmokeTest.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiCopyOnWriteMinioConnectorSmokeTest.java
@@ -35,7 +35,6 @@ public class TestHudiCopyOnWriteMinioConnectorSmokeTest
         hiveMinioDataLake.getMinioClient().ensureBucketExists(bucketName);
 
         return S3HudiQueryRunner.create(
-                ImmutableMap.of(),
                 ImmutableMap.of("hudi.columns-to-hide", COLUMNS_TO_HIDE),
                 new TpchHudiTablesInitializer(REQUIRED_TPCH_TABLES),
                 hiveMinioDataLake);

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiMergeOnReadMinioConnectorSmokeTest.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiMergeOnReadMinioConnectorSmokeTest.java
@@ -35,7 +35,6 @@ public class TestHudiMergeOnReadMinioConnectorSmokeTest
         hiveMinioDataLake.getMinioClient().ensureBucketExists(bucketName);
 
         return S3HudiQueryRunner.create(
-                ImmutableMap.of(),
                 ImmutableMap.of("hudi.columns-to-hide", COLUMNS_TO_HIDE),
                 new TpchHudiTablesInitializer(REQUIRED_TPCH_TABLES),
                 hiveMinioDataLake);

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiSmokeTest.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiSmokeTest.java
@@ -41,7 +41,7 @@ public class TestHudiSmokeTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createHudiQueryRunner(ImmutableMap.of(), ImmutableMap.of(), new ResourceHudiTablesInitializer());
+        return createHudiQueryRunner(ImmutableMap.of(), new ResourceHudiTablesInitializer());
     }
 
     @Test

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiSystemTables.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiSystemTables.java
@@ -28,7 +28,7 @@ public class TestHudiSystemTables
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createHudiQueryRunner(ImmutableMap.of(), ImmutableMap.of(), new ResourceHudiTablesInitializer());
+        return createHudiQueryRunner(ImmutableMap.of(), new ResourceHudiTablesInitializer());
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
@@ -188,7 +188,7 @@ public final class IcebergQueryRunner
 
             @SuppressWarnings("resource")
             QueryRunner queryRunner = IcebergQueryRunner.builder()
-                    .setExtraProperties(ImmutableMap.of("http-server.http.port", "8080"))
+                    .addCoordinatorProperty("http-server.http.port", "8080")
                     .setBaseDataDir(Optional.of(warehouseLocation.toPath()))
                     .setIcebergProperties(ImmutableMap.of(
                             "iceberg.catalog.type", "rest",
@@ -213,7 +213,7 @@ public final class IcebergQueryRunner
             // See https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
             @SuppressWarnings("resource")
             QueryRunner queryRunner = IcebergQueryRunner.builder()
-                    .setExtraProperties(ImmutableMap.of("http-server.http.port", "8080"))
+                    .addCoordinatorProperty("http-server.http.port", "8080")
                     .setIcebergProperties(ImmutableMap.of("iceberg.catalog.type", "glue"))
                     .build();
 
@@ -237,8 +237,7 @@ public final class IcebergQueryRunner
 
             @SuppressWarnings("resource")
             QueryRunner queryRunner = IcebergQueryRunner.builder()
-                    .setCoordinatorProperties(Map.of(
-                            "http-server.http.port", "8080"))
+                    .addCoordinatorProperty("http-server.http.port", "8080")
                     .setIcebergProperties(Map.of(
                             "iceberg.catalog.type", "HIVE_METASTORE",
                             "hive.metastore.uri", hiveMinioDataLake.getHiveHadoop().getHiveMetastoreEndpoint().toString(),
@@ -281,8 +280,7 @@ public final class IcebergQueryRunner
 
             @SuppressWarnings("resource")
             QueryRunner queryRunner = IcebergQueryRunner.builder()
-                    .setCoordinatorProperties(Map.of(
-                            "http-server.http.port", "8080"))
+                    .addCoordinatorProperty("http-server.http.port", "8080")
                     .setIcebergProperties(Map.of(
                             "iceberg.catalog.type", "TESTING_FILE_METASTORE",
                             "hive.metastore.catalog.dir", "s3://%s/".formatted(bucketName),
@@ -336,8 +334,7 @@ public final class IcebergQueryRunner
 
             @SuppressWarnings("resource")
             QueryRunner queryRunner = IcebergQueryRunner.builder()
-                    .setCoordinatorProperties(Map.of(
-                            "http-server.http.port", "8080"))
+                    .addCoordinatorProperty("http-server.http.port", "8080")
                     .setIcebergProperties(Map.of(
                             "iceberg.catalog.type", "HIVE_METASTORE",
                             "hive.metastore.uri", hiveHadoop.getHiveMetastoreEndpoint().toString(),
@@ -373,7 +370,7 @@ public final class IcebergQueryRunner
 
             @SuppressWarnings("resource")
             QueryRunner queryRunner = IcebergQueryRunner.builder()
-                    .setExtraProperties(ImmutableMap.of("http-server.http.port", "8080"))
+                    .addCoordinatorProperty("http-server.http.port", "8080")
                     .setIcebergProperties(ImmutableMap.<String, String>builder()
                             .put("iceberg.catalog.type", "jdbc")
                             .put("iceberg.jdbc-catalog.driver-class", "org.postgresql.Driver")
@@ -401,7 +398,7 @@ public final class IcebergQueryRunner
         {
             @SuppressWarnings("resource")
             QueryRunner queryRunner = IcebergQueryRunner.builder()
-                    .setExtraProperties(ImmutableMap.of("http-server.http.port", "8080"))
+                    .addCoordinatorProperty("http-server.http.port", "8080")
                     .setIcebergProperties(ImmutableMap.<String, String>builder()
                             .put("iceberg.catalog.type", "snowflake")
                             .put("fs.native-s3.enabled", "true")
@@ -436,7 +433,7 @@ public final class IcebergQueryRunner
             Logger log = Logger.get(DefaultIcebergQueryRunnerMain.class);
             @SuppressWarnings("resource")
             QueryRunner queryRunner = IcebergQueryRunner.builder()
-                    .setExtraProperties(ImmutableMap.of("http-server.http.port", "8080"))
+                    .addCoordinatorProperty("http-server.http.port", "8080")
                     .setInitialTables(TpchTable.getTables())
                     .build();
             log.info("======== SERVER STARTED ========");

--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/IgniteQueryRunner.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/IgniteQueryRunner.java
@@ -49,7 +49,7 @@ public final class IgniteQueryRunner
     // TODO convert to builder
     private static QueryRunner createIgniteQueryRunner(
             TestingIgniteServer server,
-            Map<String, String> extraProperties,
+            Map<String, String> coordinatorProperties,
             Map<String, String> connectorProperties,
             List<TpchTable<?>> tables)
             throws Exception
@@ -57,7 +57,7 @@ public final class IgniteQueryRunner
         QueryRunner queryRunner = null;
         try {
             queryRunner = DistributedQueryRunner.builder(createSession())
-                    .setExtraProperties(extraProperties)
+                    .setCoordinatorProperties(coordinatorProperties)
                     .build();
 
             queryRunner.installPlugin(new TpchPlugin());

--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/IgniteQueryRunner.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/IgniteQueryRunner.java
@@ -33,11 +33,21 @@ import static io.trino.testing.TestingSession.testSessionBuilder;
 
 public final class IgniteQueryRunner
 {
-    private static final String IGNITE_SCHEMA = "public";
-
     private IgniteQueryRunner() {}
 
+    private static final String IGNITE_SCHEMA = "public";
+
     public static QueryRunner createIgniteQueryRunner(
+            TestingIgniteServer server,
+            Map<String, String> connectorProperties,
+            List<TpchTable<?>> tables)
+            throws Exception
+    {
+        return createIgniteQueryRunner(server, ImmutableMap.of(), connectorProperties, tables);
+    }
+
+    // TODO convert to builder
+    private static QueryRunner createIgniteQueryRunner(
             TestingIgniteServer server,
             Map<String, String> extraProperties,
             Map<String, String> connectorProperties,

--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteCaseInsensitiveMapping.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteCaseInsensitiveMapping.java
@@ -50,7 +50,6 @@ public class TestIgniteCaseInsensitiveMapping
         igniteServer = closeAfterClass(TestingIgniteServer.getInstance()).get();
         return createIgniteQueryRunner(
                 igniteServer,
-                ImmutableMap.of(),
                 ImmutableMap.<String, String>builder()
                         .put("case-insensitive-name-matching", "true")
                         .put("case-insensitive-name-matching.config-file", mappingFile.toFile().getAbsolutePath())

--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteConnectorTest.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteConnectorTest.java
@@ -52,7 +52,6 @@ public class TestIgniteConnectorTest
         return createIgniteQueryRunner(
                 igniteServer,
                 ImmutableMap.of(),
-                ImmutableMap.of(),
                 REQUIRED_TPCH_TABLES);
     }
 

--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteTypeMapping.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteTypeMapping.java
@@ -72,7 +72,6 @@ public class TestIgniteTypeMapping
         return createIgniteQueryRunner(
                 igniteServer,
                 ImmutableMap.of(),
-                ImmutableMap.of(),
                 ImmutableList.of());
     }
 

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/KuduQueryRunnerFactory.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/KuduQueryRunnerFactory.java
@@ -96,11 +96,25 @@ public final class KuduQueryRunnerFactory
             Iterable<TpchTable<?>> tables)
             throws Exception
     {
+        return createKuduQueryRunnerTpch(kuduServer, kuduSchemaEmulationPrefix, kuduSessionProperties, extraProperties, ImmutableMap.of(), tables);
+    }
+
+    // TODO convert to builder
+    private static QueryRunner createKuduQueryRunnerTpch(
+            TestingKuduServer kuduServer,
+            Optional<String> kuduSchemaEmulationPrefix,
+            Map<String, String> kuduSessionProperties,
+            Map<String, String> extraProperties,
+            Map<String, String> coordinatorProperties,
+            Iterable<TpchTable<?>> tables)
+            throws Exception
+    {
         QueryRunner runner = null;
         try {
             String kuduSchema = kuduSchemaEmulationPrefix.isPresent() ? "tpch" : "default";
             runner = DistributedQueryRunner.builder(createSession(kuduSchema, kuduSessionProperties))
                     .setExtraProperties(extraProperties)
+                    .setCoordinatorProperties(coordinatorProperties)
                     .build();
 
             runner.installPlugin(new TpchPlugin());
@@ -166,6 +180,7 @@ public final class KuduQueryRunnerFactory
         QueryRunner queryRunner = createKuduQueryRunnerTpch(
                 new TestingKuduServer(),
                 Optional.empty(),
+                ImmutableMap.of(),
                 ImmutableMap.of(),
                 ImmutableMap.of("http-server.http.port", "8080"),
                 TpchTable.getTables());

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/KuduQueryRunnerFactory.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/KuduQueryRunnerFactory.java
@@ -37,6 +37,7 @@ public final class KuduQueryRunnerFactory
 {
     private KuduQueryRunnerFactory() {}
 
+    // TODO convert to builder
     public static QueryRunner createKuduQueryRunner(TestingKuduServer kuduServer, Session session)
             throws Exception
     {
@@ -54,6 +55,7 @@ public final class KuduQueryRunnerFactory
         }
     }
 
+    // TODO convert to builder
     public static QueryRunner createKuduQueryRunner(TestingKuduServer kuduServer, String kuduSchema)
             throws Exception
     {
@@ -71,18 +73,21 @@ public final class KuduQueryRunnerFactory
         }
     }
 
+    // TODO convert to builder
     public static QueryRunner createKuduQueryRunnerTpch(TestingKuduServer kuduServer, Optional<String> kuduSchemaEmulationPrefix, TpchTable<?>... tables)
             throws Exception
     {
         return createKuduQueryRunnerTpch(kuduServer, kuduSchemaEmulationPrefix, ImmutableList.copyOf(tables));
     }
 
+    // TODO convert to builder
     public static QueryRunner createKuduQueryRunnerTpch(TestingKuduServer kuduServer, Optional<String> kuduSchemaEmulationPrefix, Iterable<TpchTable<?>> tables)
             throws Exception
     {
         return createKuduQueryRunnerTpch(kuduServer, kuduSchemaEmulationPrefix, ImmutableMap.of(), ImmutableMap.of(), tables);
     }
 
+    // TODO convert to builder
     public static QueryRunner createKuduQueryRunnerTpch(
             TestingKuduServer kuduServer,
             Optional<String> kuduSchemaEmulationPrefix,

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/BaseMariaDbTableStatisticsTest.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/BaseMariaDbTableStatisticsTest.java
@@ -69,7 +69,6 @@ public abstract class BaseMariaDbTableStatisticsTest
 
         return createMariaDbQueryRunner(
                 mariaDbServer,
-                Map.of(),
                 Map.of("case-insensitive-name-matching", "true"),
                 List.of(ORDERS));
     }

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/MariaDbQueryRunner.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/MariaDbQueryRunner.java
@@ -55,13 +55,13 @@ public final class MariaDbQueryRunner
     // TODO convert to builder
     private static QueryRunner createMariaDbQueryRunner(
             TestingMariaDbServer server,
-            Map<String, String> extraProperties,
+            Map<String, String> coordinatorProperties,
             Map<String, String> connectorProperties,
             Iterable<TpchTable<?>> tables)
             throws Exception
     {
         QueryRunner queryRunner = DistributedQueryRunner.builder(createSession())
-                .setExtraProperties(extraProperties)
+                .setCoordinatorProperties(coordinatorProperties)
                 .build();
         try {
             queryRunner.installPlugin(new TpchPlugin());

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/MariaDbQueryRunner.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/MariaDbQueryRunner.java
@@ -42,7 +42,18 @@ public final class MariaDbQueryRunner
 
     private MariaDbQueryRunner() {}
 
+    // TODO convert to builder
     public static QueryRunner createMariaDbQueryRunner(
+            TestingMariaDbServer server,
+            Map<String, String> connectorProperties,
+            Iterable<TpchTable<?>> tables)
+            throws Exception
+    {
+        return createMariaDbQueryRunner(server, ImmutableMap.of(), connectorProperties, tables);
+    }
+
+    // TODO convert to builder
+    private static QueryRunner createMariaDbQueryRunner(
             TestingMariaDbServer server,
             Map<String, String> extraProperties,
             Map<String, String> connectorProperties,

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbCaseInsensitiveMapping.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbCaseInsensitiveMapping.java
@@ -41,7 +41,6 @@ public class TestMariaDbCaseInsensitiveMapping
         server = closeAfterClass(new TestingMariaDbServer());
         return createMariaDbQueryRunner(
                 server,
-                ImmutableMap.of(),
                 ImmutableMap.<String, String>builder()
                         .put("case-insensitive-name-matching", "true")
                         .put("case-insensitive-name-matching.config-file", mappingFile.toFile().getAbsolutePath())

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbConnectorTest.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbConnectorTest.java
@@ -27,7 +27,7 @@ public class TestMariaDbConnectorTest
             throws Exception
     {
         server = closeAfterClass(new TestingMariaDbServer());
-        return createMariaDbQueryRunner(server, ImmutableMap.of(), ImmutableMap.of(), REQUIRED_TPCH_TABLES);
+        return createMariaDbQueryRunner(server, ImmutableMap.of(), REQUIRED_TPCH_TABLES);
     }
 
     @Override

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbLatestConnectorSmokeTest.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbLatestConnectorSmokeTest.java
@@ -38,6 +38,6 @@ public class TestMariaDbLatestConnectorSmokeTest
             throws Exception
     {
         TestingMariaDbServer server = closeAfterClass(new TestingMariaDbServer(LATEST_VERSION));
-        return createMariaDbQueryRunner(server, ImmutableMap.of(), ImmutableMap.of(), REQUIRED_TPCH_TABLES);
+        return createMariaDbQueryRunner(server, ImmutableMap.of(), REQUIRED_TPCH_TABLES);
     }
 }

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbTypeMapping.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbTypeMapping.java
@@ -100,7 +100,7 @@ public class TestMariaDbTypeMapping
             throws Exception
     {
         server = closeAfterClass(new TestingMariaDbServer());
-        return createMariaDbQueryRunner(server, ImmutableMap.of(), ImmutableMap.of(), ImmutableList.of());
+        return createMariaDbQueryRunner(server, ImmutableMap.of(), ImmutableList.of());
     }
 
     @Test

--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/MemoryQueryRunner.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/MemoryQueryRunner.java
@@ -109,7 +109,7 @@ public final class MemoryQueryRunner
             throws Exception
     {
         QueryRunner queryRunner = builder()
-                .addExtraProperty("http-server.http.port", "8080")
+                .addCoordinatorProperty("http-server.http.port", "8080")
                 .addExtraProperty("sql.path", CATALOG + ".functions")
                 .addExtraProperty("sql.default-function-catalog", CATALOG)
                 .addExtraProperty("sql.default-function-schema", "functions")
@@ -133,8 +133,8 @@ public final class MemoryQueryRunner
                     .buildOrThrow();
 
             QueryRunner queryRunner = MemoryQueryRunner.builder()
+                    .addCoordinatorProperty("http-server.http.port", "8080")
                     .setExtraProperties(ImmutableMap.<String, String>builder()
-                            .put("http-server.http.port", "8080")
                             .put("retry-policy", "TASK")
                             .put("fault-tolerant-execution-task-memory", "1GB")
                             .buildOrThrow())

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoQueryRunner.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoQueryRunner.java
@@ -113,7 +113,7 @@ public final class MongoQueryRunner
             throws Exception
     {
         QueryRunner queryRunner = builder(new MongoServer())
-                .addExtraProperty("http-server.http.port", "8080")
+                .addCoordinatorProperty("http-server.http.port", "8080")
                 .setInitialTables(TpchTable.getTables())
                 .build();
         Logger log = Logger.get(MongoQueryRunner.class);

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/MySqlQueryRunner.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/MySqlQueryRunner.java
@@ -101,7 +101,7 @@ public final class MySqlQueryRunner
             throws Exception
     {
         QueryRunner queryRunner = builder(new TestingMySqlServer())
-                .setExtraProperties(Map.of("http-server.http.port", "8080"))
+                .addCoordinatorProperty("http-server.http.port", "8080")
                 .setInitialTables(TpchTable.getTables())
                 .build();
 

--- a/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/OpenSearchQueryRunner.java
+++ b/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/OpenSearchQueryRunner.java
@@ -149,7 +149,7 @@ public final class OpenSearchQueryRunner
             throws Exception
     {
         QueryRunner queryRunner = builder(new OpenSearchServer(OPENSEARCH_IMAGE, false, ImmutableMap.of()).getAddress())
-                .addExtraProperty("http-server.http.port", "8080")
+                .addCoordinatorProperty("http-server.http.port", "8080")
                 .setInitialTables(TpchTable.getTables())
                 .build();
 

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/OracleQueryRunner.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/OracleQueryRunner.java
@@ -105,7 +105,7 @@ public final class OracleQueryRunner
     {
         TestingOracleServer server = new TestingOracleServer();
         QueryRunner queryRunner = builder(server)
-                .addExtraProperty("http-server.http.port", "8080")
+                .addCoordinatorProperty("http-server.http.port", "8080")
                 .addConnectorProperties(ImmutableMap.<String, String>builder()
                         .put("oracle.connection-pool.enabled", "false")
                         .put("oracle.remarks-reporting.enabled", "false")

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/PhoenixQueryRunner.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/PhoenixQueryRunner.java
@@ -55,11 +55,11 @@ public final class PhoenixQueryRunner
     }
 
     // TODO convert to builder
-    private static QueryRunner createPhoenixQueryRunner(TestingPhoenixServer server, Map<String, String> extraProperties, List<TpchTable<?>> tables)
+    private static QueryRunner createPhoenixQueryRunner(TestingPhoenixServer server, Map<String, String> coordinatorProperties, List<TpchTable<?>> tables)
             throws Exception
     {
         QueryRunner queryRunner = DistributedQueryRunner.builder(createSession())
-                .setExtraProperties(extraProperties)
+                .setCoordinatorProperties(coordinatorProperties)
                 .build();
 
         queryRunner.installPlugin(new TpchPlugin());

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/PhoenixQueryRunner.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/PhoenixQueryRunner.java
@@ -47,7 +47,15 @@ public final class PhoenixQueryRunner
     {
     }
 
-    public static QueryRunner createPhoenixQueryRunner(TestingPhoenixServer server, Map<String, String> extraProperties, List<TpchTable<?>> tables)
+    // TODO convert to builder
+    public static QueryRunner createPhoenixQueryRunner(TestingPhoenixServer server, List<TpchTable<?>> tables)
+            throws Exception
+    {
+        return createPhoenixQueryRunner(server, ImmutableMap.of(), tables);
+    }
+
+    // TODO convert to builder
+    private static QueryRunner createPhoenixQueryRunner(TestingPhoenixServer server, Map<String, String> extraProperties, List<TpchTable<?>> tables)
             throws Exception
     {
         QueryRunner queryRunner = DistributedQueryRunner.builder(createSession())

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
@@ -77,7 +77,7 @@ public class TestPhoenixConnectorTest
             throws Exception
     {
         testingPhoenixServer = closeAfterClass(TestingPhoenixServer.getInstance()).get();
-        return createPhoenixQueryRunner(testingPhoenixServer, ImmutableMap.of(), REQUIRED_TPCH_TABLES);
+        return createPhoenixQueryRunner(testingPhoenixServer, REQUIRED_TPCH_TABLES);
     }
 
     @Override

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixTypeMapping.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixTypeMapping.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.phoenix5;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.plugin.jdbc.UnsupportedTypeHandling;
 import io.trino.spi.type.ArrayType;
@@ -109,7 +108,7 @@ public class TestPhoenixTypeMapping
             throws Exception
     {
         phoenixServer = closeAfterClass(TestingPhoenixServer.getInstance()).get();
-        return createPhoenixQueryRunner(phoenixServer, ImmutableMap.of(), ImmutableList.of());
+        return createPhoenixQueryRunner(phoenixServer, ImmutableList.of());
     }
 
     @Test

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/BasePinotConnectorSmokeTest.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/BasePinotConnectorSmokeTest.java
@@ -161,7 +161,6 @@ public abstract class BasePinotConnectorSmokeTest
         return createPinotQueryRunner(
                 kafka,
                 pinot,
-                ImmutableMap.of(),
                 pinotProperties(),
                 REQUIRED_TPCH_TABLES);
     }

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/PinotQueryRunner.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/PinotQueryRunner.java
@@ -37,13 +37,25 @@ import static io.trino.tpch.TpchTable.NATION;
 import static io.trino.tpch.TpchTable.ORDERS;
 import static io.trino.tpch.TpchTable.REGION;
 
-public class PinotQueryRunner
+public final class PinotQueryRunner
 {
-    public static final String PINOT_CATALOG = "pinot";
-
     private PinotQueryRunner() {}
 
+    public static final String PINOT_CATALOG = "pinot";
+
+    // TODO convert to builder
     public static QueryRunner createPinotQueryRunner(
+            TestingKafka kafka,
+            TestingPinotCluster pinot,
+            Map<String, String> extraPinotProperties,
+            Iterable<TpchTable<?>> tables)
+            throws Exception
+    {
+        return createPinotQueryRunner(kafka, pinot, ImmutableMap.of(), extraPinotProperties, tables);
+    }
+
+    // TODO convert to builder
+    private static QueryRunner createPinotQueryRunner(
             TestingKafka kafka,
             TestingPinotCluster pinot,
             Map<String, String> extraProperties,

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/PinotQueryRunner.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/PinotQueryRunner.java
@@ -58,13 +58,13 @@ public final class PinotQueryRunner
     private static QueryRunner createPinotQueryRunner(
             TestingKafka kafka,
             TestingPinotCluster pinot,
-            Map<String, String> extraProperties,
+            Map<String, String> coordinatorProperties,
             Map<String, String> extraPinotProperties,
             Iterable<TpchTable<?>> tables)
             throws Exception
     {
         QueryRunner queryRunner = DistributedQueryRunner.builder(createSession())
-                .setExtraProperties(extraProperties)
+                .setCoordinatorProperties(coordinatorProperties)
                 .build();
 
         queryRunner.installPlugin(new PinotPlugin(Optional.of(binder -> newOptionalBinder(binder, PinotHostMapper.class).setBinding()

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotConnectorTest.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotConnectorTest.java
@@ -43,7 +43,6 @@ public class TestPinotConnectorTest
         return createPinotQueryRunner(
                 kafka,
                 pinot,
-                ImmutableMap.of(),
                 ImmutableMap.of("pinot.grpc.enabled", "true"),
                 REQUIRED_TPCH_TABLES);
     }

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/PostgreSqlQueryRunner.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/PostgreSqlQueryRunner.java
@@ -103,7 +103,7 @@ public final class PostgreSqlQueryRunner
             throws Exception
     {
         QueryRunner queryRunner = builder(new TestingPostgreSqlServer(true))
-                .setExtraProperties(Map.of("http-server.http.port", "8080"))
+                .addCoordinatorProperty("http-server.http.port", "8080")
                 .setInitialTables(TpchTable.getTables())
                 .build();
 

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/PrometheusQueryRunner.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/PrometheusQueryRunner.java
@@ -34,7 +34,15 @@ public final class PrometheusQueryRunner
 {
     private PrometheusQueryRunner() {}
 
-    public static QueryRunner createPrometheusQueryRunner(PrometheusServer server, Map<String, String> extraProperties, Map<String, String> connectorProperties)
+    // TODO convert to builder
+    public static QueryRunner createPrometheusQueryRunner(PrometheusServer server, Map<String, String> connectorProperties)
+            throws Exception
+    {
+        return createPrometheusQueryRunner(server, ImmutableMap.of(), connectorProperties);
+    }
+
+    // TODO convert to builder
+    private static QueryRunner createPrometheusQueryRunner(PrometheusServer server, Map<String, String> extraProperties, Map<String, String> connectorProperties)
             throws Exception
     {
         QueryRunner queryRunner = null;

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/PrometheusQueryRunner.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/PrometheusQueryRunner.java
@@ -42,12 +42,14 @@ public final class PrometheusQueryRunner
     }
 
     // TODO convert to builder
-    private static QueryRunner createPrometheusQueryRunner(PrometheusServer server, Map<String, String> extraProperties, Map<String, String> connectorProperties)
+    private static QueryRunner createPrometheusQueryRunner(PrometheusServer server, Map<String, String> coordinatorProperties, Map<String, String> connectorProperties)
             throws Exception
     {
         QueryRunner queryRunner = null;
         try {
-            queryRunner = DistributedQueryRunner.builder(createSession()).setExtraProperties(extraProperties).build();
+            queryRunner = DistributedQueryRunner.builder(createSession())
+                    .setCoordinatorProperties(coordinatorProperties)
+                    .build();
 
             queryRunner.installPlugin(new PrometheusPlugin());
             // note: additional copy via ImmutableList so that if fails on nulls

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusBasicAuth.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusBasicAuth.java
@@ -40,7 +40,7 @@ public class TestPrometheusBasicAuth
             throws Exception
     {
         server = closeAfterClass(new PrometheusServer(LATEST_VERSION, true));
-        return createPrometheusQueryRunner(server, ImmutableMap.of(), ImmutableMap.of("prometheus.auth.user", USER, "prometheus.auth.password", PASSWORD));
+        return createPrometheusQueryRunner(server, ImmutableMap.of("prometheus.auth.user", USER, "prometheus.auth.password", PASSWORD));
     }
 
     @Test

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusIntegration.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusIntegration.java
@@ -45,7 +45,7 @@ public class TestPrometheusIntegration
     {
         this.server = closeAfterClass(new PrometheusServer());
         this.client = createPrometheusClient(server);
-        return createPrometheusQueryRunner(server, ImmutableMap.of(), ImmutableMap.of());
+        return createPrometheusQueryRunner(server, ImmutableMap.of());
     }
 
     @Test

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/RaptorQueryRunner.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/RaptorQueryRunner.java
@@ -47,11 +47,22 @@ import static java.lang.String.format;
 
 public final class RaptorQueryRunner
 {
-    private static final Logger log = Logger.get(RaptorQueryRunner.class);
-
     private RaptorQueryRunner() {}
 
+    private static final Logger log = Logger.get(RaptorQueryRunner.class);
+
+    // TODO convert to builder
     public static QueryRunner createRaptorQueryRunner(
+            List<TpchTable<?>> tablesToLoad,
+            boolean bucketed,
+            Map<String, String> extraRaptorProperties)
+            throws Exception
+    {
+        return createRaptorQueryRunner(ImmutableMap.of(), tablesToLoad, bucketed, extraRaptorProperties);
+    }
+
+    // TODO convert to builder
+    private static QueryRunner createRaptorQueryRunner(
             Map<String, String> extraProperties,
             List<TpchTable<?>> tablesToLoad,
             boolean bucketed,

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/TestRaptorBucketedConnectorTest.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/TestRaptorBucketedConnectorTest.java
@@ -27,7 +27,7 @@ public class TestRaptorBucketedConnectorTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createRaptorQueryRunner(ImmutableMap.of(), REQUIRED_TPCH_TABLES, true, ImmutableMap.of("storage.compaction-enabled", "false"));
+        return createRaptorQueryRunner(REQUIRED_TPCH_TABLES, true, ImmutableMap.of("storage.compaction-enabled", "false"));
     }
 
     @Test

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/TestRaptorConnectorTest.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/TestRaptorConnectorTest.java
@@ -25,6 +25,6 @@ public class TestRaptorConnectorTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createRaptorQueryRunner(ImmutableMap.of(), REQUIRED_TPCH_TABLES, false, ImmutableMap.of("storage.compaction-enabled", "false"));
+        return createRaptorQueryRunner(REQUIRED_TPCH_TABLES, false, ImmutableMap.of("storage.compaction-enabled", "false"));
     }
 }

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/security/TestRaptorFileBasedSecurity.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/security/TestRaptorFileBasedSecurity.java
@@ -43,7 +43,6 @@ public class TestRaptorFileBasedSecurity
     {
         String path = new File(Resources.getResource(getClass(), "security.json").toURI()).getPath();
         queryRunner = createRaptorQueryRunner(
-                ImmutableMap.of(),
                 TpchTable.getTables(),
                 false,
                 ImmutableMap.of("security.config-file", path, "raptor.security", "file"));

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/security/TestRaptorReadOnlySecurity.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/security/TestRaptorReadOnlySecurity.java
@@ -27,7 +27,7 @@ public class TestRaptorReadOnlySecurity
     public void testCannotWrite()
             throws Exception
     {
-        try (QueryRunner queryRunner = createRaptorQueryRunner(ImmutableMap.of(), ImmutableList.of(), false, ImmutableMap.of("raptor.security", "read-only"))) {
+        try (QueryRunner queryRunner = createRaptorQueryRunner(ImmutableList.of(), false, ImmutableMap.of("raptor.security", "read-only"))) {
             assertThatThrownBy(() -> {
                 queryRunner.execute("CREATE TABLE test_create (a bigint, b double, c varchar)");
             })

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/RedisQueryRunner.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/RedisQueryRunner.java
@@ -61,7 +61,7 @@ public final class RedisQueryRunner
     // TODO convert to builder
     private static QueryRunner createRedisQueryRunner(
             RedisServer redisServer,
-            Map<String, String> extraProperties,
+            Map<String, String> coordinatorProperties,
             Map<String, String> connectorProperties,
             String dataFormat,
             Iterable<TpchTable<?>> tables)
@@ -70,7 +70,7 @@ public final class RedisQueryRunner
         DistributedQueryRunner queryRunner = null;
         try {
             queryRunner = DistributedQueryRunner.builder(createSession())
-                    .setExtraProperties(extraProperties)
+                    .setCoordinatorProperties(coordinatorProperties)
                     .build();
 
             queryRunner.installPlugin(new TpchPlugin());

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/RedisQueryRunner.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/RedisQueryRunner.java
@@ -47,7 +47,19 @@ public final class RedisQueryRunner
     private static final Logger log = Logger.get(RedisQueryRunner.class);
     private static final String TPCH_SCHEMA = "tpch";
 
+    // TODO convert to builder
     public static QueryRunner createRedisQueryRunner(
+            RedisServer redisServer,
+            Map<String, String> connectorProperties,
+            String dataFormat,
+            Iterable<TpchTable<?>> tables)
+            throws Exception
+    {
+        return createRedisQueryRunner(redisServer, ImmutableMap.of(), connectorProperties, dataFormat, tables);
+    }
+
+    // TODO convert to builder
+    private static QueryRunner createRedisQueryRunner(
             RedisServer redisServer,
             Map<String, String> extraProperties,
             Map<String, String> connectorProperties,

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisConnectorTest.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisConnectorTest.java
@@ -27,6 +27,6 @@ public class TestRedisConnectorTest
             throws Exception
     {
         RedisServer redisServer = closeAfterClass(new RedisServer());
-        return createRedisQueryRunner(redisServer, ImmutableMap.of(), ImmutableMap.of(), "string", REQUIRED_TPCH_TABLES);
+        return createRedisQueryRunner(redisServer, ImmutableMap.of(), "string", REQUIRED_TPCH_TABLES);
     }
 }

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisDistributedHash.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisDistributedHash.java
@@ -31,7 +31,7 @@ public class TestRedisDistributedHash
             throws Exception
     {
         RedisServer redisServer = closeAfterClass(new RedisServer());
-        return createRedisQueryRunner(redisServer, ImmutableMap.of(), ImmutableMap.of(), "hash", REQUIRED_TPCH_TABLES);
+        return createRedisQueryRunner(redisServer, ImmutableMap.of(), "hash", REQUIRED_TPCH_TABLES);
     }
 
     @Test

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisLatestConnectorTest.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisLatestConnectorTest.java
@@ -32,7 +32,6 @@ public class TestRedisLatestConnectorTest
         RedisServer redisServer = closeAfterClass(new RedisServer(LATEST_VERSION, true));
         return createRedisQueryRunner(
                 redisServer,
-                ImmutableMap.of(),
                 ImmutableMap.of("redis.user", USER, "redis.password", PASSWORD),
                 "string",
                 REQUIRED_TPCH_TABLES);

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/RedshiftQueryRunner.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/RedshiftQueryRunner.java
@@ -252,7 +252,7 @@ public final class RedshiftQueryRunner
         Logging.initialize();
 
         QueryRunner queryRunner = builder()
-                .addExtraProperty("http-server.http.port", "8080")
+                .addCoordinatorProperty("http-server.http.port", "8080")
                 .build();
 
         log.info("======== SERVER STARTED ========");

--- a/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/SingleStoreQueryRunner.java
+++ b/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/SingleStoreQueryRunner.java
@@ -29,13 +29,24 @@ import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 
-public class SingleStoreQueryRunner
+public final class SingleStoreQueryRunner
 {
     private SingleStoreQueryRunner() {}
 
     private static final String TPCH_SCHEMA = "tpch";
 
+    // TODO convert to builder
     public static QueryRunner createSingleStoreQueryRunner(
+            TestingSingleStoreServer server,
+            Map<String, String> connectorProperties,
+            Iterable<TpchTable<?>> tables)
+            throws Exception
+    {
+        return createSingleStoreQueryRunner(server, ImmutableMap.of(), connectorProperties, tables);
+    }
+
+    // TODO convert to builder
+    private static QueryRunner createSingleStoreQueryRunner(
             TestingSingleStoreServer server,
             Map<String, String> extraProperties,
             Map<String, String> connectorProperties,

--- a/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/SingleStoreQueryRunner.java
+++ b/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/SingleStoreQueryRunner.java
@@ -48,12 +48,14 @@ public final class SingleStoreQueryRunner
     // TODO convert to builder
     private static QueryRunner createSingleStoreQueryRunner(
             TestingSingleStoreServer server,
-            Map<String, String> extraProperties,
+            Map<String, String> coordinatorProperties,
             Map<String, String> connectorProperties,
             Iterable<TpchTable<?>> tables)
             throws Exception
     {
-        QueryRunner queryRunner = DistributedQueryRunner.builder(createSession()).setExtraProperties(extraProperties).build();
+        QueryRunner queryRunner = DistributedQueryRunner.builder(createSession())
+                .setCoordinatorProperties(coordinatorProperties)
+                .build();
         try {
             queryRunner.installPlugin(new TpchPlugin());
             queryRunner.createCatalog("tpch", "tpch");

--- a/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/TestSingleStoreCaseInsensitiveMapping.java
+++ b/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/TestSingleStoreCaseInsensitiveMapping.java
@@ -41,7 +41,6 @@ public class TestSingleStoreCaseInsensitiveMapping
         singleStoreServer = closeAfterClass(new TestingSingleStoreServer());
         return createSingleStoreQueryRunner(
                 singleStoreServer,
-                ImmutableMap.of(),
                 ImmutableMap.<String, String>builder()
                         .put("case-insensitive-name-matching", "true")
                         .put("case-insensitive-name-matching.config-file", mappingFile.toFile().getAbsolutePath())

--- a/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/TestSingleStoreConnectorTest.java
+++ b/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/TestSingleStoreConnectorTest.java
@@ -54,7 +54,7 @@ public class TestSingleStoreConnectorTest
             throws Exception
     {
         singleStoreServer = new TestingSingleStoreServer();
-        return createSingleStoreQueryRunner(singleStoreServer, ImmutableMap.of(), ImmutableMap.of(), REQUIRED_TPCH_TABLES);
+        return createSingleStoreQueryRunner(singleStoreServer, ImmutableMap.of(), REQUIRED_TPCH_TABLES);
     }
 
     @AfterAll

--- a/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/TestSingleStoreLatestConnectorSmokeTest.java
+++ b/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/TestSingleStoreLatestConnectorSmokeTest.java
@@ -28,7 +28,7 @@ public class TestSingleStoreLatestConnectorSmokeTest
             throws Exception
     {
         TestingSingleStoreServer singleStoreServer = closeAfterClass(new TestingSingleStoreServer(TestingSingleStoreServer.LATEST_TESTED_TAG));
-        return createSingleStoreQueryRunner(singleStoreServer, ImmutableMap.of(), ImmutableMap.of(), REQUIRED_TPCH_TABLES);
+        return createSingleStoreQueryRunner(singleStoreServer, ImmutableMap.of(), REQUIRED_TPCH_TABLES);
     }
 
     @Override

--- a/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/TestSingleStoreTypeMapping.java
+++ b/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/TestSingleStoreTypeMapping.java
@@ -102,7 +102,7 @@ public class TestSingleStoreTypeMapping
             throws Exception
     {
         singleStoreServer = closeAfterClass(new TestingSingleStoreServer());
-        return createSingleStoreQueryRunner(singleStoreServer, ImmutableMap.of(), ImmutableMap.of(), ImmutableList.of());
+        return createSingleStoreQueryRunner(singleStoreServer, ImmutableMap.of(), ImmutableList.of());
     }
 
     @BeforeAll

--- a/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/SnowflakeQueryRunner.java
+++ b/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/SnowflakeQueryRunner.java
@@ -31,11 +31,21 @@ import static io.trino.testing.TestingSession.testSessionBuilder;
 
 public final class SnowflakeQueryRunner
 {
-    public static final String TPCH_SCHEMA = "tpch";
-
     private SnowflakeQueryRunner() {}
 
+    public static final String TPCH_SCHEMA = "tpch";
+
+    // TODO convert to builder
     public static DistributedQueryRunner createSnowflakeQueryRunner(
+            Map<String, String> connectorProperties,
+            Iterable<TpchTable<?>> tables)
+            throws Exception
+    {
+        return createSnowflakeQueryRunner(ImmutableMap.of(), connectorProperties, tables);
+    }
+
+    // TODO convert to builder
+    private static DistributedQueryRunner createSnowflakeQueryRunner(
             Map<String, String> extraProperties,
             Map<String, String> connectorProperties,
             Iterable<TpchTable<?>> tables)

--- a/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/SnowflakeQueryRunner.java
+++ b/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/SnowflakeQueryRunner.java
@@ -46,13 +46,13 @@ public final class SnowflakeQueryRunner
 
     // TODO convert to builder
     private static DistributedQueryRunner createSnowflakeQueryRunner(
-            Map<String, String> extraProperties,
+            Map<String, String> coordinatorProperties,
             Map<String, String> connectorProperties,
             Iterable<TpchTable<?>> tables)
             throws Exception
     {
         DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(createSession())
-                .setExtraProperties(extraProperties)
+                .setCoordinatorProperties(coordinatorProperties)
                 .build();
         try {
             queryRunner.installPlugin(new TpchPlugin());

--- a/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestSnowflakeConnectorTest.java
+++ b/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestSnowflakeConnectorTest.java
@@ -53,7 +53,7 @@ public class TestSnowflakeConnectorTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createSnowflakeQueryRunner(ImmutableMap.of(), ImmutableMap.of(), REQUIRED_TPCH_TABLES);
+        return createSnowflakeQueryRunner(ImmutableMap.of(), REQUIRED_TPCH_TABLES);
     }
 
     @Override

--- a/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestSnowflakeTypeMapping.java
+++ b/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestSnowflakeTypeMapping.java
@@ -80,7 +80,6 @@ public class TestSnowflakeTypeMapping
             throws Exception
     {
         return createSnowflakeQueryRunner(
-                ImmutableMap.of(),
                 ImmutableMap.of("jdbc-types-mapped-to-varchar", "ARRAY"),
                 ImmutableList.of());
     }

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/SqlServerQueryRunner.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/SqlServerQueryRunner.java
@@ -116,7 +116,7 @@ public final class SqlServerQueryRunner
         Runtime.getRuntime().addShutdownHook(new Thread(testingSqlServer::close));
 
         QueryRunner queryRunner = builder(testingSqlServer)
-                .addExtraProperty("http-server.http.port", "8080")
+                .addCoordinatorProperty("http-server.http.port", "8080")
                 .setInitialTables(TpchTable.getTables())
                 .build();
 

--- a/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/integration/TestThriftConnectorTest.java
+++ b/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/integration/TestThriftConnectorTest.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.thrift.integration;
 
-import com.google.common.collect.ImmutableMap;
 import io.trino.testing.BaseConnectorTest;
 import io.trino.testing.MaterializedResult;
 import io.trino.testing.QueryRunner;
@@ -56,7 +55,7 @@ public class TestThriftConnectorTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createThriftQueryRunner(3, false, ImmutableMap.of());
+        return createThriftQueryRunner(3, false);
     }
 
     @Override

--- a/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/integration/TestThriftDistributedQueriesIndexed.java
+++ b/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/integration/TestThriftDistributedQueriesIndexed.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.thrift.integration;
 
-import com.google.common.collect.ImmutableMap;
 import io.trino.testing.AbstractTestIndexedQueries;
 import io.trino.testing.QueryRunner;
 import org.junit.jupiter.api.Test;
@@ -27,7 +26,7 @@ public class TestThriftDistributedQueriesIndexed
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createThriftQueryRunner(2, true, ImmutableMap.of());
+        return createThriftQueryRunner(2, true);
     }
 
     @Test

--- a/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/integration/ThriftQueryRunner.java
+++ b/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/integration/ThriftQueryRunner.java
@@ -79,14 +79,14 @@ public final class ThriftQueryRunner
     }
 
     // TODO convert to builder
-    private static QueryRunner createThriftQueryRunner(int thriftServers, boolean enableIndexJoin, Map<String, String> extraProperties)
+    private static QueryRunner createThriftQueryRunner(int thriftServers, boolean enableIndexJoin, Map<String, String> coordinatorProperties)
             throws Exception
     {
         List<DriftServer> servers = null;
         QueryRunner runner = null;
         try {
             servers = startThriftServers(thriftServers, enableIndexJoin);
-            runner = createThriftQueryRunnerInternal(servers, extraProperties);
+            runner = createThriftQueryRunnerInternal(servers, coordinatorProperties);
             return new ThriftQueryRunnerWithServers(runner, servers);
         }
         catch (Throwable t) {
@@ -105,8 +105,8 @@ public final class ThriftQueryRunner
             throws Exception
     {
         Logging.initialize();
-        Map<String, String> extraProperties = ImmutableMap.of("http-server.http.port", "8080");
-        QueryRunner queryRunner = createThriftQueryRunner(3, true, extraProperties);
+        Map<String, String> coordinatorProperties = ImmutableMap.of("http-server.http.port", "8080");
+        QueryRunner queryRunner = createThriftQueryRunner(3, true, coordinatorProperties);
         Logger log = Logger.get(ThriftQueryRunner.class);
         log.info("======== SERVER STARTED ========");
         log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());
@@ -129,7 +129,7 @@ public final class ThriftQueryRunner
         return servers;
     }
 
-    private static QueryRunner createThriftQueryRunnerInternal(List<DriftServer> servers, Map<String, String> extraProperties)
+    private static QueryRunner createThriftQueryRunnerInternal(List<DriftServer> servers, Map<String, String> coordinatorProperties)
             throws Exception
     {
         String addresses = servers.stream()
@@ -142,7 +142,7 @@ public final class ThriftQueryRunner
                 .build();
 
         QueryRunner queryRunner = DistributedQueryRunner.builder(defaultSession)
-                .setExtraProperties(extraProperties)
+                .setCoordinatorProperties(coordinatorProperties)
                 .build();
 
         queryRunner.installPlugin(new ThriftPlugin());

--- a/plugin/trino-tpcds/src/test/java/io/trino/plugin/tpcds/TpcdsQueryRunner.java
+++ b/plugin/trino-tpcds/src/test/java/io/trino/plugin/tpcds/TpcdsQueryRunner.java
@@ -35,7 +35,7 @@ public final class TpcdsQueryRunner
     }
 
     // TODO convert to builder
-    private static QueryRunner createQueryRunner(Map<String, String> extraProperties)
+    private static QueryRunner createQueryRunner(Map<String, String> coordinatorProperties)
             throws Exception
     {
         Session session = testSessionBuilder()
@@ -45,7 +45,7 @@ public final class TpcdsQueryRunner
                 .build();
 
         QueryRunner queryRunner = DistributedQueryRunner.builder(session)
-                .setExtraProperties(extraProperties)
+                .setCoordinatorProperties(coordinatorProperties)
                 .build();
 
         try {

--- a/plugin/trino-tpcds/src/test/java/io/trino/plugin/tpcds/TpcdsQueryRunner.java
+++ b/plugin/trino-tpcds/src/test/java/io/trino/plugin/tpcds/TpcdsQueryRunner.java
@@ -27,13 +27,15 @@ public final class TpcdsQueryRunner
 {
     private TpcdsQueryRunner() {}
 
+    // TODO convert to builder
     public static QueryRunner createQueryRunner()
             throws Exception
     {
         return createQueryRunner(ImmutableMap.of());
     }
 
-    public static QueryRunner createQueryRunner(Map<String, String> extraProperties)
+    // TODO convert to builder
+    private static QueryRunner createQueryRunner(Map<String, String> extraProperties)
             throws Exception
     {
         Session session = testSessionBuilder()

--- a/plugin/trino-tpcds/src/test/java/io/trino/plugin/tpcds/TpcdsQueryRunner.java
+++ b/plugin/trino-tpcds/src/test/java/io/trino/plugin/tpcds/TpcdsQueryRunner.java
@@ -36,12 +36,6 @@ public final class TpcdsQueryRunner
     public static QueryRunner createQueryRunner(Map<String, String> extraProperties)
             throws Exception
     {
-        return createQueryRunner(extraProperties, ImmutableMap.of());
-    }
-
-    public static QueryRunner createQueryRunner(Map<String, String> extraProperties, Map<String, String> coordinatorProperties)
-            throws Exception
-    {
         Session session = testSessionBuilder()
                 .setSource("test")
                 .setCatalog("tpcds")
@@ -50,7 +44,6 @@ public final class TpcdsQueryRunner
 
         QueryRunner queryRunner = DistributedQueryRunner.builder(session)
                 .setExtraProperties(extraProperties)
-                .setCoordinatorProperties(coordinatorProperties)
                 .build();
 
         try {

--- a/testing/trino-tests/src/test/java/io/trino/tests/tpch/TpchQueryRunner.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/tpch/TpchQueryRunner.java
@@ -76,8 +76,8 @@ public final class TpchQueryRunner
     {
         Logging.initialize();
         QueryRunner queryRunner = builder()
+                .addCoordinatorProperty("http-server.http.port", "8080")
                 .setExtraProperties(ImmutableMap.<String, String>builder()
-                        .put("http-server.http.port", "8080")
                         .put("sql.default-catalog", "tpch")
                         .put("sql.default-schema", "tiny")
                         .buildOrThrow())


### PR DESCRIPTION
Tests generally do not provide a HTTP port to `TestingTrinoServer`.
Typically the port is provided in query runners' main methods. Before
the change, query runners' main methods would provide it via "extra
properties" (i.e. for all nodes), but `TestingTrinoServer` would ignore
it unless it is a coordinator. After the change, `TestingTrinoServer`
obeys the HTTP port provided in the config, and query runners' main
methods now provide the fixed HTTP port via "coordinator properties".

Extracted from https://github.com/trinodb/trino/pull/21744