### PR TITLE
Do not shade io.trino.client in jdbc driver

### DIFF
--- a/client/trino-jdbc/pom.xml
+++ b/client/trino-jdbc/pom.xml
@@ -399,10 +399,6 @@
                             <shadeSourcesContent>true</shadeSourcesContent>
                             <relocations>
                                 <relocation>
-                                    <pattern>io.trino.client</pattern>
-                                    <shadedPattern>${shadeBase}.client</shadedPattern>
-                                </relocation>
-                                <relocation>
                                     <pattern>com.fasterxml.jackson</pattern>
                                     <shadedPattern>${shadeBase}.jackson</shadedPattern>
                                 </relocation>

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/JdbcDriverIT.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/JdbcDriverIT.java
@@ -54,6 +54,6 @@ public class JdbcDriverIT
 
     public static boolean isExpectedFile(String filename)
     {
-        return MANIFEST_FILES.contains(filename) || filename.startsWith("io/trino/jdbc");
+        return MANIFEST_FILES.contains(filename) || filename.startsWith("io/trino");
     }
 }


### PR DESCRIPTION
Basic premise of shading is to avoid a conflict of transitive/unmanaged dependencies.

This is not the case for trino-client.

This also makes it possible to use `InMemoryTrinoResultSet` which accepts `io.trino.client.Column` which will be relocated in the jdbc driver and classes names will not match.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
