### PR TITLE
Fix Alluxio CacheManager leak on coordinator

### DIFF
--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioCoordinatorFileSystemCache.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioCoordinatorFileSystemCache.java
@@ -25,6 +25,7 @@ import io.trino.filesystem.TrinoInputFile;
 import io.trino.filesystem.TrinoInputStream;
 import io.trino.filesystem.cache.AllowFilesystemCacheOnCoordinator;
 import io.trino.filesystem.cache.TrinoFileSystemCache;
+import jakarta.annotation.PreDestroy;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -61,6 +62,15 @@ public class AlluxioCoordinatorFileSystemCache
             catch (Exception e) {
                 throw new RuntimeException(e);
             }
+        }
+    }
+
+    @PreDestroy
+    public void shutdown()
+            throws Exception
+    {
+        if (alluxioFileSystemCache.isPresent()) {
+            alluxioFileSystemCache.get().shutdown();
         }
     }
 


### PR DESCRIPTION
Same as https://github.com/trinodb/trino/pull/20998 but for alluxio cache on the coordinator.

Found by https://github.com/trinodb/trino/pull/21913