### PR TITLE
Add customTraceAttributes to session

### DIFF
--- a/core/trino-main/src/main/java/io/trino/ExtraTraceAttributes.java
+++ b/core/trino-main/src/main/java/io/trino/ExtraTraceAttributes.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino;
+
+import com.google.inject.Inject;
+import io.trino.dispatcher.DispatchManager;
+import io.trino.spi.QueryId;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+
+public class ExtraTraceAttributes
+        implements ExtraTraceAttributesProvider
+{
+    public static final String CLIENT_TAGS = "clientTags";
+
+    private final DispatchManager dispatchManager;
+
+    @Inject
+    public ExtraTraceAttributes(DispatchManager dispatchManager)
+    {
+        this.dispatchManager = requireNonNull(dispatchManager, "dispatchManager is null");
+    }
+
+    /**
+     * @throws java.util.NoSuchElementException if the query is not found
+     */
+    @Override
+    public Map<String, String> getExtraTraceAttributes(QueryId queryId)
+    {
+        return dispatchManager.getQueryInfo(queryId).getSession().getCustomTraceAttributes();
+    }
+
+    /**
+     * @throws java.util.NoSuchElementException if the query is not found
+     */
+    public String getClientTags(QueryId queryId)
+    {
+        return getExtraTraceAttributes(queryId).get(CLIENT_TAGS);
+    }
+
+    public static String sortAndConsolidateForValue(Collection<String> vals)
+    {
+        PriorityQueue<String> valQueue = new PriorityQueue<>(vals);
+        return valQueue.stream().collect(Collectors.joining(","));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/ExtraTraceAttributesProvider.java
+++ b/core/trino-main/src/main/java/io/trino/ExtraTraceAttributesProvider.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino;
+
+import io.trino.spi.QueryId;
+
+import java.util.Map;
+
+interface ExtraTraceAttributesProvider
+{
+    Map<String, String> getExtraTraceAttributes(QueryId queryId);
+}

--- a/core/trino-main/src/main/java/io/trino/SessionRepresentation.java
+++ b/core/trino-main/src/main/java/io/trino/SessionRepresentation.java
@@ -71,6 +71,7 @@ public final class SessionRepresentation
     private final Map<String, SelectedRole> catalogRoles;
     private final Map<String, String> preparedStatements;
     private final String protocolName;
+    private final Map<String, String> customTraceAttributes;
 
     @JsonCreator
     public SessionRepresentation(
@@ -102,7 +103,8 @@ public final class SessionRepresentation
             @JsonProperty("catalogProperties") Map<String, Map<String, String>> catalogProperties,
             @JsonProperty("catalogRoles") Map<String, SelectedRole> catalogRoles,
             @JsonProperty("preparedStatements") Map<String, String> preparedStatements,
-            @JsonProperty("protocolName") String protocolName)
+            @JsonProperty("protocolName") String protocolName,
+            @JsonProperty("customTraceAttributes") Map<String, String> customTraceAttributes)
     {
         this.queryId = requireNonNull(queryId, "queryId is null");
         this.querySpan = requireNonNull(querySpan, "querySpan is null");
@@ -132,6 +134,7 @@ public final class SessionRepresentation
         this.catalogRoles = ImmutableMap.copyOf(catalogRoles);
         this.preparedStatements = ImmutableMap.copyOf(preparedStatements);
         this.protocolName = requireNonNull(protocolName, "protocolName is null");
+        this.customTraceAttributes = ImmutableMap.copyOf(requireNonNull(customTraceAttributes, "customTraceAttributes is null"));
 
         ImmutableMap.Builder<String, Map<String, String>> catalogPropertiesBuilder = ImmutableMap.builder();
         for (Entry<String, Map<String, String>> entry : catalogProperties.entrySet()) {
@@ -320,6 +323,12 @@ public final class SessionRepresentation
         return timeZoneKey.getId();
     }
 
+    @JsonProperty
+    public Map<String, String> getCustomTraceAttributes()
+    {
+        return customTraceAttributes;
+    }
+
     public Identity toIdentity()
     {
         return toIdentity(emptyMap());
@@ -378,6 +387,7 @@ public final class SessionRepresentation
                 sessionPropertyManager,
                 preparedStatements,
                 createProtocolHeaders(protocolName),
-                exchangeEncryptionKey);
+                exchangeEncryptionKey,
+                customTraceAttributes);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/event/QueryMonitor.java
+++ b/core/trino-main/src/main/java/io/trino/event/QueryMonitor.java
@@ -632,7 +632,8 @@ public class QueryMonitor
                     running,
                     finishing,
                     queryStartTime,
-                    queryEndTime);
+                    queryEndTime,
+                    queryInfo.getSession().getCustomTraceAttributes());
         }
         catch (Exception e) {
             log.error(e, "Error logging query timeline");
@@ -662,7 +663,8 @@ public class QueryMonitor
                 0,
                 0,
                 queryStartTime,
-                queryEndTime);
+                queryEndTime,
+                queryInfo.getSession().getCustomTraceAttributes());
     }
 
     private static void logQueryTimeline(
@@ -676,10 +678,17 @@ public class QueryMonitor
             long runningMillis,
             long finishingMillis,
             DateTime queryStartTime,
-            DateTime queryEndTime)
+            DateTime queryEndTime,
+            Map<String, String> customTraceAttributes)
     {
-        log.info("TIMELINE: Query %s :: %s%s :: elapsed %sms :: planning %sms :: waiting %sms :: scheduling %sms :: running %sms :: finishing %sms :: begin %s :: end %s",
+        String customAttributeSection = customTraceAttributes.entrySet().stream()
+                .map(entry -> "custom:%s %s".formatted(entry.getKey(), entry.getValue()))
+                .collect(Collectors.joining(" :: "));
+        customAttributeSection = customAttributeSection.isEmpty() ? customAttributeSection : " :: %s".formatted(customAttributeSection);
+
+        log.info("TIMELINE: Query %s%s :: %s%s :: elapsed %sms :: planning %sms :: waiting %sms :: scheduling %sms :: running %sms :: finishing %sms :: begin %s :: end %s",
                 queryId,
+                customAttributeSection,
                 queryState,
                 errorCode.map(code -> " (%s)".formatted(code.getName())).orElse(""),
                 elapsedMillis,

--- a/core/trino-main/src/main/java/io/trino/server/QuerySessionSupplier.java
+++ b/core/trino-main/src/main/java/io/trino/server/QuerySessionSupplier.java
@@ -112,7 +112,8 @@ public class QuerySessionSupplier
                 .setClientCapabilities(context.getClientCapabilities())
                 .setTraceToken(context.getTraceToken())
                 .setResourceEstimates(context.getResourceEstimates())
-                .setProtocolHeaders(context.getProtocolHeaders());
+                .setProtocolHeaders(context.getProtocolHeaders())
+                .addAllCustomTraceAttribute(context.getCustomTraceAttributes());
 
         if (context.getCatalog().isPresent()) {
             sessionBuilder.setCatalog(context.getCatalog());

--- a/core/trino-main/src/main/java/io/trino/server/SessionContext.java
+++ b/core/trino-main/src/main/java/io/trino/server/SessionContext.java
@@ -62,6 +62,7 @@ public class SessionContext
     private final Optional<TransactionId> transactionId;
     private final boolean clientTransactionSupport;
     private final Optional<String> clientInfo;
+    private final Map<String, String> customTraceAttributes;
 
     public SessionContext(
             ProtocolHeaders protocolHeaders,
@@ -86,7 +87,8 @@ public class SessionContext
             Map<String, String> preparedStatements,
             Optional<TransactionId> transactionId,
             boolean clientTransactionSupport,
-            Optional<String> clientInfo)
+            Optional<String> clientInfo,
+            Map<String, String> customTraceAttributes)
     {
         this.protocolHeaders = requireNonNull(protocolHeaders, "protocolHeaders is null");
         this.catalog = requireNonNull(catalog, "catalog is null");
@@ -113,6 +115,7 @@ public class SessionContext
         this.transactionId = requireNonNull(transactionId, "transactionId is null");
         this.clientTransactionSupport = clientTransactionSupport;
         this.clientInfo = requireNonNull(clientInfo, "clientInfo is null");
+        this.customTraceAttributes = ImmutableMap.copyOf(requireNonNull(customTraceAttributes, "clientTrackingProperties is null)"));
     }
 
     public ProtocolHeaders getProtocolHeaders()
@@ -230,6 +233,11 @@ public class SessionContext
         return traceToken;
     }
 
+    public Map<String, String> getCustomTraceAttributes()
+    {
+        return customTraceAttributes;
+    }
+
     @VisibleForTesting
     public static SessionContext fromSession(Session session)
     {
@@ -270,6 +278,7 @@ public class SessionContext
                 session.getPreparedStatements(),
                 session.getTransactionId(),
                 session.isClientTransactionSupport(),
-                session.getClientInfo());
+                session.getClientInfo(),
+                session.getCustomTraceAttributes());
     }
 }

--- a/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
+++ b/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
@@ -488,7 +488,8 @@ public class PlanTester
                 sessionPropertyManager,
                 defaultSession.getPreparedStatements(),
                 defaultSession.getProtocolHeaders(),
-                defaultSession.getExchangeEncryptionKey());
+                defaultSession.getExchangeEncryptionKey(),
+                defaultSession.getCustomTraceAttributes());
     }
 
     private static SessionPropertyManager createSessionPropertyManager(

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -5374,7 +5374,8 @@ public abstract class AbstractTestEngineOnlyQueries
                 getQueryRunner().getSessionPropertyManager(),
                 getSession().getPreparedStatements(),
                 getSession().getProtocolHeaders(),
-                getSession().getExchangeEncryptionKey());
+                getSession().getExchangeEncryptionKey(),
+                getSession().getCustomTraceAttributes());
         MaterializedResult result = computeActual(session, "SHOW SESSION");
 
         ImmutableMap<String, MaterializedRow> properties = Maps.uniqueIndex(result.getMaterializedRows(), input -> {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This change is support custom trace attributes for both the `QueryMonitor` logging of completed queries and OpenTelemetry Trace objects for queries.  It has no effect other than the additional information logged for queries that are run on Trino.

The attributes will be printed with a prefix "custom:" so that there will not be a collision with any existing attributes.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

When a query is created, it has an associated `Session`.  This session contains context information regarding the query and additionally is part of the `QueryInfo` object passed to the `QueryMonitor`, which logs information regarding completed queries.  By creating a member in the `Session` (as well as the associated `SessionContext` and `SessionRepresentation`) the custom trace attributes are available downstream in the query lifecycle.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Add custom trace attributes to query session. ({issue}`22178`)
```
