### PR TITLE
Fix test naming in TransformCorrelatedGlobalAggregationWithProjection

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedGlobalAggregationWithProjection.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedGlobalAggregationWithProjection.java
@@ -59,7 +59,7 @@ public class TestTransformCorrelatedGlobalAggregationWithProjection
     private static final ResolvedFunction SUBTRACT_INTEGER = FUNCTIONS.resolveOperator(OperatorType.SUBTRACT, ImmutableList.of(INTEGER, INTEGER));
 
     @Test
-    public void doesNotFireOnPlanWithoutCorrelatedJoinNode()
+    public void testDoesNotFireOnPlanWithoutCorrelatedJoinNode()
     {
         tester().assertThat(new TransformCorrelatedGlobalAggregationWithProjection(tester().getPlannerContext()))
                 .on(p -> p.values(p.symbol("a")))
@@ -67,7 +67,7 @@ public class TestTransformCorrelatedGlobalAggregationWithProjection
     }
 
     @Test
-    public void doesNotFireOnCorrelatedWithoutAggregation()
+    public void testDoesNotFireOnCorrelatedWithoutAggregation()
     {
         tester().assertThat(new TransformCorrelatedGlobalAggregationWithProjection(tester().getPlannerContext()))
                 .on(p -> p.correlatedJoin(
@@ -78,7 +78,7 @@ public class TestTransformCorrelatedGlobalAggregationWithProjection
     }
 
     @Test
-    public void doesNotFireOnUncorrelated()
+    public void testDoesNotFireOnUncorrelated()
     {
         tester().assertThat(new TransformCorrelatedGlobalAggregationWithProjection(tester().getPlannerContext()))
                 .on(p -> p.correlatedJoin(
@@ -89,7 +89,7 @@ public class TestTransformCorrelatedGlobalAggregationWithProjection
     }
 
     @Test
-    public void doesNotFireOnCorrelatedWithNonScalarAggregation()
+    public void testDoesNotFireOnCorrelatedWithNonScalarAggregation()
     {
         tester().assertThat(new TransformCorrelatedGlobalAggregationWithProjection(tester().getPlannerContext()))
                 .on(p -> p.correlatedJoin(
@@ -103,7 +103,7 @@ public class TestTransformCorrelatedGlobalAggregationWithProjection
     }
 
     @Test
-    public void doesNotFireOnMultipleProjections()
+    public void testDoesNotFireOnMultipleProjections()
     {
         tester().assertThat(new TransformCorrelatedGlobalAggregationWithProjection(tester().getPlannerContext()))
                 .on(p -> p.correlatedJoin(
@@ -121,7 +121,7 @@ public class TestTransformCorrelatedGlobalAggregationWithProjection
     }
 
     @Test
-    public void doesNotFireOnSubqueryWithoutProjection()
+    public void testDoesNotFireOnSubqueryWithoutProjection()
     {
         tester().assertThat(new TransformCorrelatedGlobalAggregationWithProjection(tester().getPlannerContext()))
                 .on(p -> p.correlatedJoin(
@@ -135,7 +135,7 @@ public class TestTransformCorrelatedGlobalAggregationWithProjection
     }
 
     @Test
-    public void rewritesOnSubqueryWithProjection()
+    public void testRewritesOnSubqueryWithProjection()
     {
         tester().assertThat(new TransformCorrelatedGlobalAggregationWithProjection(tester().getPlannerContext()))
                 .on(p -> p.correlatedJoin(
@@ -157,7 +157,7 @@ public class TestTransformCorrelatedGlobalAggregationWithProjection
     }
 
     @Test
-    public void rewritesOnSubqueryWithDistinct()
+    public void testRewritesOnSubqueryWithDistinct()
     {
         tester().assertThat(new TransformCorrelatedGlobalAggregationWithProjection(tester().getPlannerContext()))
                 .on(p -> p.correlatedJoin(
@@ -208,7 +208,7 @@ public class TestTransformCorrelatedGlobalAggregationWithProjection
     }
 
     @Test
-    public void rewritesOnSubqueryWithDecorrelatableDistinct()
+    public void testRewritesOnSubqueryWithDecorrelatableDistinct()
     {
         // distinct aggregation can be decorrelated in the subquery by PlanNodeDecorrelator
         // because the correlated predicate is equality comparison
@@ -291,7 +291,7 @@ public class TestTransformCorrelatedGlobalAggregationWithProjection
     }
 
     @Test
-    public void rewritesOnSubqueryWithBoolOr()
+    public void testRewritesOnSubqueryWithBoolOr()
     {
         tester().assertThat(new TransformCorrelatedGlobalAggregationWithProjection(tester().getPlannerContext()))
                 .on(p -> p.correlatedJoin(


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Make test naming in TestTransformCorrelatedGlobalAggregationWithProjection consistent across all methods.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
