### PR TITLE
Use hive.metastore of JVM options in DeltaLakeExternalQueryRunnerMain

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
@@ -208,6 +208,7 @@ public final class DeltaLakeQueryRunner
             // Please set Delta Lake connector properties via VM options. e.g. -Dhive.metastore=glue -D..
             QueryRunner queryRunner = builder()
                     .addCoordinatorProperty("http-server.http.port", "8080")
+                    .addDeltaProperty("hive.metastore", System.getProperty("hive.metastore"))
                     .build();
 
             Logger log = Logger.get(DeltaLakeExternalQueryRunnerMain.class);


### PR DESCRIPTION
## Description

We could specify metastore type with JVM options before https://github.com/trinodb/trino/commit/ddf931f65c93f53ce46dfb70d3efa2cfc66b2b7a. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
