### PR TITLE
Set air.compiler.fail-warnings as true in Redis and remove deprecated DateTimeUtils.parseLegacyTime

### DIFF
--- a/core/trino-main/src/main/java/io/trino/util/DateTimeUtils.java
+++ b/core/trino-main/src/main/java/io/trino/util/DateTimeUtils.java
@@ -47,7 +47,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.trino.sql.tree.IntervalLiteral.IntervalField;
 import static io.trino.util.DateTimeZoneIndex.getChronology;
-import static io.trino.util.DateTimeZoneIndex.getDateTimeZone;
 import static io.trino.util.DateTimeZoneIndex.packDateTimeWithZone;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
@@ -182,29 +181,6 @@ public final class DateTimeUtils
     {
         DateTime dateTime = TIMESTAMP_WITH_OR_WITHOUT_TIME_ZONE_FORMATTER.withChronology(getChronology(timeZoneKey)).withOffsetParsed().parseDateTime(timestampWithTimeZone);
         return packDateTimeWithZone(dateTime);
-    }
-
-    private static final DateTimeFormatter TIME_FORMATTER;
-
-    static {
-        DateTimeParser[] timeWithoutTimeZoneParser = {
-                DateTimeFormat.forPattern("H:m").getParser(),
-                DateTimeFormat.forPattern("H:m:s").getParser(),
-                DateTimeFormat.forPattern("H:m:s.SSS").getParser()};
-        DateTimePrinter timeWithoutTimeZonePrinter = DateTimeFormat.forPattern("HH:mm:ss.SSS").getPrinter();
-        TIME_FORMATTER = new DateTimeFormatterBuilder().append(timeWithoutTimeZonePrinter, timeWithoutTimeZoneParser).toFormatter().withZoneUTC();
-    }
-
-    /**
-     * Parse a string (without a zone) as a value of TIME type, interpreted in {@code timeZoneKey} zone.
-     *
-     * @return stack representation of legacy TIME type
-     * @deprecated applicable in legacy timestamp semantics only
-     */
-    @Deprecated
-    public static long parseLegacyTime(TimeZoneKey timeZoneKey, String value)
-    {
-        return TIME_FORMATTER.withZone(getDateTimeZone(timeZoneKey)).parseMillis(value);
     }
 
     private static final int YEAR_FIELD = 0;

--- a/plugin/trino-redis/pom.xml
+++ b/plugin/trino-redis/pom.xml
@@ -15,6 +15,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+        <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
     </properties>
 
     <dependencies>

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisMetadata.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisMetadata.java
@@ -30,8 +30,8 @@ import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTableVersion;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.ConstraintApplicationResult;
+import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.SchemaTableName;
-import io.trino.spi.connector.SchemaTablePrefix;
 import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.Range;
@@ -42,17 +42,19 @@ import io.trino.spi.predicate.ValueSet;
 import jakarta.annotation.Nullable;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import static io.trino.plugin.redis.RedisSplit.toRedisDataType;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
-import static java.util.Objects.requireNonNull;
+import static io.trino.spi.connector.RelationColumnsMetadata.forTable;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
@@ -251,28 +253,24 @@ public class RedisMetadata
     }
 
     @Override
-    public Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
+    public Iterator<RelationColumnsMetadata> streamRelationColumns(
+            ConnectorSession session,
+            Optional<String> schemaName,
+            UnaryOperator<Set<SchemaTableName>> relationFilter)
     {
-        requireNonNull(prefix, "prefix is null");
+        Map<SchemaTableName, RelationColumnsMetadata> relationColumns = new HashMap<>();
 
-        ImmutableMap.Builder<SchemaTableName, List<ColumnMetadata>> columns = ImmutableMap.builder();
-
-        List<SchemaTableName> tableNames;
-        if (prefix.getTable().isEmpty()) {
-            tableNames = listTables(session, prefix.getSchema());
-        }
-        else {
-            tableNames = ImmutableList.of(prefix.toSchemaTableName());
-        }
-
-        for (SchemaTableName tableName : tableNames) {
+        for (SchemaTableName tableName : listTables(session, schemaName)) {
             ConnectorTableMetadata tableMetadata = getTableMetadata(tableName);
             // table can disappear during listing operation
             if (tableMetadata != null) {
-                columns.put(tableName, tableMetadata.getColumns());
+                relationColumns.put(tableName, forTable(tableName, tableMetadata.getColumns()));
             }
         }
-        return columns.buildOrThrow();
+
+        return relationFilter.apply(relationColumns.keySet()).stream()
+                .map(relationColumns::get)
+                .iterator();
     }
 
     @Override


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
