### PR TITLE
Throw TrinoException in case of not found catalog

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/StaticCatalogManager.java
+++ b/core/trino-main/src/main/java/io/trino/connector/StaticCatalogManager.java
@@ -54,6 +54,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.configuration.ConfigurationLoader.loadPropertiesFrom;
 import static io.trino.spi.StandardErrorCode.CATALOG_NOT_AVAILABLE;
+import static io.trino.spi.StandardErrorCode.CATALOG_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.connector.CatalogHandle.createRootCatalogHandle;
 import static io.trino.util.Executors.executeUntilFailure;
@@ -214,7 +215,9 @@ public class StaticCatalogManager
     public ConnectorServices getConnectorServices(CatalogHandle catalogHandle)
     {
         CatalogConnector catalogConnector = catalogs.get(catalogHandle.getCatalogName());
-        checkArgument(catalogConnector != null, "No catalog '%s'", catalogHandle.getCatalogName());
+        if (catalogConnector == null) {
+            throw new TrinoException(CATALOG_NOT_FOUND, "No catalog '%s'".formatted(catalogHandle.getCatalogName()));
+        }
         return catalogConnector.getMaterializedConnector(catalogHandle.getType());
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

In case not found catalog in catalog manager throw TrinoException with clear error type.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Example stack trace:
```
 "type": "java.lang.IllegalArgumentException",
  "message": "No catalog 'test'",
  "suppressed": [],
  "stack": [
    "com.google.common.base.Preconditions.checkArgument(Preconditions.java:220)",
    "io.trino.connector.StaticCatalogManager.getConnectorServices(StaticCatalogManager.java:229)",
    "io.trino.connector.ConnectorCatalogServiceProvider.getService(ConnectorCatalogServiceProvider.java:40)",
    "io.trino.split.PageSourceManager.createPageSource(PageSourceManager.java:57)",
```


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
