### PR TITLE
Remove redundant testng exclusion from trino-thrift-testing-server

### DIFF
--- a/plugin/trino-thrift-testing-server/pom.xml
+++ b/plugin/trino-thrift-testing-server/pom.xml
@@ -90,10 +90,6 @@
                     <groupId>org.junit.jupiter</groupId>
                     <artifactId>junit-jupiter-api</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.testng</groupId>
-                    <artifactId>testng</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
## Description

https://github.com/trinodb/trino/commit/8cfddff78bff6fab861cb847e3a74a147bd8ccfd#diff-1a33fdf426dd013a6e774e71e9ffcbd1a61a27ae2c57f1b1e239d416d5d6d00a removed testng from trino-testing module

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
