### PR TITLE
Update docker-images version to 96

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
         <dep.aws-sdk.version>1.12.729</dep.aws-sdk.version>
         <dep.cassandra.version>4.17.0</dep.cassandra.version>
         <dep.confluent.version>7.5.1</dep.confluent.version>
-        <dep.docker.images.version>95</dep.docker.images.version>
+        <dep.docker.images.version>96</dep.docker.images.version>
         <dep.drift.version>1.22</dep.drift.version>
         <dep.errorprone.version>2.27.1</dep.errorprone.version>
         <dep.flyway.version>10.13.0</dep.flyway.version>


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
