### PR TITLE
Improve speed when bigquery.case-insensitive-name-matching is enabled

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
@@ -124,6 +124,11 @@ public class BigQueryClient
 
     public Optional<RemoteDatabaseObject> toRemoteDataset(String projectId, String datasetName)
     {
+        return toRemoteDataset(projectId, datasetName, listDatasetIds(projectId));
+    }
+
+    public Optional<RemoteDatabaseObject> toRemoteDataset(String projectId, String datasetName, List<DatasetId> datasetIds)
+    {
         requireNonNull(projectId, "projectId is null");
         requireNonNull(datasetName, "datasetName is null");
         verify(datasetName.codePoints().noneMatch(Character::isUpperCase), "Expected schema name from internal metadata to be lowercase: %s", datasetName);
@@ -132,7 +137,7 @@ public class BigQueryClient
         }
 
         Map<String, Optional<RemoteDatabaseObject>> mapping = new HashMap<>();
-        for (DatasetId datasetId : listDatasetIds(projectId)) {
+        for (DatasetId datasetId : datasetIds) {
             mapping.merge(
                     datasetId.getDataset().toLowerCase(ENGLISH),
                     Optional.of(RemoteDatabaseObject.of(datasetId.getDataset())),
@@ -241,7 +246,7 @@ public class BigQueryClient
         return datasetId.getDataset();
     }
 
-    public Iterable<DatasetId> listDatasetIds(String projectId)
+    public List<DatasetId> listDatasetIds(String projectId)
     {
         try {
             return remoteDatasetIdCache.get(projectId);

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
@@ -283,6 +283,7 @@ public class BigQueryClient
     public void createSchema(DatasetInfo datasetInfo)
     {
         bigQuery.create(datasetInfo);
+        remoteDatasetIdCache.invalidate(datasetInfo.getDatasetId().getProject());
     }
 
     public void dropSchema(DatasetId datasetId, boolean cascade)
@@ -293,6 +294,7 @@ public class BigQueryClient
         else {
             bigQuery.delete(datasetId);
         }
+        remoteDatasetIdCache.invalidate(datasetId.getProject());
     }
 
     public void createTable(TableInfo tableInfo)


### PR DESCRIPTION
## Description

Invalidate remoteDatasetIdCache when after creating or dropping a schema.
This PR improves `SHOW SCHEMAS` speed 60 seconds → ~1 second with 75 schemas.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# BigQuery
* Improve performance when listing schemas and `bigquery.case-insensitive-name-matching` is enabled. ({issue}`issuenumber`)
```
