### PR TITLE
Handle constraintExpressions in table scan redirection

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
@@ -851,6 +851,10 @@ public class DefaultJdbcMetadata
         }
 
         JdbcTableHandle tableHandle = (JdbcTableHandle) table;
+        if (!tableHandle.getConstraintExpressions().isEmpty()) {
+            // constraintExpressions is not currently supported by the TableScanRedirectApplicationResult
+            return Optional.empty();
+        }
         return jdbcClient.getTableScanRedirection(session, tableHandle);
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Since `JdbcTableHandle.constraintExpressions` is not supported by the `TableScanRedirectApplicationResult` SPI, we cannot apply redirection if constraintExpressions is present to avoid silent correctness issue

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

() This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( X) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix incorrect results for queries with complex predicates on JDBC connectors that utilize table scan redirections
```
