### PR TITLE
MongoDB: Support DBRef pushdown

### DIFF
--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
@@ -723,9 +723,6 @@ public class MongoMetadata
         }
         if (connectorExpression instanceof FieldDereference fieldDereference) {
             RowType rowType = (RowType) fieldDereference.getTarget().getType();
-            if (isDBRefField(rowType)) {
-                return false;
-            }
             Field field = rowType.getFields().get(fieldDereference.getField());
             if (field.getName().isEmpty()) {
                 return false;

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSource.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSource.java
@@ -61,8 +61,11 @@ import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static io.trino.plugin.base.util.JsonTypeUtil.jsonParse;
 import static io.trino.plugin.mongodb.MongoSession.COLLECTION_NAME;
+import static io.trino.plugin.mongodb.MongoSession.COLLECTION_NAME_NATIVE;
 import static io.trino.plugin.mongodb.MongoSession.DATABASE_NAME;
+import static io.trino.plugin.mongodb.MongoSession.DATABASE_NAME_NATIVE;
 import static io.trino.plugin.mongodb.MongoSession.ID;
+import static io.trino.plugin.mongodb.MongoSession.ID_NATIVE;
 import static io.trino.plugin.mongodb.ObjectIdType.OBJECT_ID;
 import static io.trino.plugin.mongodb.TypeUtils.isJsonType;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
@@ -416,9 +419,9 @@ public class MongoPageSource
         checkState(!dereferenceNames.isEmpty(), "dereferenceNames is empty");
         String leafColumnName = dereferenceNames.getLast();
         return switch (leafColumnName) {
-            case DATABASE_NAME -> dbRefValue.getDatabaseName();
-            case COLLECTION_NAME -> dbRefValue.getCollectionName();
-            case ID -> dbRefValue.getId();
+            case DATABASE_NAME_NATIVE -> dbRefValue.getDatabaseName();
+            case COLLECTION_NAME_NATIVE -> dbRefValue.getCollectionName();
+            case ID_NATIVE -> dbRefValue.getId();
             default -> throw new IllegalStateException("Unsupported DBRef column name: " + leafColumnName);
         };
     }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
@@ -156,6 +156,9 @@ public class MongoSession
     public static final String DATABASE_NAME = "databaseName";
     public static final String COLLECTION_NAME = "collectionName";
     public static final String ID = "id";
+    public static final String DATABASE_NAME_NATIVE = "$db";
+    public static final String COLLECTION_NAME_NATIVE = "$ref";
+    public static final String ID_NATIVE = "$id";
 
     // The 'simple' locale is the default collection in MongoDB. The locale doesn't allow specifying other fields (e.g. numericOrdering)
     // https://www.mongodb.com/docs/manual/reference/collation/

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoTableHandle.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoTableHandle.java
@@ -117,7 +117,7 @@ public class TestMongoTableHandle
                         false,
                         false,
                         Optional.empty()),
-                new MongoColumnHandle("creator", ImmutableList.of("databasename"), VARCHAR, false, true, Optional.empty()));
+                new MongoColumnHandle("creator", ImmutableList.of("databaseName"), VARCHAR, false, true, Optional.empty()));
 
         MongoTableHandle expected = new MongoTableHandle(
                 schemaTableName,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This PR adds support for pushing down DBRef fields. [DBRefs](https://www.mongodb.com/docs/manual/reference/database-references/) in MongoDB are special documents that reference another document. They are often used as "foreign keys" so not pushing them down carries a significant performance penalty (you basically load the whole table into Trino every time).

What this PR adds is translation of DBRef columns into their corresponding Mongo names:

- `databaseName` -> `$db`
- `collectionName` -> `$ref`
- `id` -> `$id`

So a filter like `WHERE creators.id = 'abcd'` becomes something like `{'creators.$id': 'abcd'}` in Mongo.

Resolves https://github.com/trinodb/trino/issues/21739 


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
This is my first PR in Trino so I might be missing some conventions or context - happy to adjust if necessary.

I did have to change certain tests and I didn't have full context with some so leaving inline questions and hoping to discuss on this PR if what I've done is correct or not.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes
(X) Release notes are required, with the following suggested text:

```markdown
# MongoDB
* Improve read and filter performance when selecting or filtering on DBRef fields. ({issue}`issuenumber`)
```
