### PR TITLE
Fix a hot loop in DirectExchangeClient

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/DirectExchangeClient.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DirectExchangeClient.java
@@ -73,7 +73,7 @@ public class DirectExchangeClient
     private final Map<URI, HttpPageBufferClient> allClients = new ConcurrentHashMap<>();
 
     @GuardedBy("this")
-    private final LinkedHashSet<HttpPageBufferClient> queuedClients = new LinkedHashSet<>();
+    private final Set<HttpPageBufferClient> queuedClients = new LinkedHashSet<>();
 
     private final Set<HttpPageBufferClient> completedClients = newConcurrentHashSet();
     private final DirectExchangeBuffer buffer;
@@ -284,9 +284,9 @@ public class DirectExchangeClient
         long projectedBytesToBeRequested = 0;
         int clientCount = 0;
 
-        Iterator<HttpPageBufferClient> queuedClientsIterator = queuedClients.iterator();
-        while (queuedClientsIterator.hasNext()) {
-            HttpPageBufferClient client = queuedClientsIterator.next();
+        Iterator<HttpPageBufferClient> clientIterator = queuedClients.iterator();
+        while (clientIterator.hasNext()) {
+            HttpPageBufferClient client = clientIterator.next();
             if (projectedBytesToBeRequested >= neededBytes * concurrentRequestMultiplier - reservedBytesForScheduledClients) {
                 break;
             }
@@ -295,7 +295,7 @@ public class DirectExchangeClient
             client.scheduleRequest();
 
             // Remove the client from the queuedClient's set.
-            queuedClientsIterator.remove();
+            clientIterator.remove();
 
             clientCount++;
         }
@@ -309,7 +309,7 @@ public class DirectExchangeClient
     }
 
     @VisibleForTesting
-    LinkedHashSet<HttpPageBufferClient> getQueuedClients()
+    Set<HttpPageBufferClient> getQueuedClients()
     {
         return queuedClients;
     }

--- a/core/trino-main/src/main/java/io/trino/operator/DirectExchangeClient.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DirectExchangeClient.java
@@ -35,8 +35,8 @@ import jakarta.annotation.Nullable;
 
 import java.io.Closeable;
 import java.net.URI;
-import java.util.Deque;
-import java.util.LinkedList;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -73,7 +73,7 @@ public class DirectExchangeClient
     private final Map<URI, HttpPageBufferClient> allClients = new ConcurrentHashMap<>();
 
     @GuardedBy("this")
-    private final Deque<HttpPageBufferClient> queuedClients = new LinkedList<>();
+    private final LinkedHashSet<HttpPageBufferClient> queuedClients = new LinkedHashSet<>();
 
     private final Set<HttpPageBufferClient> completedClients = newConcurrentHashSet();
     private final DirectExchangeBuffer buffer;
@@ -284,17 +284,22 @@ public class DirectExchangeClient
         long projectedBytesToBeRequested = 0;
         int clientCount = 0;
 
-        for (HttpPageBufferClient client : queuedClients) {
+        Iterator<HttpPageBufferClient> queuedClientsIterator = queuedClients.iterator();
+        while (queuedClientsIterator.hasNext()) {
+            HttpPageBufferClient client = queuedClientsIterator.next();
             if (projectedBytesToBeRequested >= neededBytes * concurrentRequestMultiplier - reservedBytesForScheduledClients) {
                 break;
             }
             projectedBytesToBeRequested += client.getAverageRequestSizeInBytes();
+
+            client.scheduleRequest();
+
+            // Remove the client from the queuedClient's set.
+            queuedClientsIterator.remove();
+
             clientCount++;
         }
-        for (int i = 0; i < clientCount; i++) {
-            HttpPageBufferClient client = queuedClients.poll();
-            client.scheduleRequest();
-        }
+
         return clientCount;
     }
 
@@ -304,7 +309,7 @@ public class DirectExchangeClient
     }
 
     @VisibleForTesting
-    Deque<HttpPageBufferClient> getQueuedClients()
+    LinkedHashSet<HttpPageBufferClient> getQueuedClients()
     {
         return queuedClients;
     }


### PR DESCRIPTION
## Description
The fix changes queuedClients to LinkedHashSet, this helps with the filter condition in scheduleRequestIfNecessary. In addition two for loops are modified to become one loop on Iterator.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
We experienced some performance regression as a result of https://github.com/trinodb/trino/commit/1ef442738fc51d1d7cf167bf6ca413378d928026 and this is an attempt to fix the same.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
