### PR TITLE
Do not add BUILDHOST to rpm

### DIFF
--- a/core/trino-server-rpm/pom.xml
+++ b/core/trino-server-rpm/pom.xml
@@ -177,6 +177,7 @@
                             <version>${project.version}</version>
                             <outputFileName>trino-server-rpm-${project.version}.noarch.rpm</outputFileName>
                             <release>1</release>
+                            <evalHostname>false</evalHostname>
                             <forceRelease>true</forceRelease>
                             <description>Trino Server RPM Package.</description>
                             <epoch>0</epoch>

--- a/core/trino-server-rpm/src/test/java/io/trino/server/rpm/ServerIT.java
+++ b/core/trino-server-rpm/src/test/java/io/trino/server/rpm/ServerIT.java
@@ -310,19 +310,19 @@ public class ServerIT
         public Set<List<String>> execute(String sql)
         {
             try (Connection connection = getConnection(format("jdbc:trino://%s:%s", host, port), "test", null);
-                    Statement statement = connection.createStatement()) {
-                try (ResultSet resultSet = statement.executeQuery(sql)) {
-                    ImmutableSet.Builder<List<String>> rows = ImmutableSet.builder();
-                    int columnCount = resultSet.getMetaData().getColumnCount();
-                    while (resultSet.next()) {
-                        ImmutableList.Builder<String> row = ImmutableList.builder();
-                        for (int column = 1; column <= columnCount; column++) {
-                            row.add(resultSet.getString(column));
-                        }
-                        rows.add(row.build());
+                 Statement statement = connection.createStatement();
+                 ResultSet resultSet = statement.executeQuery(sql))
+            {
+                ImmutableSet.Builder<List<String>> rows = ImmutableSet.builder();
+                int columnCount = resultSet.getMetaData().getColumnCount();
+                while (resultSet.next()) {
+                    ImmutableList.Builder<String> row = ImmutableList.builder();
+                    for (int column = 1; column <= columnCount; column++) {
+                        row.add(resultSet.getString(column));
                     }
-                    return rows.build();
+                    rows.add(row.build());
                 }
+                return rows.build();
             }
             catch (SQLException e) {
                 throw new RuntimeException(e);

--- a/core/trino-server-rpm/src/test/java/io/trino/server/rpm/ServerIT.java
+++ b/core/trino-server-rpm/src/test/java/io/trino/server/rpm/ServerIT.java
@@ -208,6 +208,7 @@ public class ServerIT
 
             Map<String, String> rpmMetadata = getRpmMetadata(container, rpm);
             assertThat(rpmMetadata).extractingByKey("Name").isEqualTo("trino-server-rpm");
+            assertThat(rpmMetadata).extractingByKey("Build Host").isEqualTo("localhost");
             assertThat(rpmMetadata).extractingByKey("Epoch").isEqualTo("0");
             assertThat(rpmMetadata).extractingByKey("Release").isEqualTo("1");
             assertThat(rpmMetadata).extractingByKey("Version").isEqualTo(getProjectVersion());

--- a/core/trino-server-rpm/src/test/java/io/trino/server/rpm/ServerIT.java
+++ b/core/trino-server-rpm/src/test/java/io/trino/server/rpm/ServerIT.java
@@ -300,15 +300,11 @@ public class ServerIT
         return builder.buildOrThrow();
     }
 
-    private static class QueryRunner
+    private record QueryRunner(String host, int port)
     {
-        private final String host;
-        private final int port;
-
-        private QueryRunner(String host, int port)
+        private QueryRunner
         {
-            this.host = requireNonNull(host, "host is null");
-            this.port = port;
+            requireNonNull(host, "host is null");
         }
 
         public Set<List<String>> execute(String sql)

--- a/core/trino-server-rpm/src/test/java/io/trino/server/rpm/ServerIT.java
+++ b/core/trino-server-rpm/src/test/java/io/trino/server/rpm/ServerIT.java
@@ -54,10 +54,10 @@ import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 import static org.testcontainers.containers.wait.strategy.Wait.forLogMessage;
 
-@Execution(SAME_THREAD)
+@Execution(CONCURRENT)
 public class ServerIT
 {
     private static final DockerImageName BASE_IMAGE = DockerImageName.parse("registry.access.redhat.com/ubi9/ubi-minimal:latest");

--- a/core/trino-server-rpm/src/test/java/io/trino/server/rpm/ServerIT.java
+++ b/core/trino-server-rpm/src/test/java/io/trino/server/rpm/ServerIT.java
@@ -359,14 +359,6 @@ public class ServerIT
             return this;
         }
 
-        public PathInfoAssert isNotOwnerExecutable()
-        {
-            if (actual.permissions.contains(OWNER_EXECUTE)) {
-                failWithMessage("Expected %s not to be executable", actual.path);
-            }
-            return this;
-        }
-
         public PathInfoAssert linksTo(String target)
         {
             if (actual.link.isEmpty()) {

--- a/core/trino-server-rpm/src/test/java/io/trino/server/rpm/ServerIT.java
+++ b/core/trino-server-rpm/src/test/java/io/trino/server/rpm/ServerIT.java
@@ -118,7 +118,6 @@ public class ServerIT
         }
     }
 
-
     private void testUninstall(String temurinReleaseName, String javaHome)
             throws Exception
     {


### PR DESCRIPTION
This makes build non-reproducible if building on different hosts. With the evalHostname set to false, localhost will be used instead.

See: https://github.com/ctron/rpm-builder/blob/master/src/main/java/de/dentrassi/rpm/builder/RpmMojo.java#L1331

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
