### PR TITLE
Enable warning/error logs from libraries in tests

### DIFF
--- a/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/AccumuloQueryRunner.java
+++ b/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/AccumuloQueryRunner.java
@@ -43,9 +43,9 @@ public final class AccumuloQueryRunner
 {
     static {
         Logging logging = Logging.initialize();
-        logging.setLevel("org.apache.accumulo", Level.OFF);
-        logging.setLevel("org.apache.zookeeper", Level.OFF);
-        logging.setLevel("org.apache.curator", Level.OFF);
+        logging.setLevel("org.apache.accumulo", Level.WARN);
+        logging.setLevel("org.apache.zookeeper", Level.WARN);
+        logging.setLevel("org.apache.curator", Level.WARN);
     }
 
     private static final Logger LOG = Logger.get(AccumuloQueryRunner.class);

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
@@ -64,7 +64,7 @@ public final class BigQueryQueryRunner
 
     static {
         Logging logging = Logging.initialize();
-        logging.setLevel("com.google.cloud.bigquery.storage", Level.OFF);
+        logging.setLevel("com.google.cloud.bigquery.storage", Level.WARN);
     }
 
     private BigQueryQueryRunner() {}

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraQueryRunner.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraQueryRunner.java
@@ -40,7 +40,7 @@ public final class CassandraQueryRunner
 
     static {
         Logging logging = Logging.initialize();
-        logging.setLevel("com.datastax.oss.driver.internal", Level.OFF);
+        logging.setLevel("com.datastax.oss.driver.internal", Level.WARN);
     }
 
     public static Builder builder(CassandraServer server)

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/ClickHouseQueryRunner.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/ClickHouseQueryRunner.java
@@ -37,7 +37,7 @@ public final class ClickHouseQueryRunner
 {
     static {
         Logging logging = Logging.initialize();
-        logging.setLevel("com.clickhouse.jdbc.internal", Level.OFF);
+        logging.setLevel("com.clickhouse.jdbc.internal", Level.WARN);
     }
 
     public static final String TPCH_SCHEMA = "tpch";

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
@@ -46,9 +46,9 @@ public final class DeltaLakeQueryRunner
 {
     static {
         Logging logging = Logging.initialize();
-        logging.setLevel("org.apache.parquet.filter2.compat.FilterCompat", Level.OFF);
-        logging.setLevel("com.amazonaws.util.Base64", Level.OFF);
-        logging.setLevel("com.google.cloud", Level.OFF);
+        logging.setLevel("org.apache.parquet.filter2.compat.FilterCompat", Level.WARN);
+        logging.setLevel("com.amazonaws.util.Base64", Level.WARN);
+        logging.setLevel("com.google.cloud", Level.WARN);
     }
 
     public static final String DELTA_CATALOG = "delta";

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchQueryRunner.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchQueryRunner.java
@@ -51,7 +51,7 @@ public final class ElasticsearchQueryRunner
 
     static {
         Logging logging = Logging.initialize();
-        logging.setLevel("org.elasticsearch.client.RestClient", Level.OFF);
+        logging.setLevel("org.elasticsearch.client.RestClient", Level.WARN);
     }
 
     private static final Logger LOG = Logger.get(ElasticsearchQueryRunner.class);

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/HudiQueryRunner.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/HudiQueryRunner.java
@@ -38,7 +38,7 @@ public final class HudiQueryRunner
 
     static {
         Logging logging = Logging.initialize();
-        logging.setLevel("org.apache.hudi", Level.OFF);
+        logging.setLevel("org.apache.hudi", Level.WARN);
     }
 
     private static final String SCHEMA_NAME = "tests";

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
@@ -62,7 +62,7 @@ public final class IcebergQueryRunner
 
     static {
         Logging logging = Logging.initialize();
-        logging.setLevel("org.apache.iceberg", Level.OFF);
+        logging.setLevel("org.apache.iceberg", Level.WARN);
     }
 
     public static Builder builder()

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/KafkaQueryRunner.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/KafkaQueryRunner.java
@@ -61,7 +61,7 @@ public final class KafkaQueryRunner
 
     static {
         Logging logging = Logging.initialize();
-        logging.setLevel("org.apache.kafka", Level.OFF);
+        logging.setLevel("org.apache.kafka", Level.WARN);
     }
 
     private static final Logger log = Logger.get(KafkaQueryRunner.class);

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/MariaDbQueryRunner.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/MariaDbQueryRunner.java
@@ -35,7 +35,7 @@ public final class MariaDbQueryRunner
 {
     static {
         Logging logging = Logging.initialize();
-        logging.setLevel("org.mariadb.jdbc", Level.OFF);
+        logging.setLevel("org.mariadb.jdbc", Level.WARN);
     }
 
     private static final String TPCH_SCHEMA = "tpch";

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoQueryRunner.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoQueryRunner.java
@@ -41,7 +41,7 @@ public final class MongoQueryRunner
 
     static {
         Logging logging = Logging.initialize();
-        logging.setLevel("org.mongodb.driver", Level.OFF);
+        logging.setLevel("org.mongodb.driver", Level.WARN);
     }
 
     private static final String TPCH_SCHEMA = "tpch";

--- a/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/OpenSearchQueryRunner.java
+++ b/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/OpenSearchQueryRunner.java
@@ -51,7 +51,7 @@ public final class OpenSearchQueryRunner
 
     static {
         Logging logging = Logging.initialize();
-        logging.setLevel("org.opensearch.client.RestClient", Level.OFF);
+        logging.setLevel("org.opensearch.client.RestClient", Level.WARN);
     }
 
     private static final Logger LOG = Logger.get(OpenSearchQueryRunner.class);

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestingPhoenixServer.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestingPhoenixServer.java
@@ -65,7 +65,7 @@ public final class TestingPhoenixServer
         securityLogger = java.util.logging.Logger.getLogger("SecurityLogger.org.apache");
         securityLogger.setLevel(Level.SEVERE);
         // to squelch the SecurityLogger,
-        // instantiate logger with config above before config is overridden again in HBase test franework
+        // instantiate logger with config above before config is overridden again in HBase test framework
         org.apache.commons.logging.LogFactory.getLog("SecurityLogger.org.apache.hadoop.hbase.server");
         this.conf.set("hbase.security.logger", "ERROR");
         this.conf.setInt(MASTER_INFO_PORT, -1);

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/SqlServerQueryRunner.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/SqlServerQueryRunner.java
@@ -39,7 +39,7 @@ public final class SqlServerQueryRunner
 
     static {
         Logging logging = Logging.initialize();
-        logging.setLevel("com.microsoft.sqlserver.jdbc", Level.OFF);
+        logging.setLevel("com.microsoft.sqlserver.jdbc", Level.WARN);
     }
 
     private static final Logger log = Logger.get(SqlServerQueryRunner.class);


### PR DESCRIPTION
Warning and errors are rarely seen by engineers, but still it's better not to hide them, they may (now or in the future) contain some actionable information. When a library over-verbosely logs some warnings/errors, let's suppress these selectively.

Follows https://github.com/trinodb/trino/pull/19676