### PR TITLE
Allow pinning to WebIdentityTokenCredentialsProvider in legacy S3 client

### DIFF
--- a/docs/src/main/sphinx/object-storage/legacy-s3.md
+++ b/docs/src/main/sphinx/object-storage/legacy-s3.md
@@ -128,6 +128,12 @@ setting AWS access and secret keys in the `hive.s3.aws-access-key`
 and `hive.s3.aws-secret-key` settings, and also allows EC2 to automatically
 rotate credentials on a regular basis without any additional work on your part.
 
+If you are running Trino on Amazon EKS, and authenticate using a Kubernetes
+service account, you can set the
+`trino.s3.use-web-identity-token-credentials-provider` to `true`, so Trino does
+not try using different credential providers from the default credential
+provider chain.
+
 ## Custom S3 credentials provider
 
 You can configure a custom S3 credentials provider by setting the configuration

--- a/lib/trino-hdfs/src/main/java/io/trino/hdfs/s3/TrinoS3FileSystem.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/hdfs/s3/TrinoS3FileSystem.java
@@ -30,6 +30,7 @@ import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.amazonaws.auth.Signer;
 import com.amazonaws.auth.SignerFactory;
+import com.amazonaws.auth.WebIdentityTokenCredentialsProvider;
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.event.ProgressEvent;
 import com.amazonaws.event.ProgressEventType;
@@ -192,6 +193,7 @@ public class TrinoS3FileSystem
 {
     public static final String S3_USER_AGENT_PREFIX = "trino.s3.user-agent-prefix";
     public static final String S3_CREDENTIALS_PROVIDER = "trino.s3.credentials-provider";
+    public static final String S3_USE_WEB_IDENTITY_TOKEN_CREDENTIALS_PROVIDER = "trino.s3.use-web-identity-token-credentials-provider";
     public static final String S3_SSE_TYPE = "trino.s3.sse.type";
     public static final String S3_SSE_ENABLED = "trino.s3.sse.enabled";
     public static final String S3_SSE_KMS_KEY_ID = "trino.s3.sse.kms-key-id";
@@ -1146,6 +1148,10 @@ public class TrinoS3FileSystem
         Optional<AWSCredentials> credentials = getEmbeddedAwsCredentials(uri);
         if (credentials.isPresent()) {
             return new AWSStaticCredentialsProvider(credentials.get());
+        }
+
+        if (conf.getBoolean(S3_USE_WEB_IDENTITY_TOKEN_CREDENTIALS_PROVIDER, false)) {
+            return new WebIdentityTokenCredentialsProvider();
         }
 
         // a custom credential provider is also used alone


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Allow users to only use the `WebIdentityTokenCredentialsProvider` instead of the default credentials provider chain.

This is preferred over #22007. This at least makes the workaround for #15267 easier, I'm not sure if it will allow closing that issue. I haven't updated the docs yet, I'll wait for some initial feedback first.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
