### PR TITLE
Do not use SkewedPartitionRebalancer for remote exchange in FTE

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/output/SkewedPartitionRebalancer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/SkewedPartitionRebalancer.java
@@ -109,7 +109,7 @@ public class SkewedPartitionRebalancer
         // In case of connector partitioning, check if bucketToPartitions has fixed mapping or not. If it is fixed
         // then we can't distribute a bucket across multiple tasks.
         boolean hasFixedNodeMapping = partitioningHandle.getCatalogHandle()
-                .map(handle -> nodePartitioningManager.getConnectorBucketNodeMap(session, partitioningHandle)
+                .map(_ -> nodePartitioningManager.getConnectorBucketNodeMap(session, partitioningHandle)
                         .map(ConnectorBucketNodeMap::hasFixedMapping)
                         .orElse(false))
                 .orElse(false);

--- a/core/trino-main/src/main/java/io/trino/operator/output/SkewedPartitionRebalancer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/SkewedPartitionRebalancer.java
@@ -295,6 +295,7 @@ public class SkewedPartitionRebalancer
         dataProcessedAtLastRebalance.set(dataProcessed);
     }
 
+    @GuardedBy("this")
     private void calculatePartitionDataSize(long dataProcessed)
     {
         long totalPartitionRowCount = 0;
@@ -315,6 +316,7 @@ public class SkewedPartitionRebalancer
         }
     }
 
+    @GuardedBy("this")
     private long calculateTaskBucketDataSizeSinceLastRebalance(IndexedPriorityQueue<Integer> maxPartitions)
     {
         long estimatedDataSizeSinceLastRebalance = 0;
@@ -324,6 +326,7 @@ public class SkewedPartitionRebalancer
         return estimatedDataSizeSinceLastRebalance;
     }
 
+    @GuardedBy("this")
     private void rebalanceBasedOnTaskBucketSkewness(
             IndexedPriorityQueue<TaskBucket> maxTaskBuckets,
             IndexedPriorityQueue<TaskBucket> minTaskBuckets,
@@ -376,6 +379,7 @@ public class SkewedPartitionRebalancer
         }
     }
 
+    @GuardedBy("this")
     private List<TaskBucket> findSkewedMinTaskBuckets(TaskBucket maxTaskBucket, IndexedPriorityQueue<TaskBucket> minTaskBuckets)
     {
         ImmutableList.Builder<TaskBucket> minSkewedTaskBuckets = ImmutableList.builder();
@@ -395,6 +399,7 @@ public class SkewedPartitionRebalancer
         return minSkewedTaskBuckets.build();
     }
 
+    @GuardedBy("this")
     private boolean rebalancePartition(
             int partitionId,
             TaskBucket toTaskBucket,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -79,7 +79,6 @@ import io.trino.operator.PagesIndex;
 import io.trino.operator.PagesSpatialIndexFactory;
 import io.trino.operator.PartitionFunction;
 import io.trino.operator.RefreshMaterializedViewOperator.RefreshMaterializedViewOperatorFactory;
-import io.trino.operator.RetryPolicy;
 import io.trino.operator.RowNumberOperator;
 import io.trino.operator.ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory;
 import io.trino.operator.SetBuilderOperator.SetBuilderOperatorFactory;
@@ -330,6 +329,7 @@ import static io.trino.operator.OperatorFactories.join;
 import static io.trino.operator.OperatorFactories.spillingJoin;
 import static io.trino.operator.OutputSpoolingOperatorFactory.layoutUnionWithSpooledMetadata;
 import static io.trino.operator.OutputSpoolingOperatorFactory.spooledOutputLayout;
+import static io.trino.operator.RetryPolicy.NONE;
 import static io.trino.operator.TableFinishOperator.TableFinishOperatorFactory;
 import static io.trino.operator.TableFinishOperator.TableFinisher;
 import static io.trino.operator.TableWriterOperator.FRAGMENT_CHANNEL;
@@ -905,7 +905,7 @@ public class LocalExecutionPlanner
         private PhysicalOperation createMergeSource(RemoteSourceNode node, LocalExecutionPlanContext context)
         {
             checkArgument(node.getOrderingScheme().isPresent(), "orderingScheme is absent");
-            checkArgument(node.getRetryPolicy() == RetryPolicy.NONE, "unexpected retry policy: %s", node.getRetryPolicy());
+            checkArgument(node.getRetryPolicy() == NONE, "unexpected retry policy: %s", node.getRetryPolicy());
 
             // merging remote source must have a single driver
             context.setDriverInstanceCount(1);


### PR DESCRIPTION
The rebalancing logic from SkewedPartitionRebalancer is already covered by partitions splitting/merging in HashDistributionSplitAssigner. Also the way remote SkewedPartitionRebalancer is configured does not match FTE behaviour as there is assumption that data will be consumed by N tasks where N is number of cluster nodes. This is not true for FTE.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:


