### PR TITLE
Disable HTTP/2 negotiation for trino-client/jdbc

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/OkHttpUtil.java
+++ b/client/trino-client/src/main/java/io/trino/client/OkHttpUtil.java
@@ -15,6 +15,7 @@ package io.trino.client;
 
 import com.google.common.base.CharMatcher;
 import com.google.common.base.StandardSystemProperty;
+import com.google.common.collect.ImmutableList;
 import com.google.common.net.HostAndPort;
 import io.trino.client.auth.kerberos.DelegatedConstrainedContextProvider;
 import io.trino.client.auth.kerberos.DelegatedUnconstrainedContextProvider;
@@ -25,6 +26,7 @@ import okhttp3.Credentials;
 import okhttp3.Interceptor;
 import okhttp3.JavaNetCookieJar;
 import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
 import okhttp3.internal.tls.LegacyHostnameVerifier;
 import org.ietf.jgss.GSSCredential;
 
@@ -109,6 +111,12 @@ public final class OkHttpUtil
     public static void setupCookieJar(OkHttpClient.Builder clientBuilder)
     {
         clientBuilder.cookieJar(new JavaNetCookieJar(new CookieManager()));
+    }
+
+    public static void disableHttp2(OkHttpClient.Builder clientBuilder)
+    {
+        // Disable HTTP/2 as it's not tested nor supported
+        clientBuilder.protocols(ImmutableList.of(Protocol.HTTP_1_1, Protocol.HTTP_1_1));
     }
 
     public static void setupSocksProxy(OkHttpClient.Builder clientBuilder, Optional<HostAndPort> socksProxy)

--- a/client/trino-client/src/main/java/io/trino/client/uri/TrinoUri.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/TrinoUri.java
@@ -53,6 +53,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.client.KerberosUtil.defaultCredentialCachePath;
 import static io.trino.client.OkHttpUtil.basicAuth;
+import static io.trino.client.OkHttpUtil.disableHttp2;
 import static io.trino.client.OkHttpUtil.setupAlternateHostnameVerification;
 import static io.trino.client.OkHttpUtil.setupCookieJar;
 import static io.trino.client.OkHttpUtil.setupHttpProxy;
@@ -603,6 +604,7 @@ public class TrinoUri
             throws SQLException
     {
         try {
+            disableHttp2(builder);
             setupCookieJar(builder);
             setupSocksProxy(builder, socksProxy);
             setupHttpProxy(builder, httpProxy);


### PR DESCRIPTION
When Trino cluster is exposed through the proxy/LB that supports HTTP/2, OkHttp client can negotiate and use HTTP/2. Since we don't have support for HTTP/2 in the Trino itself, this lacks testing and therefore should be unsupported.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
