### PR TITLE
Reuse temp variables in Row Constructor code

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/gen/RowConstructorCodeGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/RowConstructorCodeGenerator.java
@@ -72,11 +72,13 @@ public class RowConstructorCodeGenerator
 
         Variable fieldBlocks = scope.createTempVariable(Block[].class);
         block.append(fieldBlocks.set(newArray(type(Block[].class), arguments.size())));
+        // Cache local variable declarations per java type on stack for reuse
+        Map<Class<?>, Variable> javaTypeTempVariables = new HashMap<>();
 
         Variable blockBuilder = scope.createTempVariable(BlockBuilder.class);
         for (int i = 0; i < arguments.size(); ++i) {
             Type fieldType = types.get(i);
-            Variable field = scope.createTempVariable(fieldType.getJavaType());
+            Variable field = javaTypeTempVariables.computeIfAbsent(fieldType.getJavaType(), scope::createTempVariable);
 
             block.append(blockBuilder.set(constantType(binder, fieldType).invoke(
                     "createBlockBuilder",


### PR DESCRIPTION
## Description
Allows reusing temporary variables with the same on-stack type across fields in RowConstructorCodeGenerator. This approach is already taken in the large row codepath and can reduce the generated code size when multiple fields have the same matching type.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Related change in PR https://github.com/airlift/bytecode/pull/18 so that this style of variable reuse can be extended to share temp variables between different code generators producing code within the same method scope.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
