### PR TITLE
Make cassandra.partition-size-for-batch-select work expectedly

### DIFF
--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSplitManager.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSplitManager.java
@@ -228,7 +228,7 @@ public class CassandraSplitManager
                     }
                     sb.append(value);
                     size++;
-                    if (size > partitionSizeForBatchSelect) {
+                    if (size >= partitionSizeForBatchSelect) {
                         String partitionId = format("%s in (%s)", partitionKeyColumnName, sb);
                         builder.add(createSplitForClusteringPredicates(partitionId, hostMap.get(entry.getKey()), clusteringPredicates));
                         size = 0;

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraSplitManager.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraSplitManager.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.cassandra;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.connector.ConnectorSplitSource;
+import io.trino.spi.predicate.NullableValue;
+import io.trino.spi.predicate.TupleDomain;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.airlift.testing.Closeables.closeAll;
+import static io.trino.plugin.cassandra.CassandraTestingUtils.CASSANDRA_TYPE_MANAGER;
+import static io.trino.plugin.cassandra.CassandraTestingUtils.createKeyspace;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+final class TestCassandraSplitManager
+{
+    private static final String KEYSPACE = "test_cassandra_split_manager_keyspace";
+
+    private CassandraServer server;
+    private CassandraSession session;
+
+    @BeforeAll
+    void setUp()
+            throws Exception
+    {
+        server = new CassandraServer();
+        session = server.getSession();
+        createKeyspace(session, KEYSPACE);
+    }
+
+    @AfterAll
+    void tearDown()
+            throws Exception
+    {
+        closeAll(server, session);
+        server = null;
+        session = null;
+    }
+
+    @Test
+    void testGetSplitsWithSinglePartitionKeyColumn()
+            throws Exception
+    {
+        String tableName = "single_partition_key_column_table";
+        int partitionCount = 3;
+
+        session.execute(format("""
+            CREATE TABLE %s.%s (
+              partition_key int,
+              clustering_key text,
+              PRIMARY KEY(partition_key, clustering_key)
+            )
+        """, KEYSPACE, tableName));
+
+        CassandraColumnHandle columnHandle = new CassandraColumnHandle("partition_key", 0, CassandraTypes.INT, true, false, false, false);
+        ImmutableList.Builder<CassandraPartition> partitions = ImmutableList.builderWithExpectedSize(partitionCount);
+        for (int i = 0; i < partitionCount; i++) {
+            TupleDomain<ColumnHandle> tupleDomain = TupleDomain.fromFixedValues(Map.of(columnHandle, NullableValue.of(CassandraTypes.INT.trinoType(), (long) i)));
+            partitions.add(new CassandraPartition(new byte[] {0, 0, 0, (byte) i}, format("\"partition_key\" = %d", i), tupleDomain, false));
+            session.execute(format("INSERT INTO %s.%s (partition_key, clustering_key) VALUES (%d, '%d')", KEYSPACE, tableName, i, i));
+        }
+
+        CassandraPartitionManager partitionManager = new CassandraPartitionManager(session, CASSANDRA_TYPE_MANAGER);
+        CassandraClientConfig config = new CassandraClientConfig().setPartitionSizeForBatchSelect(partitionCount - 1);
+        CassandraSplitManager splitManager = new CassandraSplitManager(config, session, null, partitionManager, CASSANDRA_TYPE_MANAGER);
+
+        CassandraTableHandle tableHandle = new CassandraTableHandle(
+                new CassandraNamedRelationHandle(KEYSPACE, tableName, Optional.of(partitions.build()), ""));
+        try (ConnectorSplitSource splitSource = splitManager.getSplits(null, null, tableHandle, null, null)) {
+            List<ConnectorSplit> splits = splitSource.getNextBatch(100).get().getSplits();
+            assertThat(splits).hasSize(2);
+            assertThat(((CassandraSplit) splits.get(0)).getPartitionId()).isEqualTo("\"partition_key\" in (0,1)");
+            assertThat(((CassandraSplit) splits.get(1)).getPartitionId()).isEqualTo("\"partition_key\" in (2)");
+        }
+
+        session.execute(format("DROP TABLE %s.%s", KEYSPACE, tableName));
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This PR fixes `cassandra.partition-size-for-batch-select` behavior that uses one more partition than expected when executing CQLs.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

### Steps to reproduce

Firstly, prepare a Cassandra table and records:

```console
$ cqlsh
Connected to Test Cluster at 127.0.0.1:9042
[cqlsh 6.1.0 | Cassandra 4.1.3 | CQL spec 3.4.6 | Native protocol v5]
Use HELP for help.
cqlsh> CREATE TABLE test_cassandra_split_manager_keyspace.single_partition_key_column_table (partition_key int, clustering_key text, PRIMARY KEY(partition_key, clustering_key));
cqlsh> INSERT INTO test_cassandra_split_manager_keyspace.single_partition_key_column_table (partition_key, clustering_key) VALUES (0, '0');
cqlsh> INSERT INTO test_cassandra_split_manager_keyspace.single_partition_key_column_table (partition_key, clustering_key) VALUES (1, '1');
cqlsh> INSERT INTO test_cassandra_split_manager_keyspace.single_partition_key_column_table (partition_key, clustering_key) VALUES (2, '2');
```

Then, launch trino-esrver-dev with the following changes:

```diff
diff --git a/testing/trino-server-dev/etc/catalog/cassandra.properties b/testing/trino-server-dev/etc/catalog/cassandra.properties
index d62b8a86cd4..1fb8208b60f 100644
--- a/testing/trino-server-dev/etc/catalog/cassandra.properties
+++ b/testing/trino-server-dev/etc/catalog/cassandra.properties
@@ -3,3 +3,4 @@ connector.name=cassandra
 cassandra.contact-points=localhost
 cassandra.allow-drop-table=true
 cassandra.load-policy.dc-aware.local-dc=datacenter1
+cassandra.partition-size-for-batch-select=2
diff --git a/testing/trino-server-dev/etc/log.properties b/testing/trino-server-dev/etc/log.properties
index b615d661c74..8bec119a802 100644
--- a/testing/trino-server-dev/etc/log.properties
+++ b/testing/trino-server-dev/etc/log.properties
@@ -6,6 +6,7 @@
 #
 
 io.trino=INFO
+io.trino.plugin.cassandra.CassandraSession=DEBUG
 
 # show classpath for plugins
 io.trino.server.PluginManager=DEBUG
```

After the server launches, you can reproduce the bug by executing the following Trino query:

```sql
select * from cassandra.test_cassandra_split_manager_keyspace.single_partition_key_column_table where partition_key in (0, 1, 2);
```

Here is an output from the server, and, as you can see in the log, the CQL Trino executed includes three partitions even though we set `cassandra.partition-size-for-batch-select` to 2.

```
2024-05-12T21:33:20.427+0900	DEBUG	Query-20240512_123318_00000_vupj4-174	io.trino.plugin.cassandra.CassandraSession	Execute cql for partition keys with IN clauses: SELECT DISTINCT partition_key FROM test_cassandra_split_manager_keyspace.single_partition_key_column_table WHERE partition_key IN (0,1,2)
2024-05-12T21:33:21.003+0900	DEBUG	SplitRunner-20240512_123318_00000_vupj4.0.0.0-1-201	io.trino.plugin.cassandra.CassandraSession	Execute cql: SELECT partition_key,clustering_key FROM test_cassandra_split_manager_keyspace.single_partition_key_column_table WHERE "partition_key" in (0,1,2)
```

The expected output should be as follows (I got the log when I checked the behavior of this PR):

```
2024-05-12T21:45:20.869+0900	DEBUG	Query-20240512_124519_00000_gkm5v-172	io.trino.plugin.cassandra.CassandraSession	Execute cql for partition keys with IN clauses: SELECT DISTINCT partition_key FROM test_cassandra_split_manager_keyspace.single_partition_key_column_table WHERE partition_key IN (0,1,2)
2024-05-12T21:45:21.441+0900	DEBUG	SplitRunner-20240512_124519_00000_gkm5v.0.0.0-1-201	io.trino.plugin.cassandra.CassandraSession	Execute cql: SELECT partition_key,clustering_key FROM test_cassandra_split_manager_keyspace.single_partition_key_column_table WHERE "partition_key" in (0,1)
2024-05-12T21:45:21.441+0900	DEBUG	SplitRunner-20240512_124519_00000_gkm5v.0.0.0-2-202	io.trino.plugin.cassandra.CassandraSession	Execute cql: SELECT partition_key,clustering_key FROM test_cassandra_split_manager_keyspace.single_partition_key_column_table WHERE "partition_key" in (2)
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Cassandra connector
* Fix `cassandra.partition-size-for-batch-select` behavior that uses one more partition than expected when executing CQLs (#21940)
```
