### PR TITLE
Add configurable retry policy for S3 client

### DIFF
--- a/docs/src/main/sphinx/object-storage/file-system-s3.md
+++ b/docs/src/main/sphinx/object-storage/file-system-s3.md
@@ -68,7 +68,16 @@ support:
 * - `s3.http-proxy`
   - URL of a HTTP proxy server to use for connecting to S3.
 * - `s3.http-proxy.secure`
-  - Set to `true` to enable HTTPS for the proxy server..
+  - Set to `true` to enable HTTPS for the proxy server.
+* - `s3.retry-mode`
+  - Specifies how the AWS SDK attempts retries. Default value is `LEGACY`.
+    Other allowed values are `STANDARD` and `ADAPTIVE`. The `STANDARD` mode
+    includes a standard set of errors that are retried. `ADAPTIVE` mode is
+    experimental, which includes the functionality of `STANDARD` mode and
+    includes automatic client-side throttling.
+* - `s3.max-error-retries`
+  - Specifies maximum number of retries the client will make on errors.
+    Defaults to `10`.
 :::
 
 ## Authentication

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
@@ -60,6 +60,22 @@ public class S3FileSystemConfig
         }
     }
 
+    public enum RetryMode
+    {
+        STANDARD,
+        LEGACY,
+        ADAPTIVE;
+
+        public static software.amazon.awssdk.core.retry.RetryMode getRetryMode(RetryMode retryMode)
+        {
+            return switch (retryMode) {
+                case STANDARD -> software.amazon.awssdk.core.retry.RetryMode.STANDARD;
+                case LEGACY -> software.amazon.awssdk.core.retry.RetryMode.LEGACY;
+                case ADAPTIVE -> software.amazon.awssdk.core.retry.RetryMode.ADAPTIVE;
+            };
+        }
+    }
+
     private String awsAccessKey;
     private String awsSecretKey;
     private String endpoint;
@@ -83,6 +99,8 @@ public class S3FileSystemConfig
     private HostAndPort httpProxy;
     private boolean httpProxySecure;
     private ObjectCannedAcl objectCannedAcl = ObjectCannedAcl.NONE;
+    private RetryMode retryMode = RetryMode.LEGACY;
+    private int maxErrorRetries = 10;
 
     public String getAwsAccessKey()
     {
@@ -221,6 +239,32 @@ public class S3FileSystemConfig
     public S3FileSystemConfig setCannedAcl(ObjectCannedAcl objectCannedAcl)
     {
         this.objectCannedAcl = objectCannedAcl;
+        return this;
+    }
+
+    public RetryMode getRetryMode()
+    {
+        return retryMode;
+    }
+
+    @Config("s3.retry-mode")
+    @ConfigDescription("Specifies how the AWS SDK attempts retries, default is LEGACY")
+    public S3FileSystemConfig setRetryMode(RetryMode retryMode)
+    {
+        this.retryMode = retryMode;
+        return this;
+    }
+
+    @Min(1) // minimum set to 1 as the SDK validates this has to be > 0
+    public int getMaxErrorRetries()
+    {
+        return maxErrorRetries;
+    }
+
+    @Config("s3.max-error-retries")
+    public S3FileSystemConfig setMaxErrorRetries(int maxErrorRetries)
+    {
+        this.maxErrorRetries = maxErrorRetries;
         return this;
     }
 

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemConfig.java
@@ -27,6 +27,8 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertFullMappin
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static io.trino.filesystem.s3.S3FileSystemConfig.RetryMode.LEGACY;
+import static io.trino.filesystem.s3.S3FileSystemConfig.RetryMode.STANDARD;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class TestS3FileSystemConfig
@@ -47,6 +49,8 @@ public class TestS3FileSystemConfig
                 .setStsRegion(null)
                 .setCannedAcl(ObjectCannedAcl.NONE)
                 .setSseType(S3SseType.NONE)
+                .setRetryMode(LEGACY)
+                .setMaxErrorRetries(10)
                 .setSseKmsKeyId(null)
                 .setStreamingPartSize(DataSize.of(16, MEGABYTE))
                 .setRequesterPays(false)
@@ -75,6 +79,8 @@ public class TestS3FileSystemConfig
                 .put("s3.sts.endpoint", "sts.example.com")
                 .put("s3.sts.region", "us-west-2")
                 .put("s3.canned-acl", "BUCKET_OWNER_FULL_CONTROL")
+                .put("s3.retry-mode", "STANDARD")
+                .put("s3.max-error-retries", "12")
                 .put("s3.sse.type", "KMS")
                 .put("s3.sse.kms-key-id", "mykey")
                 .put("s3.streaming.part-size", "42MB")
@@ -102,6 +108,8 @@ public class TestS3FileSystemConfig
                 .setStsRegion("us-west-2")
                 .setCannedAcl(ObjectCannedAcl.BUCKET_OWNER_FULL_CONTROL)
                 .setStreamingPartSize(DataSize.of(42, MEGABYTE))
+                .setRetryMode(STANDARD)
+                .setMaxErrorRetries(12)
                 .setSseType(S3SseType.KMS)
                 .setSseKmsKeyId("mykey")
                 .setRequesterPays(true)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The stress testing and benchmarking of the S3 filesystem revealed errors in Hive connector  as below:
```
Caused by: java.io.IOException: Failed to list location: s3://benchmark-sep-hive-us-east-2-tpcds-sf1000-01/sf1000/catalog_returns/cr_returned_date_sk=2451790
    at io.trino.filesystem.s3.S3FileSystem.listFiles(S3FileSystem.java:195)
    at io.trino.filesystem.manager.SwitchingFileSystem.listFiles(SwitchingFileSystem.java:110)
    at io.trino.filesystem.tracing.TracingFileSystem.lambda$listFiles$4(TracingFileSystem.java:109)
    at io.trino.filesystem.tracing.Tracing.withTracing(Tracing.java:47)
    at io.trino.filesystem.tracing.TracingFileSystem.listFiles(TracingFileSystem.java:109)
    at io.trino.filesystem.ForwardingTrinoFileSystem.listFiles(ForwardingTrinoFileSystem.java:89)
    at io.trino.plugin.hive.fs.CachingDirectoryLister.listFilesRecursively(CachingDirectoryLister.java:96)
    at io.trino.plugin.hive.fs.TransactionScopeCachingDirectoryLister.createListingRemoteIterator(TransactionScopeCachingDirectoryLister.java:97)
    at io.trino.plugin.hive.fs.TransactionScopeCachingDirectoryLister.lambda$listInternal$0(TransactionScopeCachingDirectoryLister.java:78)
    at com.google.common.cache.LocalCache$LocalManualCache$1.load(LocalCache.java:4955)
    at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3589)
    at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2328)
    at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2187)
    at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2081)
    at com.google.common.cache.LocalCache.get(LocalCache.java:4036)
    at com.google.common.cache.LocalCache$LocalManualCache.get(LocalCache.java:4950)
    at io.trino.cache.EvictableCache.get(EvictableCache.java:112)
    at io.trino.plugin.hive.fs.TransactionScopeCachingDirectoryLister.listInternal(TransactionScopeCachingDirectoryLister.java:78)
    at io.trino.plugin.hive.fs.TransactionScopeCachingDirectoryLister.listFilesRecursively(TransactionScopeCachingDirectoryLister.java:70)
    at io.trino.plugin.hive.fs.HiveFileIterator$FileStatusIterator.<init>(HiveFileIterator.java:140)
    ... 11 more
Caused by: software.amazon.awssdk.services.s3.model.S3Exception: Please reduce your request rate. (Service: S3, Status Code: 503, Request ID: 3TWYHXY49Z761P7Y, Extended Request ID: nDKplvh5sDhgsEEJAVCPHmiDsF0vUlIQMKbvRfjs1sFK+4WGtsZYtDHn6ed1mCmHx/9VjgWKRoI=)
    at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handleErrorResponse(AwsXmlPredicatedResponseHandler.java:156)
    at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handleResponse(AwsXmlPredicatedResponseHandler.java:108)
    at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handle(AwsXmlPredicatedResponseHandler.java:85)
    at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handle(AwsXmlPredicatedResponseHandler.java:43)
    at software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler$Crc32ValidationResponseHandler.handle(AwsSyncClientHandler.java:93)
    at software.amazon.awssdk.core.internal.handler.BaseClientHandler.lambda$successTransformationResponseHandler$7(BaseClientHandler.java:279)
    at software.amazon.awssdk.core.internal.http.pipeline.stages.HandleResponseStage.execute(HandleResponseStage.java:50)
    a
```

This change allows native filesytem S3 client to have a configurable retry mechanism since the default retry mechanism does not seem to be good enough. As per AWS team's recommendations, played around with the max error retry count, and bumping this up from the default of 3 helped with fixing the issue. AWS support also suggests having a retry mode to `STANDARD` for some workloads. As per https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/ the default "Equal Jitter" is the loser. So having this configurable might help for some workloads. So exposing this setting to be configurable as well



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
