### PR TITLE
Fix broken column name test in BigQuery

### DIFF
--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryAvroConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryAvroConnectorTest.java
@@ -35,6 +35,7 @@ public class TestBigQueryAvroConnectorTest
             .add("a:colon")
             .add("an'apostrophe")
             .add("0startwithdigit")
+            .add("カラム")
             .build();
 
     @Override


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
