### PR TITLE
Shutdown ThriftTpchService in thrift connector tests 

### DIFF
--- a/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/integration/TestThriftProjectionPushdown.java
+++ b/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/integration/TestThriftProjectionPushdown.java
@@ -16,7 +16,6 @@ package io.trino.plugin.thrift.integration;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.io.Closer;
 import io.airlift.drift.server.DriftServer;
 import io.trino.Session;
 import io.trino.cost.ScalarStatsCalculator;
@@ -25,6 +24,7 @@ import io.trino.plugin.thrift.ThriftColumnHandle;
 import io.trino.plugin.thrift.ThriftPlugin;
 import io.trino.plugin.thrift.ThriftTableHandle;
 import io.trino.plugin.thrift.ThriftTransactionHandle;
+import io.trino.plugin.thrift.integration.ThriftQueryRunner.StartedServers;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.predicate.TupleDomain;
@@ -35,12 +35,12 @@ import io.trino.sql.planner.iterative.rule.PushProjectionIntoTableScan;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.plan.Assignments;
 import io.trino.testing.PlanTester;
+import io.trino.util.AutoCloseableCloser;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -62,7 +62,7 @@ public class TestThriftProjectionPushdown
         extends BaseRuleTest
 {
     private static final String TINY_SCHEMA = "tiny";
-    private List<DriftServer> servers;
+    private StartedServers startedServers;
 
     private static final Session SESSION = testSessionBuilder()
             .setCatalog(TEST_CATALOG_NAME)
@@ -73,7 +73,7 @@ public class TestThriftProjectionPushdown
     protected Optional<PlanTester> createPlanTester()
     {
         try {
-            servers = startThriftServers(1, false);
+            startedServers = startThriftServers(1, false);
         }
         catch (Throwable t) {
             try {
@@ -86,7 +86,7 @@ public class TestThriftProjectionPushdown
             throw t;
         }
 
-        String addresses = servers.stream()
+        String addresses = startedServers.servers().stream()
                 .map(server -> "localhost:" + driftServerPort(server))
                 .collect(joining(","));
 
@@ -104,18 +104,20 @@ public class TestThriftProjectionPushdown
 
     @AfterAll
     public void cleanup()
+            throws Exception
     {
-        if (servers != null) {
-            try (Closer closer = Closer.create()) {
-                for (DriftServer server : servers) {
+        if (startedServers != null) {
+            try (AutoCloseableCloser closer = AutoCloseableCloser.create()) {
+                for (DriftServer server : startedServers.servers()) {
                     closer.register(server::shutdown);
                 }
+                startedServers.resources().forEach(closer::register);
             }
             catch (IOException e) {
                 throw new RuntimeException(e);
             }
 
-            servers = null;
+            startedServers = null;
         }
     }
 

--- a/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/integration/ThriftQueryRunner.java
+++ b/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/integration/ThriftQueryRunner.java
@@ -13,10 +13,8 @@
  */
 package io.trino.plugin.thrift.integration;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.io.Closer;
 import io.airlift.drift.codec.ThriftCodecManager;
 import io.airlift.drift.server.DriftServer;
 import io.airlift.drift.server.DriftService;
@@ -26,43 +24,19 @@ import io.airlift.drift.transport.netty.server.DriftNettyServerTransport;
 import io.airlift.drift.transport.netty.server.DriftNettyServerTransportFactory;
 import io.airlift.log.Logger;
 import io.airlift.log.Logging;
-import io.opentelemetry.sdk.trace.data.SpanData;
 import io.trino.Session;
-import io.trino.cost.StatsCalculator;
-import io.trino.execution.FailureInjector.InjectedFailureType;
-import io.trino.metadata.FunctionBundle;
-import io.trino.metadata.QualifiedObjectName;
-import io.trino.metadata.SessionPropertyManager;
 import io.trino.plugin.thrift.ThriftPlugin;
 import io.trino.plugin.thrift.server.ThriftIndexedTpchService;
 import io.trino.plugin.thrift.server.ThriftTpchService;
 import io.trino.plugin.tpch.TpchPlugin;
-import io.trino.server.testing.TestingTrinoServer;
-import io.trino.spi.ErrorType;
-import io.trino.spi.Plugin;
-import io.trino.split.PageSourceManager;
-import io.trino.split.SplitManager;
-import io.trino.sql.PlannerContext;
-import io.trino.sql.analyzer.QueryExplainer;
-import io.trino.sql.planner.NodePartitioningManager;
-import io.trino.sql.planner.Plan;
 import io.trino.testing.DistributedQueryRunner;
-import io.trino.testing.MaterializedResult;
 import io.trino.testing.QueryRunner;
-import io.trino.testing.TestingAccessControlManager;
-import io.trino.testing.TestingGroupProviderManager;
-import io.trino.transaction.TransactionManager;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.locks.Lock;
 
-import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.trino.testing.TestingSession.testSessionBuilder;
-import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
 public final class ThriftQueryRunner
@@ -83,15 +57,11 @@ public final class ThriftQueryRunner
             throws Exception
     {
         List<DriftServer> servers = null;
-        QueryRunner runner = null;
         try {
             servers = startThriftServers(thriftServers, enableIndexJoin);
-            runner = createThriftQueryRunnerInternal(servers, coordinatorProperties);
-            return new ThriftQueryRunnerWithServers(runner, servers);
+            return createThriftQueryRunnerInternal(servers, coordinatorProperties);
         }
         catch (Throwable t) {
-            closeAllSuppress(t, runner);
-            // runner might be null, so closing servers explicitly
             if (servers != null) {
                 for (DriftServer server : servers) {
                     server.shutdown();
@@ -143,6 +113,7 @@ public final class ThriftQueryRunner
 
         QueryRunner queryRunner = DistributedQueryRunner.builder(defaultSession)
                 .setCoordinatorProperties(coordinatorProperties)
+                .registerResources(servers.stream().map(server -> (AutoCloseable) server::shutdown).toList())
                 .build();
 
         queryRunner.installPlugin(new ThriftPlugin());
@@ -162,197 +133,5 @@ public final class ThriftQueryRunner
     static int driftServerPort(DriftServer server)
     {
         return ((DriftNettyServerTransport) server.getServerTransport()).getPort();
-    }
-
-    /**
-     * Wraps QueryRunner and a list of ThriftServers to clean them up together.
-     */
-    private static class ThriftQueryRunnerWithServers
-            implements QueryRunner
-    {
-        private QueryRunner source;
-        private List<DriftServer> thriftServers;
-
-        private ThriftQueryRunnerWithServers(QueryRunner source, List<DriftServer> thriftServers)
-        {
-            this.source = requireNonNull(source, "source is null");
-            this.thriftServers = ImmutableList.copyOf(requireNonNull(thriftServers, "thriftServers is null"));
-        }
-
-        @Override
-        public TestingTrinoServer getCoordinator()
-        {
-            return source.getCoordinator();
-        }
-
-        @Override
-        public void close()
-        {
-            try (Closer closer = Closer.create()) {
-                if (thriftServers != null) {
-                    for (DriftServer server : thriftServers) {
-                        closer.register(server::shutdown);
-                    }
-                    thriftServers = null;
-                }
-                if (source != null) {
-                    closer.register(source);
-                    source = null;
-                }
-            }
-            catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        @Override
-        public int getNodeCount()
-        {
-            return source.getNodeCount();
-        }
-
-        @Override
-        public Session getDefaultSession()
-        {
-            return source.getDefaultSession();
-        }
-
-        @Override
-        public TransactionManager getTransactionManager()
-        {
-            return source.getTransactionManager();
-        }
-
-        @Override
-        public PlannerContext getPlannerContext()
-        {
-            return source.getPlannerContext();
-        }
-
-        @Override
-        public QueryExplainer getQueryExplainer()
-        {
-            return source.getQueryExplainer();
-        }
-
-        @Override
-        public SessionPropertyManager getSessionPropertyManager()
-        {
-            return source.getSessionPropertyManager();
-        }
-
-        @Override
-        public SplitManager getSplitManager()
-        {
-            return source.getSplitManager();
-        }
-
-        @Override
-        public PageSourceManager getPageSourceManager()
-        {
-            return source.getPageSourceManager();
-        }
-
-        @Override
-        public NodePartitioningManager getNodePartitioningManager()
-        {
-            return source.getNodePartitioningManager();
-        }
-
-        @Override
-        public StatsCalculator getStatsCalculator()
-        {
-            return source.getStatsCalculator();
-        }
-
-        @Override
-        public TestingGroupProviderManager getGroupProvider()
-        {
-            return source.getGroupProvider();
-        }
-
-        @Override
-        public TestingAccessControlManager getAccessControl()
-        {
-            return source.getAccessControl();
-        }
-
-        @Override
-        public List<SpanData> getSpans()
-        {
-            return source.getSpans();
-        }
-
-        @Override
-        public MaterializedResult execute(Session session, String sql)
-        {
-            return source.execute(session, sql);
-        }
-
-        @Override
-        public MaterializedResultWithPlan executeWithPlan(Session session, String sql)
-        {
-            return source.executeWithPlan(session, sql);
-        }
-
-        @Override
-        public Plan createPlan(Session session, String sql)
-        {
-            return source.createPlan(session, sql);
-        }
-
-        @Override
-        public List<QualifiedObjectName> listTables(Session session, String catalog, String schema)
-        {
-            return source.listTables(session, catalog, schema);
-        }
-
-        @Override
-        public boolean tableExists(Session session, String table)
-        {
-            return source.tableExists(session, table);
-        }
-
-        @Override
-        public void installPlugin(Plugin plugin)
-        {
-            source.installPlugin(plugin);
-        }
-
-        @Override
-        public void addFunctions(FunctionBundle functionBundle)
-        {
-            source.addFunctions(functionBundle);
-        }
-
-        @Override
-        public void createCatalog(String catalogName, String connectorName, Map<String, String> properties)
-        {
-            source.createCatalog(catalogName, connectorName, properties);
-        }
-
-        @Override
-        public Lock getExclusiveLock()
-        {
-            return source.getExclusiveLock();
-        }
-
-        @Override
-        public void injectTaskFailure(
-                String traceToken,
-                int stageId,
-                int partitionId,
-                int attemptId,
-                InjectedFailureType injectionType,
-                Optional<ErrorType> errorType)
-        {
-            source.injectTaskFailure(traceToken, stageId, partitionId, attemptId, injectionType, errorType);
-        }
-
-        @Override
-        public void loadExchangeManager(String name, Map<String, String> properties)
-        {
-            source.loadExchangeManager(name, properties);
-        }
     }
 }


### PR DESCRIPTION
`ThriftTpchService` / `ThriftIndexedTpchService` needs to be closed.
Let's close them to prevent resource leak.

Found by https://github.com/trinodb/trino/pull/21913