### PR TITLE
Extend automatic type coercion support in Delta table creation to char

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -132,6 +132,7 @@ import io.trino.spi.statistics.TableStatisticType;
 import io.trino.spi.statistics.TableStatistics;
 import io.trino.spi.statistics.TableStatisticsMetadata;
 import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.CharType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.FixedWidthType;
 import io.trino.spi.type.HyperLogLogType;
@@ -662,6 +663,9 @@ public class DeltaLakeMetadata
     {
         if (type instanceof TimestampType) {
             return TIMESTAMP_MICROS;
+        }
+        if (type instanceof CharType) {
+            return VARCHAR;
         }
         if (type instanceof ArrayType arrayType) {
             return new ArrayType(coerceType(arrayType.getElementType()));

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -292,14 +292,6 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     protected abstract String bucketUrl();
 
     @Test
-    public void testCharTypeIsNotSupported()
-    {
-        String tableName = "test_char_type_not_supported" + randomNameSuffix();
-        assertQueryFails("CREATE TABLE " + tableName + " (a int, b CHAR(5)) WITH (location = '" + getLocationForTable(bucketName, tableName) + "')",
-                "Unsupported type: char\\(5\\)");
-    }
-
-    @Test
     public void testCreateTableInNonexistentSchemaFails()
     {
         String tableName = "test_create_table_in_nonexistent_schema_" + randomNameSuffix();

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -3932,7 +3932,7 @@ public class TestDeltaLakeConnectorTest
     }
 
     @Test
-    public void testTimestampCoercionOnCreateTable()
+    public void testTypeCoercionOnCreateTable()
     {
         testTimestampCoercionOnCreateTable("TIMESTAMP '1970-01-01 00:00:00'", "TIMESTAMP '1970-01-01 00:00:00.000000'");
         testTimestampCoercionOnCreateTable("TIMESTAMP '1970-01-01 00:00:00.9'", "TIMESTAMP '1970-01-01 00:00:00.900000'");
@@ -3976,7 +3976,7 @@ public class TestDeltaLakeConnectorTest
     }
 
     @Test
-    public void testTimestampCoercionOnCreateTableAsSelect()
+    public void testTypeCoercionOnCreateTableAsSelect()
     {
         testTimestampCoercionOnCreateTableAsSelect("TIMESTAMP '1970-01-01 00:00:00'", "TIMESTAMP '1970-01-01 00:00:00.000000'");
         testTimestampCoercionOnCreateTableAsSelect("TIMESTAMP '1970-01-01 00:00:00.9'", "TIMESTAMP '1970-01-01 00:00:00.900000'");
@@ -4019,7 +4019,7 @@ public class TestDeltaLakeConnectorTest
     }
 
     @Test
-    public void testTimestampCoercionOnCreateTableAsSelectWithNoData()
+    public void testTypeCoercionOnCreateTableAsSelectWithNoData()
     {
         testTimestampCoercionOnCreateTableAsSelectWithNoData("TIMESTAMP '1970-01-01 00:00:00'");
         testTimestampCoercionOnCreateTableAsSelectWithNoData("TIMESTAMP '1970-01-01 00:00:00.9'");
@@ -4061,7 +4061,7 @@ public class TestDeltaLakeConnectorTest
     }
 
     @Test
-    public void testTimestampCoercionOnCreateTableAsWithRowType()
+    public void testTypeCoercionOnCreateTableAsWithRowType()
     {
         testTimestampCoercionOnCreateTableAsWithRowType("TIMESTAMP '1970-01-01 00:00:00'", "TIMESTAMP '1970-01-01 00:00:00'");
         testTimestampCoercionOnCreateTableAsWithRowType("TIMESTAMP '1970-01-01 00:00:00.9'", "TIMESTAMP '1970-01-01 00:00:00.9'");
@@ -4106,7 +4106,7 @@ public class TestDeltaLakeConnectorTest
     }
 
     @Test
-    public void testTimestampCoercionOnCreateTableAsWithArrayType()
+    public void testTypeCoercionOnCreateTableAsWithArrayType()
     {
         testTimestampCoercionOnCreateTableAsWithArrayType("TIMESTAMP '1970-01-01 00:00:00'", "TIMESTAMP '1970-01-01 00:00:00'");
         testTimestampCoercionOnCreateTableAsWithArrayType("TIMESTAMP '1970-01-01 00:00:00.9'", "TIMESTAMP '1970-01-01 00:00:00.9'");
@@ -4151,7 +4151,7 @@ public class TestDeltaLakeConnectorTest
     }
 
     @Test
-    public void testTimestampCoercionOnCreateTableAsWithMapType()
+    public void testTypeCoercionOnCreateTableAsWithMapType()
     {
         testTimestampCoercionOnCreateTableAsWithMapType("TIMESTAMP '1970-01-01 00:00:00'", "TIMESTAMP '1970-01-01 00:00:00'");
         testTimestampCoercionOnCreateTableAsWithMapType("TIMESTAMP '1970-01-01 00:00:00.9'", "TIMESTAMP '1970-01-01 00:00:00.9'");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
- extend automatic type coercion support in Iceberg table creation to `char` type
- generify existing test names

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
https://github.com/trinodb/trino/pull/21515

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
