### PR TITLE
Add optimizer rule to push filter into values

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -207,6 +207,7 @@ public final class SystemSessionProperties
     public static final String MIN_INPUT_ROWS_PER_TASK = "min_input_rows_per_task";
     public static final String USE_EXACT_PARTITIONING = "use_exact_partitioning";
     public static final String USE_COST_BASED_PARTITIONING = "use_cost_based_partitioning";
+    public static final String PUSH_FILTER_INTO_VALUES_MAX_ROW_COUNT = "push_filter_into_values_max_row_count";
     public static final String FORCE_SPILLING_JOIN = "force_spilling_join";
     public static final String PAGE_PARTITIONING_BUFFER_POOL_SIZE = "page_partitioning_buffer_pool_size";
     public static final String IDLE_WRITER_MIN_DATA_SIZE_THRESHOLD = "idle_writer_min_data_size_threshold";
@@ -1056,6 +1057,11 @@ public final class SystemSessionProperties
                         "When enabled the cost based optimizer is used to determine if repartitioning the output of an already partitioned stage is necessary",
                         optimizerConfig.isUseCostBasedPartitioning(),
                         false),
+                integerProperty(
+                        PUSH_FILTER_INTO_VALUES_MAX_ROW_COUNT,
+                        "Maximum number of rows in values for which filter is pushed down into values",
+                        optimizerConfig.getPushFilterIntoValuesMaxRowCount(),
+                        false),
                 booleanProperty(
                         FORCE_SPILLING_JOIN,
                         "Force the usage of spliing join operator in favor of the non-spilling one, even if spill is not enabled",
@@ -1898,6 +1904,11 @@ public final class SystemSessionProperties
     public static boolean isUseCostBasedPartitioning(Session session)
     {
         return session.getSystemProperty(USE_COST_BASED_PARTITIONING, Boolean.class);
+    }
+
+    public static int getPushFilterIntoValuesMaxRowCount(Session session)
+    {
+        return session.getSystemProperty(PUSH_FILTER_INTO_VALUES_MAX_ROW_COUNT, Integer.class);
     }
 
     public static boolean isForceSpillingOperator(Session session)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/OptimizerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/OptimizerConfig.java
@@ -87,6 +87,7 @@ public class OptimizerConfig
     private boolean forceSingleNodeOutput;
     private boolean useExactPartitioning;
     private boolean useCostBasedPartitioning = true;
+    private int pushFilterIntoValuesMaxRowCount = 100;
     // adaptive partial aggregation
     private boolean adaptivePartialAggregationEnabled = true;
     private double adaptivePartialAggregationUniqueRowsRatioThreshold = 0.8;
@@ -785,6 +786,20 @@ public class OptimizerConfig
     public OptimizerConfig setUseCostBasedPartitioning(boolean useCostBasedPartitioning)
     {
         this.useCostBasedPartitioning = useCostBasedPartitioning;
+        return this;
+    }
+
+    @Min(0)
+    public int getPushFilterIntoValuesMaxRowCount()
+    {
+        return pushFilterIntoValuesMaxRowCount;
+    }
+
+    @Config("optimizer.push-filter-into-values-max-row-count")
+    @ConfigDescription("Maximum number of rows in values for which filter is pushed down into values")
+    public OptimizerConfig setPushFilterIntoValuesMaxRowCount(int pushFilterIntoValuesMaxRowCount)
+    {
+        this.pushFilterIntoValuesMaxRowCount = pushFilterIntoValuesMaxRowCount;
         return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushFilterIntoValues.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushFilterIntoValues.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.Row;
+import io.trino.sql.planner.IrExpressionInterpreter;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.SymbolsExtractor;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.plan.FilterNode;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.ValuesNode;
+
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.trino.SystemSessionProperties.getPushFilterIntoValuesMaxRowCount;
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.sql.ir.Booleans.FALSE;
+import static io.trino.sql.ir.Booleans.NULL_BOOLEAN;
+import static io.trino.sql.ir.Booleans.TRUE;
+import static io.trino.sql.planner.DeterminismEvaluator.isDeterministic;
+import static io.trino.sql.planner.ExpressionSymbolInliner.inlineSymbols;
+import static io.trino.sql.planner.SymbolsExtractor.extractUnique;
+import static io.trino.sql.planner.plan.Patterns.filter;
+import static io.trino.sql.planner.plan.Patterns.source;
+import static io.trino.sql.planner.plan.Patterns.values;
+import static java.util.Objects.requireNonNull;
+
+public class PushFilterIntoValues
+        implements Rule<FilterNode>
+{
+    private static final Capture<ValuesNode> VALUES = newCapture();
+
+    private static final Pattern<FilterNode> PATTERN = filter()
+            .with(source().matching(values()
+                    .matching(PushFilterIntoValues::isSupportedValues)
+                    .capturedAs(VALUES)));
+
+    private final PlannerContext plannerContext;
+
+    public PushFilterIntoValues(PlannerContext plannerContext)
+    {
+        this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
+    }
+
+    @Override
+    public Pattern<FilterNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(FilterNode node, Captures captures, Context context)
+    {
+        ValuesNode valuesNode = captures.get(VALUES);
+
+        if (valuesNode.getRows().orElseThrow().size() > getPushFilterIntoValuesMaxRowCount(context.getSession())) {
+            return Result.empty();
+        }
+
+        Expression predicate = node.getPredicate();
+        if (!isDeterministic(predicate)) {
+            return Result.empty();
+        }
+
+        if (valuesNode.getRows().orElseThrow().isEmpty()) {
+            // empty values node, filter is redundant
+            return Result.ofPlanNode(valuesNode);
+        }
+
+        if (valuesNode.getRows().orElseThrow().stream()
+                .anyMatch(row -> !isDeterministic(row))) {
+            return Result.empty();
+        }
+
+        Set<Symbol> valuesExpressionsSymbols = valuesNode.getRows().orElseThrow().stream()
+                .map(SymbolsExtractor::extractUnique)
+                .flatMap(Set::stream)
+                .collect(toImmutableSet());
+        if (!valuesExpressionsSymbols.isEmpty()) {
+            // unresolved correlation
+            return Result.empty();
+        }
+
+        Set<Symbol> valuesOutputSymbols = ImmutableSet.copyOf(valuesNode.getOutputSymbols());
+        Set<Symbol> predicateSymbols = extractUnique(predicate);
+        if (!valuesOutputSymbols.containsAll(predicateSymbols)) {
+            // filter is correlated
+            return Result.empty();
+        }
+
+        ImmutableList.Builder<Expression> filteredRows = ImmutableList.builder();
+        boolean optimized = false;
+        boolean keepFilter = false;
+        for (Expression expression : valuesNode.getRows().orElseThrow()) {
+            Row row = (Row) expression;
+            ImmutableMap.Builder<Symbol, Expression> mapping = ImmutableMap.builder();
+            for (int i = 0; i < valuesNode.getOutputSymbols().size(); i++) {
+                mapping.put(valuesNode.getOutputSymbols().get(i), row.items().get(i));
+            }
+            Expression rewrittenPredicate = inlineSymbols(mapping.buildOrThrow(), predicate);
+            Expression optimizedPredicate = new IrExpressionInterpreter(rewrittenPredicate, plannerContext, context.getSession()).optimize();
+            if (optimizedPredicate.equals(TRUE)) {
+                filteredRows.add(row);
+            }
+            else if (optimizedPredicate.equals(FALSE) || optimizedPredicate.equals(NULL_BOOLEAN)) {
+                // skip row
+                optimized = true;
+            }
+            else {
+                // could not evaluate the predicate for the row
+                filteredRows.add(row);
+                keepFilter = true;
+            }
+        }
+
+        if (!optimized && keepFilter) {
+            return Result.empty();
+        }
+
+        PlanNode optimizedValues = new ValuesNode(
+                valuesNode.getId(),
+                valuesNode.getOutputSymbols(),
+                filteredRows.build());
+
+        if (keepFilter) {
+            return Result.ofPlanNode(node.replaceChildren(ImmutableList.of(optimizedValues)));
+        }
+
+        return Result.ofPlanNode(optimizedValues);
+    }
+
+    private static boolean isSupportedValues(ValuesNode valuesNode)
+    {
+        // If valuesNode.getRows().isEmpty() then values has no outputs. Filter predicate should be evaluated
+        // to a constant true or false literal, and plan should be optimized by RemoveTrivialFilters,
+        // so we don't need to handle this case here.
+        // Also, do not optimize if any values row is not a Row instance, because we cannot easily inline
+        // the columns of non-row expressions in the filter predicate.
+        return valuesNode.getRows().isPresent() && valuesNode.getRows().get().stream().allMatch(Row.class::isInstance);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/cost/TestOptimizerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/cost/TestOptimizerConfig.java
@@ -91,7 +91,8 @@ public class TestOptimizerConfig
                 .setMinInputSizePerTask(DataSize.of(5, GIGABYTE))
                 .setMinInputRowsPerTask(10_000_000L)
                 .setUseExactPartitioning(false)
-                .setUseCostBasedPartitioning(true));
+                .setUseCostBasedPartitioning(true)
+                .setPushFilterIntoValuesMaxRowCount(100));
     }
 
     @Test
@@ -150,6 +151,7 @@ public class TestOptimizerConfig
                 .put("optimizer.min-input-rows-per-task", "1000000")
                 .put("optimizer.use-exact-partitioning", "true")
                 .put("optimizer.use-cost-based-partitioning", "false")
+                .put("optimizer.push-filter-into-values-max-row-count", "5")
                 .buildOrThrow();
 
         OptimizerConfig expected = new OptimizerConfig()
@@ -204,7 +206,8 @@ public class TestOptimizerConfig
                 .setMinInputSizePerTask(DataSize.of(1, MEGABYTE))
                 .setMinInputRowsPerTask(1_000_000L)
                 .setUseExactPartitioning(true)
-                .setUseCostBasedPartitioning(false);
+                .setUseCostBasedPartitioning(false)
+                .setPushFilterIntoValuesMaxRowCount(5);
         assertFullMapping(properties, expected);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/AbstractPredicatePushdownTest.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/AbstractPredicatePushdownTest.java
@@ -290,9 +290,9 @@ public abstract class AbstractPredicatePushdownTest
                         join(LEFT, builder -> builder
                                 .equiCriteria("A", "B")
                                 .left(
-                                        assignUniqueId("unique", filter(new Comparison(EQUAL, new Reference(INTEGER, "A"), new Constant(INTEGER, 1L)), values("A"))))
+                                        assignUniqueId("unique", values("A")))
                                 .right(
-                                        filter(new Comparison(EQUAL, new Constant(INTEGER, 1L), new Reference(INTEGER, "B")), values("B"))))));
+                                        values("B")))));
     }
 
     @Test
@@ -480,8 +480,7 @@ public abstract class AbstractPredicatePushdownTest
                                                         ImmutableMap.of(
                                                                 "ORDERSTATUS", "orderstatus",
                                                                 "ORDERKEY", "orderkey")))),
-                                anyTree(
-                                        values("COL")))));
+                                values())));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
@@ -692,7 +692,7 @@ public class TestLogicalPlanner
                 anyTree(
                         node(AggregationNode.class,
                                 project(ImmutableMap.of("subquerytrue", expression(TRUE)),
-                                tableScan("orders")))));
+                                        tableScan("orders")))));
     }
 
     @Test
@@ -1975,11 +1975,9 @@ public class TestLogicalPlanner
                                                         ImmutableMap.of("ORDER_STATUS", "orderstatus", "ORDER_KEY", "orderkey"),
                                                         ImmutableMap.of("orderstatus", multipleValues(createVarcharType(1), ImmutableList.of(utf8Slice("F"), utf8Slice("O")))))))
                                 .right(
-                                        filter(
-                                                new In(new Reference(createVarcharType(1), "expr"), ImmutableList.of(new Constant(createVarcharType(1), utf8Slice("F")), new Constant(createVarcharType(1), utf8Slice("O")))),
-                                                values(
-                                                        ImmutableList.of("expr"),
-                                                        ImmutableList.of(ImmutableList.of(new Constant(createVarcharType(1), utf8Slice("O"))), ImmutableList.of(new Constant(createVarcharType(1), utf8Slice("F"))))))))));
+                                        values(
+                                                ImmutableList.of("expr"),
+                                                ImmutableList.of(ImmutableList.of(new Constant(createVarcharType(1), utf8Slice("O"))), ImmutableList.of(new Constant(createVarcharType(1), utf8Slice("F")))))))));
     }
 
     @Test
@@ -2078,9 +2076,7 @@ public class TestLogicalPlanner
                                                         ImmutableMap.of("ORDER_STATUS", "orderstatus", "ORDER_KEY", "orderkey"),
                                                         ImmutableMap.of("orderstatus", multipleValues(createVarcharType(1), ImmutableList.of(utf8Slice("F"), utf8Slice("O")))))))
                                 .right(
-                                        filter(
-                                                new In(new Reference(createVarcharType(1), "expr"), ImmutableList.of(new Constant(createVarcharType(1), utf8Slice("F")), new Constant(createVarcharType(1), utf8Slice("O")))),
-                                                values(ImmutableList.of("expr"), ImmutableList.of(ImmutableList.of(new Constant(createVarcharType(1), utf8Slice("O"))), ImmutableList.of(new Constant(createVarcharType(1), utf8Slice("F"))))))))));
+                                        values(ImmutableList.of("expr"), ImmutableList.of(ImmutableList.of(new Constant(createVarcharType(1), utf8Slice("O"))), ImmutableList.of(new Constant(createVarcharType(1), utf8Slice("F")))))))));
 
         // Constraint for the table is derived, based on constant values in the other branch of the join.
         // It is not accepted by the connector, and remains in form of a filter over TableScan.
@@ -2100,9 +2096,7 @@ public class TestLogicalPlanner
                                                         ImmutableMap.of("ORDER_STATUS", "orderstatus", "ORDER_KEY", "orderkey"),
                                                         ImmutableMap.of())))
                                 .right(
-                                        filter(
-                                                new In(new Reference(BIGINT, "expr"), ImmutableList.of(new Constant(BIGINT, 1L), new Constant(BIGINT, 2L))),
-                                                values(ImmutableList.of("expr"), ImmutableList.of(ImmutableList.of(new Constant(BIGINT, 1L)), ImmutableList.of(new Constant(BIGINT, 2L)))))))));
+                                        values(ImmutableList.of("expr"), ImmutableList.of(ImmutableList.of(new Constant(BIGINT, 1L)), ImmutableList.of(new Constant(BIGINT, 2L))))))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestRemoveDuplicatePredicates.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestRemoveDuplicatePredicates.java
@@ -13,12 +13,14 @@
  */
 package io.trino.sql.planner;
 
+import io.trino.Session;
 import io.trino.sql.ir.Comparison;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.planner.assertions.BasePlanTest;
 import org.junit.jupiter.api.Test;
 
+import static io.trino.SystemSessionProperties.PUSH_FILTER_INTO_VALUES_MAX_ROW_COUNT;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.sql.ir.Comparison.Operator.EQUAL;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
@@ -33,6 +35,7 @@ public class TestRemoveDuplicatePredicates
     {
         assertPlan(
                 "SELECT * FROM (VALUES 1) t(a) WHERE a = 1 AND 1 = a AND a = 1",
+                disablePushFilterIntoValues(),
                 anyTree(
                         filter(
                                 new Comparison(EQUAL, new Reference(INTEGER, "A"), new Constant(INTEGER, 1L)),
@@ -44,9 +47,17 @@ public class TestRemoveDuplicatePredicates
     {
         assertPlan(
                 "SELECT * FROM (VALUES 1) t(a) WHERE a = 1 OR 1 = a OR a = 1",
+                disablePushFilterIntoValues(),
                 anyTree(
                         filter(
                                 new Comparison(EQUAL, new Reference(INTEGER, "A"), new Constant(INTEGER, 1L)),
                                 values("A"))));
+    }
+
+    private Session disablePushFilterIntoValues()
+    {
+        return Session.builder(getPlanTester().getDefaultSession())
+                .setSystemProperty(PUSH_FILTER_INTO_VALUES_MAX_ROW_COUNT, "0")
+                .build();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestSimplifyIn.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestSimplifyIn.java
@@ -13,16 +13,10 @@
  */
 package io.trino.sql.planner;
 
-import io.trino.sql.ir.Comparison;
-import io.trino.sql.ir.Constant;
-import io.trino.sql.ir.Reference;
 import io.trino.sql.planner.assertions.BasePlanTest;
 import org.junit.jupiter.api.Test;
 
-import static io.trino.spi.type.IntegerType.INTEGER;
-import static io.trino.sql.ir.Comparison.Operator.EQUAL;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
-import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
 
 public class TestSimplifyIn
@@ -33,9 +27,6 @@ public class TestSimplifyIn
     {
         assertPlan(
                 "SELECT * FROM (VALUES 0) t(a) WHERE a IN (5)",
-                anyTree(
-                        filter(
-                                new Comparison(EQUAL, new Reference(INTEGER, "A"), new Constant(INTEGER, 5L)),
-                                values("A"))));
+                anyTree(values("A")));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestUnwrapCastInComparison.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestUnwrapCastInComparison.java
@@ -33,6 +33,7 @@ import io.trino.type.DateTimes;
 import io.trino.util.DateTimeUtils;
 import org.junit.jupiter.api.Test;
 
+import static io.trino.SystemSessionProperties.PUSH_FILTER_INTO_VALUES_MAX_ROW_COUNT;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.CharType.createCharType;
@@ -457,6 +458,9 @@ public class TestUnwrapCastInComparison
         // ensure the optimization works when the terms of the comparison are reversed
         // vs the canonical <expr> <op> <literal> form
         assertPlan("SELECT * FROM (VALUES REAL '1') t(a) WHERE DOUBLE '1' = a",
+                Session.builder(getPlanTester().getDefaultSession())
+                        .setSystemProperty(PUSH_FILTER_INTO_VALUES_MAX_ROW_COUNT, "0")
+                        .build(),
                 output(
                         filter(
                                 new Comparison(EQUAL, new Reference(REAL, "A"), new Constant(REAL, toReal(1.0f))),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestUnwrapYearInComparison.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestUnwrapYearInComparison.java
@@ -14,6 +14,7 @@
 package io.trino.sql.planner;
 
 import com.google.common.collect.ImmutableList;
+import io.trino.Session;
 import io.trino.metadata.ResolvedFunction;
 import io.trino.metadata.TestingFunctionResolution;
 import io.trino.spi.type.LongTimestamp;
@@ -34,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import static io.trino.SystemSessionProperties.PUSH_FILTER_INTO_VALUES_MAX_ROW_COUNT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DoubleType.DOUBLE;
@@ -303,6 +305,9 @@ public class TestUnwrapYearInComparison
         // ensure the optimization works when the terms of the comparison are reversed
         // vs the canonical <expr> <op> <literal> form
         assertPlan("SELECT * FROM (VALUES DATE '2022-01-01') t(a) WHERE 2022 = year(a)",
+                Session.builder(getPlanTester().getDefaultSession())
+                        .setSystemProperty(PUSH_FILTER_INTO_VALUES_MAX_ROW_COUNT, "0")
+                        .build(),
                 output(
                         filter(
                                 new Between(new Reference(DATE, "A"), new Constant(DATE, (long) DateTimeUtils.parseDate("2022-01-01")), new Constant(DATE, (long) DateTimeUtils.parseDate("2022-12-31"))),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushFilterIntoValues.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushFilterIntoValues.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.sql.ir.Call;
+import io.trino.sql.ir.Cast;
+import io.trino.sql.ir.Comparison;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.ir.Row;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RowType.anonymousRow;
+import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static io.trino.sql.ir.Booleans.TRUE;
+import static io.trino.sql.ir.Comparison.Operator.GREATER_THAN;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+
+class TestPushFilterIntoValues
+        extends BaseRuleTest
+{
+    @Test
+    public void testDoesNotFireWhenValuesHasNoOutputs()
+    {
+        tester().assertThat(new PushFilterIntoValues(tester().getPlannerContext()))
+                .on(p -> p.filter(TRUE, p.values(5)))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireWhenValuesHasNonRowExpression()
+    {
+        tester().assertThat(new PushFilterIntoValues(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol a = p.symbol("a", BIGINT);
+                    Symbol b = p.symbol("b", BIGINT);
+                    return p.filter(TRUE, p.valuesOfExpressions(
+                            ImmutableList.of(a, b),
+                            ImmutableList.of(
+                                    new Row(ImmutableList.of(new Constant(BIGINT, 1L), new Constant(BIGINT, 2L))),
+                                    new Cast(new Row(ImmutableList.of(new Constant(INTEGER, 3L), new Constant(INTEGER, 4L))), anonymousRow(BIGINT, BIGINT)))));
+                }).doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireWhenFilterPredicateNonDeterministic()
+    {
+        ResolvedFunction random = new TestingFunctionResolution().resolveFunction("random", fromTypes());
+
+        tester().assertThat(new PushFilterIntoValues(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol a = p.symbol("a", DOUBLE);
+                    Symbol b = p.symbol("b", DOUBLE);
+                    return p.filter(
+                            new Comparison(GREATER_THAN, new Reference(DOUBLE, "a"), new Call(random, ImmutableList.of())),
+                            p.values(5, a, b));
+                }).doesNotFire();
+    }
+
+    @Test
+    public void testEmptyValues()
+    {
+        tester().assertThat(new PushFilterIntoValues(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol a = p.symbol("a", BIGINT);
+                    Symbol b = p.symbol("b", BIGINT);
+                    return p.filter(
+                            new Comparison(GREATER_THAN, new Reference(BIGINT, "a"), new Constant(BIGINT, 0L)),
+                            p.values(a, b));
+                }).matches(
+                        values(ImmutableList.of("a", "b")));
+    }
+
+    @Test
+    public void testDoesNotFireWhenValuesNonDeterministic()
+    {
+        ResolvedFunction random = new TestingFunctionResolution().resolveFunction("random", fromTypes());
+
+        tester().assertThat(new PushFilterIntoValues(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol a = p.symbol("a", DOUBLE);
+                    Symbol b = p.symbol("b", DOUBLE);
+                    return p.filter(
+                            TRUE,
+                            p.values(
+                                    ImmutableList.of(a, b),
+                                    ImmutableList.of(ImmutableList.of(new Constant(DOUBLE, 1.0), new Call(random, ImmutableList.of())))));
+                }).doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireWhenValuesCorrelated()
+    {
+        tester().assertThat(new PushFilterIntoValues(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol a = p.symbol("a", DOUBLE);
+                    Symbol b = p.symbol("b", DOUBLE);
+                    return p.filter(
+                            TRUE,
+                            p.values(
+                                    ImmutableList.of(a, b),
+                                    ImmutableList.of(ImmutableList.of(new Constant(DOUBLE, 1.0), new Reference(DOUBLE, "c")))));
+                }).doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireWhenFilterCorrelated()
+    {
+        tester().assertThat(new PushFilterIntoValues(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol a = p.symbol("a", DOUBLE);
+                    Symbol b = p.symbol("b", DOUBLE);
+                    return p.filter(
+                            new Comparison(GREATER_THAN, new Reference(DOUBLE, "c"), new Constant(DOUBLE, 0.0)),
+                            p.values(5, a, b));
+                }).doesNotFire();
+    }
+
+    @Test
+    public void testRetainAllRowsAndRemoveFilter()
+    {
+        tester().assertThat(new PushFilterIntoValues(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol a = p.symbol("a", BIGINT);
+                    Symbol b = p.symbol("b", BIGINT);
+                    return p.filter(
+                            new Comparison(GREATER_THAN, new Reference(BIGINT, "a"), new Reference(BIGINT, "b")),
+                            p.values(
+                                    ImmutableList.of(a, b),
+                                    ImmutableList.of(
+                                            ImmutableList.of(new Constant(BIGINT, 5L), new Constant(BIGINT, 4L)),
+                                            ImmutableList.of(new Constant(BIGINT, 500L), new Constant(BIGINT, 400L)))));
+                }).matches(
+                        values(ImmutableList.of("a", "b")));
+    }
+
+    @Test
+    public void testRemoveSomeRowsAndRemoveFilter()
+    {
+        tester().assertThat(new PushFilterIntoValues(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol a = p.symbol("a", BIGINT);
+                    Symbol b = p.symbol("b", BIGINT);
+                    return p.filter(
+                            new Comparison(GREATER_THAN, new Reference(BIGINT, "a"), new Reference(BIGINT, "b")),
+                            p.values(
+                                    ImmutableList.of(a, b),
+                                    ImmutableList.of(
+                                            ImmutableList.of(new Constant(BIGINT, 5L), new Constant(BIGINT, 4L)),
+                                            ImmutableList.of(new Constant(BIGINT, 1L), new Constant(BIGINT, 2L)))));
+                }).matches(
+                        values(
+                                ImmutableList.of("a", "b"),
+                                ImmutableList.of(ImmutableList.of(new Constant(BIGINT, 5L), new Constant(BIGINT, 4L)))));
+    }
+
+    @Test
+    public void testRemoveAllRowsAndRemoveFilter()
+    {
+        tester().assertThat(new PushFilterIntoValues(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol a = p.symbol("a", BIGINT);
+                    Symbol b = p.symbol("b", BIGINT);
+                    return p.filter(
+                            new Comparison(GREATER_THAN, new Reference(BIGINT, "a"), new Reference(BIGINT, "b")),
+                            p.values(
+                                    ImmutableList.of(a, b),
+                                    ImmutableList.of(
+                                            ImmutableList.of(new Constant(BIGINT, 4L), new Constant(BIGINT, 5L)),
+                                            ImmutableList.of(new Constant(BIGINT, 1L), new Constant(BIGINT, 2L)))));
+                }).matches(
+                        values(ImmutableList.of("a", "b")));
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestPartialTopNWithPresortedInput.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestPartialTopNWithPresortedInput.java
@@ -187,15 +187,14 @@ public class TestPartialTopNWithPresortedInput
     public void testWithConstantProperty()
     {
         assertDistributedPlan("SELECT * FROM (VALUES (1), (1)) AS t (id) WHERE id = 1 ORDER BY 1 LIMIT 1", output(
-                        topN(1, ImmutableList.of(sort("id", ASCENDING, LAST)), FINAL,
-                                exchange(LOCAL, GATHER, ImmutableList.of(),
-                                        limit(1, ImmutableList.of(), true, ImmutableList.of("id"),
-                                                anyTree(
-                                                        values(
-                                                                ImmutableList.of("id"),
-                                                                ImmutableList.of(
-                                                                        ImmutableList.of(new Constant(INTEGER, 1L)),
-                                                                        ImmutableList.of(new Constant(INTEGER, 1L))))))))));
+                topN(1, ImmutableList.of(sort("id", ASCENDING, LAST)), FINAL,
+                        exchange(LOCAL, GATHER, ImmutableList.of(),
+                                anyTree(
+                                        values(
+                                                ImmutableList.of("id"),
+                                                ImmutableList.of(
+                                                        ImmutableList.of(new Constant(INTEGER, 1L)),
+                                                        ImmutableList.of(new Constant(INTEGER, 1L)))))))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestSubqueries.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestSubqueries.java
@@ -318,8 +318,7 @@ public class TestSubqueries
                                         aggregation(ImmutableMap.of(), FINAL,
                                                 anyTree(
                                                         aggregation(ImmutableMap.of(), PARTIAL,
-                                                                anyTree(
-                                                                        values("a")))))))));
+                                                                values("a"))))))));
 
         assertThat(assertions.query(
                 "SELECT (SELECT count(*) FROM (VALUES 1, 1, 3) t(a) WHERE t.a=t2.b LIMIT 1) FROM (VALUES 1) t2(b)"))
@@ -336,8 +335,7 @@ public class TestSubqueries
                                         aggregation(ImmutableMap.of(), FINAL,
                                                 anyTree(
                                                         aggregation(ImmutableMap.of(), PARTIAL,
-                                                                anyTree(
-                                                                        values("u_x", "u_cid")))))))));
+                                                                values("u_cid"))))))));
 
         assertThat(assertions.query(
                 "SELECT (SELECT t.a FROM (VALUES 1, 2, 3) t(a) WHERE t.a = t2.b ORDER BY a FETCH FIRST ROW WITH TIES) FROM (VALUES 1) t2(b)"))
@@ -488,8 +486,7 @@ public class TestSubqueries
                                         aggregation(ImmutableMap.of(), FINAL,
                                                 anyTree(
                                                         aggregation(ImmutableMap.of(), PARTIAL,
-                                                                anyTree(
-                                                                        values("a")))))))));
+                                                                values("a"))))))));
 
         assertions.assertQueryAndPlan(
                 "SELECT EXISTS(SELECT 1 FROM (VALUES (1, 2), (1, 2), (null, null), (3, 3)) t(a, b) WHERE t.a=t2.b GROUP BY t.a, t.b) FROM (VALUES 1, 2) t2(b)",
@@ -506,8 +503,7 @@ public class TestSubqueries
                                                                         aggregation(ImmutableMap.of(), FINAL,
                                                                                 anyTree(
                                                                                         aggregation(ImmutableMap.of(), PARTIAL,
-                                                                                                anyTree(
-                                                                                                        values("t_a", "t_b")))))))))))));
+                                                                                                values("t_a", "t_b"))))))))))));
 
         assertions.assertQueryAndPlan(
                 "SELECT EXISTS(SELECT 1 FROM (VALUES (1, 2), (1, 2), (null, null), (3, 3)) t(a, b) WHERE t.a<t2.b GROUP BY t.a, t.b) FROM (VALUES 1, 2) t2(b)",
@@ -568,8 +564,7 @@ public class TestSubqueries
                                                                         aggregation(ImmutableMap.of(), FINAL,
                                                                                 anyTree(
                                                                                         aggregation(ImmutableMap.of(), PARTIAL,
-                                                                                                anyTree(
-                                                                                                        values("t_a", "t_b")))))))))))));
+                                                                                                values("t_a", "t_b"))))))))))));
 
         assertions.assertQueryAndPlan(
                 "SELECT EXISTS(SELECT * FROM (VALUES 1, 1, 2, 3) t(a) WHERE t.a=t2.b GROUP BY t.a HAVING count(*) > 1) FROM (VALUES 1, 2) t2(b)",
@@ -582,8 +577,7 @@ public class TestSubqueries
                                         aggregation(ImmutableMap.of(), FINAL,
                                                 anyTree(
                                                         aggregation(ImmutableMap.of(), PARTIAL,
-                                                                anyTree(
-                                                                        values("a")))))))));
+                                                                values("a"))))))));
 
         assertThat(assertions.query(
                 "SELECT EXISTS(SELECT * FROM (SELECT t.a FROM (VALUES (1, 1), (1, 1), (1, 2), (1, 2), (3, 3)) t(a, b) WHERE t.b=t2.b GROUP BY t.a HAVING count(*) > 1) t WHERE t.a=t2.b)" +
@@ -601,8 +595,7 @@ public class TestSubqueries
                                         aggregation(ImmutableMap.of(), FINAL,
                                                 anyTree(
                                                         aggregation(ImmutableMap.of(), PARTIAL,
-                                                                anyTree(
-                                                                        values("a")))))))));
+                                                                values("a"))))))));
     }
 
     @Test


### PR DESCRIPTION
Should unblock other optimizations, like inlining values into join as project.

Adds a new session property `optimizer.push-filter-into-values-max-row-count` wih default value 100. It should be documented.
