### PR TITLE
Reuse temp variables in other code generators

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/gen/ArrayConstructorCodeGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/ArrayConstructorCodeGenerator.java
@@ -53,10 +53,10 @@ public class ArrayConstructorCodeGenerator
 
         BytecodeBlock block = new BytecodeBlock().setDescription("Constructor for array(%s)".formatted(elementType));
 
-        Variable blockBuilder = scope.createTempVariable(BlockBuilder.class);
+        Variable blockBuilder = scope.getOrCreateTempVariable(BlockBuilder.class);
         block.append(blockBuilder.set(constantType(binder, elementType).invoke("createBlockBuilder", BlockBuilder.class, constantNull(BlockBuilderStatus.class), constantInt(elements.size()))));
 
-        Variable element = scope.createTempVariable(elementType.getJavaType());
+        Variable element = scope.getOrCreateTempVariable(elementType.getJavaType());
 
         for (RowExpression item : elements) {
             block.append(context.wasNull().set(constantFalse()));
@@ -67,8 +67,10 @@ public class ArrayConstructorCodeGenerator
                     .ifTrue(blockBuilder.invoke("appendNull", BlockBuilder.class).pop())
                     .ifFalse(constantType(binder, elementType).writeValue(blockBuilder, element).pop()));
         }
+        scope.releaseTempVariableForReuse(element);
 
         block.append(blockBuilder.invoke("build", Block.class));
+        scope.releaseTempVariableForReuse(blockBuilder);
         block.append(context.wasNull().set(constantFalse()));
 
         return block;

--- a/core/trino-main/src/main/java/io/trino/sql/gen/BetweenCodeGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/BetweenCodeGenerator.java
@@ -59,7 +59,7 @@ public class BetweenCodeGenerator
     @Override
     public BytecodeNode generateExpression(BytecodeGeneratorContext context)
     {
-        Variable firstValue = context.getScope().createTempVariable(value.type().getJavaType());
+        Variable firstValue = context.getScope().getOrCreateTempVariable(value.type().getJavaType());
         VariableReferenceExpression valueReference = createTempVariableReferenceExpression(firstValue, value.type());
 
         SpecialForm newExpression = new SpecialForm(
@@ -78,6 +78,8 @@ public class BetweenCodeGenerator
                 .putVariable(firstValue)
                 .append(context.generate(newExpression))
                 .visitLabel(done);
+
+        context.getScope().releaseTempVariableForReuse(firstValue);
 
         return block;
     }

--- a/core/trino-main/src/main/java/io/trino/sql/gen/BytecodeUtils.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/BytecodeUtils.java
@@ -470,9 +470,9 @@ public final class BytecodeUtils
         // use temp variables to re-shuffle the stack to the right shape before Type.writeXXX is called
         // Unfortunately, because of the assumptions made by try_cast, we can't get around it yet.
         // TODO: clean up once try_cast is fixed
-        Variable tempValue = scope.createTempVariable(valueJavaType);
-        Variable tempOutput = scope.createTempVariable(BlockBuilder.class);
-        return new BytecodeBlock()
+        Variable tempValue = scope.getOrCreateTempVariable(valueJavaType);
+        Variable tempOutput = scope.getOrCreateTempVariable(BlockBuilder.class);
+        BytecodeBlock block = new BytecodeBlock()
                 .comment("if (wasNull)")
                 .append(new IfStatement()
                         .condition(wasNullVariable)
@@ -489,5 +489,8 @@ public final class BytecodeUtils
                                 .getVariable(tempOutput)
                                 .getVariable(tempValue)
                                 .invokeInterface(Type.class, methodName, void.class, BlockBuilder.class, valueJavaType)));
+        scope.releaseTempVariableForReuse(tempOutput);
+        scope.releaseTempVariableForReuse(tempValue);
+        return block;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/gen/DereferenceCodeGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/DereferenceCodeGenerator.java
@@ -55,7 +55,7 @@ public class DereferenceCodeGenerator
 
         BytecodeBlock block = new BytecodeBlock().comment("DEREFERENCE").setDescription("DEREFERENCE");
         Variable wasNull = generator.wasNull();
-        Variable row = generator.getScope().createTempVariable(SqlRow.class);
+        Variable row = generator.getScope().getOrCreateTempVariable(SqlRow.class);
 
         // clear the wasNull flag before evaluating the row value
         block.putVariable(wasNull, false);
@@ -88,6 +88,8 @@ public class DereferenceCodeGenerator
                 .comment("otherwise call type.getTYPE(row, index)")
                 .append(value)
                 .putVariable(wasNull, false);
+
+        generator.getScope().releaseTempVariableForReuse(row);
 
         block.append(ifFieldIsNull)
                 .visitLabel(end);

--- a/core/trino-main/src/main/java/io/trino/sql/gen/InCodeGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/InCodeGenerator.java
@@ -170,10 +170,10 @@ public class InCodeGenerator
         LabelNode defaultLabel = new LabelNode("default");
 
         Scope scope = generatorContext.getScope();
-        Variable value = scope.createTempVariable(javaType);
+        Variable value = scope.getOrCreateTempVariable(javaType);
 
         BytecodeNode switchBlock;
-        Variable expression = scope.createTempVariable(int.class);
+        Variable expression = scope.getOrCreateTempVariable(int.class);
         SwitchBuilder switchBuilder = new SwitchBuilder().expression(expression);
 
         switch (switchGenerationCase) {
@@ -278,6 +278,9 @@ public class InCodeGenerator
 
         block.visitLabel(end);
 
+        scope.releaseTempVariableForReuse(expression);
+        scope.releaseTempVariableForReuse(value);
+
         return block;
     }
 
@@ -299,7 +302,7 @@ public class InCodeGenerator
     {
         Variable caseWasNull = null; // caseWasNull is set to true the first time a null in `testValues` is encountered
         if (checkForNulls) {
-            caseWasNull = scope.createTempVariable(boolean.class);
+            caseWasNull = scope.getOrCreateTempVariable(boolean.class);
         }
 
         BytecodeBlock caseBlock = new BytecodeBlock();
@@ -360,6 +363,10 @@ public class InCodeGenerator
             elseLabel = testLabel;
         }
         caseBlock.append(elseNode);
+
+        if (checkForNulls) {
+            scope.releaseTempVariableForReuse(caseWasNull);
+        }
         return caseBlock;
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/gen/NullIfCodeGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/NullIfCodeGenerator.java
@@ -66,7 +66,7 @@ public class NullIfCodeGenerator
         LabelNode notMatch = new LabelNode("notMatch");
 
         // push first arg on the stack
-        Variable firstValue = scope.createTempVariable(first.type().getJavaType());
+        Variable firstValue = scope.getOrCreateTempVariable(first.type().getJavaType());
         BytecodeBlock block = new BytecodeBlock()
                 .comment("check if first arg is null")
                 .append(generatorContext.generate(first))
@@ -98,6 +98,8 @@ public class NullIfCodeGenerator
                 .condition(conditionBlock)
                 .ifTrue(trueBlock)
                 .ifFalse(notMatch));
+
+        scope.releaseTempVariableForReuse(firstValue);
 
         return block;
     }

--- a/core/trino-main/src/main/java/io/trino/sql/gen/SwitchCodeGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/SwitchCodeGenerator.java
@@ -126,7 +126,7 @@ public class SwitchCodeGenerator
 
         // evaluate the value and store it in a variable
         LabelNode nullValue = new LabelNode("nullCondition");
-        Variable tempVariable = scope.createTempVariable(valueType);
+        Variable tempVariable = scope.getOrCreateTempVariable(valueType);
         BytecodeBlock block = new BytecodeBlock()
                 .append(valueBytecode)
                 .append(BytecodeUtils.ifWasNullClearPopAndGoto(scope, nullValue, void.class, valueType))
@@ -163,6 +163,8 @@ public class SwitchCodeGenerator
                     .ifFalse(elseValue);
         }
 
-        return block.append(elseValue);
+        block.append(elseValue);
+        scope.releaseTempVariableForReuse(tempVariable);
+        return block;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutineCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutineCompiler.java
@@ -424,7 +424,7 @@ public final class SqlRoutineCompiler
         {
             BytecodeBlock block = new BytecodeBlock();
 
-            Variable interruption = scope.createTempVariable(int.class);
+            Variable interruption = scope.getOrCreateTempVariable(int.class);
             block.putVariable(interruption, 0);
 
             BytecodeBlock interruptionBlock = new BytecodeBlock()
@@ -449,6 +449,8 @@ public final class SqlRoutineCompiler
             if (label.isPresent()) {
                 block.visitLabel(breakLabel);
             }
+
+            scope.releaseTempVariableForReuse(interruption);
 
             return block;
         }


### PR DESCRIPTION
## Description
Updates more code generators to use `Scope#getOrCreateTempVariable` to increase variable reuse opportunities and reduce overall generated code size.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Follows up on work done in https://github.com/trinodb/trino/pull/22004 on `RowExpressionCodeGenerator` and enabled by https://github.com/airlift/bytecode/pull/18


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
