### PR TITLE
Prevent IntelliJ from failing to import Maven project

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -11,4 +11,5 @@
 --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
 -XX:+UnlockDiagnosticVMOptions
 -XX:+ExitOnOutOfMemoryError
+-XX:+IgnoreUnrecognizedVMOptions
 -XX:G1NumCollectionsKeepPinned=10000000


### PR DESCRIPTION
IntelliJ is using bundled JDK to invoke maven wrapper which will fail if JDK is lower than 22