### PR TITLE
Account for local exchanges in getDefaultBucketCount

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/TaskManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TaskManagerConfig.java
@@ -48,6 +48,8 @@ import static java.math.BigDecimal.TWO;
 })
 public class TaskManagerConfig
 {
+    public static final int MAX_WRITER_COUNT = 64;
+
     private boolean threadPerDriverSchedulerEnabled = true;
     private boolean perOperatorCpuTimerEnabled = true;
     private boolean taskCpuTimerEnabled = true;
@@ -88,7 +90,7 @@ public class TaskManagerConfig
     // available processor. Whereas, on the worker nodes due to more available processors, the default value could
     // be above 1. Therefore, it can cause error due to config mismatch during execution. Additionally, cap
     // it to 64 in order to avoid small pages produced by local partitioning exchanges.
-    private int maxWriterCount = clamp(nextPowerOfTwo(getAvailablePhysicalProcessorCount() * 2), 2, 64);
+    private int maxWriterCount = clamp(nextPowerOfTwo(getAvailablePhysicalProcessorCount() * 2), 2, MAX_WRITER_COUNT);
     // Default value of task concurrency should be above 1, otherwise it can create a plan with a single gather
     // exchange node on the coordinator due to a single available processor. Whereas, on the worker nodes due to
     // more available processors, the default value could be above 1. Therefore, it can cause error due to config

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchange.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchange.java
@@ -66,7 +66,7 @@ import static java.util.function.Function.identity;
 @ThreadSafe
 public class LocalExchange
 {
-    private static final int SCALE_WRITERS_MAX_PARTITIONS_PER_WRITER = 128;
+    public static final int SCALE_WRITERS_MAX_PARTITIONS_PER_WRITER = 128;
 
     private final Supplier<LocalExchanger> exchangerSupplier;
 


### PR DESCRIPTION

## Description

    The default bucket count is used by both remote and local
    exchanges to assign buckets to nodes and drivers.

Follow up of https://github.com/trinodb/trino/pull/21977

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
