### PR TITLE
Do not exclude protobuf for trino-exchange-filesystem

### DIFF
--- a/plugin/trino-exchange-filesystem/pom.xml
+++ b/plugin/trino-exchange-filesystem/pom.xml
@@ -69,10 +69,6 @@
             <artifactId>gax</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>com.google.protobuf</groupId>
-                    <artifactId>protobuf-java</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>io.opencensus</groupId>
                     <artifactId>opencensus-api</artifactId>
                 </exclusion>
@@ -133,10 +129,6 @@
                 <exclusion>
                     <groupId>com.google.oauth-client</groupId>
                     <artifactId>google-oauth-client</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.protobuf</groupId>
-                    <artifactId>protobuf-java</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>io.opencensus</groupId>


### PR DESCRIPTION
I don't know why it was excluded in the first place.

```
(base) ➜  trino git:(serafin/do-not-exclude-protobuf) ✗ ./mvnw dependency:tree -pl ':trino-exchange-filesystem' | grep protobuf
[INFO] |  +- com.google.protobuf:protobuf-java:jar:3.25.3:compile
[INFO] |  +- com.google.protobuf:protobuf-java-util:jar:3.25.3:compile
[INFO] |  +- io.grpc:grpc-protobuf:jar:1.62.2:compile
[INFO] |  +- io.grpc:grpc-protobuf-lite:jar:1.62.2:runtime
(base) ➜  trino git:(serafin/do-not-exclude-protobuf) ✗ git checkout master
Switched to branch 'master'
Your branch is ahead of 'origin/master' by 25 commits.
  (use "git push" to publish your local commits)
(base) ➜  trino git:(master) ✗ ./mvnw dependency:tree -pl ':trino-exchange-filesystem' | grep protobuf
[INFO] |  +- com.google.protobuf:protobuf-java-util:jar:3.25.3:compile
[INFO] |  +- io.grpc:grpc-protobuf:jar:1.62.2:compile
[INFO] |  +- io.grpc:grpc-protobuf-lite:jar:1.62.2:runtime
```