### PR TITLE
Remove unused members of InformationSchemaMetadata

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaMetadata.java
@@ -77,8 +77,6 @@ public class InformationSchemaMetadata
     private static final InformationSchemaColumnHandle CATALOG_COLUMN_HANDLE = new InformationSchemaColumnHandle("table_catalog");
     private static final InformationSchemaColumnHandle SCHEMA_COLUMN_HANDLE = new InformationSchemaColumnHandle("table_schema");
     private static final InformationSchemaColumnHandle TABLE_NAME_COLUMN_HANDLE = new InformationSchemaColumnHandle("table_name");
-    private static final InformationSchemaColumnHandle ROLE_NAME_COLUMN_HANDLE = new InformationSchemaColumnHandle("role_name");
-    private static final InformationSchemaColumnHandle GRANTEE_COLUMN_HANDLE = new InformationSchemaColumnHandle("grantee");
 
     private final String catalogName;
     private final Metadata metadata;
@@ -368,16 +366,6 @@ public class InformationSchemaMetadata
     private Map<ColumnHandle, NullableValue> schemaAsFixedValues(String schema)
     {
         return ImmutableMap.of(SCHEMA_COLUMN_HANDLE, new NullableValue(createUnboundedVarcharType(), utf8Slice(schema)));
-    }
-
-    private Map<ColumnHandle, NullableValue> roleAsFixedValues(String schema)
-    {
-        return ImmutableMap.of(ROLE_NAME_COLUMN_HANDLE, new NullableValue(createUnboundedVarcharType(), utf8Slice(schema)));
-    }
-
-    private Map<ColumnHandle, NullableValue> granteeAsFixedValues(String schema)
-    {
-        return ImmutableMap.of(GRANTEE_COLUMN_HANDLE, new NullableValue(createUnboundedVarcharType(), utf8Slice(schema)));
     }
 
     private Map<ColumnHandle, NullableValue> asFixedValues(QualifiedObjectName objectName)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Remove unused private fields and methods of `InformationSchemaMetadata`


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
The use of these members seem to have been dropped in https://github.com/trinodb/trino/pull/11341


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
