### PR TITLE
Make it easier to use AWS classes as a custom credentials provider

### DIFF
--- a/docs/src/main/sphinx/object-storage/legacy-s3.md
+++ b/docs/src/main/sphinx/object-storage/legacy-s3.md
@@ -132,6 +132,11 @@ rotate credentials on a regular basis without any additional work on your part.
 
 ## Custom S3 credentials provider
 
+A custom credentials provider can be used to provide temporary credentials from
+STS (using `STSSessionCredentialsProvider`), IAM role-based credentials (using
+`STSAssumeRoleSessionCredentialsProvider`), or credentials for a specific use
+case (e.g., bucket/user specific credentials).
+
 You can configure a custom S3 credentials provider by setting the configuration
 property `trino.s3.credentials-provider` to the fully qualified class name of
 a custom AWS credentials provider implementation. The property must be set in
@@ -140,12 +145,10 @@ connector property.
 
 The class must implement the
 [AWSCredentialsProvider](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/AWSCredentialsProvider.html)
-interface and provide a two-argument constructor that takes a
-`java.net.URI` and a Hadoop `org.apache.hadoop.conf.Configuration`
-as arguments. A custom credentials provider can be used to provide
-temporary credentials from STS (using `STSSessionCredentialsProvider`),
-IAM role-based credentials (using `STSAssumeRoleSessionCredentialsProvider`),
-or credentials for a specific use case (e.g., bucket/user specific credentials).
+interface and provide one of the following:
+* A two-argument constructor that takes a `java.net.URI` and a Hadoop
+  `org.apache.hadoop.conf.Configuration` as arguments.
+* A constructor without any arguments.
 
 (hive-s3-security-mapping)=
 

--- a/lib/trino-hdfs/src/test/java/io/trino/hdfs/s3/TestTrinoS3FileSystem.java
+++ b/lib/trino-hdfs/src/test/java/io/trino/hdfs/s3/TestTrinoS3FileSystem.java
@@ -22,6 +22,7 @@ import com.amazonaws.auth.AWSSessionCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+import com.amazonaws.auth.WebIdentityTokenCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3EncryptionClient;
 import com.amazonaws.services.s3.S3ClientOptions;
@@ -573,10 +574,18 @@ public class TestTrinoS3FileSystem
             throws Exception
     {
         Configuration config = new Configuration(false);
+        // use a class which constructor takes a URI and a Configuration object
         config.set(S3_CREDENTIALS_PROVIDER, TestCredentialsProvider.class.getName());
         try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
             fs.initialize(new URI("s3n://test-bucket/"), config);
             assertInstanceOf(getAwsCredentialsProvider(fs), TestCredentialsProvider.class);
+        }
+
+        // use a class which constructor doesn't take any arguments
+        config.set(S3_CREDENTIALS_PROVIDER, WebIdentityTokenCredentialsProvider.class.getName());
+        try (TrinoS3FileSystem fs = new TrinoS3FileSystem()) {
+            fs.initialize(new URI("s3n://test-bucket/"), config);
+            assertInstanceOf(getAwsCredentialsProvider(fs), WebIdentityTokenCredentialsProvider.class);
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The `trino.s3.credentials-provider` configuration property allows specifying a class used as the credentials provider, but it requires the class to have a constructor that accepts a URI and a Configuration object. The AWS SDK classes implementing `AWSCredentialsProvider` have constructors without any arguments, so to use them, a wrapper class had to be created, and an extra JAR had to be added to the deployment.

Trying to instantiate the custom credentials provider class without any arguments makes it easier to pin to exactly one provider without using the default providers chain.

This actually makes the docs correct, because it already mentioned using providers from the AWS SDK, which was not possible without a wrapper class.

This at least makes the workaround for #15267 easier, I'm not sure if it will allow closing that issue.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
