### PR TITLE
Optimize DATE_TRUNC, DATE_ADD and DATE_DIFF functions for DATE and TIMESTAMP types

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/DateTimeFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/DateTimeFunctions.java
@@ -48,6 +48,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.util.Locale;
+import java.util.function.Function;
 
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.operator.scalar.QuarterOfYearDateTimeField.QUARTER_OF_YEAR;
@@ -66,7 +67,7 @@ import static java.lang.Math.floorDiv;
 import static java.lang.Math.floorMod;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
-import static java.util.Locale.ENGLISH;
+import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -90,6 +91,24 @@ public final class DateTimeFunctions
     private static final int MILLISECONDS_IN_DAY = 24 * MILLISECONDS_IN_HOUR;
     private static final int PIVOT_YEAR = 2020; // yy = 70 will correspond to 1970 but 69 to 2069
     private static final Slice ISO_8601_DATE_FORMAT = Slices.utf8Slice("%Y-%m-%d");
+    private static final DateTimeFieldProvider[] DATE_FIELDS = new DateTimeFieldProvider[] {
+            new DateTimeFieldProvider("day", ISOChronology::dayOfMonth),
+            new DateTimeFieldProvider("week", ISOChronology::weekOfWeekyear),
+            new DateTimeFieldProvider("month", ISOChronology::monthOfYear),
+            new DateTimeFieldProvider("quarter", QUARTER_OF_YEAR::getField),
+            new DateTimeFieldProvider("year", ISOChronology::year)
+    };
+    private static final DateTimeFieldProvider[] TIMESTAMP_FIELDS = new DateTimeFieldProvider[] {
+            new DateTimeFieldProvider("millisecond", ISOChronology::millisOfSecond),
+            new DateTimeFieldProvider("second", ISOChronology::secondOfMinute),
+            new DateTimeFieldProvider("minute", ISOChronology::minuteOfHour),
+            new DateTimeFieldProvider("hour", ISOChronology::hourOfDay),
+            new DateTimeFieldProvider("day", ISOChronology::dayOfMonth),
+            new DateTimeFieldProvider("week", ISOChronology::weekOfWeekyear),
+            new DateTimeFieldProvider("month", ISOChronology::monthOfYear),
+            new DateTimeFieldProvider("quarter", QUARTER_OF_YEAR::getField),
+            new DateTimeFieldProvider("year", ISOChronology::year)
+    };
 
     private DateTimeFunctions() {}
 
@@ -308,34 +327,59 @@ public final class DateTimeFunctions
         return getDateField(UTC_CHRONOLOGY, unit).getDifferenceAsLong(DAYS.toMillis(date2), DAYS.toMillis(date1));
     }
 
+    /**
+     * Data tuple to store mapping between date time unit and date fraction extraction logic.
+     * This record is intended to be used for a specific use case only, raw bytes are used for performance reasons.
+     *
+     * @param unitBytes date time unit represented as ASCII bytes
+     * @param dateTimeFieldProvider callback to extract fraction of date
+     */
+    private record DateTimeFieldProvider(byte[] unitBytes, Function<ISOChronology, DateTimeField> dateTimeFieldProvider)
+    {
+        public DateTimeFieldProvider(String unit, Function<ISOChronology, DateTimeField> dateTimeFieldProvider)
+        {
+            this(unit.getBytes(US_ASCII), dateTimeFieldProvider);
+        }
+
+        public boolean match(Slice unit)
+        {
+            int length = unit.length();
+            if (length != unitBytes.length) {
+                return false;
+            }
+            for (int i = 0; i < length; i++) {
+                // Each lowercase letter has an ASCII code 0x20 more than the corresponding uppercase letter
+                if ((unit.getByteUnchecked(i) | 0x20) != unitBytes[i]) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public DateTimeField apply(ISOChronology chronology)
+        {
+            return dateTimeFieldProvider.apply(chronology);
+        }
+    }
+
     private static DateTimeField getDateField(ISOChronology chronology, Slice unit)
     {
-        String unitString = unit.toStringUtf8().toLowerCase(ENGLISH);
-        return switch (unitString) {
-            case "day" -> chronology.dayOfMonth();
-            case "week" -> chronology.weekOfWeekyear();
-            case "month" -> chronology.monthOfYear();
-            case "quarter" -> QUARTER_OF_YEAR.getField(chronology);
-            case "year" -> chronology.year();
-            default -> throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "'" + unitString + "' is not a valid DATE field");
-        };
+        for (DateTimeFieldProvider dateField : DATE_FIELDS) {
+            if (dateField.match(unit)) {
+                return dateField.apply(chronology);
+            }
+        }
+        throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "'" + unit.toStringUtf8() + "' is not a valid DATE field");
     }
 
     public static DateTimeField getTimestampField(ISOChronology chronology, Slice unit)
     {
-        String unitString = unit.toStringUtf8().toLowerCase(ENGLISH);
-        return switch (unitString) {
-            case "millisecond" -> chronology.millisOfSecond();
-            case "second" -> chronology.secondOfMinute();
-            case "minute" -> chronology.minuteOfHour();
-            case "hour" -> chronology.hourOfDay();
-            case "day" -> chronology.dayOfMonth();
-            case "week" -> chronology.weekOfWeekyear();
-            case "month" -> chronology.monthOfYear();
-            case "quarter" -> QUARTER_OF_YEAR.getField(chronology);
-            case "year" -> chronology.year();
-            default -> throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "'" + unitString + "' is not a valid TIMESTAMP field");
-        };
+        for (DateTimeFieldProvider timestampField : TIMESTAMP_FIELDS) {
+            if (timestampField.match(unit)) {
+                return timestampField.apply(chronology);
+            }
+        }
+        throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "'" + unit.toStringUtf8() + "' is not a valid TIMESTAMP field");
     }
 
     @Description("Parses the specified date/time by the given format")

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkDateTimeFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkDateTimeFunctions.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.spi.TrinoException;
+import org.joda.time.DateTimeField;
+import org.joda.time.chrono.ISOChronology;
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.util.concurrent.TimeUnit;
+
+import static io.trino.jmh.Benchmarks.benchmark;
+import static io.trino.operator.scalar.QuarterOfYearDateTimeField.QUARTER_OF_YEAR;
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static java.util.Locale.ENGLISH;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+@Warmup(iterations = 10, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkDateTimeFunctions
+{
+    private static final ISOChronology ISO_CHRONOLOGY = ISOChronology.getInstanceUTC();
+
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        @Param({"millisecond", "second", "minute", "hour", "day", "week", "month", "quarter", "year",
+                "MILLISECOND", "SECOND", "MINUTE", "HOUR", "DAY", "WEEK", "MONTH", "QUARTER", "YEAR"})
+        private String unitString = "year";
+        private Slice unit;
+
+        @Setup
+        public void setup()
+        {
+            this.unit = Slices.utf8Slice(unitString);
+        }
+
+        public Slice getUnit()
+        {
+            return unit;
+        }
+    }
+
+    // Old implementation
+    public static DateTimeField getTimestampFieldOld(ISOChronology chronology, Slice unit)
+    {
+        String unitString = unit.toStringUtf8().toLowerCase(ENGLISH);
+        return switch (unitString) {
+            case "millisecond" -> chronology.millisOfSecond();
+            case "second" -> chronology.secondOfMinute();
+            case "minute" -> chronology.minuteOfHour();
+            case "hour" -> chronology.hourOfDay();
+            case "day" -> chronology.dayOfMonth();
+            case "week" -> chronology.weekOfWeekyear();
+            case "month" -> chronology.monthOfYear();
+            case "quarter" -> QUARTER_OF_YEAR.getField(chronology);
+            case "year" -> chronology.year();
+            default -> throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "'" + unitString + "' is not a valid TIMESTAMP field");
+        };
+    }
+
+    @Benchmark
+    public DateTimeField getTimestampFieldOld(BenchmarkData data)
+    {
+        return getTimestampFieldOld(ISO_CHRONOLOGY, data.getUnit());
+    }
+
+    @Benchmark
+    public DateTimeField getTimestampFieldNew(BenchmarkData data)
+    {
+        return DateTimeFunctions.getTimestampField(ISO_CHRONOLOGY, data.getUnit());
+    }
+
+    @Test
+    public void test()
+    {
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        getTimestampFieldOld(data);
+        getTimestampFieldNew(data);
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        benchmark(BenchmarkDateTimeFunctions.class).run();
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
We have observed poor performance when using the `DATE_TRUNC` function. Profiling revealed that the function spends most of its time resolving date time units. The main bottleneck is in the `io.trino.operator.scalar.DateTimeFunctions#getDateField` method. This method contains 2 string allocations and a hash lookup, which takes a noticeable amount of CPU time.

![before](https://github.com/trinodb/trino/assets/11261786/f7558b72-7b68-4873-a797-1eea66ec09d5)

The new approach doesn't create new strings and works directly with bytes. This is possible because the date time unit can only use ASCII symbols. Also, the hash lookup has been replaced with a simple loop, which works quite well with small amounts of values.

![after](https://github.com/trinodb/trino/assets/11261786/b3be55e8-5774-4298-8bdf-6157b72b3559)

Here is the benchmark results. All the tests were performed on Apple Silicon M1 MAX, OpenJDK 64-Bit Server VM, 22.0.1+8.
```
Benchmark                                        (unitString)  Mode  Cnt    Score    Error  Units
BenchmarkDateTimeFunctions.getTimestampFieldNew   millisecond  avgt   20    6.578 ±  0.222  ns/op
BenchmarkDateTimeFunctions.getTimestampFieldNew   MILLISECOND  avgt   20    6.440 ±  0.043  ns/op
BenchmarkDateTimeFunctions.getTimestampFieldOld   millisecond  avgt   20   24.328 ±  2.810  ns/op
BenchmarkDateTimeFunctions.getTimestampFieldOld   MILLISECOND  avgt   20   64.824 ±  1.651  ns/op

BenchmarkDateTimeFunctions.getTimestampFieldNew        second  avgt   20    5.303 ±  0.083  ns/op
BenchmarkDateTimeFunctions.getTimestampFieldNew        SECOND  avgt   20    5.408 ±  0.360  ns/op
BenchmarkDateTimeFunctions.getTimestampFieldOld        second  avgt   20   26.958 ±  0.648  ns/op
BenchmarkDateTimeFunctions.getTimestampFieldOld        SECOND  avgt   20   84.577 ± 11.841  ns/op

BenchmarkDateTimeFunctions.getTimestampFieldNew        minute  avgt   20    7.124 ±  0.151  ns/op
BenchmarkDateTimeFunctions.getTimestampFieldNew        MINUTE  avgt   20    7.041 ±  0.148  ns/op
BenchmarkDateTimeFunctions.getTimestampFieldOld        minute  avgt   20   27.429 ±  0.475  ns/op
BenchmarkDateTimeFunctions.getTimestampFieldOld        MINUTE  avgt   20   73.585 ± 11.993  ns/op

BenchmarkDateTimeFunctions.getTimestampFieldNew          hour  avgt   20    5.341 ±  0.377  ns/op
BenchmarkDateTimeFunctions.getTimestampFieldNew          HOUR  avgt   20    4.897 ±  0.064  ns/op
BenchmarkDateTimeFunctions.getTimestampFieldOld          hour  avgt   20   33.435 ±  2.004  ns/op
BenchmarkDateTimeFunctions.getTimestampFieldOld          HOUR  avgt   20   56.233 ±  4.317  ns/op

BenchmarkDateTimeFunctions.getTimestampFieldNew           day  avgt   20    5.061 ±  0.126  ns/op
BenchmarkDateTimeFunctions.getTimestampFieldNew           DAY  avgt   20    5.022 ±  0.033  ns/op
BenchmarkDateTimeFunctions.getTimestampFieldOld           day  avgt   20   28.863 ±  1.056  ns/op
BenchmarkDateTimeFunctions.getTimestampFieldOld           DAY  avgt   20   76.999 ±  8.112  ns/op

BenchmarkDateTimeFunctions.getTimestampFieldNew          week  avgt   20    8.032 ±  0.144  ns/op
BenchmarkDateTimeFunctions.getTimestampFieldNew          WEEK  avgt   20    7.909 ±  0.040  ns/op
BenchmarkDateTimeFunctions.getTimestampFieldOld          week  avgt   20   28.985 ±  1.604  ns/op
BenchmarkDateTimeFunctions.getTimestampFieldOld          WEEK  avgt   20   84.112 ±  8.137  ns/op

BenchmarkDateTimeFunctions.getTimestampFieldNew         month  avgt   20    6.530 ±  0.069  ns/op
BenchmarkDateTimeFunctions.getTimestampFieldNew         MONTH  avgt   20    6.568 ±  0.094  ns/op
BenchmarkDateTimeFunctions.getTimestampFieldOld         month  avgt   20   29.953 ±  1.834  ns/op
BenchmarkDateTimeFunctions.getTimestampFieldOld         MONTH  avgt   20   83.186 ± 10.773  ns/op

BenchmarkDateTimeFunctions.getTimestampFieldNew       quarter  avgt   20   22.135 ±  0.877  ns/op
BenchmarkDateTimeFunctions.getTimestampFieldNew       QUARTER  avgt   20   22.200 ±  0.799  ns/op
BenchmarkDateTimeFunctions.getTimestampFieldOld       quarter  avgt   20   78.707 ±  5.599  ns/op
BenchmarkDateTimeFunctions.getTimestampFieldOld       QUARTER  avgt   20  115.353 ±  8.914  ns/op

BenchmarkDateTimeFunctions.getTimestampFieldNew          year  avgt   20   11.206 ±  0.370  ns/op
BenchmarkDateTimeFunctions.getTimestampFieldNew          YEAR  avgt   20   11.020 ±  0.266  ns/op
BenchmarkDateTimeFunctions.getTimestampFieldOld          year  avgt   20   29.169 ±  0.842  ns/op
BenchmarkDateTimeFunctions.getTimestampFieldOld          YEAR  avgt   20   67.568 ± 11.769  ns/op
```
The benchmark shows that the new lookup implementation is 4-10 times faster. Interestingly, the new algorithm also removes the disrepancy between lowercase and mixed-case unit representation. In the current Trino version, `DATE_TRUNC('month', date)` works faster than `DATE_TRUNC('MONTH', date)`.

To test a close-to-real-world scenario, the following query was used. This cross join produces ~1.8 billion rows.
```
explain analyze select date_trunc('month', a.i_rec_start_date) from tpcds.sf1.item a, tpcds.sf10.item b;
```

`EXPLAIN` shows that the `DATE_TRUNC` CPU usage has been significantly reduced.
Before optimization
```
Project[]                                                                                                                                                                             
│   Layout: [expr:date]                                                                                                                                                               
│   Estimates: {rows: ? (?), cpu: ?, memory: 0B, network: 0B}                                                                                                                         
│   CPU: 1.28m (96.96%), Scheduled: 1.32m (96.39%), Blocked: 0.00ns (0.00%), Output: 1836000000 rows (8.55GB)                                                                         
│   Input avg.: 459000000.00 rows, Input std.dev.: 173.21%                                                                                                                            
│   expr := date_trunc(varchar(5) 'month', i_rec_start_date)   
```
After optimization
```
Project[]                                                                                                                                                                               
│   Layout: [expr:date]                                                                                                                                                                 
│   Estimates: {rows: ? (?), cpu: ?, memory: 0B, network: 0B}                                                                                                                           
│   CPU: 41.59s (95.67%), Scheduled: 44.83s (95.75%), Blocked: 0.00ns (0.00%), Output: 1836000000 rows (8.55GB)                                                                         
│   Input avg.: 459000000.00 rows, Input std.dev.: 173.21%                                                                                                                              
│   expr := date_trunc(varchar(5) 'month', i_rec_start_date)
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
**Note 1**
The same performance issue can occur with the `at_timezone` function, which uses even more complex timezone resolution logic for each call. Ideally, if a constant literal is used in a query, it should only be resolved once. 
For example, instead of calling `DateTimeFunctions#truncateDate(Slice unit, long date)`, Trino should call `DateTimeFunctions#truncateDate(DateTimeField unit, long date)`.

**Note 2**
This optimization covers only DATE and TIMESTAMP types. If the maintainers are OK with the proposed solution, the optimization for TIME type can also be implemented using the same approach.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Improved performance for DATE_TRUNC, DATE_ADD and DATE_DIFF functions
```
