### PR TITLE
Add support for vacuumProtocolCheck feature in Delta Lake

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeSchemaSupport.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeSchemaSupport.java
@@ -104,12 +104,14 @@ public final class DeltaLakeSchemaSupport
     private static final String IDENTITY_COLUMNS_FEATURE_NAME = "identityColumns";
     private static final String INVARIANTS_FEATURE_NAME = "invariants";
     public static final String TIMESTAMP_NTZ_FEATURE_NAME = "timestampNtz";
+    public static final String VACUUM_PROTOCOL_CHECK_FEATURE_NAME = "vacuumProtocolCheck";
     public static final String V2_CHECKPOINT_FEATURE_NAME = "v2Checkpoint";
 
     private static final Set<String> SUPPORTED_READER_FEATURES = ImmutableSet.<String>builder()
             .add(COLUMN_MAPPING_FEATURE_NAME)
             .add(TIMESTAMP_NTZ_FEATURE_NAME)
             .add(DELETION_VECTORS_FEATURE_NAME)
+            .add(VACUUM_PROTOCOL_CHECK_FEATURE_NAME)
             .add(V2_CHECKPOINT_FEATURE_NAME)
             .build();
     private static final Set<String> SUPPORTED_WRITER_FEATURES = ImmutableSet.<String>builder()
@@ -119,6 +121,7 @@ public final class DeltaLakeSchemaSupport
             .add(CHANGE_DATA_FEED_FEATURE_NAME)
             .add(COLUMN_MAPPING_FEATURE_NAME)
             .add(TIMESTAMP_NTZ_FEATURE_NAME)
+            .add(VACUUM_PROTOCOL_CHECK_FEATURE_NAME)
             .build();
 
     public enum ColumnMappingMode


### PR DESCRIPTION
## Description

We don't need to check anything about vacuum protocol check when reading the table.
The connector already verifies unsupported writer features in VacuumProcedure:
https://github.com/trinodb/trino/blob/a5d93ee5109fc65294895a2b61acaa0ba65d8eee/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/VacuumProcedure.java#L190-L193

Relates to https://github.com/delta-io/delta/pull/2730
Fixes #21398

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Delta Lake
* Add support for reading and writing tables with [VACUUM Protocol Check](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#vacuum-protocol-check). ({issue}`21398`)
```
