### PR TITLE
Implement dynamic row filtering in hive, iceberg and delta

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/DynamicFilterConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DynamicFilterConfig.java
@@ -18,12 +18,16 @@ import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.DefunctConfig;
 import io.airlift.configuration.LegacyConfig;
 import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
 import io.airlift.units.MaxDataSize;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 @DefunctConfig({
         "dynamic-filtering-max-per-driver-row-count",
@@ -72,6 +76,9 @@ public class DynamicFilterConfig
     private int largePartitionedRangeRowLimitPerDriver = 2_000;
     private DataSize largePartitionedMaxSizePerOperator = DataSize.of(2, MEGABYTE);
     private DataSize largeMaxSizePerFilter = DataSize.of(5, MEGABYTE);
+    private boolean dynamicRowFilteringEnabled = true;
+    private double dynamicRowFilterSelectivityThreshold = 0.7;
+    private Duration dynamicRowFilteringBlockingTimeout = new Duration(0, SECONDS);
 
     public boolean isEnableDynamicFiltering()
     {
@@ -349,6 +356,48 @@ public class DynamicFilterConfig
     public DynamicFilterConfig setLargeMaxSizePerFilter(DataSize largeMaxSizePerFilter)
     {
         this.largeMaxSizePerFilter = largeMaxSizePerFilter;
+        return this;
+    }
+
+    public boolean isDynamicRowFilteringEnabled()
+    {
+        return dynamicRowFilteringEnabled;
+    }
+
+    @Config("dynamic-row-filtering.enabled")
+    @ConfigDescription("Enable dynamic row filtering")
+    public DynamicFilterConfig setDynamicRowFilteringEnabled(boolean dynamicRowFilteringEnabled)
+    {
+        this.dynamicRowFilteringEnabled = dynamicRowFilteringEnabled;
+        return this;
+    }
+
+    @DecimalMin("0.0")
+    @DecimalMax("1.0")
+    public double getDynamicRowFilterSelectivityThreshold()
+    {
+        return dynamicRowFilterSelectivityThreshold;
+    }
+
+    @Config("dynamic-row-filtering.selectivity-threshold")
+    @ConfigDescription("Avoid using dynamic row filters when fraction of rows selected is above threshold")
+    public DynamicFilterConfig setDynamicRowFilterSelectivityThreshold(double dynamicRowFilterSelectivityThreshold)
+    {
+        this.dynamicRowFilterSelectivityThreshold = dynamicRowFilterSelectivityThreshold;
+        return this;
+    }
+
+    @NotNull
+    public Duration getDynamicRowFilteringWaitTimeout()
+    {
+        return dynamicRowFilteringBlockingTimeout;
+    }
+
+    @Config("dynamic-row-filtering.wait-timeout")
+    @ConfigDescription("Duration to wait for completion of dynamic filters")
+    public DynamicFilterConfig setDynamicRowFilteringWaitTimeout(Duration dynamicRowFilteringBlockingTimeout)
+    {
+        this.dynamicRowFilteringBlockingTimeout = dynamicRowFilteringBlockingTimeout;
         return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/dynamicfiltering/DictionaryAwareBlockFilter.java
+++ b/core/trino-main/src/main/java/io/trino/operator/dynamicfiltering/DictionaryAwareBlockFilter.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.dynamicfiltering;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.trino.operator.project.SelectedPositions;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.DictionaryBlock;
+import jakarta.annotation.Nullable;
+
+import static io.trino.operator.project.SelectedPositions.positionsList;
+import static io.trino.operator.project.SelectedPositions.positionsRange;
+
+public class DictionaryAwareBlockFilter
+{
+    @Nullable
+    private Block lastDictionary;
+    @Nullable
+    private boolean[] lastDictionaryPositionsMask;
+    private long lastDictionaryUsageCount;
+
+    public SelectedPositions filter(Block block, DynamicPageFilter.BlockFilter blockFilter, SelectedPositions selectedPositions)
+    {
+        Block loadedBlock = block.getLoadedBlock();
+        if (loadedBlock instanceof DictionaryBlock) {
+            DictionaryBlock dictionaryBlock = (DictionaryBlock) loadedBlock;
+            // Attempt to process the dictionary.  If dictionary processing has not been considered effective, null will be returned
+            boolean[] dictionaryPositionsMask = processDictionary(blockFilter, dictionaryBlock);
+            // record the usage count regardless of dictionary processing choice, so we have stats for next time
+            lastDictionaryUsageCount += dictionaryBlock.getPositionCount();
+            // if dictionary was processed, produce a dictionary block; otherwise do normal processing
+            if (dictionaryPositionsMask != null) {
+                return selectDictionaryPositions(dictionaryPositionsMask, dictionaryBlock, selectedPositions);
+            }
+        }
+        return blockFilter.filter(loadedBlock, selectedPositions);
+    }
+
+    // Should be called after we know that a filter is ineffective
+    // to avoid holding on to cached dictionary and mask as they won't be used again
+    public void cleanUp()
+    {
+        lastDictionary = null;
+        lastDictionaryPositionsMask = null;
+    }
+
+    @VisibleForTesting
+    boolean wasLastBlockDictionaryProcessed()
+    {
+        return lastDictionaryPositionsMask != null;
+    }
+
+    private boolean[] processDictionary(DynamicPageFilter.BlockFilter blockFilter, DictionaryBlock dictionaryBlock)
+    {
+        Block dictionary = dictionaryBlock.getDictionary();
+        if (lastDictionary == dictionary) {
+            return lastDictionaryPositionsMask;
+        }
+        // Process dictionary if:
+        //   this is the first block
+        //   dictionary positions count is smaller than block
+        //   the last dictionary was used for more positions than were in the dictionary
+        boolean shouldProcessDictionary = lastDictionary == null || dictionary.getPositionCount() < dictionaryBlock.getPositionCount() || lastDictionaryUsageCount >= lastDictionary.getPositionCount();
+        lastDictionaryUsageCount = 0;
+        lastDictionary = dictionary;
+
+        if (shouldProcessDictionary) {
+            lastDictionaryPositionsMask = blockFilter.selectedPositionsMask(dictionary);
+        }
+        else {
+            lastDictionaryPositionsMask = null;
+        }
+        return lastDictionaryPositionsMask;
+    }
+
+    private static SelectedPositions selectDictionaryPositions(boolean[] dictionaryPositionsMask, DictionaryBlock block, SelectedPositions selectedPositions)
+    {
+        int positionCount = selectedPositions.size();
+        int outputPositionsCount = 0;
+        int[] outputPositions = new int[positionCount];
+        if (selectedPositions.isList()) {
+            int[] positions = selectedPositions.getPositions();
+            for (int i = 0; i < positionCount; i++) {
+                int position = positions[i];
+                // extra copying to avoid branch
+                outputPositions[outputPositionsCount] = position;
+                // cast to byte
+                outputPositionsCount += dictionaryPositionsMask[block.getId(position)] ? 1 : 0;
+            }
+        }
+        else {
+            for (int position = 0; position < positionCount; position++) {
+                // extra copying to avoid branch
+                outputPositions[outputPositionsCount] = position;
+                // cast to byte
+                outputPositionsCount += dictionaryPositionsMask[block.getId(position)] ? 1 : 0;
+            }
+            // full range was selected
+            if (outputPositionsCount == positionCount) {
+                return positionsRange(0, outputPositionsCount);
+            }
+        }
+        return positionsList(outputPositions, 0, outputPositionsCount);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/dynamicfiltering/DictionaryAwarePageFilter.java
+++ b/core/trino-main/src/main/java/io/trino/operator/dynamicfiltering/DictionaryAwarePageFilter.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.dynamicfiltering;
+
+import io.trino.operator.project.SelectedPositions;
+import io.trino.spi.Page;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.trino.operator.dynamicfiltering.DynamicPageFilter.BlockFilter.EMPTY;
+import static io.trino.operator.project.SelectedPositions.positionsRange;
+import static java.util.Objects.requireNonNull;
+
+public class DictionaryAwarePageFilter
+{
+    // BlockFilter is a shared structure which cannot contain mutable state.
+    // Therefore, we use this class per split to save results from previously processed dictionary
+    private final DictionaryAwareBlockFilter[] dictionaryAwareBlockFilters;
+
+    public DictionaryAwarePageFilter(int columnsCount)
+    {
+        this.dictionaryAwareBlockFilters = new DictionaryAwareBlockFilter[columnsCount];
+    }
+
+    public SelectedPositionsWithStats filterPage(Page page, DynamicPageFilter.BlockFilter[] blockFilters, int length)
+    {
+        SelectedPositions positions = positionsRange(0, page.getPositionCount());
+        List<BlockFilterStats> blockFilterStats = new ArrayList<>(length);
+        for (int index = 0; index < length; index++) {
+            DynamicPageFilter.BlockFilter blockFilter = blockFilters[index];
+            int channelIndex = blockFilter.getChannelIndex();
+            DictionaryAwareBlockFilter dictionaryAwareBlockFilter = dictionaryAwareBlockFilters[channelIndex];
+            if (dictionaryAwareBlockFilter == null) {
+                dictionaryAwareBlockFilter = new DictionaryAwareBlockFilter();
+                dictionaryAwareBlockFilters[channelIndex] = dictionaryAwareBlockFilter;
+            }
+
+            int inputPositions = positions.size();
+            positions = dictionaryAwareBlockFilter.filter(page.getBlock(channelIndex), blockFilter, positions);
+            blockFilterStats.add(new BlockFilterStats(
+                    inputPositions,
+                    positions.size(),
+                    blockFilter.getChannelIndex()));
+
+            if (positions.isEmpty()) {
+                return new SelectedPositionsWithStats(EMPTY, blockFilterStats);
+            }
+        }
+        return new SelectedPositionsWithStats(positions, blockFilterStats);
+    }
+
+    public void cleanUp(int channelIndex)
+    {
+        dictionaryAwareBlockFilters[channelIndex].cleanUp();
+    }
+
+    static class SelectedPositionsWithStats
+    {
+        private final SelectedPositions positions;
+        private final List<BlockFilterStats> blockFilterStats;
+
+        private SelectedPositionsWithStats(SelectedPositions positions, List<BlockFilterStats> blockFilterStats)
+        {
+            this.positions = requireNonNull(positions, "positions is null");
+            this.blockFilterStats = requireNonNull(blockFilterStats, "blockFilterStats is null");
+        }
+
+        SelectedPositions getPositions()
+        {
+            return positions;
+        }
+
+        List<BlockFilterStats> getBlockFilterStats()
+        {
+            return blockFilterStats;
+        }
+    }
+
+    static class BlockFilterStats
+    {
+        private final int inputPositions;
+        private final int outputPositions;
+        private final int channelIndex;
+
+        BlockFilterStats(int inputPositions, int outputPositions, int channelIndex)
+        {
+            this.inputPositions = inputPositions;
+            this.outputPositions = outputPositions;
+            this.channelIndex = channelIndex;
+        }
+
+        int getInputPositions()
+        {
+            return inputPositions;
+        }
+
+        int getOutputPositions()
+        {
+            return outputPositions;
+        }
+
+        int getChannelIndex()
+        {
+            return channelIndex;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            BlockFilterStats that = (BlockFilterStats) o;
+            return inputPositions == that.inputPositions
+                    && outputPositions == that.outputPositions
+                    && channelIndex == that.channelIndex;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(inputPositions, outputPositions, channelIndex);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("inputPositions", inputPositions)
+                    .add("outputPositions", outputPositions)
+                    .add("channelIndex", channelIndex)
+                    .toString();
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/dynamicfiltering/DynamicPageFilter.java
+++ b/core/trino-main/src/main/java/io/trino/operator/dynamicfiltering/DynamicPageFilter.java
@@ -1,0 +1,333 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.dynamicfiltering;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import io.trino.operator.project.SelectedPositions;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.DynamicFilter;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.TypeOperators;
+import jakarta.annotation.Nullable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.airlift.concurrent.MoreFutures.toListenableFuture;
+import static io.airlift.concurrent.MoreFutures.unmodifiableFuture;
+import static io.trino.operator.dynamicfiltering.TupleDomainFilterUtils.createTupleDomainFilters;
+import static io.trino.operator.project.SelectedPositions.positionsList;
+import static io.trino.operator.project.SelectedPositions.positionsRange;
+import static java.util.Objects.requireNonNull;
+
+public class DynamicPageFilter
+{
+    static final List<BlockFilter> NONE_BLOCK_FILTER = ImmutableList.of(new NoneBlockFilter());
+
+    private final DynamicFilter dynamicFilter;
+    private final Map<ColumnHandle, Integer> channelIndexes;
+    private final TypeOperators typeOperators;
+    private final IsolatedBlockFilterFactory isolatedBlockFilterFactory;
+    private final Executor executor;
+
+    private final AtomicReference<List<BlockFilter>> currentFilter = new AtomicReference<>();
+
+    @Nullable
+    @GuardedBy("this")
+    private TupleDomain<ColumnHandle> collectedDynamicFilter = TupleDomain.all();
+
+    private final CompletableFuture<?> isBlocked;
+
+    public DynamicPageFilter(
+            DynamicFilter dynamicFilter,
+            Map<ColumnHandle, Integer> channelIndexes,
+            TypeOperators typeOperators,
+            IsolatedBlockFilterFactory isolatedBlockFilterFactory,
+            Executor executor)
+    {
+        this.dynamicFilter = requireNonNull(dynamicFilter, "dynamicFilter is null");
+        this.channelIndexes = ImmutableMap.copyOf(requireNonNull(channelIndexes, "channelIndexes is null"));
+        this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
+        this.isolatedBlockFilterFactory = requireNonNull(isolatedBlockFilterFactory, "isolatedBlockFilterFactory is null");
+        this.executor = requireNonNull(executor, "executorService is null");
+        this.isBlocked = new CompletableFuture<>();
+        executor.execute(this::collectDynamicFilterAsync);
+    }
+
+    public CompletableFuture<?> isBlocked()
+    {
+        return unmodifiableFuture(isBlocked);
+    }
+
+    public boolean isAwaitable()
+    {
+        return !isBlocked.isDone();
+    }
+
+    public Optional<List<BlockFilter>> getBlockFilters()
+    {
+        return Optional.ofNullable(currentFilter.get());
+    }
+
+    private void collectDynamicFilterAsync()
+    {
+        if (!dynamicFilter.isAwaitable()) {
+            updatePageFilter();
+            isBlocked.complete(null);
+            return;
+        }
+
+        toListenableFuture(dynamicFilter.isBlocked()).addListener(this::collectDynamicFilterAsync, executor);
+        // Update page filter since we might miss a DF update between the isAwaitable check
+        // and getting the next future from isBlocked
+        updatePageFilter();
+    }
+
+    private synchronized void updatePageFilter()
+    {
+        boolean dynamicFilterComplete = !dynamicFilter.isAwaitable();
+        TupleDomain<ColumnHandle> currentDynamicFilter = dynamicFilter.getCurrentPredicate();
+        if (collectedDynamicFilter == null || currentDynamicFilter.equals(collectedDynamicFilter)) {
+            if (dynamicFilterComplete) {
+                // dynamicFilter completed with an ALL update
+                // save on memory as we have already created the complete page filter
+                collectedDynamicFilter = null;
+            }
+            return;
+        }
+        collectedDynamicFilter = currentDynamicFilter;
+        createPageFilter(currentDynamicFilter, channelIndexes, typeOperators, isolatedBlockFilterFactory)
+                .ifPresent(currentFilter::set);
+        if (dynamicFilterComplete) {
+            // save on memory as we have already created the complete page filter
+            collectedDynamicFilter = null;
+        }
+    }
+
+    @VisibleForTesting
+    static Optional<List<BlockFilter>> createPageFilter(
+            TupleDomain<ColumnHandle> tupleDomain,
+            Map<ColumnHandle, Integer> channelIndexes,
+            TypeOperators typeOperators,
+            IsolatedBlockFilterFactory isolatedBlockFilterFactory)
+    {
+        if (tupleDomain.isAll()) {
+            return Optional.empty();
+        }
+        if (tupleDomain.isNone()) {
+            return Optional.of(NONE_BLOCK_FILTER);
+        }
+
+        Map<ColumnHandle, TupleDomainFilter> columnFilters = createTupleDomainFilters(tupleDomain, typeOperators);
+        if (columnFilters.isEmpty()) {
+            return Optional.empty();
+        }
+
+        ImmutableList.Builder<BlockFilter> channelBlockFilters = ImmutableList.builderWithExpectedSize(columnFilters.size());
+        for (Map.Entry<ColumnHandle, TupleDomainFilter> entry : columnFilters.entrySet()) {
+            TupleDomainFilter filter = entry.getValue();
+            int channelIndex = requireNonNull(channelIndexes.get(entry.getKey()));
+            channelBlockFilters.add(isolatedBlockFilterFactory.createIsolatedBlockFilter(filter, channelIndex));
+        }
+        return Optional.of(channelBlockFilters.build());
+    }
+
+    private static class NoneBlockFilter
+            implements BlockFilter
+    {
+        @Override
+        public SelectedPositions filter(Block block, SelectedPositions selectedPositions)
+        {
+            return BlockFilter.EMPTY;
+        }
+
+        @Override
+        public boolean[] selectedPositionsMask(Block block)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int getChannelIndex()
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    // Needs to be public for class loader isolation to work
+    public interface BlockFilter
+    {
+        SelectedPositions EMPTY = positionsRange(0, 0);
+
+        SelectedPositions filter(Block block, SelectedPositions selectedPositions);
+
+        // Used to generate a mask of selected positions for dictionaries
+        boolean[] selectedPositionsMask(Block block);
+
+        int getChannelIndex();
+    }
+
+    // Needs to be public for class loader isolation to work
+    public static class InternalBlockFilter
+            implements BlockFilter
+    {
+        private final TupleDomainFilter filter;
+        private final int channelIndex;
+
+        public InternalBlockFilter(TupleDomainFilter filter, int channelIndex)
+        {
+            this.filter = requireNonNull(filter, "filter is null");
+            this.channelIndex = channelIndex;
+        }
+
+        @Override
+        public SelectedPositions filter(Block block, SelectedPositions selectedPositions)
+        {
+            if (block instanceof RunLengthEncodedBlock) {
+                return filterRleBlock((RunLengthEncodedBlock) block, selectedPositions);
+            }
+            return filterNonRleBlock(block, selectedPositions);
+        }
+
+        @Override
+        public boolean[] selectedPositionsMask(Block block)
+        {
+            int positionCount = block.getPositionCount();
+            boolean[] selectionMask = new boolean[positionCount];
+            boolean nullAllowed = filter.isNullAllowed();
+            if (block.mayHaveNull()) {
+                for (int position = 0; position < positionCount; position++) {
+                    selectionMask[position] = block.isNull(position)
+                            ? nullAllowed
+                            : filter.testContains(block, position);
+                }
+            }
+            else {
+                for (int position = 0; position < positionCount; position++) {
+                    selectionMask[position] = filter.testContains(block, position);
+                }
+            }
+            return selectionMask;
+        }
+
+        @Override
+        public int getChannelIndex()
+        {
+            return channelIndex;
+        }
+
+        private SelectedPositions filterNonRleBlock(Block block, SelectedPositions selectedPositions)
+        {
+            if (!block.mayHaveNull()) {
+                // Block is guaranteed to be non-null
+                if (selectedPositions.isList()) {
+                    return filterBlockWithoutNulls(block, selectedPositions);
+                }
+                return filterBlockWithoutNulls(block, selectedPositions.size());
+            }
+
+            if (selectedPositions.isList()) {
+                return filterBlockWithNulls(block, filter.isNullAllowed(), selectedPositions);
+            }
+            return filterBlockWithNulls(block, filter.isNullAllowed(), selectedPositions.size());
+        }
+
+        private SelectedPositions filterRleBlock(RunLengthEncodedBlock block, SelectedPositions positions)
+        {
+            boolean nullAllowed = filter.isNullAllowed();
+            if (positions.isEmpty()) {
+                return positions;
+            }
+            if (block.isNull(0)) {
+                return nullAllowed ? positions : BlockFilter.EMPTY;
+            }
+            return filter.testContains(block.getValue(), 0) ? positions : BlockFilter.EMPTY;
+        }
+
+        private SelectedPositions filterBlockWithoutNulls(Block block, SelectedPositions selectedPositions)
+        {
+            int[] positions = selectedPositions.getPositions();
+            int positionCount = selectedPositions.size();
+            int outputPositionsCount = 0;
+            int[] outputPositions = new int[positionCount];
+            for (int i = 0; i < positionCount; i++) {
+                int position = positions[i];
+                // extra copying to avoid branch
+                outputPositions[outputPositionsCount] = position;
+                outputPositionsCount += filter.testContains(block, position) ? 1 : 0;
+            }
+            return positionsList(outputPositions, 0, outputPositionsCount);
+        }
+
+        private SelectedPositions filterBlockWithoutNulls(Block block, int positionCount)
+        {
+            int outputPositionsCount = 0;
+            int[] outputPositions = new int[positionCount];
+            for (int position = 0; position < positionCount; position++) {
+                // extra copying to avoid branch
+                outputPositions[outputPositionsCount] = position;
+                outputPositionsCount += filter.testContains(block, position) ? 1 : 0;
+            }
+            // full range was selected
+            if (outputPositionsCount == positionCount) {
+                return positionsRange(0, outputPositionsCount);
+            }
+            return positionsList(outputPositions, 0, outputPositionsCount);
+        }
+
+        private SelectedPositions filterBlockWithNulls(Block block, boolean nullAllowed, SelectedPositions selectedPositions)
+        {
+            int[] positions = selectedPositions.getPositions();
+            int positionCount = selectedPositions.size();
+            int outputPositionsCount = 0;
+            int[] outputPositions = new int[positionCount];
+            for (int i = 0; i < positionCount; i++) {
+                int position = positions[i];
+                // extra copying to avoid branch
+                outputPositions[outputPositionsCount] = position;
+                outputPositionsCount += block.isNull(position)
+                        ? (nullAllowed ? 1 : 0)
+                        : (filter.testContains(block, position) ? 1 : 0);
+            }
+            return positionsList(outputPositions, 0, outputPositionsCount);
+        }
+
+        private SelectedPositions filterBlockWithNulls(Block block, boolean nullAllowed, int positionCount)
+        {
+            int[] outputPositions = new int[positionCount];
+            int outputPositionsCount = 0;
+            for (int position = 0; position < positionCount; position++) {
+                // extra copying to avoid branch
+                outputPositions[outputPositionsCount] = position;
+                outputPositionsCount += block.isNull(position)
+                        ? (nullAllowed ? 1 : 0)
+                        : (filter.testContains(block, position) ? 1 : 0);
+            }
+            // full range was selected
+            if (outputPositionsCount == positionCount) {
+                return positionsRange(0, outputPositionsCount);
+            }
+            return positionsList(outputPositions, 0, outputPositionsCount);
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/dynamicfiltering/DynamicPageFilterCache.java
+++ b/core/trino-main/src/main/java/io/trino/operator/dynamicfiltering/DynamicPageFilterCache.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.dynamicfiltering;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import io.airlift.jmx.CacheStatsMBean;
+import io.trino.cache.NonEvictableCache;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.DynamicFilter;
+import io.trino.spi.type.TypeOperators;
+import jakarta.annotation.PreDestroy;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
+
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+
+import static com.google.common.base.Throwables.throwIfInstanceOf;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.trino.cache.SafeCaches.buildNonEvictableCache;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newFixedThreadPool;
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+public class DynamicPageFilterCache
+{
+    private static final int COLLECTION_THREADS = 4;
+
+    private final TypeOperators typeOperators;
+    private final ExecutorService executor;
+    private final NonEvictableCache<CacheKey, DynamicPageFilter> cache;
+    private final IsolatedBlockFilterFactory isolatedBlockFilterFactory;
+
+    @Inject
+    public DynamicPageFilterCache(TypeOperators typeOperators)
+    {
+        this.typeOperators = requireNonNull(typeOperators, "typeManager is null");
+        this.executor = newFixedThreadPool(COLLECTION_THREADS, daemonThreadsNamed("dynamic-page-filter-collector-%s"));
+        this.cache = buildNonEvictableCache(CacheBuilder.newBuilder()
+                .maximumSize(1000)
+                .expireAfterAccess(2, MINUTES)
+                .recordStats());
+        this.isolatedBlockFilterFactory = new IsolatedBlockFilterFactory();
+    }
+
+    @PreDestroy
+    public void shutdown()
+    {
+        executor.shutdownNow();
+    }
+
+    @Managed
+    @Nested
+    public CacheStatsMBean getDynamicPageFilterCacheStats()
+    {
+        return new CacheStatsMBean(cache);
+    }
+
+    public DynamicPageFilter getDynamicPageFilter(DynamicFilter dynamicFilter, Map<ColumnHandle, Integer> channelIndexes)
+    {
+        try {
+            return cache.get(new CacheKey(channelIndexes, dynamicFilter), () -> new DynamicPageFilter(
+                    dynamicFilter,
+                    channelIndexes,
+                    typeOperators,
+                    isolatedBlockFilterFactory,
+                    executor));
+        }
+        catch (ExecutionException e) {
+            throwIfInstanceOf(e.getCause(), TrinoException.class);
+            throw new RuntimeException(e.getCause());
+        }
+    }
+
+    private record CacheKey(Map<ColumnHandle, Integer> channelIndexes, DynamicFilter dynamicFilter)
+    {
+        public CacheKey(Map<ColumnHandle, Integer> channelIndexes, DynamicFilter dynamicFilter)
+        {
+            this.channelIndexes = ImmutableMap.copyOf(requireNonNull(channelIndexes, "channelIndexes is null"));
+            this.dynamicFilter = requireNonNull(dynamicFilter, "dynamicFilter is null");
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/dynamicfiltering/DynamicRowFilteringPageSource.java
+++ b/core/trino-main/src/main/java/io/trino/operator/dynamicfiltering/DynamicRowFilteringPageSource.java
@@ -1,0 +1,286 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.dynamicfiltering;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import io.trino.operator.project.SelectedPositions;
+import io.trino.plugin.base.metrics.LongCount;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.DictionaryBlock;
+import io.trino.spi.block.LazyBlock;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.metrics.Metrics;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+
+import static io.trino.operator.dynamicfiltering.DictionaryAwarePageFilter.BlockFilterStats;
+import static io.trino.operator.dynamicfiltering.DictionaryAwarePageFilter.SelectedPositionsWithStats;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+public class DynamicRowFilteringPageSource
+        implements ConnectorPageSource
+{
+    public static final String FILTER_INPUT_POSITIONS = "filterInputPositions";
+    public static final String FILTER_OUTPUT_POSITIONS = "filterOutputPositions";
+    public static final String ROW_FILTERING_TIME_MILLIS = "rowFilteringTimeMillis";
+
+    static final Page EMPTY_PAGE = new Page(0);
+
+    private final ConnectorPageSource delegate;
+    private final DynamicPageFilter dynamicPageFilter;
+    private final long blockingTimeoutNanos;
+    private final long startNanos;
+    private final FilterProfiler profiler;
+
+    private final DictionaryAwarePageFilter filter;
+
+    private long rowFilteringTimeNanos;
+
+    public DynamicRowFilteringPageSource(
+            ConnectorPageSource delegate,
+            double dynamicRowFilterSelectivityThreshold,
+            Duration blockingTimeout,
+            int columnCount,
+            DynamicPageFilter dynamicPageFilter)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        this.blockingTimeoutNanos = (long) requireNonNull(blockingTimeout, "blockingTimeout is null").getValue(NANOSECONDS);
+        this.dynamicPageFilter = requireNonNull(dynamicPageFilter, "dynamicPageFilter is null");
+        this.startNanos = System.nanoTime();
+        this.profiler = new FilterProfiler(dynamicRowFilterSelectivityThreshold, columnCount);
+        this.filter = new DictionaryAwarePageFilter(columnCount);
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return delegate.getCompletedBytes();
+    }
+
+    @Override
+    public OptionalLong getCompletedPositions()
+    {
+        // Delegate ConnectorPageSource should implement getCompletedPositions
+        // to ensure that physical input positions stats are accurate
+        return delegate.getCompletedPositions();
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return delegate.getReadTimeNanos();
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return delegate.isFinished();
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        Page dataPage = delegate.getNextPage();
+        if (dataPage == null || dataPage.getPositionCount() == 0) {
+            return dataPage;
+        }
+        Optional<List<DynamicPageFilter.BlockFilter>> blockFilters = dynamicPageFilter.getBlockFilters();
+        if (blockFilters.isEmpty()) {
+            return dataPage;
+        }
+        if (blockFilters.get() == DynamicPageFilter.NONE_BLOCK_FILTER) {
+            profiler.record(dataPage.getPositionCount(), 0, ImmutableList.of(), filter);
+            return EMPTY_PAGE;
+        }
+
+        List<DynamicPageFilter.BlockFilter> filters = blockFilters.get();
+        DynamicPageFilter.BlockFilter[] effectiveFilters = new DynamicPageFilter.BlockFilter[filters.size()];
+        int length = 0;
+        for (DynamicPageFilter.BlockFilter blockFilter : filters) {
+            if (profiler.isChannelFilterEffective(blockFilter.getChannelIndex())) {
+                effectiveFilters[length++] = blockFilter;
+            }
+        }
+        if (length == 0) {
+            return dataPage;
+        }
+
+        long start = System.nanoTime();
+        int inputPositions = dataPage.getPositionCount();
+        SelectedPositionsWithStats positionsWithStats = filter.filterPage(dataPage, effectiveFilters, length);
+        SelectedPositions selectedPositions = positionsWithStats.getPositions();
+        int selectedPositionsCount = selectedPositions.size();
+        profiler.record(inputPositions, selectedPositionsCount, positionsWithStats.getBlockFilterStats(), filter);
+
+        Page resultPage = dataPage;
+        if (selectedPositionsCount == 0) {
+            resultPage = EMPTY_PAGE;
+        }
+        else if (selectedPositionsCount < inputPositions) {
+            if (selectedPositions.isList()) {
+                Block[] blocks = new Block[dataPage.getChannelCount()];
+                for (int channel = 0; channel < blocks.length; channel++) {
+                    Block block = dataPage.getBlock(channel);
+                    if (block.isLoaded()) {
+                        blocks[channel] = getOrCopyPositions(block, selectedPositions);
+                    }
+                    else {
+                        blocks[channel] = new LazyBlock(selectedPositionsCount, () -> {
+                            Block loadedBlock;
+                            if (block instanceof LazyBlock) {
+                                // load top-level block only
+                                loadedBlock = ((LazyBlock) block).getBlock();
+                            }
+                            else {
+                                loadedBlock = block;
+                            }
+                            return getOrCopyPositions(loadedBlock, selectedPositions);
+                        });
+                    }
+                }
+                resultPage = new Page(blocks);
+            }
+            else {
+                resultPage = dataPage.getRegion(0, selectedPositions.size());
+            }
+        }
+        rowFilteringTimeNanos += System.nanoTime() - start;
+        return resultPage;
+    }
+
+    private Block getOrCopyPositions(Block block, SelectedPositions selectedPositions)
+    {
+        if (block instanceof DictionaryBlock) {
+            return block.getPositions(selectedPositions.getPositions(), 0, selectedPositions.size());
+        }
+        else {
+            // Copy positions for non-dictionary blocks. If we used Block#getPositions instead,
+            // then non-dictionary blocks would be converted to (masking) dictionaries. It might
+            // happen that non-dictionary input blocks are interleaved with dictionary input blocks
+            // which share same dictionary. In such case, using Block#getPositions for non-dictionary
+            // input blocks might confuse downstream dictionary-aware operators that keep track of
+            // dictionaries which are shared across input blocks.
+            // TODO: revise as part of https://starburstdata.atlassian.net/browse/SEP-6818
+            return block.copyPositions(selectedPositions.getPositions(), 0, selectedPositions.size());
+        }
+    }
+
+    @Override
+    public Metrics getMetrics()
+    {
+        // Don't add custom metrics to scan operator if there hasn't been any filtering
+        if (profiler.getFilterInputPositions() == 0) {
+            return delegate.getMetrics();
+        }
+        return delegate.getMetrics().mergeWith(
+                new Metrics(ImmutableMap.of(
+                        FILTER_INPUT_POSITIONS, new LongCount(profiler.getFilterInputPositions()),
+                        FILTER_OUTPUT_POSITIONS, new LongCount(profiler.getFilterOutputPositions()),
+                        ROW_FILTERING_TIME_MILLIS, new LongCount(NANOSECONDS.toMillis(rowFilteringTimeNanos)))));
+    }
+
+    @Override
+    public long getMemoryUsage()
+    {
+        return delegate.getMemoryUsage();
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        delegate.close();
+    }
+
+    @Override
+    public CompletableFuture<?> isBlocked()
+    {
+        // Block until one of below conditions is met:
+        // 1. Timeout after waiting for the configured time
+        // 2. Creation of final DynamicPageFilter
+        long timeLeft = blockingTimeoutNanos - (System.nanoTime() - startNanos);
+        if (timeLeft > 0 && dynamicPageFilter.isAwaitable()) {
+            return dynamicPageFilter.isBlocked()
+                    .completeOnTimeout(null, timeLeft, NANOSECONDS)
+                    .thenCompose(ignored -> delegate.isBlocked());
+        }
+        return delegate.isBlocked();
+    }
+
+    private static class FilterProfiler
+    {
+        private static final int MIN_SAMPLE_POSITIONS = 2047;
+
+        private final double selectivityThreshold;
+        private long filterInputPositions;
+        private long filterOutputPositions;
+        private final long[] channelInputPositions;
+        private final long[] channelOutputPositions;
+        private final IntOpenHashSet ineffectiveFilterChannels = new IntOpenHashSet();
+
+        public FilterProfiler(double selectivityThreshold, int columnsCount)
+        {
+            this.selectivityThreshold = selectivityThreshold;
+            this.channelInputPositions = new long[columnsCount];
+            this.channelOutputPositions = new long[columnsCount];
+        }
+
+        void record(
+                int inputPositions,
+                int selectedPositions,
+                List<BlockFilterStats> blockFiltersStats,
+                DictionaryAwarePageFilter filter)
+        {
+            filterInputPositions += inputPositions;
+            filterOutputPositions += selectedPositions;
+            for (BlockFilterStats blockFilterStats : blockFiltersStats) {
+                int channelIndex = blockFilterStats.getChannelIndex();
+                channelOutputPositions[channelIndex] += blockFilterStats.getOutputPositions();
+                channelInputPositions[channelIndex] += blockFilterStats.getInputPositions();
+
+                if (channelInputPositions[channelIndex] < MIN_SAMPLE_POSITIONS) {
+                    continue;
+                }
+                if (channelOutputPositions[channelIndex] > (selectivityThreshold * channelInputPositions[channelIndex])) {
+                    ineffectiveFilterChannels.add(channelIndex);
+                    filter.cleanUp(channelIndex);
+                }
+            }
+        }
+
+        public boolean isChannelFilterEffective(int channelIndex)
+        {
+            return !ineffectiveFilterChannels.contains(channelIndex);
+        }
+
+        public long getFilterInputPositions()
+        {
+            return filterInputPositions;
+        }
+
+        public long getFilterOutputPositions()
+        {
+            return filterOutputPositions;
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/dynamicfiltering/DynamicRowFilteringPageSourceProvider.java
+++ b/core/trino-main/src/main/java/io/trino/operator/dynamicfiltering/DynamicRowFilteringPageSourceProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.dynamicfiltering;
+
+import com.google.inject.Inject;
+import io.trino.Session;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.DynamicFilter;
+import io.trino.spi.connector.RecordPageSource;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.trino.SystemSessionProperties.getDynamicRowFilterSelectivityThreshold;
+import static io.trino.SystemSessionProperties.getDynamicRowFilteringWaitTimeout;
+import static io.trino.SystemSessionProperties.isDynamicRowFilteringEnabled;
+import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
+
+public class DynamicRowFilteringPageSourceProvider
+{
+    private final DynamicPageFilterCache dynamicPageFilterCache;
+
+    @Inject
+    public DynamicRowFilteringPageSourceProvider(DynamicPageFilterCache dynamicPageFilterCache)
+    {
+        this.dynamicPageFilterCache = requireNonNull(dynamicPageFilterCache, "dynamicPageFilterCollector is null");
+    }
+
+    public ConnectorPageSource createPageSource(ConnectorPageSource delegatePageSource, Session session, List<ColumnHandle> columns, DynamicFilter dynamicFilter)
+    {
+        requireNonNull(columns, "columns is null");
+        Map<ColumnHandle, Integer> columnHandleMap = IntStream.range(0, columns.size())
+                .boxed()
+                .collect(toImmutableMap(columns::get, identity()));
+        return createPageSource(delegatePageSource, session, columns.size(), columnHandleMap, dynamicFilter);
+    }
+
+    public ConnectorPageSource createPageSource(ConnectorPageSource delegatePageSource, Session session, int columnCount, Map<ColumnHandle, Integer> channelIndexes, DynamicFilter dynamicFilter)
+    {
+        if (dynamicFilter.isComplete() && dynamicFilter.getCurrentPredicate().isAll()) {
+            return delegatePageSource;
+        }
+        if (delegatePageSource instanceof RecordPageSource || !isDynamicRowFilteringEnabled(session)) {
+            return delegatePageSource;
+        }
+
+        return new DynamicRowFilteringPageSource(
+                delegatePageSource,
+                getDynamicRowFilterSelectivityThreshold(session),
+                getDynamicRowFilteringWaitTimeout(session),
+                columnCount,
+                dynamicPageFilterCache.getDynamicPageFilter(dynamicFilter, channelIndexes));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/dynamicfiltering/IsolatedBlockFilterFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/dynamicfiltering/IsolatedBlockFilterFactory.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.dynamicfiltering;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import io.airlift.bytecode.DynamicClassLoader;
+import io.trino.cache.NonEvictableLoadingCache;
+import io.trino.spi.type.Type;
+
+import java.lang.reflect.Constructor;
+import java.util.Objects;
+
+import static io.trino.cache.SafeCaches.buildNonEvictableCache;
+import static io.trino.sql.gen.IsolatedClass.isolateClass;
+import static java.util.Objects.requireNonNull;
+
+public class IsolatedBlockFilterFactory
+{
+    private final NonEvictableLoadingCache<CacheKey, Constructor<? extends DynamicPageFilter.BlockFilter>> cache;
+
+    public IsolatedBlockFilterFactory()
+    {
+        this.cache = buildNonEvictableCache(
+                CacheBuilder.newBuilder()
+                        .maximumSize(1000),
+                CacheLoader.from(key -> {
+                    Class<? extends DynamicPageFilter.BlockFilter> isolatedBlockFilter = isolateClass(
+                            new DynamicClassLoader(DynamicPageFilter.class.getClassLoader()),
+                            DynamicPageFilter.BlockFilter.class,
+                            DynamicPageFilter.InternalBlockFilter.class);
+                    try {
+                        return isolatedBlockFilter.getConstructor(TupleDomainFilter.class, int.class);
+                    }
+                    catch (NoSuchMethodException e) {
+                        throw new RuntimeException(e);
+                    }
+                }));
+    }
+
+    public DynamicPageFilter.BlockFilter createIsolatedBlockFilter(TupleDomainFilter filter, int channelIndex)
+    {
+        try {
+            return cache.getUnchecked(new CacheKey(filter.getType().getClass(), filter.getClass()))
+                    .newInstance(filter, channelIndex);
+        }
+        catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static class CacheKey
+    {
+        private final Class<? extends Type> type;
+        private final Class<? extends TupleDomainFilter> filter;
+
+        CacheKey(Class<? extends Type> type, Class<? extends TupleDomainFilter> filter)
+        {
+            this.type = requireNonNull(type, "type is null");
+            this.filter = requireNonNull(filter, "filter is null");
+        }
+
+        public Class<? extends Type> getType()
+        {
+            return type;
+        }
+
+        public Class<? extends TupleDomainFilter> getFilter()
+        {
+            return filter;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            CacheKey cacheKey = (CacheKey) o;
+            return Objects.equals(type, cacheKey.type)
+                    && Objects.equals(filter, cacheKey.filter);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(type, filter);
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/dynamicfiltering/TupleDomainFilter.java
+++ b/core/trino-main/src/main/java/io/trino/operator/dynamicfiltering/TupleDomainFilter.java
@@ -1,0 +1,637 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.dynamicfiltering;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.airlift.slice.Slice;
+import io.airlift.slice.XxHash64;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.Block;
+import io.trino.spi.type.Type;
+import it.unimi.dsi.fastutil.longs.LongHash;
+import it.unimi.dsi.fastutil.longs.LongOpenCustomHashSet;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.List;
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
+import static com.google.common.base.Verify.verifyNotNull;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static java.lang.Boolean.TRUE;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public interface TupleDomainFilter
+{
+    boolean isNullAllowed();
+
+    Type getType();
+
+    boolean testContains(Block block, int position);
+
+    abstract class AbstractTupleDomainFilter
+            implements TupleDomainFilter
+    {
+        protected final boolean nullAllowed;
+        protected final Type type;
+
+        public AbstractTupleDomainFilter(boolean nullAllowed, Type type)
+        {
+            this.nullAllowed = nullAllowed;
+            this.type = requireNonNull(type, "type is null");
+        }
+
+        @Override
+        public boolean isNullAllowed()
+        {
+            return nullAllowed;
+        }
+
+        @Override
+        public Type getType()
+        {
+            return type;
+        }
+
+        @Override
+        public boolean testContains(Block block, int position)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof AbstractTupleDomainFilter)) {
+                return false;
+            }
+            AbstractTupleDomainFilter that = (AbstractTupleDomainFilter) o;
+            return nullAllowed == that.nullAllowed && Objects.equals(type, that.type);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(nullAllowed, type);
+        }
+    }
+
+    final class LongCustomHashSetFilter
+            extends AbstractTupleDomainFilter
+    {
+        private final LongOpenCustomHashSet hashSet;
+
+        /**
+         * Based on io.trino.util.FastutilSetHelper.
+         */
+        public LongCustomHashSetFilter(boolean nullAllowed, Type type, MethodHandle hashCodeHandle, MethodHandle equalsHandle, List<Long> values)
+        {
+            super(nullAllowed, type);
+            requireNonNull(values, "values is null");
+            checkArgument(!values.isEmpty(), "values must not be empty");
+            this.hashSet = new LongOpenCustomHashSet(values, 0.25f, new LongStrategy(hashCodeHandle, equalsHandle));
+        }
+
+        @Override
+        public boolean testContains(Block block, int position)
+        {
+            return hashSet.contains(type.getLong(block, position));
+        }
+
+        // Allows easier benchmarking without going through Block APIs
+        public boolean testContains(long value)
+        {
+            return hashSet.contains(value);
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            if (!super.equals(o)) {
+                return false;
+            }
+            LongCustomHashSetFilter that = (LongCustomHashSetFilter) o;
+            return Objects.equals(hashSet, that.hashSet);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(super.hashCode(), hashSet);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("nullAllowed", nullAllowed)
+                    .add("type", type)
+                    .add("hashSet", hashSet)
+                    .toString();
+        }
+
+        private static final class LongStrategy
+                implements LongHash.Strategy
+        {
+            private final MethodHandle hashCodeHandle;
+            private final MethodHandle equalsHandle;
+
+            public LongStrategy(MethodHandle hashCodeHandle, MethodHandle equalsHandle)
+            {
+                this.hashCodeHandle = requireNonNull(hashCodeHandle, "hashCodeHandle is null");
+                this.equalsHandle = requireNonNull(equalsHandle, "equalsHandle is null");
+            }
+
+            @Override
+            public int hashCode(long value)
+            {
+                try {
+                    return Long.hashCode((long) hashCodeHandle.invokeExact(value));
+                }
+                catch (Throwable t) {
+                    throwIfInstanceOf(t, Error.class);
+                    throwIfInstanceOf(t, TrinoException.class);
+                    throw new TrinoException(GENERIC_INTERNAL_ERROR, t);
+                }
+            }
+
+            @Override
+            public boolean equals(long a, long b)
+            {
+                try {
+                    Boolean result = (Boolean) equalsHandle.invokeExact(a, b);
+                    // FastutilHashSet is not intended be used for indeterminate values lookup
+                    verifyNotNull(result, "result is null");
+                    return TRUE.equals(result);
+                }
+                catch (Throwable t) {
+                    throwIfInstanceOf(t, Error.class);
+                    throwIfInstanceOf(t, TrinoException.class);
+                    throw new TrinoException(GENERIC_INTERNAL_ERROR, t);
+                }
+            }
+        }
+    }
+
+    final class LongHashSetFilter
+            extends AbstractTupleDomainFilter
+    {
+        private final LongOpenHashSet hashSet;
+        private final long min;
+        private final long max;
+
+        public LongHashSetFilter(boolean nullAllowed, Type type, List<Long> values, long min, long max)
+        {
+            super(nullAllowed, type);
+            requireNonNull(values, "values is null");
+            checkArgument(min <= max, "min must be less than or equal to max");
+            checkArgument(!values.isEmpty(), "values must not be empty");
+            this.hashSet = new LongOpenHashSet(values, 0.25f);
+            this.min = min;
+            this.max = max;
+        }
+
+        @Override
+        public boolean testContains(Block block, int position)
+        {
+            return testContains(type.getLong(block, position));
+        }
+
+        // Allows easier benchmarking without going through Block APIs
+        public boolean testContains(long value)
+        {
+            if (value < min || value > max) {
+                return false;
+            }
+            return hashSet.contains(value);
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            if (!super.equals(o)) {
+                return false;
+            }
+            LongHashSetFilter that = (LongHashSetFilter) o;
+            return min == that.min &&
+                    max == that.max &&
+                    Objects.equals(hashSet, that.hashSet);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(super.hashCode(), hashSet, min, max);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("nullAllowed", nullAllowed)
+                    .add("type", type)
+                    .add("hashSet", hashSet)
+                    .add("min", min)
+                    .add("max", max)
+                    .toString();
+        }
+    }
+
+    final class LongBitSetFilter
+            extends AbstractTupleDomainFilter
+    {
+        private final BitSet bitmask;
+        private final long min;
+        private final long max;
+        private final int size;
+
+        public LongBitSetFilter(boolean nullAllowed, Type type, List<Long> values, long min, long max)
+        {
+            super(nullAllowed, type);
+            requireNonNull(values, "values is null");
+            checkArgument(min <= max, "min must be less than or equal to max");
+            checkArgument(!values.isEmpty(), "values must not be empty");
+            this.size = values.size();
+            this.min = min;
+            this.max = max;
+            long range = max - min + 1;
+            checkArgument((int) range == range, format("Values range %d is outside integer range", range));
+            bitmask = new BitSet((int) range);
+
+            for (long value : values) {
+                bitmask.set((int) (value - min));
+            }
+        }
+
+        @Override
+        public boolean testContains(Block block, int position)
+        {
+            return testContains(type.getLong(block, position));
+        }
+
+        // Allows easier benchmarking without going through Block APIs
+        public boolean testContains(long value)
+        {
+            if (value < min || value > max) {
+                return false;
+            }
+
+            return bitmask.get((int) (value - min));
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            if (!super.equals(o)) {
+                return false;
+            }
+            LongBitSetFilter that = (LongBitSetFilter) o;
+            return min == that.min &&
+                    max == that.max &&
+                    size == that.size &&
+                    Objects.equals(bitmask, that.bitmask);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(super.hashCode(), bitmask, min, max, size);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("type", type)
+                    .add("min", min)
+                    .add("max", max)
+                    .add("bitmask", bitmask)
+                    .add("nullAllowed", nullAllowed)
+                    .toString();
+        }
+    }
+
+    final class LongRangeFilter
+            extends AbstractTupleDomainFilter
+    {
+        private final long lower;
+        private final long upper;
+
+        /**
+         * A filter for a range of long values between lower and upper with both ends of the range included.
+         *
+         * @param nullAllowed true if NULLs should be included
+         * @param type Type of the values being filtered
+         * @param lower minimum allowed value
+         * @param upper maximum allowed value
+         */
+        public LongRangeFilter(boolean nullAllowed, Type type, long lower, long upper)
+        {
+            super(nullAllowed, type);
+            checkArgument(lower <= upper, "lower must be less than or equal to upper");
+            this.lower = lower;
+            this.upper = upper;
+        }
+
+        @Override
+        public boolean testContains(Block block, int position)
+        {
+            long value = type.getLong(block, position);
+            return value >= lower && value <= upper;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            if (!super.equals(o)) {
+                return false;
+            }
+            LongRangeFilter that = (LongRangeFilter) o;
+            return lower == that.lower && upper == that.upper;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(super.hashCode(), lower, upper);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("lower", lower)
+                    .add("upper", upper)
+                    .add("nullAllowed", nullAllowed)
+                    .toString();
+        }
+    }
+
+    final class SliceBloomFilter
+            extends AbstractTupleDomainFilter
+    {
+        private final long[] bloom;
+        private final int bloomSizeMask;
+
+        /**
+         * A Bloom filter for a set of Slice values.
+         * This is approx 2X faster than Standard Bloom filter because
+         * it uses single hash function and uses that to set 3 bits within a 64 bit word.
+         * It has low memory footprint, up to (4 * values.size()) bytes
+         *
+         * @param nullAllowed true if NULLs should be included
+         * @param type Type of the values being filtered
+         * @param values List of Slice values used for filtering
+         */
+        public SliceBloomFilter(boolean nullAllowed, Type type, List<Slice> values)
+        {
+            super(nullAllowed, type);
+
+            requireNonNull(values, "values is null");
+            checkArgument(values.size() > 0, "values must not be empty");
+
+            int bloomSize = getBloomFilterSize(values.size());
+            bloom = new long[bloomSize];
+            bloomSizeMask = bloomSize - 1;
+            for (Slice value : values) {
+                long hashCode = XxHash64.hash(value);
+                // Set 3 bits in a 64 bit word
+                bloom[bloomIndex(hashCode)] |= bloomMask(hashCode);
+            }
+        }
+
+        public static int getBloomFilterSize(int valuesCount)
+        {
+            // Linear hash table size is the highest power of two less than or equal to number of values * 4. This means that the
+            // table is under half full, e.g. 127 elements gets 256 slots.
+            int hashTableSize = Integer.highestOneBit(valuesCount * 4);
+            // We will allocate 8 bits in the bloom filter for every slot in a comparable hash table.
+            // The bloomSize is a count of longs, hence / 8.
+            return Math.max(1, hashTableSize / 8);
+        }
+
+        @Override
+        public boolean testContains(Block block, int position)
+        {
+            return testContains(type.getSlice(block, position));
+        }
+
+        @VisibleForTesting
+        public boolean testContains(Slice value)
+        {
+            long hashCode = XxHash64.hash(value);
+            long mask = bloomMask(hashCode);
+            return mask == (bloom[bloomIndex(hashCode)] & mask);
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            if (!super.equals(o)) {
+                return false;
+            }
+            SliceBloomFilter that = (SliceBloomFilter) o;
+            return bloomSizeMask == that.bloomSizeMask
+                    && Arrays.equals(bloom, that.bloom);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            int result = Objects.hash(super.hashCode(), bloomSizeMask);
+            result = 31 * result + Arrays.hashCode(bloom);
+            return result;
+        }
+
+        private int bloomIndex(long hashCode)
+        {
+            // Lower 20 bits are not used by bloomMask
+            // These are enough for the maximum size array that will be used here
+            return (int) (hashCode & bloomSizeMask);
+        }
+
+        private static long bloomMask(long hashCode)
+        {
+            // returned mask sets 3 bits based on portions of given hash
+            // Extract 39 to 44th bits
+            return (1L << ((hashCode >> 20) & 63))
+                    // Extract 33rd to 38th bits
+                    | (1L << ((hashCode >> 26) & 63))
+                    // Extract 27th to 32nd bits
+                    | (1L << ((hashCode >> 32) & 63));
+        }
+    }
+
+    final class AlwaysFalse
+            extends AbstractTupleDomainFilter
+    {
+        public AlwaysFalse(Type type)
+        {
+            super(false, type);
+        }
+
+        @Override
+        public boolean testContains(Block block, int position)
+        {
+            return false;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            return super.equals(o);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return super.hashCode();
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("type", type)
+                    .toString();
+        }
+    }
+
+    final class IsNullFilter
+            extends AbstractTupleDomainFilter
+    {
+        public IsNullFilter(Type type)
+        {
+            super(true, type);
+        }
+
+        @Override
+        public boolean testContains(Block block, int position)
+        {
+            return false;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            return super.equals(o);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return super.hashCode();
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("type", type)
+                    .toString();
+        }
+    }
+
+    final class IsNotNullFilter
+            extends AbstractTupleDomainFilter
+    {
+        public IsNotNullFilter(Type type)
+        {
+            super(false, type);
+        }
+
+        @Override
+        public boolean testContains(Block block, int position)
+        {
+            return true;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            return super.equals(o);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return super.hashCode();
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("type", type)
+                    .toString();
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/dynamicfiltering/TupleDomainFilterUtils.java
+++ b/core/trino-main/src/main/java/io/trino/operator/dynamicfiltering/TupleDomainFilterUtils.java
@@ -1,0 +1,261 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.dynamicfiltering;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeOperators;
+import io.trino.spi.type.VarcharType;
+import it.unimi.dsi.fastutil.HashCommon;
+
+import java.lang.invoke.MethodHandle;
+import java.math.BigInteger;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.trino.operator.dynamicfiltering.TupleDomainFilter.AlwaysFalse;
+import static io.trino.operator.dynamicfiltering.TupleDomainFilter.IsNotNullFilter;
+import static io.trino.operator.dynamicfiltering.TupleDomainFilter.IsNullFilter;
+import static io.trino.operator.dynamicfiltering.TupleDomainFilter.LongBitSetFilter;
+import static io.trino.operator.dynamicfiltering.TupleDomainFilter.LongCustomHashSetFilter;
+import static io.trino.operator.dynamicfiltering.TupleDomainFilter.LongHashSetFilter;
+import static io.trino.operator.dynamicfiltering.TupleDomainFilter.LongRangeFilter;
+import static io.trino.operator.dynamicfiltering.TupleDomainFilter.SliceBloomFilter;
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
+import static io.trino.spi.function.InvocationConvention.simpleConvention;
+import static io.trino.spi.predicate.Domain.DiscreteSet;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimeType.TIME_MICROS;
+import static io.trino.spi.type.TimeType.TIME_MILLIS;
+import static io.trino.spi.type.TimeType.TIME_NANOS;
+import static io.trino.spi.type.TimeType.TIME_PICOS;
+import static io.trino.spi.type.TimeType.TIME_SECONDS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_SECONDS;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static java.util.Objects.requireNonNull;
+
+public class TupleDomainFilterUtils
+{
+    private static final long FILTER_MAX_SIZE_BYTES = 15 * 1024 * 1024;
+
+    private TupleDomainFilterUtils() {}
+
+    static Map<ColumnHandle, TupleDomainFilter> createTupleDomainFilters(
+            TupleDomain<ColumnHandle> tupleDomain,
+            TypeOperators typeOperators)
+    {
+        requireNonNull(tupleDomain, "tupleDomain is null");
+        checkArgument(!tupleDomain.isNone(), "tupleDomain is none");
+        // NONE case is handled in DynamicPageFilter#createPageFilter
+        return tupleDomain.getDomains().orElseThrow()
+                .entrySet().stream()
+                .map(entry -> {
+                    Type type = entry.getValue().getType();
+                    Optional<TupleDomainFilter> filter = createTupleDomainFilter(entry.getValue(), type, typeOperators);
+                    if (filter.isEmpty()) {
+                        return Optional.empty();
+                    }
+                    return Optional.of(new SimpleEntry<>(entry.getKey(), filter.get()));
+                })
+                .filter(Optional::isPresent)
+                .map(optionalEntry -> (SimpleEntry<ColumnHandle, TupleDomainFilter>) optionalEntry.get())
+                .collect(toImmutableMap(SimpleEntry::getKey, SimpleEntry::getValue));
+    }
+
+    private static Optional<TupleDomainFilter> createTupleDomainFilter(Domain domain, Type type, TypeOperators typeOperators)
+    {
+        if (!(type.isComparable() && type.isOrderable())) {
+            return Optional.empty();
+        }
+        if (domain.isNullableDiscreteSet()) {
+            return createTupleDomainFilter(domain.getNullableDiscreteSet(), type, typeOperators);
+        }
+
+        // When type is orderable, ValueSet is always a SortedRangeSet
+        return createTupleDomainFilter(domain.isNullAllowed(), domain.getValues().getRanges().getSpan());
+    }
+
+    private static Optional<TupleDomainFilter> createTupleDomainFilter(DiscreteSet nullableDiscreteSet, Type type, TypeOperators typeOperators)
+    {
+        if (type.getJavaType() == long.class) {
+            return createTupleDomainFilterForLongJavaType(nullableDiscreteSet, type, typeOperators);
+        }
+        if (type.getJavaType() == Slice.class) {
+            return createTupleDomainFilterForSliceJavaType(nullableDiscreteSet, type);
+        }
+        // Skipping boolean type as joins on boolean data type are rare
+        // Skipping double type as equality joins on double are rare
+        return Optional.empty();
+    }
+
+    private static Optional<TupleDomainFilter> createTupleDomainFilterForLongJavaType(DiscreteSet nullableDiscreteSet, Type type, TypeOperators typeOperators)
+    {
+        checkArgument(
+                type.getJavaType() == long.class,
+                "Expected java type to be long");
+        boolean nullAllowed = nullableDiscreteSet.containsNull();
+        @SuppressWarnings("unchecked")
+        List<Long> values = (List<Long>) (List<?>) nullableDiscreteSet.getNonNullValues();
+
+        if (values.isEmpty()) {
+            checkState(nullAllowed, "Unexpected always-false filter");
+            return Optional.of(new IsNullFilter(type));
+        }
+
+        long min = values.get(0);
+        long max = min;
+        for (int i = 1; i < values.size(); i++) {
+            min = Math.min(min, values.get(i));
+            max = Math.max(max, values.get(i));
+        }
+        boolean isIntegerArithmeticValid = isIntegerArithmeticValidType(type);
+        // If all values within a range are included, use a range filter
+        if (isIntegerArithmeticValid && (max - min + 1) == values.size()) {
+            return Optional.of(new LongRangeFilter(nullAllowed, type, min, max));
+        }
+        // Filter based on a fast utils hash set uses next power of two (size / load-factor)
+        // slots in a hash table which is an array of longs.
+        long fastUtilsSetEntries = (int) Math.min(
+                1 << 30,
+                HashCommon.nextPowerOfTwo((long) Math.ceil(values.size() / 0.25f)));
+        // Filter based on a bitmap uses (max - min) / 64 longs
+        // Choose the filter that uses fewer entries
+        BigInteger range = BigInteger.valueOf(max)
+                .subtract(BigInteger.valueOf(min))
+                .add(BigInteger.valueOf(1));
+        if (!isIntegerArithmeticValid
+                || range.compareTo(BigInteger.valueOf(Integer.MAX_VALUE)) > 0
+                || (range.intValueExact() / 64) + 1 > fastUtilsSetEntries) {
+            if (fastUtilsSetEntries * 8 > FILTER_MAX_SIZE_BYTES) {
+                // Bail out on filter size above 15MB
+                return Optional.empty();
+            }
+            if (isIntegerArithmeticValid) {
+                return Optional.of(new LongHashSetFilter(nullAllowed, type, values, min, max));
+            }
+            MethodHandle hashCodeHandle = typeOperators.getHashCodeOperator(type, simpleConvention(FAIL_ON_NULL, NEVER_NULL));
+            MethodHandle equalsHandle = typeOperators.getEqualOperator(type, simpleConvention(NULLABLE_RETURN, NEVER_NULL, NEVER_NULL));
+            return Optional.of(new LongCustomHashSetFilter(nullAllowed, type, hashCodeHandle, equalsHandle, values));
+        }
+        if ((range.intValueExact() / 64 + 1) * 8L > FILTER_MAX_SIZE_BYTES) {
+            // Bail out on filter size above 15MB
+            return Optional.empty();
+        }
+        return Optional.of(new LongBitSetFilter(nullAllowed, type, values, min, max));
+    }
+
+    private static Optional<TupleDomainFilter> createTupleDomainFilterForSliceJavaType(DiscreteSet nullableDiscreteSet, Type type)
+    {
+        checkArgument(
+                type.getJavaType() == Slice.class,
+                "Expected java type to be Slice");
+        boolean nullAllowed = nullableDiscreteSet.containsNull();
+        @SuppressWarnings("unchecked")
+        List<Slice> values = (List<Slice>) (List<?>) nullableDiscreteSet.getNonNullValues();
+
+        if (values.isEmpty()) {
+            checkState(nullAllowed, "Unexpected always-false filter");
+            return Optional.of(new IsNullFilter(type));
+        }
+
+        if (!(type instanceof VarcharType || type instanceof CharType)) {
+            return Optional.empty();
+        }
+        if (SliceBloomFilter.getBloomFilterSize(values.size()) > FILTER_MAX_SIZE_BYTES / 8) {
+            return Optional.empty();
+        }
+        return Optional.of(new SliceBloomFilter(nullAllowed, type, values));
+    }
+
+    private static Optional<TupleDomainFilter> createTupleDomainFilter(boolean nullAllowed, Range range)
+    {
+        Type type = range.getType();
+        if (type.getJavaType() != long.class) {
+            return Optional.empty();
+        }
+        if (!isIntegerArithmeticValidType(type)) {
+            // TODO (https://starburstdata.atlassian.net/browse/SEP-6647) add support for double/real type here
+            // as they may be used in in-equality joins. We receive range filter for in-equality join case
+            return Optional.empty();
+        }
+        long lower = range.getLowValue().map(Long.class::cast).orElse(Long.MIN_VALUE);
+        long upper = range.getHighValue().map(Long.class::cast).orElse(Long.MAX_VALUE);
+        if (range.isLowUnbounded() && range.isHighUnbounded()) {
+            checkState(!nullAllowed, "Unexpected range of ALL values");
+            return Optional.of(new IsNotNullFilter(type));
+        }
+        if (!range.isLowUnbounded() && !range.isLowInclusive()) {
+            if (lower == Long.MAX_VALUE) {
+                return Optional.of(getNullOrFalseFilter(nullAllowed, type));
+            }
+            lower++;
+        }
+        if (!range.isHighUnbounded() && !range.isHighInclusive()) {
+            if (upper == Long.MIN_VALUE) {
+                return Optional.of(getNullOrFalseFilter(nullAllowed, type));
+            }
+            upper--;
+        }
+        if (upper < lower) {
+            return Optional.of(getNullOrFalseFilter(nullAllowed, type));
+        }
+        return Optional.of(new LongRangeFilter(nullAllowed, type, lower, upper));
+    }
+
+    private static TupleDomainFilter getNullOrFalseFilter(boolean nullAllowed, Type type)
+    {
+        if (nullAllowed) {
+            return new IsNullFilter(type);
+        }
+        return new AlwaysFalse(type);
+    }
+
+    private static boolean isIntegerArithmeticValidType(Type type)
+    {
+        // Types for which we can safely use equality and comparison on the stored long value
+        // instead of going through type specific methods
+        return type == TINYINT ||
+                type == SMALLINT ||
+                type == INTEGER ||
+                type == BIGINT ||
+                type == TIME_SECONDS ||
+                type == TIME_MILLIS ||
+                type == TIME_MICROS ||
+                type == TIME_NANOS ||
+                type == TIME_PICOS ||
+                type == DATE ||
+                type == TIMESTAMP_SECONDS ||
+                type == TIMESTAMP_MILLIS ||
+                type == TIMESTAMP_MICROS ||
+                (type instanceof DecimalType && ((DecimalType) type).isShort());
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -92,6 +92,8 @@ import io.trino.operator.GroupByHashPageIndexerFactory;
 import io.trino.operator.PagesIndex;
 import io.trino.operator.PagesIndexPageSorter;
 import io.trino.operator.RetryPolicy;
+import io.trino.operator.dynamicfiltering.DynamicPageFilterCache;
+import io.trino.operator.dynamicfiltering.DynamicRowFilteringPageSourceProvider;
 import io.trino.operator.index.IndexJoinLookupStats;
 import io.trino.operator.index.IndexManager;
 import io.trino.operator.scalar.json.JsonExistsFunction;
@@ -374,6 +376,10 @@ public class ServerMainModule
         // data stream provider
         binder.bind(PageSourceManager.class).in(Scopes.SINGLETON);
         binder.bind(PageSourceProviderFactory.class).to(PageSourceManager.class).in(Scopes.SINGLETON);
+
+        // dynamic row filtering
+        binder.bind(DynamicRowFilteringPageSourceProvider.class).in(Scopes.SINGLETON);
+        binder.bind(DynamicPageFilterCache.class).in(Scopes.SINGLETON);
 
         // page sink provider
         binder.bind(PageSinkManager.class).in(Scopes.SINGLETON);

--- a/core/trino-main/src/main/java/io/trino/split/PageSourceManager.java
+++ b/core/trino-main/src/main/java/io/trino/split/PageSourceManager.java
@@ -18,6 +18,7 @@ import io.trino.Session;
 import io.trino.connector.CatalogServiceProvider;
 import io.trino.metadata.Split;
 import io.trino.metadata.TableHandle;
+import io.trino.operator.dynamicfiltering.DynamicRowFilteringPageSourceProvider;
 import io.trino.spi.connector.CatalogHandle;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorPageSource;
@@ -37,21 +38,23 @@ public class PageSourceManager
         implements PageSourceProviderFactory
 {
     private final CatalogServiceProvider<ConnectorPageSourceProviderFactory> pageSourceProviderFactory;
+    private final DynamicRowFilteringPageSourceProvider dynamicRowFilteringPageSourceProvider;
 
     @Inject
-    public PageSourceManager(CatalogServiceProvider<ConnectorPageSourceProviderFactory> pageSourceProviderFactory)
+    public PageSourceManager(CatalogServiceProvider<ConnectorPageSourceProviderFactory> pageSourceProviderFactory, DynamicRowFilteringPageSourceProvider dynamicRowFilteringPageSourceProvider)
     {
         this.pageSourceProviderFactory = requireNonNull(pageSourceProviderFactory, "pageSourceProviderFactory is null");
+        this.dynamicRowFilteringPageSourceProvider = requireNonNull(dynamicRowFilteringPageSourceProvider, "dynamicRowFilteringPageSourceProvider is null");
     }
 
     @Override
     public PageSourceProvider createPageSourceProvider(CatalogHandle catalogHandle)
     {
         ConnectorPageSourceProviderFactory provider = pageSourceProviderFactory.getService(catalogHandle);
-        return new PageSourceProviderInstance(provider.createPageSourceProvider());
+        return new PageSourceProviderInstance(provider.createPageSourceProvider(), dynamicRowFilteringPageSourceProvider);
     }
 
-    private record PageSourceProviderInstance(ConnectorPageSourceProvider pageSourceProvider)
+    private record PageSourceProviderInstance(ConnectorPageSourceProvider pageSourceProvider, DynamicRowFilteringPageSourceProvider dynamicRowFilteringPageSourceProvider)
             implements PageSourceProvider
     {
         private PageSourceProviderInstance
@@ -76,11 +79,19 @@ public class PageSourceManager
             if (!isAllowPushdownIntoConnectors(session)) {
                 dynamicFilter = DynamicFilter.EMPTY;
             }
-            return pageSourceProvider.createPageSource(
+            ConnectorPageSource pageSource = pageSourceProvider.createPageSource(
                     table.transaction(),
                     session.toConnectorSession(table.catalogHandle()),
                     split.getConnectorSplit(),
                     table.connectorHandle(),
+                    columns,
+                    dynamicFilter);
+            if (!pageSourceProvider.shouldPerformDynamicRowFiltering()) {
+                return pageSource;
+            }
+            return dynamicRowFilteringPageSourceProvider.createPageSource(
+                    pageSource,
+                    session,
                     columns,
                     dynamicFilter);
         }

--- a/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
+++ b/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
@@ -114,6 +114,8 @@ import io.trino.operator.GroupByHashPageIndexerFactory;
 import io.trino.operator.PagesIndex;
 import io.trino.operator.PagesIndexPageSorter;
 import io.trino.operator.TaskContext;
+import io.trino.operator.dynamicfiltering.DynamicPageFilterCache;
+import io.trino.operator.dynamicfiltering.DynamicRowFilteringPageSourceProvider;
 import io.trino.operator.index.IndexJoinLookupStats;
 import io.trino.operator.index.IndexManager;
 import io.trino.operator.scalar.json.JsonExistsFunction;
@@ -270,6 +272,7 @@ public class PlanTester
     private final TaskCountEstimator taskCountEstimator;
     private final TestingAccessControlManager accessControl;
     private final SplitManager splitManager;
+    private final DynamicRowFilteringPageSourceProvider dynamicRowFilteringPageSourceProvider;
     private final PageSourceManager pageSourceManager;
     private final IndexManager indexManager;
     private final NodePartitioningManager nodePartitioningManager;
@@ -376,7 +379,8 @@ public class PlanTester
                 nodeSchedulerConfig,
                 optimizerConfig));
         this.splitManager = new SplitManager(createSplitManagerProvider(catalogManager), tracer, new QueryManagerConfig());
-        this.pageSourceManager = new PageSourceManager(createPageSourceProviderFactory(catalogManager));
+        this.dynamicRowFilteringPageSourceProvider = new DynamicRowFilteringPageSourceProvider(new DynamicPageFilterCache(typeOperators));
+        this.pageSourceManager = new PageSourceManager(createPageSourceProviderFactory(catalogManager), dynamicRowFilteringPageSourceProvider);
         this.pageSinkManager = new PageSinkManager(createPageSinkProvider(catalogManager));
         this.indexManager = new IndexManager(createIndexProvider(catalogManager));
         NodeScheduler nodeScheduler = new NodeScheduler(new UniformNodeSelectorFactory(nodeManager, nodeSchedulerConfig, new NodeTaskMap(finalizerService)));

--- a/core/trino-main/src/test/java/io/trino/block/BlockAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/block/BlockAssertions.java
@@ -686,6 +686,11 @@ public final class BlockAssertions
         return createTypedLongsBlock(BIGINT, values);
     }
 
+    public static ValueBlock createTypedLongsBlock(Type type, Long... values)
+    {
+        return createBlock(type, type::writeLong, Arrays.asList(values));
+    }
+
     public static ValueBlock createTypedLongsBlock(Type type, Iterable<Long> values)
     {
         return createBlock(type, type::writeLong, values);
@@ -693,10 +698,14 @@ public final class BlockAssertions
 
     public static ValueBlock createLongSequenceBlock(int start, int end)
     {
-        BlockBuilder builder = BIGINT.createFixedSizeBlockBuilder(end - start);
+        return createLongSequenceBlock(start, end, BIGINT);
+    }
 
+    public static ValueBlock createLongSequenceBlock(int start, int end, Type type)
+    {
+        BlockBuilder builder = type.createBlockBuilder(null, end - start);
         for (int i = start; i < end; i++) {
-            BIGINT.writeLong(builder, i);
+            type.writeLong(builder, i);
         }
 
         return builder.buildValueBlock();

--- a/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
@@ -36,6 +36,8 @@ import io.trino.metadata.InMemoryNodeManager;
 import io.trino.metadata.Split;
 import io.trino.operator.FlatHashStrategyCompiler;
 import io.trino.operator.PagesIndex;
+import io.trino.operator.dynamicfiltering.DynamicPageFilterCache;
+import io.trino.operator.dynamicfiltering.DynamicRowFilteringPageSourceProvider;
 import io.trino.operator.index.IndexJoinLookupStats;
 import io.trino.operator.index.IndexManager;
 import io.trino.spi.connector.CatalogHandle;
@@ -135,7 +137,11 @@ public final class TaskTestUtils
 
     public static LocalExecutionPlanner createTestingPlanner()
     {
-        PageSourceManager pageSourceManager = new PageSourceManager(CatalogServiceProvider.singleton(CATALOG_HANDLE, new TestingPageSourceProvider()));
+        DynamicRowFilteringPageSourceProvider dynamicRowFilteringPageSourceProvider = new DynamicRowFilteringPageSourceProvider(
+                new DynamicPageFilterCache(PLANNER_CONTEXT.getTypeOperators()));
+        PageSourceManager pageSourceManager = new PageSourceManager(
+                CatalogServiceProvider.singleton(CATALOG_HANDLE, new TestingPageSourceProvider()),
+                dynamicRowFilteringPageSourceProvider);
 
         // we don't start the finalizer so nothing will be collected, which is ok for a test
         FinalizerService finalizerService = new FinalizerService();

--- a/core/trino-main/src/test/java/io/trino/execution/TestDynamicFilterConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestDynamicFilterConfig.java
@@ -15,6 +15,7 @@ package io.trino.execution;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -24,6 +25,7 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDe
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class TestDynamicFilterConfig
 {
@@ -51,7 +53,10 @@ public class TestDynamicFilterConfig
                 .setLargePartitionedMaxSizePerDriver(DataSize.of(200, KILOBYTE))
                 .setLargePartitionedRangeRowLimitPerDriver(2_000)
                 .setLargePartitionedMaxSizePerOperator(DataSize.of(2, MEGABYTE))
-                .setLargeMaxSizePerFilter(DataSize.of(5, MEGABYTE)));
+                .setLargeMaxSizePerFilter(DataSize.of(5, MEGABYTE))
+                .setDynamicRowFilteringEnabled(true)
+                .setDynamicRowFilterSelectivityThreshold(0.7)
+                .setDynamicRowFilteringWaitTimeout(new Duration(0, SECONDS)));
     }
 
     @Test
@@ -79,6 +84,9 @@ public class TestDynamicFilterConfig
                 .put("dynamic-filtering.large-partitioned.range-row-limit-per-driver", "200000")
                 .put("dynamic-filtering.large-partitioned.max-size-per-operator", "643kB")
                 .put("dynamic-filtering.large.max-size-per-filter", "3411kB")
+                .put("dynamic-row-filtering.enabled", "false")
+                .put("dynamic-row-filtering.selectivity-threshold", "0.9")
+                .put("dynamic-row-filtering.wait-timeout", "10s")
                 .buildOrThrow();
 
         DynamicFilterConfig expected = new DynamicFilterConfig()
@@ -102,7 +110,10 @@ public class TestDynamicFilterConfig
                 .setLargePartitionedMaxSizePerDriver(DataSize.of(64, KILOBYTE))
                 .setLargePartitionedRangeRowLimitPerDriver(200000)
                 .setLargePartitionedMaxSizePerOperator(DataSize.of(643, KILOBYTE))
-                .setLargeMaxSizePerFilter(DataSize.of(3411, KILOBYTE));
+                .setLargeMaxSizePerFilter(DataSize.of(3411, KILOBYTE))
+                .setDynamicRowFilteringEnabled(false)
+                .setDynamicRowFilterSelectivityThreshold(0.9)
+                .setDynamicRowFilteringWaitTimeout(new Duration(10, SECONDS));
 
         assertFullMapping(properties, expected);
     }

--- a/core/trino-main/src/test/java/io/trino/operator/dynamicfiltering/BenchmarkDynamicPageFilter.java
+++ b/core/trino-main/src/test/java/io/trino/operator/dynamicfiltering/BenchmarkDynamicPageFilter.java
@@ -1,0 +1,381 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.dynamicfiltering;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slices;
+import io.trino.operator.project.SelectedPositions;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.DictionaryBlock;
+import io.trino.spi.block.LazyBlock;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.TestingColumnHandle;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeOperators;
+import io.trino.tpch.CustomerColumn;
+import io.trino.tpch.TpchColumn;
+import io.trino.tpch.TpchEntity;
+import io.trino.tpch.TpchTable;
+import io.trino.type.BlockTypeOperators;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.jmh.Benchmarks.benchmark;
+import static io.trino.operator.dynamicfiltering.TypedSet.createEqualityTypedSet;
+import static io.trino.spi.predicate.Domain.DiscreteSet;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.TypeUtils.readNativeValue;
+import static io.trino.spi.type.TypeUtils.writeNativeValue;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.tpch.TpchTable.CUSTOMER;
+import static java.lang.Float.floatToIntBits;
+import static java.util.Objects.requireNonNull;
+import static org.openjdk.jmh.annotations.Scope.Thread;
+
+@State(Thread)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(2)
+@Warmup(iterations = 10, time = 1)
+@Measurement(iterations = 15, time = 1)
+public class BenchmarkDynamicPageFilter
+{
+    private static final int MAX_ROWS = 200_000;
+    private static final TypeOperators TYPE_OPERATORS = new TypeOperators();
+    private static final IsolatedBlockFilterFactory BLOCK_FILTER_FACTORY = new IsolatedBlockFilterFactory();
+
+    @Param(".05")
+    private double inputNullChance = 0.05;
+
+    @Param("0.2")
+    private double nonNullsSelectivity = 0.2;
+
+    @Param({"100", "1000", "5000"})
+    private int filterSize = 100;
+
+    @Param("false")
+    private boolean nullsAllowed = true;
+
+    @Param({
+            "INT32_RANDOM",
+            "INT64_RANDOM",
+            "INT32_FIXED_4K",
+            "INT64_FIXED_16K",
+            "REAL_RANDOM",
+            "VARCHAR_RANDOM",
+            "VARCHAR_DICTIONARY"
+    })
+    public DataSet inputDataSet;
+
+    private TestData inputData;
+    private DynamicPageFilter.BlockFilter[] blockFilters;
+
+    public enum DataSet
+    {
+        INT32_RANDOM(INTEGER, false, (block, r, i) -> INTEGER.writeLong(block, r.nextInt())),
+        INT32_FIXED_4K(INTEGER, false, (block, r, i) -> INTEGER.writeLong(block, i % 4096)), // LongRangeFilter
+        INT64_RANDOM(BIGINT, false, (block, r, i) -> BIGINT.writeLong(block, r.nextLong())),
+        INT64_FIXED_16K(BIGINT, false, (block, r, i) -> BIGINT.writeLong(block, r.nextLong() % 32768)), // LongBitSetFilter
+        REAL_RANDOM(REAL, false, (block, r, i) -> REAL.writeLong(block, floatToIntBits(r.nextFloat()))),
+        VARCHAR_DICTIONARY(VARCHAR, true, new TpchValuesWriter<>(CUSTOMER, CustomerColumn.MARKET_SEGMENT)),
+        VARCHAR_RANDOM(VARCHAR, false, (block, r, i) -> {
+            byte[] buffer = new byte[25];
+            r.nextBytes(buffer);
+            VARCHAR.writeSlice(block, Slices.wrappedBuffer(buffer, 0, buffer.length));
+        });
+
+        private final Type type;
+        private final ValueWriter valueWriter;
+        private final boolean convertToDictionary;
+
+        DataSet(Type type, boolean convertToDictionary, ValueWriter valueWriter)
+        {
+            this.type = requireNonNull(type, "type is null");
+            this.convertToDictionary = convertToDictionary;
+            this.valueWriter = requireNonNull(valueWriter, "valueWriter is null");
+        }
+
+        public TupleDomain<ColumnHandle> createFilterTupleDomain(int filterSize, boolean nullsAllowed)
+        {
+            TestData filterValues = createSingleColumnData(valueWriter, type, 0, filterSize);
+            ImmutableList.Builder<Object> valuesBuilder = ImmutableList.builder();
+            for (Page page : filterValues.getPages()) {
+                Block block = page.getBlock(0).getLoadedBlock();
+                for (int position = 0; position < block.getPositionCount(); position++) {
+                    valuesBuilder.add(readNativeValue(type, block, position));
+                }
+            }
+            return TupleDomain.withColumnDomains(ImmutableMap.of(
+                    new TestingColumnHandle("dummy"),
+                    Domain.create(ValueSet.copyOf(type, valuesBuilder.build()), nullsAllowed)));
+        }
+
+        private TestData createInputTestData(
+                TupleDomain<ColumnHandle> filter,
+                double inputNullChance,
+                double nonNullsSelectivity,
+                long inputRows)
+        {
+            List<Object> nonNullValues = filter.getDomains().orElseThrow()
+                    .values().stream()
+                    .flatMap(domain -> {
+                        DiscreteSet nullableDiscreteSet = domain.getNullableDiscreteSet();
+                        return nullableDiscreteSet.getNonNullValues().stream();
+                    })
+                    .collect(toImmutableList());
+
+            TestData testData = createSingleColumnData(
+                    (block, r, i) -> {
+                        if (isTrue(r, nonNullsSelectivity)) {
+                            // pick a random value from the filter
+                            Object value = nonNullValues.get(r.nextInt(nonNullValues.size()));
+                            writeNativeValue(type, block, value);
+                            return;
+                        }
+                        valueWriter.write(block, r, i);
+                    },
+                    type,
+                    inputNullChance,
+                    inputRows);
+            if (convertToDictionary) {
+                return convertToDictionaryBlocks(testData);
+            }
+            return testData;
+        }
+    }
+
+    public static class TpchValuesWriter<E extends TpchEntity>
+            implements ValueWriter
+    {
+        private final TpchTable<E> tpchTable;
+        private final TpchColumn<E> column;
+
+        private Iterator<E> generator = Collections.emptyIterator();
+
+        public TpchValuesWriter(TpchTable<E> tpchTable, TpchColumn<E> column)
+        {
+            this.tpchTable = requireNonNull(tpchTable, "tpchTable is null");
+            this.column = requireNonNull(column, "column is null");
+        }
+
+        @Override
+        public void write(BlockBuilder blockBuilder, Random r, int index)
+        {
+            if (!generator.hasNext()) {
+                generator = tpchTable.createGenerator(1, 1, 1).iterator();
+            }
+            writeToBlock(blockBuilder, generator.next(), column);
+        }
+    }
+
+    private static class TestData
+    {
+        private final Type type;
+        private final List<Page> pages;
+
+        public TestData(Type type, List<Page> pages)
+        {
+            this.type = requireNonNull(type, "type is null");
+            this.pages = ImmutableList.copyOf(requireNonNull(pages, "pages is null"));
+        }
+
+        public Type getType()
+        {
+            return type;
+        }
+
+        public List<Page> getPages()
+        {
+            return pages;
+        }
+    }
+
+    @Setup
+    public void setup()
+    {
+        setup(MAX_ROWS);
+    }
+
+    public void setup(long inputRows)
+    {
+        // Pollute the JVM profile
+        for (DataSet dataSet : ImmutableList.of(DataSet.INT32_FIXED_4K, DataSet.REAL_RANDOM, DataSet.INT64_FIXED_16K, DataSet.INT64_RANDOM, DataSet.VARCHAR_RANDOM, DataSet.VARCHAR_DICTIONARY)) {
+            TupleDomain<ColumnHandle> filterPredicate = dataSet.createFilterTupleDomain(filterSize, nullsAllowed);
+            inputData = dataSet.createInputTestData(filterPredicate, inputNullChance, nonNullsSelectivity, 50_000);
+            blockFilters = DynamicPageFilter.createPageFilter(
+                    filterPredicate,
+                    ImmutableMap.of(new TestingColumnHandle("dummy"), 0),
+                    TYPE_OPERATORS,
+                    BLOCK_FILTER_FACTORY).orElseThrow().toArray(new DynamicPageFilter.BlockFilter[0]);
+            filterPages();
+        }
+        TupleDomain<ColumnHandle> filterPredicate = inputDataSet.createFilterTupleDomain(filterSize, nullsAllowed);
+        inputData = inputDataSet.createInputTestData(filterPredicate, inputNullChance, nonNullsSelectivity, inputRows);
+        blockFilters = DynamicPageFilter.createPageFilter(
+                filterPredicate,
+                ImmutableMap.of(new TestingColumnHandle("dummy"), 0),
+                TYPE_OPERATORS,
+                BLOCK_FILTER_FACTORY).orElseThrow().toArray(new DynamicPageFilter.BlockFilter[0]);
+    }
+
+    @Benchmark
+    public double filterPages()
+    {
+        long rowsProcessed = 0;
+        long rowsFiltered = 0;
+        DictionaryAwarePageFilter filter = new DictionaryAwarePageFilter(blockFilters.length);
+        for (Page page : inputData.getPages()) {
+            SelectedPositions selectedPositions = filter.filterPage(page, blockFilters, blockFilters.length).getPositions();
+            int selectedPositionCount = selectedPositions.size();
+            rowsProcessed += page.getPositionCount();
+            rowsFiltered += page.getPositionCount() - selectedPositionCount;
+        }
+        return ((double) rowsFiltered / rowsProcessed) * 100;
+    }
+
+    private static TestData createSingleColumnData(ValueWriter valueWriter, Type type, double nullChance, long rows)
+    {
+        ImmutableList.Builder<Page> pages = ImmutableList.builder();
+        Random random = new Random(32167);
+        int batchSize = 1;
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, batchSize);
+        for (int i = 0; i < rows; i++) {
+            if (isTrue(random, nullChance)) {
+                blockBuilder.appendNull();
+            }
+            else {
+                valueWriter.write(blockBuilder, random, i);
+            }
+
+            if (blockBuilder.getPositionCount() >= batchSize) {
+                Block block = blockBuilder.build();
+                pages.add(new Page(new LazyBlock(block.getPositionCount(), () -> block)));
+                batchSize = Math.min(1024, batchSize * 2);
+                blockBuilder = type.createBlockBuilder(null, batchSize);
+            }
+        }
+        if (blockBuilder.getPositionCount() > 0) {
+            Block block = blockBuilder.build();
+            pages.add(new Page(new LazyBlock(block.getPositionCount(), () -> block)));
+        }
+        return new TestData(type, pages.build());
+    }
+
+    private static TestData convertToDictionaryBlocks(TestData testData)
+    {
+        Type type = testData.getType();
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, 1024);
+        BlockTypeOperators blockTypeOperators = new BlockTypeOperators();
+        TypedSet typedSet = createEqualityTypedSet(
+                type,
+                blockTypeOperators.getEqualOperator(type),
+                blockTypeOperators.getHashCodeOperator(type),
+                blockBuilder,
+                1024,
+                "BenchmarkDynamicPageFilter");
+
+        for (Page page : testData.getPages()) {
+            Block block = page.getBlock(0).getLoadedBlock();
+            for (int position = 0; position < block.getPositionCount(); position++) {
+                typedSet.add(block, position);
+            }
+            if (typedSet.size() > 1024) {
+                throw new IllegalArgumentException("Number of distinct elements is too big for dictionary");
+            }
+        }
+        Block dictionary = blockBuilder.build();
+
+        ImmutableList.Builder<Page> pages = ImmutableList.builder();
+        for (Page page : testData.getPages()) {
+            Block block = page.getBlock(0).getLoadedBlock();
+            int[] ids = new int[block.getPositionCount()];
+            for (int position = 0; position < block.getPositionCount(); position++) {
+                ids[position] = typedSet.positionOf(block, position);
+            }
+            Block dictionaryBlock = DictionaryBlock.create(ids.length, dictionary, ids);
+            pages.add(new Page(new LazyBlock(ids.length, () -> dictionaryBlock)));
+        }
+        return new TestData(type, pages.build());
+    }
+
+    @FunctionalInterface
+    private interface ValueWriter
+    {
+        void write(BlockBuilder blockBuilder, Random r, int index);
+    }
+
+    private static boolean isTrue(Random random, double chance)
+    {
+        double value = 0;
+        // chance has to be 0 to 1 exclusive.
+        while (value == 0) {
+            value = random.nextDouble();
+        }
+        return value < chance;
+    }
+
+    private static <E extends TpchEntity> void writeToBlock(BlockBuilder blockBuilder, E row, TpchColumn<E> column)
+    {
+        switch (column.getType().getBase()) {
+            case IDENTIFIER:
+                BIGINT.writeLong(blockBuilder, column.getIdentifier(row));
+                break;
+            case INTEGER:
+                INTEGER.writeLong(blockBuilder, column.getInteger(row));
+                break;
+            case DATE:
+                DATE.writeLong(blockBuilder, column.getDate(row));
+                break;
+            case DOUBLE:
+                DOUBLE.writeDouble(blockBuilder, column.getDouble(row));
+                break;
+            case VARCHAR:
+                createUnboundedVarcharType().writeSlice(blockBuilder, Slices.utf8Slice(column.getString(row)));
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported type " + column.getType());
+        }
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        benchmark(BenchmarkDynamicPageFilter.class)
+                .withOptions(optionsBuilder -> optionsBuilder.jvmArgsAppend("-Xmx4g", "-Xms4g"))
+                .run();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/dynamicfiltering/TestDynamicPageFilter.java
+++ b/core/trino-main/src/test/java/io/trino/operator/dynamicfiltering/TestDynamicPageFilter.java
@@ -1,0 +1,759 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.dynamicfiltering;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.operator.project.SelectedPositions;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.DictionaryBlock;
+import io.trino.spi.block.LazyBlock;
+import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.DynamicFilter;
+import io.trino.spi.connector.TestingColumnHandle;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
+import io.trino.spi.type.TypeOperators;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.LongStream;
+
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static io.airlift.concurrent.MoreFutures.unmodifiableFuture;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.block.BlockAssertions.createBlockOfReals;
+import static io.trino.block.BlockAssertions.createLongDictionaryBlock;
+import static io.trino.block.BlockAssertions.createLongSequenceBlock;
+import static io.trino.block.BlockAssertions.createLongsBlock;
+import static io.trino.block.BlockAssertions.createRepeatedValuesBlock;
+import static io.trino.block.BlockAssertions.createSlicesBlock;
+import static io.trino.block.BlockAssertions.createStringsBlock;
+import static io.trino.block.BlockAssertions.createTypedLongsBlock;
+import static io.trino.operator.dynamicfiltering.DictionaryAwarePageFilter.BlockFilterStats;
+import static io.trino.operator.dynamicfiltering.DictionaryAwarePageFilter.SelectedPositionsWithStats;
+import static io.trino.operator.project.SelectedPositions.positionsRange;
+import static io.trino.spi.predicate.Domain.multipleValues;
+import static io.trino.spi.predicate.Domain.onlyNull;
+import static io.trino.spi.predicate.Domain.singleValue;
+import static io.trino.spi.predicate.Range.greaterThan;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.CharType.createCharType;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.lang.Float.floatToRawIntBits;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestDynamicPageFilter
+{
+    private static final TypeOperators TYPE_OPERATORS = new TypeOperators();
+    private static final IsolatedBlockFilterFactory BLOCK_FILTER_FACTORY = new IsolatedBlockFilterFactory();
+
+    @Test
+    public void testAllPageFilter()
+    {
+        assertThat(createBlockFilters(TupleDomain.all(), ImmutableMap.of())).isEmpty();
+    }
+
+    @Test
+    public void testNonePageFilter()
+    {
+        Optional<List<DynamicPageFilter.BlockFilter>> blockFilters = createBlockFilters(TupleDomain.none(), ImmutableMap.of());
+        assertThat(blockFilters).isEqualTo(Optional.of(DynamicPageFilter.NONE_BLOCK_FILTER));
+        // NONE_BLOCK_FILTER case is handled outside of DynamicRowFilteringPageSource#filterPage
+        // It is verified in TestDynamicRowFilteringPageSource#testNoneDynamicFilter
+    }
+
+    @Test
+    public void testUnsupportedTypePageFilter()
+    {
+        ColumnHandle column = new TestingColumnHandle("column");
+        Optional<List<DynamicPageFilter.BlockFilter>> blockFilters = createBlockFilters(
+                TupleDomain.withColumnDomains(ImmutableMap.of(column, singleValue(VARBINARY, utf8Slice("abc")))),
+                ImmutableMap.of(column, 0));
+        assertThat(blockFilters).isEmpty();
+
+        blockFilters = createBlockFilters(
+                TupleDomain.withColumnDomains(ImmutableMap.of(column, Domain.create(
+                        ValueSet.ofRanges(greaterThan(createCharType(10), utf8Slice("abc"))),
+                        false))),
+                ImmutableMap.of(column, 0));
+        assertThat(blockFilters).isEmpty();
+    }
+
+    @Test
+    public void testSliceBlockFilter()
+    {
+        ColumnHandle column = new TestingColumnHandle("column");
+        Optional<List<DynamicPageFilter.BlockFilter>> blockFilters = createBlockFilters(
+                TupleDomain.withColumnDomains(ImmutableMap.of(column, onlyNull(VARCHAR))),
+                ImmutableMap.of(column, 0));
+        assertThat(blockFilters).isPresent();
+        Page page = new Page(
+                createStringsBlock("ab", "bc", null, "cd", null),
+                createStringsBlock(null, "de", "ef", null, "fg"));
+        verifySelectedPositions(filterPage(page, blockFilters.get()).getPositions(), new int[] {2, 4});
+
+        blockFilters = createBlockFilters(
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        column,
+                        multipleValues(VARCHAR, ImmutableList.of("bc", "cd")))),
+                ImmutableMap.of(column, 0));
+        assertThat(blockFilters).isPresent();
+        verifySelectedPositions(filterPage(page, blockFilters.get()).getPositions(), new int[] {1, 3});
+
+        blockFilters = createBlockFilters(
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        column,
+                        Domain.create(ValueSet.of(VARCHAR, utf8Slice("ab")), true))),
+                ImmutableMap.of(column, 0));
+        assertThat(blockFilters).isPresent();
+        verifySelectedPositions(filterPage(page, blockFilters.get()).getPositions(), new int[] {0, 2, 4});
+    }
+
+    @Test
+    public void testLongBlockFilter()
+    {
+        ColumnHandle column = new TestingColumnHandle("column");
+        Optional<List<DynamicPageFilter.BlockFilter>> blockFilters = createBlockFilters(
+                TupleDomain.withColumnDomains(ImmutableMap.of(column, onlyNull(INTEGER))),
+                ImmutableMap.of(column, 0));
+        assertThat(blockFilters).isPresent();
+        Page page = new Page(
+                createTypedLongsBlock(INTEGER, 1L, 2L, null, 5L, null),
+                createTypedLongsBlock(INTEGER, null, 102L, 135L, null, 3L));
+        verifySelectedPositions(
+                filterPage(page, blockFilters.get()).getPositions(),
+                new int[] {2, 4});
+
+        blockFilters = createBlockFilters(
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        column,
+                        multipleValues(INTEGER, ImmutableList.of(2L, 5L)))),
+                ImmutableMap.of(column, 0));
+        assertThat(blockFilters).isPresent();
+        verifySelectedPositions(
+                filterPage(page, blockFilters.get()).getPositions(),
+                new int[] {1, 3});
+
+        blockFilters = createBlockFilters(
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        column,
+                        Domain.create(ValueSet.of(INTEGER, 1L), true))),
+                ImmutableMap.of(column, 0));
+        assertThat(blockFilters).isPresent();
+        verifySelectedPositions(
+                filterPage(page, blockFilters.get()).getPositions(),
+                new int[] {0, 2, 4});
+    }
+
+    @Test
+    public void testSelectivePageFilter()
+    {
+        ColumnHandle columnB = new TestingColumnHandle("columnB");
+        Optional<List<DynamicPageFilter.BlockFilter>> blockFilters = createBlockFilters(
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(columnB, multipleValues(BIGINT, ImmutableList.of(-10L, 5L, 15L, 135L, 185L, 250L)))),
+                ImmutableMap.of(columnB, 1));
+        assertThat(blockFilters).isPresent();
+
+        // page without null
+        Page page = new Page(createLongSequenceBlock(0, 101), createLongSequenceBlock(100, 201));
+        verifySelectedPositions(filterPage(page, blockFilters.get()).getPositions(), new int[] {35, 85});
+
+        // page with null
+        page = new Page(
+                createLongsBlock(1L, 2L, null, 5L, null),
+                createLongsBlock(null, 102L, 135L, null, 3L));
+        verifySelectedPositions(filterPage(page, blockFilters.get()).getPositions(), new int[] {2});
+    }
+
+    @Test
+    public void testNonSelectivePageFilter()
+    {
+        ColumnHandle columnB = new TestingColumnHandle("columnB");
+        List<Long> filterValues = LongStream.range(-5, 205).boxed().collect(toImmutableList());
+        Optional<List<DynamicPageFilter.BlockFilter>> blockFilters = createBlockFilters(
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(columnB, multipleValues(BIGINT, filterValues))),
+                ImmutableMap.of(columnB, 1));
+        assertThat(blockFilters).isPresent();
+
+        // page without null
+        Page page = new Page(
+                createLongSequenceBlock(0, 101),
+                createLongSequenceBlock(100, 201));
+        verifySelectedPositions(filterPage(page, blockFilters.get()).getPositions(), 101);
+
+        // page with null
+        page = new Page(
+                createLongsBlock(1L, 2L, null, 5L, null),
+                createLongsBlock(null, 102L, 135L, null, 3L));
+        verifySelectedPositions(
+                filterPage(page, blockFilters.get()).getPositions(),
+                new int[] {1, 2, 4});
+    }
+
+    @Test
+    public void testPageFilterWithNullsAllowed()
+    {
+        ColumnHandle column = new TestingColumnHandle("column");
+        Optional<List<DynamicPageFilter.BlockFilter>> blockFilters = createBlockFilters(
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                column,
+                                Domain.create(ValueSet.of(INTEGER, 1L, 2L, 3L), true))),
+                ImmutableMap.of(column, 0));
+        assertThat(blockFilters).isPresent();
+
+        Block blockWithNulls = createTypedLongsBlock(INTEGER, 3L, null, 4L);
+        verifySelectedPositions(
+                filterPage(new Page(blockWithNulls), blockFilters.get()).getPositions(),
+                new int[] {0, 1});
+
+        // select all values in block
+        verifySelectedPositions(
+                filterPage(new Page(createTypedLongsBlock(INTEGER, 3L, null, 1L)), blockFilters.get()).getPositions(),
+                3);
+
+        Block blockWithoutNulls = createTypedLongsBlock(INTEGER, 3L, 4L, 5L);
+        verifySelectedPositions(
+                filterPage(new Page(blockWithoutNulls), blockFilters.get()).getPositions(),
+                new int[] {0});
+    }
+
+    @Test
+    public void testFilterNullBlockWithPositionsList()
+    {
+        ColumnHandle columnA = new TestingColumnHandle("columnA");
+        ColumnHandle columnB = new TestingColumnHandle("columnB");
+        Optional<List<DynamicPageFilter.BlockFilter>> blockFilters = createBlockFilters(
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                columnA, Domain.create(ValueSet.of(BIGINT, 1L, 2L, 3L), true),
+                                columnB, Domain.create(ValueSet.of(BIGINT, 1L, 2L, 3L), true))),
+                ImmutableMap.of(columnA, 0, columnB, 1));
+        assertThat(blockFilters).isPresent();
+
+        // block with nulls is second column (positions list instead of range)
+        verifySelectedPositions(
+                filterPage(
+                        new Page(
+                                createLongsBlock(3, 1, 5),
+                                createLongsBlock(3L, null, 1L)),
+                        blockFilters.get()).getPositions(),
+                new int[] {0, 1});
+    }
+
+    @Test
+    public void testPageFilterWithRealNaN()
+    {
+        ColumnHandle column = new TestingColumnHandle("column");
+        Optional<List<DynamicPageFilter.BlockFilter>> blockFilters = createBlockFilters(
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                column,
+                                // Domain cannot contain floating point NaN
+                                multipleValues(REAL, ImmutableList.of((long) floatToRawIntBits(32.0f), (long) floatToRawIntBits(54.6f))))),
+                ImmutableMap.of(column, 0));
+        assertThat(blockFilters).isPresent();
+
+        verifySelectedPositions(
+                filterPage(
+                        new Page(createBlockOfReals(42.0f, Float.NaN, 32.0f, null, 53.1f)),
+                        blockFilters.get()).getPositions(),
+                new int[] {2});
+    }
+
+    @Test
+    public void testBooleanPageFilter()
+    {
+        ColumnHandle column = new TestingColumnHandle("column");
+        Optional<List<DynamicPageFilter.BlockFilter>> blockFilters = createBlockFilters(
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(column, singleValue(BOOLEAN, false))),
+                ImmutableMap.of(column, 0));
+        assertThat(blockFilters).isEmpty();
+    }
+
+    @Test
+    public void testRleBlock()
+    {
+        ColumnHandle column = new TestingColumnHandle("column");
+        Optional<List<DynamicPageFilter.BlockFilter>> blockFilters = createBlockFilters(
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(column, multipleValues(BIGINT, ImmutableList.of(-10L, 5L, 15L, 135L)))),
+                ImmutableMap.of(column, 0));
+        assertThat(blockFilters).isPresent();
+
+        Page page = new Page(createRepeatedValuesBlock(15, 50));
+        verifySelectedPositions(filterPage(page, blockFilters.get()).getPositions(), 50);
+
+        page = new Page(createRepeatedValuesBlock(10, 50));
+        assertThat(filterPage(page, blockFilters.get()).getPositions().isEmpty()).isTrue();
+
+        page = new Page(RunLengthEncodedBlock.create(createLongsBlock((Long) null), 20));
+        assertThat(filterPage(page, blockFilters.get()).getPositions().isEmpty()).isTrue();
+    }
+
+    @Test
+    public void testRleBlockWithNullsAllowed()
+    {
+        ColumnHandle column = new TestingColumnHandle("column");
+        Optional<List<DynamicPageFilter.BlockFilter>> blockFilters = createBlockFilters(
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(column, Domain.create(ValueSet.of(BIGINT, 1L, 2L, 3L), true))),
+                ImmutableMap.of(column, 0));
+        assertThat(blockFilters).isPresent();
+
+        Page page = new Page(RunLengthEncodedBlock.create(createLongsBlock((Long) null), 20));
+        verifySelectedPositions(filterPage(page, blockFilters.get()).getPositions(), 20);
+
+        page = new Page(createRepeatedValuesBlock(10, 50));
+        assertThat(filterPage(page, blockFilters.get()).getPositions().isEmpty()).isTrue();
+
+        page = new Page(createRepeatedValuesBlock(1, 50));
+        verifySelectedPositions(filterPage(page, blockFilters.get()).getPositions(), 50);
+    }
+
+    @Test
+    public void testMultipleColumnsWithRleBlockFirst()
+    {
+        ColumnHandle columnA = new TestingColumnHandle("columnA");
+        ColumnHandle columnB = new TestingColumnHandle("columnB");
+        Optional<List<DynamicPageFilter.BlockFilter>> blockFilters = createBlockFilters(
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        columnA, multipleValues(BIGINT, ImmutableList.of(-10L, 5L, 15L, 135L)),
+                        columnB, multipleValues(BIGINT, ImmutableList.of(5L, 15L)))),
+                ImmutableMap.of(columnA, 0, columnB, 1));
+        assertThat(blockFilters).isPresent();
+
+        Page page = new Page(
+                RunLengthEncodedBlock.create(createLongsBlock(5), 20),
+                createLongSequenceBlock(0, 20));
+        verifySelectedPositions(
+                filterPage(page, blockFilters.get()).getPositions(),
+                new int[] {5, 15});
+
+        page = new Page(
+                RunLengthEncodedBlock.create(createLongsBlock(1000), 20),
+                createLongSequenceBlock(0, 20));
+        assertThat(filterPage(page, blockFilters.get()).getPositions().isEmpty()).isTrue();
+    }
+
+    @Test
+    public void testMultipleColumnsWithRleBlockLast()
+    {
+        ColumnHandle columnA = new TestingColumnHandle("columnA");
+        ColumnHandle columnB = new TestingColumnHandle("columnB");
+        Optional<List<DynamicPageFilter.BlockFilter>> blockFilters = createBlockFilters(
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        columnA, multipleValues(BIGINT, ImmutableList.of(5L, 10L, 13L, 15L)),
+                        columnB, multipleValues(BIGINT, ImmutableList.of(5L, 15L)))),
+                ImmutableMap.of(columnA, 0, columnB, 1));
+        assertThat(blockFilters).isPresent();
+
+        Page page = new Page(
+                createLongSequenceBlock(0, 20),
+                RunLengthEncodedBlock.create(createLongsBlock(5), 20));
+        verifySelectedPositions(
+                filterPage(page, blockFilters.get()).getPositions(),
+                new int[] {5, 10, 13, 15});
+
+        page = new Page(
+                createLongSequenceBlock(0, 20),
+                RunLengthEncodedBlock.create(createLongsBlock(1000), 20));
+        assertThat(filterPage(page, blockFilters.get()).getPositions().isEmpty()).isTrue();
+    }
+
+    @Test
+    public void testDictionaryBlock()
+    {
+        ColumnHandle column = new TestingColumnHandle("column");
+        Optional<List<DynamicPageFilter.BlockFilter>> blockFiltersOptional = createBlockFilters(
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(column, multipleValues(BIGINT, ImmutableList.of(-10L, 5L, 12L, 135L)))),
+                ImmutableMap.of(column, 0));
+        assertThat(blockFiltersOptional).isPresent();
+        DynamicPageFilter.BlockFilter[] blockFilters = blockFiltersOptional.get().toArray(new DynamicPageFilter.BlockFilter[0]);
+
+        DictionaryAwarePageFilter filter = new DictionaryAwarePageFilter(1);
+        // DictionaryBlock will contain values from 0-9 repeated 6 times
+        Block dictionary = createLongSequenceBlock(0, 20);
+        int[] ids = new int[60];
+        Arrays.setAll(ids, i -> i % 10);
+        Block dictionaryBlock = DictionaryBlock.create(ids.length, dictionary, ids);
+        verifySelectedPositions(
+                filter.filterPage(new Page(dictionaryBlock), blockFilters, blockFilters.length).getPositions(),
+                new int[] {5, 15, 25, 35, 45, 55});
+        // Wrap dictionary in lazy block
+        LazyBlock lazyBlock = new LazyBlock(ids.length, () -> dictionaryBlock);
+        verifySelectedPositions(
+                filter.filterPage(new Page(lazyBlock), blockFilters, blockFilters.length).getPositions(),
+                new int[] {5, 15, 25, 35, 45, 55});
+
+        // Another DictionaryBlock with same dictionary but different ids
+        // Contains values from 5-15 repeated 6 times
+        Arrays.setAll(ids, i -> (i % 10) + 5);
+        verifySelectedPositions(
+                filter.filterPage(new Page(DictionaryBlock.create(ids.length, dictionary, ids)), blockFilters, blockFilters.length).getPositions(),
+                new int[] {0, 7, 10, 17, 20, 27, 30, 37, 40, 47, 50, 57});
+
+        // No position is selected
+        Page page = new Page(createLongDictionaryBlock(200, 50));
+        assertThat(filter.filterPage(page, blockFilters, blockFilters.length).getPositions().isEmpty()).isTrue();
+
+        // All positions are selected
+        Arrays.fill(ids, 5);
+        verifySelectedPositions(
+                filter.filterPage(new Page(DictionaryBlock.create(ids.length, dictionary, ids)), blockFilters, blockFilters.length).getPositions(),
+                ids.length);
+    }
+
+    @Test
+    public void testDictionaryBlockWithNulls()
+    {
+        ColumnHandle column = new TestingColumnHandle("column");
+        Optional<List<DynamicPageFilter.BlockFilter>> blockFiltersOptional = createBlockFilters(
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(column, multipleValues(VARCHAR, ImmutableList.of("bc", "cd")))),
+                ImmutableMap.of(column, 0));
+        assertThat(blockFiltersOptional).isPresent();
+        DynamicPageFilter.BlockFilter[] blockFilters = blockFiltersOptional.get().toArray(new DynamicPageFilter.BlockFilter[0]);
+
+        DictionaryAwarePageFilter filter = new DictionaryAwarePageFilter(1);
+        // DictionaryBlock will contain below values repeated 10 times
+        Block dictionary = createSlicesBlock(
+                utf8Slice("ab"),
+                utf8Slice("bc"),
+                null,
+                utf8Slice("cc"));
+        int[] ids = new int[20];
+        Arrays.setAll(ids, i -> i % 4);
+        Block dictionaryBlock = DictionaryBlock.create(ids.length, dictionary, ids);
+        verifySelectedPositions(
+                filter.filterPage(new Page(dictionaryBlock), blockFilters, blockFilters.length).getPositions(),
+                new int[] {1, 5, 9, 13, 17});
+
+        // All nulls
+        ids = new int[20];
+        Arrays.fill(ids, 2);
+        Block allNulls = DictionaryBlock.create(ids.length, dictionary, ids);
+        assertThat(
+                filter.filterPage(new Page(allNulls), blockFilters, blockFilters.length).getPositions().isEmpty())
+                .isTrue();
+
+        filter = new DictionaryAwarePageFilter(1);
+        blockFiltersOptional = createBlockFilters(
+                TupleDomain.withColumnDomains(ImmutableMap.of(column, Domain.create(
+                        ValueSet.of(VARCHAR, utf8Slice("bc"), utf8Slice("cd")),
+                        true))),
+                ImmutableMap.of(column, 0));
+        blockFilters = blockFiltersOptional.orElseThrow().toArray(new DynamicPageFilter.BlockFilter[0]);
+        verifySelectedPositions(
+                filter.filterPage(new Page(dictionaryBlock), blockFilters, blockFilters.length).getPositions(),
+                new int[] {1, 2, 5, 6, 9, 10, 13, 14, 17, 18});
+
+        verifySelectedPositions(
+                filter.filterPage(new Page(allNulls), blockFilters, blockFilters.length).getPositions(),
+                allNulls.getPositionCount());
+    }
+
+    @Test
+    public void testDictionaryProcessingEnableDisable()
+    {
+        ColumnHandle column = new TestingColumnHandle("column");
+        Optional<List<DynamicPageFilter.BlockFilter>> blockFiltersOptional = createBlockFilters(
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(column, multipleValues(BIGINT, ImmutableList.of(-10L, 4L, 12L)))),
+                ImmutableMap.of(column, 0));
+        assertThat(blockFiltersOptional).isPresent();
+        DynamicPageFilter.BlockFilter blockFilter = blockFiltersOptional.get().toArray(new DynamicPageFilter.BlockFilter[0])[0];
+
+        SelectedPositions allPositions = positionsRange(0, 10);
+        DictionaryAwareBlockFilter dictionaryAwareFilter = new DictionaryAwareBlockFilter();
+        // DictionaryBlock will contain 10 values from 0-4
+        Block dictionary = createLongSequenceBlock(0, 30);
+        int[] ids = new int[allPositions.size()];
+        Arrays.setAll(ids, i -> i % 5);
+        // Dictionary is bigger than the block
+        Block dictionaryBlock = DictionaryBlock.create(ids.length, dictionary, ids);
+        // Dictionary is always processed for first block
+        verifySelectedPositions(
+                dictionaryAwareFilter.filter(dictionaryBlock, blockFilter, allPositions),
+                new int[] {4, 9});
+        assertThat(dictionaryAwareFilter.wasLastBlockDictionaryProcessed()).isTrue();
+
+        // Dictionary is smaller than the block
+        dictionary = createLongSequenceBlock(0, 5);
+        dictionaryBlock = DictionaryBlock.create(ids.length, dictionary, ids);
+        verifySelectedPositions(
+                dictionaryAwareFilter.filter(dictionaryBlock, blockFilter, allPositions),
+                new int[] {4, 9});
+        assertThat(dictionaryAwareFilter.wasLastBlockDictionaryProcessed()).isTrue();
+
+        // New dictionary is bigger than block but last dictionary was well utilized
+        dictionary = createLongSequenceBlock(0, 15);
+        dictionaryBlock = DictionaryBlock.create(ids.length, dictionary, ids);
+        verifySelectedPositions(
+                dictionaryAwareFilter.filter(dictionaryBlock, blockFilter, allPositions),
+                new int[] {4, 9});
+        assertThat(dictionaryAwareFilter.wasLastBlockDictionaryProcessed()).isTrue();
+
+        // New dictionary is bigger than block and last dictionary was not well utilized
+        dictionary = createLongSequenceBlock(0, 15);
+        dictionaryBlock = DictionaryBlock.create(ids.length, dictionary, ids);
+        verifySelectedPositions(
+                dictionaryAwareFilter.filter(dictionaryBlock, blockFilter, allPositions),
+                new int[] {4, 9});
+        assertThat(dictionaryAwareFilter.wasLastBlockDictionaryProcessed()).isFalse();
+
+        // Get usage count up
+        verifySelectedPositions(
+                dictionaryAwareFilter.filter(dictionaryBlock, blockFilter, allPositions),
+                new int[] {4, 9});
+        assertThat(dictionaryAwareFilter.wasLastBlockDictionaryProcessed()).isFalse();
+        // New dictionary is bigger than block but last dictionary was well utilized
+        dictionary = createLongSequenceBlock(0, 20);
+        dictionaryBlock = DictionaryBlock.create(ids.length, dictionary, ids);
+        verifySelectedPositions(
+                dictionaryAwareFilter.filter(dictionaryBlock, blockFilter, allPositions),
+                new int[] {4, 9});
+        assertThat(dictionaryAwareFilter.wasLastBlockDictionaryProcessed()).isTrue();
+    }
+
+    @Test
+    public void testMultipleDictionaryBlocks()
+    {
+        ColumnHandle columnA = new TestingColumnHandle("columnA");
+        ColumnHandle columnB = new TestingColumnHandle("columnB");
+        Optional<List<DynamicPageFilter.BlockFilter>> blockFiltersOptional = createBlockFilters(
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                columnA, multipleValues(BIGINT, LongStream.range(3, 8).boxed().collect(toImmutableList())),
+                                columnB, singleValue(BIGINT, 5L))),
+                ImmutableMap.of(columnA, 0, columnB, 1));
+        assertThat(blockFiltersOptional).isPresent();
+        DynamicPageFilter.BlockFilter[] blockFilters = blockFiltersOptional.get().toArray(new DynamicPageFilter.BlockFilter[0]);
+
+        DictionaryAwarePageFilter filter = new DictionaryAwarePageFilter(2);
+        Page page = new Page(
+                createLongDictionaryBlock(0, 50),
+                createLongDictionaryBlock(0, 50));
+        verifySelectedPositions(
+                filter.filterPage(page, blockFilters, blockFilters.length).getPositions(),
+                new int[] {5, 15, 25, 35, 45});
+
+        page = new Page(
+                createLongDictionaryBlock(0, 50),
+                createLongDictionaryBlock(0, 50));
+        verifySelectedPositions(
+                filter.filterPage(page, blockFilters, blockFilters.length).getPositions(),
+                new int[] {5, 15, 25, 35, 45});
+    }
+
+    @Test
+    public void testMultipleColumnsOverlap()
+    {
+        ColumnHandle columnA = new TestingColumnHandle("columnA");
+        ColumnHandle columnB = new TestingColumnHandle("columnB");
+        ColumnHandle columnC = new TestingColumnHandle("columnC");
+        Optional<List<DynamicPageFilter.BlockFilter>> blockFilters = createBlockFilters(
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                columnA, multipleValues(BIGINT, ImmutableList.of(-10L, 5L, 15L, 35L, 50L, 85L, 95L, 105L)),
+                                columnB, multipleValues(BIGINT, LongStream.range(100, 200).boxed().collect(toImmutableList())),
+                                columnC, multipleValues(BIGINT, LongStream.range(150, 250).boxed().collect(toImmutableList())))),
+                ImmutableMap.of(columnA, 0, columnB, 1, columnC, 2));
+        assertThat(blockFilters).isPresent();
+
+        Page page = new Page(
+                createLongSequenceBlock(0, 101),
+                createLongSequenceBlock(100, 201),
+                createLongSequenceBlock(200, 301));
+        verifySelectedPositions(
+                filterPage(page, blockFilters.get()).getPositions(),
+                new int[] {5, 15, 35});
+    }
+
+    @Test
+    public void testMultipleColumnsShortCircuit()
+    {
+        ColumnHandle columnA = new TestingColumnHandle("columnA");
+        ColumnHandle columnB = new TestingColumnHandle("columnB");
+        ColumnHandle columnC = new TestingColumnHandle("columnC");
+        Optional<List<DynamicPageFilter.BlockFilter>> blockFilters = createBlockFilters(
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                columnA, multipleValues(BIGINT, ImmutableList.of(-10L, 5L, 15L, 35L, 50L, 85L, 95L, 105L)),
+                                columnB, singleValue(BIGINT, 0L),
+                                columnC, multipleValues(BIGINT, LongStream.range(150, 250).boxed().collect(toImmutableList())))),
+                ImmutableMap.of(columnA, 0, columnB, 1, columnC, 2));
+        assertThat(blockFilters).isPresent();
+
+        Page page = new Page(
+                createLongSequenceBlock(0, 101),
+                createLongSequenceBlock(100, 201),
+                createLongSequenceBlock(200, 301));
+        SelectedPositionsWithStats positionsWithStats = filterPage(page, blockFilters.get());
+        assertThat(positionsWithStats.getPositions()).isEqualTo(DynamicPageFilter.BlockFilter.EMPTY);
+        assertThat(positionsWithStats.getBlockFilterStats()).isEqualTo(ImmutableList.of(
+                new BlockFilterStats(101, 6, 0),
+                new BlockFilterStats(6, 0, 1)));
+    }
+
+    @Test
+    public void testDynamicFilterUpdates()
+    {
+        ColumnHandle columnA = new TestingColumnHandle("columnA");
+        ColumnHandle columnB = new TestingColumnHandle("columnB");
+        ColumnHandle columnC = new TestingColumnHandle("columnC");
+        TestingDynamicFilter dynamicFilter = new TestingDynamicFilter(4);
+        DynamicPageFilter pageFilter = new DynamicPageFilter(
+                dynamicFilter,
+                ImmutableMap.of(columnA, 0, columnB, 1, columnC, 2),
+                TYPE_OPERATORS,
+                BLOCK_FILTER_FACTORY,
+                directExecutor());
+        assertThat(pageFilter.getBlockFilters()).isEmpty();
+
+        dynamicFilter.update(TupleDomain.withColumnDomains(
+                ImmutableMap.of(columnB, multipleValues(BIGINT, ImmutableList.of(131L, 142L)))));
+        Optional<List<DynamicPageFilter.BlockFilter>> blockFilters = pageFilter.getBlockFilters();
+        assertThat(blockFilters).isPresent();
+        Page page = new Page(
+                createLongSequenceBlock(0, 101),
+                createLongSequenceBlock(100, 201),
+                createLongSequenceBlock(200, 301));
+        verifySelectedPositions(
+                filterPage(page, blockFilters.get()).getPositions(),
+                new int[] {31, 42});
+
+        dynamicFilter.update(TupleDomain.all());
+        assertThat(pageFilter.getBlockFilters()).isEqualTo(blockFilters);
+
+        dynamicFilter.update(TupleDomain.withColumnDomains(
+                ImmutableMap.of(columnC, singleValue(BIGINT, 231L))));
+        assertThat(pageFilter.getBlockFilters()).isNotEqualTo(blockFilters);
+        blockFilters = pageFilter.getBlockFilters();
+        assertThat(blockFilters).isPresent();
+        verifySelectedPositions(filterPage(page, blockFilters.get()).getPositions(), new int[] {31});
+
+        dynamicFilter.update(TupleDomain.all());
+        assertThat(pageFilter.getBlockFilters().get()).isEqualTo(blockFilters.get());
+    }
+
+    private static Optional<List<DynamicPageFilter.BlockFilter>> createBlockFilters(
+            TupleDomain<ColumnHandle> tupleDomain,
+            Map<ColumnHandle, Integer> channels)
+    {
+        return DynamicPageFilter.createPageFilter(tupleDomain, channels, TYPE_OPERATORS, BLOCK_FILTER_FACTORY);
+    }
+
+    private static SelectedPositionsWithStats filterPage(Page page, List<DynamicPageFilter.BlockFilter> blockFilters)
+    {
+        DynamicPageFilter.BlockFilter[] effectiveBlockFilters = blockFilters.toArray(new DynamicPageFilter.BlockFilter[0]);
+        return filterPage(page, effectiveBlockFilters);
+    }
+
+    private static SelectedPositionsWithStats filterPage(Page page, DynamicPageFilter.BlockFilter[] blockFilters)
+    {
+        DictionaryAwarePageFilter filter = new DictionaryAwarePageFilter(page.getChannelCount());
+        return filter.filterPage(page, blockFilters, blockFilters.length);
+    }
+
+    private static void verifySelectedPositions(SelectedPositions selectedPositions, int[] positions)
+    {
+        assertThat(selectedPositions.isList()).isTrue();
+        assertThat(selectedPositions.getOffset()).isEqualTo(0);
+        assertThat(selectedPositions.size()).isEqualTo(positions.length);
+        assertThat(Arrays.copyOf(selectedPositions.getPositions(), positions.length)).isEqualTo(positions);
+    }
+
+    private static void verifySelectedPositions(SelectedPositions selectedPositions, int rangeSize)
+    {
+        assertThat(selectedPositions.isList()).isFalse();
+        assertThat(selectedPositions.getOffset()).isEqualTo(0);
+        assertThat(selectedPositions.size()).isEqualTo(rangeSize);
+    }
+
+    private static class TestingDynamicFilter
+            implements DynamicFilter
+    {
+        private CompletableFuture<?> isBlocked;
+        private TupleDomain<ColumnHandle> currentPredicate;
+        private int futuresLeft;
+
+        private TestingDynamicFilter(int expectedFilters)
+        {
+            this.futuresLeft = expectedFilters;
+            this.isBlocked = expectedFilters == 0 ? NOT_BLOCKED : new CompletableFuture<>();
+            this.currentPredicate = TupleDomain.all();
+        }
+
+        public void update(TupleDomain<ColumnHandle> predicate)
+        {
+            futuresLeft -= 1;
+            verify(futuresLeft >= 0);
+            currentPredicate = currentPredicate.intersect(predicate);
+            CompletableFuture<?> currentFuture = isBlocked;
+            // create next blocking future (if needed)
+            isBlocked = isComplete() ? NOT_BLOCKED : new CompletableFuture<>();
+            verify(currentFuture.complete(null));
+        }
+
+        @Override
+        public Set<ColumnHandle> getColumnsCovered()
+        {
+            return currentPredicate.getDomains().orElseThrow().keySet();
+        }
+
+        @Override
+        public CompletableFuture<?> isBlocked()
+        {
+            return unmodifiableFuture(isBlocked);
+        }
+
+        @Override
+        public boolean isComplete()
+        {
+            return futuresLeft == 0;
+        }
+
+        @Override
+        public boolean isAwaitable()
+        {
+            return futuresLeft > 0;
+        }
+
+        @Override
+        public TupleDomain<ColumnHandle> getCurrentPredicate()
+        {
+            return currentPredicate;
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/dynamicfiltering/TestDynamicRowFilteringBenchmark.java
+++ b/core/trino-main/src/test/java/io/trino/operator/dynamicfiltering/TestDynamicRowFilteringBenchmark.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.dynamicfiltering;
+
+import org.junit.jupiter.api.Test;
+
+import static io.trino.operator.dynamicfiltering.BenchmarkDynamicPageFilter.DataSet;
+
+public class TestDynamicRowFilteringBenchmark
+{
+    @Test
+    public void testAllDataSets()
+    {
+        for (DataSet dataSet : DataSet.values()) {
+            executeBenchmark(dataSet);
+        }
+    }
+
+    private static void executeBenchmark(DataSet dataSet)
+    {
+        BenchmarkDynamicPageFilter benchmark = new BenchmarkDynamicPageFilter();
+        benchmark.inputDataSet = dataSet;
+        benchmark.setup();
+        benchmark.filterPages();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/dynamicfiltering/TestDynamicRowFilteringPageSource.java
+++ b/core/trino-main/src/test/java/io/trino/operator/dynamicfiltering/TestDynamicRowFilteringPageSource.java
@@ -1,0 +1,551 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.dynamicfiltering;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import io.trino.plugin.base.metrics.LongCount;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.DictionaryBlock;
+import io.trino.spi.block.LazyBlock;
+import io.trino.spi.block.LongArrayBlock;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.DynamicFilter;
+import io.trino.spi.connector.EmptyPageSource;
+import io.trino.spi.connector.TestingColumnHandle;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
+import io.trino.spi.type.TypeOperators;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalLong;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.util.concurrent.Futures.getUnchecked;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static io.airlift.concurrent.MoreFutures.unmodifiableFuture;
+import static io.trino.block.BlockAssertions.createLongSequenceBlock;
+import static io.trino.block.BlockAssertions.createLongsBlock;
+import static io.trino.operator.dynamicfiltering.DynamicRowFilteringPageSource.EMPTY_PAGE;
+import static io.trino.operator.dynamicfiltering.DynamicRowFilteringPageSource.FILTER_INPUT_POSITIONS;
+import static io.trino.operator.dynamicfiltering.DynamicRowFilteringPageSource.FILTER_OUTPUT_POSITIONS;
+import static io.trino.spi.predicate.Domain.multipleValues;
+import static io.trino.spi.predicate.Domain.singleValue;
+import static io.trino.spi.testing.InterfaceTestUtils.assertAllMethodsOverridden;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.testing.assertions.Assert.assertEventually;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.function.Function.identity;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestDynamicRowFilteringPageSource
+{
+    private static final TypeOperators TYPE_OPERATORS = new TypeOperators();
+    private static final IsolatedBlockFilterFactory BLOCK_FILTER_FACTORY = new IsolatedBlockFilterFactory();
+
+    @Test
+    public void testEverythingImplemented()
+    {
+        assertAllMethodsOverridden(ConnectorPageSource.class, DynamicRowFilteringPageSource.class);
+    }
+
+    @Test
+    public void testEmptyPageSource()
+    {
+        DynamicRowFilteringPageSource pageSource = new DynamicRowFilteringPageSource(
+                new EmptyPageSource(),
+                1,
+                Duration.valueOf("0s"),
+                0,
+                createDynamicPageFilter(
+                        getDynamicFilter(TupleDomain.all()),
+                        ImmutableList.of()));
+        assertThat(pageSource.getNextPage()).isNull();
+        assertThat(pageSource.getMetrics().getMetrics()).isEmpty();
+    }
+
+    @Test
+    public void testEmptyPage()
+    {
+        DynamicRowFilteringPageSource pageSource = new DynamicRowFilteringPageSource(
+                new TestingConnectorPageSource().addPages(ImmutableList.of(new Page(0))),
+                1,
+                Duration.valueOf("0s"),
+                0,
+                createDynamicPageFilter(
+                        getDynamicFilter(TupleDomain.all()),
+                        ImmutableList.of()));
+        assertThat(pageSource.getNextPage().getPositionCount()).isEqualTo(0);
+        assertThat(pageSource.getMetrics().getMetrics()).isEmpty();
+    }
+
+    @Test
+    public void testEmptyDynamicFilter()
+    {
+        List<ColumnHandle> columnHandleList = ImmutableList.of(new TestingColumnHandle("column"));
+        TestingConnectorPageSource testingPageSource = new TestingConnectorPageSource()
+                .addPages(ImmutableList.of(new Page(createLongSequenceBlock(0, 1024))));
+        DynamicRowFilteringPageSource pageSource = new DynamicRowFilteringPageSource(
+                testingPageSource,
+                1,
+                Duration.valueOf("0s"),
+                columnHandleList.size(),
+                createDynamicPageFilter(DynamicFilter.EMPTY, columnHandleList));
+        assertThat(pageSource.getNextPage().getPositionCount()).isEqualTo(1024);
+        assertThat(pageSource.getMetrics().getMetrics()).isEmpty();
+    }
+
+    @Test
+    public void testAllDynamicFilter()
+    {
+        List<ColumnHandle> columnHandleList = ImmutableList.of(new TestingColumnHandle("column"));
+        Page inputPage = new Page(createLongSequenceBlock(0, 1024));
+        TestingConnectorPageSource testingPageSource = new TestingConnectorPageSource()
+                .addPages(ImmutableList.of(inputPage));
+        DynamicRowFilteringPageSource pageSource = new DynamicRowFilteringPageSource(
+                testingPageSource,
+                1,
+                Duration.valueOf("0s"),
+                columnHandleList.size(),
+                createDynamicPageFilter(
+                        getDynamicFilter(TupleDomain.all()),
+                        columnHandleList));
+        Page outputPage = pageSource.getNextPage();
+        assertThat(outputPage).isEqualTo(inputPage);
+        assertThat(outputPage.getPositionCount()).isEqualTo(1024);
+        assertThat(pageSource.getMetrics().getMetrics()).isEmpty();
+    }
+
+    @Test
+    public void testNoneDynamicFilter()
+    {
+        List<ColumnHandle> columnHandleList = ImmutableList.of(new TestingColumnHandle("column"));
+        TestingConnectorPageSource testingPageSource = new TestingConnectorPageSource()
+                .addPages(ImmutableList.of(new Page(createLongSequenceBlock(0, 1024))));
+        DynamicRowFilteringPageSource pageSource = new DynamicRowFilteringPageSource(
+                testingPageSource,
+                1,
+                Duration.valueOf("0s"),
+                columnHandleList.size(),
+                createDynamicPageFilter(
+                        getDynamicFilter(TupleDomain.none()),
+                        columnHandleList));
+        assertThat(pageSource.getNextPage()).isEqualTo(EMPTY_PAGE);
+        assertThat(pageSource.getMetrics().getMetrics())
+                .containsAllEntriesOf(ImmutableMap.of(
+                        FILTER_INPUT_POSITIONS, new LongCount(1024),
+                        FILTER_OUTPUT_POSITIONS, new LongCount(0)));
+    }
+
+    @Test
+    public void testIneffectiveFilter()
+    {
+        ColumnHandle column = new TestingColumnHandle("column");
+        List<ColumnHandle> columnHandleList = ImmutableList.of(column);
+        int pageCount = 3;
+        TestingConnectorPageSource testingPageSource = new TestingConnectorPageSource()
+                .addPages(generateInputPages(pageCount, 1, 1024));
+        DynamicRowFilteringPageSource pageSource = new DynamicRowFilteringPageSource(
+                testingPageSource,
+                0.9,
+                Duration.valueOf("0s"),
+                columnHandleList.size(),
+                createDynamicPageFilter(
+                        getDynamicFilter(TupleDomain.withColumnDomains(ImmutableMap.of(
+                                column,
+                                getRangePredicate(100, 5000)))),
+                        columnHandleList));
+        for (int i = 0; i < pageCount - 1; i++) {
+            assertThat(pageSource.getNextPage().getPositionCount()).isEqualTo(924);
+        }
+
+        // FilterProfiler should turn off row filtering
+        assertThat(pageSource.getNextPage().getPositionCount()).isEqualTo(1024);
+    }
+
+    @Test
+    public void testSingleIneffectiveBlockFilterFirst()
+    {
+        ColumnHandle columnA = new TestingColumnHandle("columnA");
+        ColumnHandle columnB = new TestingColumnHandle("columnB");
+        List<ColumnHandle> columnHandleList = List.of(columnA, columnB);
+        int pageCount = 3;
+        TestingConnectorPageSource testingPageSource = new TestingConnectorPageSource()
+                .addPages(generateInputPages(pageCount, 2, 1024));
+        DynamicRowFilteringPageSource pageSource = new DynamicRowFilteringPageSource(
+                testingPageSource,
+                0.9,
+                Duration.valueOf("0s"),
+                columnHandleList.size(),
+                createDynamicPageFilter(
+                        getDynamicFilter(TupleDomain.withColumnDomains(ImmutableMap.of(
+                                columnA, getRangePredicate(100, 1024),
+                                columnB, singleValue(BIGINT, 13L)))),
+                        columnHandleList));
+        for (int i = 0; i < pageCount - 1; i++) {
+            assertThat(pageSource.getNextPage().getPositionCount()).isEqualTo(0);
+        }
+
+        // FilterProfiler should turn off row filtering from first block
+        assertThat(pageSource.getNextPage().getPositionCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void testSingleIneffectiveBlockFilterLast()
+    {
+        ColumnHandle columnA = new TestingColumnHandle("columnA");
+        ColumnHandle columnB = new TestingColumnHandle("columnB");
+        List<ColumnHandle> columnHandleList = List.of(columnA, columnB);
+        int pageCount = 3;
+        TestingConnectorPageSource testingPageSource = new TestingConnectorPageSource()
+                .addPages(generateInputPages(pageCount, 2, 1024));
+        DynamicRowFilteringPageSource pageSource = new DynamicRowFilteringPageSource(
+                testingPageSource,
+                0.9,
+                Duration.valueOf("0s"),
+                columnHandleList.size(),
+                createDynamicPageFilter(
+                        getDynamicFilter(TupleDomain.withColumnDomains(ImmutableMap.of(
+                                columnA, getRangePredicate(0, 1024),
+                                columnB, getRangePredicate(100, 1024)))),
+                        columnHandleList));
+        for (int i = 0; i < pageCount - 1; i++) {
+            assertThat(pageSource.getNextPage().getPositionCount()).isEqualTo(924);
+        }
+
+        // FilterProfiler should turn off row filtering from last block
+        assertThat(pageSource.getNextPage().getPositionCount()).isEqualTo(1024);
+    }
+
+    @Test
+    public void testEffectiveFilter()
+    {
+        ColumnHandle column = new TestingColumnHandle("column");
+        List<ColumnHandle> columnHandleList = ImmutableList.of(column);
+        int pageCount = 5;
+        TestingConnectorPageSource testingPageSource = new TestingConnectorPageSource()
+                .addPages(generateInputPages(pageCount, 1, 1024));
+        DynamicRowFilteringPageSource pageSource = new DynamicRowFilteringPageSource(
+                testingPageSource,
+                0.1,
+                Duration.valueOf("0s"),
+                columnHandleList.size(),
+                createDynamicPageFilter(
+                        getDynamicFilter(TupleDomain.withColumnDomains(ImmutableMap.of(
+                                column,
+                                singleValue(BIGINT, 13L)))),
+                        columnHandleList));
+        // FilterProfiler should not turn off row filtering
+        for (int i = 0; i < pageCount; i++) {
+            assertThat(pageSource.getNextPage().getPositionCount()).isEqualTo(1);
+        }
+
+        assertThat(pageSource.getCompletedPositions()).isEqualTo(OptionalLong.of(5 * 1024));
+        assertThat(pageSource.getMetrics().getMetrics())
+                .containsAllEntriesOf(ImmutableMap.of(
+                        FILTER_INPUT_POSITIONS, new LongCount(5 * 1024),
+                        FILTER_OUTPUT_POSITIONS, new LongCount(5)));
+    }
+
+    @Test
+    public void testMultipleColumnsShortCircuit()
+    {
+        ColumnHandle columnA = new TestingColumnHandle("columnA");
+        ColumnHandle columnB = new TestingColumnHandle("columnB");
+        ColumnHandle columnC = new TestingColumnHandle("columnC");
+        List<ColumnHandle> columnHandleList = ImmutableList.of(columnA, columnB, columnC);
+        TestingConnectorPageSource testingPageSource = new TestingConnectorPageSource()
+                .addPages(generateInputPages(1, 3, 100));
+        DynamicRowFilteringPageSource pageSource = new DynamicRowFilteringPageSource(
+                testingPageSource,
+                1,
+                Duration.valueOf("0s"),
+                columnHandleList.size(),
+                createDynamicPageFilter(
+                        getDynamicFilter(TupleDomain.withColumnDomains(ImmutableMap.of(
+                                columnA, multipleValues(BIGINT, ImmutableList.of(-10L, 5L, 15L, 35L, 50L, 85L, 95L, 105L)),
+                                columnB, singleValue(BIGINT, 0L),
+                                columnC, getRangePredicate(150, 250)))),
+                        columnHandleList));
+        assertThat(pageSource.getNextPage()).isEqualTo(EMPTY_PAGE);
+    }
+
+    @Test
+    public void testDynamicFilterOnSubsetOfColumns()
+    {
+        ColumnHandle columnA = new TestingColumnHandle("columnA");
+        ColumnHandle columnB = new TestingColumnHandle("columnB");
+        ColumnHandle columnC = new TestingColumnHandle("columnC");
+        ColumnHandle columnD = new TestingColumnHandle("columnD");
+        ColumnHandle columnE = new TestingColumnHandle("columnE");
+        List<ColumnHandle> columnHandleList = ImmutableList.of(columnA, columnB, columnC, columnD, columnE);
+        int pageCount = 5;
+        TestingConnectorPageSource testingPageSource = new TestingConnectorPageSource()
+                .addPages(generateInputPages(pageCount, 5, 1024));
+        DynamicRowFilteringPageSource pageSource = new DynamicRowFilteringPageSource(
+                testingPageSource,
+                1,
+                Duration.valueOf("0s"),
+                columnHandleList.size(),
+                createDynamicPageFilter(
+                        getDynamicFilter(TupleDomain.withColumnDomains(ImmutableMap.of(
+                                columnB, multipleValues(BIGINT, ImmutableList.of(-10L, 5L, 15L, 35L, 50L, 85L, 95L, 105L)),
+                                columnD, getRangePredicate(-50, 90)))),
+                        columnHandleList));
+        for (int i = 0; i < pageCount; i++) {
+            assertThat(pageSource.getNextPage().getPositionCount()).isEqualTo(5);
+        }
+    }
+
+    @Test
+    @Timeout(10)
+    public void testDynamicFilterBlockingTimeout()
+    {
+        ColumnHandle column = new TestingColumnHandle("column");
+        List<ColumnHandle> columnHandleList = ImmutableList.of(column);
+        TestingConnectorPageSource testingPageSource = new TestingConnectorPageSource()
+                .addPages(ImmutableList.of(new Page(createLongSequenceBlock(0, 1024))));
+        DynamicRowFilteringPageSource pageSource = new DynamicRowFilteringPageSource(
+                testingPageSource,
+                0.1,
+                Duration.valueOf("2s"),
+                columnHandleList.size(),
+                createDynamicPageFilter(
+                        getDynamicFilter(TupleDomain.all(), Duration.valueOf("1h")),
+                        columnHandleList));
+        assertEventually(() -> {
+            CompletableFuture<?> future = pageSource.isBlocked();
+            assertThat(future).isCompleted();
+            // verify that after timeout we get the future from delegate page source
+            assertThat(getUnchecked(future)).isEqualTo(TestingConnectorPageSource.TESTING_FUTURE_VALUE);
+        });
+    }
+
+    @Test
+    public void testDynamicFilterWithDictionariesAndLazyBlocks()
+    {
+        ColumnHandle columnA = new TestingColumnHandle("columnA");
+        ColumnHandle columnB = new TestingColumnHandle("columnB");
+        List<ColumnHandle> columnHandleList = ImmutableList.of(columnA, columnB);
+
+        Block longsBlock = createLongsBlock(0, 1, 2, 3);
+        Block dictionary = createLongsBlock(0, 1);
+        int[] firstPageBlockIds = new int[] {0, 0, 1, 1};
+        Page firstPage = new Page(
+                longsBlock,
+                // top level dictionary block is lazy
+                new LazyBlock(4, () -> DictionaryBlock.create(firstPageBlockIds.length, dictionary, firstPageBlockIds)));
+        Page secondPage = new Page(longsBlock, longsBlock);
+
+        TestingConnectorPageSource testingPageSource = new TestingConnectorPageSource()
+                .addPages(ImmutableList.of(secondPage, firstPage));
+        DynamicRowFilteringPageSource pageSource = new DynamicRowFilteringPageSource(
+                testingPageSource,
+                1,
+                Duration.valueOf("0s"),
+                columnHandleList.size(),
+                createDynamicPageFilter(
+                        getDynamicFilter(TupleDomain.withColumnDomains(ImmutableMap.of(
+                                columnA, multipleValues(BIGINT, ImmutableList.of(1L, 2L))))),
+                        columnHandleList));
+
+        // three pages should be produced
+        Page firstOutputPage = pageSource.getNextPage();
+        assertThat(firstOutputPage).isNotNull();
+        Page secondOutputPage = pageSource.getNextPage();
+        assertThat(secondOutputPage).isNotNull();
+        assertThat(pageSource.getNextPage()).isNull();
+
+        // all output pages should have two positions
+        assertThat(firstOutputPage.getPositionCount()).isEqualTo(2);
+        assertThat(secondOutputPage.getPositionCount()).isEqualTo(2);
+
+        // make sure first and third blocks are still lazy
+        assertThat(firstOutputPage.getBlock(1)).isInstanceOf(LazyBlock.class);
+
+        // make sure that first and second output block have correct type
+        Block firstOutputBlock = ((LazyBlock) firstOutputPage.getBlock(1)).getBlock();
+        assertThat(firstOutputBlock).isInstanceOf(DictionaryBlock.class);
+        assertThat(firstOutputBlock.isLoaded()).isTrue();
+
+        Block secondOutputBlock = secondOutputPage.getBlock(1);
+        assertThat(secondOutputBlock).isInstanceOf(LongArrayBlock.class);
+        assertThat(secondOutputBlock.isLoaded()).isTrue();
+
+        // make sure first and third page share same dictionary
+        Block firstOutputDictionary = ((DictionaryBlock) firstOutputBlock).getDictionary();
+
+        // assert that output dictionary is same as input dictionary
+        assertThat(firstOutputDictionary).isSameAs(dictionary);
+    }
+
+    private static DynamicPageFilter createDynamicPageFilter(DynamicFilter dynamicFilter, List<ColumnHandle> columns)
+    {
+        Map<ColumnHandle, Integer> columnHandleMap = IntStream.range(0, columns.size())
+                .boxed()
+                .collect(toImmutableMap(columns::get, identity()));
+        return new DynamicPageFilter(dynamicFilter, columnHandleMap, TYPE_OPERATORS, BLOCK_FILTER_FACTORY, directExecutor());
+    }
+
+    private static class TestingConnectorPageSource
+            implements ConnectorPageSource
+    {
+        static final String TESTING_FUTURE_VALUE = "testing_future_value";
+
+        private List<Page> pages = ImmutableList.of();
+        long completedPositions;
+
+        public TestingConnectorPageSource addPages(List<Page> pages)
+        {
+            this.pages = new ArrayList<>(pages);
+            return this;
+        }
+
+        @Override
+        public long getCompletedBytes()
+        {
+            return 0;
+        }
+
+        @Override
+        public OptionalLong getCompletedPositions()
+        {
+            return OptionalLong.of(completedPositions);
+        }
+
+        @Override
+        public long getReadTimeNanos()
+        {
+            return 0;
+        }
+
+        @Override
+        public boolean isFinished()
+        {
+            return false;
+        }
+
+        @Override
+        public CompletableFuture<?> isBlocked()
+        {
+            return completedFuture(TESTING_FUTURE_VALUE);
+        }
+
+        @Override
+        public Page getNextPage()
+        {
+            if (pages.isEmpty()) {
+                return null;
+            }
+            Page page = pages.remove(pages.size() - 1);
+            completedPositions += page.getPositionCount();
+            return page;
+        }
+
+        @Override
+        public long getMemoryUsage()
+        {
+            return 0;
+        }
+
+        @Override
+        public void close()
+                throws IOException
+        {}
+    }
+
+    private static List<Page> generateInputPages(int pages, int blocks, int positionsPerBlock)
+    {
+        return IntStream.range(0, pages)
+                .mapToObj(i -> new Page(IntStream.range(0, blocks)
+                        .mapToObj(idx -> createLongSequenceBlock(0, positionsPerBlock))
+                        .toArray(Block[]::new)))
+                .collect(toImmutableList());
+    }
+
+    private static Domain getRangePredicate(long start, long end)
+    {
+        return Domain.create(ValueSet.ofRanges(Range.range(BIGINT, start, true, end, false)), false);
+    }
+
+    private static DynamicFilter getDynamicFilter(TupleDomain<ColumnHandle> tupleDomain)
+    {
+        return getDynamicFilter(tupleDomain, Duration.valueOf("0s"));
+    }
+
+    private static DynamicFilter getDynamicFilter(TupleDomain<ColumnHandle> tupleDomain, Duration blockingTimeout)
+    {
+        CompletableFuture<?> future;
+        if (blockingTimeout.toMillis() > 0) {
+            future = unmodifiableFuture(CompletableFuture.runAsync(() -> {
+                try {
+                    TimeUnit.MILLISECONDS.sleep(blockingTimeout.toMillis());
+                }
+                catch (InterruptedException e) {
+                    throw new IllegalStateException(e);
+                }
+            }));
+        }
+        else {
+            future = completedFuture(null);
+        }
+        return new DynamicFilter()
+        {
+            @Override
+            public Set<ColumnHandle> getColumnsCovered()
+            {
+                return tupleDomain.getDomains().orElseThrow().keySet();
+            }
+
+            @Override
+            public CompletableFuture<?> isBlocked()
+            {
+                return future;
+            }
+
+            @Override
+            public boolean isComplete()
+            {
+                return future.isDone();
+            }
+
+            @Override
+            public boolean isAwaitable()
+            {
+                return !future.isDone();
+            }
+
+            @Override
+            public TupleDomain<ColumnHandle> getCurrentPredicate()
+            {
+                return tupleDomain;
+            }
+        };
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/dynamicfiltering/TestTupleDomainFilterUtils.java
+++ b/core/trino-main/src/test/java/io/trino/operator/dynamicfiltering/TestTupleDomainFilterUtils.java
@@ -1,0 +1,614 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.dynamicfiltering;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.VariableWidthBlockBuilder;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.TestingColumnHandle;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
+import io.trino.spi.type.Int128;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeOperators;
+import io.trino.spi.type.TypeUtils;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.block.BlockAssertions.createLongSequenceBlock;
+import static io.trino.spi.predicate.Domain.multipleValues;
+import static io.trino.spi.predicate.Domain.notNull;
+import static io.trino.spi.predicate.Domain.onlyNull;
+import static io.trino.spi.predicate.Domain.singleValue;
+import static io.trino.spi.predicate.Range.greaterThan;
+import static io.trino.spi.predicate.Range.greaterThanOrEqual;
+import static io.trino.spi.predicate.Range.lessThan;
+import static io.trino.spi.predicate.Range.range;
+import static io.trino.spi.predicate.TupleDomain.none;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.HyperLogLogType.HYPER_LOG_LOG;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TestingIdType.ID;
+import static io.trino.spi.type.TimeType.TIME_MICROS;
+import static io.trino.spi.type.TimeType.TIME_MILLIS;
+import static io.trino.spi.type.TimeType.TIME_NANOS;
+import static io.trino.spi.type.TimeType.TIME_PICOS;
+import static io.trino.spi.type.TimeType.TIME_SECONDS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_SECONDS;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.type.JsonType.JSON;
+import static java.lang.Float.POSITIVE_INFINITY;
+import static java.lang.Float.floatToRawIntBits;
+import static java.lang.Math.toIntExact;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestTupleDomainFilterUtils
+{
+    private static final TypeOperators TYPE_OPERATORS = new TypeOperators();
+
+    @ParameterizedTest
+    @MethodSource("testTupleDomainDiscreteValues")
+    public void testCreateTupleDomainFilters(Type type, List<Long> values)
+    {
+        ColumnHandle column = new TestingColumnHandle("column");
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, multipleValues(type, values)));
+        Map<ColumnHandle, TupleDomainFilter> filters = TupleDomainFilterUtils.createTupleDomainFilters(tupleDomain, TYPE_OPERATORS);
+        TupleDomainFilter filter = filters.get(column);
+        assertThat(filter).isInstanceOf(TupleDomainFilter.LongHashSetFilter.class);
+        verifyFilterContainsValues(filter, ImmutableSet.copyOf(values), type);
+
+        assertThat(testContains(filter, -0L, type)).isTrue();
+        long minValue;
+        long maxValue;
+        if (type == DATE) {
+            minValue = Integer.MIN_VALUE;
+            maxValue = Integer.MAX_VALUE;
+        }
+        else {
+            minValue = (long) type.getRange().map(Type.Range::getMin).orElse(Long.MIN_VALUE);
+            maxValue = (long) type.getRange().map(Type.Range::getMax).orElse(Long.MAX_VALUE);
+        }
+        assertThat(testContains(filter, minValue, type)).isFalse();
+        assertThat(testContains(filter, maxValue, type)).isFalse();
+
+        long min = values.get(0);
+        long max = min;
+        for (int i = 1; i < values.size(); i++) {
+            min = Math.min(min, values.get(i));
+            max = Math.max(max, values.get(i));
+        }
+        assertThat(testContains(filter, min - 1, type)).isFalse();
+        assertThat(testContains(filter, max + 1, type)).isFalse();
+        assertThat(testContains(filter, min + 1, type)).isFalse();
+        assertThat(testContains(filter, max - 1, type)).isFalse();
+    }
+
+    public static Object[][] testTupleDomainDiscreteValues()
+    {
+        return new Object[][] {
+                {INTEGER, ImmutableList.of(0L, 3L, 500L, 7000L)},
+                {BIGINT, ImmutableList.of(0L, 3L, 500L, 7000L)},
+                {SMALLINT, ImmutableList.of(0L, 3L, 500L, 7000L)},
+                {TIMESTAMP_SECONDS, ImmutableList.of(0L, 3L, 500L, 7000L)},
+                {TIMESTAMP_MILLIS, ImmutableList.of(0L, 3L, 500L, 7000L)},
+                {TIMESTAMP_MICROS, ImmutableList.of(0L, 3L, 500L, 7000L)},
+                {TIME_SECONDS, ImmutableList.of(0L, 3L, 500L, 7000L)},
+                {TIME_MILLIS, ImmutableList.of(0L, 3L, 500L, 7000L)},
+                {TIME_MICROS, ImmutableList.of(0L, 3L, 500L, 7000L)},
+                {TIME_NANOS, ImmutableList.of(0L, 3L, 500L, 7000L)},
+                {TIME_PICOS, ImmutableList.of(0L, 3L, 500L, 7000L)},
+                {DATE, ImmutableList.of(0L, 3L, 500L, 7000L)},
+                {createDecimalType(6, 1), ImmutableList.of(0L, 3L, 500L, 7000L)}
+        };
+    }
+
+    @Test
+    public void testUnsupportedNonPrimitiveTypes()
+    {
+        ColumnHandle column = new TestingColumnHandle("column");
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, singleValue(VARBINARY, utf8Slice("abc"))));
+        Assertions.assertThat(TupleDomainFilterUtils.createTupleDomainFilters(tupleDomain, TYPE_OPERATORS)).isEmpty();
+
+        tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, singleValue(JSON, utf8Slice("abc"))));
+        Assertions.assertThat(TupleDomainFilterUtils.createTupleDomainFilters(tupleDomain, TYPE_OPERATORS)).isEmpty();
+
+        tupleDomain = TupleDomain.withColumnDomains(ImmutableMap.of(
+                column, Domain.create(ValueSet.ofRanges(greaterThan(VARCHAR, utf8Slice("abc"))), false)));
+        Assertions.assertThat(TupleDomainFilterUtils.createTupleDomainFilters(tupleDomain, TYPE_OPERATORS)).isEmpty();
+    }
+
+    @Test
+    public void testSliceBloomFilter()
+    {
+        TupleDomainFilter.SliceBloomFilter filter = new TupleDomainFilter.SliceBloomFilter(
+                false,
+                VARCHAR,
+                ImmutableList.of(
+                        utf8Slice("Igne"),
+                        utf8Slice("natura"),
+                        utf8Slice("renovitur"),
+                        utf8Slice("integra.")));
+        assertThat(testContains(filter, utf8Slice("Igne"))).isTrue();
+        assertThat(testContains(filter, utf8Slice("natura"))).isTrue();
+        assertThat(testContains(filter, utf8Slice("renovitur"))).isTrue();
+        assertThat(testContains(filter, utf8Slice("integra."))).isTrue();
+
+        assertThat(filter.isNullAllowed()).isFalse();
+        assertThat(testContains(filter, utf8Slice("natur"))).isFalse();
+        assertThat(testContains(filter, utf8Slice("apple"))).isFalse();
+
+        int valuesCount = 10000;
+        List<Slice> testValues = new ArrayList<>(valuesCount);
+        List<Slice> filterValues = new ArrayList<>((valuesCount / 9) + 1);
+        byte base = 0;
+        for (int i = 0; i < valuesCount; i++) {
+            Slice value = sequentialBytes(base, i);
+            testValues.add(value);
+            base = (byte) (base + i);
+            if (i % 9 == 0) {
+                filterValues.add(value);
+            }
+        }
+
+        filter = new TupleDomainFilter.SliceBloomFilter(false, VARCHAR, filterValues);
+        int hits = 0;
+        for (int i = 0; i < valuesCount; i++) {
+            boolean contains = testContains(filter, testValues.get(i));
+            if (i % 9 == 0) {
+                // No false negatives
+                assertThat(contains).isTrue();
+            }
+            hits += contains ? 1 : 0;
+        }
+        assertThat((double) hits / valuesCount).isBetween(0.1, 0.115);
+    }
+
+    private static Slice sequentialBytes(byte base, int length)
+    {
+        byte[] bytes = new byte[length];
+        for (int i = 0; i < length; i++) {
+            bytes[i] = (byte) (base + i);
+        }
+        return Slices.wrappedBuffer(bytes);
+    }
+
+    @Test
+    public void testAlwaysFalseFilter()
+    {
+        TupleDomainFilter filter = new TupleDomainFilter.AlwaysFalse(INTEGER);
+        assertThat(testContains(filter, 123, BIGINT)).isFalse();
+        filter = new TupleDomainFilter.AlwaysFalse(VARCHAR);
+        assertThat(testContains(filter, utf8Slice("123"))).isFalse();
+        assertThat(filter.isNullAllowed()).isFalse();
+    }
+
+    @Test
+    public void testIsNullFilter()
+    {
+        TupleDomainFilter filter = new TupleDomainFilter.IsNullFilter(INTEGER);
+        assertThat(testContains(filter, 123, BIGINT)).isFalse();
+        filter = new TupleDomainFilter.IsNullFilter(VARCHAR);
+        assertThat(testContains(filter, utf8Slice("123"))).isFalse();
+        assertThat(filter.isNullAllowed()).isTrue();
+    }
+
+    @Test
+    public void testIsNotNullFilter()
+    {
+        TupleDomainFilter filter = new TupleDomainFilter.IsNotNullFilter(INTEGER);
+        assertThat(testContains(filter, 123, BIGINT)).isTrue();
+        filter = new TupleDomainFilter.IsNotNullFilter(VARCHAR);
+        assertThat(testContains(filter, utf8Slice("123"))).isTrue();
+        assertThat(filter.isNullAllowed()).isFalse();
+    }
+
+    @Test
+    public void testBooleanType()
+    {
+        ColumnHandle column = new TestingColumnHandle("column");
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, singleValue(BOOLEAN, true)));
+        Assertions.assertThat(TupleDomainFilterUtils.createTupleDomainFilters(tupleDomain, TYPE_OPERATORS)).isEmpty();
+
+        tupleDomain = TupleDomain.withColumnDomains(ImmutableMap.of(
+                column, Domain.create(ValueSet.ofRanges(greaterThan(BOOLEAN, true)), false)));
+        Assertions.assertThat(TupleDomainFilterUtils.createTupleDomainFilters(tupleDomain, TYPE_OPERATORS)).isEmpty();
+    }
+
+    @Test
+    public void testDoubleType()
+    {
+        ColumnHandle column = new TestingColumnHandle("column");
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, multipleValues(DOUBLE, ImmutableList.of(-0.0, 0.0, 1.0))));
+        Assertions.assertThat(TupleDomainFilterUtils.createTupleDomainFilters(tupleDomain, TYPE_OPERATORS)).isEmpty();
+
+        tupleDomain = TupleDomain.withColumnDomains(ImmutableMap.of(
+                column, Domain.create(ValueSet.ofRanges(greaterThan(DOUBLE, 0.0)), false)));
+        Assertions.assertThat(TupleDomainFilterUtils.createTupleDomainFilters(tupleDomain, TYPE_OPERATORS)).isEmpty();
+    }
+
+    @Test
+    public void testRealType()
+    {
+        ColumnHandle column = new TestingColumnHandle("column");
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(ImmutableMap.of(
+                column,
+                Domain.create(ValueSet.ofRanges(greaterThan(REAL, (long) floatToRawIntBits(3.0f))), false)));
+        Assertions.assertThat(TupleDomainFilterUtils.createTupleDomainFilters(tupleDomain, TYPE_OPERATORS)).isEmpty();
+
+        List<Long> values = ImmutableList.of(
+                (long) floatToRawIntBits(Float.NEGATIVE_INFINITY),
+                (long) floatToRawIntBits(-3.0f),
+                (long) floatToRawIntBits(-5.0f),
+                (long) floatToRawIntBits(0.0f));
+        Map<ColumnHandle, TupleDomainFilter> filters = TupleDomainFilterUtils.createTupleDomainFilters(
+                TupleDomain.withColumnDomains(ImmutableMap.of(column, multipleValues(REAL, values))),
+                TYPE_OPERATORS);
+        TupleDomainFilter filter = filters.get(column);
+        assertThat(filter).isInstanceOf(TupleDomainFilter.LongCustomHashSetFilter.class);
+        verifyFilterContainsValues(filter, ImmutableSet.copyOf(values), REAL);
+        assertThat(testContains(filter, floatToRawIntBits(POSITIVE_INFINITY), REAL)).isFalse();
+        assertThat(testContains(filter, floatToRawIntBits(-0.0f), REAL)).isTrue();
+        assertThat(testContains(filter, floatToRawIntBits(0.1f), REAL)).isFalse();
+    }
+
+    @Test
+    public void testLongDecimalType()
+    {
+        ColumnHandle column = new TestingColumnHandle("column");
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(
+                        column,
+                        singleValue(createDecimalType(20, 10), Int128.valueOf(2342342343L))));
+        Assertions.assertThat(TupleDomainFilterUtils.createTupleDomainFilters(tupleDomain, TYPE_OPERATORS)).isEmpty();
+
+        tupleDomain = TupleDomain.withColumnDomains(ImmutableMap.of(
+                column,
+                Domain.create(ValueSet.ofRanges(greaterThan(
+                        createDecimalType(20, 10),
+                        Int128.valueOf(2342342343L))), false)));
+        Assertions.assertThat(TupleDomainFilterUtils.createTupleDomainFilters(tupleDomain, TYPE_OPERATORS)).isEmpty();
+    }
+
+    @Test
+    public void testShortDecimalRange()
+    {
+        ColumnHandle column = new TestingColumnHandle("column");
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(ImmutableMap.of(
+                column,
+                Domain.create(
+                        ValueSet.ofRanges(greaterThanOrEqual(createDecimalType(6, 1), 234243L)),
+                        false)));
+        Map<ColumnHandle, TupleDomainFilter> filters = TupleDomainFilterUtils.createTupleDomainFilters(tupleDomain, TYPE_OPERATORS);
+        assertThat(filters).isEqualTo(ImmutableMap.of(
+                column,
+                new TupleDomainFilter.LongRangeFilter(false, createDecimalType(6, 1), 234243L, Long.MAX_VALUE)));
+    }
+
+    @Test
+    public void testLongBitSetFilter()
+    {
+        ColumnHandle column = new TestingColumnHandle("column");
+        List<Long> values = ImmutableList.of(0L, 5L, 60L, 90L);
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, multipleValues(TINYINT, values)));
+        Map<ColumnHandle, TupleDomainFilter> filters = TupleDomainFilterUtils.createTupleDomainFilters(tupleDomain, TYPE_OPERATORS);
+        TupleDomainFilter filter = new TupleDomainFilter.LongBitSetFilter(false, TINYINT, values, 0L, 90L);
+        assertThat(filters).isEqualTo(ImmutableMap.of(column, filter));
+        verifyFilterValues(values, filter, 0, 100);
+
+        // (max - min) larger than bitset capacity
+        filters = TupleDomainFilterUtils.createTupleDomainFilters(
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        column,
+                        multipleValues(BIGINT, ImmutableList.of(Long.MIN_VALUE, Long.MAX_VALUE)))),
+                TYPE_OPERATORS);
+        assertThat(filters.get(column)).isInstanceOf(TupleDomainFilter.LongHashSetFilter.class);
+        verifyFilterContainsValues(filters.get(column), ImmutableSet.of(Long.MIN_VALUE, Long.MAX_VALUE), BIGINT);
+    }
+
+    @Test
+    public void testCreateFilterFromAll()
+    {
+        Map<ColumnHandle, TupleDomainFilter> filters =
+                TupleDomainFilterUtils.createTupleDomainFilters(TupleDomain.all(), TYPE_OPERATORS);
+        assertThat(filters).isEmpty();
+    }
+
+    @Test
+    public void testCreateFilterFromOnlyNullDomain()
+    {
+        ColumnHandle column = new TestingColumnHandle("column");
+        Type type = INTEGER;
+        Map<ColumnHandle, TupleDomainFilter> filters =
+                TupleDomainFilterUtils.createTupleDomainFilters(
+                        TupleDomain.withColumnDomains(ImmutableMap.of(column, onlyNull(type))),
+                        TYPE_OPERATORS);
+        assertThat(filters).isEqualTo(ImmutableMap.of(column, new TupleDomainFilter.IsNullFilter(type)));
+    }
+
+    @Test
+    public void testCreateFilterFromSingleValueDomain()
+    {
+        ColumnHandle column = new TestingColumnHandle("column");
+        Type type = INTEGER;
+        Map<ColumnHandle, TupleDomainFilter> filters =
+                TupleDomainFilterUtils.createTupleDomainFilters(
+                        TupleDomain.withColumnDomains(ImmutableMap.of(column, singleValue(type, 100L))),
+                        TYPE_OPERATORS);
+        assertThat(filters).isEqualTo(ImmutableMap.of(
+                column,
+                new TupleDomainFilter.LongRangeFilter(false, type, 100L, 100L)));
+    }
+
+    @Test
+    public void testCreateFilterFromNotNullDomain()
+    {
+        ColumnHandle column = new TestingColumnHandle("column");
+        Map<ColumnHandle, TupleDomainFilter> filters =
+                TupleDomainFilterUtils.createTupleDomainFilters(
+                        TupleDomain.withColumnDomains(ImmutableMap.of(column, notNull(INTEGER))),
+                        TYPE_OPERATORS);
+        assertThat(filters).isEqualTo(
+                ImmutableMap.of(column, new TupleDomainFilter.IsNotNullFilter(INTEGER)));
+    }
+
+    @Test
+    public void testLongRangeFilter()
+    {
+        // greaterThan range
+        ColumnHandle column = new TestingColumnHandle("column");
+        Map<ColumnHandle, TupleDomainFilter> filters = TupleDomainFilterUtils.createTupleDomainFilters(
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        column,
+                        Domain.create(ValueSet.ofRanges(greaterThan(BIGINT, 0L)), false))),
+                TYPE_OPERATORS);
+        TupleDomainFilter.LongRangeFilter rangeFilter = new TupleDomainFilter.LongRangeFilter(false, BIGINT, 1L, Long.MAX_VALUE);
+        assertThat(filters).isEqualTo(ImmutableMap.of(column, rangeFilter));
+        assertThat(rangeFilter.isNullAllowed()).isFalse();
+        assertThat(testContains(rangeFilter, 0, BIGINT)).isFalse();
+        assertThat(testContains(rangeFilter, 1, BIGINT)).isTrue();
+        assertThat(testContains(rangeFilter, Long.MAX_VALUE, BIGINT)).isTrue();
+
+        // lessThan range
+        filters = TupleDomainFilterUtils.createTupleDomainFilters(
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        column,
+                        Domain.create(ValueSet.ofRanges(lessThan(BIGINT, 100L)), false))),
+                TYPE_OPERATORS);
+        rangeFilter = new TupleDomainFilter.LongRangeFilter(false, BIGINT, Long.MIN_VALUE, 99L);
+        assertThat(filters).isEqualTo(ImmutableMap.of(column, rangeFilter));
+        assertThat(testContains(rangeFilter, 100, BIGINT)).isFalse();
+        assertThat(testContains(rangeFilter, 99, BIGINT)).isTrue();
+        assertThat(testContains(rangeFilter, Long.MIN_VALUE, BIGINT)).isTrue();
+
+        // [low, high] inclusive range
+        filters = TupleDomainFilterUtils.createTupleDomainFilters(
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        column,
+                        Domain.create(ValueSet.ofRanges(range(INTEGER, 5L, true, 10L, true)), false))),
+                TYPE_OPERATORS);
+        rangeFilter = new TupleDomainFilter.LongRangeFilter(false, INTEGER, 5L, 10L);
+        assertThat(filters).isEqualTo(ImmutableMap.of(column, rangeFilter));
+        for (int i = 5; i <= 10; i++) {
+            assertThat(testContains(rangeFilter, i, INTEGER)).isTrue();
+        }
+
+        // (low, high) exclusive range
+        filters = TupleDomainFilterUtils.createTupleDomainFilters(
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        column,
+                        Domain.create(ValueSet.ofRanges(range(INTEGER, 5L, false, 10L, false)), true))),
+                TYPE_OPERATORS);
+        rangeFilter = new TupleDomainFilter.LongRangeFilter(true, INTEGER, 6L, 9L);
+        assertThat(filters).isEqualTo(ImmutableMap.of(column, rangeFilter));
+        assertThat(testContains(rangeFilter, 5, INTEGER)).isFalse();
+        assertThat(testContains(rangeFilter, 10, INTEGER)).isFalse();
+        assertThat(rangeFilter.isNullAllowed()).isTrue();
+        for (int i = 6; i <= 9; i++) {
+            assertThat(testContains(rangeFilter, i, INTEGER)).isTrue();
+        }
+
+        // empty range with null allowed
+        Assertions.assertThat(TupleDomainFilterUtils.createTupleDomainFilters(
+                        TupleDomain.withColumnDomains(ImmutableMap.of(
+                                column,
+                                Domain.create(ValueSet.ofRanges(range(INTEGER, 1L, false, 2L, false)), true))),
+                        TYPE_OPERATORS))
+                .isEqualTo(ImmutableMap.of(column, new TupleDomainFilter.IsNullFilter(INTEGER)));
+
+        // empty range with null not allowed
+        Assertions.assertThat(TupleDomainFilterUtils.createTupleDomainFilters(
+                        TupleDomain.withColumnDomains(ImmutableMap.of(
+                                column,
+                                Domain.create(ValueSet.ofRanges(range(INTEGER, 1L, false, 2L, false)), false))),
+                        TYPE_OPERATORS))
+                .isEqualTo(ImmutableMap.of(column, new TupleDomainFilter.AlwaysFalse(INTEGER)));
+
+        // all without null
+        Assertions.assertThat(TupleDomainFilterUtils.createTupleDomainFilters(
+                        TupleDomain.withColumnDomains(ImmutableMap.of(
+                                column,
+                                Domain.create(ValueSet.ofRanges(Range.all(INTEGER)), false))),
+                        TYPE_OPERATORS))
+                .isEqualTo(ImmutableMap.of(column, new TupleDomainFilter.IsNotNullFilter(INTEGER)));
+
+        // all with null allowed
+        Assertions.assertThat(TupleDomainFilterUtils.createTupleDomainFilters(
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        column,
+                        Domain.create(ValueSet.ofRanges(Range.all(INTEGER)), true))),
+                TYPE_OPERATORS)).isEmpty();
+
+        // greater than MAX
+        Assertions.assertThat(TupleDomainFilterUtils.createTupleDomainFilters(
+                        TupleDomain.withColumnDomains(ImmutableMap.of(
+                                column,
+                                Domain.create(ValueSet.ofRanges(greaterThan(BIGINT, Long.MAX_VALUE)), false))),
+                        TYPE_OPERATORS))
+                .isEqualTo(ImmutableMap.of(column, new TupleDomainFilter.AlwaysFalse(BIGINT)));
+        Assertions.assertThat(TupleDomainFilterUtils.createTupleDomainFilters(
+                        TupleDomain.withColumnDomains(ImmutableMap.of(
+                                column,
+                                Domain.create(ValueSet.ofRanges(greaterThan(BIGINT, Long.MAX_VALUE)), true))),
+                        TYPE_OPERATORS))
+                .isEqualTo(ImmutableMap.of(column, new TupleDomainFilter.IsNullFilter(BIGINT)));
+
+        // less than MIN
+        Assertions.assertThat(TupleDomainFilterUtils.createTupleDomainFilters(
+                        TupleDomain.withColumnDomains(ImmutableMap.of(
+                                column,
+                                Domain.create(ValueSet.ofRanges(lessThan(BIGINT, Long.MIN_VALUE)), false))),
+                        TYPE_OPERATORS))
+                .isEqualTo(ImmutableMap.of(column, new TupleDomainFilter.AlwaysFalse(BIGINT)));
+        Assertions.assertThat(TupleDomainFilterUtils.createTupleDomainFilters(
+                        TupleDomain.withColumnDomains(ImmutableMap.of(
+                                column,
+                                Domain.create(ValueSet.ofRanges(lessThan(BIGINT, Long.MIN_VALUE)), true))),
+                        TYPE_OPERATORS))
+                .isEqualTo(ImmutableMap.of(column, new TupleDomainFilter.IsNullFilter(BIGINT)));
+    }
+
+    @Test
+    public void testRangeFilterFromPackedDomain()
+    {
+        ColumnHandle column = new TestingColumnHandle("column");
+        List<Long> values = ImmutableList.of(1231L, 1232L, 1233L, 1234L, 1235L);
+        Map<ColumnHandle, TupleDomainFilter> filters = TupleDomainFilterUtils.createTupleDomainFilters(
+                TupleDomain.withColumnDomains(ImmutableMap.of(column, multipleValues(BIGINT, values))),
+                TYPE_OPERATORS);
+        TupleDomainFilter filter = new TupleDomainFilter.LongRangeFilter(false, BIGINT, 1231L, 1235L);
+        assertThat(filters).isEqualTo(ImmutableMap.of(column, filter));
+        verifyFilterValues(values, filter, 0, 2000);
+    }
+
+    @Test
+    public void testCreateFilterFromAllOrNoneValueSet()
+    {
+        ColumnHandle column = new TestingColumnHandle("column");
+        Assertions.assertThat(TupleDomainFilterUtils.createTupleDomainFilters(
+                        TupleDomain.withColumnDomains(ImmutableMap.of(
+                                column, Domain.create(ValueSet.all(HYPER_LOG_LOG), true))),
+                        TYPE_OPERATORS))
+                .isEmpty();
+        Assertions.assertThat(TupleDomainFilterUtils.createTupleDomainFilters(
+                        TupleDomain.withColumnDomains(ImmutableMap.of(
+                                column, Domain.create(ValueSet.all(HYPER_LOG_LOG), false))),
+                        TYPE_OPERATORS))
+                .isEmpty();
+        Assertions.assertThat(TupleDomainFilterUtils.createTupleDomainFilters(
+                        TupleDomain.withColumnDomains(ImmutableMap.of(
+                                column, Domain.create(ValueSet.none(HYPER_LOG_LOG), true))),
+                        TYPE_OPERATORS))
+                .isEmpty();
+    }
+
+    @Test
+    public void testCreateFilterFromEquatableValueSet()
+    {
+        ColumnHandle column = new TestingColumnHandle("column");
+        Assertions.assertThat(TupleDomainFilterUtils.createTupleDomainFilters(
+                        TupleDomain.withColumnDomains(ImmutableMap.of(
+                                column, Domain.create(ValueSet.of(ID, 1L, 2L, 3L), true))),
+                        TYPE_OPERATORS))
+                .isEmpty();
+        Assertions.assertThat(TupleDomainFilterUtils.createTupleDomainFilters(
+                        TupleDomain.withColumnDomains(ImmutableMap.of(
+                                column, Domain.create(ValueSet.of(ID, 1L, 2L, 3L), false))),
+                        TYPE_OPERATORS))
+                .isEmpty();
+    }
+
+    @Test
+    public void testCreateFilterFromNone()
+    {
+        assertThatThrownBy(() -> TupleDomainFilterUtils.createTupleDomainFilters(none(), TYPE_OPERATORS))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("tupleDomain is none");
+    }
+
+    @Test
+    public void testTooLargeBitSetFilter()
+    {
+        assertThatThrownBy(() -> new TupleDomainFilter.LongBitSetFilter(true, INTEGER, ImmutableList.of(0L), 0, ((long) Integer.MAX_VALUE) + 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Values range 2147483649 is outside integer range");
+    }
+
+    private static boolean testContains(TupleDomainFilter filter, long value, Type type)
+    {
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, 1);
+        type.writeLong(blockBuilder, value);
+        return filter.testContains(blockBuilder.build(), 0);
+    }
+
+    private static boolean testContains(TupleDomainFilter filter, Slice value)
+    {
+        VariableWidthBlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, 1);
+        VARCHAR.writeSlice(blockBuilder, value);
+        return filter.testContains(blockBuilder.build(), 0);
+    }
+
+    private static void verifyFilterValues(List<Long> values, TupleDomainFilter filter, int start, int end)
+    {
+        Set<Long> valuesSet = ImmutableSet.copyOf(values);
+        Block block = createLongSequenceBlock(start, end, filter.getType());
+        for (long i = 0; i < block.getPositionCount(); i++) {
+            assertThat(filter.testContains(block, toIntExact(i))).isEqualTo(valuesSet.contains(i));
+        }
+    }
+
+    private static void verifyFilterContainsValues(TupleDomainFilter filter, Set<?> values, Type type)
+    {
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, values.size());
+        for (Object value : values) {
+            TypeUtils.writeNativeValue(type, blockBuilder, value);
+        }
+        Block block = blockBuilder.build();
+        for (int i = 0; i < block.getPositionCount(); i++) {
+            assertThat(filter.testContains(block, i)).isTrue();
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/dynamicfiltering/TypedSet.java
+++ b/core/trino-main/src/test/java/io/trino/operator/dynamicfiltering/TypedSet.java
@@ -1,0 +1,265 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.dynamicfiltering;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.airlift.units.DataSize;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.type.Type;
+import io.trino.type.BlockTypeOperators.BlockPositionEqual;
+import io.trino.type.BlockTypeOperators.BlockPositionHashCode;
+import io.trino.type.BlockTypeOperators.BlockPositionIsIdentical;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static io.trino.spi.StandardErrorCode.EXCEEDED_FUNCTION_MEMORY_LIMIT;
+import static io.trino.spi.StandardErrorCode.GENERIC_INSUFFICIENT_RESOURCES;
+import static it.unimi.dsi.fastutil.HashCommon.arraySize;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A set of unique SQL values stored in a {@link Block}.
+ *
+ * <p>Depending on the factory method used, the values' equality may be
+ * determined using SQL equality or {@code IS DISTINCT FROM} semantics.
+ */
+public class TypedSet
+{
+    @VisibleForTesting
+    public static final DataSize MAX_FUNCTION_MEMORY = DataSize.of(4, MEGABYTE);
+
+    private static final float FILL_RATIO = 0.75f;
+
+    private final Type elementType;
+    private final BlockPositionEqual elementEqualOperator;
+    private final BlockPositionIsIdentical elementIsIdenticalOperator;
+    private final BlockPositionHashCode elementHashCodeOperator;
+    private final IntArrayList blockPositionByHash;
+    private final BlockBuilder elementBlock;
+    private final String functionName;
+    private final long maxBlockMemoryInBytes;
+
+    private final int initialElementBlockOffset;
+    private final long initialElementBlockSizeInBytes;
+    // The number of elements added to the TypedSet (including null). Should
+    // always be equal to elementBlock.getPositionsCount() - initialElementBlockOffset.
+    private int size;
+    private int hashCapacity;
+    private int maxFill;
+    private int hashMask;
+    private static final int EMPTY_SLOT = -1;
+
+    private boolean containsNullElement;
+
+    /**
+     * Create a {@code TypedSet} that compares its elements using SQL equality
+     * comparison.
+     *
+     * <p>The elements of the set will be written in the given {@code BlockBuilder}.
+     * If the {@code BlockBuilder} is modified by the caller, the set will stop
+     * functioning correctly.
+     */
+    public static TypedSet createEqualityTypedSet(
+            Type elementType,
+            BlockPositionEqual elementEqualOperator,
+            BlockPositionHashCode elementHashCodeOperator,
+            BlockBuilder elementBlock,
+            int expectedSize,
+            String functionName)
+    {
+        return new TypedSet(
+                elementType,
+                elementEqualOperator,
+                null,
+                elementHashCodeOperator,
+                elementBlock,
+                expectedSize,
+                functionName,
+                false);
+    }
+
+    private TypedSet(
+            Type elementType,
+            BlockPositionEqual elementEqualOperator,
+            BlockPositionIsIdentical elementIsIdenticalOperator,
+            BlockPositionHashCode elementHashCodeOperator,
+            BlockBuilder elementBlock,
+            int expectedSize,
+            String functionName,
+            boolean unboundedMemory)
+    {
+        checkArgument(expectedSize >= 0, "expectedSize must not be negative");
+        this.elementType = requireNonNull(elementType, "elementType is null");
+
+        checkArgument(elementEqualOperator == null ^ elementIsIdenticalOperator == null, "Element equal or distinct_from operator must be provided");
+        this.elementEqualOperator = elementEqualOperator;
+        this.elementIsIdenticalOperator = elementIsIdenticalOperator;
+        this.elementHashCodeOperator = requireNonNull(elementHashCodeOperator, "elementHashCodeOperator is null");
+
+        this.elementBlock = requireNonNull(elementBlock, "elementBlock must not be null");
+        this.functionName = functionName;
+        this.maxBlockMemoryInBytes = unboundedMemory ? Long.MAX_VALUE : MAX_FUNCTION_MEMORY.toBytes();
+
+        initialElementBlockOffset = elementBlock.getPositionCount();
+        initialElementBlockSizeInBytes = elementBlock.getSizeInBytes();
+
+        this.size = 0;
+        this.hashCapacity = arraySize(expectedSize, FILL_RATIO);
+        this.maxFill = calculateMaxFill(hashCapacity);
+        this.hashMask = hashCapacity - 1;
+
+        blockPositionByHash = new IntArrayList(hashCapacity);
+        blockPositionByHash.size(hashCapacity);
+        for (int i = 0; i < hashCapacity; i++) {
+            blockPositionByHash.set(i, EMPTY_SLOT);
+        }
+
+        this.containsNullElement = false;
+    }
+
+    /**
+     * Add the value at the given {@code position} in the given {@code block}
+     * to this set.
+     *
+     * @return {@code true} if the value was added, or {@code false} if it was
+     * already in this set.
+     */
+    public boolean add(Block block, int position)
+    {
+        requireNonNull(block, "block must not be null");
+        checkArgument(position >= 0, "position must be >= 0");
+
+        // containsNullElement flag is maintained so contains() method can have shortcut for null value
+        if (block.isNull(position)) {
+            if (containsNullElement) {
+                return false;
+            }
+            containsNullElement = true;
+        }
+
+        int hashPosition = getHashPositionOfElement(block, position);
+        if (blockPositionByHash.getInt(hashPosition) == EMPTY_SLOT) {
+            addNewElement(hashPosition, block, position);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Returns the number of elements in this set.
+     */
+    public int size()
+    {
+        return size;
+    }
+
+    /**
+     * Return the position in this set's {@code BlockBuilder} of the value at
+     * the given {@code position} in the given {@code block}, or -1 if the
+     * value is not in this set.
+     */
+    public int positionOf(Block block, int position)
+    {
+        return blockPositionByHash.getInt(getHashPositionOfElement(block, position));
+    }
+
+    /**
+     * Get slot position of element at {@code position} of {@code block}
+     */
+    private int getHashPositionOfElement(Block block, int position)
+    {
+        int hashPosition = getMaskedHash(elementHashCodeOperator.hashCodeNullSafe(block, position));
+        while (true) {
+            int blockPosition = blockPositionByHash.getInt(hashPosition);
+            if (blockPosition == EMPTY_SLOT) {
+                // Doesn't have this element
+                return hashPosition;
+            }
+            if (isNotDistinct(elementBlock.build(), blockPosition, block, position)) {
+                // Already has this element
+                return hashPosition;
+            }
+
+            hashPosition = getMaskedHash(hashPosition + 1);
+        }
+    }
+
+    private boolean isNotDistinct(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
+    {
+        if (elementIsIdenticalOperator != null) {
+            return elementIsIdenticalOperator.isIdentical(leftBlock, leftPosition, rightBlock, rightPosition);
+        }
+        return elementEqualOperator.equalNullSafe(leftBlock, leftPosition, rightBlock, rightPosition);
+    }
+
+    private void addNewElement(int hashPosition, Block block, int position)
+    {
+        elementType.appendTo(block, position, elementBlock);
+        if (elementBlock.getSizeInBytes() - initialElementBlockSizeInBytes > maxBlockMemoryInBytes) {
+            throw new TrinoException(
+                    EXCEEDED_FUNCTION_MEMORY_LIMIT,
+                    format("The input to %s is too large. More than %s of memory is needed to hold the intermediate hash set.\n",
+                            functionName,
+                            MAX_FUNCTION_MEMORY));
+        }
+        blockPositionByHash.set(hashPosition, elementBlock.getPositionCount() - 1);
+
+        // increase capacity, if necessary
+        size++;
+        if (size >= maxFill) {
+            rehash();
+        }
+    }
+
+    private void rehash()
+    {
+        long newCapacityLong = hashCapacity * 2L;
+        if (newCapacityLong > Integer.MAX_VALUE) {
+            throw new TrinoException(GENERIC_INSUFFICIENT_RESOURCES, "Size of hash table cannot exceed 1 billion entries");
+        }
+        int newCapacity = (int) newCapacityLong;
+
+        hashCapacity = newCapacity;
+        hashMask = newCapacity - 1;
+        maxFill = calculateMaxFill(newCapacity);
+        blockPositionByHash.size(newCapacity);
+        for (int i = 0; i < newCapacity; i++) {
+            blockPositionByHash.set(i, EMPTY_SLOT);
+        }
+
+        for (int blockPosition = initialElementBlockOffset; blockPosition < elementBlock.getPositionCount(); blockPosition++) {
+            blockPositionByHash.set(getHashPositionOfElement(elementBlock.build(), blockPosition), blockPosition);
+        }
+    }
+
+    private static int calculateMaxFill(int hashSize)
+    {
+        checkArgument(hashSize > 0, "hashSize must be greater than 0");
+        int maxFill = (int) Math.ceil(hashSize * FILL_RATIO);
+        if (maxFill == hashSize) {
+            maxFill--;
+        }
+        checkArgument(hashSize > maxFill, "hashSize must be larger than maxFill");
+        return maxFill;
+    }
+
+    private int getMaskedHash(long rawHash)
+    {
+        return (int) (rawHash & hashMask);
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorPageSourceProvider.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorPageSourceProvider.java
@@ -28,4 +28,13 @@ public interface ConnectorPageSourceProvider
             ConnectorTableHandle table,
             List<ColumnHandle> columns,
             DynamicFilter dynamicFilter);
+
+    /**
+     * Returns whether the engine should perform dynamic row filtering on top of the returned page source.
+     * While dynamic row filtering can be extended to any connector, it is currently restricted to data lake connectors.
+     */
+    default boolean shouldPerformDynamicRowFiltering()
+    {
+        return false;
+    }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorPageSourceProvider.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorPageSourceProvider.java
@@ -48,4 +48,12 @@ public class ClassLoaderSafeConnectorPageSourceProvider
             return delegate.createPageSource(transaction, session, split, table, columns, dynamicFilter);
         }
     }
+
+    @Override
+    public boolean shouldPerformDynamicRowFiltering()
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.shouldPerformDynamicRowFiltering();
+        }
+    }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSourceProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSourceProvider.java
@@ -303,6 +303,12 @@ public class DeltaLakePageSourceProvider
         }
     }
 
+    @Override
+    public boolean shouldPerformDynamicRowFiltering()
+    {
+        return true;
+    }
+
     public Map<Integer, String> loadParquetIdAndNameMapping(TrinoInputFile inputFile, ParquetReaderOptions options)
     {
         try (ParquetDataSource dataSource = new TrinoParquetDataSource(inputFile, options, fileFormatDataSourceStats)) {

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeDynamicRowFiltering.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeDynamicRowFiltering.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import io.trino.execution.DynamicFilterConfig;
+import io.trino.plugin.hive.containers.HiveMinioDataLake;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.testing.AbstractTestDynamicRowFiltering;
+import io.trino.testing.QueryRunner;
+
+import static com.google.common.base.Verify.verify;
+import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.DELTA_CATALOG;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static java.lang.String.format;
+
+public class TestDeltaLakeDynamicRowFiltering
+        extends AbstractTestDynamicRowFiltering
+{
+    private HiveMinioDataLake hiveMinioDataLake;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        verify(new DynamicFilterConfig().isEnableDynamicFiltering(), "this class assumes dynamic filtering is enabled by default");
+
+        String bucketName = "delta-test-dynamic-row-filtering-" + randomNameSuffix();
+        hiveMinioDataLake = closeAfterClass(new HiveMinioDataLake(bucketName));
+        hiveMinioDataLake.start();
+
+        QueryRunner queryRunner = DeltaLakeQueryRunner.builder()
+                .addS3Properties(hiveMinioDataLake.getMinio(), bucketName)
+                .addMetastoreProperties(hiveMinioDataLake.getHiveHadoop())
+                .addDeltaProperty("delta.register-table-procedure.enabled", "true")
+                .build();
+
+        queryRunner.execute(format("CREATE SCHEMA IF NOT EXISTS %s.tpch", DELTA_CATALOG));
+
+        REQUIRED_TPCH_TABLES.forEach(table -> {
+            String tableName = table.getTableName();
+            hiveMinioDataLake.copyResources("io/trino/plugin/deltalake/testing/resources/databricks73/" + tableName, tableName);
+            queryRunner.execute(format("CALL %1$s.system.register_table('%2$s', '%3$s', 's3://%4$s/%3$s')",
+                    DELTA_CATALOG,
+                    "tpch",
+                    tableName,
+                    bucketName));
+        });
+        return queryRunner;
+    }
+
+    @Override
+    protected SchemaTableName getSchemaTableName(ConnectorTableHandle connectorHandle)
+    {
+        return ((DeltaLakeTableHandle) connectorHandle).getSchemaTableName();
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceProvider.java
@@ -234,6 +234,12 @@ public class HivePageSourceProvider
         return Optional.empty();
     }
 
+    @Override
+    public boolean shouldPerformDynamicRowFiltering()
+    {
+        return true;
+    }
+
     private static boolean shouldSkipBucket(HiveTableHandle hiveTable, HiveSplit hiveSplit, DynamicFilter dynamicFilter)
     {
         if (hiveSplit.getTableBucketNumber().isEmpty()) {

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveDynamicRowFiltering.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveDynamicRowFiltering.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.sql.planner.OptimizerConfig.JoinDistributionType;
+import io.trino.testing.AbstractTestDynamicRowFiltering;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class TestHiveDynamicRowFiltering
+        extends AbstractTestDynamicRowFiltering
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return HiveQueryRunner.builder()
+                .setInitialTables(REQUIRED_TPCH_TABLES)
+                .build();
+    }
+
+    @BeforeAll
+    public void createTestData()
+    {
+        assertUpdate(
+                "CREATE TABLE orders AS SELECT " +
+                        "CAST(clerk AS CHAR(15)) clerk, " +
+                        "CAST(orderstatus AS CHAR(5)) orderstatus, " +
+                        "custkey FROM tpch.tiny.orders",
+                15000);
+    }
+
+    @ParameterizedTest
+    @MethodSource("joinDistributionTypes")
+    @Timeout(30)
+    public void testRowFilteringWithCharStrings(JoinDistributionType joinDistributionType)
+    {
+        assertRowFiltering(
+                "SELECT o1.clerk, o1.custkey, CAST(o1.orderstatus AS VARCHAR(1)) FROM orders o1, orders o2 WHERE o1.clerk = o2.clerk AND o2.custkey < 10",
+                joinDistributionType,
+                "orders");
+
+        assertNoRowFiltering(
+                "SELECT COUNT(*) FROM orders o1, orders o2 WHERE o1.orderstatus = o2.orderstatus AND o2.custkey < 20",
+                joinDistributionType,
+                "orders");
+    }
+
+    @Override
+    protected SchemaTableName getSchemaTableName(ConnectorTableHandle connectorHandle)
+    {
+        return ((HiveTableHandle) connectorHandle).getSchemaTableName();
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -471,6 +471,12 @@ public class IcebergPageSourceProvider
                 .filter((handle, domain) -> !domain.contains(fileStatisticsDomain.getDomain(handle, domain.getType())));
     }
 
+    @Override
+    public boolean shouldPerformDynamicRowFiltering()
+    {
+        return true;
+    }
+
     private Set<IcebergColumnHandle> requiredColumnsForDeletes(Schema schema, List<DeleteFile> deletes)
     {
         ImmutableSet.Builder<IcebergColumnHandle> requiredColumns = ImmutableSet.builder();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergDynamicRowFiltering.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergDynamicRowFiltering.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import io.trino.execution.DynamicFilterConfig;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.testing.AbstractTestDynamicRowFiltering;
+import io.trino.testing.QueryRunner;
+
+import static com.google.common.base.Verify.verify;
+
+public class TestIcebergDynamicRowFiltering
+        extends AbstractTestDynamicRowFiltering
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        verify(new DynamicFilterConfig().isEnableDynamicFiltering(), "this class assumes dynamic filtering is enabled by default");
+
+        return IcebergQueryRunner.builder()
+                .setInitialTables(REQUIRED_TPCH_TABLES)
+                .build();
+    }
+
+    @Override
+    protected SchemaTableName getSchemaTableName(ConnectorTableHandle connectorTableHandle)
+    {
+        return ((IcebergTableHandle) connectorTableHandle).getSchemaTableName();
+    }
+}

--- a/testing/trino-testing/pom.xml
+++ b/testing/trino-testing/pom.xml
@@ -222,6 +222,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <scope>provided</scope>

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestDynamicRowFiltering.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestDynamicRowFiltering.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.MoreCollectors;
+import io.trino.Session;
+import io.trino.operator.OperatorStats;
+import io.trino.operator.dynamicfiltering.DynamicRowFilteringPageSource;
+import io.trino.spi.QueryId;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.metrics.Count;
+import io.trino.spi.metrics.Metric;
+import io.trino.sql.planner.OptimizerConfig.JoinDistributionType;
+import io.trino.sql.planner.Plan;
+import io.trino.sql.planner.optimizations.PlanNodeSearcher;
+import io.trino.sql.planner.plan.FilterNode;
+import io.trino.sql.planner.plan.PlanNodeId;
+import io.trino.sql.planner.plan.TableScanNode;
+import io.trino.tpch.TpchTable;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.trino.SystemSessionProperties.DYNAMIC_ROW_FILTERING_ENABLED;
+import static io.trino.SystemSessionProperties.DYNAMIC_ROW_FILTERING_SELECTIVITY_THRESHOLD;
+import static io.trino.SystemSessionProperties.DYNAMIC_ROW_FILTERING_WAIT_TIMEOUT;
+import static io.trino.sql.DynamicFilters.extractDynamicFilters;
+import static io.trino.sql.planner.OptimizerConfig.JoinDistributionType.BROADCAST;
+import static io.trino.sql.planner.OptimizerConfig.JoinDistributionType.PARTITIONED;
+import static io.trino.testing.QueryAssertions.assertEqualsIgnoreOrder;
+import static io.trino.tpch.TpchTable.CUSTOMER;
+import static io.trino.tpch.TpchTable.NATION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class AbstractTestDynamicRowFiltering
+        extends AbstractTestQueryFramework
+{
+    protected static final List<TpchTable<?>> REQUIRED_TPCH_TABLES = ImmutableList.of(CUSTOMER, NATION);
+
+    @Test
+    public void verifyDynamicFilteringEnabled()
+    {
+        assertQuery(
+                "SHOW SESSION LIKE 'enable_dynamic_filtering'",
+                "VALUES ('enable_dynamic_filtering', 'true', 'true', 'boolean', 'Enable dynamic filtering')");
+    }
+
+    public Object[][] joinDistributionTypes()
+    {
+        return new Object[][] {{BROADCAST}, {PARTITIONED}};
+    }
+
+    @ParameterizedTest
+    @MethodSource("joinDistributionTypes")
+    @Timeout(30)
+    public void testJoinWithSelectiveRowFiltering(JoinDistributionType joinDistributionType)
+    {
+        assertRowFiltering(
+                "SELECT * FROM customer c, nation n WHERE c.nationkey = n.nationkey and n.name = 'ALGERIA'",
+                joinDistributionType);
+    }
+
+    @ParameterizedTest
+    @MethodSource("joinDistributionTypes")
+    @Timeout(30)
+    public void testJoinWithNonSelectiveRowFiltering(JoinDistributionType joinDistributionType)
+    {
+        assertNoRowFiltering(
+                "SELECT * FROM  customer c, nation n WHERE c.nationkey = n.nationkey",
+                joinDistributionType);
+    }
+
+    @ParameterizedTest
+    @MethodSource("joinDistributionTypes")
+    @Timeout(30)
+    public void testRowFilteringWithStrings(JoinDistributionType joinDistributionType)
+    {
+        // name is high cardinality, VariableWidthBlock is used
+        assertRowFiltering(
+                "SELECT * FROM customer c1, customer c2 WHERE c1.name = c2.name AND c2.acctbal > 9000",
+                joinDistributionType);
+
+        // mktsegment is low cardinality, DictionaryBlock is used
+        assertRowFiltering(
+                "SELECT * FROM customer c1, customer c2 WHERE c1.mktsegment = c2.mktsegment AND c2.custkey = 1",
+                joinDistributionType);
+
+        assertNoRowFiltering(
+                "SELECT * FROM customer c1, customer c2 WHERE c1.mktsegment = c2.mktsegment AND c2.custkey < 10",
+                joinDistributionType);
+    }
+
+    @ParameterizedTest
+    @MethodSource("joinDistributionTypes")
+    @Timeout(30)
+    public void testJoinWithMultipleDynamicFilters(JoinDistributionType joinDistributionType)
+    {
+        assertNoRowFiltering(
+                "SELECT a.* FROM customer a INNER JOIN customer b ON a.nationkey = b.nationkey" +
+                        " AND a.mktsegment = b.mktsegment",
+                joinDistributionType);
+
+        assertRowFiltering(
+                "SELECT * FROM (" +
+                        "SELECT a.* FROM customer a INNER JOIN customer b ON a.mktsegment = b.mktsegment AND a.custkey = b.custkey) c" +
+                        " INNER JOIN nation on c.nationkey = nation.nationkey AND  nation.name IN ('ALGERIA')",
+                joinDistributionType);
+    }
+
+    protected void assertRowFiltering(@Language("SQL") String sql, JoinDistributionType joinDistributionType, String tableName)
+    {
+        QueryRunner.MaterializedResultWithPlan rowFilteringResultWithQueryId = getDistributedQueryRunner().executeWithPlan(
+                dynamicRowFiltering(joinDistributionType),
+                sql);
+
+        QueryRunner.MaterializedResultWithPlan noRowFilteringResultWithQueryId = getDistributedQueryRunner().executeWithPlan(
+                noDynamicRowFiltering(joinDistributionType),
+                sql);
+
+        // ensure results are correct
+        MaterializedResult expected = computeExpected(sql, rowFilteringResultWithQueryId.result().getTypes());
+        assertEqualsIgnoreOrder(rowFilteringResultWithQueryId.result(), expected, "For query: \n " + sql);
+        assertEqualsIgnoreOrder(noRowFilteringResultWithQueryId.result(), expected, "For query: \n " + sql);
+
+        OperatorStats rowFilteringProbeStats = getScanFilterAndProjectOperatorStats(
+                rowFilteringResultWithQueryId.queryId(),
+                tableName);
+        // input positions is smaller than physical input positions due to row filtering
+        assertThat(rowFilteringProbeStats.getInputPositions())
+                .isLessThan(rowFilteringProbeStats.getPhysicalInputPositions());
+
+        OperatorStats noRowFilteringProbeStats = getScanFilterAndProjectOperatorStats(
+                noRowFilteringResultWithQueryId.queryId(),
+                tableName);
+        assertThat(noRowFilteringProbeStats.getInputPositions())
+                .isEqualTo(noRowFilteringProbeStats.getPhysicalInputPositions());
+        // input positions is smaller in row filtering case than in no row filtering case
+        assertThat(rowFilteringProbeStats.getInputPositions())
+                .isLessThan(noRowFilteringProbeStats.getInputPositions());
+
+        Map<String, Metric<?>> metrics = rowFilteringProbeStats.getConnectorMetrics().getMetrics();
+        long filterOutputPositions = ((Count<?>) metrics.get(DynamicRowFilteringPageSource.FILTER_OUTPUT_POSITIONS)).getTotal();
+        long filterInputPositions = ((Count<?>) metrics.get(DynamicRowFilteringPageSource.FILTER_INPUT_POSITIONS)).getTotal();
+        assertThat(filterOutputPositions).isLessThan(filterInputPositions);
+        assertThat(filterOutputPositions).isLessThan(rowFilteringProbeStats.getPhysicalInputPositions());
+        assertThat(((Count<?>) metrics.get(DynamicRowFilteringPageSource.ROW_FILTERING_TIME_MILLIS)).getTotal()).isGreaterThanOrEqualTo(0);
+    }
+
+    protected void assertRowFiltering(@Language("SQL") String sql, JoinDistributionType joinDistributionType)
+    {
+        assertRowFiltering(sql, joinDistributionType, "customer");
+    }
+
+    protected void assertNoRowFiltering(@Language("SQL") String sql, JoinDistributionType joinDistributionType, String tableName)
+    {
+        QueryRunner.MaterializedResultWithPlan rowFilteringResultWithQueryId = getDistributedQueryRunner().executeWithPlan(
+                dynamicRowFiltering(joinDistributionType),
+                sql);
+
+        // ensure results are correct
+        MaterializedResult expected = computeExpected(sql, rowFilteringResultWithQueryId.result().getTypes());
+        assertEqualsIgnoreOrder(rowFilteringResultWithQueryId.result(), expected, "For query: \n " + sql);
+
+        OperatorStats rowFilteringProbeStats = getScanFilterAndProjectOperatorStats(
+                rowFilteringResultWithQueryId.queryId(),
+                tableName);
+        // input positions is equal to physical input positions due to no row filtering
+        assertThat(rowFilteringProbeStats.getInputPositions())
+                .isEqualTo(rowFilteringProbeStats.getPhysicalInputPositions());
+
+        Map<String, Metric<?>> metrics = rowFilteringProbeStats.getConnectorMetrics().getMetrics();
+        Count<?> filterOutputPositions = (Count<?>) metrics.get(DynamicRowFilteringPageSource.FILTER_OUTPUT_POSITIONS);
+        Count<?> filterInputPositions = (Count<?>) metrics.get(DynamicRowFilteringPageSource.FILTER_INPUT_POSITIONS);
+        assertThat(filterOutputPositions).isEqualTo(filterInputPositions);
+        assertThat(((Count<?>) metrics.get(DynamicRowFilteringPageSource.ROW_FILTERING_TIME_MILLIS)).getTotal()).isGreaterThanOrEqualTo(0);
+    }
+
+    protected void assertNoRowFiltering(@Language("SQL") String sql, JoinDistributionType joinDistributionType)
+    {
+        assertNoRowFiltering(sql, joinDistributionType, "customer");
+    }
+
+    protected OperatorStats getScanFilterAndProjectOperatorStats(QueryId queryId, String tableName)
+    {
+        Plan plan = getDistributedQueryRunner().getQueryPlan(queryId);
+        FilterNode planNode = (FilterNode) PlanNodeSearcher.searchFrom(plan.getRoot())
+                .where(node -> {
+                    if (!(node instanceof FilterNode filterNode)) {
+                        return false;
+                    }
+                    if (!(filterNode.getSource() instanceof TableScanNode tableScanNode)) {
+                        return false;
+                    }
+                    if (extractDynamicFilters(filterNode.getPredicate()).getDynamicConjuncts().isEmpty()) {
+                        return false;
+                    }
+                    return getSchemaTableName(tableScanNode.getTable().connectorHandle())
+                            .equals(new SchemaTableName("tpch", tableName));
+                })
+                .findOnlyElement();
+
+        return extractOperatorStatsForNodeId(getDistributedQueryRunner(), queryId, planNode.getId());
+    }
+
+    private static OperatorStats extractOperatorStatsForNodeId(DistributedQueryRunner queryRunner, QueryId queryId, PlanNodeId nodeId)
+    {
+        return queryRunner.getCoordinator()
+                .getQueryManager()
+                .getFullQueryInfo(queryId)
+                .getQueryStats()
+                .getOperatorSummaries()
+                .stream()
+                .filter(summary -> nodeId.equals(summary.getPlanNodeId()) && summary.getOperatorType().equals("TableScanOperator"))
+                .collect(MoreCollectors.onlyElement());
+    }
+
+    protected abstract SchemaTableName getSchemaTableName(ConnectorTableHandle connectorTableHandle);
+
+    protected Session dynamicRowFiltering(JoinDistributionType distributionType)
+    {
+        return Session.builder(noJoinReordering(distributionType))
+                .setSystemProperty(DYNAMIC_ROW_FILTERING_ENABLED, "true")
+                .setSystemProperty(DYNAMIC_ROW_FILTERING_WAIT_TIMEOUT, "10m")
+                .setSystemProperty(DYNAMIC_ROW_FILTERING_SELECTIVITY_THRESHOLD, "1")
+                .build();
+    }
+
+    protected Session noDynamicRowFiltering(JoinDistributionType distributionType)
+    {
+        return Session.builder(noJoinReordering(distributionType))
+                .setSystemProperty(DYNAMIC_ROW_FILTERING_ENABLED, "false")
+                .build();
+    }
+}


### PR DESCRIPTION
## Description

Dynamic row filtering performs fine-grained filtering of rows at table scan level thus greatly improving performance of some queries.




<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# General
* Improve query performance by pruning filtered-out rows early. ({issue}`issuenumber`)
```
