### PR TITLE
Suppress single table errors during metadata listing

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -510,11 +510,18 @@ public final class MetadataManager
 
         Optional<QualifiedObjectName> objectName = prefix.asQualifiedObjectName();
         if (objectName.isPresent()) {
-            Optional<RelationType> relationType = getRelationTypeIfExists(session, objectName.get());
-            if (relationType.isPresent()) {
-                return ImmutableList.of(objectName.get());
+            try {
+                Optional<RelationType> relationType = getRelationTypeIfExists(session, objectName.get());
+                if (relationType.isPresent()) {
+                    return ImmutableList.of(objectName.get());
+                }
+                // TODO we can probably return empty list here
             }
-            // TODO we can probably return empty list here
+            catch (RuntimeException e) {
+                handleListingError(e, prefix);
+                // TODO This could be potentially improved to not return empty results https://github.com/trinodb/trino/issues/6551
+                return ImmutableList.of();
+            }
         }
 
         Optional<CatalogMetadata> catalog = getOptionalCatalogMetadata(session, prefix.getCatalogName());

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -514,7 +514,7 @@ public final class MetadataManager
             if (relationType.isPresent()) {
                 return ImmutableList.of(objectName.get());
             }
-            // TODO we can probably return empty lit here
+            // TODO we can probably return empty list here
         }
 
         Optional<CatalogMetadata> catalog = getOptionalCatalogMetadata(session, prefix.getCatalogName());

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveMetadataListing.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveMetadataListing.java
@@ -139,6 +139,7 @@ public class TestHiveMetadataListing
                 FAILING_STORAGE_DESCRIPTOR_VIEW.getSchemaTableName().getTableName());
         assertQueryReturnsEmptyResult(withSchemaAndFailingSDViewFilter);
 
+        // TODO This could be potentially improved to not return empty results https://github.com/trinodb/trino/issues/6551
         String withSchemaAndFailingGeneralViewFilter = format(
                 "SELECT table_name FROM information_schema.views WHERE table_schema = '%s' AND table_name = '%s'",
                 DATABASE_NAME,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

In case of table error (e.g Table SerdeInfo is null) listing is failing.
This change filter outs views causing errors from lists returned when listing tables.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Example stack trace:
 ```
   "type": "io.trino.spi.TrinoException",
    "message": "Table SerdeInfo is null for table 'table'
    "stack":
      "io.trino.plugin.hive.metastore.glue.converter.GlueToTrinoConverter.convertTable(GlueToTrinoConverter.java:167)",
      "io.trino.plugin.hive.metastore.glue.GlueHiveMetastore.getTable(GlueHiveMetastore.java:282)",
      "io.trino.plugin.hive.metastore.tracing.TracingHiveMetastore.lambda$getTable$2(TracingHiveMetastore.java:103)",
      "io.trino.plugin.hive.metastore.tracing.Tracing.withTracing(Tracing.java:39)",
      "io.trino.plugin.hive.metastore.tracing.TracingHiveMetastore.getTable(TracingHiveMetastore.java:103)",
      "io.trino.plugin.hive.metastore.cache.CachingHiveMetastore.loadTable(CachingHiveMetastore.java:438)",
      "com.google.common.cache.CacheLoader$FunctionToCacheLoader.load(CacheLoader.java:169)",
      "com.google.common.cache.CacheLoader$1.load(CacheLoader.java:192)",
      "io.trino.cache.EvictableCache$TokenCacheLoader.load(EvictableCache.java:447)",
      "io.trino.cache.EvictableCache$TokenCacheLoader.load(EvictableCache.java:433)",
      "com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3576)",
      "com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2318)",
      "com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2191)",
      "com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2081)",
      "com.google.common.cache.LocalCache.get(LocalCache.java:4019)",
      "com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:4042)",
      "com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:5024)",
      "io.trino.cache.EvictableCache.get(EvictableCache.java:145)",
      "com.google.common.cache.AbstractLoadingCache.getUnchecked(AbstractLoadingCache.java:53)",
      "io.trino.plugin.hive.metastore.cache.CachingHiveMetastore.getOptional(CachingHiveMetastore.java:288)",
      "io.trino.plugin.hive.metastore.cache.CachingHiveMetastore.getTable(CachingHiveMetastore.java:433)",
      "io.trino.plugin.hive.metastore.cache.CachingHiveMetastore.loadTable(CachingHiveMetastore.java:438)",
      "com.google.common.cache.CacheLoader$FunctionToCacheLoader.load(CacheLoader.java:169)",
      "io.trino.cache.EvictableCache$TokenCacheLoader.load(EvictableCache.java:447)",
      "io.trino.cache.EvictableCache$TokenCacheLoader.load(EvictableCache.java:433)",
      "com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3576)",
      "com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2318)",
      "com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2191)",
      "com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2081)",
      "com.google.common.cache.LocalCache.get(LocalCache.java:4019)",
      "com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:4042)",
      "com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:5024)",
      "io.trino.cache.EvictableCache.get(EvictableCache.java:145)",
      "com.google.common.cache.AbstractLoadingCache.getUnchecked(AbstractLoadingCache.java:53)",
      "io.trino.plugin.hive.metastore.cache.CachingHiveMetastore.getOptional(CachingHiveMetastore.java:288)",
      "io.trino.plugin.hive.metastore.cache.CachingHiveMetastore.getTable(CachingHiveMetastore.java:433)",
      "io.trino.plugin.hive.HiveMetastoreClosure.getTable(HiveMetastoreClosure.java:91)",
      "io.trino.plugin.hive.metastore.SemiTransactionalHiveMetastore.getTable(SemiTransactionalHiveMetastore.java:263)",
      "io.trino.plugin.hive.HiveMetadata.getView(HiveMetadata.java:2888)",
      "io.trino.tracing.TracingConnectorMetadata.getView(TracingConnectorMetadata.java:878)",
      "io.trino.metadata.MetadataManager.getViewInternal(MetadataManager.java:1545)",
      "io.trino.metadata.MetadataManager.isView(MetadataManager.java:1477)",
      "io.trino.metadata.MetadataManager.getRelationTypeIfExists(MetadataManager.java:582)",
      "io.trino.metadata.MetadataManager.listTables(MetadataManager.java:514)",
      "io.trino.tracing.TracingMetadata.listTables(TracingMetadata.java:319)",
      "io.trino.metadata.MetadataListing.doListTables(MetadataListing.java:128)",
      "io.trino.metadata.MetadataListing.listTables(MetadataListing.java:119)",
      "io.trino.connector.informationschema.InformationSchemaPageSource.addTablesRecords(InformationSchemaPageSource.java:292)",
      "io.trino.connector.informationschema.InformationSchemaPageSource.buildPages(InformationSchemaPageSource.java:221)",
      "io.trino.connector.informationschema.InformationSchemaPageSource.getNextPage(InformationSchemaPageSource.java:185)",
      "io.trino.operator.ScanFilterAndProjectOperator$ConnectorPageSourceToPages.process(ScanFilterAndProjectOperator.java:384)",
      "io.trino.operator.WorkProcessorUtils$ProcessWorkProcessor.process(WorkProcessorUtils.java:412)",
      "io.trino.operator.WorkProcessorUtils.getNextState(WorkProcessorUtils.java:261)",
        ...
```



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Fix failure when listing Hive tables having unsupported syntax. ({issue}`21981`)
```
