### PR TITLE
Throw TrinoException in dropNamespace when REST error

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -129,6 +129,9 @@ public class TrinoRestCatalog
         catch (NoSuchNamespaceException e) {
             throw new SchemaNotFoundException(namespace);
         }
+        catch (RESTException e) {
+            throw new TrinoException(ICEBERG_CATALOG_ERROR, format("Failed to drop namespace: %s", namespace), e);
+        }
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

In case External REST catalog throws exception it should be wrapped into TrinoException and have more clear error type.



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Example stack:
```
 "type": "org.apache.iceberg.exceptions.ForbiddenException",
  "message": "Forbidden: Access Denied",
  "suppressed": [],
  "stack": [
    "org.apache.iceberg.rest.ErrorHandlers$DefaultErrorHandler.accept(ErrorHandlers.java:212)",
    "org.apache.iceberg.rest.ErrorHandlers$NamespaceErrorHandler.accept(ErrorHandlers.java:180)",
    "org.apache.iceberg.rest.ErrorHandlers$NamespaceErrorHandler.accept(ErrorHandlers.java:166)",
    "org.apache.iceberg.rest.HTTPClient.throwFailure(HTTPClient.java:201)",
    "org.apache.iceberg.rest.HTTPClient.execute(HTTPClient.java:313)",
    "org.apache.iceberg.rest.HTTPClient.execute(HTTPClient.java:252)",
    "org.apache.iceberg.rest.HTTPClient.delete(HTTPClient.java:389)",
    "org.apache.iceberg.rest.RESTClient.delete(RESTClient.java:52)",
    "org.apache.iceberg.rest.RESTSessionCatalog.dropNamespace(RESTSessionCatalog.java:530)",
    "io.trino.plugin.iceberg.catalog.rest.TrinoRestCatalog.dropNamespace(TrinoRestCatalog.java:147)",
    "io.trino.plugin.iceberg.IcebergMetadata.dropSchema(IcebergMetadata.java:901)",
    "io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata.dropSchema(ClassLoaderSafeConnectorMetadata.java:430)",
    "io.trino.tracing.TracingConnectorMetadata.dropSchema(TracingConnectorMetadata.java:358)",
    "io.trino.metadata.MetadataManager.dropSchema(MetadataManager.java:789)",
    "io.trino.tracing.TracingMetadata.dropSchema(TracingMetadata.java:382)",
    "io.trino.execution.DropSchemaTask.execute(DropSchemaTask.java:79)",
    "io.trino.execution.DropSchemaTask.execute(DropSchemaTask.java:37)",
```


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
