### PR TITLE
Revert "Limit product tests Trino nodes memory"

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/DockerContainer.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/DockerContainer.java
@@ -26,7 +26,6 @@ import dev.failsafe.FailsafeExecutor;
 import dev.failsafe.Timeout;
 import dev.failsafe.function.CheckedRunnable;
 import io.airlift.log.Logger;
-import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.testing.containers.ConditionalPullPolicy;
 import org.testcontainers.containers.BindMode;
@@ -222,13 +221,6 @@ public class DockerContainer
 
         return withCopyFileToContainer(forHostPath(healthCheckScript), "/usr/local/bin/health.sh")
                 .withCreateContainerCmdModifier(command -> command.withHealthcheck(cmd));
-    }
-
-    public DockerContainer withMemoryLimit(DataSize limit)
-    {
-        return withCreateContainerCmdModifier(command ->
-                command.withHostConfig(requireNonNull(command.getHostConfig(), "hostConfig is null")
-                        .withMemory(limit.toBytes())));
     }
 
     /**

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Standard.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Standard.java
@@ -16,7 +16,6 @@ package io.trino.tests.product.launcher.env.common;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
-import io.airlift.units.DataSize;
 import io.trino.tests.product.launcher.docker.DockerFiles;
 import io.trino.tests.product.launcher.env.Debug;
 import io.trino.tests.product.launcher.env.DockerContainer;
@@ -47,7 +46,6 @@ import java.util.regex.Pattern;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.net.UrlEscapers.urlFragmentEscaper;
-import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.OPENTRACING_COLLECTOR;
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.TESTS;
@@ -67,9 +65,6 @@ public final class Standard
         implements EnvironmentExtender
 {
     private static final Logger log = Logger.get(Standard.class);
-
-    private static final DataSize TRINO_NODE_MEMORY_LIMIT = DataSize.of(2048 + 512, MEGABYTE); // Xmx + headroom
-
     private static final int COLLECTOR_UI_PORT = 16686;
     private static final int COLLECTOR_GRPC_PORT = 4317;
 
@@ -201,7 +196,6 @@ public final class Standard
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("health-checks/trino-health-check.sh")), CONTAINER_HEALTH_D + "trino-health-check.sh")
                 // the server package is hundreds MB and file system bind is much more efficient
                 .withFileSystemBind(serverPackage.getPath(), "/docker/presto-server.tar.gz", READ_ONLY)
-                .withMemoryLimit(TRINO_NODE_MEMORY_LIMIT)
                 .withEnv("JAVA_HOME", jdkProvider.getJavaHome())
                 .withCommand("/docker/presto-product-tests/run-presto.sh")
                 .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())


### PR DESCRIPTION
This reverts commit ca209630136eabda2449594ef2b6a4d82fb9c2e5.

This causes PT flakiness from time to time.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
