### PR TITLE
Add SystemAccessControl.getTableColumnMasks SPI function and OPA implementation

### DIFF
--- a/core/trino-main/src/main/java/io/trino/security/AccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/AccessControl.java
@@ -14,10 +14,12 @@
 package io.trino.security;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.spi.QueryId;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.ColumnSchema;
 import io.trino.spi.connector.EntityKindAndName;
 import io.trino.spi.connector.EntityPrivilege;
 import io.trino.spi.connector.SchemaTableName;
@@ -27,7 +29,6 @@ import io.trino.spi.security.Identity;
 import io.trino.spi.security.Privilege;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.security.ViewExpression;
-import io.trino.spi.type.Type;
 
 import java.security.Principal;
 import java.util.Collection;
@@ -615,8 +616,8 @@ public interface AccessControl
         return ImmutableList.of();
     }
 
-    default Optional<ViewExpression> getColumnMask(SecurityContext context, QualifiedObjectName tableName, String columnName, Type type)
+    default Map<ColumnSchema, ViewExpression> getColumnMasks(SecurityContext context, QualifiedObjectName tableName, List<ColumnSchema> columns)
     {
-        return Optional.empty();
+        return ImmutableMap.of();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
@@ -40,6 +40,7 @@ import io.trino.spi.connector.CatalogHandle.CatalogHandleType;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.CatalogSchemaRoutineName;
 import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.ColumnSchema;
 import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorSecurityContext;
 import io.trino.spi.connector.EntityKindAndName;
@@ -55,7 +56,6 @@ import io.trino.spi.security.SystemAccessControlFactory.SystemAccessControlConte
 import io.trino.spi.security.SystemSecurityContext;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.security.ViewExpression;
-import io.trino.spi.type.Type;
 import io.trino.transaction.TransactionId;
 import io.trino.transaction.TransactionManager;
 import jakarta.annotation.PreDestroy;
@@ -1411,30 +1411,31 @@ public class AccessControlManager
     }
 
     @Override
-    public Optional<ViewExpression> getColumnMask(SecurityContext context, QualifiedObjectName tableName, String columnName, Type type)
+    public Map<ColumnSchema, ViewExpression> getColumnMasks(SecurityContext context, QualifiedObjectName tableName, List<ColumnSchema> columns)
     {
         requireNonNull(context, "context is null");
         requireNonNull(tableName, "tableName is null");
+        requireNonNull(columns, "columns is null");
 
-        ImmutableList.Builder<ViewExpression> masks = ImmutableList.builder();
+        ImmutableMap.Builder<ColumnSchema, ViewExpression> columnMasksBuilder = ImmutableMap.builder();
 
         ConnectorAccessControl connectorAccessControl = getConnectorAccessControl(context.getTransactionId(), tableName.catalogName());
         if (connectorAccessControl != null) {
-            connectorAccessControl.getColumnMask(toConnectorSecurityContext(tableName.catalogName(), context), tableName.asSchemaTableName(), columnName, type)
-                    .ifPresent(masks::add);
+            Map<ColumnSchema, ViewExpression> connectorMasks = connectorAccessControl.getColumnMasks(toConnectorSecurityContext(tableName.catalogName(), context), tableName.asSchemaTableName(), columns);
+            columnMasksBuilder.putAll(connectorMasks);
         }
 
         for (SystemAccessControl systemAccessControl : getSystemAccessControls()) {
-            systemAccessControl.getColumnMask(context.toSystemSecurityContext(), tableName.asCatalogSchemaTableName(), columnName, type)
-                    .ifPresent(masks::add);
+            Map<ColumnSchema, ViewExpression> systemMasks = systemAccessControl.getColumnMasks(context.toSystemSecurityContext(), tableName.asCatalogSchemaTableName(), columns);
+            columnMasksBuilder.putAll(systemMasks);
         }
 
-        List<ViewExpression> allMasks = masks.build();
-        if (allMasks.size() > 1) {
-            throw new TrinoException(INVALID_COLUMN_MASK, format("Column must have a single mask: %s", columnName));
+        try {
+            return columnMasksBuilder.buildOrThrow();
         }
-
-        return allMasks.stream().findFirst();
+        catch (IllegalArgumentException exception) {
+            throw new TrinoException(INVALID_COLUMN_MASK, "Multiple masks for the same column found", exception);
+        }
     }
 
     private ConnectorAccessControl getConnectorAccessControl(TransactionId transactionId, String catalogName)

--- a/core/trino-main/src/main/java/io/trino/security/ForwardingAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/ForwardingAccessControl.java
@@ -17,6 +17,7 @@ import io.trino.metadata.QualifiedObjectName;
 import io.trino.spi.QueryId;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.ColumnSchema;
 import io.trino.spi.connector.EntityKindAndName;
 import io.trino.spi.connector.EntityPrivilege;
 import io.trino.spi.connector.SchemaTableName;
@@ -25,7 +26,6 @@ import io.trino.spi.security.Identity;
 import io.trino.spi.security.Privilege;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.security.ViewExpression;
-import io.trino.spi.type.Type;
 
 import java.security.Principal;
 import java.util.Collection;
@@ -531,8 +531,8 @@ public abstract class ForwardingAccessControl
     }
 
     @Override
-    public Optional<ViewExpression> getColumnMask(SecurityContext context, QualifiedObjectName tableName, String columnName, Type type)
+    public Map<ColumnSchema, ViewExpression> getColumnMasks(SecurityContext context, QualifiedObjectName tableName, List<ColumnSchema> columns)
     {
-        return delegate().getColumnMask(context, tableName, columnName, type);
+        return delegate().getColumnMasks(context, tableName, columns);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/security/InjectedConnectorAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/InjectedConnectorAccessControl.java
@@ -14,10 +14,12 @@
 package io.trino.security;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.ColumnSchema;
 import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorSecurityContext;
 import io.trino.spi.connector.SchemaRoutineName;
@@ -515,8 +517,19 @@ public class InjectedConnectorAccessControl
     public Optional<ViewExpression> getColumnMask(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
     {
         checkArgument(context == null, "context must be null");
-        if (accessControl.getColumnMask(securityContext, new QualifiedObjectName(catalogName, tableName.getSchemaName(), tableName.getTableName()), columnName, type).isEmpty()) {
+        ColumnSchema column = ColumnSchema.builder().setName(columnName).setType(type).build();
+        if (accessControl.getColumnMasks(securityContext, new QualifiedObjectName(catalogName, tableName.getSchemaName(), tableName.getTableName()), ImmutableList.of(column)).containsKey(column)) {
             return Optional.empty();
+        }
+        throw new TrinoException(NOT_SUPPORTED, "Column masking not supported");
+    }
+
+    @Override
+    public Map<ColumnSchema, ViewExpression> getColumnMasks(ConnectorSecurityContext context, SchemaTableName tableName, List<ColumnSchema> columns)
+    {
+        checkArgument(context == null, "context must be null");
+        if (accessControl.getColumnMasks(securityContext, new QualifiedObjectName(catalogName, tableName.getSchemaName(), tableName.getTableName()), columns).isEmpty()) {
+            return ImmutableMap.of();
         }
         throw new TrinoException(NOT_SUPPORTED, "Column masking not supported");
     }

--- a/core/trino-main/src/main/java/io/trino/security/ViewAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/ViewAccessControl.java
@@ -14,14 +14,13 @@
 package io.trino.security;
 
 import io.trino.metadata.QualifiedObjectName;
+import io.trino.spi.connector.ColumnSchema;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.security.AccessDeniedException;
 import io.trino.spi.security.ViewExpression;
-import io.trino.spi.type.Type;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.Verify.verify;
@@ -84,9 +83,9 @@ public class ViewAccessControl
     }
 
     @Override
-    public Optional<ViewExpression> getColumnMask(SecurityContext context, QualifiedObjectName tableName, String columnName, Type type)
+    public Map<ColumnSchema, ViewExpression> getColumnMasks(SecurityContext context, QualifiedObjectName tableName, List<ColumnSchema> columns)
     {
-        return delegate.getColumnMask(context, tableName, columnName, type);
+        return delegate.getColumnMasks(context, tableName, columns);
     }
 
     private static void wrapAccessDeniedException(Runnable runnable)

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -593,10 +593,8 @@ class StatementAnalyzer
                     .collect(toImmutableList());
             List<String> checkConstraints = tableSchema.tableSchema().getCheckConstraints();
 
-            for (ColumnSchema column : columns) {
-                if (accessControl.getColumnMask(session.toSecurityContext(), targetTable, column.getName(), column.getType()).isPresent()) {
-                    throw semanticException(NOT_SUPPORTED, insert, "Insert into table with column masks is not supported");
-                }
+            if (!accessControl.getColumnMasks(session.toSecurityContext(), targetTable, columns).isEmpty()) {
+                throw semanticException(NOT_SUPPORTED, insert, "Insert into table with column masks is not supported");
             }
 
             Map<String, ColumnHandle> columnHandles = metadata.getColumnHandles(session, targetTableHandle.get());
@@ -829,10 +827,8 @@ class StatementAnalyzer
             accessControl.checkCanDeleteFromTable(session.toSecurityContext(), tableName);
 
             TableSchema tableSchema = metadata.getTableSchema(session, handle);
-            for (ColumnSchema tableColumn : tableSchema.columns()) {
-                if (accessControl.getColumnMask(session.toSecurityContext(), tableName, tableColumn.getName(), tableColumn.getType()).isPresent()) {
-                    throw semanticException(NOT_SUPPORTED, node, "Delete from table with column mask");
-                }
+            if (!accessControl.getColumnMasks(session.toSecurityContext(), tableName, tableSchema.tableSchema().getColumns()).isEmpty()) {
+                throw semanticException(NOT_SUPPORTED, node, "Delete from table with column mask");
             }
 
             // Analyzer checks for select permissions but DELETE has a separate permission, so disable access checks
@@ -1256,10 +1252,8 @@ class StatementAnalyzer
             }
 
             TableMetadata tableMetadata = metadata.getTableMetadata(session, tableHandle);
-            for (ColumnMetadata tableColumn : tableMetadata.columns()) {
-                if (accessControl.getColumnMask(session.toSecurityContext(), tableName, tableColumn.getName(), tableColumn.getType()).isPresent()) {
-                    throw semanticException(NOT_SUPPORTED, node, "ALTER TABLE EXECUTE is not supported for table with column masks");
-                }
+            if (!accessControl.getColumnMasks(session.toSecurityContext(), tableName, tableMetadata.columns().stream().map(ColumnMetadata::getColumnSchema).collect(toImmutableList())).isEmpty()) {
+                throw semanticException(NOT_SUPPORTED, node, "ALTER TABLE EXECUTE is not supported for table with column masks");
             }
 
             Scope tableScope = analyze(table);
@@ -2381,15 +2375,25 @@ class StatementAnalyzer
 
         private void analyzeFiltersAndMasks(Table table, QualifiedObjectName name, RelationType relationType, Scope accessControlScope)
         {
+            ImmutableList.Builder<ColumnSchema> columnSchemaBuilder = ImmutableList.builder();
             for (int index = 0; index < relationType.getAllFieldCount(); index++) {
                 Field field = relationType.getFieldByIndex(index);
-                if (field.getName().isPresent()) {
-                    Optional<ViewExpression> mask = accessControl.getColumnMask(session.toSecurityContext(), name, field.getName().get(), field.getType());
+                field.getName().ifPresent(fieldName -> columnSchemaBuilder.add(ColumnSchema.builder()
+                        .setName(fieldName)
+                        .setType(field.getType())
+                        .setHidden(field.isHidden())
+                        .build()));
+            }
+            List<ColumnSchema> columnSchemas = columnSchemaBuilder.build();
 
-                    if (mask.isPresent() && checkCanSelectFromColumn(name, field.getName().orElseThrow())) {
-                        analyzeColumnMask(session.getIdentity().getUser(), table, name, field, accessControlScope, mask.get());
+            Map<ColumnSchema, ViewExpression> masks = accessControl.getColumnMasks(session.toSecurityContext(), name, columnSchemas);
+
+            for (ColumnSchema columnSchema : columnSchemas) {
+                Optional.ofNullable(masks.get(columnSchema)).ifPresent(mask -> {
+                    if (checkCanSelectFromColumn(name, columnSchema.getName())) {
+                        analyzeColumnMask(session.getIdentity().getUser(), table, name, columnSchema, accessControlScope, mask);
                     }
-                }
+                });
             }
 
             accessControl.getRowFilters(session.toSecurityContext(), name)
@@ -3398,10 +3402,8 @@ class StatementAnalyzer
 
             // TODO: how to deal with connectors that need to see the pre-image of rows to perform the update without
             //       flowing that data through the masking logic
-            for (ColumnSchema tableColumn : allColumns) {
-                if (accessControl.getColumnMask(session.toSecurityContext(), tableName, tableColumn.getName(), tableColumn.getType()).isPresent()) {
-                    throw semanticException(NOT_SUPPORTED, update, "Updating a table with column masks is not supported");
-                }
+            if (!accessControl.getColumnMasks(session.toSecurityContext(), tableName, tableSchema.columns()).isEmpty()) {
+                throw semanticException(NOT_SUPPORTED, update, "Updating a table with column masks is not supported");
             }
 
             List<ColumnSchema> updatedColumnSchemas = allColumns.stream()
@@ -3545,10 +3547,8 @@ class StatementAnalyzer
             analyzeCheckConstraints(table, tableName, targetTableScope, tableSchema.tableSchema().getCheckConstraints());
             analysis.registerTable(table, redirection.tableHandle(), tableName, session.getIdentity().getUser(), targetTableScope, Optional.empty());
 
-            for (ColumnSchema column : dataColumnSchemas) {
-                if (accessControl.getColumnMask(session.toSecurityContext(), tableName, column.getName(), column.getType()).isPresent()) {
-                    throw semanticException(NOT_SUPPORTED, merge, "Cannot merge into a table with column masks");
-                }
+            if (!accessControl.getColumnMasks(session.toSecurityContext(), tableName, tableSchema.columns()).isEmpty()) {
+                throw semanticException(NOT_SUPPORTED, merge, "Cannot merge into a table with column masks");
             }
 
             Map<String, ColumnHandle> allColumnHandles = metadata.getColumnHandles(session, targetTableHandle);
@@ -5198,9 +5198,9 @@ class StatementAnalyzer
             analysis.addCheckConstraints(table, expression);
         }
 
-        private void analyzeColumnMask(String currentIdentity, Table table, QualifiedObjectName tableName, Field field, Scope scope, ViewExpression mask)
+        private void analyzeColumnMask(String currentIdentity, Table table, QualifiedObjectName tableName, ColumnSchema columnSchema, Scope scope, ViewExpression mask)
         {
-            String column = field.getName().orElseThrow();
+            String column = columnSchema.getName();
             if (analysis.hasColumnMask(tableName, column, currentIdentity)) {
                 throw new TrinoException(INVALID_ROW_FILTER, extractLocation(table), format("Column mask for '%s.%s' is recursive", tableName, column), null);
             }
@@ -5244,13 +5244,13 @@ class StatementAnalyzer
 
             analysis.recordSubqueries(expression, expressionAnalysis);
 
-            Type expectedType = field.getType();
+            Type expectedType = columnSchema.getType();
             Type actualType = expressionAnalysis.getType(expression);
             if (!actualType.equals(expectedType)) {
                 TypeCoercion coercion = new TypeCoercion(plannerContext.getTypeManager()::getType);
 
-                if (!coercion.canCoerce(actualType, field.getType())) {
-                    throw new TrinoException(TYPE_MISMATCH, extractLocation(table), format("Expected column mask for '%s.%s' to be of type %s, but was %s", tableName, column, field.getType(), actualType), null);
+                if (!coercion.canCoerce(actualType, columnSchema.getType())) {
+                    throw new TrinoException(TYPE_MISMATCH, extractLocation(table), format("Expected column mask for '%s.%s' to be of type %s, but was %s", tableName, column, columnSchema.getType(), actualType), null);
                 }
 
                 // TODO: this should be "coercion.isTypeOnlyCoercion(actualType, expectedType)", but type-only coercions are broken

--- a/core/trino-main/src/main/java/io/trino/testing/TestingAccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingAccessControlManager.java
@@ -26,10 +26,10 @@ import io.trino.security.SecurityContext;
 import io.trino.spi.QueryId;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.ColumnSchema;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.security.Identity;
 import io.trino.spi.security.ViewExpression;
-import io.trino.spi.type.Type;
 import io.trino.transaction.TransactionManager;
 
 import java.security.Principal;
@@ -739,13 +739,16 @@ public class TestingAccessControlManager
     }
 
     @Override
-    public Optional<ViewExpression> getColumnMask(SecurityContext context, QualifiedObjectName tableName, String column, Type type)
+    public Map<ColumnSchema, ViewExpression> getColumnMasks(SecurityContext context, QualifiedObjectName tableName, List<ColumnSchema> columns)
     {
-        ViewExpression mask = columnMasks.get(new ColumnMaskKey(context.getIdentity().getUser(), tableName, column));
-        if (mask != null) {
-            return Optional.of(mask);
-        }
-        return super.getColumnMask(context, tableName, column, type);
+        Map<ColumnSchema, ViewExpression> superResult = super.getColumnMasks(context, tableName, columns);
+        return columns.stream()
+                .flatMap(column ->
+                    Optional.ofNullable(columnMasks.get(new ColumnMaskKey(context.getIdentity().getUser(), tableName, column.getName())))
+                            .or(() -> Optional.ofNullable(superResult.get(column)))
+                            .map(viewExpression -> Map.entry(column, viewExpression))
+                            .stream())
+                .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     private boolean shouldDenyPrivilege(String actorName, String entityName, TestingPrivilegeType verb)

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingAccessControl.java
@@ -23,6 +23,7 @@ import io.trino.security.SecurityContext;
 import io.trino.spi.QueryId;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.ColumnSchema;
 import io.trino.spi.connector.EntityKindAndName;
 import io.trino.spi.connector.EntityPrivilege;
 import io.trino.spi.connector.SchemaTableName;
@@ -31,7 +32,6 @@ import io.trino.spi.security.Identity;
 import io.trino.spi.security.Privilege;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.security.ViewExpression;
-import io.trino.spi.type.Type;
 
 import java.security.Principal;
 import java.util.Collection;
@@ -774,11 +774,11 @@ public class TracingAccessControl
     }
 
     @Override
-    public Optional<ViewExpression> getColumnMask(SecurityContext context, QualifiedObjectName tableName, String columnName, Type type)
+    public Map<ColumnSchema, ViewExpression> getColumnMasks(SecurityContext context, QualifiedObjectName tableName, List<ColumnSchema> columns)
     {
-        Span span = startSpan("getColumnMask");
+        Span span = startSpan("getColumnMasks");
         try (var _ = scopedSpan(span)) {
-            return delegate.getColumnMask(context, tableName, columnName, type);
+            return delegate.getColumnMasks(context, tableName, columns);
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnectorAccessControl.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnectorAccessControl.java
@@ -15,21 +15,23 @@ package io.trino.connector;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.plugin.base.security.AllowAllAccessControl;
+import io.trino.spi.connector.ColumnSchema;
 import io.trino.spi.connector.ConnectorSecurityContext;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.security.ConnectorIdentity;
 import io.trino.spi.security.Privilege;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.security.ViewExpression;
-import io.trino.spi.type.Type;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.spi.security.AccessDeniedException.denyGrantSchemaPrivilege;
 import static io.trino.spi.security.AccessDeniedException.denyGrantTablePrivilege;
@@ -130,9 +132,12 @@ class MockConnectorAccessControl
     }
 
     @Override
-    public Optional<ViewExpression> getColumnMask(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
+    public Map<ColumnSchema, ViewExpression> getColumnMasks(ConnectorSecurityContext context, SchemaTableName tableName, List<ColumnSchema> columns)
     {
-        return Optional.ofNullable(columnMasks.apply(tableName, columnName));
+        return columns.stream()
+                .map(column -> Map.entry(column, Optional.ofNullable(columnMasks.apply(tableName, column.getName()))))
+                .filter(entry -> entry.getValue().isPresent())
+                .collect(toImmutableMap(Map.Entry::getKey, entry -> entry.getValue().orElseThrow()));
     }
 
     public void grantSchemaPrivileges(String schemaName, Set<Privilege> privileges, TrinoPrincipal grantee, boolean grantOption)

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorAccessControl.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorAccessControl.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static io.trino.spi.security.AccessDeniedException.denyAddColumn;
 import static io.trino.spi.security.AccessDeniedException.denyAlterColumn;
@@ -701,9 +702,27 @@ public interface ConnectorAccessControl
      * must be written in terms of columns in the table.
      *
      * @return the mask if present, or empty if not applicable
+     * @deprecated use {@link #getColumnMasks(ConnectorSecurityContext, SchemaTableName, List)}
      */
+    @Deprecated
     default Optional<ViewExpression> getColumnMask(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
     {
         return Optional.empty();
+    }
+
+    /**
+     * Bulk method for getting column masks for a subset of columns in a table.
+     * <p>
+     * Each mask must be a scalar SQL expression of a type coercible to the type of the column being masked. The expression
+     * must be written in terms of columns in the table.
+     *
+     * @return a mapping from columns to masks. The keys of the return Map are a subset of {@code columns}.
+     */
+    default Map<ColumnSchema, ViewExpression> getColumnMasks(ConnectorSecurityContext context, SchemaTableName tableName, List<ColumnSchema> columns)
+    {
+        return columns.stream()
+                .map(column -> Map.entry(column, getColumnMask(context, tableName, column.getName(), column.getType())))
+                .filter(entry -> entry.getValue().isPresent())
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().get()));
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/security/SystemAccessControl.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/SystemAccessControl.java
@@ -17,6 +17,7 @@ import io.trino.spi.QueryId;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.CatalogSchemaRoutineName;
 import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.ColumnSchema;
 import io.trino.spi.connector.EntityKindAndName;
 import io.trino.spi.connector.EntityPrivilege;
 import io.trino.spi.connector.SchemaTableName;
@@ -947,10 +948,28 @@ public interface SystemAccessControl
      * must be written in terms of columns in the table.
      *
      * @return the mask if present, or empty if not applicable
+     * @deprecated use {@link #getColumnMasks(SystemSecurityContext, CatalogSchemaTableName, List)}
      */
+    @Deprecated
     default Optional<ViewExpression> getColumnMask(SystemSecurityContext context, CatalogSchemaTableName tableName, String columnName, Type type)
     {
         return Optional.empty();
+    }
+
+    /**
+     * Bulk method for getting column masks for a subset of columns in a table.
+     * <p>
+     * Each mask must be a scalar SQL expression of a type coercible to the type of the column being masked. The expression
+     * must be written in terms of columns in the table.
+     *
+     * @return a mapping from columns to masks. The keys of the return Map are a subset of {@code columns}.
+     */
+    default Map<ColumnSchema, ViewExpression> getColumnMasks(SystemSecurityContext context, CatalogSchemaTableName tableName, List<ColumnSchema> columns)
+    {
+        return columns.stream()
+                .map(column -> Map.entry(column, getColumnMask(context, tableName, column.getName(), column.getType())))
+                .filter(entry -> entry.getValue().isPresent())
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().get()));
     }
 
     /**

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorAccessControl.java
@@ -15,6 +15,7 @@ package io.trino.plugin.base.classloader;
 
 import com.google.inject.Inject;
 import io.trino.spi.classloader.ThreadContextClassLoader;
+import io.trino.spi.connector.ColumnSchema;
 import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorSecurityContext;
 import io.trino.spi.connector.SchemaRoutineName;
@@ -570,6 +571,14 @@ public class ClassLoaderSafeConnectorAccessControl
     {
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
             return delegate.getColumnMask(context, tableName, columnName, type);
+        }
+    }
+
+    @Override
+    public Map<ColumnSchema, ViewExpression> getColumnMasks(ConnectorSecurityContext context, SchemaTableName tableName, List<ColumnSchema> columns)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getColumnMasks(context, tableName, columns);
         }
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllAccessControl.java
@@ -14,6 +14,8 @@
 package io.trino.plugin.base.security;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.spi.connector.ColumnSchema;
 import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorSecurityContext;
 import io.trino.spi.connector.SchemaRoutineName;
@@ -249,5 +251,11 @@ public class AllowAllAccessControl
     public Optional<ViewExpression> getColumnMask(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
     {
         return Optional.empty();
+    }
+
+    @Override
+    public Map<ColumnSchema, ViewExpression> getColumnMasks(ConnectorSecurityContext context, SchemaTableName tableName, List<ColumnSchema> columns)
+    {
+        return ImmutableMap.of();
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllSystemAccessControl.java
@@ -13,11 +13,13 @@
  */
 package io.trino.plugin.base.security;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.spi.QueryId;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.CatalogSchemaRoutineName;
 import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.ColumnSchema;
 import io.trino.spi.connector.EntityKindAndName;
 import io.trino.spi.connector.EntityPrivilege;
 import io.trino.spi.connector.SchemaTableName;
@@ -355,6 +357,12 @@ public class AllowAllSystemAccessControl
     public Optional<ViewExpression> getColumnMask(SystemSecurityContext context, CatalogSchemaTableName tableName, String columnName, Type type)
     {
         return Optional.empty();
+    }
+
+    @Override
+    public Map<ColumnSchema, ViewExpression> getColumnMasks(SystemSecurityContext context, CatalogSchemaTableName tableName, List<ColumnSchema> columns)
+    {
+        return ImmutableMap.of();
     }
 
     @Override

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
@@ -14,10 +14,12 @@
 package io.trino.plugin.base.security;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.plugin.base.security.TableAccessControlRule.TablePrivilege;
 import io.trino.spi.TrinoException;
 import io.trino.spi.catalog.CatalogName;
+import io.trino.spi.connector.ColumnSchema;
 import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorSecurityContext;
 import io.trino.spi.connector.SchemaRoutineName;
@@ -745,6 +747,30 @@ public class FileBasedAccessControl
         }
 
         return masks.stream().findFirst();
+    }
+
+    @Override
+    public Map<ColumnSchema, ViewExpression> getColumnMasks(ConnectorSecurityContext context, SchemaTableName tableName, List<ColumnSchema> columns)
+    {
+        if (INFORMATION_SCHEMA_NAME.equals(tableName.getSchemaName())) {
+            return ImmutableMap.of();
+        }
+
+        ConnectorIdentity identity = context.getIdentity();
+        try {
+            return columns.stream()
+                    .flatMap(columnSchema -> tableRules.stream()
+                            .filter(rule -> rule.matches(identity.getUser(), identity.getEnabledSystemRoles(), identity.getGroups(), tableName))
+                            .map(rule -> rule.getColumnMask(catalogName, tableName.getSchemaName(), columnSchema.getName()))
+                            .findFirst()
+                            .stream()
+                            .flatMap(Optional::stream)
+                            .map(viewExpression -> Map.entry(columnSchema, viewExpression)))
+                    .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+        }
+        catch (IllegalArgumentException exception) {
+            throw new TrinoException(INVALID_COLUMN_MASK, "Multiple column masks defined for the same column", exception);
+        }
     }
 
     private boolean canSetSessionProperty(ConnectorSecurityContext context, String property)

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.base.security;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
@@ -25,6 +26,7 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.CatalogSchemaRoutineName;
 import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.ColumnSchema;
 import io.trino.spi.connector.EntityKindAndName;
 import io.trino.spi.connector.EntityPrivilege;
 import io.trino.spi.connector.SchemaTableName;
@@ -48,6 +50,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.trino.plugin.base.security.CatalogAccessControlRule.AccessMode.ALL;
@@ -1087,6 +1090,31 @@ public class FileBasedSystemAccessControl
         }
 
         return masks.stream().findFirst();
+    }
+
+    @Override
+    public Map<ColumnSchema, ViewExpression> getColumnMasks(SystemSecurityContext context, CatalogSchemaTableName table, List<ColumnSchema> columns)
+    {
+        SchemaTableName tableName = table.getSchemaTableName();
+        if (INFORMATION_SCHEMA_NAME.equals(tableName.getSchemaName())) {
+            return ImmutableMap.of();
+        }
+
+        Identity identity = context.getIdentity();
+        try {
+            return columns.stream()
+                    .flatMap(columnSchema -> tableRules.stream()
+                            .filter(rule -> rule.matches(identity.getUser(), identity.getEnabledRoles(), identity.getGroups(), table))
+                            .map(rule -> rule.getColumnMask(table.getCatalogName(), tableName.getSchemaName(), columnSchema.getName()))
+                            .findFirst()
+                            .stream()
+                            .flatMap(Optional::stream)
+                            .map(viewExpression -> Map.entry(columnSchema, viewExpression)))
+                    .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+        }
+        catch (IllegalArgumentException exception) {
+            throw new TrinoException(INVALID_COLUMN_MASK, "Multiple column masks defined for the same column", exception);
+        }
     }
 
     private boolean checkAnyCatalogAccess(SystemSecurityContext context, String catalogName)

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingConnectorAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingConnectorAccessControl.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.base.security;
 
+import io.trino.spi.connector.ColumnSchema;
 import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorSecurityContext;
 import io.trino.spi.connector.SchemaRoutineName;
@@ -445,5 +446,11 @@ public abstract class ForwardingConnectorAccessControl
     public Optional<ViewExpression> getColumnMask(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
     {
         return delegate().getColumnMask(context, tableName, columnName, type);
+    }
+
+    @Override
+    public Map<ColumnSchema, ViewExpression> getColumnMasks(ConnectorSecurityContext context, SchemaTableName tableName, List<ColumnSchema> columns)
+    {
+        return delegate().getColumnMasks(context, tableName, columns);
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingSystemAccessControl.java
@@ -17,6 +17,7 @@ import io.trino.spi.QueryId;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.CatalogSchemaRoutineName;
 import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.ColumnSchema;
 import io.trino.spi.connector.EntityKindAndName;
 import io.trino.spi.connector.EntityPrivilege;
 import io.trino.spi.connector.SchemaTableName;
@@ -560,6 +561,12 @@ public abstract class ForwardingSystemAccessControl
     public Optional<ViewExpression> getColumnMask(SystemSecurityContext context, CatalogSchemaTableName tableName, String columnName, Type type)
     {
         return delegate().getColumnMask(context, tableName, columnName, type);
+    }
+
+    @Override
+    public Map<ColumnSchema, ViewExpression> getColumnMasks(SystemSecurityContext context, CatalogSchemaTableName tableName, List<ColumnSchema> columns)
+    {
+        return delegate().getColumnMasks(context, tableName, columns);
     }
 
     @Override

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/BaseFileBasedSystemAccessControlTest.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/BaseFileBasedSystemAccessControlTest.java
@@ -21,6 +21,7 @@ import io.trino.spi.QueryId;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.CatalogSchemaRoutineName;
 import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.ColumnSchema;
 import io.trino.spi.connector.SchemaRoutineName;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.function.SchemaFunctionName;
@@ -42,7 +43,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.io.Files.copy;
 import static io.trino.spi.security.PrincipalType.ROLE;
 import static io.trino.spi.security.PrincipalType.USER;
@@ -1352,6 +1355,47 @@ public abstract class BaseFileBasedSystemAccessControlTest
                         .schema("bobschema")
                         .expression("'mask-with-user'")
                         .build());
+    }
+
+    @Test
+    public void testGetColumnMasks()
+    {
+        SystemAccessControl accessControl = newFileBasedSystemAccessControl("file-based-system-access-table.json");
+        ImmutableList<ColumnSchema> columns = Stream.of("private", "restricted", "masked", "masked_with_user")
+                .map(BaseFileBasedSystemAccessControlTest::createColumnSchema)
+                .collect(toImmutableList());
+
+        assertThat(accessControl.getColumnMasks(
+                 ALICE,
+                 new CatalogSchemaTableName("some-catalog", "bobschema", "bobcolumns"),
+                 columns)).isEmpty();
+
+        Map<ColumnSchema, ViewExpression> charlieColumnMasks = accessControl.getColumnMasks(
+                 CHARLIE,
+                 new CatalogSchemaTableName("some-catalog", "bobschema", "bobcolumns"),
+                 columns);
+        assertThat(charlieColumnMasks).doesNotContainKey(createColumnSchema("private"));
+        assertThat(charlieColumnMasks).doesNotContainKey(createColumnSchema("restricted"));
+        assertViewExpressionEquals(
+                charlieColumnMasks.get(createColumnSchema("masked")),
+                ViewExpression.builder()
+                        .catalog("some-catalog")
+                        .schema("bobschema")
+                        .expression("'mask'")
+                        .build());
+        assertViewExpressionEquals(
+                charlieColumnMasks.get(createColumnSchema("masked_with_user")),
+                 ViewExpression.builder()
+                        .identity("mask-user")
+                        .catalog("some-catalog")
+                        .schema("bobschema")
+                        .expression("'mask-with-user'")
+                        .build());
+    }
+
+    public static ColumnSchema createColumnSchema(String columnName)
+    {
+        return ColumnSchema.builder().setName(columnName).setType(VARCHAR).build();
     }
 
     @Test

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControl.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControl.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.hive.security;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import io.trino.plugin.hive.metastore.Database;
@@ -21,6 +22,7 @@ import io.trino.plugin.hive.metastore.HivePrincipal;
 import io.trino.plugin.hive.metastore.HivePrivilegeInfo;
 import io.trino.spi.TrinoException;
 import io.trino.spi.catalog.CatalogName;
+import io.trino.spi.connector.ColumnSchema;
 import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorSecurityContext;
 import io.trino.spi.connector.SchemaRoutineName;
@@ -648,6 +650,12 @@ public class SqlStandardAccessControl
     public Optional<ViewExpression> getColumnMask(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
     {
         return Optional.empty();
+    }
+
+    @Override
+    public Map<ColumnSchema, ViewExpression> getColumnMasks(ConnectorSecurityContext context, SchemaTableName tableName, List<ColumnSchema> columns)
+    {
+        return ImmutableMap.of();
     }
 
     private boolean isAdmin(ConnectorSecurityContext context)

--- a/plugin/trino-opa/pom.xml
+++ b/plugin/trino-opa/pom.xml
@@ -55,6 +55,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>trace-token</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaConfig.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaConfig.java
@@ -30,6 +30,7 @@ public class OpaConfig
     private boolean allowPermissionManagementOperations;
     private Optional<URI> opaRowFiltersUri = Optional.empty();
     private Optional<URI> opaColumnMaskingUri = Optional.empty();
+    private Optional<URI> opaBatchColumnMaskingUri = Optional.empty();
 
     @NotNull
     public URI getOpaUri()
@@ -123,6 +124,20 @@ public class OpaConfig
     public OpaConfig setOpaColumnMaskingUri(URI opaColumnMaskingUri)
     {
         this.opaColumnMaskingUri = Optional.ofNullable(opaColumnMaskingUri);
+        return this;
+    }
+
+    @NotNull
+    public Optional<URI> getOpaBatchColumnMaskingUri()
+    {
+        return opaBatchColumnMaskingUri;
+    }
+
+    @Config("opa.policy.batch-column-masking-uri")
+    @ConfigDescription("URI for fetching batch column masks - if not set column-masking-uri will be used")
+    public OpaConfig setOpaBatchColumnMaskingUri(URI opaBatchColumnMaskingUri)
+    {
+        this.opaBatchColumnMaskingUri = Optional.ofNullable(opaBatchColumnMaskingUri);
         return this;
     }
 }

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaHighLevelClient.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaHighLevelClient.java
@@ -14,8 +14,10 @@
 package io.trino.plugin.opa;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.airlift.json.JsonCodec;
+import io.trino.plugin.opa.schema.OpaBatchColumnMaskQueryResult;
 import io.trino.plugin.opa.schema.OpaColumnMaskQueryResult;
 import io.trino.plugin.opa.schema.OpaQueryContext;
 import io.trino.plugin.opa.schema.OpaQueryInput;
@@ -27,16 +29,19 @@ import io.trino.plugin.opa.schema.OpaViewExpression;
 import io.trino.plugin.opa.schema.TrinoColumn;
 import io.trino.plugin.opa.schema.TrinoTable;
 import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.ColumnSchema;
 import io.trino.spi.security.AccessDeniedException;
-import io.trino.spi.type.Type;
 
 import java.net.URI;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Objects.requireNonNull;
 
 public class OpaHighLevelClient
@@ -44,26 +49,31 @@ public class OpaHighLevelClient
     private final JsonCodec<OpaQueryResult> queryResultCodec;
     private final JsonCodec<OpaRowFiltersQueryResult> rowFiltersQueryResultCodec;
     private final JsonCodec<OpaColumnMaskQueryResult> columnMaskQueryResultCodec;
+    private final JsonCodec<OpaBatchColumnMaskQueryResult> batchColumnMaskQueryResultCodec;
     private final OpaHttpClient opaHttpClient;
     private final URI opaPolicyUri;
     private final Optional<URI> opaRowFiltersUri;
     private final Optional<URI> opaColumnMaskingUri;
+    private final Optional<URI> opaBatchColumnMaskingUri;
 
     @Inject
     public OpaHighLevelClient(
             JsonCodec<OpaQueryResult> queryResultCodec,
             JsonCodec<OpaRowFiltersQueryResult> rowFiltersQueryResultCodec,
             JsonCodec<OpaColumnMaskQueryResult> columnMaskQueryResultCodec,
+            JsonCodec<OpaBatchColumnMaskQueryResult> batchColumnMaskQueryResultCodec,
             OpaHttpClient opaHttpClient,
             OpaConfig config)
     {
         this.queryResultCodec = requireNonNull(queryResultCodec, "queryResultCodec is null");
         this.rowFiltersQueryResultCodec = requireNonNull(rowFiltersQueryResultCodec, "rowFiltersQueryResultCodec is null");
         this.columnMaskQueryResultCodec = requireNonNull(columnMaskQueryResultCodec, "columnMaskQueryResultCodec is null");
+        this.batchColumnMaskQueryResultCodec = requireNonNull(batchColumnMaskQueryResultCodec, "batchColumnMaskQueryResultCodec is null");
         this.opaHttpClient = requireNonNull(opaHttpClient, "opaHttpClient is null");
         this.opaPolicyUri = config.getOpaUri();
         this.opaRowFiltersUri = config.getOpaRowFiltersUri();
         this.opaColumnMaskingUri = config.getOpaColumnMaskingUri();
+        this.opaBatchColumnMaskingUri = config.getOpaBatchColumnMaskingUri();
     }
 
     public boolean queryOpa(OpaQueryInput input)
@@ -138,21 +148,42 @@ public class OpaHighLevelClient
                 .orElse(ImmutableList.of());
     }
 
-    public Optional<OpaViewExpression> getColumnMaskFromOpa(OpaQueryContext context, CatalogSchemaTableName table, String columnName, Type type)
+    public Map<ColumnSchema, OpaViewExpression> getColumnMasksFromOpa(OpaQueryContext context, CatalogSchemaTableName table, List<ColumnSchema> columns)
     {
-        OpaQueryInput queryInput = new OpaQueryInput(
-                context,
-                OpaQueryInputAction.builder()
-                        .operation("GetColumnMask")
-                        .resource(OpaQueryInputResource.builder().column(new TrinoColumn(table, columnName, type)).build())
-                        .build());
-        return opaColumnMaskingUri
-                .flatMap(uri -> opaHttpClient.consumeOpaResponse(opaHttpClient.submitOpaRequest(queryInput, uri, columnMaskQueryResultCodec)).result());
+        return opaBatchColumnMaskingUri.map(batchUri -> getBatchColumnMasksFromOpa(batchUri, context, table, columns))
+                .or(() -> opaColumnMaskingUri.map(maskUri -> getParallelColumnMasksFromOpa(maskUri, context, table, columns)))
+                .orElse(ImmutableMap.of());
     }
 
     public static OpaQueryInput buildQueryInputForSimpleResource(OpaQueryContext context, String operation, OpaQueryInputResource resource)
     {
         return new OpaQueryInput(context, OpaQueryInputAction.builder().operation(operation).resource(resource).build());
+    }
+
+    private Map<ColumnSchema, OpaViewExpression> getBatchColumnMasksFromOpa(URI uri, OpaQueryContext context, CatalogSchemaTableName table, List<ColumnSchema> columns)
+    {
+        OpaQueryInput input = new OpaQueryInput(context, OpaQueryInputAction.builder()
+                .operation("GetColumnMask")
+                .filterResources(columns.stream().map(column -> OpaQueryInputResource.builder().column(new TrinoColumn(table, column.getName(), column.getType())).build()).collect(toImmutableList()))
+                .build());
+        OpaBatchColumnMaskQueryResult result = opaHttpClient.consumeOpaResponse(opaHttpClient.submitOpaRequest(input, uri, batchColumnMaskQueryResultCodec));
+
+        return result.result().stream()
+                .collect(toImmutableMap(item -> columns.get(item.index()), OpaBatchColumnMaskQueryResult.OpaBatchColumnMaskQueryResultItem::viewExpression));
+    }
+
+    private Map<ColumnSchema, OpaViewExpression> getParallelColumnMasksFromOpa(URI uri, OpaQueryContext context, CatalogSchemaTableName table, List<ColumnSchema> columns)
+    {
+        return opaHttpClient.parallelColumnMasksFromOpa(
+                columns,
+                column -> new OpaQueryInput(
+                        context,
+                        OpaQueryInputAction.builder()
+                                .operation("GetColumnMask")
+                                .resource(OpaQueryInputResource.builder().column(new TrinoColumn(table, column.getName(), column.getType())).build())
+                                .build()),
+                uri,
+                columnMaskQueryResultCodec);
     }
 
     private static OpaQueryInput buildQueryInputForSimpleAction(OpaQueryContext context, String operation)

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/schema/OpaBatchColumnMaskQueryResult.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/schema/OpaBatchColumnMaskQueryResult.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.opa.schema;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public record OpaBatchColumnMaskQueryResult(@JsonProperty("decision_id") String decisionId, List<OpaBatchColumnMaskQueryResultItem> result)
+{
+    public OpaBatchColumnMaskQueryResult
+    {
+        requireNonNull(result, "result is null");
+    }
+
+    public record OpaBatchColumnMaskQueryResultItem(int index, OpaViewExpression viewExpression) {}
+}

--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/QueryRunnerHelper.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/QueryRunnerHelper.java
@@ -13,14 +13,21 @@
  */
 package io.trino.plugin.opa;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
 import io.trino.spi.security.Identity;
+import io.trino.testing.MaterializedResult;
+import io.trino.testing.MaterializedRow;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.StandaloneQueryRunner;
 import org.intellij.lang.annotations.Language;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.plugin.opa.TestHelpers.opaConfigToDict;
 import static io.trino.testing.TestingSession.testSession;
@@ -50,7 +57,32 @@ public final class QueryRunnerHelper
 
     public Set<String> querySetOfStrings(Session session, @Language("SQL") String query)
     {
-        return runner.execute(session, query).getMaterializedRows().stream().map(row -> row.getField(0) == null ? "<NULL>" : row.getField(0).toString()).collect(toImmutableSet());
+        return runner.execute(session, query).getOnlyColumnAsSet().stream().map(QueryRunnerHelper::getFieldValueAsString).collect(toImmutableSet());
+    }
+
+    public Map<String, Set<String>> queryColumnsAsSetOfStrings(String user, @Language("SQL") String query)
+    {
+        return queryColumnsAsSetOfStrings(userSession(user), query);
+    }
+
+    public Map<String, Set<String>> queryColumnsAsSetOfStrings(Session session, @Language("SQL") String query)
+    {
+        MaterializedResult result = runner.execute(session, query);
+        List<String> columnNames = result.getColumnNames();
+        ImmutableMap<String, ImmutableSet.Builder<String>> columnarBuilders = columnNames
+                .stream()
+                .map(columName -> Map.entry(columName, ImmutableSet.<String>builder()))
+                .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+        for (MaterializedRow row : result.getMaterializedRows()) {
+            for (int index = 0; index < row.getFieldCount(); ++index) {
+                columnarBuilders.get(columnNames.get(index)).add(getFieldValueAsString(row.getField(index)));
+            }
+        }
+        return columnarBuilders
+                .entrySet()
+                .stream()
+                .map(entry -> Map.entry(entry.getKey(), entry.getValue().build()))
+                .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     public QueryRunner getBaseQueryRunner()
@@ -66,5 +98,10 @@ public final class QueryRunnerHelper
     private static Session userSession(String user)
     {
         return testSessionBuilder().setOriginalIdentity(Identity.ofUser(user)).setIdentity(Identity.ofUser(user)).build();
+    }
+
+    private static String getFieldValueAsString(Object field)
+    {
+        return field == null ? "<NULL>" : field.toString();
     }
 }

--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestConstants.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestConstants.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableSet;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
 import io.trino.execution.QueryIdGenerator;
+import io.trino.spi.connector.CatalogSchemaTableName;
 import io.trino.spi.security.Identity;
 import io.trino.spi.security.SystemAccessControlFactory;
 import io.trino.spi.security.SystemSecurityContext;
@@ -56,6 +57,7 @@ public final class TestConstants
     public static final URI OPA_COLUMN_MASKING_URI = URI.create("http://my-column-masking-uri/");
     public static final Identity TEST_IDENTITY = Identity.forUser("source-user").withGroups(ImmutableSet.of("some-group")).build();
     public static final SystemSecurityContext TEST_SECURITY_CONTEXT = new SystemSecurityContext(TEST_IDENTITY, new QueryIdGenerator().createNextQueryId(), Instant.now());
+    public static final CatalogSchemaTableName TEST_COLUMN_MASKING_TABLE_NAME = new CatalogSchemaTableName("some_catalog", "some_schema", "some_table");
 
     public static OpaConfig simpleOpaConfig()
     {
@@ -96,13 +98,13 @@ public final class TestConstants
         @Override
         public OpenTelemetry getOpenTelemetry()
         {
-            return null;
+            return OpenTelemetry.noop();
         }
 
         @Override
         public Tracer getTracer()
         {
-            return null;
+            return OpenTelemetry.noop().getTracer("TEST_TRACER");
         }
     }
 }

--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaAccessControl.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaAccessControl.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.opa;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -26,6 +27,7 @@ import io.trino.plugin.opa.schema.OpaViewExpression;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.CatalogSchemaRoutineName;
 import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.ColumnSchema;
 import io.trino.spi.security.Identity;
 import io.trino.spi.security.PrincipalType;
 import io.trino.spi.security.SystemAccessControlFactory;
@@ -41,23 +43,36 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.plugin.opa.RequestTestUtilities.assertStringRequestsEqual;
 import static io.trino.plugin.opa.RequestTestUtilities.buildValidatingRequestHandler;
+import static io.trino.plugin.opa.TestConstants.BAD_REQUEST_RESPONSE;
+import static io.trino.plugin.opa.TestConstants.MALFORMED_RESPONSE;
 import static io.trino.plugin.opa.TestConstants.NO_ACCESS_RESPONSE;
 import static io.trino.plugin.opa.TestConstants.OK_RESPONSE;
 import static io.trino.plugin.opa.TestConstants.OPA_COLUMN_MASKING_URI;
 import static io.trino.plugin.opa.TestConstants.OPA_ROW_FILTERING_URI;
 import static io.trino.plugin.opa.TestConstants.OPA_SERVER_URI;
+import static io.trino.plugin.opa.TestConstants.SERVER_ERROR_RESPONSE;
+import static io.trino.plugin.opa.TestConstants.TEST_COLUMN_MASKING_TABLE_NAME;
 import static io.trino.plugin.opa.TestConstants.TEST_IDENTITY;
 import static io.trino.plugin.opa.TestConstants.TEST_SECURITY_CONTEXT;
+import static io.trino.plugin.opa.TestConstants.UNDEFINED_RESPONSE;
 import static io.trino.plugin.opa.TestConstants.columnMaskingOpaConfig;
 import static io.trino.plugin.opa.TestConstants.rowFilteringOpaConfig;
 import static io.trino.plugin.opa.TestConstants.simpleOpaConfig;
 import static io.trino.plugin.opa.TestHelpers.assertAccessControlMethodThrowsForIllegalResponses;
 import static io.trino.plugin.opa.TestHelpers.assertAccessControlMethodThrowsForResponse;
+import static io.trino.plugin.opa.TestHelpers.assertAccessControlMethodThrowsForResponseHandler;
+import static io.trino.plugin.opa.TestHelpers.createColumnSchema;
 import static io.trino.plugin.opa.TestHelpers.createMockHttpClient;
 import static io.trino.plugin.opa.TestHelpers.createOpaAuthorizer;
+import static io.trino.plugin.opa.TestHelpers.createResponseHandlerForParallelColumnMasking;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestOpaAccessControl
@@ -642,8 +657,7 @@ public class TestOpaAccessControl
     @Test
     public void testGetRowFiltersThrowsForIllegalResponse()
     {
-        CatalogSchemaTableName tableName = new CatalogSchemaTableName("some_catalog", "some_schema", "some_table");
-        Consumer<OpaAccessControl> methodUnderTest = authorizer -> authorizer.getRowFilters(TEST_SECURITY_CONTEXT, tableName);
+        Consumer<OpaAccessControl> methodUnderTest = authorizer -> authorizer.getRowFilters(TEST_SECURITY_CONTEXT, TEST_COLUMN_MASKING_TABLE_NAME);
         assertAccessControlMethodThrowsForIllegalResponses(methodUnderTest, rowFilteringOpaConfig(), OPA_ROW_FILTERING_URI);
 
         // Also test a valid JSON response, but containing invalid fields for a row filters request
@@ -707,9 +721,8 @@ public class TestOpaAccessControl
     {
         InstrumentedHttpClient httpClient = createMockHttpClient(OPA_ROW_FILTERING_URI, buildValidatingRequestHandler(TEST_IDENTITY, new MockResponse(responseContent, 200)));
         OpaAccessControl authorizer = createOpaAuthorizer(rowFilteringOpaConfig(), httpClient);
-        CatalogSchemaTableName tableName = new CatalogSchemaTableName("some_catalog", "some_schema", "some_table");
 
-        List<ViewExpression> result = authorizer.getRowFilters(TEST_SECURITY_CONTEXT, tableName);
+        List<ViewExpression> result = authorizer.getRowFilters(TEST_SECURITY_CONTEXT, TEST_COLUMN_MASKING_TABLE_NAME);
         assertThat(result).allSatisfy(expression -> {
             assertThat(expression.getCatalog()).contains("some_catalog");
             assertThat(expression.getSchema()).contains("some_schema");
@@ -720,17 +733,20 @@ public class TestOpaAccessControl
                         viewExpression.getSecurityIdentity()))
                 .containsExactlyInAnyOrderElementsOf(expectedExpressions);
 
-        String expectedRequest = """
+        String expectedRequest = String.format("""
                 {
                     "operation": "GetRowFilters",
                     "resource": {
                         "table": {
-                            "catalogName": "some_catalog",
-                            "schemaName": "some_schema",
-                            "tableName": "some_table"
+                            "catalogName": "%s",
+                            "schemaName": "%s",
+                            "tableName": "%s"
                         }
                     }
-                }""";
+                }""",
+                TEST_COLUMN_MASKING_TABLE_NAME.getCatalogName(),
+                TEST_COLUMN_MASKING_TABLE_NAME.getSchemaTableName().getSchemaName(),
+                TEST_COLUMN_MASKING_TABLE_NAME.getSchemaTableName().getTableName());
         assertStringRequestsEqual(ImmutableSet.of(expectedRequest), httpClient.getRequests(), "/input/action");
     }
 
@@ -743,21 +759,129 @@ public class TestOpaAccessControl
                     throw new AssertionError("Should not have been called");
                 });
         OpaAccessControl authorizer = createOpaAuthorizer(simpleOpaConfig(), httpClient);
-        CatalogSchemaTableName tableName = new CatalogSchemaTableName("some_catalog", "some_schema", "some_table");
 
-        List<ViewExpression> result = authorizer.getRowFilters(TEST_SECURITY_CONTEXT, tableName);
+        List<ViewExpression> result = authorizer.getRowFilters(TEST_SECURITY_CONTEXT, TEST_COLUMN_MASKING_TABLE_NAME);
+        assertThat(result).isEmpty();
+        assertThat(httpClient.getRequests()).isEmpty();
+    }
+
+    /**
+     * `SystemAccessControl#getColumnMask` is deprecated in favour of `getColumnMasks`.
+     * We don't implement this function, it is provided as a default by the interface.
+     * We test that it is a no-op if called.
+     */
+    @Test
+    public void testGetColumnMaskDoesNothing()
+    {
+        InstrumentedHttpClient httpClient = createMockHttpClient(
+                OPA_SERVER_URI,
+                _ -> {
+                    throw new AssertionError("Should not have been called");
+                });
+        OpaAccessControl authorizer = createOpaAuthorizer(simpleOpaConfig(), httpClient);
+
+        Optional<ViewExpression> result = authorizer.getColumnMask(TEST_SECURITY_CONTEXT, TEST_COLUMN_MASKING_TABLE_NAME, "some_column", VarcharType.VARCHAR);
         assertThat(result).isEmpty();
         assertThat(httpClient.getRequests()).isEmpty();
     }
 
     @Test
-    public void testGetColumnMaskThrowsForIllegalResponse()
+    public void testGetColumnMasks()
     {
-        CatalogSchemaTableName tableName = new CatalogSchemaTableName("some_catalog", "some_schema", "some_table");
-        Consumer<OpaAccessControl> methodUnderTest = authorizer -> authorizer.getColumnMask(TEST_SECURITY_CONTEXT, tableName, "some_column", VarcharType.VARCHAR);
-        assertAccessControlMethodThrowsForIllegalResponses(methodUnderTest, columnMaskingOpaConfig(), OPA_COLUMN_MASKING_URI);
+        testGetColumnMasks(ImmutableMap.of(createColumnSchema("some-column"), "{}"), ImmutableMap.of());
 
-        // Also test a valid JSON response, but containing invalid fields for a row filters request
+        String nullResponse = """
+                {
+                    "result": null
+                }""";
+        testGetColumnMasks(ImmutableMap.of(createColumnSchema("some-column"), nullResponse), ImmutableMap.of());
+
+        Map<ColumnSchema, String> expressionWithoutIdentityResponses = IntStream.range(1, 10)
+                .mapToObj(index -> Map.entry(
+                        createColumnSchema(String.format("some-column-%d", index)),
+                        String.format("""
+                        {
+                            "result": {"expression": "expression-%d"}
+                        }""", index)))
+                .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+        testGetColumnMasks(
+                expressionWithoutIdentityResponses,
+                IntStream.range(1, 10).mapToObj(index -> Map.entry(
+                        createColumnSchema(String.format("some-column-%d", index)),
+                        new OpaViewExpression(String.format("expression-%d", index), Optional.empty())
+                )).collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)));
+
+        Map<ColumnSchema, String> expressionWithIdentityResponses = IntStream.range(1, 10)
+                .mapToObj(index -> Map.entry(
+                        createColumnSchema(String.format("some-column-%d", index)),
+                        String.format("""
+                        {
+                            "result": {"expression": "expression-%1$d", "identity": "some_identity-%1$d"}
+                        }""", index)))
+                .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+        testGetColumnMasks(
+                expressionWithIdentityResponses,
+                IntStream.range(1, 10).mapToObj(index -> Map.entry(
+                        createColumnSchema(String.format("some-column-%d", index)),
+                        new OpaViewExpression(String.format("expression-%d", index), Optional.of(String.format("some_identity-%d", index)))
+                )).collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)));
+
+        Map<ColumnSchema, String> mixedExpressions = ImmutableMap.of(
+                createColumnSchema("some-column-1"), "{}",
+                createColumnSchema("some-column-2"), nullResponse,
+                createColumnSchema("some-column-3"), """
+                        {
+                            "result": {"expression": "expression-1"}
+                        }""",
+                createColumnSchema("some-column-4"), """
+                        {
+                            "result": {"expression": "expression-2", "identity": "some_identity-1"}
+                        }""");
+        testGetColumnMasks(
+                mixedExpressions,
+                ImmutableMap.of(
+                        createColumnSchema("some-column-3"), new OpaViewExpression("expression-1", Optional.empty()),
+                        createColumnSchema("some-column-4"), new OpaViewExpression("expression-2", Optional.of("some_identity-1"))));
+    }
+
+    @Test
+    public void testGetColumnMasksDoesNothingIfNotConfigured()
+    {
+        InstrumentedHttpClient httpClient = createMockHttpClient(
+                OPA_SERVER_URI,
+                request -> {
+                    throw new AssertionError("Should not have been called");
+                });
+
+        OpaAccessControl authorizer = createOpaAuthorizer(simpleOpaConfig(), httpClient);
+
+        Map<ColumnSchema, ViewExpression> result = authorizer.getColumnMasks(TEST_SECURITY_CONTEXT, TEST_COLUMN_MASKING_TABLE_NAME,
+                Stream.of("some_column_1", "another_column_2").map(TestHelpers::createColumnSchema).collect(toImmutableList()));
+        assertThat(result).isEmpty();
+        assertThat(httpClient.getRequests()).isEmpty();
+    }
+
+    @Test
+    public void testGetColumnMasksThrowsForIllegalResponse()
+    {
+        OpaConfig opaConfig = columnMaskingOpaConfig();
+
+        List<ColumnSchema> tableColumnSchemas = Stream.of("some_column_1", "other_column_2", "illegal_response_column").map(TestHelpers::createColumnSchema).collect(toImmutableList());
+        Consumer<OpaAccessControl> methodUnderTest = authorizer -> authorizer.getColumnMasks(TEST_SECURITY_CONTEXT, TEST_COLUMN_MASKING_TABLE_NAME, tableColumnSchemas);
+        assertAccessControlMethodThrowsForIllegalResponses(methodUnderTest, opaConfig, OPA_COLUMN_MASKING_URI);
+
+        // Test invalid JSON response for just one of the columns
+        assertAccessControlMethodThrowsForResponseHandler(
+                createResponseHandlerForParallelColumnMasking(ImmutableMap.of(createColumnSchema("illegal_response_column"), UNDEFINED_RESPONSE)),
+                OPA_COLUMN_MASKING_URI, opaConfig, methodUnderTest, OpaQueryException.OpaServerError.PolicyNotFound.class, "did not return a value");
+        assertAccessControlMethodThrowsForResponseHandler(
+                createResponseHandlerForParallelColumnMasking(ImmutableMap.of(createColumnSchema("illegal_response_column"), BAD_REQUEST_RESPONSE)), OPA_COLUMN_MASKING_URI, opaConfig, methodUnderTest, OpaQueryException.OpaServerError.class, "returned status 400");
+        assertAccessControlMethodThrowsForResponseHandler(
+                createResponseHandlerForParallelColumnMasking(ImmutableMap.of(createColumnSchema("illegal_response_column"), SERVER_ERROR_RESPONSE)), OPA_COLUMN_MASKING_URI, opaConfig, methodUnderTest, OpaQueryException.OpaServerError.class, "returned status 500");
+        assertAccessControlMethodThrowsForResponseHandler(
+                createResponseHandlerForParallelColumnMasking(ImmutableMap.of(createColumnSchema("illegal_response_column"), MALFORMED_RESPONSE)), OPA_COLUMN_MASKING_URI, opaConfig, methodUnderTest, OpaQueryException.class, "Failed to deserialize");
+
+        // Also test a valid JSON response that contains invalid fields
         String validJsonButIllegalSchemaResponseContents = """
                 {
                     "result": {"expression": {"foo": "bar"}}
@@ -770,88 +894,57 @@ public class TestOpaAccessControl
                 methodUnderTest,
                 OpaQueryException.class,
                 "Failed to deserialize");
+
+        // Same test with only one column having the valid but illegal JSON response
+        assertAccessControlMethodThrowsForResponseHandler(
+                createResponseHandlerForParallelColumnMasking(ImmutableMap.of(createColumnSchema("illegal_response_column"), response)),
+                OPA_COLUMN_MASKING_URI,
+                opaConfig,
+                methodUnderTest,
+                OpaQueryException.class,
+                "Failed to deserialize");
     }
 
-    @Test
-    public void testGetColumnMask()
-    {
-        // Similar note to the test for row level filtering:
-        // This example is a bit strange - an undefined policy would in most cases
-        // result in an access denied situation. However, since this is column masking,
-        // we will accept this as meaning there are no masks to be applied.
-        testGetColumnMask("{}", Optional.empty());
-
-        String nullResponse = """
-                {
-                    "result": null
-                }""";
-        testGetColumnMask(nullResponse, Optional.empty());
-
-        String expressionWithoutIdentityResponse = """
-                {
-                    "result": {"expression": "expr1"}
-                }""";
-        testGetColumnMask(
-                expressionWithoutIdentityResponse,
-                Optional.of(new OpaViewExpression("expr1", Optional.empty())));
-
-        String expressionWithIdentityResponse = """
-                {
-                    "result": {"expression": "expr1", "identity": "some_identity"}
-                }""";
-        testGetColumnMask(
-                expressionWithIdentityResponse,
-                Optional.of(new OpaViewExpression("expr1", Optional.of("some_identity"))));
-    }
-
-    private void testGetColumnMask(String responseContent, Optional<OpaViewExpression> expectedExpression)
+    private void testGetColumnMasks(Map<ColumnSchema, String> columnResponseContent, Map<ColumnSchema, OpaViewExpression> expectedResult)
     {
         InstrumentedHttpClient httpClient = createMockHttpClient(
                 OPA_COLUMN_MASKING_URI,
-                buildValidatingRequestHandler(TEST_IDENTITY, new MockResponse(responseContent, 200)));
+                buildValidatingRequestHandler(TEST_IDENTITY, createResponseHandlerForParallelColumnMasking(columnResponseContent.entrySet().stream()
+                                .collect(toImmutableMap(Map.Entry::getKey, entry -> new MockResponse(entry.getValue(), 200))))));
         OpaAccessControl authorizer = createOpaAuthorizer(columnMaskingOpaConfig(), httpClient);
 
-        CatalogSchemaTableName tableName = new CatalogSchemaTableName("some_catalog", "some_schema", "some_table");
+        Map<ColumnSchema, ViewExpression> result = authorizer.getColumnMasks(TEST_SECURITY_CONTEXT, TEST_COLUMN_MASKING_TABLE_NAME, ImmutableList.copyOf(columnResponseContent.keySet()));
 
-        Optional<ViewExpression> result = authorizer.getColumnMask(TEST_SECURITY_CONTEXT, tableName, "some_column", VarcharType.VARCHAR);
+        assertColumnMaskBehaviour(columnResponseContent.keySet().stream().map(ColumnSchema::getName).collect(toImmutableList()), result, expectedResult, httpClient.getRequests());
+    }
 
-        assertThat(result.isEmpty()).isEqualTo(expectedExpression.isEmpty());
-        assertThat(result.map(viewExpression -> {
-            assertThat(viewExpression.getCatalog()).contains("some_catalog");
-            assertThat(viewExpression.getSchema()).contains("some_schema");
-            return new OpaViewExpression(viewExpression.getExpression(), viewExpression.getSecurityIdentity());
-        })).isEqualTo(expectedExpression);
+    private void assertColumnMaskBehaviour(List<String> columnNames, Map<ColumnSchema, ViewExpression> actualResult, Map<ColumnSchema, OpaViewExpression> expectedResult, List<JsonNode> requests)
+    {
+        assertThat(actualResult.entrySet().stream().map(entry -> {
+            ViewExpression viewExpression = entry.getValue();
+            assertThat(viewExpression.getCatalog()).contains(TEST_COLUMN_MASKING_TABLE_NAME.getCatalogName());
+            assertThat(viewExpression.getSchema()).contains(TEST_COLUMN_MASKING_TABLE_NAME.getSchemaTableName().getSchemaName());
+            return Map.entry(entry.getKey(), new OpaViewExpression(viewExpression.getExpression(), viewExpression.getSecurityIdentity()));
+        })).containsExactlyInAnyOrderElementsOf(expectedResult.entrySet());
 
-        String expectedRequest = """
+        Set<String> expectedRequests = columnNames.stream().map(columnName -> String.format("""
                 {
                     "operation": "GetColumnMask",
                     "resource": {
                         "column": {
-                            "catalogName": "some_catalog",
-                            "schemaName": "some_schema",
-                            "tableName": "some_table",
-                            "columnName": "some_column",
+                            "catalogName": "%s",
+                            "schemaName": "%s",
+                            "tableName": "%s",
+                            "columnName": "%s",
                             "columnType": "varchar"
                         }
                     }
-                }""";
-        assertStringRequestsEqual(ImmutableSet.of(expectedRequest), httpClient.getRequests(), "/input/action");
-    }
-
-    @Test
-    public void testGetColumnMaskDoesNothingIfNotConfigured()
-    {
-        InstrumentedHttpClient httpClient = createMockHttpClient(
-                OPA_SERVER_URI,
-                request -> {
-                    throw new AssertionError("Should not have been called");
-                });
-        OpaAccessControl authorizer = createOpaAuthorizer(simpleOpaConfig(), httpClient);
-        CatalogSchemaTableName tableName = new CatalogSchemaTableName("some_catalog", "some_schema", "some_table");
-
-        Optional<ViewExpression> result = authorizer.getColumnMask(TEST_SECURITY_CONTEXT, tableName, "some_column", VarcharType.VARCHAR);
-        assertThat(result).isEmpty();
-        assertThat(httpClient.getRequests()).isEmpty();
+                }""",
+                TEST_COLUMN_MASKING_TABLE_NAME.getCatalogName(),
+                TEST_COLUMN_MASKING_TABLE_NAME.getSchemaTableName().getSchemaName(),
+                TEST_COLUMN_MASKING_TABLE_NAME.getSchemaTableName().getTableName(),
+                columnName)).collect(toImmutableSet());
+        assertStringRequestsEqual(expectedRequests, requests, "/input/action");
     }
 
     private static void assertAccessControlMethodBehaviour(MethodWrapper method, Set<String> expectedRequests)

--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaConfig.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaConfig.java
@@ -33,6 +33,7 @@ public class TestOpaConfig
                 .setOpaBatchUri(null)
                 .setOpaRowFiltersUri(null)
                 .setOpaColumnMaskingUri(null)
+                .setOpaBatchColumnMaskingUri(null)
                 .setLogRequests(false)
                 .setLogResponses(false)
                 .setAllowPermissionManagementOperations(false));
@@ -46,6 +47,7 @@ public class TestOpaConfig
                 .put("opa.policy.batched-uri", "https://opa-batch.example.com")
                 .put("opa.policy.row-filters-uri", "https://opa-row-filtering.example.com")
                 .put("opa.policy.column-masking-uri", "https://opa-column-masking.example.com")
+                .put("opa.policy.batch-column-masking-uri", "https://opa-column-masking.example.com")
                 .put("opa.log-requests", "true")
                 .put("opa.log-responses", "true")
                 .put("opa.allow-permission-management-operations", "true")
@@ -56,6 +58,7 @@ public class TestOpaConfig
                 .setOpaBatchUri(URI.create("https://opa-batch.example.com"))
                 .setOpaRowFiltersUri(URI.create("https://opa-row-filtering.example.com"))
                 .setOpaColumnMaskingUri(URI.create("https://opa-column-masking.example.com"))
+                .setOpaBatchColumnMaskingUri(URI.create("https://opa-column-masking.example.com"))
                 .setLogRequests(true)
                 .setLogResponses(true)
                 .setAllowPermissionManagementOperations(true);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Addresses issues raised in https://github.com/trinodb/trino/issues/21359.

Adds the `getTableColumnMasks` function to the SPI

```java
Map<ColumnSchema, ViewExpression> getTableColumnMasks(ConnectorSecurityContext context, SchemaTableName tableName, List<ColumnSchema> columns);
```

(which defaults to calling `getColumnMask` repeatedly) that `SystemAcessControl`/`ConnectorAccessControl` plugins can implement to process column mask requests in batches.

Updates the `StatementAnalyzer` and `AccessControl` to use this batched method of getting column masks whenever possible (which is all cases).

The issue linked above goes into the performance implications.

This PR updates the OPA plugin to implement the new SPI function with 2 modes of operation:

- Sending requests to fetch each column mask in parallel; This is a drop-in improvement that doesn't require any config/Rego changes.
- Using a new `batchColumnMasksUri` OPA Server endpoint that delegates collection of column masks to the Rego policy code; This requires changes to the Rego code running on the OPA server and the Trino configs.

> For the latter mode, the following Rego rule can be added (assuming the `columnMask` rule is already implemented) to quickly add support for batched column masks. This approach isn't particularly efficient (the `with` operator in Rego can be costly) and I haven't had the time to benchmark.
>  ```rego
>  batchColumnMasks contains {
>     "index": i,
>     "viewExpression": cm
> } if {
>    some i
>    cm := columnMask with input.action.resource.column as input.action.filterResources[i].
>  }
> ```

> Later edit: did some testing on using the above "trick" - it is very slow (column masks for 1k columns took on avg. 16 seconds to compute). So DO NOT USE THIS IN PRODUCTION. The parallel mode (which this PR enables by default) is much faster.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

https://github.com/trinodb/trino/issues/21359



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
