### PR TITLE
Improve docs for HTTP server config

### DIFF
--- a/docs/src/main/sphinx/admin/properties-http-server.md
+++ b/docs/src/main/sphinx/admin/properties-http-server.md
@@ -1,0 +1,161 @@
+# HTTP server properties
+
+HTTP server properties allow you to configure the HTTP server of Trino that
+handles [](/security) including [](/security/internal-communication),  and
+serves the [](/admin/web-interface) and the [client
+API](/develop/client-protocol).
+
+## General
+
+(http-server-process-forwarded)=
+### `http-server.process-forwarded`
+
+- **Type:** [](prop-type-boolean)
+- **Default value:** `false`
+
+Enable treating forwarded HTTPS requests over HTTP as secure. Requires the
+[`X-Forwarded` headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For#see_also)
+to be set to `HTTPS` on forwarded requests. This is commonly performed by a load
+balancer that terminates HTTPS to HTTP. Set to `true` when using such a load
+balancer in front of Trino or [Trino
+Gateway](https://trinodb.github.io/trino-gateway/). Find more details in
+[](https-load-balancer).
+
+## HTTP and HTTPS
+
+### `http-server.http.port`
+
+- **Type:** [](prop-type-integer)
+- **Default value:** `8080`
+
+Specify the HTTP port for the HTTP server.
+
+### `http-server.https.enabled`
+
+- **Type:** [](prop-type-boolean)
+- **Default value:** `false`
+
+Enable [](/security/tls).
+
+### `http-server.https.port`
+
+- **Type:** [](prop-type-integer)
+- **Default value:** `8443`
+
+Specify the HTTPS port for the HTTP server.
+
+### `http-server.https.included-cipher` and `http-server.https.excluded-cipher`
+
+Optional configuration for ciphers to use TLS, find details in
+[](tls-version-and-ciphers).
+
+### `http-server.https.keystore.path`
+
+- **Type:** [](prop-type-string)
+
+The location of the PEM or Java keystore file used to enable [](/security/tls).
+
+### `http-server.https.keystore.key`
+
+- **Type:** [](prop-type-string)
+
+The password for the PEM or Java keystore.
+
+### `http-server.https.truststore.path`
+
+- **Type:** [](prop-type-boolean)
+- **Default value:** `false`
+
+The location of the optional PEM or Java truststore file for additional
+certificate authorities. Find details in [](/security/tls).
+
+### `http-server.https.truststore.key`
+
+- **Type:** [](prop-type-boolean)
+- **Default value:** `false`
+
+The password for the optional PEM or Java truststore.
+
+### `http-server.https.keymanager.password`
+
+- **Type:** [](prop-type-string)
+
+Password for a key within a keystore, when a different password is configured
+for the specific key. Find details in [](/security/tls).
+
+### `http-server.https.secure-random-algorithm`
+
+- **Type:** [](prop-type-string)
+
+Optional name of the algorithm to generate secure random values for
+[internal communication](internal-performance).
+
+### `http-server.https.ssl-session-timeout`
+
+- **Type:** [](prop-type-duration)
+- **Default value:** `4h`
+
+Time duration for a valid TLS client session.
+
+### `http-server.https.ssl-session-cache-size`
+
+- **Type:** [](prop-type-integer)
+- **Default value:** `10000`
+
+Maximum number of SSL session cache entries.
+
+### `http-server.https.ssl-context.refresh-time`
+
+- **Type:** [](prop-type-duration)
+- **Default value:** `1m`
+
+Time between reloading default certificates.
+
+## Authentication
+
+### `http-server.authentication.type`
+
+- **Type:** [](prop-type-string)
+
+Configures the ordered list of enabled [authentication
+types](/security/authentication-types).
+
+All authentication requires secure connections using [](/security/tls) or
+[process forwarding enabled](http-server-process-forwarded), and [a configured
+shared secret](/security/internal-communication).
+
+### `http-server.authentication.allow-insecure-over-http`
+
+- **Type:** [](prop-type-boolean)
+
+Enable HTTP when any authentication is active. Defaults to `true`, but is
+automatically set to `false` with active authentication. Overriding the value to
+`true` can be useful for testing, but is not secure. More details in
+[](/security/tls).
+
+### `http-server.authentication.certificate.*`
+
+Configuration properties for [](/security/certificate).
+
+### `http-server.authentication.jwt.*`
+
+Configuration properties for [](/security/jwt).
+
+### `http-server.authentication.krb5.*`
+
+Configuration properties for [](/security/kerberos).
+
+### `http-server.authentication.oauth2.*`
+
+Configuration properties for [](/security/oauth2).
+
+### `http-server.authentication.password.*`
+
+Configuration properties for the `PASSWORD` authentication types
+[](/security/ldap), [](/security/password-file), and [](/security/salesforce).
+
+## Logging
+
+### `http-server.log.*`
+
+Configuration properties for [](/admin/properties-logging).

--- a/docs/src/main/sphinx/admin/properties.md
+++ b/docs/src/main/sphinx/admin/properties.md
@@ -15,6 +15,7 @@ properties, refer to the {doc}`connector documentation </connector/>`.
 :titlesonly: true
 
 General <properties-general>
+HTTP server <properties-http-server>
 Resource management <properties-resource-management>
 Query management <properties-query-management>
 Catalog management <properties-catalog>

--- a/docs/src/main/sphinx/installation/deployment.md
+++ b/docs/src/main/sphinx/installation/deployment.md
@@ -220,8 +220,8 @@ These properties require some explanation:
   available for the critical task of scheduling, managing and monitoring
   query execution.
 - `http-server.http.port`:
-  Specifies the port for the HTTP server. Trino uses HTTP for all
-  communication, internal and external.
+  Specifies the port for the [HTTP server](/admin/properties-http-server).
+  Trino uses HTTP for all communication, internal and external.
 - `discovery.uri`:
   The Trino coordinator has a discovery service that is used by all the nodes
   to find each other. Every Trino instance registers itself with the discovery

--- a/docs/src/main/sphinx/security/authentication-types.md
+++ b/docs/src/main/sphinx/security/authentication-types.md
@@ -2,8 +2,11 @@
 
 Trino supports multiple authentication types to ensure all users of the system
 are authenticated. Different authenticators allow user management in one or more
-systems. Using {doc}`TLS <tls>` and {doc}`a configured shared secret
-</security/internal-communication>` are required for all authentications types.
+systems.
+
+All authentication requires secure connections using [](/security/tls) or
+[process forwarding enabled](http-server-process-forwarded), and [a configured
+shared secret](/security/internal-communication).
 
 You can configure one or more authentication types with the
 `http-server.authentication.type` property. The following authentication types

--- a/docs/src/main/sphinx/security/internal-communication.md
+++ b/docs/src/main/sphinx/security/internal-communication.md
@@ -122,6 +122,7 @@ window functions, which require repartitioning), the performance impact can be
 considerable. The slowdown may vary from 10% to even 100%+, depending on the network
 traffic and the CPU utilization.
 
+(internal-performance)=
 ### Advanced performance tuning
 
 In some cases, changing the source of random numbers improves performance

--- a/docs/src/main/sphinx/security/ldap.md
+++ b/docs/src/main/sphinx/security/ldap.md
@@ -41,16 +41,22 @@ http-server.https.keystore.path=/etc/trino/keystore.jks
 http-server.https.keystore.key=keystore_password
 ```
 
-| Property                                                   | Description                                                                                                                                                                  |
-| ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `http-server.authentication.type`                          | Enable the password {doc}`authentication type <authentication-types>` for the Trino coordinator. Must be set to `PASSWORD`.                                                  |
-| `http-server.https.enabled`                                | Enables HTTPS access for the Trino coordinator. Should be set to `true`. Default value is `false`.                                                                           |
-| `http-server.https.port`                                   | HTTPS server port.                                                                                                                                                           |
-| `http-server.https.keystore.path`                          | The location of the PEM or Java keystore file is used to enable TLS.                                                                                                         |
-| `http-server.https.keystore.key`                           | The password for the PEM or Java keystore. This must match the password you specified when creating the PEM or keystore.                                                     |
-| `http-server.process-forwarded`                            | Enable treating forwarded HTTPS requests over HTTP as secure.  Requires the `X-Forwarded-Proto` header to be set to `https` on forwarded requests. Default value is `false`. |
-| `http-server.authentication.password.user-mapping.pattern` | Regex to match against user.  If matched, user will be replaced with first regex group. If not matched, authentication is denied.  Default is `(.*)`.                        |
-| `http-server.authentication.password.user-mapping.file`    | File containing rules for mapping user.  See {doc}`/security/user-mapping` for more information.                                                                             |
+Find detailed description for the available properties in
+[](/admin/properties-http-server) and the following table:
+
+:::{list-table}
+:widths: 15, 85
+:header-rows: 1
+
+* - Property
+  - Description
+* - `http-server.authentication.password.user-mapping.pattern`
+  - Regex to match against user.  If matched, user is replaced with first regex
+    group. If not matched, authentication is denied.  Defaults to `(.*)`.
+* - `http-server.authentication.password.user-mapping.file`
+  - File containing rules for mapping user.  See [](/security/user-mapping)
+    for more information.
+:::
 
 #### Password authenticator configuration
 

--- a/docs/src/main/sphinx/security/tls.md
+++ b/docs/src/main/sphinx/security/tls.md
@@ -58,7 +58,7 @@ suites. See the discussion in Java documentation that begins with [Customizing
 the Encryption Algorithm Providers](https://docs.oracle.com/en/java/javase/22/security/java-secure-socket-extension-jsse-reference-guide.html#GUID-316FB978-7588-442E-B829-B4973DB3B584).
 
 :::{note}
-If you manage the coordinator's direct TLS implementatation, monitor the CPU
+If you manage the coordinator's direct TLS implementation, monitor the CPU
 usage on the Trino coordinator after enabling HTTPS. Java prefers the more
 CPU-intensive cipher suites, if you allow it to choose from a big list of
 ciphers. If the CPU usage is unacceptably high after enabling HTTPS, you can
@@ -104,6 +104,9 @@ However, to enable processing of such forwarded headers, the server's
 ```text
 http-server.process-forwarded=true
 ```
+
+More information about HTTP server configuration is available in
+[](/admin/properties-http-server).
 
 This completes any necessary configuration for using HTTPS with a load balancer.
 Client tools can access Trino with the URL exposed by the load balancer.


### PR DESCRIPTION
## Description

Originally just wanted to add docs for `http-server.process-forwarded` but found that the http-server.* properties are either not found at all or sprinkled across docs. This PR adds a new properties reference page that either documents the properties or links to relevant info. 

As a result I had to also clean up some related duplication.. but it all belongs together really. 

## Additional context and related issues

See for example chat in https://trinodb.slack.com/archives/CG9K9MX1V/p1715826092248509

I will also create a PR related Trino Gateway docs PR.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
