### PR TITLE
Restrict drop column operations for hive table

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveStorageFormat.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveStorageFormat.java
@@ -208,8 +208,8 @@ public enum HiveStorageFormat
     public boolean supportsColumnDropOperation()
     {
         return switch (this) {
-            case ORC, PARQUET, RCTEXT, SEQUENCEFILE, TEXTFILE -> true;
-            case AVRO, RCBINARY, JSON, OPENX_JSON, CSV, REGEX -> false;
+            case PARQUET, RCTEXT, SEQUENCEFILE, TEXTFILE -> true;
+            case AVRO, ORC, RCBINARY, JSON, OPENX_JSON, CSV, REGEX -> false;
         };
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveStorageFormat.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveStorageFormat.java
@@ -204,4 +204,12 @@ public enum HiveStorageFormat
             default -> toString();
         };
     }
+
+    public boolean supportsColumnDropOperation()
+    {
+        return switch (this) {
+            case ORC, PARQUET, RCTEXT, SEQUENCEFILE, TEXTFILE -> true;
+            case AVRO, RCBINARY, JSON, OPENX_JSON, CSV, REGEX -> false;
+        };
+    }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestAlterTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestAlterTable.java
@@ -93,7 +93,7 @@ public class TestAlterTable
     @Test(groups = SMOKE)
     public void dropColumn()
     {
-        onTrino().executeQuery(format("CREATE TABLE %s AS SELECT n_nationkey, n_regionkey, n_name FROM nation", TABLE_NAME));
+        onTrino().executeQuery(format("CREATE TABLE %s WITH (format = 'RCTEXT') AS SELECT n_nationkey, n_regionkey, n_name FROM nation", TABLE_NAME));
 
         assertThat(onTrino().executeQuery(format("SELECT count(n_nationkey) FROM %s", TABLE_NAME)))
                 .containsExactlyInOrder(row(25));

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTransactionalTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTransactionalTable.java
@@ -1083,27 +1083,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, dataProvider = "transactionModeProvider")
-    public void testOrcColumnDropAdd(boolean transactional)
-    {
-        withTemporaryTable("test_orc_add_drop", false, NONE, tableName -> {
-            onTrino().executeQuery(format("CREATE TABLE %s (id BIGINT, old_name VARCHAR, age INT, old_state VARCHAR) WITH (transactional = %s)", tableName, transactional));
-            onTrino().executeQuery(format("INSERT INTO %s VALUES (111, 'Katy', 57, 'CA'), (222, 'Joe', 72, 'WA')", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(111, "Katy", 57, "CA"), row(222, "Joe", 72, "WA"));
-
-            onTrino().executeQuery(format("ALTER TABLE %s DROP COLUMN old_state", tableName));
-            log.info("This shows that neither Trino nor Hive see the old data after a column is dropped");
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(111, "Katy", 57), row(222, "Joe", 72));
-
-            onTrino().executeQuery(format("INSERT INTO %s VALUES (333, 'Kelly', 45)", tableName));
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(111, "Katy", 57), row(222, "Joe", 72), row(333, "Kelly", 45));
-
-            onTrino().executeQuery(format("ALTER TABLE %s ADD COLUMN new_state VARCHAR", tableName));
-            log.info("This shows that for ORC, Trino and Hive both see data inserted into a dropped column when a column of the same type but different name is added");
-            verifySelectForTrinoAndHive("SELECT * FROM " + tableName, row(111, "Katy", 57, "CA"), row(222, "Joe", 72, "WA"), row(333, "Kelly", 45, null));
-        });
-    }
-
-    @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, dataProvider = "transactionModeProvider")
     public void testOrcColumnTypeChange(boolean transactional)
     {
         withTemporaryTable("test_orc_column_type_change", false, NONE, tableName -> {

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -61,6 +61,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.ConcurrentHashMap;
@@ -2489,7 +2490,8 @@ public abstract class BaseConnectorTest
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_TABLE));
 
         String tableName;
-        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_drop_column_", "AS SELECT 123 x, 456 y, 111 a")) {
+        String tableProperty = Objects.equals(tableFormatWhichAllowDroppingColumn(), "") ? "" : format("WITH (%s) ", tableFormatWhichAllowDroppingColumn());
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_drop_column_", tableProperty + "AS SELECT 123 x, 456 y, 111 a")) {
             tableName = table.getName();
             assertUpdate("ALTER TABLE " + tableName + " DROP COLUMN x");
             assertUpdate("ALTER TABLE " + tableName + " DROP COLUMN IF EXISTS y");
@@ -2504,6 +2506,11 @@ public abstract class BaseConnectorTest
         assertUpdate("ALTER TABLE IF EXISTS " + tableName + " DROP COLUMN notExistColumn");
         assertUpdate("ALTER TABLE IF EXISTS " + tableName + " DROP COLUMN IF EXISTS notExistColumn");
         assertThat(getQueryRunner().tableExists(getSession(), tableName)).isFalse();
+    }
+
+    protected String tableFormatWhichAllowDroppingColumn()
+    {
+        return "";
     }
 
     @Test
@@ -2690,7 +2697,8 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_DROP_COLUMN) && hasBehavior(SUPPORTS_ADD_COLUMN));
 
-        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_drop_add_column", "AS SELECT 1 x, 2 y, 3 z")) {
+        String tableProperty = Objects.equals(tableFormatWhichAllowDroppingColumn(), "") ? "" : format("WITH (%s) ", tableFormatWhichAllowDroppingColumn());
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_drop_add_column", tableProperty + "AS SELECT 1 x, 2 y, 3 z")) {
             assertUpdate("ALTER TABLE " + table.getName() + " DROP COLUMN y");
             assertQuery("SELECT * FROM " + table.getName(), "VALUES (1, 3)");
 
@@ -5450,7 +5458,8 @@ public abstract class BaseConnectorTest
      */
     protected String createTableSqlForAddingAndDroppingColumn(String tableName, String columnNameInSql)
     {
-        return "CREATE TABLE " + tableName + "(" + columnNameInSql + " varchar(50), value varchar(50))";
+        String tableProperty = Objects.equals(tableFormatWhichAllowDroppingColumn(), "") ? "" : format(" WITH (%s)", tableFormatWhichAllowDroppingColumn());
+        return "CREATE TABLE " + tableName + "(" + columnNameInSql + " varchar(50), value varchar(50))" + tableProperty;
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. --> 

<!-- Provide an overview of the PR for maintainers and reviewers. --> 

## Description 
Restrict drop column operations for hive tables. 
Fixes: https://github.com/trinodb/trino/issues/20807 


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. --> 

## Additional context and related issues 
Hive `REPLACE COLUMNS` can be used to drop columns, but it is restricted to supported SerDe table format. 

Hive's SerDe verification before `REPLACE COLUMNS` operation is described in: 
https://github.com/apache/hive/blob/master/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/replace/AlterTableReplaceColumnsOperation.java 

VALID_SERIALIZATION_LIBS points which table formats are supported in hive to drop column. 

### Tests
A few tests required fixes, because drop operation was used for unsupported SerDe format.
I am not sure if removing unsupported SerDe format from tests is the only way to fix them (maybe there is the way to cover test case without using `DROP COLUMN` operation).
 
<!-- Mark the appropriate option with an (x). Propose a release note if you can. --> 
## Release notes 
(x) This is not user-visible or is docs only, and no release notes are required. 
( ) Release notes are required. Please propose a release note for me. 
( ) Release notes are required, with the following suggested text: 