### PR TITLE
Fix failure when translating $try_cast to/from connector expression

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/expression/StandardFunctions.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/expression/StandardFunctions.java
@@ -44,6 +44,7 @@ public final class StandardFunctions
      * $cast function result type is determined by the {@link Call#getType()}
      */
     public static final FunctionName CAST_FUNCTION_NAME = new FunctionName("$cast");
+    public static final FunctionName TRY_CAST_FUNCTION_NAME = new FunctionName("$try_cast");
 
     public static final FunctionName EQUAL_OPERATOR_FUNCTION_NAME = new FunctionName("$equal");
     public static final FunctionName NOT_EQUAL_OPERATOR_FUNCTION_NAME = new FunctionName("$not_equal");


### PR DESCRIPTION
Fixes #21952

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix potential failure when queries contain `try_cast`. ({issue}`21952`)
```
