### PR TITLE
Revert "Avoid flakiness in test when dropping table"

### DIFF
--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftTypeMapping.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftTypeMapping.java
@@ -831,7 +831,7 @@ public class TestRedshiftTypeMapping
                             .collect(joining("), (", "VALUES (", ")")));
         }
         finally {
-            getTrinoExecutor().execute("DROP TABLE IF EXISTS " + tableName);
+            getTrinoExecutor().execute("DROP TABLE " + tableName);
         }
     }
 


### PR DESCRIPTION
This reverts commit b061560d7c7b7b306e1dab06bb625f0c8e5173e9.

 Since we know that CREATE TABLE succeeded the table exists when we drop it.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
