### PR TITLE
Add support for case insensitive name cache in BigQuery

### DIFF
--- a/docs/src/main/sphinx/connector/bigquery.md
+++ b/docs/src/main/sphinx/connector/bigquery.md
@@ -177,6 +177,10 @@ a few caveats:
 * - `bigquery.case-insensitive-name-matching`
   - Match dataset and table names case-insensitively.
   - `false`
+* - `bigquery.case-insensitive-name-matching.cache-ttl`
+  - [Duration](prop-type-duration) for which case insensitive schema and table
+    names are cached. Set to `0ms` to disable the cache.
+  - `0ms`
 * - `bigquery.query-results-cache.enabled`
   - Enable [query results cache](https://cloud.google.com/bigquery/docs/cached-results).
   - `false`

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClientFactory.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClientFactory.java
@@ -35,6 +35,7 @@ public class BigQueryClientFactory
     private final BigQueryTypeManager typeManager;
     private final Optional<String> projectId;
     private final boolean caseInsensitiveNameMatching;
+    private final Duration caseInsensitiveNameMatchingCacheTtl;
     private final ViewMaterializationCache materializationCache;
     private final BigQueryLabelFactory labelFactory;
 
@@ -56,6 +57,7 @@ public class BigQueryClientFactory
         requireNonNull(bigQueryConfig, "bigQueryConfig is null");
         this.projectId = bigQueryConfig.getProjectId();
         this.caseInsensitiveNameMatching = bigQueryConfig.isCaseInsensitiveNameMatching();
+        this.caseInsensitiveNameMatchingCacheTtl = bigQueryConfig.getCaseInsensitiveNameMatchingCacheTtl();
         this.materializationCache = requireNonNull(materializationCache, "materializationCache is null");
         this.labelFactory = requireNonNull(labelFactory, "labelFactory is null");
         this.metadataCacheTtl = bigQueryConfig.getMetadataCacheTtl();
@@ -75,7 +77,15 @@ public class BigQueryClientFactory
 
     protected BigQueryClient createBigQueryClient(ConnectorSession session)
     {
-        return new BigQueryClient(createBigQuery(session), labelFactory, typeManager, caseInsensitiveNameMatching, materializationCache, metadataCacheTtl, projectId);
+        return new BigQueryClient(
+                createBigQuery(session),
+                labelFactory,
+                typeManager,
+                caseInsensitiveNameMatching,
+                caseInsensitiveNameMatchingCacheTtl,
+                materializationCache,
+                metadataCacheTtl,
+                projectId);
     }
 
     protected BigQuery createBigQuery(ConnectorSession session)

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryCaseInsensitiveMapping.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryCaseInsensitiveMapping.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.bigquery;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.plugin.bigquery.BigQueryQueryRunner.BigQuerySqlExecutor;
 import io.trino.testing.AbstractTestQueryFramework;
@@ -21,7 +22,6 @@ import io.trino.testing.sql.TestTable;
 import io.trino.testing.sql.TestView;
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -43,7 +43,11 @@ public class TestBigQueryCaseInsensitiveMapping
             throws Exception
     {
         return BigQueryQueryRunner.builder()
-                .setConnectorProperties(Map.of("bigquery.case-insensitive-name-matching", "true"))
+                .setConnectorProperties(ImmutableMap.<String, String>builder()
+                        .put("bigquery.case-insensitive-name-matching", "true")
+                        .put("bigquery.case-insensitive-name-matching.cache-ttl", "1m")
+                        .put("bigquery.service-cache-ttl", "0ms") // Disable service cache to focus on metadata cache
+                        .buildOrThrow())
                 .build();
     }
 

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConfig.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConfig.java
@@ -44,6 +44,7 @@ public class TestBigQueryConfig
                 .setViewMaterializationDataset(null)
                 .setMaxReadRowsRetries(3)
                 .setCaseInsensitiveNameMatching(false)
+                .setCaseInsensitiveNameMatchingCacheTtl(new Duration(0, MILLISECONDS))
                 .setViewsCacheTtl(new Duration(15, MINUTES))
                 .setServiceCacheTtl(new Duration(3, MINUTES))
                 .setMetadataCacheTtl(new Duration(0, MILLISECONDS))
@@ -73,6 +74,7 @@ public class TestBigQueryConfig
                 .put("bigquery.view-materialization-dataset", "vmdataset")
                 .put("bigquery.max-read-rows-retries", "10")
                 .put("bigquery.case-insensitive-name-matching", "true")
+                .put("bigquery.case-insensitive-name-matching.cache-ttl", "1h")
                 .put("bigquery.views-cache-ttl", "1m")
                 .put("bigquery.service-cache-ttl", "10d")
                 .put("bigquery.metadata.cache-ttl", "5d")
@@ -97,6 +99,7 @@ public class TestBigQueryConfig
                 .setViewMaterializationDataset("vmdataset")
                 .setMaxReadRowsRetries(10)
                 .setCaseInsensitiveNameMatching(true)
+                .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, HOURS))
                 .setViewsCacheTtl(new Duration(1, MINUTES))
                 .setServiceCacheTtl(new Duration(10, DAYS))
                 .setMetadataCacheTtl(new Duration(5, DAYS))
@@ -133,5 +136,12 @@ public class TestBigQueryConfig
                 .validate())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("bigquery.views-enabled config property must be enabled when view materialization with filter is enabled");
+
+        assertThatThrownBy(() -> new BigQueryConfig()
+                .setCaseInsensitiveNameMatching(false)
+                .setCaseInsensitiveNameMatchingCacheTtl(new Duration(30, MINUTES))
+                .validate())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("bigquery.case-insensitive-name-matching config must be enabled when case insensitive name matching cache TTL is set");
     }
 }


### PR DESCRIPTION
## Description

Supersedes #19624
Fixes #10740

Test on a schema with 180 tables:
```
trino> select * from bigquery.test.test_ebi;
 a
---
 1
(1 row)
9.47 [1 rows, 2B] [0 rows/s, 0B/s]

trino> select * from bigquery.test.test_ebi;
 a
---
 1
(1 row)
2.27 [1 rows, 2B] [0 rows/s, 1B/s]

trino> select * from bigquery.test.test_ebi;
 a
---
 1
(1 row)
2.93 [1 rows, 2B] [0 rows/s, 1B/s]
```

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# BigQuery
* Fix some things. ({issue}`issuenumber`)
```
