### PR TITLE
Downgrade mysql-connector-j to 8.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -586,7 +586,7 @@
             <dependency>
                 <groupId>com.mysql</groupId>
                 <artifactId>mysql-connector-j</artifactId>
-                <version>8.4.0</version>
+                <version>8.3.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This reverts commit 689b7cea1b458d1426535b613268961d6be15e1e.

Fixes https://github.com/trinodb/trino/issues/21945