### PR TITLE
Fail when multiple JVM args matching

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/Server.java
+++ b/core/trino-main/src/main/java/io/trino/server/Server.java
@@ -80,8 +80,7 @@ import java.util.Set;
 import static com.google.common.collect.MoreCollectors.toOptional;
 import static io.airlift.discovery.client.ServiceAnnouncement.ServiceAnnouncementBuilder;
 import static io.airlift.discovery.client.ServiceAnnouncement.serviceAnnouncement;
-import static io.trino.server.TrinoSystemRequirements.verifyJvmRequirements;
-import static io.trino.server.TrinoSystemRequirements.verifySystemTimeIsReasonable;
+import static io.trino.server.TrinoSystemRequirements.verifySystemRequirements;
 import static java.lang.String.format;
 import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
 import static java.util.function.Predicate.not;
@@ -101,8 +100,7 @@ public class Server
         Locale.setDefault(Locale.US);
 
         long startTime = System.nanoTime();
-        verifyJvmRequirements();
-        verifySystemTimeIsReasonable();
+        verifySystemRequirements();
 
         Logger log = Logger.get(Server.class);
         log.info("Java version: %s", StandardSystemProperty.JAVA_VERSION.value());

--- a/core/trino-main/src/main/java/io/trino/server/TrinoSystemRequirements.java
+++ b/core/trino-main/src/main/java/io/trino/server/TrinoSystemRequirements.java
@@ -186,7 +186,7 @@ final class TrinoSystemRequirements
     public static void verifySystemTimeIsReasonable()
     {
         int currentYear = DateTime.now().year().get();
-        if (currentYear < 2022) {
+        if (currentYear < 2024) {
             failRequirement("Trino requires the system time to be current (found year %s)", currentYear);
         }
     }

--- a/core/trino-main/src/main/java/io/trino/server/TrinoSystemRequirements.java
+++ b/core/trino-main/src/main/java/io/trino/server/TrinoSystemRequirements.java
@@ -190,13 +190,13 @@ final class TrinoSystemRequirements
         }
     }
 
-    private static Optional<String> getJvmConfigurationFlag(String pattern)
+    private static Optional<String> getJvmConfigurationFlag(String flag)
     {
-        Pattern compiled = Pattern.compile("-%s=(.*)".formatted(quote(pattern)), Pattern.DOTALL);
+        Pattern pattern = Pattern.compile("-%s=(.*)".formatted(quote(flag)), Pattern.DOTALL);
         return ManagementFactory.getRuntimeMXBean()
                 .getInputArguments()
                 .stream()
-                .map(compiled::matcher)
+                .map(pattern::matcher)
                 .filter(Matcher::matches)
                 .map(matcher -> matcher.group(1))
                 .findFirst();

--- a/core/trino-main/src/main/java/io/trino/server/TrinoSystemRequirements.java
+++ b/core/trino-main/src/main/java/io/trino/server/TrinoSystemRequirements.java
@@ -47,7 +47,13 @@ final class TrinoSystemRequirements
 
     private TrinoSystemRequirements() {}
 
-    public static void verifyJvmRequirements()
+    public static void verifySystemRequirements()
+    {
+        verifyJvmRequirements();
+        verifySystemTimeIsReasonable();
+    }
+
+    private static void verifyJvmRequirements()
     {
         verifyJavaVersion();
         verify64BitJvm();
@@ -183,7 +189,7 @@ final class TrinoSystemRequirements
      * Perform a sanity check to make sure that the year is reasonably current, to guard against
      * issues in third party libraries.
      */
-    public static void verifySystemTimeIsReasonable()
+    private static void verifySystemTimeIsReasonable()
     {
         int currentYear = DateTime.now().year().get();
         if (currentYear < 2024) {

--- a/core/trino-main/src/test/java/io/trino/server/TestTrinoSystemRequirements.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestTrinoSystemRequirements.java
@@ -15,20 +15,13 @@ package io.trino.server;
 
 import org.junit.jupiter.api.Test;
 
-import static io.trino.server.TrinoSystemRequirements.verifyJvmRequirements;
-import static io.trino.server.TrinoSystemRequirements.verifySystemTimeIsReasonable;
+import static io.trino.server.TrinoSystemRequirements.verifySystemRequirements;
 
 public class TestTrinoSystemRequirements
 {
     @Test
-    public void testVerifyJvmRequirements()
+    public void testVerifySystemRequirements()
     {
-        verifyJvmRequirements();
-    }
-
-    @Test
-    public void testSystemTimeSanityCheck()
-    {
-        verifySystemTimeIsReasonable();
+        verifySystemRequirements();
     }
 }


### PR DESCRIPTION
The JVM args verification would take first argument matching, silently ignoring any subsequent matching arguments. It's unclear whether first one or last one is effective (or something else), so it's better to bail out on multiple matches.
