### PR TITLE
fixing typo in Big Query Connector docs -  "bigquery.view-materialization-with-filter"

### DIFF
--- a/docs/src/main/sphinx/connector/bigquery.md
+++ b/docs/src/main/sphinx/connector/bigquery.md
@@ -154,7 +154,7 @@ a few caveats:
   - Use REST API to access views instead of Storage API. BigQuery `BIGNUMERIC` 
     and `TIMESTAMP` types are unsupported.
   - `false`
-* - `bigqueryview-materialization-with-filter`
+* - `bigquery.view-materialization-with-filter`
   - Use filter conditions when materializing views.
   - `false`
 * - `bigquery.views-cache-ttl`


### PR DESCRIPTION
## Description
There's a minor typo in the parameter for Big query connector, I just found it because I had to use it. 
It's simply missing a "." between bigquery and view. in the `bigquery.view-materialization-with-filter`.

## Additional context and related issues
The right parameter can be seen here https://github.com/trinodb/trino/blob/master/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConfig.java#L166

## Release notes

(X ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: