### PR TITLE
Add catalog session property doc

### DIFF
--- a/docs/src/main/sphinx/connector/hive.md
+++ b/docs/src/main/sphinx/connector/hive.md
@@ -134,6 +134,8 @@ Hive connector documentation.
     * `APPEND` - appends data to existing partitions
     * `OVERWRITE` - overwrites existing partitions
     * `ERROR` - modifying existing partitions is not allowed
+
+    The equivalent catalog session property is `insert_existing_partitions_behavior`.
   - `APPEND`
 * - `hive.target-max-file-size`
   - Best effort maximum size of new files.
@@ -195,7 +197,7 @@ Hive connector documentation.
   - JVM default
 * - `hive.timestamp-precision`
   - Specifies the precision to use for Hive columns of type `TIMESTAMP`.
-    Possible values are `MILLISECONDS`, `MICROSECONDS` and `NANOSECONDS`. 
+    Possible values are `MILLISECONDS`, `MICROSECONDS` and `NANOSECONDS`.
     Values with higher precision than configured are rounded. The equivalent
     [catalog session property](/sql/set-session) is `timestamp_precision` for
     session specific use.


### PR DESCRIPTION
## Description

Stumbled into this gap in the docs on https://stackoverflow.com/questions/78447353/issue-with-insert-into-statement-in-trino-version-389-using-hive-connector-ve/

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
