### PR TITLE
Make scheduling of remote accessible splits with addresses more strict

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/UniformNodeSelector.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/UniformNodeSelector.java
@@ -20,27 +20,19 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.SetMultimap;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.log.Logger;
 import io.trino.execution.NodeTaskMap;
 import io.trino.execution.RemoteTask;
-import io.trino.execution.resourcegroups.IndexedPriorityQueue;
 import io.trino.execution.scheduler.NodeSchedulerConfig.SplitsBalancingPolicy;
 import io.trino.metadata.InternalNode;
 import io.trino.metadata.InternalNodeManager;
 import io.trino.metadata.Split;
-import io.trino.spi.HostAddress;
-import io.trino.spi.SplitWeight;
 import io.trino.spi.TrinoException;
 import jakarta.annotation.Nullable;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -49,7 +41,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.execution.scheduler.NodeScheduler.calculateLowWatermark;
 import static io.trino.execution.scheduler.NodeScheduler.filterNodes;
 import static io.trino.execution.scheduler.NodeScheduler.getAllNodes;
@@ -59,7 +50,6 @@ import static io.trino.execution.scheduler.NodeScheduler.selectExactNodes;
 import static io.trino.execution.scheduler.NodeScheduler.selectNodes;
 import static io.trino.execution.scheduler.NodeScheduler.toWhenHasSplitQueueSpaceFuture;
 import static io.trino.spi.StandardErrorCode.NO_NODES_AVAILABLE;
-import static java.util.Comparator.comparingLong;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -168,47 +158,37 @@ public class UniformNodeSelector
         queueSizeAdjuster.update(existingTasks, assignmentStats);
         Set<InternalNode> blockedExactNodes = new HashSet<>();
         boolean splitWaitingForAnyNode = false;
-        // splitsToBeRedistributed becomes true only when splits go through locality-based assignment
-        boolean splitsToBeRedistributed = false;
-        Set<Split> remainingSplits = new HashSet<>(splits.size());
 
         List<InternalNode> filteredNodes = filterNodes(nodeMap, includeCoordinator, ImmutableSet.of());
         ResettableRandomizedIterator<InternalNode> randomCandidates = new ResettableRandomizedIterator<>(filteredNodes);
         Set<InternalNode> schedulableNodes = new HashSet<>(filteredNodes);
 
-        // optimizedLocalScheduling enables prioritized assignment of splits to local nodes when splits contain locality information
-        if (optimizedLocalScheduling) {
-            for (Split split : splits) {
-                if (split.isRemotelyAccessible() && !split.getAddresses().isEmpty()) {
-                    List<InternalNode> candidateNodes = selectExactNodes(nodeMap, split.getAddresses(), includeCoordinator);
-
-                    Optional<InternalNode> chosenNode = candidateNodes.stream()
-                            .filter(ownerNode -> assignmentStats.getTotalSplitsWeight(ownerNode) < maxSplitsWeightPerNode && assignmentStats.getUnacknowledgedSplitCountForStage(ownerNode) < maxUnacknowledgedSplitsPerTask)
-                            .min(comparingLong(assignmentStats::getTotalSplitsWeight));
-
-                    if (chosenNode.isPresent()) {
-                        assignment.put(chosenNode.get(), split);
-                        assignmentStats.addAssignedSplit(chosenNode.get(), split.getSplitWeight());
-                        splitsToBeRedistributed = true;
-                        continue;
-                    }
-                }
-                remainingSplits.add(split);
-            }
-        }
-        else {
-            remainingSplits = splits;
-        }
-
-        for (Split split : remainingSplits) {
+        for (Split split : splits) {
             randomCandidates.reset();
 
             List<InternalNode> candidateNodes;
+            boolean exactNodes;
             if (!split.isRemotelyAccessible()) {
                 candidateNodes = selectExactNodes(nodeMap, split.getAddresses(), includeCoordinator);
+                exactNodes = true;
             }
             else {
-                candidateNodes = selectNodes(minCandidates, randomCandidates);
+                // optimizedLocalScheduling enables prioritized assignment of splits to local nodes when splits contain locality information
+                if (optimizedLocalScheduling && !split.getAddresses().isEmpty()) {
+                    candidateNodes = selectExactNodes(nodeMap, split.getAddresses(), includeCoordinator);
+                    if (candidateNodes.isEmpty()) {
+                        // choose any other node if preferred node is not available
+                        candidateNodes = selectNodes(minCandidates, randomCandidates);
+                        exactNodes = false;
+                    }
+                    else {
+                        exactNodes = true;
+                    }
+                }
+                else {
+                    candidateNodes = selectNodes(minCandidates, randomCandidates);
+                    exactNodes = false;
+                }
             }
             if (candidateNodes.isEmpty()) {
                 log.debug("No nodes available to schedule %s. Available nodes %s", split, nodeMap.getNodesByHost().keys());
@@ -238,7 +218,7 @@ public class UniformNodeSelector
             }
             else {
                 candidateNodes.forEach(schedulableNodes::remove);
-                if (split.isRemotelyAccessible()) {
+                if (!exactNodes) {
                     splitWaitingForAnyNode = true;
                 }
                 // Exact node set won't matter, if a split is waiting for any node
@@ -261,9 +241,6 @@ public class UniformNodeSelector
             blocked = toWhenHasSplitQueueSpaceFuture(blockedExactNodes, existingTasks, calculateLowWatermark(minPendingSplitsWeightPerTask));
         }
 
-        if (splitsToBeRedistributed) {
-            equateDistribution(assignment, assignmentStats, nodeMap, includeCoordinator);
-        }
         return new SplitPlacementResult(blocked, assignment);
     }
 
@@ -316,129 +293,6 @@ public class UniformNodeSelector
             }
         }
         return freeNodes.build();
-    }
-
-    /**
-     * The method tries to make the distribution of splits more uniform. All nodes are arranged into a maxHeap and a minHeap
-     * based on the number of splits that are assigned to them. Splits are redistributed, one at a time, from a maxNode to a
-     * minNode until we have as uniform a distribution as possible.
-     *
-     * @param assignment the node-splits multimap after the first and the second stage
-     * @param assignmentStats required to obtain info regarding splits assigned to a node outside the current batch of assignment
-     * @param nodeMap to get a list of all nodes to which splits can be assigned
-     */
-    private void equateDistribution(Multimap<InternalNode, Split> assignment, NodeAssignmentStats assignmentStats, NodeMap nodeMap, boolean includeCoordinator)
-    {
-        if (assignment.isEmpty()) {
-            return;
-        }
-
-        Collection<InternalNode> allNodes = nodeMap.getNodesByHostAndPort().values().stream()
-                .filter(node -> includeCoordinator || !nodeMap.getCoordinatorNodeIds().contains(node.getNodeIdentifier()))
-                .collect(toImmutableList());
-
-        if (allNodes.size() < 2) {
-            return;
-        }
-
-        IndexedPriorityQueue<InternalNode> maxNodes = new IndexedPriorityQueue<>();
-        for (InternalNode node : assignment.keySet()) {
-            maxNodes.addOrUpdate(node, assignmentStats.getTotalSplitsWeight(node));
-        }
-
-        IndexedPriorityQueue<InternalNode> minNodes = new IndexedPriorityQueue<>();
-        for (InternalNode node : allNodes) {
-            minNodes.addOrUpdate(node, Long.MAX_VALUE - assignmentStats.getTotalSplitsWeight(node));
-        }
-
-        while (true) {
-            if (maxNodes.isEmpty()) {
-                return;
-            }
-
-            // fetch min and max node
-            InternalNode maxNode = maxNodes.poll();
-            InternalNode minNode = minNodes.poll();
-
-            // Allow some degree of non uniformity when assigning splits to nodes. Usually data distribution
-            // among nodes in a cluster won't be fully uniform (e.g. because hash function with non-uniform
-            // distribution is used like consistent hashing). In such case it makes sense to assign splits to nodes
-            // with data because of potential savings in network throughput and CPU time.
-            // The difference of 5 between node with maximum and minimum splits is a tradeoff between ratio of
-            // misassigned splits and assignment uniformity. Using larger numbers doesn't reduce the number of
-            // misassigned splits greatly (in absolute values).
-            if (assignmentStats.getTotalSplitsWeight(maxNode) - assignmentStats.getTotalSplitsWeight(minNode) <= SplitWeight.rawValueForStandardSplitCount(5)) {
-                return;
-            }
-
-            // move split from max to min
-            Split redistributed = redistributeSplit(assignment, maxNode, minNode, nodeMap.getNodesByHost());
-            assignmentStats.removeAssignedSplit(maxNode, redistributed.getSplitWeight());
-            assignmentStats.addAssignedSplit(minNode, redistributed.getSplitWeight());
-
-            // add max back into maxNodes only if it still has assignments
-            if (assignment.containsKey(maxNode)) {
-                maxNodes.addOrUpdate(maxNode, assignmentStats.getTotalSplitsWeight(maxNode));
-            }
-
-            // Add or update both the Priority Queues with the updated node priorities
-            maxNodes.addOrUpdate(minNode, assignmentStats.getTotalSplitsWeight(minNode));
-            minNodes.addOrUpdate(minNode, Long.MAX_VALUE - assignmentStats.getTotalSplitsWeight(minNode));
-            minNodes.addOrUpdate(maxNode, Long.MAX_VALUE - assignmentStats.getTotalSplitsWeight(maxNode));
-        }
-    }
-
-    /**
-     * The method selects and removes a split from the fromNode and assigns it to the toNode. There is an attempt to
-     * redistribute a Non-local split if possible. This case is possible when there are multiple queries running
-     * simultaneously. If a Non-local split cannot be found in the maxNode, any split is selected randomly and reassigned.
-     */
-    @VisibleForTesting
-    public static Split redistributeSplit(Multimap<InternalNode, Split> assignment, InternalNode fromNode, InternalNode toNode, SetMultimap<InetAddress, InternalNode> nodesByHost)
-    {
-        Iterator<Split> splitIterator = assignment.get(fromNode).iterator();
-        Split splitToBeRedistributed = null;
-        while (splitIterator.hasNext()) {
-            Split split = splitIterator.next();
-            // Try to select non-local split for redistribution
-            if (!split.getAddresses().isEmpty() && !isSplitLocal(split.getAddresses(), fromNode.getHostAndPort(), nodesByHost)) {
-                splitToBeRedistributed = split;
-                break;
-            }
-        }
-        // Select any split if maxNode has no non-local splits in the current batch of assignment
-        if (splitToBeRedistributed == null) {
-            splitIterator = assignment.get(fromNode).iterator();
-            splitToBeRedistributed = splitIterator.next();
-        }
-        splitIterator.remove();
-        assignment.put(toNode, splitToBeRedistributed);
-        return splitToBeRedistributed;
-    }
-
-    /**
-     * Helper method to determine if a split is local to a node irrespective of whether splitAddresses contain port information or not
-     */
-    private static boolean isSplitLocal(List<HostAddress> splitAddresses, HostAddress nodeAddress, SetMultimap<InetAddress, InternalNode> nodesByHost)
-    {
-        for (HostAddress address : splitAddresses) {
-            if (nodeAddress.equals(address)) {
-                return true;
-            }
-            InetAddress inetAddress;
-            try {
-                inetAddress = address.toInetAddress();
-            }
-            catch (UnknownHostException e) {
-                continue;
-            }
-            if (!address.hasPort()) {
-                Set<InternalNode> localNodes = nodesByHost.get(inetAddress);
-                return localNodes.stream()
-                        .anyMatch(node -> node.getHostAndPort().equals(nodeAddress));
-            }
-        }
-        return false;
     }
 
     static class QueueSizeAdjuster

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/ArbitraryDistributionSplitAssigner.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/ArbitraryDistributionSplitAssigner.java
@@ -28,6 +28,7 @@ import io.trino.split.RemoteSplit;
 import io.trino.sql.planner.plan.PlanNodeId;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -64,7 +65,7 @@ class ArbitraryDistributionSplitAssigner
     private long targetPartitionSizeInBytes;
     private long roundedTargetPartitionSizeInBytes;
     private final List<PartitionAssignment> allAssignments = new ArrayList<>();
-    private final Map<Optional<HostAddress>, PartitionAssignment> openAssignments = new HashMap<>();
+    private final Map<NodeRequirements, PartitionAssignment> openAssignments = new HashMap<>();
 
     private final Set<PlanNodeId> completedSources = new HashSet<>();
 
@@ -153,7 +154,7 @@ class ArbitraryDistributionSplitAssigner
             if (allAssignments.isEmpty()) {
                 // at least a single partition is expected to be created
                 allAssignments.add(new PartitionAssignment(0));
-                assignment.addPartition(new Partition(0, new NodeRequirements(catalogRequirement, ImmutableSet.of())));
+                assignment.addPartition(new Partition(0, new NodeRequirements(catalogRequirement, ImmutableSet.of(), true)));
                 for (PlanNodeId replicatedSourceId : replicatedSources) {
                     assignment.updatePartition(new PartitionUpdate(
                             0,
@@ -208,8 +209,8 @@ class ArbitraryDistributionSplitAssigner
         AssignmentResult.Builder assignment = AssignmentResult.builder();
 
         for (Split split : splits) {
-            Optional<HostAddress> hostRequirement = getHostRequirement(split);
-            PartitionAssignment partitionAssignment = openAssignments.get(hostRequirement);
+            NodeRequirements nodeRequirements = getNodeRequirements(split);
+            PartitionAssignment partitionAssignment = openAssignments.get(nodeRequirements);
             long splitSizeInBytes = getSplitSizeInBytes(split);
             if (partitionAssignment != null && ((partitionAssignment.getAssignedDataSizeInBytes() + splitSizeInBytes > roundedTargetPartitionSizeInBytes)
                     || (partitionAssignment.getAssignedSplitCount() + 1 > maxTaskSplitCount))) {
@@ -226,7 +227,7 @@ class ArbitraryDistributionSplitAssigner
                     assignment.sealPartition(partitionAssignment.getPartitionId());
                 }
                 partitionAssignment = null;
-                openAssignments.remove(hostRequirement);
+                openAssignments.remove(nodeRequirements);
 
                 adaptiveCounter++;
                 if (adaptiveCounter >= adaptiveGrowthPeriod) {
@@ -240,10 +241,10 @@ class ArbitraryDistributionSplitAssigner
             if (partitionAssignment == null) {
                 partitionAssignment = new PartitionAssignment(nextPartitionId++);
                 allAssignments.add(partitionAssignment);
-                openAssignments.put(hostRequirement, partitionAssignment);
+                openAssignments.put(nodeRequirements, partitionAssignment);
                 assignment.addPartition(new Partition(
                         partitionAssignment.getPartitionId(),
-                        new NodeRequirements(catalogRequirement, hostRequirement.map(ImmutableSet::of).orElseGet(ImmutableSet::of))));
+                        nodeRequirements));
 
                 for (PlanNodeId replicatedSourceId : replicatedSources) {
                     assignment.updatePartition(new PartitionUpdate(
@@ -271,7 +272,7 @@ class ArbitraryDistributionSplitAssigner
             if (allAssignments.isEmpty()) {
                 // at least a single partition is expected to be created
                 allAssignments.add(new PartitionAssignment(0));
-                assignment.addPartition(new Partition(0, new NodeRequirements(catalogRequirement, ImmutableSet.of())));
+                assignment.addPartition(new Partition(0, new NodeRequirements(catalogRequirement, ImmutableSet.of(), true)));
                 for (PlanNodeId replicatedSourceId : replicatedSources) {
                     assignment.updatePartition(new PartitionUpdate(
                             0,
@@ -341,30 +342,37 @@ class ArbitraryDistributionSplitAssigner
                 .toString();
     }
 
-    private Optional<HostAddress> getHostRequirement(Split split)
+    /**
+     * Ranks the desirability of selecting a node for the next split assignment.  Lower is better.
+     */
+    private long rank(HostAddress address)
     {
-        if (split.getConnectorSplit().isRemotelyAccessible()) {
-            return Optional.empty();
+        // The node-to-split map can have two entries for this address: one for remotely accessible splits and one for non remotely accessible splits.
+        PartitionAssignment flexEntry = openAssignments.get(new NodeRequirements(catalogRequirement, ImmutableSet.of(address), true));
+        PartitionAssignment rigidEntry = openAssignments.get(new NodeRequirements(catalogRequirement, ImmutableSet.of(address), false));
+        if (flexEntry == null && rigidEntry == null) {
+            return -1; // Most desirable: an unassigned node.
         }
-        List<HostAddress> addresses = split.getAddresses();
-        checkArgument(!addresses.isEmpty(), "split is not remotely accessible but the list of hosts is empty: %s", split);
-        HostAddress selectedAddress = null;
-        long selectedAssignmentDataSize = Long.MAX_VALUE;
-        for (HostAddress address : addresses) {
-            PartitionAssignment assignment = openAssignments.get(Optional.of(address));
-            if (assignment == null) {
-                // prioritize unused addresses
-                selectedAddress = address;
-                break;
-            }
-            if (assignment.getAssignedDataSizeInBytes() < selectedAssignmentDataSize) {
-                // otherwise prioritize the smallest assignment
-                selectedAddress = address;
-                selectedAssignmentDataSize = assignment.getAssignedDataSizeInBytes();
-            }
+        // The more data assigned to this node, the less desirable it is.
+        if (flexEntry == null) {
+            return rigidEntry.getAssignedDataSizeInBytes();
         }
-        verify(selectedAddress != null, "selectedAddress is null");
-        return Optional.of(selectedAddress);
+        if (rigidEntry == null) {
+            return flexEntry.getAssignedDataSizeInBytes();
+        }
+        return flexEntry.getAssignedDataSizeInBytes() + rigidEntry.getAssignedDataSizeInBytes();
+    }
+
+    private NodeRequirements getNodeRequirements(Split split)
+    {
+        if (split.getAddresses().isEmpty()) {
+            checkArgument(split.isRemotelyAccessible(), "split is not remotely accessible but the list of hosts is empty: %s", split);
+            return new NodeRequirements(catalogRequirement, ImmutableSet.of(), true);
+        }
+        HostAddress selectedAddress = split.getAddresses().stream()
+                .min(Comparator.comparing(this::rank))
+                .orElseThrow();
+        return new NodeRequirements(catalogRequirement, ImmutableSet.of(selectedAddress), split.isRemotelyAccessible());
     }
 
     private long getSplitSizeInBytes(Split split)

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/HashDistributionSplitAssigner.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/HashDistributionSplitAssigner.java
@@ -139,7 +139,7 @@ class HashDistributionSplitAssigner
                                 .orElse(ImmutableSet.of());
                         assignment.addPartition(new Partition(
                                 taskPartitionId,
-                                new NodeRequirements(catalogRequirement, hostRequirement)));
+                                new NodeRequirements(catalogRequirement, hostRequirement, hostRequirement.isEmpty())));
                         createdTaskPartitions.add(taskPartitionId);
                     }
                 }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/NodeRequirements.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/NodeRequirements.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
@@ -33,11 +34,14 @@ public class NodeRequirements
 
     private final Optional<CatalogHandle> catalogHandle;
     private final Set<HostAddress> addresses;
+    private final boolean remotelyAccessible;
 
-    public NodeRequirements(Optional<CatalogHandle> catalogHandle, Set<HostAddress> addresses)
+    public NodeRequirements(Optional<CatalogHandle> catalogHandle, Set<HostAddress> addresses, boolean remotelyAccessible)
     {
+        checkArgument(remotelyAccessible || !addresses.isEmpty(), "addresses is empty and node is not remotely accessible");
         this.catalogHandle = requireNonNull(catalogHandle, "catalogHandle is null");
         this.addresses = ImmutableSet.copyOf(requireNonNull(addresses, "addresses is null"));
+        this.remotelyAccessible = remotelyAccessible;
     }
 
     /*
@@ -56,6 +60,11 @@ public class NodeRequirements
         return addresses;
     }
 
+    public boolean isRemotelyAccessible()
+    {
+        return remotelyAccessible;
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -66,13 +75,15 @@ public class NodeRequirements
             return false;
         }
         NodeRequirements that = (NodeRequirements) o;
-        return Objects.equals(catalogHandle, that.catalogHandle) && Objects.equals(addresses, that.addresses);
+        return Objects.equals(catalogHandle, that.catalogHandle)
+                && Objects.equals(addresses, that.addresses)
+                && remotelyAccessible == that.remotelyAccessible;
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(catalogHandle, addresses);
+        return Objects.hash(catalogHandle, addresses, remotelyAccessible);
     }
 
     @Override
@@ -81,6 +92,7 @@ public class NodeRequirements
         return toStringHelper(this)
                 .add("catalogHandle", catalogHandle)
                 .add("addresses", addresses)
+                .add("remotelyAccessible", remotelyAccessible)
                 .toString();
     }
 

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/SingleDistributionSplitAssigner.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/SingleDistributionSplitAssigner.java
@@ -49,7 +49,7 @@ class SingleDistributionSplitAssigner
         AssignmentResult.Builder assignment = AssignmentResult.builder();
         if (!partitionAdded) {
             partitionAdded = true;
-            assignment.addPartition(new Partition(0, new NodeRequirements(Optional.empty(), hostRequirement)));
+            assignment.addPartition(new Partition(0, new NodeRequirements(Optional.empty(), hostRequirement, hostRequirement.isEmpty())));
             assignment.setNoMorePartitions();
         }
         if (!splits.isEmpty()) {
@@ -83,7 +83,7 @@ class SingleDistributionSplitAssigner
         if (!partitionAdded) {
             partitionAdded = true;
             result
-                    .addPartition(new Partition(0, new NodeRequirements(Optional.empty(), hostRequirement)))
+                    .addPartition(new Partition(0, new NodeRequirements(Optional.empty(), hostRequirement, hostRequirement.isEmpty())))
                     .sealPartition(0)
                     .setNoMorePartitions();
         }

--- a/core/trino-main/src/test/java/io/trino/execution/TestNodeScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestNodeScheduler.java
@@ -14,16 +14,13 @@
 package io.trino.execution;
 
 import com.google.common.base.Splitter;
-import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
-import com.google.common.hash.Hashing;
 import io.trino.Session;
 import io.trino.SystemSessionProperties;
 import io.trino.client.NodeVersion;
@@ -36,7 +33,6 @@ import io.trino.execution.scheduler.NodeSelectorFactory;
 import io.trino.execution.scheduler.SplitPlacementResult;
 import io.trino.execution.scheduler.TopologyAwareNodeSelectorConfig;
 import io.trino.execution.scheduler.TopologyAwareNodeSelectorFactory;
-import io.trino.execution.scheduler.UniformNodeSelector;
 import io.trino.execution.scheduler.UniformNodeSelectorFactory;
 import io.trino.metadata.InMemoryNodeManager;
 import io.trino.metadata.InternalNode;
@@ -55,9 +51,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.parallel.Execution;
 
-import java.net.InetAddress;
 import java.net.URI;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -66,7 +60,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -79,7 +72,6 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
 import static io.airlift.slice.SizeOf.instanceSize;
-import static io.airlift.testing.Assertions.assertLessThanOrEqual;
 import static io.trino.spi.StandardErrorCode.NO_NODES_AVAILABLE;
 import static io.trino.testing.TestingHandles.TEST_CATALOG_HANDLE;
 import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
@@ -90,6 +82,7 @@ import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
 import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
@@ -161,7 +154,7 @@ public class TestNodeScheduler
         Set<Split> splits = new HashSet<>();
         splits.add(new Split(TEST_CATALOG_HANDLE, new TestSplitRemote()));
 
-        assertTrinoExceptionThrownBy(() -> nodeSelector.computeAssignments(splits, ImmutableList.copyOf(taskMap.values())))
+        assertTrinoExceptionThrownBy(() -> computeSingleAssignment(nodeSelector, new Split(TEST_CATALOG_HANDLE, new TestSplitRemote())))
                 .hasErrorCode(NO_NODES_AVAILABLE)
                 .hasMessageMatching("No nodes available to run query");
     }
@@ -171,9 +164,7 @@ public class TestNodeScheduler
     {
         setUpNodes();
         Split split = new Split(TEST_CATALOG_HANDLE, new TestSplitLocallyAccessible());
-        Set<Split> splits = ImmutableSet.of(split);
-
-        Map.Entry<InternalNode, Split> assignment = getOnlyElement(nodeSelector.computeAssignments(splits, ImmutableList.copyOf(taskMap.values())).getAssignments().entries());
+        Map.Entry<InternalNode, Split> assignment = getOnlyElement(computeSingleAssignment(nodeSelector, split).entries());
         assertThat(assignment.getKey().getHostAndPort()).isEqualTo(split.getAddresses().get(0));
         assertThat(assignment.getValue()).isEqualTo(split);
     }
@@ -293,7 +284,7 @@ public class TestNodeScheduler
         setUpNodes();
         Set<Split> splits = new HashSet<>();
         splits.add(new Split(TEST_CATALOG_HANDLE, new TestSplitRemote()));
-        Multimap<InternalNode, Split> assignments = nodeSelector.computeAssignments(splits, ImmutableList.copyOf(taskMap.values())).getAssignments();
+        Multimap<InternalNode, Split> assignments = computeSingleAssignment(nodeSelector, new Split(TEST_CATALOG_HANDLE, new TestSplitRemote()));
         assertThat(assignments.size()).isEqualTo(1);
     }
 
@@ -478,88 +469,6 @@ public class TestNodeScheduler
     }
 
     @Test
-    public void testPrioritizedAssignmentOfLocalSplit()
-    {
-        InternalNode node = new InternalNode("node1", URI.create("http://10.0.0.1:11"), NodeVersion.UNKNOWN, false);
-        nodeManager.addNodes(node);
-
-        // Check for Split assignments till maxSplitsPerNode (20)
-        Set<Split> splits = new LinkedHashSet<>();
-        // 20 splits with node1 as a non-local node to be assigned in the second iteration of computeAssignments
-        for (int i = 0; i < 20; i++) {
-            splits.add(new Split(TEST_CATALOG_HANDLE, new TestSplitRemote()));
-        }
-        // computeAssignments just returns a mapping of nodes with splits to be assigned, it does not assign splits
-        Multimap<InternalNode, Split> initialAssignment = nodeSelector.computeAssignments(splits, ImmutableList.copyOf(taskMap.values())).getAssignments();
-        // Check that all splits are being assigned to node1
-        assertThat(initialAssignment.size()).isEqualTo(20);
-        assertThat(initialAssignment.keySet().size()).isEqualTo(1);
-        assertThat(initialAssignment.keySet()).contains(node);
-
-        // Check for assignment of splits beyond maxSplitsPerNode (2 splits should remain unassigned)
-        // 1 split with node1 as local node
-        splits.add(new Split(TEST_CATALOG_HANDLE, new TestSplitLocal()));
-        // 1 split with node1 as a non-local node
-        splits.add(new Split(TEST_CATALOG_HANDLE, new TestSplitRemote()));
-        //splits now contains 22 splits : 1 with node1 as local node and 21 with node1 as a non-local node
-        Multimap<InternalNode, Split> finalAssignment = nodeSelector.computeAssignments(splits, ImmutableList.copyOf(taskMap.values())).getAssignments();
-        // Check that only 20 splits are being assigned as there is a single task
-        assertThat(finalAssignment.size()).isEqualTo(20);
-        assertThat(finalAssignment.keySet().size()).isEqualTo(1);
-        assertThat(finalAssignment.keySet()).contains(node);
-
-        // When optimized-local-scheduling is enabled, the split with node1 as local node should be assigned
-        long countLocalSplits = finalAssignment.values().stream()
-                .map(Split::getConnectorSplit)
-                .filter(TestSplitLocal.class::isInstance)
-                .count();
-        assertThat(countLocalSplits).isEqualTo(1);
-    }
-
-    @Test
-    public void testAssignmentWhenMixedSplits()
-    {
-        InternalNode node = new InternalNode("node1", URI.create("http://10.0.0.1:11"), NodeVersion.UNKNOWN, false);
-        nodeManager.addNodes(node);
-
-        // Check for Split assignments till maxSplitsPerNode (20)
-        Set<Split> splits = new LinkedHashSet<>();
-        // 10 splits with node1 as local node to be assigned in the first iteration of computeAssignments
-        for (int i = 0; i < 10; i++) {
-            splits.add(new Split(TEST_CATALOG_HANDLE, new TestSplitLocal()));
-        }
-        // 10 splits with node1 as a non-local node to be assigned in the second iteration of computeAssignments
-        for (int i = 0; i < 10; i++) {
-            splits.add(new Split(TEST_CATALOG_HANDLE, new TestSplitRemote()));
-        }
-        // computeAssignments just returns a mapping of nodes with splits to be assigned, it does not assign splits
-        Multimap<InternalNode, Split> initialAssignment = nodeSelector.computeAssignments(splits, ImmutableList.copyOf(taskMap.values())).getAssignments();
-        // Check that all splits are being assigned to node1
-        assertThat(initialAssignment.size()).isEqualTo(20);
-        assertThat(initialAssignment.keySet().size()).isEqualTo(1);
-        assertThat(initialAssignment.keySet()).contains(node);
-
-        // Check for assignment of splits beyond maxSplitsPerNode (2 splits should remain unassigned)
-        // 1 split with node1 as local node
-        splits.add(new Split(TEST_CATALOG_HANDLE, new TestSplitLocal()));
-        // 1 split with node1 as a non-local node
-        splits.add(new Split(TEST_CATALOG_HANDLE, new TestSplitRemote()));
-        //splits now contains 22 splits : 11 with node1 as local node and 11 with node1 as a non-local node
-        Multimap<InternalNode, Split> finalAssignment = nodeSelector.computeAssignments(splits, ImmutableList.copyOf(taskMap.values())).getAssignments();
-        // Check that only 20 splits are being assigned as there is a single task
-        assertThat(finalAssignment.size()).isEqualTo(20);
-        assertThat(finalAssignment.keySet().size()).isEqualTo(1);
-        assertThat(finalAssignment.keySet()).contains(node);
-
-        // When optimized-local-scheduling is enabled, all 11 splits with node1 as local node should be assigned
-        long countLocalSplits = finalAssignment.values().stream()
-                .map(Split::getConnectorSplit)
-                .filter(TestSplitLocal.class::isInstance)
-                .count();
-        assertThat(countLocalSplits).isEqualTo(11);
-    }
-
-    @Test
     public void testOptimizedLocalScheduling()
     {
         InternalNode node1 = new InternalNode("node1", URI.create("http://10.0.0.1:11"), NodeVersion.UNKNOWN, false);
@@ -576,9 +485,8 @@ public class TestNodeScheduler
         Multimap<InternalNode, Split> assignments1 = nodeSelector.computeAssignments(splits, ImmutableList.copyOf(taskMap.values())).getAssignments();
         // Check that all 20 splits are being assigned to node1 as optimized-local-scheduling is enabled
         assertThat(assignments1.size()).isEqualTo(20);
-        assertThat(assignments1.keySet().size()).isEqualTo(2);
+        assertThat(assignments1.keySet().size()).isEqualTo(1);
         assertThat(assignments1.keySet()).contains(node1);
-        assertThat(assignments1.keySet()).contains(node2);
 
         // 19 splits with node2 as local node to be assigned in the first iteration of computeAssignments
         for (int i = 0; i < 19; i++) {
@@ -629,187 +537,6 @@ public class TestNodeScheduler
                 .filter(TestSplitRemote.class::isInstance)
                 .count();
         assertThat(node2Splits).isEqualTo(20);
-    }
-
-    @Test
-    public void testEquateDistribution()
-    {
-        InternalNode node1 = new InternalNode("node1", URI.create("http://10.0.0.1:11"), NodeVersion.UNKNOWN, false);
-        nodeManager.addNodes(node1);
-        InternalNode node2 = new InternalNode("node2", URI.create("http://10.0.0.1:12"), NodeVersion.UNKNOWN, false);
-        nodeManager.addNodes(node2);
-        InternalNode node3 = new InternalNode("node3", URI.create("http://10.0.0.1:13"), NodeVersion.UNKNOWN, false);
-        nodeManager.addNodes(node3);
-        InternalNode node4 = new InternalNode("node4", URI.create("http://10.0.0.1:14"), NodeVersion.UNKNOWN, false);
-        nodeManager.addNodes(node4);
-
-        Set<Split> splits = new LinkedHashSet<>();
-        // 20 splits with node1 as local node to be assigned in the first iteration of computeAssignments
-        for (int i = 0; i < 20; i++) {
-            splits.add(new Split(TEST_CATALOG_HANDLE, new TestSplitLocal()));
-        }
-        // check that splits are divided uniformly across all nodes
-        Multimap<InternalNode, Split> assignment = nodeSelector.computeAssignments(splits, ImmutableList.copyOf(taskMap.values())).getAssignments();
-        assertThat(assignment.size()).isEqualTo(20);
-        assertThat(assignment.keySet().size()).isEqualTo(4);
-        assertThat(assignment.get(node1).size()).isEqualTo(8);
-        assertThat(assignment.get(node2).size()).isEqualTo(4);
-        assertThat(assignment.get(node3).size()).isEqualTo(4);
-        assertThat(assignment.get(node4).size()).isEqualTo(4);
-    }
-
-    @Test
-    public void testEquateDistributionConsistentHashing()
-    {
-        testEquateDistributionConsistentHashing(5, 10, 0.00);
-        testEquateDistributionConsistentHashing(5, 20, 0.055);
-        testEquateDistributionConsistentHashing(10, 50, 0.00);
-        testEquateDistributionConsistentHashing(10, 100, 0.045);
-        testEquateDistributionConsistentHashing(10, 200, 0.090);
-        testEquateDistributionConsistentHashing(50, 550, 0.045);
-        testEquateDistributionConsistentHashing(50, 600, 0.047);
-        testEquateDistributionConsistentHashing(50, 700, 0.045);
-        testEquateDistributionConsistentHashing(100, 550, 0.036);
-        testEquateDistributionConsistentHashing(100, 600, 0.054);
-        testEquateDistributionConsistentHashing(100, 1000, 0.039);
-        testEquateDistributionConsistentHashing(100, 1500, 0.045);
-    }
-
-    private void testEquateDistributionConsistentHashing(int numberOfNodes, int numberOfSplits, double misassignedSplitsRatio)
-    {
-        setUp();
-
-        ImmutableList.Builder<InternalNode> nodesBuilder = ImmutableList.builder();
-        for (int i = 0; i < numberOfNodes; ++i) {
-            InternalNode node = new InternalNode("node" + i, URI.create("http://10.0.0.1:" + (i + 10)), NodeVersion.UNKNOWN, false);
-            nodesBuilder.add(node);
-            nodeManager.addNodes(node);
-        }
-        List<InternalNode> nodes = nodesBuilder.build();
-
-        Set<Split> splits = new LinkedHashSet<>();
-        Random random = new Random(0);
-        ImmutableSetMultimap.Builder<InternalNode, Split> originalAssignmentBuilder = ImmutableSetMultimap.builder();
-        // assign splits randomly according to consistent hashing
-        for (int i = 0; i < numberOfSplits; i++) {
-            InternalNode node = nodes.get(Hashing.consistentHash(random.nextInt(), nodes.size()));
-            Split split = new Split(TEST_CATALOG_HANDLE, new TestSplitLocal(node.getHostAndPort()));
-            splits.add(split);
-            originalAssignmentBuilder.put(node, split);
-        }
-
-        Multimap<Split, InternalNode> originalNodeAssignment = originalAssignmentBuilder.build().inverse();
-        Multimap<InternalNode, Split> assignment = nodeSelector.computeAssignments(splits, ImmutableList.copyOf(taskMap.values())).getAssignments();
-        Multimap<Split, InternalNode> nodeAssignment = ImmutableSetMultimap.copyOf(assignment).inverse();
-
-        int misassignedSplits = 0;
-        for (Split split : splits) {
-            if (!getOnlyElement(originalNodeAssignment.get(split)).equals(getOnlyElement(nodeAssignment.get(split)))) {
-                misassignedSplits++;
-            }
-        }
-
-        assertLessThanOrEqual((double) misassignedSplits / numberOfSplits, misassignedSplitsRatio);
-    }
-
-    @Test
-    public void testRedistributeSplit()
-    {
-        InternalNode node1 = new InternalNode("node1", URI.create("http://10.0.0.1:11"), NodeVersion.UNKNOWN, false);
-        nodeManager.addNodes(node1);
-        InternalNode node2 = new InternalNode("node2", URI.create("http://10.0.0.1:12"), NodeVersion.UNKNOWN, false);
-        nodeManager.addNodes(node2);
-
-        Multimap<InternalNode, Split> assignment = HashMultimap.create();
-
-        Set<Split> splitsAssignedToNode1 = new LinkedHashSet<>();
-        // Node1 to be assigned 12 splits out of which 6 are local to it
-        for (int i = 0; i < 6; i++) {
-            splitsAssignedToNode1.add(new Split(TEST_CATALOG_HANDLE, new TestSplitLocal()));
-            splitsAssignedToNode1.add(new Split(TEST_CATALOG_HANDLE, new TestSplitRemote()));
-        }
-        for (Split split : splitsAssignedToNode1) {
-            assignment.put(node1, split);
-        }
-
-        Set<Split> splitsAssignedToNode2 = new LinkedHashSet<>();
-        // Node2 to be assigned 10 splits
-        for (int i = 0; i < 10; i++) {
-            splitsAssignedToNode2.add(new Split(TEST_CATALOG_HANDLE, new TestSplitRemote()));
-        }
-        for (Split split : splitsAssignedToNode2) {
-            assignment.put(node2, split);
-        }
-
-        assertThat(assignment.get(node1).size()).isEqualTo(12);
-        assertThat(assignment.get(node2).size()).isEqualTo(10);
-
-        ImmutableSetMultimap.Builder<InetAddress, InternalNode> nodesByHost = ImmutableSetMultimap.builder();
-        try {
-            nodesByHost.put(node1.getInternalAddress(), node1);
-            nodesByHost.put(node2.getInternalAddress(), node2);
-        }
-        catch (UnknownHostException e) {
-            System.out.println("Could not convert the address");
-        }
-
-        // Redistribute 1 split from Node 1 to Node 2
-        UniformNodeSelector.redistributeSplit(assignment, node1, node2, nodesByHost.build());
-
-        assertThat(assignment.get(node1).size()).isEqualTo(11);
-        assertThat(assignment.get(node2).size()).isEqualTo(11);
-
-        Set<Split> redistributedSplit = Sets.difference(new HashSet<>(assignment.get(node2)), splitsAssignedToNode2);
-        assertThat(redistributedSplit.size()).isEqualTo(1);
-
-        // Assert that the redistributed split is not a local split in Node 1. This test ensures that redistributeSingleSplit() prioritizes the transfer of a non-local split
-        assertThat(redistributedSplit.iterator().next().getConnectorSplit() instanceof TestSplitRemote).isTrue();
-    }
-
-    @Test
-    public void testEmptyAssignmentWithFullNodes()
-    {
-        InternalNode node1 = new InternalNode("node1", URI.create("http://10.0.0.1:11"), NodeVersion.UNKNOWN, false);
-        nodeManager.addNodes(node1);
-        InternalNode node2 = new InternalNode("node2", URI.create("http://10.0.0.1:12"), NodeVersion.UNKNOWN, false);
-        nodeManager.addNodes(node2);
-
-        Set<Split> splits = new LinkedHashSet<>();
-        // 20 splits with node1 as local node to be assigned in the first iteration of computeAssignments
-        for (int i = 0; i < (20 + 10 + 5) * 2; i++) {
-            splits.add(new Split(TEST_CATALOG_HANDLE, new TestSplitLocal()));
-        }
-        // computeAssignments just returns a mapping of nodes with splits to be assigned, it does not assign splits
-        Multimap<InternalNode, Split> assignments1 = nodeSelector.computeAssignments(splits, ImmutableList.copyOf(taskMap.values())).getAssignments();
-        assertThat(assignments1.size()).isEqualTo(40);
-        assertThat(assignments1.keySet().size()).isEqualTo(2);
-        assertThat(assignments1.get(node1).size()).isEqualTo(20);
-        assertThat(assignments1.get(node2).size()).isEqualTo(20);
-        MockRemoteTaskFactory remoteTaskFactory = new MockRemoteTaskFactory(remoteTaskExecutor, remoteTaskScheduledExecutor);
-        int task = 0;
-        for (InternalNode node : assignments1.keySet()) {
-            TaskId taskId = new TaskId(new StageId("test", 1), task, 0);
-            task++;
-            MockRemoteTaskFactory.MockRemoteTask remoteTask = remoteTaskFactory.createTableScanTask(taskId, node, ImmutableList.copyOf(assignments1.get(node)), nodeTaskMap.createPartitionedSplitCountTracker(node, taskId));
-            remoteTask.startSplits(15); // 15 running, 5 queued, no maxSplitWeightPerTask adjustment
-            nodeTaskMap.addTask(node, remoteTask);
-            taskMap.put(node, remoteTask);
-        }
-        Set<Split> unassignedSplits = Sets.difference(splits, new HashSet<>(assignments1.values()));
-        assertThat(unassignedSplits.size()).isEqualTo(30);
-
-        Multimap<InternalNode, Split> assignments2 = nodeSelector.computeAssignments(unassignedSplits, ImmutableList.copyOf(taskMap.values())).getAssignments();
-        for (InternalNode node : assignments2.keySet()) {
-            RemoteTask remoteTask = taskMap.get(node);
-            remoteTask.addSplits(ImmutableMultimap.<PlanNodeId, Split>builder()
-                    .putAll(new PlanNodeId("sourceId"), assignments2.get(node))
-                    .build());
-        }
-        unassignedSplits = Sets.difference(unassignedSplits, new HashSet<>(assignments2.values()));
-        assertThat(unassignedSplits.size()).isEqualTo(20); // 30 (unassignedSplits) - (10 (maxPendingSplitsPerTask) - 5(queued)) * 2 (nodes))
-
-        Multimap<InternalNode, Split> assignments3 = nodeSelector.computeAssignments(unassignedSplits, ImmutableList.copyOf(taskMap.values())).getAssignments();
-        assertThat(assignments3.isEmpty()).isTrue();
     }
 
     @Test
@@ -871,6 +598,31 @@ public class TestNodeScheduler
         assertThat(splitPlacements.getAssignments().keySet().containsAll(nodes)).isTrue();
     }
 
+    @Test
+    @Timeout(60)
+    public void testTopologyAwareFailover()
+    {
+        nodeManager = new InMemoryNodeManager(
+                new InternalNode("node1", URI.create("http://host1.rack1:11"), NodeVersion.UNKNOWN, false),
+                new InternalNode("node2", URI.create("http://host2.rack1:12"), NodeVersion.UNKNOWN, false),
+                new InternalNode("node3", URI.create("http://host3.rack2:13"), NodeVersion.UNKNOWN, false));
+        NodeSelectorFactory nodeSelectorFactory = new TopologyAwareNodeSelectorFactory(
+                new TestNetworkTopology(), nodeManager, nodeSchedulerConfig, nodeTaskMap, getNetworkTopologyConfig());
+        NodeScheduler nodeScheduler = new NodeScheduler(nodeSelectorFactory);
+        NodeSelector nodeSelector = nodeScheduler.createNodeSelector(session, Optional.of(TEST_CATALOG_HANDLE));
+
+        Split rigidSplit = new Split(TEST_CATALOG_HANDLE, new TestSplitLocal(HostAddress.fromString("host99.rack1:11")));
+        assertThatThrownBy(() -> computeSingleAssignment(nodeSelector, rigidSplit)).hasMessageContaining("No nodes available");
+
+        Split flexibleSplit = new Split(TEST_CATALOG_HANDLE, new TestSplitRemote(HostAddress.fromString("host99.rack1:11")));
+        org.assertj.guava.api.Assertions.assertThat(computeSingleAssignment(nodeSelector, flexibleSplit)).containsValues(flexibleSplit);
+    }
+
+    private Multimap<InternalNode, Split> computeSingleAssignment(NodeSelector nodeSelector, Split split)
+    {
+        return nodeSelector.computeAssignments(ImmutableSet.of(split), ImmutableList.copyOf(taskMap.values())).getAssignments();
+    }
+
     private static Session sessionWithMaxUnacknowledgedSplitsPerTask(int maxUnacknowledgedSplitsPerTask)
     {
         return TestingSession.testSessionBuilder()
@@ -905,7 +657,7 @@ public class TestNodeScheduler
         @Override
         public boolean isRemotelyAccessible()
         {
-            return true;
+            return false;
         }
 
         @Override

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestArbitraryDistributionSplitAssigner.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestArbitraryDistributionSplitAssigner.java
@@ -357,6 +357,17 @@ public class TestArbitraryDistributionSplitAssigner
                         new SplitBatch(PARTITIONED_1, ImmutableList.of(createSplit(6, ImmutableList.of(HOST_1, HOST_2))), true)),
                 2,
                 false);
+        testAssigner(
+                ImmutableSet.of(PARTITIONED_1, PARTITIONED_2),
+                ImmutableSet.of(),
+                ImmutableList.of(
+                        new SplitBatch(PARTITIONED_2, ImmutableList.of(createSplit(1, ImmutableList.of(HOST_1, HOST_2))), true),
+                        new SplitBatch(PARTITIONED_1, ImmutableList.of(createSplit(2), createRemoteAccessibleSplit(3, ImmutableList.of(HOST_3))), false),
+                        new SplitBatch(PARTITIONED_1, ImmutableList.of(createRemoteAccessibleSplit(4, ImmutableList.of(HOST_1, HOST_2))), false),
+                        new SplitBatch(PARTITIONED_1, ImmutableList.of(createSplit(5, ImmutableList.of(HOST_3))), false),
+                        new SplitBatch(PARTITIONED_1, ImmutableList.of(createSplit(6, ImmutableList.of(HOST_1, HOST_2))), true)),
+                2,
+                false);
 
         // single replicated source
         testAssigner(
@@ -659,7 +670,7 @@ public class TestArbitraryDistributionSplitAssigner
         ListMultimap<PlanNodeId, Split> expectedReplicatedSplits = ArrayListMultimap.create();
         Map<Integer, ListMultimap<PlanNodeId, Split>> expectedPartitionedSplits = new HashMap<>();
         Set<PlanNodeId> finishedReplicatedSources = new HashSet<>();
-        Map<Optional<HostAddress>, PartitionAssignment> currentSplitAssignments = new HashMap<>();
+        Map<Map.Entry<Optional<HostAddress>, Boolean>, PartitionAssignment> currentSplitAssignments = new HashMap<>();
         AtomicInteger nextPartitionId = new AtomicInteger();
         for (SplitBatch batch : batches) {
             PlanNodeId planNodeId = batch.getPlanNodeId();
@@ -674,28 +685,25 @@ public class TestArbitraryDistributionSplitAssigner
             }
             else {
                 for (Split split : splits) {
+                    boolean remotelyAccessible = split.isRemotelyAccessible();
                     Optional<HostAddress> hostRequirement = Optional.empty();
-                    if (!split.isRemotelyAccessible()) {
+                    if (!split.getAddresses().isEmpty()) {
                         int splitCount = Integer.MAX_VALUE;
                         for (HostAddress hostAddress : split.getConnectorSplit().getAddresses()) {
-                            PartitionAssignment currentAssignment = currentSplitAssignments.get(Optional.of(hostAddress));
-                            if (currentAssignment == null) {
-                                hostRequirement = Optional.of(hostAddress);
-                                break;
-                            }
-                            if (currentAssignment.getSplits().size() < splitCount) {
-                                splitCount = currentAssignment.getSplits().size();
+                            int currentSplitCount = addUpSplits(hostAddress, currentSplitAssignments);
+                            if (currentSplitCount < splitCount) {
+                                splitCount = currentSplitCount;
                                 hostRequirement = Optional.of(hostAddress);
                             }
                         }
                     }
-                    PartitionAssignment currentAssignment = currentSplitAssignments.get(hostRequirement);
+                    PartitionAssignment currentAssignment = currentSplitAssignments.get(Map.entry(hostRequirement, remotelyAccessible));
                     if (currentAssignment != null && currentAssignment.getSplits().size() + 1 > partitionedSplitsPerPartition) {
                         expectedPartitionedSplits.computeIfAbsent(currentAssignment.getPartitionId(), key -> ArrayListMultimap.create()).putAll(currentAssignment.getSplits());
-                        currentSplitAssignments.remove(hostRequirement);
+                        currentSplitAssignments.remove(Map.entry(hostRequirement, remotelyAccessible));
                     }
                     currentSplitAssignments
-                            .computeIfAbsent(hostRequirement, key -> new PartitionAssignment(nextPartitionId.getAndIncrement()))
+                            .computeIfAbsent(Map.entry(hostRequirement, remotelyAccessible), key -> new PartitionAssignment(nextPartitionId.getAndIncrement()))
                             .getSplits()
                             .put(planNodeId, split);
                 }
@@ -743,6 +751,13 @@ public class TestArbitraryDistributionSplitAssigner
         }
     }
 
+    private static int addUpSplits(HostAddress address, Map<Map.Entry<Optional<HostAddress>, Boolean>, PartitionAssignment> assignments)
+    {
+        PartitionAssignment assignment1 = assignments.get(Map.entry(Optional.of(address), true));
+        PartitionAssignment assignment2 = assignments.get(Map.entry(Optional.of(address), false));
+        return (assignment1 == null ? 0 : assignment1.getSplits().size()) + (assignment2 == null ? 0 : assignment2.getSplits().size());
+    }
+
     private static Split createSplit(int id)
     {
         return new Split(TEST_CATALOG_HANDLE, new TestingConnectorSplit(id, OptionalInt.empty(), Optional.empty()));
@@ -751,6 +766,18 @@ public class TestArbitraryDistributionSplitAssigner
     private static Split createSplit(int id, List<HostAddress> addresses)
     {
         return new Split(TEST_CATALOG_HANDLE, new TestingConnectorSplit(id, OptionalInt.empty(), Optional.of(addresses)));
+    }
+
+    private static Split createRemoteAccessibleSplit(int id, List<HostAddress> addresses)
+    {
+        return new Split(TEST_CATALOG_HANDLE, new TestingConnectorSplit(id, OptionalInt.empty(), Optional.of(addresses))
+        {
+            @Override
+            public boolean isRemotelyAccessible()
+            {
+                return true;
+            }
+        });
     }
 
     private static ListMultimap<Integer, Split> createSplitsMultimap(List<Split> splits)
@@ -774,19 +801,22 @@ public class TestArbitraryDistributionSplitAssigner
             assertThat(taskDescriptor.getSplits().getSplits(planNodeId).keySet()).isEqualTo(ImmutableSet.of(SINGLE_SOURCE_PARTITION_ID));
         });
         assertSplitsEqual(taskDescriptor.getSplits().getSplitsFlat(), expectedSplits);
+        NodeRequirements taskNodeRequirements = taskDescriptor.getNodeRequirements();
         Set<HostAddress> hostRequirement = null;
         for (Split split : taskDescriptor.getSplits().getSplitsFlat().values()) {
-            if (!split.isRemotelyAccessible()) {
+            if (!split.getAddresses().isEmpty()) {
                 if (hostRequirement == null) {
                     hostRequirement = ImmutableSet.copyOf(split.getAddresses());
                 }
                 else {
                     hostRequirement = Sets.intersection(hostRequirement, ImmutableSet.copyOf(split.getAddresses()));
                 }
+                // The split's remove-accessible flag should be recorded in NodeRequirements, and we don't mix remote accessible and non-remote accessible splits in the same task.
+                assertThat(taskNodeRequirements.isRemotelyAccessible()).as("%s", split).isEqualTo(split.isRemotelyAccessible());
             }
         }
-        assertThat(taskDescriptor.getNodeRequirements().getCatalogHandle()).isEqualTo(Optional.of(TEST_CATALOG_HANDLE));
-        assertThat(taskDescriptor.getNodeRequirements().getAddresses()).containsAnyElementsOf(hostRequirement == null ? ImmutableSet.of() : hostRequirement);
+        assertThat(taskNodeRequirements.getCatalogHandle()).isEqualTo(Optional.of(TEST_CATALOG_HANDLE));
+        assertThat(taskNodeRequirements.getAddresses()).containsAnyElementsOf(hostRequirement == null ? ImmutableSet.of() : hostRequirement);
     }
 
     private static void assertSplitsEqual(ListMultimap<PlanNodeId, Split> actual, ListMultimap<PlanNodeId, Split> expected)

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestEventDrivenTaskSource.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestEventDrivenTaskSource.java
@@ -671,7 +671,7 @@ public class TestEventDrivenTaskSource
             AssignmentResult.Builder result = AssignmentResult.builder();
             Multimaps.asMap(splitsMap).forEach((partition, splits) -> {
                 if (partitions.add(partition)) {
-                    result.addPartition(new Partition(partition, new NodeRequirements(Optional.empty(), ImmutableSet.of())));
+                    result.addPartition(new Partition(partition, new NodeRequirements(Optional.empty(), ImmutableSet.of(), true)));
                     for (PlanNodeId finishedSource : finishedSources) {
                         result.updatePartition(new PartitionUpdate(partition, finishedSource, false, ImmutableListMultimap.of(), true));
                     }
@@ -706,7 +706,7 @@ public class TestEventDrivenTaskSource
             if (partitions.isEmpty()) {
                 partitions.add(0);
                 result
-                        .addPartition(new Partition(0, new NodeRequirements(Optional.empty(), ImmutableSet.of())))
+                        .addPartition(new Partition(0, new NodeRequirements(Optional.empty(), ImmutableSet.of(), true)))
                         .sealPartition(0);
             }
             return result.setNoMorePartitions()

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestSingleDistributionSplitAssigner.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestSingleDistributionSplitAssigner.java
@@ -41,7 +41,7 @@ public class TestSingleDistributionSplitAssigner
         tester.update(splitAssigner.finish());
 
         assertThat(tester.getTaskPartitionCount()).isEqualTo(1);
-        assertThat(tester.getNodeRequirements(0)).isEqualTo(new NodeRequirements(Optional.empty(), hostRequirement));
+        assertThat(tester.getNodeRequirements(0)).isEqualTo(new NodeRequirements(Optional.empty(), hostRequirement, false));
         assertThat(tester.isSealed(0)).isTrue();
         assertThat(tester.isNoMoreTaskPartitions()).isTrue();
     }
@@ -59,7 +59,7 @@ public class TestSingleDistributionSplitAssigner
         tester.update(splitAssigner.finish());
 
         assertThat(tester.getTaskPartitionCount()).isEqualTo(1);
-        assertThat(tester.getNodeRequirements(0)).isEqualTo(new NodeRequirements(Optional.empty(), hostRequirement));
+        assertThat(tester.getNodeRequirements(0)).isEqualTo(new NodeRequirements(Optional.empty(), hostRequirement, false));
         assertThat(tester.getSplitIds(0, PLAN_NODE_1)).isEmpty();
         assertThat(tester.isNoMoreSplits(0, PLAN_NODE_1)).isTrue();
         assertThat(tester.isSealed(0)).isTrue();

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestTaskDescriptorStorage.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestTaskDescriptorStorage.java
@@ -203,7 +203,7 @@ public class TestTaskDescriptorStorage
                 SplitsMapping.builder()
                         .addSplit(new PlanNodeId("1"), 1, new Split(REMOTE_CATALOG_HANDLE, new RemoteSplit(new SpoolingExchangeInput(ImmutableList.of(new TestingExchangeSourceHandle(retainedSize.toBytes())), Optional.empty()))))
                         .build(),
-                new NodeRequirements(catalog, ImmutableSet.of()));
+                new NodeRequirements(catalog, ImmutableSet.of(), true));
     }
 
     private static Optional<String> getCatalogName(TaskDescriptor descriptor)


### PR DESCRIPTION
## Description

UniformNodeSelector or FTE scheduler will schedule remote accessible splits on selected nodes if such nodes are available and only fallback to other nodes is nodes are no longer part of cluster. Connector might have stalled node information while creating splits which could result in selecting nodes which are now offline. Additionally, in FTE mode nodes can go down so split addresses could no longer be valid then task is restarted.

Additionally, this commit simplifies UniformNodeSelector optimizedLocalScheduling which was hard to reason about and was not taking advantages of recent improvements like adaptive split queue length.

Extracted from: https://github.com/trinodb/trino/pull/21888


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Make scheduling of splits more strict when preferred workers are present. ({issue}`issuenumber`)
```
