### PR TITLE
Fix Iceberg value for varbinary

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
@@ -513,7 +513,7 @@ public class IcebergPageSink
             return timestampTzToMicros(getTimestampTz(block, position));
         }
         if (type instanceof VarbinaryType varbinaryType) {
-            return varbinaryType.getSlice(block, position).getBytes();
+            return varbinaryType.getSlice(block, position).toByteBuffer();
         }
         if (type instanceof VarcharType varcharType) {
             return varcharType.getSlice(block, position).toStringUtf8();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -3236,6 +3236,7 @@ public abstract class BaseIcebergConnectorTest
                 "CAST('206caec7-68b9-4778-81b2-a12ece70c8b1' AS UUID)",
                 "CAST('906caec7-68b9-4778-81b2-a12ece70c8b1' AS UUID)",
                 "CAST('406caec7-68b9-4778-81b2-a12ece70c8b1' AS UUID)");
+        testBucketTransformForType("VARBINARY", "x'04'", "x'21'", "x'02'");
     }
 
     protected void testBucketTransformForType(


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Fix #22071 

The exception appeared since a Iceberg value of `VARBINARY` was interpreted as a byte array (`io.trino.plugin.iceberg.IcebergPageSink#getIcebergValue`), but the Iceberg function (`org.apache.iceberg.transforms.Bucket.BucketByteBuffer`) of `bucket` requires a `ByteBuffer`.

To fix this, Iceberg value of `VARBINARY` was changed to byte buffer.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text