### PR TITLE
Add IF EXISTS to DROP ROLE

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -121,7 +121,7 @@ statement
     | CREATE ROLE name=identifier
         (WITH ADMIN grantor)?
         (IN catalog=identifier)?                                       #createRole
-    | DROP ROLE name=identifier (IN catalog=identifier)?               #dropRole
+    | DROP ROLE (IF EXISTS)? name=identifier (IN catalog=identifier)?  #dropRole
     | GRANT
         privilegeOrRole (',' privilegeOrRole)*
         TO principal (',' principal)*

--- a/core/trino-main/src/main/java/io/trino/execution/DropRoleTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropRoleTask.java
@@ -61,6 +61,9 @@ public class DropRoleTask
         Session session = stateMachine.getSession();
         Optional<String> catalog = processRoleCommandCatalog(metadata, session, statement, statement.getCatalog().map(Identifier::getValue));
         String role = statement.getName().getValue().toLowerCase(ENGLISH);
+        if (statement.isExists() && !metadata.roleExists(session, role, catalog)) {
+            return immediateVoidFuture();
+        }
         accessControl.checkCanDropRole(session.toSecurityContext(), role, catalog);
         checkRoleExists(session, statement, metadata, role, catalog);
         metadata.dropRole(session, role, catalog);

--- a/core/trino-main/src/test/java/io/trino/execution/TestRoleTasks.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestRoleTasks.java
@@ -59,7 +59,7 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 @TestInstance(PER_CLASS)
 @Execution(CONCURRENT)
-public class TestSetRoleTask
+public class TestRoleTasks
 {
     private static final String CATALOG_NAME = "foo";
     private static final String SYSTEM_ROLE_CATALOG_NAME = "system_role";

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -1560,7 +1560,8 @@ class AstBuilder
         return new DropRole(
                 getLocation(context),
                 (Identifier) visit(context.name),
-                visitIfPresent(context.catalog, Identifier.class));
+                visitIfPresent(context.catalog, Identifier.class),
+                context.EXISTS() != null);
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DropRole.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DropRole.java
@@ -27,22 +27,24 @@ public class DropRole
 {
     private final Identifier name;
     private final Optional<Identifier> catalog;
+    private final boolean exists;
 
     public DropRole(Identifier name, Optional<Identifier> catalog)
     {
-        this(Optional.empty(), name, catalog);
+        this(Optional.empty(), name, catalog, false);
     }
 
-    public DropRole(NodeLocation location, Identifier name, Optional<Identifier> catalog)
+    public DropRole(NodeLocation location, Identifier name, Optional<Identifier> catalog, boolean exists)
     {
-        this(Optional.of(location), name, catalog);
+        this(Optional.of(location), name, catalog, exists);
     }
 
-    private DropRole(Optional<NodeLocation> location, Identifier name, Optional<Identifier> catalog)
+    private DropRole(Optional<NodeLocation> location, Identifier name, Optional<Identifier> catalog, boolean exists)
     {
         super(location);
         this.name = requireNonNull(name, "name is null");
         this.catalog = requireNonNull(catalog, "catalog is null");
+        this.exists = exists;
     }
 
     public Identifier getName()
@@ -53,6 +55,11 @@ public class DropRole
     public Optional<Identifier> getCatalog()
     {
         return catalog;
+    }
+
+    public boolean isExists()
+    {
+        return exists;
     }
 
     @Override

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -4538,6 +4538,7 @@ public class TestSqlParser
     public void testDropRole()
     {
         assertStatement("DROP ROLE role", new DropRole(new Identifier("role"), Optional.empty()));
+        assertStatement("DROP ROLE IF EXISTS role", new DropRole(new Identifier("role"), Optional.empty()));
         assertStatement("DROP ROLE \"role\"", new DropRole(new Identifier("role"), Optional.empty()));
         assertStatement("DROP ROLE \"ro le\"", new DropRole(new Identifier("ro le"), Optional.empty()));
         assertStatement("DROP ROLE \"!@#$%^&*'ад\"\"мін\"", new DropRole(new Identifier("!@#$%^&*'ад\"мін"), Optional.empty()));

--- a/docs/src/main/sphinx/sql/drop-role.md
+++ b/docs/src/main/sphinx/sql/drop-role.md
@@ -3,7 +3,7 @@
 ## Synopsis
 
 ```text
-DROP ROLE role_name
+DROP ROLE [ IF EXISTS ] role_name
 [ IN catalog ]
 ```
 
@@ -13,6 +13,9 @@ DROP ROLE role_name
 
 For `DROP ROLE` statement to succeed, the user executing it should possess
 admin privileges for the given role.
+
+The optional `IF EXISTS` prevents the statement from failing if the role
+isn't found.
 
 The optional `IN catalog` clause drops the role in a catalog as opposed
 to a system role.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Add optional `IF EXISTS` to `DROP ROLE`, which suppresses the role-not-found error that you'd otherwise get.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Although this option isn't in the ANSI SQL, it's a UX improvement that Trino has traditionally admitted.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Extend `DROP ROLE` to allow `IF EXISTS`.
```
