### PR TITLE
Fix ArrayType indeterminateOperator with a DictionaryBlock

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/type/ArrayType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ArrayType.java
@@ -670,7 +670,7 @@ public class ArrayType
 
         if (array instanceof DictionaryBlock dictionaryBlock) {
             ValueBlock valuesBlock = dictionaryBlock.getDictionary();
-            for (int position = 0; position < valuesBlock.getPositionCount(); position++) {
+            for (int position = 0; position < dictionaryBlock.getPositionCount(); position++) {
                 int index = dictionaryBlock.getId(position);
                 if (valuesBlock.isNull(index)) {
                     return true;


### PR DESCRIPTION
## Description

The indeterminate operator was not checking the correct number of indexes in the dictionary. This could result in out of bounds exception or in rare situations checking too few indexes resulting in an incorrect result.

Fixes #21911
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix rare out of bounds or incorrect result from indeterminate operator for array type when the data is dictionary encoded. ({issue}`21911`)
```
