### PR TITLE
Change getTableMeta alternative for HttpThrift metastore

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/DefaultThriftMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/DefaultThriftMetastoreClientFactory.java
@@ -47,7 +47,6 @@ public class DefaultThriftMetastoreClientFactory
     private final String hostname;
 
     private final MetastoreSupportsDateStatistics metastoreSupportsDateStatistics = new MetastoreSupportsDateStatistics();
-    private final AtomicInteger chosenGetTableMetaAlternative = new AtomicInteger(Integer.MAX_VALUE);
     private final AtomicInteger chosenGetTableAlternative = new AtomicInteger(Integer.MAX_VALUE);
     private final AtomicInteger chosenAlterTransactionalTableAlternative = new AtomicInteger(Integer.MAX_VALUE);
     private final AtomicInteger chosenAlterPartitionsAlternative = new AtomicInteger(Integer.MAX_VALUE);
@@ -109,7 +108,7 @@ public class DefaultThriftMetastoreClientFactory
                 transportSupplier,
                 hostname,
                 metastoreSupportsDateStatistics,
-                chosenGetTableMetaAlternative,
+                true,
                 chosenGetTableAlternative,
                 chosenAlterTransactionalTableAlternative,
                 chosenAlterPartitionsAlternative);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/HttpThriftMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/HttpThriftMetastoreClientFactory.java
@@ -56,7 +56,6 @@ public class HttpThriftMetastoreClientFactory
     private final Map<String, String> additionalHeaders;
     private final OpenTelemetry openTelemetry;
 
-    private final AtomicInteger chosenGetTableMetaAlternative = new AtomicInteger(Integer.MAX_VALUE);
     private final AtomicInteger chosenGetTableAlternative = new AtomicInteger(Integer.MAX_VALUE);
     private final AtomicInteger chosenAlterTransactionalTableAlternative = new AtomicInteger(Integer.MAX_VALUE);
     private final AtomicInteger chosenAlterPartitionsAlternative = new AtomicInteger(Integer.MAX_VALUE);
@@ -83,7 +82,7 @@ public class HttpThriftMetastoreClientFactory
                 () -> createHttpTransport(uri),
                 hostname,
                 new MetastoreSupportsDateStatistics(),
-                chosenGetTableMetaAlternative,
+                false,
                 chosenGetTableAlternative,
                 chosenAlterTransactionalTableAlternative,
                 chosenAlterPartitionsAlternative);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftHiveMetastoreClient.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftHiveMetastoreClient.java
@@ -45,7 +45,7 @@ public class TestThriftHiveMetastoreClient
                 },
                 "dummy",
                 new MetastoreSupportsDateStatistics(),
-                new AtomicInteger(),
+                true,
                 new AtomicInteger(),
                 new AtomicInteger(),
                 new AtomicInteger());


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Fixes https://github.com/trinodb/trino/issues/21885

Http Thrift metastore stopped throwing `MetaException` for `getTableMeta`, but this call returns invalid values (no results when tables are present in schema).

Logic in `ThriftHiveMetastoreClient` uses alternative `1` in case `getTableMeta` throws `MetaException` for alternative `0`. This PR changes default alternative to 1 in case HttpThriftMetastore.

https://github.com/trinodb/trino/blob/21a7f37b3b4e83fecbcc8161b68c533e9e833589/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java#L180-L200


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
