### PR TITLE
Throw TrinoException for Glue external failures

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -1472,6 +1472,9 @@ public class TrinoGlueCatalog
                 catch (EntityNotFoundException e) {
                     throw new TableNotFoundException(tableName, e);
                 }
+                catch (AmazonServiceException e) {
+                    throw new TrinoException(ICEBERG_CATALOG_ERROR, e);
+                }
             });
         }
         catch (UncheckedExecutionException e) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
In case external Glue failure in getTable function throw `TrinoException` with more clear error type.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Example stack trace:
```
"type": "com.amazonaws.services.glue.model.AccessDeniedException",
    "message": "User:  is not authorized to perform: glue:GetTable on resource .... (Service: AWSGlue; Status Code: 400; Error Code: AccessDeniedException; Request ID: ; Proxy: null)",
    "suppressed": [],
    "stack": [
      "com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleErrorResponse(AmazonHttpClient.java:1879)",
   "com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleServiceErrorResponse(AmazonHttpClient.java:1418)",
      "com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeOneRequest(AmazonHttpClient.java:1387)",
      "com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeHelper(AmazonHttpClient.java:1157)",
      "com.amazonaws.http.AmazonHttpClient$RequestExecutor.doExecute(AmazonHttpClient.java:814)",
      "com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeWithTimer(AmazonHttpClient.java:781)",
      "com.amazonaws.http.AmazonHttpClient$RequestExecutor.execute(AmazonHttpClient.java:755)",
      "com.amazonaws.http.AmazonHttpClient$RequestExecutor.access$500(AmazonHttpClient.java:715)",
      "com.amazonaws.http.AmazonHttpClient$RequestExecutionBuilderImpl.execute(AmazonHttpClient.java:697)",
      "com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:561)",
      "com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:541)",
      "com.amazonaws.services.glue.AWSGlueClient.doInvoke(AWSGlueClient.java:14501)",
      "com.amazonaws.services.glue.AWSGlueClient.invoke(AWSGlueClient.java:14468)",
      "com.amazonaws.services.glue.AWSGlueClient.invoke(AWSGlueClient.java:14457)",
      "com.amazonaws.services.glue.AWSGlueClient.executeGetTable(AWSGlueClient.java:8273)",
      "com.amazonaws.services.glue.AWSGlueClient.getTable(AWSGlueClient.java:8242)",
      "io.trino.plugin.iceberg.catalog.glue.TrinoGlueCatalog.lambda$getTable$52(TrinoGlueCatalog.java:1619)",
      "io.trino.plugin.hive.metastore.glue.AwsApiCallStats.call(AwsApiCallStats.java:36)",
      "io.trino.plugin.iceberg.catalog.glue.TrinoGlueCatalog.lambda$getTable$53(TrinoGlueCatalog.java:1619)",
      "com.google.common.cache.LocalCache$LocalManualCache$1.load(LocalCache.java:4938)",
      "com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3576)",
      "com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2318)",
      "com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2191)",
      "com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2081)",
      "com.google.common.cache.LocalCache.get(LocalCache.java:4019)",
      "com.google.common.cache.LocalCache$LocalManualCache.get(LocalCache.java:4933)",
      "io.trino.cache.EvictableCache.get(EvictableCache.java:112)",
      "io.trino.cache.CacheUtils.uncheckedCacheGet(CacheUtils.java:37)",
      "io.trino.plugin.iceberg.catalog.glue.TrinoGlueCatalog.getTable(TrinoGlueCatalog.java:1614)",
      "io.trino.plugin.iceberg.catalog.glue.TrinoGlueCatalog.getTableAndCacheMetadata(TrinoGlueCatalog.java:929)",
      "io.trino.plugin.iceberg.catalog.glue.TrinoGlueCatalog.doGetMaterializedView(TrinoGlueCatalog.java:1417)",
      "io.trino.plugin.iceberg.catalog.AbstractTrinoCatalog.lambda$getMaterializedView$2(AbstractTrinoCatalog.java:207)",
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
