### PR TITLE
Increase testManyFunctionsWithSameWindow timeout

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/query/TestWindow.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestWindow.java
@@ -36,7 +36,7 @@ public class TestWindow
     }
 
     @Test
-    @Timeout(5)
+    @Timeout(10)
     public void testManyFunctionsWithSameWindow()
     {
         assertThat(assertions.query("""


### PR DESCRIPTION
The previous timeout was not sufficient for the test not to be flaky on CI.

Fixes https://github.com/trinodb/trino/issues/20077