### PR TITLE
Fix milestone workflow

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -15,6 +15,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        timeout-minutes: 10
+        with:
+          java-version: 22
       - name: Get milestone from pom.xml
         run: |
           .github/bin/retry ./mvnw -v


### PR DESCRIPTION
```
+ ./mvnw -v
Unrecognized VM option 'G1NumCollectionsKeepPinned=10000000'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```