### PR TITLE
Apply workaround for JDK-8329528

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -11,3 +11,4 @@
 --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
 -XX:+UnlockDiagnosticVMOptions
 -XX:+ExitOnOutOfMemoryError
+-XX:G1NumCollectionsKeepPinned=10000000

--- a/core/docker/default/etc/jvm.config
+++ b/core/docker/default/etc/jvm.config
@@ -14,3 +14,6 @@
 -Djdk.nio.maxCachedBufferSize=2000000
 # Allow loading dynamic agent used by JOL
 -XX:+EnableDynamicAgentLoading
+-XX:+UnlockDiagnosticVMOptions
+# https://bugs.openjdk.org/browse/JDK-8329528
+-XX:G1NumCollectionsKeepPinned=10000000

--- a/core/trino-main/src/main/java/io/trino/server/TrinoSystemRequirements.java
+++ b/core/trino-main/src/main/java/io/trino/server/TrinoSystemRequirements.java
@@ -29,11 +29,15 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
+import static java.util.regex.Pattern.quote;
 
 final class TrinoSystemRequirements
 {
@@ -49,6 +53,7 @@ final class TrinoSystemRequirements
         verifyOsArchitecture();
         verifyByteOrder();
         verifyUsingG1Gc();
+        verifyJdk8329528Workaround();
         verifyFileDescriptor();
         verifySlice();
         verifyUtf8();
@@ -118,6 +123,17 @@ final class TrinoSystemRequirements
         }
     }
 
+    private static void verifyJdk8329528Workaround()
+    {
+        if (Runtime.version().compareTo(Version.parse("22.0.2")) < 0) {
+            Optional<String> collectionsKeepPinned = getJvmConfigurationFlag("XX:G1NumCollectionsKeepPinned");
+            int requiredValue = 10000000;
+            if (collectionsKeepPinned.isEmpty() || collectionsKeepPinned.map(Integer::parseInt).orElse(0) < requiredValue) {
+                failRequirement("Trino requires -XX:+UnlockDiagnosticVMOptions -XX:G1NumCollectionsKeepPinned=%d on Java versions lower than 22.0.2 due to JDK-8329528", requiredValue);
+            }
+        }
+    }
+
     private static void verifyFileDescriptor()
     {
         OptionalLong maxFileDescriptorCount = getMaxFileDescriptorCount();
@@ -172,6 +188,18 @@ final class TrinoSystemRequirements
         if (currentYear < 2022) {
             failRequirement("Trino requires the system time to be current (found year %s)", currentYear);
         }
+    }
+
+    private static Optional<String> getJvmConfigurationFlag(String pattern)
+    {
+        Pattern compiled = Pattern.compile("-%s=(.*)".formatted(quote(pattern)), Pattern.DOTALL);
+        return ManagementFactory.getRuntimeMXBean()
+                .getInputArguments()
+                .stream()
+                .map(compiled::matcher)
+                .filter(Matcher::matches)
+                .map(matcher -> matcher.group(1))
+                .findFirst();
     }
 
     @FormatMethod

--- a/core/trino-main/src/main/java/io/trino/server/TrinoSystemRequirements.java
+++ b/core/trino-main/src/main/java/io/trino/server/TrinoSystemRequirements.java
@@ -99,7 +99,7 @@ final class TrinoSystemRequirements
 
     private static void verifyJavaVersion()
     {
-        Version required = Version.parse("21.0.1");
+        Version required = Version.parse("22.0.1");
 
         if (Runtime.version().compareTo(required) < 0) {
             failRequirement("Trino requires Java %s at minimum (found %s)", required, Runtime.version());

--- a/core/trino-server-rpm/src/main/resources/dist/config/jvm.config
+++ b/core/trino-server-rpm/src/main/resources/dist/config/jvm.config
@@ -13,3 +13,6 @@
 -Djdk.nio.maxCachedBufferSize=2000000
 # Allow loading dynamic agent used by JOL
 -XX:+EnableDynamicAgentLoading
+-XX:+UnlockDiagnosticVMOptions
+# https://bugs.openjdk.org/browse/JDK-8329528
+-XX:G1NumCollectionsKeepPinned=10000000

--- a/core/trino-server-rpm/src/test/java/io/trino/server/rpm/ServerIT.java
+++ b/core/trino-server-rpm/src/test/java/io/trino/server/rpm/ServerIT.java
@@ -75,8 +75,8 @@ public class ServerIT
             throws Exception
     {
         // Release names as in the https://api.adoptium.net/q/swagger-ui/#/Release%20Info/getReleaseNames
-        testInstall("jdk-22+36", "/usr/lib/jvm/temurin-22", "22");
-        testUninstall("jdk-22+36", "/usr/lib/jvm/temurin-22");
+        testInstall("jdk-22.0.1+8", "/usr/lib/jvm/temurin-22", "22");
+        testUninstall("jdk-22.0.1+8", "/usr/lib/jvm/temurin-22");
     }
 
     private void testInstall(String temurinReleaseName, String javaHome, String expectedJavaVersion)

--- a/docs/src/main/sphinx/installation/deployment.md
+++ b/docs/src/main/sphinx/installation/deployment.md
@@ -144,6 +144,9 @@ The following provides a good starting point for creating `etc/jvm.config`:
 -Dfile.encoding=UTF-8
 # Allow loading dynamic agent used by JOL
 -XX:+EnableDynamicAgentLoading
+# https://bugs.openjdk.org/browse/JDK-8329528
+-XX:+UnlockDiagnosticVMOptions
+-XX:G1NumCollectionsKeepPinned=10000000
 ```
 
 You must adjust the value for the memory used by Trino, specified with `-Xmx`

--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,8 @@
             -XX:+UnlockDiagnosticVMOptions
             <!-- # Allow loading dynamic agent used by JOL -->
             -XX:+EnableDynamicAgentLoading
+            <!-- workaround for JDK-8329528 -->
+            -XX:G1NumCollectionsKeepPinned=10000000
             ${extraJavaVectorArgs}
         </air.test.jvm.additional-arguments.default>
         <air.test.jvm.additional-arguments>${air.test.jvm.additional-arguments.default}</air.test.jvm.additional-arguments>

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-all/jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-all/jvm.config
@@ -17,3 +17,7 @@
 -XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
 # Allow loading dynamic agent used by JOL
 -XX:+EnableDynamicAgentLoading
+-XX:+ExitOnOutOfMemoryError
+-XX:+UnlockDiagnosticVMOptions
+# https://bugs.openjdk.org/browse/JDK-8329528
+-XX:G1NumCollectionsKeepPinned=10000000

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-ignite/jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-ignite/jvm.config
@@ -17,3 +17,6 @@
 -XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
 # Allow loading dynamic agent used by JOL
 -XX:+EnableDynamicAgentLoading
+-XX:+UnlockDiagnosticVMOptions
+# https://bugs.openjdk.org/browse/JDK-8329528
+-XX:G1NumCollectionsKeepPinned=10000000

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-snowflake/jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-snowflake/jvm.config
@@ -16,3 +16,6 @@
 -XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
 # Allow loading dynamic agent used by JOL
 -XX:+EnableDynamicAgentLoading
+-XX:+UnlockDiagnosticVMOptions
+# https://bugs.openjdk.org/browse/JDK-8329528
+-XX:G1NumCollectionsKeepPinned=10000000

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode/multinode-master-jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode/multinode-master-jvm.config
@@ -15,3 +15,6 @@
 -XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
 # Allow loading dynamic agent used by JOL
 -XX:+EnableDynamicAgentLoading
+-XX:+UnlockDiagnosticVMOptions
+# https://bugs.openjdk.org/browse/JDK-8329528
+-XX:G1NumCollectionsKeepPinned=10000000

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode/multinode-worker-jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode/multinode-worker-jvm.config
@@ -14,3 +14,6 @@
 -XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
 # Allow loading dynamic agent used by JOL
 -XX:+EnableDynamicAgentLoading
+-XX:+UnlockDiagnosticVMOptions
+# https://bugs.openjdk.org/browse/JDK-8329528
+-XX:G1NumCollectionsKeepPinned=10000000

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/presto/etc/jvm-pre-jdk22.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/presto/etc/jvm-pre-jdk22.config
@@ -17,5 +17,3 @@
 # Allow loading dynamic agent used by JOL
 -XX:+EnableDynamicAgentLoading
 -XX:+UnlockDiagnosticVMOptions
-# https://bugs.openjdk.org/browse/JDK-8329528
--XX:G1NumCollectionsKeepPinned=10000000


### PR DESCRIPTION
https://bugs.openjdk.org/browse/JDK-8329528

`G1NumCollectionsKeepPinned`: "After how many GCs a region has been found pinned G1 should  give up reclaiming it."

Fixes https://github.com/trinodb/trino/issues/21989

This flag defaults to 8: https://github.com/openjdk/jdk22u/blob/f5ce46f27e5489234d1305e0573e42898c9e9e32/src/hotspot/share/gc/g1/g1_globals.hpp#L327

More info:
https://github.com/openjdk/jdk22u/blob/f5ce46f27e5489234d1305e0573e42898c9e9e32/src/hotspot/share/gc/g1/g1CollectionSet.cpp#L370