### PR TITLE
Reuse more variables in row constructors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -671,7 +671,7 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>bytecode</artifactId>
-                <version>1.5</version>
+                <version>1.6</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Updates `airlift/bytecode` to 1.6 and then modifies `RowConstructorCodeGenerator` to reuse variables within the same
method scope instead of just locally within the same row constructor instance. This can significantly reduce the generated code size for complex expressions involving multiple row constructors within them.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Uses https://github.com/airlift/bytecode/pull/18 to reduce `RowConstructorCodeGenerator` code size


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
