### PR TITLE
Optimize writing RLE runs in parquet column descriptors

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
@@ -34,7 +34,6 @@ import io.trino.parquet.writer.ColumnWriter.BufferData;
 import io.trino.spi.Page;
 import io.trino.spi.type.Type;
 import jakarta.annotation.Nullable;
-import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.column.values.bloomfilter.BloomFilter;
 import org.apache.parquet.format.BloomFilterAlgorithm;
 import org.apache.parquet.format.BloomFilterCompression;
@@ -88,7 +87,6 @@ import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Objects.requireNonNull;
-import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_1_0;
 
 public class ParquetWriter
         implements Closeable
@@ -439,15 +437,9 @@ public class ParquetWriter
 
     private void initColumnWriters()
     {
-        ParquetProperties parquetProperties = ParquetProperties.builder()
-                .withWriterVersion(PARQUET_1_0)
-                .withPageSize(writerOption.getMaxPageSize())
-                .build();
-
         this.columnWriters = ParquetWriters.getColumnWriters(
                 messageType,
                 primitiveTypes,
-                parquetProperties,
                 compressionCodec,
                 writerOption,
                 parquetTimeZone);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriters.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriters.java
@@ -66,6 +66,8 @@ import java.util.function.Predicate;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.parquet.writer.ParquetWriter.SUPPORTED_BLOOM_FILTER_TYPES;
+import static io.trino.parquet.writer.valuewriter.ColumnDescriptorValuesWriter.newDefinitionLevelWriter;
+import static io.trino.parquet.writer.valuewriter.ColumnDescriptorValuesWriter.newRepetitionLevelWriter;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -270,8 +272,8 @@ final class ParquetWriters
             return new PrimitiveColumnWriter(
                     columnDescriptor,
                     getValueWriter(valuesWriterFactory.newValuesWriter(columnDescriptor, bloomFilter), trinoType, columnDescriptor.getPrimitiveType(), parquetTimeZone),
-                    parquetProperties.newDefinitionLevelWriter(columnDescriptor),
-                    parquetProperties.newRepetitionLevelWriter(columnDescriptor),
+                    newDefinitionLevelWriter(columnDescriptor, parquetProperties.getPageSizeThreshold()),
+                    newRepetitionLevelWriter(columnDescriptor, parquetProperties.getPageSizeThreshold()),
                     compressionCodec,
                     parquetProperties.getPageSizeThreshold(),
                     pageValueCountLimit,

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/PrimitiveColumnWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/PrimitiveColumnWriter.java
@@ -20,6 +20,7 @@ import io.trino.parquet.writer.repdef.DefLevelWriterProvider;
 import io.trino.parquet.writer.repdef.DefLevelWriterProviders;
 import io.trino.parquet.writer.repdef.RepLevelWriterProvider;
 import io.trino.parquet.writer.repdef.RepLevelWriterProviders;
+import io.trino.parquet.writer.valuewriter.ColumnDescriptorValuesWriter;
 import io.trino.parquet.writer.valuewriter.PrimitiveValueWriter;
 import io.trino.plugin.base.io.ChunkedSliceOutput;
 import jakarta.annotation.Nullable;
@@ -28,7 +29,6 @@ import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.statistics.Statistics;
-import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.column.values.bloomfilter.BloomFilter;
 import org.apache.parquet.format.ColumnMetaData;
 import org.apache.parquet.format.CompressionCodec;
@@ -75,8 +75,8 @@ public class PrimitiveColumnWriter
     private final CompressionCodec compressionCodec;
 
     private final PrimitiveValueWriter primitiveValueWriter;
-    private final ValuesWriter definitionLevelWriter;
-    private final ValuesWriter repetitionLevelWriter;
+    private final ColumnDescriptorValuesWriter definitionLevelWriter;
+    private final ColumnDescriptorValuesWriter repetitionLevelWriter;
 
     private boolean closed;
     private boolean getDataStreamsCalled;
@@ -113,8 +113,8 @@ public class PrimitiveColumnWriter
     public PrimitiveColumnWriter(
             ColumnDescriptor columnDescriptor,
             PrimitiveValueWriter primitiveValueWriter,
-            ValuesWriter definitionLevelWriter,
-            ValuesWriter repetitionLevelWriter,
+            ColumnDescriptorValuesWriter definitionLevelWriter,
+            ColumnDescriptorValuesWriter repetitionLevelWriter,
             CompressionCodec compressionCodec,
             int pageSizeThreshold,
             int pageValueCountLimit,

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/repdef/DefLevelWriterProvider.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/repdef/DefLevelWriterProvider.java
@@ -14,14 +14,14 @@
 package io.trino.parquet.writer.repdef;
 
 import com.google.common.collect.Iterables;
-import org.apache.parquet.column.values.ValuesWriter;
+import io.trino.parquet.writer.valuewriter.ColumnDescriptorValuesWriter;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface DefLevelWriterProvider
 {
-    DefinitionLevelWriter getDefinitionLevelWriter(Optional<DefinitionLevelWriter> nestedWriter, ValuesWriter encoder);
+    DefinitionLevelWriter getDefinitionLevelWriter(Optional<DefinitionLevelWriter> nestedWriter, ColumnDescriptorValuesWriter encoder);
 
     interface DefinitionLevelWriter
     {
@@ -34,7 +34,7 @@ public interface DefLevelWriterProvider
     {
     }
 
-    static DefinitionLevelWriter getRootDefinitionLevelWriter(List<DefLevelWriterProvider> defLevelWriterProviders, ValuesWriter encoder)
+    static DefinitionLevelWriter getRootDefinitionLevelWriter(List<DefLevelWriterProvider> defLevelWriterProviders, ColumnDescriptorValuesWriter encoder)
     {
         // Constructs hierarchy of DefinitionLevelWriter from leaf to root
         DefinitionLevelWriter rootDefinitionLevelWriter = Iterables.getLast(defLevelWriterProviders)

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/repdef/DefLevelWriterProviders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/repdef/DefLevelWriterProviders.java
@@ -84,9 +84,7 @@ public class DefLevelWriterProviders
                     checkValidPosition(offset, positionsCount, block.getPositionCount());
                     int nonNullsCount = 0;
                     if (!block.mayHaveNull()) {
-                        for (int position = offset; position < offset + positionsCount; position++) {
-                            encoder.writeInteger(maxDefinitionLevel);
-                        }
+                        encoder.writeRepeatInteger(maxDefinitionLevel, positionsCount);
                         nonNullsCount = positionsCount;
                     }
                     else {

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/repdef/DefLevelWriterProviders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/repdef/DefLevelWriterProviders.java
@@ -13,13 +13,13 @@
  */
 package io.trino.parquet.writer.repdef;
 
+import io.trino.parquet.writer.valuewriter.ColumnDescriptorValuesWriter;
 import io.trino.spi.block.ArrayBlock;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.ColumnarArray;
 import io.trino.spi.block.ColumnarMap;
 import io.trino.spi.block.MapBlock;
 import io.trino.spi.block.RowBlock;
-import org.apache.parquet.column.values.ValuesWriter;
 
 import java.util.Optional;
 
@@ -65,7 +65,7 @@ public class DefLevelWriterProviders
         }
 
         @Override
-        public DefinitionLevelWriter getDefinitionLevelWriter(Optional<DefinitionLevelWriter> nestedWriter, ValuesWriter encoder)
+        public DefinitionLevelWriter getDefinitionLevelWriter(Optional<DefinitionLevelWriter> nestedWriter, ColumnDescriptorValuesWriter encoder)
         {
             checkArgument(nestedWriter.isEmpty(), "nestedWriter should be empty for primitive definition level writer");
             return new DefinitionLevelWriter()
@@ -117,7 +117,7 @@ public class DefLevelWriterProviders
         }
 
         @Override
-        public DefinitionLevelWriter getDefinitionLevelWriter(Optional<DefinitionLevelWriter> nestedWriterOptional, ValuesWriter encoder)
+        public DefinitionLevelWriter getDefinitionLevelWriter(Optional<DefinitionLevelWriter> nestedWriterOptional, ColumnDescriptorValuesWriter encoder)
         {
             checkArgument(nestedWriterOptional.isPresent(), "nestedWriter should be present for column row definition level writer");
             return new DefinitionLevelWriter()
@@ -180,7 +180,7 @@ public class DefLevelWriterProviders
         }
 
         @Override
-        public DefinitionLevelWriter getDefinitionLevelWriter(Optional<DefinitionLevelWriter> nestedWriterOptional, ValuesWriter encoder)
+        public DefinitionLevelWriter getDefinitionLevelWriter(Optional<DefinitionLevelWriter> nestedWriterOptional, ColumnDescriptorValuesWriter encoder)
         {
             checkArgument(nestedWriterOptional.isPresent(), "nestedWriter should be present for column map definition level writer");
             return new DefinitionLevelWriter()
@@ -265,7 +265,7 @@ public class DefLevelWriterProviders
         }
 
         @Override
-        public DefinitionLevelWriter getDefinitionLevelWriter(Optional<DefinitionLevelWriter> nestedWriterOptional, ValuesWriter encoder)
+        public DefinitionLevelWriter getDefinitionLevelWriter(Optional<DefinitionLevelWriter> nestedWriterOptional, ColumnDescriptorValuesWriter encoder)
         {
             checkArgument(nestedWriterOptional.isPresent(), "nestedWriter should be present for column map definition level writer");
             return new DefinitionLevelWriter()

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/repdef/RepLevelWriterProvider.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/repdef/RepLevelWriterProvider.java
@@ -14,14 +14,14 @@
 package io.trino.parquet.writer.repdef;
 
 import com.google.common.collect.Iterables;
-import org.apache.parquet.column.values.ValuesWriter;
+import io.trino.parquet.writer.valuewriter.ColumnDescriptorValuesWriter;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface RepLevelWriterProvider
 {
-    RepetitionLevelWriter getRepetitionLevelWriter(Optional<RepetitionLevelWriter> nestedWriter, ValuesWriter encoder);
+    RepetitionLevelWriter getRepetitionLevelWriter(Optional<RepetitionLevelWriter> nestedWriter, ColumnDescriptorValuesWriter encoder);
 
     /**
      * Parent repetition level marks at which level either:
@@ -36,7 +36,7 @@ public interface RepLevelWriterProvider
         void writeRepetitionLevels(int parentLevel);
     }
 
-    static RepetitionLevelWriter getRootRepetitionLevelWriter(List<RepLevelWriterProvider> repLevelWriterProviders, ValuesWriter encoder)
+    static RepetitionLevelWriter getRootRepetitionLevelWriter(List<RepLevelWriterProvider> repLevelWriterProviders, ColumnDescriptorValuesWriter encoder)
     {
         // Constructs hierarchy of RepetitionLevelWriter from leaf to root
         RepetitionLevelWriter rootRepetitionLevelWriter = Iterables.getLast(repLevelWriterProviders)

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/repdef/RepLevelWriterProviders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/repdef/RepLevelWriterProviders.java
@@ -13,13 +13,13 @@
  */
 package io.trino.parquet.writer.repdef;
 
+import io.trino.parquet.writer.valuewriter.ColumnDescriptorValuesWriter;
 import io.trino.spi.block.ArrayBlock;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.ColumnarArray;
 import io.trino.spi.block.ColumnarMap;
 import io.trino.spi.block.MapBlock;
 import io.trino.spi.block.RowBlock;
-import org.apache.parquet.column.values.ValuesWriter;
 
 import java.util.Optional;
 
@@ -63,7 +63,7 @@ public class RepLevelWriterProviders
         }
 
         @Override
-        public RepetitionLevelWriter getRepetitionLevelWriter(Optional<RepetitionLevelWriter> nestedWriter, ValuesWriter encoder)
+        public RepetitionLevelWriter getRepetitionLevelWriter(Optional<RepetitionLevelWriter> nestedWriter, ColumnDescriptorValuesWriter encoder)
         {
             checkArgument(nestedWriter.isEmpty(), "nestedWriter should be empty for primitive repetition level writer");
             return new RepetitionLevelWriter()
@@ -101,7 +101,7 @@ public class RepLevelWriterProviders
         }
 
         @Override
-        public RepetitionLevelWriter getRepetitionLevelWriter(Optional<RepetitionLevelWriter> nestedWriterOptional, ValuesWriter encoder)
+        public RepetitionLevelWriter getRepetitionLevelWriter(Optional<RepetitionLevelWriter> nestedWriterOptional, ColumnDescriptorValuesWriter encoder)
         {
             checkArgument(nestedWriterOptional.isPresent(), "nestedWriter should be present for column row repetition level writer");
             return new RepetitionLevelWriter()
@@ -160,7 +160,7 @@ public class RepLevelWriterProviders
         }
 
         @Override
-        public RepetitionLevelWriter getRepetitionLevelWriter(Optional<RepetitionLevelWriter> nestedWriterOptional, ValuesWriter encoder)
+        public RepetitionLevelWriter getRepetitionLevelWriter(Optional<RepetitionLevelWriter> nestedWriterOptional, ColumnDescriptorValuesWriter encoder)
         {
             checkArgument(nestedWriterOptional.isPresent(), "nestedWriter should be present for column map repetition level writer");
             return new RepetitionLevelWriter()
@@ -224,7 +224,7 @@ public class RepLevelWriterProviders
         }
 
         @Override
-        public RepetitionLevelWriter getRepetitionLevelWriter(Optional<RepetitionLevelWriter> nestedWriterOptional, ValuesWriter encoder)
+        public RepetitionLevelWriter getRepetitionLevelWriter(Optional<RepetitionLevelWriter> nestedWriterOptional, ColumnDescriptorValuesWriter encoder)
         {
             checkArgument(nestedWriterOptional.isPresent(), "nestedWriter should be present for column map repetition level writer");
             return new RepetitionLevelWriter()

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/repdef/RepLevelWriterProviders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/repdef/RepLevelWriterProviders.java
@@ -80,9 +80,7 @@ public class RepLevelWriterProviders
                 public void writeRepetitionLevels(int parentLevel, int positionsCount)
                 {
                     checkValidPosition(offset, positionsCount, block.getPositionCount());
-                    for (int i = 0; i < positionsCount; i++) {
-                        encoder.writeInteger(parentLevel);
-                    }
+                    encoder.writeRepeatInteger(parentLevel, positionsCount);
                     offset += positionsCount;
                 }
             };

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/ColumnDescriptorValuesWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/ColumnDescriptorValuesWriter.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.writer.valuewriter;
+
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.Encoding;
+
+import static org.apache.parquet.bytes.BytesUtils.getWidthFromMaxInt;
+
+/**
+ * Used for writing repetition and definition levels
+ */
+public interface ColumnDescriptorValuesWriter
+{
+    /**
+     * @param value the value to encode
+     */
+    void writeInteger(int value);
+
+    /**
+     * used to decide if we want to work to the next page
+     *
+     * @return the size of the currently buffered data (in bytes)
+     */
+    long getBufferedSize();
+
+    /**
+     * @return the allocated size of the buffer
+     */
+    long getAllocatedSize();
+
+    /**
+     * @return the bytes buffered so far to write to the current page
+     */
+    BytesInput getBytes();
+
+    /**
+     * @return the encoding that was used to encode the bytes
+     */
+    Encoding getEncoding();
+
+    /**
+     * called after getBytes() to reset the current buffer and start writing the next page
+     */
+    void reset();
+
+    static ColumnDescriptorValuesWriter newRepetitionLevelWriter(ColumnDescriptor path, int pageSizeThreshold)
+    {
+        return newColumnDescriptorValuesWriter(path.getMaxRepetitionLevel(), pageSizeThreshold);
+    }
+
+    static ColumnDescriptorValuesWriter newDefinitionLevelWriter(ColumnDescriptor path, int pageSizeThreshold)
+    {
+        return newColumnDescriptorValuesWriter(path.getMaxDefinitionLevel(), pageSizeThreshold);
+    }
+
+    private static ColumnDescriptorValuesWriter newColumnDescriptorValuesWriter(int maxLevel, int pageSizeThreshold)
+    {
+        if (maxLevel == 0) {
+            return new DevNullValuesWriter();
+        }
+        return new RunLengthBitPackingHybridValuesWriter(getWidthFromMaxInt(maxLevel), pageSizeThreshold);
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/ColumnDescriptorValuesWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/ColumnDescriptorValuesWriter.java
@@ -30,6 +30,12 @@ public interface ColumnDescriptorValuesWriter
     void writeInteger(int value);
 
     /**
+     * @param value the value to encode
+     * @param valueRepetitions number of times the input value is repeated in the input stream
+     */
+    void writeRepeatInteger(int value, int valueRepetitions);
+
+    /**
      * used to decide if we want to work to the next page
      *
      * @return the size of the currently buffered data (in bytes)

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/DevNullValuesWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/DevNullValuesWriter.java
@@ -11,59 +11,47 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.parquet.writer;
+package io.trino.parquet.writer.valuewriter;
 
-import io.trino.parquet.writer.valuewriter.ColumnDescriptorValuesWriter;
-import it.unimi.dsi.fastutil.ints.IntArrayList;
-import it.unimi.dsi.fastutil.ints.IntList;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.column.Encoding;
 
-import java.util.List;
-
-class TestingValuesWriter
+/**
+ * This is a special writer that doesn't write anything. The idea being that
+ * some columns will always be the same value, and this will capture that. An
+ * example is the set of repetition levels for a schema with no repeated fields.
+ */
+public class DevNullValuesWriter
         implements ColumnDescriptorValuesWriter
 {
-    private final IntList values = new IntArrayList();
-
     @Override
     public long getBufferedSize()
     {
-        throw new UnsupportedOperationException();
+        return 0;
     }
+
+    @Override
+    public void reset() {}
+
+    @Override
+    public void writeInteger(int v) {}
 
     @Override
     public BytesInput getBytes()
     {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Encoding getEncoding()
-    {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void reset()
-    {
-        throw new UnsupportedOperationException();
+        return BytesInput.empty();
     }
 
     @Override
     public long getAllocatedSize()
     {
-        throw new UnsupportedOperationException();
+        return 0;
     }
 
     @Override
-    public void writeInteger(int v)
+    @SuppressWarnings("deprecation")
+    public Encoding getEncoding()
     {
-        values.add(v);
-    }
-
-    List<Integer> getWrittenValues()
-    {
-        return values;
+        return Encoding.BIT_PACKED;
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/DevNullValuesWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/DevNullValuesWriter.java
@@ -37,6 +37,9 @@ public class DevNullValuesWriter
     public void writeInteger(int v) {}
 
     @Override
+    public void writeRepeatInteger(int value, int valueRepetitions) {}
+
+    @Override
     public BytesInput getBytes()
     {
         return BytesInput.empty();

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/RunLengthBitPackingHybridEncoder.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/RunLengthBitPackingHybridEncoder.java
@@ -1,0 +1,291 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.writer.valuewriter;
+
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.bytes.BytesUtils;
+import org.apache.parquet.bytes.CapacityByteArrayOutputStream;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.values.bitpacking.BytePacker;
+import org.apache.parquet.column.values.bitpacking.Packer;
+import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridValuesWriter;
+
+import java.io.IOException;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * Encodes values using a combination of run length encoding and bit packing,
+ * according to the following grammar:
+ *
+ * <pre>
+ * {@code
+ * rle-bit-packed-hybrid: <length> <encoded-data>
+ * length := length of the <encoded-data> in bytes stored as 4 bytes little endian
+ * encoded-data := <run>*
+ * run := <bit-packed-run> | <rle-run>
+ * bit-packed-run := <bit-packed-header> <bit-packed-values>
+ * bit-packed-header := varint-encode(<bit-pack-count> << 1 | 1)
+ * // we always bit-pack a multiple of 8 values at a time, so we only store the number of values / 8
+ * bit-pack-count := (number of values in this run) / 8
+ * bit-packed-values :=  bit packed back to back, from LSB to MSB
+ * rle-run := <rle-header> <repeated-value>
+ * rle-header := varint-encode( (number of times repeated) << 1)
+ * repeated-value := value that is repeated, using a fixed-width of round-up-to-next-byte(bit-width)
+ * }
+ * </pre>
+ * NOTE: this class is only responsible for creating and returning the {@code <encoded-data>}
+ * portion of the above grammar. The {@code <length>} portion is done by
+ * {@link RunLengthBitPackingHybridValuesWriter}
+ * <p>
+ * Only supports positive values (including 0)
+ */
+public class RunLengthBitPackingHybridEncoder
+{
+    private static final int INITIAL_SLAB_SIZE = 64;
+
+    private final BytePacker packer;
+    private final CapacityByteArrayOutputStream baos;
+
+    /**
+     * The bit width used for bit-packing and for writing
+     * the repeated-value
+     */
+    private final int bitWidth;
+    /**
+     * Values that are bit-packed 8 at a time are packed into this
+     * buffer, which is then written to baos
+     */
+    private final byte[] packBuffer;
+    /**
+     * Previous value written, used to detect repeated values
+     */
+    private int previousValue;
+
+    /**
+     * We buffer 8 values at a time, and either bit pack them
+     * or discard them after writing a rle-run
+     */
+    private final int[] bufferedValues;
+    private int numBufferedValues;
+
+    /**
+     * How many times a value has been repeated
+     */
+    private int repeatCount;
+    /**
+     * How many groups of 8 values have been written
+     * to the current bit-packed-run
+     */
+    private int bitPackedGroupCount;
+
+    /**
+     * A "pointer" to a single byte in baos,
+     * which we use as our bit-packed-header. It's really
+     * the logical index of the byte in baos.
+     * <p>
+     * We are only using one byte for this header,
+     * which limits us to writing 504 values per bit-packed-run.
+     * <p>
+     * MSB must be 0 for varint encoding, LSB must be 1 to signify
+     * that this is a bit-packed-header leaves 6 bits to write the
+     * number of 8-groups -> (2^6 - 1) * 8 = 504
+     */
+    private long bitPackedRunHeaderPointer;
+    private boolean toBytesCalled;
+
+    public RunLengthBitPackingHybridEncoder(int bitWidth, int maxCapacityHint)
+    {
+        checkArgument(bitWidth >= 0 && bitWidth <= 32, "bitWidth must be >= 0 and <= 32");
+
+        this.bitWidth = bitWidth;
+        this.baos = new CapacityByteArrayOutputStream(INITIAL_SLAB_SIZE, maxCapacityHint, new HeapByteBufferAllocator());
+        this.packBuffer = new byte[bitWidth];
+        this.bufferedValues = new int[8];
+        this.packer = Packer.LITTLE_ENDIAN.newBytePacker(bitWidth);
+        reset(false);
+    }
+
+    private void reset(boolean resetBaos)
+    {
+        if (resetBaos) {
+            this.baos.reset();
+        }
+        this.previousValue = 0;
+        this.numBufferedValues = 0;
+        this.repeatCount = 0;
+        this.bitPackedGroupCount = 0;
+        this.bitPackedRunHeaderPointer = -1;
+        this.toBytesCalled = false;
+    }
+
+    public void writeInt(int value)
+            throws IOException
+    {
+        if (value == previousValue) {
+            // keep track of how many times we've seen this value
+            // consecutively
+            ++repeatCount;
+
+            if (repeatCount >= 8) {
+                // we've seen this at least 8 times, we're
+                // certainly going to write an rle-run,
+                // so just keep on counting repeats for now
+                return;
+            }
+        }
+        else {
+            // This is a new value, check if it signals the end of
+            // an rle-run
+            if (repeatCount >= 8) {
+                // it does! write an rle-run
+                writeRleRun();
+            }
+
+            // this is a new value so we've only seen it once
+            repeatCount = 1;
+            // start tracking this value for repeats
+            previousValue = value;
+        }
+
+        // We have not seen enough repeats to justify an rle-run yet,
+        // so buffer this value in case we decide to write a bit-packed-run
+        bufferedValues[numBufferedValues] = value;
+        ++numBufferedValues;
+
+        if (numBufferedValues == 8) {
+            // we've encountered less than 8 repeated values, so
+            // either start a new bit-packed-run or append to the
+            // current bit-packed-run
+            writeOrAppendBitPackedRun();
+        }
+    }
+
+    private void writeOrAppendBitPackedRun()
+            throws IOException
+    {
+        if (bitPackedGroupCount >= 63) {
+            // we've packed as many values as we can for this run,
+            // end it and start a new one
+            endPreviousBitPackedRun();
+        }
+
+        if (bitPackedRunHeaderPointer == -1) {
+            // this is a new bit-packed-run, allocate a byte for the header
+            // and keep a "pointer" to it so that it can be mutated later
+            baos.write(0); // write a sentinel value
+            bitPackedRunHeaderPointer = baos.getCurrentIndex();
+        }
+
+        packer.pack8Values(bufferedValues, 0, packBuffer, 0);
+        baos.write(packBuffer);
+
+        // empty the buffer, they've all been written
+        numBufferedValues = 0;
+
+        // clear the repeat count, as some repeated values
+        // may have just been bit packed into this run
+        repeatCount = 0;
+
+        ++bitPackedGroupCount;
+    }
+
+    /**
+     * If we are currently writing a bit-packed-run, update the
+     * bit-packed-header and consider this run to be over
+     * <p>
+     * does nothing if we're not currently writing a bit-packed run
+     */
+    private void endPreviousBitPackedRun()
+    {
+        if (bitPackedRunHeaderPointer == -1) {
+            // we're not currently in a bit-packed-run
+            return;
+        }
+
+        // create bit-packed-header, which needs to fit in 1 byte
+        byte bitPackHeader = (byte) ((bitPackedGroupCount << 1) | 1);
+
+        // update this byte
+        baos.setByte(bitPackedRunHeaderPointer, bitPackHeader);
+
+        // mark that this run is over
+        bitPackedRunHeaderPointer = -1;
+
+        // reset the number of groups
+        bitPackedGroupCount = 0;
+    }
+
+    private void writeRleRun()
+            throws IOException
+    {
+        // we may have been working on a bit-packed-run
+        // so close that run if it exists before writing this
+        // rle-run
+        endPreviousBitPackedRun();
+
+        // write the rle-header (lsb of 0 signifies a rle run)
+        BytesUtils.writeUnsignedVarInt(repeatCount << 1, baos);
+        // write the repeated-value
+        BytesUtils.writeIntLittleEndianPaddedOnBitWidth(baos, previousValue, bitWidth);
+
+        // reset the repeat count
+        repeatCount = 0;
+
+        // throw away all the buffered values, they were just repeats and they've been written
+        numBufferedValues = 0;
+    }
+
+    public BytesInput toBytes()
+            throws IOException
+    {
+        checkArgument(!toBytesCalled, "You cannot call toBytes() more than once without calling reset()");
+
+        // write anything that is buffered / queued up for an rle-run
+        if (repeatCount >= 8) {
+            writeRleRun();
+        }
+        else if (numBufferedValues > 0) {
+            for (int i = numBufferedValues; i < 8; i++) {
+                bufferedValues[i] = 0;
+            }
+            writeOrAppendBitPackedRun();
+            endPreviousBitPackedRun();
+        }
+        else {
+            endPreviousBitPackedRun();
+        }
+
+        toBytesCalled = true;
+        return BytesInput.from(baos);
+    }
+
+    /**
+     * Reset this encoder for re-use
+     */
+    public void reset()
+    {
+        reset(true);
+    }
+
+    public long getBufferedSize()
+    {
+        return baos.size();
+    }
+
+    public long getAllocatedSize()
+    {
+        return baos.getCapacity();
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/RunLengthBitPackingHybridValuesWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/RunLengthBitPackingHybridValuesWriter.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.writer.valuewriter;
+
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.io.ParquetEncodingException;
+
+import java.io.IOException;
+
+import static java.lang.Math.toIntExact;
+import static org.apache.parquet.column.Encoding.RLE;
+
+public class RunLengthBitPackingHybridValuesWriter
+        implements ColumnDescriptorValuesWriter
+{
+    private final RunLengthBitPackingHybridEncoder encoder;
+
+    public RunLengthBitPackingHybridValuesWriter(int bitWidth, int maxCapacityHint)
+    {
+        this.encoder = new RunLengthBitPackingHybridEncoder(bitWidth, maxCapacityHint);
+    }
+
+    @Override
+    public void writeInteger(int value)
+    {
+        try {
+            encoder.writeInt(value);
+        }
+        catch (IOException e) {
+            throw new ParquetEncodingException(e);
+        }
+    }
+
+    @Override
+    public long getBufferedSize()
+    {
+        return encoder.getBufferedSize();
+    }
+
+    @Override
+    public long getAllocatedSize()
+    {
+        return encoder.getAllocatedSize();
+    }
+
+    @Override
+    public BytesInput getBytes()
+    {
+        try {
+            // prepend the length of the column
+            BytesInput rle = encoder.toBytes();
+            return BytesInput.concat(BytesInput.fromInt(toIntExact(rle.size())), rle);
+        }
+        catch (IOException e) {
+            throw new ParquetEncodingException(e);
+        }
+    }
+
+    @Override
+    public Encoding getEncoding()
+    {
+        return RLE;
+    }
+
+    @Override
+    public void reset()
+    {
+        encoder.reset();
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/RunLengthBitPackingHybridValuesWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/RunLengthBitPackingHybridValuesWriter.java
@@ -44,6 +44,17 @@ public class RunLengthBitPackingHybridValuesWriter
     }
 
     @Override
+    public void writeRepeatInteger(int value, int valueRepetitions)
+    {
+        try {
+            encoder.writeRepeatedInteger(value, valueRepetitions);
+        }
+        catch (IOException e) {
+            throw new ParquetEncodingException(e);
+        }
+    }
+
+    @Override
     public long getBufferedSize()
     {
         return encoder.getBufferedSize();

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/TrinoValuesWriterFactory.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/TrinoValuesWriterFactory.java
@@ -13,9 +13,9 @@
  */
 package io.trino.parquet.writer.valuewriter;
 
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Encoding;
-import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.column.values.bloomfilter.BloomFilter;
 import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter;
@@ -33,11 +33,15 @@ import static org.apache.parquet.column.Encoding.PLAIN_DICTIONARY;
  */
 public class TrinoValuesWriterFactory
 {
-    private final ParquetProperties parquetProperties;
+    private static final int INITIAL_SLAB_SIZE = 64;
 
-    public TrinoValuesWriterFactory(ParquetProperties properties)
+    private final int maxPageSize;
+    private final int maxDictionaryPageSize;
+
+    public TrinoValuesWriterFactory(int maxPageSize, int maxDictionaryPageSize)
     {
-        this.parquetProperties = properties;
+        this.maxPageSize = maxPageSize;
+        this.maxDictionaryPageSize = maxDictionaryPageSize;
     }
 
     public ValuesWriter newValuesWriter(ColumnDescriptor descriptor, Optional<BloomFilter> bloomFilter)
@@ -57,43 +61,43 @@ public class TrinoValuesWriterFactory
     private ValuesWriter getFixedLenByteArrayValuesWriter(ColumnDescriptor path, Optional<BloomFilter> bloomFilter)
     {
         // dictionary encoding was not enabled in PARQUET 1.0
-        return createBloomFilterValuesWriter(new FixedLenByteArrayPlainValuesWriter(path.getTypeLength(), parquetProperties.getInitialSlabSize(), parquetProperties.getPageSizeThreshold(), parquetProperties.getAllocator()), bloomFilter);
+        return createBloomFilterValuesWriter(new FixedLenByteArrayPlainValuesWriter(path.getTypeLength(), INITIAL_SLAB_SIZE, maxPageSize, new HeapByteBufferAllocator()), bloomFilter);
     }
 
     private ValuesWriter getBinaryValuesWriter(ColumnDescriptor path, Optional<BloomFilter> bloomFilter)
     {
-        ValuesWriter fallbackWriter = createBloomFilterValuesWriter(new PlainValuesWriter(parquetProperties.getInitialSlabSize(), parquetProperties.getPageSizeThreshold(), parquetProperties.getAllocator()), bloomFilter);
-        return dictWriterWithFallBack(path, parquetProperties, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter);
+        ValuesWriter fallbackWriter = createBloomFilterValuesWriter(new PlainValuesWriter(INITIAL_SLAB_SIZE, maxPageSize, new HeapByteBufferAllocator()), bloomFilter);
+        return dictWriterWithFallBack(path, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter);
     }
 
     private ValuesWriter getInt32ValuesWriter(ColumnDescriptor path, Optional<BloomFilter> bloomFilter)
     {
-        ValuesWriter fallbackWriter = createBloomFilterValuesWriter(new PlainValuesWriter(parquetProperties.getInitialSlabSize(), parquetProperties.getPageSizeThreshold(), parquetProperties.getAllocator()), bloomFilter);
-        return dictWriterWithFallBack(path, parquetProperties, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter);
+        ValuesWriter fallbackWriter = createBloomFilterValuesWriter(new PlainValuesWriter(INITIAL_SLAB_SIZE, maxPageSize, new HeapByteBufferAllocator()), bloomFilter);
+        return dictWriterWithFallBack(path, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter);
     }
 
     private ValuesWriter getInt64ValuesWriter(ColumnDescriptor path, Optional<BloomFilter> bloomFilter)
     {
-        ValuesWriter fallbackWriter = createBloomFilterValuesWriter(new PlainValuesWriter(parquetProperties.getInitialSlabSize(), parquetProperties.getPageSizeThreshold(), parquetProperties.getAllocator()), bloomFilter);
-        return dictWriterWithFallBack(path, parquetProperties, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter);
+        ValuesWriter fallbackWriter = createBloomFilterValuesWriter(new PlainValuesWriter(INITIAL_SLAB_SIZE, maxPageSize, new HeapByteBufferAllocator()), bloomFilter);
+        return dictWriterWithFallBack(path, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter);
     }
 
     private ValuesWriter getInt96ValuesWriter(ColumnDescriptor path, Optional<BloomFilter> bloomFilter)
     {
-        ValuesWriter fallbackWriter = createBloomFilterValuesWriter(new FixedLenByteArrayPlainValuesWriter(12, parquetProperties.getInitialSlabSize(), parquetProperties.getPageSizeThreshold(), parquetProperties.getAllocator()), bloomFilter);
-        return dictWriterWithFallBack(path, parquetProperties, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter);
+        ValuesWriter fallbackWriter = createBloomFilterValuesWriter(new FixedLenByteArrayPlainValuesWriter(12, INITIAL_SLAB_SIZE, maxPageSize, new HeapByteBufferAllocator()), bloomFilter);
+        return dictWriterWithFallBack(path, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter);
     }
 
     private ValuesWriter getDoubleValuesWriter(ColumnDescriptor path, Optional<BloomFilter> bloomFilter)
     {
-        ValuesWriter fallbackWriter = createBloomFilterValuesWriter(new PlainValuesWriter(parquetProperties.getInitialSlabSize(), parquetProperties.getPageSizeThreshold(), parquetProperties.getAllocator()), bloomFilter);
-        return dictWriterWithFallBack(path, parquetProperties, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter);
+        ValuesWriter fallbackWriter = createBloomFilterValuesWriter(new PlainValuesWriter(INITIAL_SLAB_SIZE, maxPageSize, new HeapByteBufferAllocator()), bloomFilter);
+        return dictWriterWithFallBack(path, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter);
     }
 
     private ValuesWriter getFloatValuesWriter(ColumnDescriptor path, Optional<BloomFilter> bloomFilter)
     {
-        ValuesWriter fallbackWriter = createBloomFilterValuesWriter(new PlainValuesWriter(parquetProperties.getInitialSlabSize(), parquetProperties.getPageSizeThreshold(), parquetProperties.getAllocator()), bloomFilter);
-        return dictWriterWithFallBack(path, parquetProperties, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter);
+        ValuesWriter fallbackWriter = createBloomFilterValuesWriter(new PlainValuesWriter(INITIAL_SLAB_SIZE, maxPageSize, new HeapByteBufferAllocator()), bloomFilter);
+        return dictWriterWithFallBack(path, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter);
     }
 
     @SuppressWarnings("deprecation")
@@ -108,29 +112,29 @@ public class TrinoValuesWriterFactory
         return PLAIN_DICTIONARY;
     }
 
-    private static DictionaryValuesWriter dictionaryWriter(ColumnDescriptor path, ParquetProperties properties, Encoding dictPageEncoding, Encoding dataPageEncoding)
+    private DictionaryValuesWriter dictionaryWriter(ColumnDescriptor path, Encoding dictPageEncoding, Encoding dataPageEncoding)
     {
         return switch (path.getPrimitiveType().getPrimitiveTypeName()) {
             case BOOLEAN -> throw new IllegalArgumentException("no dictionary encoding for BOOLEAN");
             case BINARY ->
-                    new DictionaryValuesWriter.PlainBinaryDictionaryValuesWriter(properties.getDictionaryPageSizeThreshold(), dataPageEncoding, dictPageEncoding, properties.getAllocator());
+                    new DictionaryValuesWriter.PlainBinaryDictionaryValuesWriter(maxDictionaryPageSize, dataPageEncoding, dictPageEncoding, new HeapByteBufferAllocator());
             case INT32 ->
-                    new DictionaryValuesWriter.PlainIntegerDictionaryValuesWriter(properties.getDictionaryPageSizeThreshold(), dataPageEncoding, dictPageEncoding, properties.getAllocator());
+                    new DictionaryValuesWriter.PlainIntegerDictionaryValuesWriter(maxDictionaryPageSize, dataPageEncoding, dictPageEncoding, new HeapByteBufferAllocator());
             case INT64 ->
-                    new DictionaryValuesWriter.PlainLongDictionaryValuesWriter(properties.getDictionaryPageSizeThreshold(), dataPageEncoding, dictPageEncoding, properties.getAllocator());
+                    new DictionaryValuesWriter.PlainLongDictionaryValuesWriter(maxDictionaryPageSize, dataPageEncoding, dictPageEncoding, new HeapByteBufferAllocator());
             case INT96 ->
-                    new DictionaryValuesWriter.PlainFixedLenArrayDictionaryValuesWriter(properties.getDictionaryPageSizeThreshold(), 12, dataPageEncoding, dictPageEncoding, properties.getAllocator());
+                    new DictionaryValuesWriter.PlainFixedLenArrayDictionaryValuesWriter(maxDictionaryPageSize, 12, dataPageEncoding, dictPageEncoding, new HeapByteBufferAllocator());
             case DOUBLE ->
-                    new DictionaryValuesWriter.PlainDoubleDictionaryValuesWriter(properties.getDictionaryPageSizeThreshold(), dataPageEncoding, dictPageEncoding, properties.getAllocator());
+                    new DictionaryValuesWriter.PlainDoubleDictionaryValuesWriter(maxDictionaryPageSize, dataPageEncoding, dictPageEncoding, new HeapByteBufferAllocator());
             case FLOAT ->
-                    new DictionaryValuesWriter.PlainFloatDictionaryValuesWriter(properties.getDictionaryPageSizeThreshold(), dataPageEncoding, dictPageEncoding, properties.getAllocator());
+                    new DictionaryValuesWriter.PlainFloatDictionaryValuesWriter(maxDictionaryPageSize, dataPageEncoding, dictPageEncoding, new HeapByteBufferAllocator());
             case FIXED_LEN_BYTE_ARRAY ->
-                    new DictionaryValuesWriter.PlainFixedLenArrayDictionaryValuesWriter(properties.getDictionaryPageSizeThreshold(), path.getTypeLength(), dataPageEncoding, dictPageEncoding, properties.getAllocator());
+                    new DictionaryValuesWriter.PlainFixedLenArrayDictionaryValuesWriter(maxDictionaryPageSize, path.getTypeLength(), dataPageEncoding, dictPageEncoding, new HeapByteBufferAllocator());
         };
     }
 
-    private static ValuesWriter dictWriterWithFallBack(ColumnDescriptor path, ParquetProperties parquetProperties, Encoding dictPageEncoding, Encoding dataPageEncoding, ValuesWriter writerToFallBackTo)
+    private ValuesWriter dictWriterWithFallBack(ColumnDescriptor path, Encoding dictPageEncoding, Encoding dataPageEncoding, ValuesWriter writerToFallBackTo)
     {
-        return new DictionaryFallbackValuesWriter(dictionaryWriter(path, parquetProperties, dictPageEncoding, dataPageEncoding), writerToFallBackTo);
+        return new DictionaryFallbackValuesWriter(dictionaryWriter(path, dictPageEncoding, dataPageEncoding), writerToFallBackTo);
     }
 }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/BenchmarkParquetFormat.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/BenchmarkParquetFormat.java
@@ -100,8 +100,6 @@ public class BenchmarkParquetFormat
             throws IOException
     {
         data = dataSet.createTestData();
-        targetDir.mkdirs();
-        writeData(new File(targetDir, UUID.randomUUID().toString()));
     }
 
     @TearDown

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/BenchmarkParquetFormat.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/BenchmarkParquetFormat.java
@@ -1,0 +1,318 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slices;
+import io.trino.parquet.writer.ParquetWriter;
+import io.trino.parquet.writer.ParquetWriterOptions;
+import io.trino.spi.Page;
+import io.trino.spi.PageBuilder;
+import io.trino.spi.block.ArrayBlockBuilder;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.MapBlockBuilder;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.Type;
+import it.unimi.dsi.fastutil.ints.IntArrays;
+import org.apache.parquet.format.CompressionCodec;
+import org.openjdk.jmh.annotations.AuxCounters;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.results.RunResult;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static io.trino.jmh.Benchmarks.benchmark;
+import static io.trino.parquet.BenchmarkParquetFormatUtils.MIN_DATA_SIZE;
+import static io.trino.parquet.BenchmarkParquetFormatUtils.TestData;
+import static io.trino.parquet.BenchmarkParquetFormatUtils.createTempDir;
+import static io.trino.parquet.BenchmarkParquetFormatUtils.createTpchDataSet;
+import static io.trino.parquet.BenchmarkParquetFormatUtils.nextRandomBetween;
+import static io.trino.parquet.BenchmarkParquetFormatUtils.printResults;
+import static io.trino.parquet.ParquetTestUtils.createParquetWriter;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.tpch.TpchTable.LINE_ITEM;
+import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 2, timeUnit = SECONDS)
+@Warmup(iterations = 10, time = 2, timeUnit = SECONDS)
+@Fork(2)
+public class BenchmarkParquetFormat
+{
+    @Param({
+            "LINEITEM",
+            "MAP_VARCHAR_DOUBLE",
+            "LARGE_MAP_VARCHAR_DOUBLE",
+            "MAP_INT_DOUBLE",
+            "LARGE_ARRAY_VARCHAR"
+    })
+    public DataSet dataSet;
+
+    @Param({
+            "UNCOMPRESSED",
+            "SNAPPY",
+            "ZSTD"
+    })
+    public CompressionCodec compression;
+
+    private TestData data;
+
+    private final File targetDir = createTempDir("trino-benchmark");
+    private final ParquetWriterOptions writerOptions = ParquetWriterOptions.builder().build();
+
+    @Setup
+    public void setup()
+            throws IOException
+    {
+        data = dataSet.createTestData();
+        targetDir.mkdirs();
+        writeData(new File(targetDir, UUID.randomUUID().toString()));
+    }
+
+    @TearDown
+    public void tearDown()
+            throws IOException
+    {
+        deleteRecursively(targetDir.toPath(), ALLOW_INSECURE);
+    }
+
+    @AuxCounters
+    @State(Scope.Thread)
+    public static class CompressionCounter
+    {
+        public long inputSize;
+        public long outputSize;
+    }
+
+    @Benchmark
+    public File write(CompressionCounter counter)
+            throws IOException
+    {
+        File targetFile = new File(targetDir, UUID.randomUUID().toString());
+        writeData(targetFile);
+        counter.inputSize += data.getInputSize();
+        counter.outputSize += targetFile.length();
+        return targetFile;
+    }
+
+    private void writeData(File targetFile)
+            throws IOException
+    {
+        List<Page> inputPages = data.getPages();
+        try (ParquetWriter writer = createParquetWriter(
+                new FileOutputStream(targetFile),
+                writerOptions,
+                data.getColumnTypes(),
+                data.getColumnNames(),
+                compression)) {
+            for (Page page : inputPages) {
+                writer.write(page);
+            }
+        }
+    }
+
+    public enum DataSet
+    {
+        LINEITEM {
+            @Override
+            public TestData createTestData()
+            {
+                return createTpchDataSet(LINE_ITEM, LINE_ITEM.getColumns());
+            }
+        },
+        MAP_VARCHAR_DOUBLE {
+            private static final int MIN_ENTRIES = 1;
+            private static final int MAX_ENTRIES = 5;
+
+            @Override
+            public TestData createTestData()
+            {
+                MapType type = new MapType(VARCHAR, DOUBLE, TESTING_TYPE_MANAGER.getTypeOperators());
+                Random random = new Random(1234);
+
+                PageBuilder pageBuilder = new PageBuilder(ImmutableList.of(type));
+                ImmutableList.Builder<Page> pages = ImmutableList.builder();
+
+                int[] keys = {1, 2, 3, 4, 5};
+
+                long dataSize = 0;
+                while (dataSize < MIN_DATA_SIZE) {
+                    pageBuilder.declarePosition();
+
+                    MapBlockBuilder builder = (MapBlockBuilder) pageBuilder.getBlockBuilder(0);
+                    builder.buildEntry((keyBuilder, valueBuilder) -> {
+                        int entries = nextRandomBetween(random, MIN_ENTRIES, MAX_ENTRIES);
+                        IntArrays.shuffle(keys, random);
+                        for (int entryId = 0; entryId < entries; entryId++) {
+                            VARCHAR.writeSlice(keyBuilder, Slices.utf8Slice("key" + keys[entryId]));
+                            DOUBLE.writeDouble(valueBuilder, random.nextDouble());
+                        }
+                    });
+
+                    if (pageBuilder.isFull()) {
+                        Page page = pageBuilder.build();
+                        pages.add(page);
+                        pageBuilder.reset();
+                        dataSize += page.getSizeInBytes();
+                    }
+                }
+                return new TestData(ImmutableList.of("map"), ImmutableList.of(type), pages.build());
+            }
+        },
+        LARGE_MAP_VARCHAR_DOUBLE {
+            private static final int MIN_ENTRIES = 5_000;
+            private static final int MAX_ENTRIES = 15_000;
+
+            @Override
+            public TestData createTestData()
+            {
+                MapType type = new MapType(VARCHAR, DOUBLE, TESTING_TYPE_MANAGER.getTypeOperators());
+                Random random = new Random(1234);
+
+                PageBuilder pageBuilder = new PageBuilder(ImmutableList.of(type));
+                ImmutableList.Builder<Page> pages = ImmutableList.builder();
+                long dataSize = 0;
+                while (dataSize < MIN_DATA_SIZE) {
+                    pageBuilder.declarePosition();
+
+                    MapBlockBuilder builder = (MapBlockBuilder) pageBuilder.getBlockBuilder(0);
+                    builder.buildEntry((keyBuilder, valueBuilder) -> {
+                        int entries = nextRandomBetween(random, MIN_ENTRIES, MAX_ENTRIES);
+                        for (int entryId = 0; entryId < entries; entryId++) {
+                            VARCHAR.writeSlice(keyBuilder, Slices.utf8Slice("key" + random.nextInt(10_000_000)));
+                            DOUBLE.writeDouble(valueBuilder, random.nextDouble());
+                        }
+                    });
+
+                    if (pageBuilder.isFull()) {
+                        Page page = pageBuilder.build();
+                        pages.add(page);
+                        pageBuilder.reset();
+                        dataSize += page.getSizeInBytes();
+                    }
+                }
+                return new TestData(ImmutableList.of("map"), ImmutableList.of(type), pages.build());
+            }
+        },
+        MAP_INT_DOUBLE {
+            private static final int MIN_ENTRIES = 1;
+            private static final int MAX_ENTRIES = 5;
+
+            @Override
+            public TestData createTestData()
+            {
+                MapType type = new MapType(INTEGER, DOUBLE, TESTING_TYPE_MANAGER.getTypeOperators());
+                Random random = new Random(1234);
+
+                PageBuilder pageBuilder = new PageBuilder(ImmutableList.of(type));
+                ImmutableList.Builder<Page> pages = ImmutableList.builder();
+
+                int[] keys = {1, 2, 3, 4, 5};
+
+                long dataSize = 0;
+                while (dataSize < MIN_DATA_SIZE) {
+                    pageBuilder.declarePosition();
+
+                    MapBlockBuilder builder = (MapBlockBuilder) pageBuilder.getBlockBuilder(0);
+                    builder.buildEntry((keyBuilder, valueBuilder) -> {
+                        int entries = nextRandomBetween(random, MIN_ENTRIES, MAX_ENTRIES);
+                        IntArrays.shuffle(keys, random);
+                        for (int entryId = 0; entryId < entries; entryId++) {
+                            INTEGER.writeLong(keyBuilder, keys[entryId]);
+                            DOUBLE.writeDouble(valueBuilder, random.nextDouble());
+                        }
+                    });
+
+                    if (pageBuilder.isFull()) {
+                        Page page = pageBuilder.build();
+                        pages.add(page);
+                        pageBuilder.reset();
+                        dataSize += page.getSizeInBytes();
+                    }
+                }
+                return new TestData(ImmutableList.of("map"), ImmutableList.of(type), pages.build());
+            }
+        },
+        LARGE_ARRAY_VARCHAR {
+            private static final int MIN_ENTRIES = 5_000;
+            private static final int MAX_ENTRIES = 15_0000;
+
+            @Override
+            public TestData createTestData()
+            {
+                Type type = new ArrayType(createUnboundedVarcharType());
+                Random random = new Random(1234);
+
+                PageBuilder pageBuilder = new PageBuilder(ImmutableList.of(type));
+                ImmutableList.Builder<Page> pages = ImmutableList.builder();
+                long dataSize = 0;
+                while (dataSize < MIN_DATA_SIZE) {
+                    pageBuilder.declarePosition();
+
+                    BlockBuilder builder = pageBuilder.getBlockBuilder(0);
+                    ((ArrayBlockBuilder) builder).buildEntry(elementBuilder -> {
+                        int entries = nextRandomBetween(random, MIN_ENTRIES, MAX_ENTRIES);
+                        for (int entryId = 0; entryId < entries; entryId++) {
+                            createUnboundedVarcharType().writeSlice(elementBuilder, Slices.utf8Slice("key" + random.nextInt(10_000_000)));
+                        }
+                    });
+
+                    if (pageBuilder.isFull()) {
+                        Page page = pageBuilder.build();
+                        pages.add(page);
+                        pageBuilder.reset();
+                        dataSize += page.getSizeInBytes();
+                    }
+                }
+                return new TestData(ImmutableList.of("map"), ImmutableList.of(type), pages.build());
+            }
+        };
+
+        public abstract TestData createTestData();
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        Collection<RunResult> results = benchmark(BenchmarkParquetFormat.class)
+                .withOptions(optionsBuilder -> optionsBuilder.jvmArgsAppend("-Xmx4g", "-Xms4g"))
+                .run();
+
+        printResults(results);
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/BenchmarkParquetFormatUtils.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/BenchmarkParquetFormatUtils.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slices;
+import io.airlift.units.DataSize;
+import io.trino.spi.Page;
+import io.trino.spi.PageBuilder;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.type.Type;
+import io.trino.tpch.TpchColumn;
+import io.trino.tpch.TpchEntity;
+import io.trino.tpch.TpchTable;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.util.Statistics;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static java.lang.String.format;
+import static java.nio.file.Files.createTempDirectory;
+
+public final class BenchmarkParquetFormatUtils
+{
+    public static final long MIN_DATA_SIZE = DataSize.of(50, MEGABYTE).toBytes();
+
+    private BenchmarkParquetFormatUtils() {}
+
+    @SafeVarargs
+    public static <E extends TpchEntity> TestData createTpchDataSet(TpchTable<E> tpchTable, TpchColumn<E>... columns)
+    {
+        return createTpchDataSet(tpchTable, ImmutableList.copyOf(columns));
+    }
+
+    public static <E extends TpchEntity> TestData createTpchDataSet(TpchTable<E> tpchTable, List<TpchColumn<E>> columns)
+    {
+        List<String> columnNames = columns.stream().map(TpchColumn::getColumnName).collect(toImmutableList());
+        List<Type> columnTypes = columns.stream().map(BenchmarkParquetFormatUtils::getColumnType)
+                .collect(toImmutableList());
+
+        PageBuilder pageBuilder = new PageBuilder(columnTypes);
+        ImmutableList.Builder<Page> pages = ImmutableList.builder();
+        long dataSize = 0;
+        for (E row : tpchTable.createGenerator(10, 1, 1)) {
+            pageBuilder.declarePosition();
+            for (int i = 0; i < columns.size(); i++) {
+                TpchColumn<E> column = columns.get(i);
+                BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(i);
+                switch (column.getType().getBase()) {
+                    case IDENTIFIER:
+                        BIGINT.writeLong(blockBuilder, column.getIdentifier(row));
+                        break;
+                    case INTEGER:
+                        INTEGER.writeLong(blockBuilder, column.getInteger(row));
+                        break;
+                    case DATE:
+                        DATE.writeLong(blockBuilder, column.getDate(row));
+                        break;
+                    case DOUBLE:
+                        DOUBLE.writeDouble(blockBuilder, column.getDouble(row));
+                        break;
+                    case VARCHAR:
+                        createUnboundedVarcharType().writeSlice(blockBuilder, Slices.utf8Slice(column.getString(row)));
+                        break;
+                    default:
+                        throw new IllegalArgumentException("Unsupported type " + column.getType());
+                }
+            }
+            if (pageBuilder.isFull()) {
+                Page page = pageBuilder.build();
+                pages.add(page);
+                pageBuilder.reset();
+                dataSize += page.getSizeInBytes();
+
+                if (dataSize >= MIN_DATA_SIZE) {
+                    break;
+                }
+            }
+        }
+        if (!pageBuilder.isEmpty()) {
+            pages.add(pageBuilder.build());
+        }
+        return new TestData(columnNames, columnTypes, pages.build());
+    }
+
+    public static Type getColumnType(TpchColumn<?> input)
+    {
+        return switch (input.getType().getBase()) {
+            case IDENTIFIER -> BIGINT;
+            case INTEGER -> INTEGER;
+            case DATE -> DATE;
+            case DOUBLE -> DOUBLE;
+            case VARCHAR -> createUnboundedVarcharType();
+        };
+    }
+
+    public static void printResults(Collection<RunResult> results)
+    {
+        for (RunResult result : results) {
+            Statistics inputSizeStats = result.getSecondaryResults().get("inputSize").getStatistics();
+            Statistics outputSizeStats = result.getSecondaryResults().get("outputSize").getStatistics();
+            double compressionRatio = inputSizeStats.getSum() / outputSizeStats.getSum();
+            String compression = result.getParams().getParam("compression");
+            String dataSet = result.getParams().getParam("dataSet");
+            System.out.printf("  %-10s  %-30s  %-10s  %2.2f  %10s ± %11s (%5.2f%%) (N = %d, α = 99.9%%)\n",
+                    result.getPrimaryResult().getLabel(),
+                    dataSet,
+                    compression,
+                    compressionRatio,
+                    toHumanReadableSpeed((long) inputSizeStats.getMean()),
+                    toHumanReadableSpeed((long) inputSizeStats.getMeanErrorAt(0.999)),
+                    inputSizeStats.getMeanErrorAt(0.999) * 100 / inputSizeStats.getMean(),
+                    inputSizeStats.getN());
+        }
+        System.out.println();
+    }
+
+    public static String toHumanReadableSpeed(long bytesPerSecond)
+    {
+        String humanReadableSpeed;
+        if (bytesPerSecond < 1024 * 10L) {
+            humanReadableSpeed = format("%dB/s", bytesPerSecond);
+        }
+        else if (bytesPerSecond < 1024 * 1024 * 10L) {
+            humanReadableSpeed = format("%.1fkB/s", bytesPerSecond / 1024.0f);
+        }
+        else if (bytesPerSecond < 1024 * 1024 * 1024 * 10L) {
+            humanReadableSpeed = format("%.1fMB/s", bytesPerSecond / (1024.0f * 1024.0f));
+        }
+        else {
+            humanReadableSpeed = format("%.1fGB/s", bytesPerSecond / (1024.0f * 1024.0f * 1024.0f));
+        }
+        return humanReadableSpeed;
+    }
+
+    public static int nextRandomBetween(Random random, int min, int max)
+    {
+        return min + random.nextInt(max - min);
+    }
+
+    public static File createTempDir(String prefix)
+    {
+        try {
+            return createTempDirectory(prefix).toFile();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public static class TestData
+    {
+        private final List<String> columnNames;
+        private final List<Type> columnTypes;
+        private final List<Page> pages;
+        private final long inputSize;
+
+        public TestData(List<String> columnNames, List<Type> columnTypes, List<Page> pages)
+        {
+            this.columnNames = ImmutableList.copyOf(columnNames);
+            this.columnTypes = ImmutableList.copyOf(columnTypes);
+            this.pages = ImmutableList.copyOf(pages);
+            this.inputSize = pages.stream().mapToLong(Page::getSizeInBytes).sum();
+        }
+
+        public List<String> getColumnNames()
+        {
+            return columnNames;
+        }
+
+        public List<Type> getColumnTypes()
+        {
+            return columnTypes;
+        }
+
+        public List<Page> getPages()
+        {
+            return pages;
+        }
+
+        public long getInputSize()
+        {
+            return inputSize;
+        }
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/ParquetTestUtils.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/ParquetTestUtils.java
@@ -78,7 +78,7 @@ public class ParquetTestUtils
             throws IOException
     {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        ParquetWriter writer = createParquetWriter(outputStream, writerOptions, types, columnNames);
+        ParquetWriter writer = createParquetWriter(outputStream, writerOptions, types, columnNames, CompressionCodec.SNAPPY);
 
         for (io.trino.spi.Page inputPage : inputPages) {
             checkArgument(types.size() == inputPage.getChannelCount());
@@ -88,7 +88,7 @@ public class ParquetTestUtils
         return Slices.wrappedBuffer(outputStream.toByteArray());
     }
 
-    public static ParquetWriter createParquetWriter(OutputStream outputStream, ParquetWriterOptions writerOptions, List<Type> types, List<String> columnNames)
+    public static ParquetWriter createParquetWriter(OutputStream outputStream, ParquetWriterOptions writerOptions, List<Type> types, List<String> columnNames, CompressionCodec compression)
     {
         checkArgument(types.size() == columnNames.size());
         ParquetSchemaConverter schemaConverter = new ParquetSchemaConverter(types, columnNames, false, false);
@@ -97,7 +97,7 @@ public class ParquetTestUtils
                 schemaConverter.getMessageType(),
                 schemaConverter.getPrimitiveTypes(),
                 writerOptions,
-                CompressionCodec.SNAPPY,
+                compression,
                 "test-version",
                 Optional.of(DateTimeZone.getDefault()),
                 Optional.empty());

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/TestParquetFormatBenchmark.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/TestParquetFormatBenchmark.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet;
+
+import org.apache.parquet.format.CompressionCodec;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static io.trino.parquet.BenchmarkParquetFormat.CompressionCounter;
+import static io.trino.parquet.BenchmarkParquetFormat.DataSet;
+
+public class TestParquetFormatBenchmark
+{
+    @Test
+    public void testAllDatasets()
+            throws Exception
+    {
+        for (DataSet dataSet : DataSet.values()) {
+            executeBenchmark(dataSet);
+        }
+    }
+
+    private static void executeBenchmark(DataSet dataSet)
+            throws IOException
+    {
+        BenchmarkParquetFormat benchmark = new BenchmarkParquetFormat();
+        try {
+            benchmark.dataSet = dataSet;
+            benchmark.compression = CompressionCodec.SNAPPY;
+            benchmark.setup();
+            benchmark.write(new CompressionCounter());
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Failed " + dataSet, e);
+        }
+        finally {
+            benchmark.tearDown();
+        }
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/AbstractColumnWriterBenchmark.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/AbstractColumnWriterBenchmark.java
@@ -18,7 +18,6 @@ import io.trino.parquet.writer.valuewriter.TrinoValuesWriterFactory;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
 import org.apache.parquet.column.ColumnDescriptor;
-import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.column.values.bloomfilter.BlockSplitBloomFilter;
 import org.apache.parquet.column.values.bloomfilter.BloomFilter;
 import org.apache.parquet.schema.PrimitiveType;
@@ -44,7 +43,6 @@ import static io.trino.jmh.Benchmarks.benchmark;
 import static io.trino.parquet.writer.ParquetWriters.getValueWriter;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_1_0;
 
 @State(Scope.Thread)
 @OutputTimeUnit(SECONDS)
@@ -96,10 +94,7 @@ public abstract class AbstractColumnWriterBenchmark
 
     private PrimitiveValueWriter createValuesWriter()
     {
-        TrinoValuesWriterFactory valuesWriterFactory = new TrinoValuesWriterFactory(ParquetProperties.builder()
-                .withWriterVersion(PARQUET_1_0)
-                .withDictionaryPageSize(dictionaryPageSize)
-                .build());
+        TrinoValuesWriterFactory valuesWriterFactory = new TrinoValuesWriterFactory(1024 * 1024, dictionaryPageSize);
         ColumnDescriptor columnDescriptor = new ColumnDescriptor(new String[] {"test"}, getParquetType(), 0, 0);
         return getValueWriter(valuesWriterFactory.newValuesWriter(columnDescriptor, bloomFilterType.getBloomFilter()), getTrinoType(), columnDescriptor.getPrimitiveType(), Optional.empty());
     }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriter.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriter.java
@@ -43,6 +43,7 @@ import io.trino.spi.type.Type;
 import org.apache.parquet.VersionParser;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.values.bloomfilter.BlockSplitBloomFilter;
+import org.apache.parquet.format.CompressionCodec;
 import org.apache.parquet.format.PageHeader;
 import org.apache.parquet.format.PageType;
 import org.apache.parquet.format.Util;
@@ -313,7 +314,8 @@ public class TestParquetWriter
                         .setMaxPageSize(DataSize.ofBytes(1024))
                         .build(),
                 types,
-                columnNames);
+                columnNames,
+                CompressionCodec.SNAPPY);
         List<io.trino.spi.Page> inputPages = generateInputPages(types, 1000, 100);
 
         long previousRetainedBytes = 0;

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestRunLengthBitPackingHybridEncoder.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestRunLengthBitPackingHybridEncoder.java
@@ -1,0 +1,321 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.writer;
+
+import io.trino.parquet.writer.valuewriter.RunLengthBitPackingHybridEncoder;
+import org.apache.parquet.column.values.bitpacking.BytePacker;
+import org.apache.parquet.column.values.bitpacking.Packer;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.parquet.bytes.BytesUtils.readIntLittleEndianOnOneByte;
+import static org.apache.parquet.bytes.BytesUtils.readIntLittleEndianOnTwoBytes;
+import static org.apache.parquet.bytes.BytesUtils.readUnsignedVarInt;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestRunLengthBitPackingHybridEncoder
+{
+    @Test
+    public void testRLEOnly()
+            throws Exception
+    {
+        RunLengthBitPackingHybridEncoder encoder = getRunLengthBitPackingHybridEncoder();
+        for (int i = 0; i < 100; i++) {
+            encoder.writeInt(4);
+        }
+        for (int i = 0; i < 100; i++) {
+            encoder.writeInt(5);
+        }
+
+        ByteArrayInputStream is = new ByteArrayInputStream(encoder.toBytes().toByteArray());
+
+        // header = 100 << 1 = 200
+        assertThat(readUnsignedVarInt(is)).isEqualTo(200);
+        // payload = 4
+        assertThat(readIntLittleEndianOnOneByte(is)).isEqualTo(4);
+
+        // header = 100 << 1 = 200
+        assertThat(readUnsignedVarInt(is)).isEqualTo(200);
+        // payload = 5
+        assertThat(readIntLittleEndianOnOneByte(is)).isEqualTo(5);
+
+        // end of stream
+        assertThat(is.read()).isEqualTo(-1);
+    }
+
+    @Test
+    public void testRepeatedZeros()
+            throws Exception
+    {
+        // previousValue is initialized to 0
+        // make sure that repeated 0s at the beginning
+        // of the stream don't trip up the repeat count
+
+        RunLengthBitPackingHybridEncoder encoder = getRunLengthBitPackingHybridEncoder();
+        for (int i = 0; i < 10; i++) {
+            encoder.writeInt(0);
+        }
+
+        ByteArrayInputStream is = new ByteArrayInputStream(encoder.toBytes().toByteArray());
+
+        // header = 10 << 1 = 20
+        assertThat(readUnsignedVarInt(is)).isEqualTo(20);
+        // payload = 4
+        assertThat(readIntLittleEndianOnOneByte(is)).isEqualTo(0);
+
+        // end of stream
+        assertThat(is.read()).isEqualTo(-1);
+    }
+
+    @Test
+    public void testBitWidthZero()
+            throws Exception
+    {
+        RunLengthBitPackingHybridEncoder encoder = getRunLengthBitPackingHybridEncoder(0, 64);
+        for (int i = 0; i < 10; i++) {
+            encoder.writeInt(0);
+        }
+
+        ByteArrayInputStream is = new ByteArrayInputStream(encoder.toBytes().toByteArray());
+
+        // header = 10 << 1 = 20
+        assertThat(readUnsignedVarInt(is)).isEqualTo(20);
+
+        // end of stream
+        assertThat(is.read()).isEqualTo(-1);
+    }
+
+    @Test
+    public void testBitPackingOnly()
+            throws Exception
+    {
+        RunLengthBitPackingHybridEncoder encoder = getRunLengthBitPackingHybridEncoder();
+        for (int i = 0; i < 100; i++) {
+            encoder.writeInt(i % 3);
+        }
+
+        ByteArrayInputStream is = new ByteArrayInputStream(encoder.toBytes().toByteArray());
+
+        // header = ((104/8) << 1) | 1 = 27
+        assertThat(readUnsignedVarInt(is)).isEqualTo(27);
+
+        List<Integer> values = unpack(3, 104, is);
+
+        for (int i = 0; i < 100; i++) {
+            assertThat((int) values.get(i)).isEqualTo(i % 3);
+        }
+
+        // end of stream
+        assertThat(is.read()).isEqualTo(-1);
+    }
+
+    @Test
+    public void testBitPackingOverflow()
+            throws Exception
+    {
+        RunLengthBitPackingHybridEncoder encoder = getRunLengthBitPackingHybridEncoder();
+
+        for (int i = 0; i < 1000; i++) {
+            encoder.writeInt(i % 3);
+        }
+
+        ByteArrayInputStream is = new ByteArrayInputStream(encoder.toBytes().toByteArray());
+
+        // 504 is the max number of values in a bit packed run
+        // that still has a header of 1 byte
+        // header = ((504/8) << 1) | 1 = 127
+        assertThat(readUnsignedVarInt(is)).isEqualTo(127);
+        List<Integer> values = unpack(3, 504, is);
+
+        for (int i = 0; i < 504; i++) {
+            assertThat((int) values.get(i)).isEqualTo(i % 3);
+        }
+
+        // there should now be 496 values in another bit-packed run
+        // header = ((496/8) << 1) | 1 = 125
+        assertThat(readUnsignedVarInt(is)).isEqualTo(125);
+        values = unpack(3, 496, is);
+        for (int i = 0; i < 496; i++) {
+            assertThat((int) values.get(i)).isEqualTo((i + 504) % 3);
+        }
+
+        // end of stream
+        assertThat(is.read()).isEqualTo(-1);
+    }
+
+    @Test
+    public void testTransitionFromBitPackingToRle()
+            throws Exception
+    {
+        RunLengthBitPackingHybridEncoder encoder = getRunLengthBitPackingHybridEncoder();
+
+        // 5 obviously bit-packed values
+        encoder.writeInt(0);
+        encoder.writeInt(1);
+        encoder.writeInt(0);
+        encoder.writeInt(1);
+        encoder.writeInt(0);
+
+        // three repeated values, that ought to be bit-packed as well
+        encoder.writeInt(2);
+        encoder.writeInt(2);
+        encoder.writeInt(2);
+
+        // lots more repeated values, that should be rle-encoded
+        for (int i = 0; i < 100; i++) {
+            encoder.writeInt(2);
+        }
+
+        ByteArrayInputStream is = new ByteArrayInputStream(encoder.toBytes().toByteArray());
+
+        // header = ((8/8) << 1) | 1 = 3
+        assertThat(readUnsignedVarInt(is)).isEqualTo(3);
+
+        List<Integer> values = unpack(3, 8, is);
+        assertThat(values).isEqualTo(Arrays.asList(0, 1, 0, 1, 0, 2, 2, 2));
+
+        // header = 100 << 1 = 200
+        assertThat(readUnsignedVarInt(is)).isEqualTo(200);
+        // payload = 2
+        assertThat(readIntLittleEndianOnOneByte(is)).isEqualTo(2);
+
+        // end of stream
+        assertThat(is.read()).isEqualTo(-1);
+    }
+
+    @Test
+    public void testPaddingZerosOnUnfinishedBitPackedRuns()
+            throws Exception
+    {
+        RunLengthBitPackingHybridEncoder encoder = getRunLengthBitPackingHybridEncoder(5, 64);
+        for (int i = 0; i < 9; i++) {
+            encoder.writeInt(i + 1);
+        }
+
+        ByteArrayInputStream is = new ByteArrayInputStream(encoder.toBytes().toByteArray());
+
+        // header = ((16/8) << 1) | 1 = 5
+        assertThat(readUnsignedVarInt(is)).isEqualTo(5);
+
+        List<Integer> values = unpack(5, 16, is);
+
+        assertThat(values).isEqualTo(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 0, 0, 0, 0, 0, 0));
+
+        assertThat(is.read()).isEqualTo(-1);
+    }
+
+    @Test
+    public void testSwitchingModes()
+            throws Exception
+    {
+        RunLengthBitPackingHybridEncoder encoder = getRunLengthBitPackingHybridEncoder(9, 1000);
+
+        // rle first
+        for (int i = 0; i < 25; i++) {
+            encoder.writeInt(17);
+        }
+
+        // bit-packing
+        for (int i = 0; i < 7; i++) {
+            encoder.writeInt(7);
+        }
+
+        encoder.writeInt(8);
+        encoder.writeInt(9);
+        encoder.writeInt(10);
+
+        // bit-packing followed by rle
+        for (int i = 0; i < 25; i++) {
+            encoder.writeInt(6);
+        }
+
+        // followed by a different rle
+        for (int i = 0; i < 8; i++) {
+            encoder.writeInt(5);
+        }
+
+        ByteArrayInputStream is = new ByteArrayInputStream(encoder.toBytes().toByteArray());
+
+        // header = 25 << 1 = 50
+        assertThat(readUnsignedVarInt(is)).isEqualTo(50);
+        // payload = 17, stored in 2 bytes
+        assertThat(readIntLittleEndianOnTwoBytes(is)).isEqualTo(17);
+
+        // header = ((16/8) << 1) | 1 = 5
+        assertThat(readUnsignedVarInt(is)).isEqualTo(5);
+        List<Integer> values = unpack(9, 16, is);
+        int v = 0;
+        for (int i = 0; i < 7; i++) {
+            assertThat((int) values.get(v)).isEqualTo(7);
+            v++;
+        }
+
+        assertThat((int) values.get(v++)).isEqualTo(8);
+        assertThat((int) values.get(v++)).isEqualTo(9);
+        assertThat((int) values.get(v++)).isEqualTo(10);
+
+        for (int i = 0; i < 6; i++) {
+            assertThat((int) values.get(v)).isEqualTo(6);
+            v++;
+        }
+
+        // header = 19 << 1 = 38
+        assertThat(readUnsignedVarInt(is)).isEqualTo(38);
+        // payload = 6, stored in 2 bytes
+        assertThat(readIntLittleEndianOnTwoBytes(is)).isEqualTo(6);
+
+        // header = 8 << 1  = 16
+        assertThat(readUnsignedVarInt(is)).isEqualTo(16);
+        // payload = 5, stored in 2 bytes
+        assertThat(readIntLittleEndianOnTwoBytes(is)).isEqualTo(5);
+
+        // end of stream
+        assertThat(is.read()).isEqualTo(-1);
+    }
+
+    private static List<Integer> unpack(int bitWidth, int numValues, ByteArrayInputStream is)
+    {
+        BytePacker packer = Packer.LITTLE_ENDIAN.newBytePacker(bitWidth);
+        int[] unpacked = new int[8];
+        byte[] next8Values = new byte[bitWidth];
+
+        List<Integer> values = new ArrayList<>(numValues);
+        while (values.size() < numValues) {
+            for (int i = 0; i < bitWidth; i++) {
+                next8Values[i] = (byte) is.read();
+            }
+
+            packer.unpack8Values(next8Values, 0, unpacked, 0);
+
+            for (int v = 0; v < 8; v++) {
+                values.add(unpacked[v]);
+            }
+        }
+        return values;
+    }
+
+    private static RunLengthBitPackingHybridEncoder getRunLengthBitPackingHybridEncoder()
+    {
+        return getRunLengthBitPackingHybridEncoder(3, 64);
+    }
+
+    private static RunLengthBitPackingHybridEncoder getRunLengthBitPackingHybridEncoder(int bitWidth, int maxCapacityHint)
+    {
+        return new RunLengthBitPackingHybridEncoder(bitWidth, maxCapacityHint);
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestRunLengthBitPackingHybridValuesWriter.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestRunLengthBitPackingHybridValuesWriter.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.writer;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slices;
+import io.trino.parquet.reader.SimpleSliceInputStream;
+import io.trino.parquet.reader.decoders.RleBitPackingHybridDecoder;
+import io.trino.parquet.writer.valuewriter.RunLengthBitPackingHybridEncoder;
+import org.apache.parquet.bytes.BytesInput;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestRunLengthBitPackingHybridValuesWriter
+{
+    @Test
+    public void verifyRoundTrip()
+            throws Exception
+    {
+        for (int i = 0; i <= 32; i++) {
+            verifyRoundTrip(i);
+        }
+    }
+
+    private static void verifyRoundTrip(int bitWidth)
+            throws Exception
+    {
+        RunLengthBitPackingHybridEncoder encoder = new RunLengthBitPackingHybridEncoder(bitWidth, 64000);
+        List<Integer> expected = generateInputValues(bitWidth);
+        for (int value : expected) {
+            encoder.writeInt(value);
+        }
+        BytesInput encodedBytes = encoder.toBytes();
+        SimpleSliceInputStream input = new SimpleSliceInputStream(Slices.wrappedBuffer(encodedBytes.toByteArray()));
+
+        RleBitPackingHybridDecoder decoder = new RleBitPackingHybridDecoder(bitWidth, true);
+        decoder.init(input);
+        int[] output = new int[expected.size()];
+        decoder.read(output, 0, expected.size());
+        assertThat(output).isEqualTo(expected.stream().mapToInt(Integer::intValue).toArray());
+    }
+
+    private static List<Integer> generateInputValues(int bitWidth)
+    {
+        long modValue = 1L << bitWidth;
+        ImmutableList.Builder<Integer> builder = ImmutableList.builder();
+        for (int i = 0; i < 100; i++) {
+            builder.add((int) (i % modValue));
+        }
+        for (int i = 0; i < 100; i++) {
+            builder.add((int) (77 % modValue));
+        }
+        for (int i = 0; i < 100; i++) {
+            builder.add((int) (88 % modValue));
+        }
+        for (int i = 0; i < 1000; i++) {
+            builder.add((int) (i % modValue));
+            builder.add((int) (i % modValue));
+            builder.add((int) (i % modValue));
+        }
+        for (int i = 0; i < 1000; i++) {
+            builder.add((int) (17 % modValue));
+        }
+        return builder.build();
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestTrinoValuesWriterFactory.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestTrinoValuesWriterFactory.java
@@ -17,7 +17,6 @@ import io.trino.parquet.writer.valuewriter.BloomFilterValuesWriter;
 import io.trino.parquet.writer.valuewriter.DictionaryFallbackValuesWriter;
 import io.trino.parquet.writer.valuewriter.TrinoValuesWriterFactory;
 import org.apache.parquet.column.ColumnDescriptor;
-import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.column.values.bloomfilter.BlockSplitBloomFilter;
 import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainBinaryDictionaryValuesWriter;
@@ -35,7 +34,6 @@ import org.junit.jupiter.api.Test;
 import java.util.Optional;
 
 import static java.util.Locale.ENGLISH;
-import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_1_0;
 import static org.apache.parquet.schema.Types.required;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -128,9 +126,7 @@ public class TestTrinoValuesWriterFactory
     private void testValueWriter(PrimitiveTypeName typeName, Class<? extends ValuesWriter> expectedValueWriterClass)
     {
         ColumnDescriptor mockPath = createColumnDescriptor(typeName);
-        TrinoValuesWriterFactory factory = new TrinoValuesWriterFactory(ParquetProperties.builder()
-                .withWriterVersion(PARQUET_1_0)
-                .build());
+        TrinoValuesWriterFactory factory = new TrinoValuesWriterFactory(1024, 1024);
         ValuesWriter writer = factory.newValuesWriter(mockPath, Optional.empty());
 
         validateWriterType(writer, expectedValueWriterClass);
@@ -139,9 +135,7 @@ public class TestTrinoValuesWriterFactory
     private void testValueWriter(PrimitiveTypeName typeName, Class<? extends ValuesWriter> initialValueWriterClass, Class<? extends ValuesWriter> fallbackValueWriterClass)
     {
         ColumnDescriptor mockPath = createColumnDescriptor(typeName);
-        TrinoValuesWriterFactory factory = new TrinoValuesWriterFactory(ParquetProperties.builder()
-                .withWriterVersion(PARQUET_1_0)
-                .build());
+        TrinoValuesWriterFactory factory = new TrinoValuesWriterFactory(1024, 1024);
         ValuesWriter writer = factory.newValuesWriter(mockPath, Optional.empty());
 
         validateFallbackWriter(writer, initialValueWriterClass, fallbackValueWriterClass);
@@ -150,9 +144,7 @@ public class TestTrinoValuesWriterFactory
     private void testValueWriterBloomFilter(PrimitiveTypeName typeName, Class<? extends ValuesWriter> initialValueWriterClass, Class<? extends ValuesWriter> fallbackValueWriterClass)
     {
         ColumnDescriptor mockPath = createColumnDescriptor(typeName);
-        TrinoValuesWriterFactory factory = new TrinoValuesWriterFactory(ParquetProperties.builder()
-                .withWriterVersion(PARQUET_1_0)
-                .build());
+        TrinoValuesWriterFactory factory = new TrinoValuesWriterFactory(1024, 1024);
         ValuesWriter writer = factory.newValuesWriter(mockPath, Optional.of(new BlockSplitBloomFilter(1024, 1024)));
 
         validateFallbackWriterBloomFilter(writer, initialValueWriterClass, fallbackValueWriterClass);

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestingValuesWriter.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestingValuesWriter.java
@@ -62,6 +62,14 @@ class TestingValuesWriter
         values.add(v);
     }
 
+    @Override
+    public void writeRepeatInteger(int value, int valueRepetitions)
+    {
+        for (int i = 0; i < valueRepetitions; i++) {
+            values.add(value);
+        }
+    }
+
     List<Integer> getWrittenValues()
     {
         return values;


### PR DESCRIPTION
## Description
Use information about nullability of Blocks to write RLE runs
for repetition and definition levels more efficiently in parquet writer

```
BenchmarkParquetFormat#write UNCOMPRESSED
                          Before                          After
LINEITEM                  293.0MB/s ± 2869.6kB/s (0.96%)  308.6MB/s ± 2269.6kB/s (0.72%) (N = 10, α = 99.9%)
MAP_VARCHAR_DOUBLE        345.4MB/s ± 3275.7kB/s (0.93%)  353.0MB/s ± 2608.4kB/s (0.72%) (N = 10, α = 99.9%)
LARGE_MAP_VARCHAR_DOUBLE  402.0MB/s ± 6815.6kB/s (1.66%)  447.1MB/s ± 4037.0kB/s (0.88%) (N = 10, α = 99.9%)
MAP_INT_DOUBLE            606.2MB/s ± 2136.1kB/s (0.34%)  671.6MB/s ± 2267.2kB/s (0.33%) (N = 10, α = 99.9%)
LARGE_ARRAY_VARCHAR       257.8MB/s ± 9303.4kB/s (3.52%)  277.0MB/s ± 8378.5kB/s (2.95%) (N = 10, α = 99.9%)
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Hudi, Delta Lake, Iceberg
* Improve performance of writing parquet files. ({issue}`issuenumber`)
```
