### PR TITLE
Set air.compiler.fail-warnings as true in HTTP and MySQL event listeners

### DIFF
--- a/plugin/trino-http-event-listener/pom.xml
+++ b/plugin/trino-http-event-listener/pom.xml
@@ -15,6 +15,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+        <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
     </properties>
 
     <dependencies>

--- a/plugin/trino-mysql-event-listener/pom.xml
+++ b/plugin/trino-mysql-event-listener/pom.xml
@@ -15,6 +15,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+        <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
