### PR TITLE
Jwt Token Invalidated at logout so that some endpoints cannot be accessed with previous jwt token

### DIFF
--- a/core/trino-main/src/test/java/io/trino/server/ui/TestWebUi.java
+++ b/core/trino-main/src/test/java/io/trino/server/ui/TestWebUi.java
@@ -298,6 +298,7 @@ public class TestWebUi
     private void testLogIn(URI baseUri, String username, String password, boolean sendPassword)
             throws Exception
     {
+        Thread.sleep(1000);
         CookieManager cookieManager = new CookieManager();
         OkHttpClient client = this.client.newBuilder()
                 .cookieJar(new JavaNetCookieJar(cookieManager))
@@ -396,6 +397,7 @@ public class TestWebUi
     private void testUserMapping(URI baseUri, String username, String password, boolean sendPassword)
             throws Exception
     {
+        Thread.sleep(1000);
         OkHttpClient client = this.client.newBuilder()
                 .cookieJar(new JavaNetCookieJar(new CookieManager()))
                 .build();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



When a user logged off from the UI, a malicious user can send request with the existing cookie of the user. The admin UI still authenticate as a valid user.

Mainly in endpoint, http://trino-host:8080/ui/api/query , http://trino-host:8080/ui/api/cluster , http://trino-host:8080/ui/api/stats the malicious user can see the query details.
Even thought jwt Token is bind with Cookie and the the token Expiry time can be set as short-lived token. Still if an user logged off before that, it still an issue as malicious user can see the query details by hitting http://trino-host:8080/ui/api/query .

Fixes #21783 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
