### PR TITLE
Replace deprecated QueryAssert.assertThat with Assertions.assertThat

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveMerge.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveMerge.java
@@ -27,7 +27,6 @@ import java.util.stream.IntStream;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
-import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tests.product.TestGroups.HIVE_TRANSACTIONAL;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static io.trino.tests.product.hive.BucketingType.BUCKETED_V2;
@@ -39,6 +38,7 @@ import static io.trino.tests.product.utils.QueryExecutors.onHive;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestHiveMerge
         extends HiveProductTest

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/jdbc/TestKerberosConstrainedDelegationJdbc.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/jdbc/TestKerberosConstrainedDelegationJdbc.java
@@ -19,7 +19,6 @@ import io.trino.tempto.BeforeMethodWithContext;
 import io.trino.tempto.ProductTest;
 import io.trino.tempto.kerberos.KerberosAuthentication;
 import io.trino.tests.product.TpchTableResults;
-import org.assertj.core.api.Assertions;
 import org.ietf.jgss.GSSCredential;
 import org.ietf.jgss.GSSManager;
 import org.ietf.jgss.Oid;
@@ -36,10 +35,10 @@ import java.sql.SQLException;
 import java.util.Properties;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tempto.query.QueryResult.forResultSet;
 import static io.trino.tests.product.TestGroups.JDBC_KERBEROS_CONSTRAINED_DELEGATION;
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.ietf.jgss.GSSCredential.DEFAULT_LIFETIME;
 import static org.ietf.jgss.GSSCredential.INITIATE_ONLY;
@@ -98,7 +97,7 @@ public class TestKerberosConstrainedDelegationJdbc
         try (Connection connection = DriverManager.getConnection(jdbcUrl, driverProperties);
                 PreparedStatement statement = connection.prepareStatement(format("CREATE TABLE %s AS SELECT * FROM tpch.tiny.nation", "test_kerberos_ctas"))) {
             int results = statement.executeUpdate();
-            Assertions.assertThat(results).isEqualTo(25);
+            assertThat(results).isEqualTo(25);
         }
         finally {
             credential.dispose();
@@ -130,7 +129,7 @@ public class TestKerberosConstrainedDelegationJdbc
         // ticket default lifetime is 80s by kerb.conf, sleep to expire ticket
         Thread.sleep(30000);
         // check before execution that current lifetime is less than 60s (MIN_LIFETIME on client), to be sure that we already expired
-        Assertions.assertThat(credential.getRemainingLifetime()).isLessThanOrEqualTo(60);
+        assertThat(credential.getRemainingLifetime()).isLessThanOrEqualTo(60);
         driverProperties.put("KerberosConstrainedDelegation", credential);
         try (Connection connection = DriverManager.getConnection(jdbcUrl, driverProperties)) {
             assertThatThrownBy(() -> connection.prepareStatement("SELECT * FROM tpch.tiny.nation"))

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/snowflake/TestSnowflake.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/snowflake/TestSnowflake.java
@@ -18,11 +18,11 @@ import io.trino.tempto.query.QueryResult;
 import org.testng.annotations.Test;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
-import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static io.trino.tests.product.TestGroups.SNOWFLAKE;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestSnowflake
         extends ProductTest


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
