### PR TITLE
Set air.compiler.fail-warnings as true in geospatial

### DIFF
--- a/plugin/trino-geospatial/pom.xml
+++ b/plugin/trino-geospatial/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+        <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
     </properties>
 
     <dependencies>

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestExtractSpatialInnerJoin.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestExtractSpatialInnerJoin.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import static io.trino.plugin.geospatial.GeometryType.GEOMETRY;
 import static io.trino.plugin.geospatial.SphericalGeographyType.SPHERICAL_GEOGRAPHY;
+import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
@@ -71,8 +72,8 @@ public class TestExtractSpatialInnerJoin
                 {
                     Symbol wkt = p.symbol("wkt", VARCHAR);
                     Symbol point = p.symbol("point", GEOMETRY);
-                    Symbol name1 = p.symbol("name_1");
-                    Symbol name2 = p.symbol("name_2");
+                    Symbol name1 = p.symbol("name_1", BIGINT);
+                    Symbol name2 = p.symbol("name_2", BIGINT);
                     return p.filter(
                             Logical.or(
                                     containsCall(geometryFromTextCall(wkt), point.toSymbolReference()),
@@ -87,8 +88,8 @@ public class TestExtractSpatialInnerJoin
                 {
                     Symbol wkt = p.symbol("wkt", VARCHAR);
                     Symbol point = p.symbol("point", GEOMETRY);
-                    Symbol name1 = p.symbol("name_1");
-                    Symbol name2 = p.symbol("name_2");
+                    Symbol name1 = p.symbol("name_1", BIGINT);
+                    Symbol name2 = p.symbol("name_2", BIGINT);
                     return p.filter(
                             new Not(containsCall(geometryFromTextCall(wkt), point.toSymbolReference())),
                             p.join(INNER,

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestPruneSpatialJoinChildrenColumns.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestPruneSpatialJoinChildrenColumns.java
@@ -52,7 +52,7 @@ public class TestPruneSpatialJoinChildrenColumns
                     Symbol a = p.symbol("a", GEOMETRY);
                     Symbol b = p.symbol("b", GEOMETRY);
                     Symbol r = p.symbol("r", DOUBLE);
-                    Symbol unused = p.symbol("unused");
+                    Symbol unused = p.symbol("unused", BIGINT);
                     return p.spatialJoin(
                             SpatialJoinNode.Type.INNER,
                             p.values(a, unused),

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestPruneSpatialJoinColumns.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestPruneSpatialJoinColumns.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Optional;
 
 import static io.trino.plugin.geospatial.GeometryType.GEOMETRY;
+import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static io.trino.sql.ir.Comparison.Operator.LESS_THAN_OR_EQUAL;
@@ -80,9 +81,9 @@ public class TestPruneSpatialJoinColumns
     {
         tester().assertThat(new PruneSpatialJoinColumns())
                 .on(p -> {
-                    Symbol a = p.symbol("a");
-                    Symbol b = p.symbol("b");
-                    Symbol r = p.symbol("r");
+                    Symbol a = p.symbol("a", BIGINT);
+                    Symbol b = p.symbol("b", BIGINT);
+                    Symbol r = p.symbol("r", BIGINT);
                     return p.project(
                             Assignments.identity(a, b, r),
                             p.spatialJoin(

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestRewriteSpatialPartitioningAggregation.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestRewriteSpatialPartitioningAggregation.java
@@ -28,6 +28,7 @@ import io.trino.sql.planner.plan.AggregationNode;
 import org.junit.jupiter.api.Test;
 
 import static io.trino.plugin.geospatial.GeometryType.GEOMETRY;
+import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.aggregation;
@@ -54,8 +55,8 @@ public class TestRewriteSpatialPartitioningAggregation
                 .on(p -> p.aggregation(a ->
                         a.globalGrouping()
                                 .step(AggregationNode.Step.SINGLE)
-                                .addAggregation(p.symbol("sp"), PlanBuilder.aggregation("spatial_partitioning", ImmutableList.of(new Reference(GEOMETRY, "geometry"), new Reference(INTEGER, "n"))), ImmutableList.of(GEOMETRY, INTEGER))
-                                .source(p.values(p.symbol("geometry"), p.symbol("n")))))
+                                .addAggregation(p.symbol("sp", BIGINT), PlanBuilder.aggregation("spatial_partitioning", ImmutableList.of(new Reference(GEOMETRY, "geometry"), new Reference(INTEGER, "n"))), ImmutableList.of(GEOMETRY, INTEGER))
+                                .source(p.values(p.symbol("geometry", BIGINT), p.symbol("n", BIGINT)))))
                 .doesNotFire();
     }
 
@@ -66,8 +67,8 @@ public class TestRewriteSpatialPartitioningAggregation
                 .on(p -> p.aggregation(a ->
                         a.globalGrouping()
                                 .step(AggregationNode.Step.SINGLE)
-                                .addAggregation(p.symbol("sp"), PlanBuilder.aggregation("spatial_partitioning", ImmutableList.of(new Reference(GEOMETRY, "geometry"))), ImmutableList.of(GEOMETRY))
-                                .source(p.values(p.symbol("geometry")))))
+                                .addAggregation(p.symbol("sp", BIGINT), PlanBuilder.aggregation("spatial_partitioning", ImmutableList.of(new Reference(GEOMETRY, "geometry"))), ImmutableList.of(GEOMETRY))
+                                .source(p.values(p.symbol("geometry", BIGINT)))))
                 .matches(
                         aggregation(
                                 ImmutableMap.of("sp", aggregationFunction("spatial_partitioning", ImmutableList.of("envelope", "partition_count"))),
@@ -80,8 +81,8 @@ public class TestRewriteSpatialPartitioningAggregation
                 .on(p -> p.aggregation(a ->
                         a.globalGrouping()
                                 .step(AggregationNode.Step.SINGLE)
-                                .addAggregation(p.symbol("sp"), PlanBuilder.aggregation("spatial_partitioning", ImmutableList.of(new Reference(GEOMETRY, "envelope"))), ImmutableList.of(GEOMETRY))
-                                .source(p.values(p.symbol("envelope")))))
+                                .addAggregation(p.symbol("sp", BIGINT), PlanBuilder.aggregation("spatial_partitioning", ImmutableList.of(new Reference(GEOMETRY, "envelope"))), ImmutableList.of(GEOMETRY))
+                                .source(p.values(p.symbol("envelope", BIGINT)))))
                 .matches(
                         aggregation(
                                 ImmutableMap.of("sp", aggregationFunction("spatial_partitioning", ImmutableList.of("envelope", "partition_count"))),


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
