### PR TITLE
Set thread context class loader in Glue threads

### DIFF
--- a/.mvn/modernizer/violations.xml
+++ b/.mvn/modernizer/violations.xml
@@ -44,6 +44,22 @@
     </violation>
 
     <violation>
+        <name>java/lang/Thread$Builder.factory:()Ljava/util/concurrent/ThreadFactory;</name>
+        <version>1.1</version>
+        <comment>Use io.airlift.concurrent.Threads's thread factories, as the set thread context class loader</comment>
+    </violation>
+    <violation>
+        <name>java/lang/Thread$Builder$OfPlatform.factory:()Ljava/util/concurrent/ThreadFactory;</name>
+        <version>1.1</version>
+        <comment>Use io.airlift.concurrent.Threads's thread factories, as the set thread context class loader</comment>
+    </violation>
+    <violation>
+        <name>java/lang/Thread$Builder$OfVirtual.factory:()Ljava/util/concurrent/ThreadFactory;</name>
+        <version>1.1</version>
+        <comment>Use io.airlift.concurrent.Threads's thread factories, as the set thread context class loader</comment>
+    </violation>
+
+    <violation>
         <name>com/google/common/primitives/Ints.checkedCast:(J)I</name>
         <version>1.8</version>
         <comment>Prefer Math.toIntExact(long)</comment>

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -117,6 +117,7 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.opentelemetry.context.Context.taskWrapping;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
@@ -208,7 +209,7 @@ public class GlueHiveMetastore
                 config.getPartitionSegments(),
                 config.isAssumeCanonicalPartitionKeys(),
                 visibleTableKinds,
-                newFixedThreadPool(config.getThreads(), Thread.ofPlatform().name("glue-%d-".formatted(poolCounter.getAndIncrement()), 0L).factory()));
+                newFixedThreadPool(config.getThreads(), daemonThreadsNamed("glue-%s-%%s".formatted(poolCounter.getAndIncrement()))));
     }
 
     private GlueHiveMetastore(


### PR DESCRIPTION
It might not be necessary, but it is also hard to verify it is not necessary, so it's better to set the TCCL. The TCCL is set in pretty much all other thread pools by virtue of default behavior of thread factories created with `io.airlift.concurrent.Threads`.
