### PR TITLE
Fix format of ProxyOptionsConfigurer and avoid using deprecated JdkSslContext constructor in BigQuery

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ProxyOptionsConfigurer.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ProxyOptionsConfigurer.java
@@ -65,7 +65,9 @@ public class ProxyOptionsConfigurer
                             ApplicationProtocolConfig.SelectorFailureBehavior.CHOOSE_MY_LAST_PROTOCOL,
                             ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
                             "h2"),
-                    OPTIONAL);
+                    OPTIONAL,
+                    null,
+                    false);
             nettyChannelBuilder
                     .sslContext(jdkSslContext)
                     .useTransportSecurity();

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ProxyOptionsConfigurer.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ProxyOptionsConfigurer.java
@@ -55,11 +55,17 @@ public class ProxyOptionsConfigurer
         checkState(managedChannelBuilder instanceof NettyChannelBuilder, "Expected ManagedChannelBuilder to be provider by Netty");
         NettyChannelBuilder nettyChannelBuilder = (NettyChannelBuilder) managedChannelBuilder;
         proxyTransportFactory.getSslContext().ifPresent(context -> {
-            JdkSslContext jdkSslContext = new JdkSslContext(context, true, null, IdentityCipherSuiteFilter.INSTANCE, new ApplicationProtocolConfig(
-                    ApplicationProtocolConfig.Protocol.ALPN,
-                    ApplicationProtocolConfig.SelectorFailureBehavior.CHOOSE_MY_LAST_PROTOCOL,
-                    ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
-                    "h2"), OPTIONAL);
+            JdkSslContext jdkSslContext = new JdkSslContext(
+                    context,
+                    true,
+                    null,
+                    IdentityCipherSuiteFilter.INSTANCE,
+                    new ApplicationProtocolConfig(
+                            ApplicationProtocolConfig.Protocol.ALPN,
+                            ApplicationProtocolConfig.SelectorFailureBehavior.CHOOSE_MY_LAST_PROTOCOL,
+                            ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
+                            "h2"),
+                    OPTIONAL);
             nettyChannelBuilder
                     .sslContext(jdkSslContext)
                     .useTransportSecurity();


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
