### PR TITLE
Fix missing QueryCompletedEvent race condition

### DIFF
--- a/core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQuery.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQuery.java
@@ -93,8 +93,13 @@ public class LocalDispatchQuery
 
         stateMachine.addStateChangeListener(state -> {
             if (state == QueryState.FAILED) {
+                // notificationSentOrGuaranteed.compareAndSet(false, true) ensures the queryCompletedEvent is only fired once.
+                // Either via an immediateFailureEvent or a finalQueryInfoListener.
+                // In cases when finalQueryInfoListener wins the race AND finalQueryInfo is not set the listener isn't triggered.
+                // getFullQueryInfo() force sets finalQueryInfo so the finalQueryInfoListener condition is met.
+                ExecutionFailureInfo failureInfo = getFullQueryInfo().getFailureInfo();
                 if (notificationSentOrGuaranteed.compareAndSet(false, true)) {
-                    queryMonitor.queryImmediateFailureEvent(getBasicQueryInfo(), getFullQueryInfo().getFailureInfo());
+                    queryMonitor.queryImmediateFailureEvent(getBasicQueryInfo(), failureInfo);
                 }
             }
             // any PLANNING or later state means the query has been submitted for execution

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
@@ -1501,6 +1501,19 @@ public class TestEventListenerBasic
                 .isEqualTo(Optional.of(ANONYMIZED_PLAN_JSON_CODEC.toJson(anonymizedPlan)));
     }
 
+    @Test
+    public void testAllImmediateFailureEventsPresent()
+            throws Exception
+    {
+        String immediatelyFailingQuery = "grant select on fake_catalog_%s.fake_schema.fake_table to fake_role";
+        String expectedFailure = "line 1:1: Table 'fake_catalog_%s.fake_schema.fake_table' does not exist";
+        int queryCount = 100;
+
+        for (int i = 0; i < queryCount; i++) {
+            assertFailedQuery(immediatelyFailingQuery.formatted(i), expectedFailure.formatted(i));
+        }
+    }
+
     private void assertLineage(String baseQuery, Set<String> inputTables, OutputColumnMetadata... outputColumnMetadata)
             throws Exception
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

`notificationSentOrGuaranteed` guards agains't publishing queryCompletedEvent twice.

Right now, when [startExecution()](https://github.com/trinodb/trino/blob/8e5ee08e525683bb471951d808aa16df46a2d63f/core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQuery.java#L146) wins the race, there exists a case where FinalQueryInfoListener is never triggered due to [finalQueryInfo](https://github.com/trinodb/trino/blob/8e5ee08e525683bb471951d808aa16df46a2d63f/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java#L1273) not being set.

This change force sets `finalQueryInfo` by calling `getFullQueryInfo()` regardless of notificationSentOrGuaranteed state, which internally calls [updateQueryInfo()](https://github.com/trinodb/trino/blob/8e5ee08e525683bb471951d808aa16df46a2d63f/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java#L1344).

`updateQueryInfo` will set `finalQueryInfo` because the previous check `state == QueryState.FAILED` guarantees the query state is final.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( x ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fixed a race condition which sometime didn't publish a QueryCompletedEvent for failed queries
```
