### PR TITLE
Unimplement deprecated fastutil method

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/join/SortedPositionLinks.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/SortedPositionLinks.java
@@ -331,11 +331,5 @@ public final class SortedPositionLinks
 
             return pagesHashStrategy.compareSortChannelPositions(leftBlockIndex, leftBlockPosition, rightBlockIndex, rightBlockPosition);
         }
-
-        @Override
-        public int compare(Integer leftPosition, Integer rightPosition)
-        {
-            return compare(leftPosition.intValue(), rightPosition.intValue());
-        }
     }
 }


### PR DESCRIPTION
It's implemented by the interface:

```
@Deprecated
@Override
default int compare(Integer ok1, Integer ok2) {
    return compare(ok1.intValue(), ok2.intValue());
}
```