### PR TITLE
Introduce projection pushdown framework for JDBC connectors

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/projection/ProjectFunctionRewriter.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/projection/ProjectFunctionRewriter.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.projection;
+
+import com.google.common.collect.ImmutableSet;
+import io.trino.matching.Match;
+import io.trino.plugin.base.expression.ConnectorExpressionRewriter;
+import io.trino.plugin.base.projection.ProjectFunctionRule.RewriteContext;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.expression.ConnectorExpression;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public final class ProjectFunctionRewriter<ProjectionResult, ExpressionResult>
+{
+    private final ConnectorExpressionRewriter<ExpressionResult> connectorExpressionRewriter;
+    private final Set<ProjectFunctionRule<ProjectionResult, ExpressionResult>> rules;
+
+    public ProjectFunctionRewriter(ConnectorExpressionRewriter<ExpressionResult> connectorExpressionRewriter, Set<ProjectFunctionRule<ProjectionResult, ExpressionResult>> rules)
+    {
+        this.connectorExpressionRewriter = requireNonNull(connectorExpressionRewriter, "connectorExpressionRewriter is null");
+        this.rules = ImmutableSet.copyOf(requireNonNull(rules, "rules is null"));
+    }
+
+    public Optional<ProjectionResult> rewrite(ConnectorSession session, ConnectorExpression projectionExpression, Map<String, ColumnHandle> assignments)
+    {
+        requireNonNull(projectionExpression, "projectionExpression is null");
+        requireNonNull(assignments, "assignments is null");
+
+        RewriteContext<ExpressionResult> context = new RewriteContext<>()
+        {
+            @Override
+            public Map<String, ColumnHandle> getAssignments()
+            {
+                return assignments;
+            }
+
+            @Override
+            public ConnectorSession getSession()
+            {
+                return session;
+            }
+
+            @Override
+            public Optional<ExpressionResult> rewriteExpression(ConnectorExpression expression)
+            {
+                return connectorExpressionRewriter.rewrite(session, expression, assignments);
+            }
+        };
+
+        for (ProjectFunctionRule<ProjectionResult, ExpressionResult> rule : rules) {
+            if (rule.isEnabled(context.getSession())) {
+                Iterator<Match> matches = rule.getPattern().match(projectionExpression, context).iterator();
+                while (matches.hasNext()) {
+                    Match match = matches.next();
+                    Optional<ProjectionResult> rewritten = rule.rewrite(projectionExpression, match.captures(), context);
+                    if (rewritten.isPresent()) {
+                        return rewritten;
+                    }
+                }
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/projection/ProjectFunctionRule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/projection/ProjectFunctionRule.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.projection;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.expression.ConnectorExpression;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.base.Verify.verifyNotNull;
+import static java.util.Objects.requireNonNull;
+
+public interface ProjectFunctionRule<ProjectionResult, ExpressionResult>
+{
+    Pattern<? extends ConnectorExpression> getPattern();
+
+    default boolean isEnabled(ConnectorSession session)
+    {
+        return true;
+    }
+
+    Optional<ProjectionResult> rewrite(ConnectorExpression projectionExpression, Captures captures, RewriteContext<ExpressionResult> context);
+
+    interface RewriteContext<ExpressionResult>
+    {
+        default ColumnHandle getAssignment(String name)
+        {
+            requireNonNull(name, "name is null");
+            ColumnHandle columnHandle = getAssignments().get(name);
+            verifyNotNull(columnHandle, "No assignment for %s", name);
+            return columnHandle;
+        }
+
+        Map<String, ColumnHandle> getAssignments();
+
+        ConnectorSession getSession();
+
+        Optional<ExpressionResult> rewriteExpression(ConnectorExpression expression);
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -240,6 +240,12 @@ public class CachingJdbcClient
     }
 
     @Override
+    public Optional<JdbcExpression> convertProjection(ConnectorSession session, ConnectorExpression expression, Map<String, ColumnHandle> assignments)
+    {
+        return delegate.convertProjection(session, expression, assignments);
+    }
+
+    @Override
     public ConnectorSplitSource getSplits(ConnectorSession session, JdbcTableHandle tableHandle)
     {
         return delegate.getSplits(session, tableHandle);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
@@ -100,6 +100,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Streams.stream;
 import static io.trino.plugin.base.expression.ConnectorExpressions.and;
 import static io.trino.plugin.base.expression.ConnectorExpressions.extractConjuncts;
+import static io.trino.plugin.base.projection.ApplyProjectionUtil.replaceWithNewVariables;
 import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_NON_TRANSIENT_ERROR;
 import static io.trino.plugin.jdbc.JdbcMetadataSessionProperties.isAggregationPushdownEnabled;
 import static io.trino.plugin.jdbc.JdbcMetadataSessionProperties.isBulkListColumns;
@@ -316,6 +317,18 @@ public class DefaultJdbcMetadata
 
         JdbcTableHandle handle = (JdbcTableHandle) table;
 
+        if (isComplexExpressionPushdown(session)) {
+            Optional<ProjectionApplicationResult<ConnectorTableHandle>> projectionApplicationResult = applyProjectionExpressions(
+                    session,
+                    handle,
+                    projections,
+                    assignments);
+
+            if (projectionApplicationResult.isPresent()) {
+                return projectionApplicationResult;
+            }
+        }
+
         List<JdbcColumnHandle> newColumns = assignments.values().stream()
                 .map(JdbcColumnHandle.class::cast)
                 .collect(toImmutableList());
@@ -356,6 +369,102 @@ public class DefaultJdbcMetadata
                                 ((JdbcColumnHandle) assignment.getValue()).getColumnType()))
                         .collect(toImmutableList()),
                 precalculateStatisticsForPushdown));
+    }
+
+    private Optional<ProjectionApplicationResult<ConnectorTableHandle>> applyProjectionExpressions(
+            ConnectorSession session,
+            JdbcTableHandle handle,
+            List<ConnectorExpression> projections,
+            Map<String, ColumnHandle> assignments)
+    {
+        int nextSyntheticColumnId = handle.getNextSyntheticColumnId();
+
+        ImmutableSet.Builder<JdbcColumnHandle> newColumnsBuilder = ImmutableSet.builder();
+        ImmutableList.Builder<Assignment> assignmentBuilder = ImmutableList.builder();
+        ImmutableMap.Builder<ConnectorExpression, Variable> newVariablesBuilder = ImmutableMap.builder();
+        ImmutableMap.Builder<String, ParameterizedExpression> columnExpressionsBuilder = ImmutableMap.builder();
+
+        for (ConnectorExpression projection : ImmutableSet.copyOf(projections)) {
+            RewrittenExpression rewrittenExpression = rewriteExpression(session, nextSyntheticColumnId, projection, assignments);
+            nextSyntheticColumnId = rewrittenExpression.nextSyntheticColumnId();
+            newVariablesBuilder.putAll(rewrittenExpression.syntheticVariables());
+            columnExpressionsBuilder.putAll(rewrittenExpression.columnExpressions());
+            newColumnsBuilder.addAll(rewrittenExpression.columnHandles());
+            assignmentBuilder.addAll(rewrittenExpression.assignments());
+        }
+
+        List<JdbcColumnHandle> newColumns = ImmutableList.copyOf(newColumnsBuilder.build());
+
+        Map<ConnectorExpression, Variable> newVariables = newVariablesBuilder.buildOrThrow();
+
+        if (newVariables.isEmpty()) {
+            return Optional.empty();
+        }
+
+        // Modify projections to refer to new variables
+        List<ConnectorExpression> newProjections = projections.stream()
+                .map(expression -> replaceWithNewVariables(expression, newVariables))
+                .collect(toImmutableList());
+
+        List<Assignment> outputAssignments = assignmentBuilder.build();
+
+        PreparedQuery preparedQuery = jdbcClient.prepareQuery(session, handle, Optional.empty(), newColumns, columnExpressionsBuilder.buildOrThrow());
+        return Optional.of(new ProjectionApplicationResult<>(
+                new JdbcTableHandle(
+                        new JdbcQueryRelationHandle(preparedQuery),
+                        TupleDomain.all(),
+                        ImmutableList.of(),
+                        Optional.empty(),
+                        OptionalLong.empty(),
+                        Optional.of(newColumns),
+                        handle.getOtherReferencedTables(),
+                        nextSyntheticColumnId,
+                        handle.getAuthorization(),
+                        handle.getUpdateAssignments()),
+                newProjections,
+                outputAssignments,
+                precalculateStatisticsForPushdown));
+    }
+
+    private RewrittenExpression rewriteExpression(
+            ConnectorSession session,
+            int nextSyntheticColumnId,
+            ConnectorExpression projection,
+            Map<String, ColumnHandle> assignments)
+    {
+        if (projection instanceof Variable variable) {
+            return new RewrittenExpression(
+                    nextSyntheticColumnId,
+                    ImmutableMap.of(),
+                    ImmutableMap.of(),
+                    ImmutableSet.of((JdbcColumnHandle) assignments.get(variable.getName())),
+                    ImmutableList.of(new Assignment(variable.getName(), assignments.get(variable.getName()), variable.getType())));
+        }
+        Optional<JdbcExpression> convertedExpression = jdbcClient.convertProjection(session, projection, assignments);
+        if (convertedExpression.isPresent()) {
+            String columnName = SYNTHETIC_COLUMN_NAME_PREFIX + nextSyntheticColumnId;
+            JdbcColumnHandle newColumn = JdbcColumnHandle.builder()
+                    .setColumnName(columnName)
+                    .setJdbcTypeHandle(convertedExpression.get().getJdbcTypeHandle())
+                    .setColumnType(projection.getType())
+                    .setComment(Optional.of("synthetic"))
+                    .build();
+            nextSyntheticColumnId++;
+            Variable newVariable = new Variable(newColumn.getColumnName(), newColumn.getColumnType());
+            Assignment newAssignment = new Assignment(columnName, newColumn, projection.getType());
+            return new RewrittenExpression(
+                    nextSyntheticColumnId,
+                    ImmutableMap.of(projection, newVariable),
+                    ImmutableMap.of(columnName, new ParameterizedExpression(convertedExpression.get().getExpression(), convertedExpression.get().getParameters())),
+                    ImmutableSet.of(newColumn),
+                    ImmutableList.of(newAssignment));
+        }
+        return new RewrittenExpression(
+                nextSyntheticColumnId,
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                ImmutableSet.of(),
+                ImmutableList.of());
     }
 
     @Override
@@ -1267,5 +1376,21 @@ public class DefaultJdbcMetadata
     private static boolean isTableHandleForProcedure(ConnectorTableHandle tableHandle)
     {
         return tableHandle instanceof JdbcProcedureHandle;
+    }
+
+    public record RewrittenExpression(
+            int nextSyntheticColumnId,
+            Map<ConnectorExpression, Variable> syntheticVariables,
+            Map<String, ParameterizedExpression> columnExpressions,
+            Set<JdbcColumnHandle> columnHandles,
+            List<Assignment> assignments)
+    {
+        public RewrittenExpression
+        {
+            syntheticVariables = ImmutableMap.copyOf(requireNonNull(syntheticVariables, "syntheticVariables is null"));
+            columnExpressions = ImmutableMap.copyOf(requireNonNull(columnExpressions, "columnExpressions is null"));
+            columnHandles = ImmutableSet.copyOf(requireNonNull(columnHandles, "columnHandles is null"));
+            assignments = ImmutableList.copyOf(requireNonNull(assignments, "assignments is null"));
+        }
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
@@ -163,6 +163,12 @@ public abstract class ForwardingJdbcClient
     }
 
     @Override
+    public Optional<JdbcExpression> convertProjection(ConnectorSession session, ConnectorExpression expression, Map<String, ColumnHandle> assignments)
+    {
+        return delegate().convertProjection(session, expression, assignments);
+    }
+
+    @Override
     public ConnectorSplitSource getSplits(ConnectorSession session, JdbcTableHandle layoutHandle)
     {
         return delegate().getSplits(session, layoutHandle);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
@@ -100,6 +100,11 @@ public interface JdbcClient
         return Optional.empty();
     }
 
+    default Optional<JdbcExpression> convertProjection(ConnectorSession session, ConnectorExpression expression, Map<String, ColumnHandle> assignments)
+    {
+        return Optional.empty();
+    }
+
     ConnectorSplitSource getSplits(ConnectorSession session, JdbcTableHandle tableHandle);
 
     ConnectorSplitSource getSplits(ConnectorSession session, JdbcProcedureHandle procedureHandle);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/JdbcClientStats.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/JdbcClientStats.java
@@ -64,6 +64,7 @@ public final class JdbcClientStats
     private final JdbcApiStats toWriteMapping = new JdbcApiStats();
     private final JdbcApiStats implementAggregation = new JdbcApiStats();
     private final JdbcApiStats convertPredicate = new JdbcApiStats();
+    private final JdbcApiStats convertProjection = new JdbcApiStats();
     private final JdbcApiStats getTableScanRedirection = new JdbcApiStats();
     private final JdbcApiStats delete = new JdbcApiStats();
     private final JdbcApiStats update = new JdbcApiStats();
@@ -389,6 +390,13 @@ public final class JdbcClientStats
     public JdbcApiStats getConvertPredicate()
     {
         return convertPredicate;
+    }
+
+    @Managed
+    @Nested
+    public JdbcApiStats getConvertProjection()
+    {
+        return convertProjection;
     }
 
     @Managed

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
@@ -185,6 +185,12 @@ public final class StatisticsAwareJdbcClient
     }
 
     @Override
+    public Optional<JdbcExpression> convertProjection(ConnectorSession session, ConnectorExpression expression, Map<String, ColumnHandle> assignments)
+    {
+        return stats.getConvertProjection().wrap(() -> delegate().convertProjection(session, expression, assignments));
+    }
+
+    @Override
     public ConnectorSplitSource getSplits(ConnectorSession session, JdbcTableHandle layoutHandle)
     {
         return stats.getGetSplits().wrap(() -> delegate().getSplits(session, layoutHandle));

--- a/plugin/trino-postgresql/pom.xml
+++ b/plugin/trino-postgresql/pom.xml
@@ -41,6 +41,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-matching</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-plugin-toolkit</artifactId>
         </dependency>
 

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/rule/RewriteStringReverseFunction.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/rule/RewriteStringReverseFunction.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.postgresql.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.projection.ProjectFunctionRule;
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcExpression;
+import io.trino.plugin.jdbc.JdbcTypeHandle;
+import io.trino.plugin.jdbc.expression.ParameterizedExpression;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.expression.Variable;
+import io.trino.spi.type.VarcharType;
+
+import java.sql.JDBCType;
+import java.util.Optional;
+
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argument;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argumentCount;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.variable;
+
+public class RewriteStringReverseFunction
+        implements ProjectFunctionRule<JdbcExpression, ParameterizedExpression>
+{
+    private static final Capture<Variable> ARGUMENT = newCapture();
+
+    private static final Pattern<Call> PATTERN = call()
+            .with(functionName().equalTo(new FunctionName("reverse")))
+            .with(type().matching(type -> type instanceof VarcharType))
+            .with(argumentCount().equalTo(1))
+            .with(argument(0).matching(variable().capturedAs(ARGUMENT).with(type().matching(type -> type instanceof VarcharType))));
+
+    @Override
+    public Pattern<? extends ConnectorExpression> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<JdbcExpression> rewrite(ConnectorExpression projectionExpression, Captures captures, RewriteContext<ParameterizedExpression> context)
+    {
+        Variable argument = captures.get(ARGUMENT);
+        JdbcTypeHandle typeHandle = ((JdbcColumnHandle) context.getAssignment(argument.getName())).getJdbcTypeHandle();
+
+        // Rewrite the expression only for `VARCHAR` columns and not for columns with special data type
+        if (JDBCType.valueOf(typeHandle.jdbcType()) == JDBCType.VARCHAR && typeHandle.jdbcTypeName().map("varchar"::equals).orElse(false)) {
+            Optional<ParameterizedExpression> translatedArgument = context.rewriteExpression(argument);
+            if (translatedArgument.isEmpty()) {
+                return Optional.empty();
+            }
+
+            return Optional.of(new JdbcExpression(
+                    "REVERSE(%s)".formatted(translatedArgument.get().expression()),
+                    ImmutableList.copyOf(translatedArgument.get().parameters()),
+                    typeHandle));
+        }
+        return Optional.empty();
+    }
+}

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -16,8 +16,11 @@ package io.trino.plugin.postgresql;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
+import io.airlift.slice.Slices;
 import io.airlift.units.Duration;
 import io.trino.Session;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.metadata.TestingFunctionResolution;
 import io.trino.plugin.jdbc.BaseJdbcConnectorTest;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcTableHandle;
@@ -26,10 +29,16 @@ import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.JoinCondition;
 import io.trino.spi.predicate.Range;
 import io.trino.spi.predicate.TupleDomain;
+import io.trino.sql.analyzer.TypeSignatureProvider;
+import io.trino.sql.ir.Call;
+import io.trino.sql.ir.Comparison;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Reference;
 import io.trino.sql.planner.assertions.PlanMatchPattern;
 import io.trino.sql.planner.plan.ExchangeNode;
 import io.trino.sql.planner.plan.FilterNode;
 import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.ProjectNode;
 import io.trino.sql.planner.plan.TableScanNode;
 import io.trino.sql.planner.plan.TopNNode;
 import io.trino.testing.QueryRunner;
@@ -55,10 +64,15 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.exchange;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.output;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_AGGREGATION_PUSHDOWN;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_JOIN_PUSHDOWN_WITH_FULL_JOIN;
@@ -77,6 +91,8 @@ public class TestPostgreSqlConnectorTest
         extends BaseJdbcConnectorTest
 {
     private static final Logger log = Logger.get(TestPostgreSqlConnectorTest.class);
+
+    private static final TestingFunctionResolution FUNCTIONS = new TestingFunctionResolution();
 
     protected TestingPostgreSqlServer postgreSqlServer;
 
@@ -1023,6 +1039,138 @@ public class TestPostgreSqlConnectorTest
             assertThat(query(format("SELECT id FROM %s WHERE ts_col >= TIMESTAMP '2019-01-01 00:00:00 %s'", table.getName(), "UTC")))
                     .matches("VALUES 1")
                     .isFullyPushedDown();
+        }
+    }
+
+    @Test
+    public void testReverseFunctionProjectionPushDown()
+    {
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "test_reverse_pushdown_for_project",
+                "(id BIGINT, varchar_col VARCHAR)",
+                ImmutableList.of("1, 'abc'", "2, null"))) {
+            assertThat(query("SELECT reverse(varchar_col) FROM " + table.getName()))
+                    .skippingTypesCheck()
+                    .matches("VALUES 'cba', NULL")
+                    .isFullyPushedDown();
+
+            assertThat(query("SELECT reverse(varchar_col) FROM " + table.getName() + " WHERE id = 1"))
+                    .skippingTypesCheck()
+                    .matches("VALUES 'cba'")
+                    .isFullyPushedDown();
+
+            assertThat(query("SELECT id, reverse(reverse(reverse(reverse(reverse(varchar_col))))) FROM " + table.getName()))
+                    .skippingTypesCheck()
+                    .matches("VALUES (BIGINT '1', 'cba'), (BIGINT '2', NULL)")
+                    .isNotFullyPushedDown(ProjectNode.class)
+                    .hasPlan(output(
+                            project(
+                                    tableScan(table.getName(), ImmutableMap.of("varchar_col", "varchar_col")))));
+
+            assertThat(query("SELECT reverse(lower(varchar_col)) FROM " + table.getName()))
+                    .skippingTypesCheck()
+                    .matches("VALUES 'cba', NULL")
+                    .isNotFullyPushedDown(ProjectNode.class)
+                    .hasPlan(output(
+                            project(ImmutableMap.of("expr", expression(
+                                    new Call(
+                                            FUNCTIONS.resolveFunction("reverse", ImmutableList.of(new TypeSignatureProvider(VARCHAR.getTypeSignature()))),
+                                            ImmutableList.of(
+                                                    new Call(
+                                                            FUNCTIONS.resolveFunction("lower", ImmutableList.of(new TypeSignatureProvider(VARCHAR.getTypeSignature()))),
+                                                            ImmutableList.of(new Reference(VARCHAR, "varchar_col"))))))),
+                                    tableScan(table.getName(), ImmutableMap.of("varchar_col", "varchar_col")))));
+        }
+    }
+
+    @Test
+    public void testProjectionsNotPushDownWhenFilterAppliedOnProjectedColumn()
+    {
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "test_projection_push_down_with_filter",
+                "(id BIGINT, cola VARCHAR, colb VARCHAR)",
+                ImmutableList.of("1, 'abc', 'def'"))) {
+            ResolvedFunction concatFunction = FUNCTIONS.resolveFunction(
+                    "concat",
+                    ImmutableList.of(
+                            new TypeSignatureProvider(VARCHAR.getTypeSignature()),
+                            new TypeSignatureProvider(VARCHAR.getTypeSignature())));
+            ResolvedFunction reverseFunction = FUNCTIONS.resolveFunction(
+                    "reverse",
+                    ImmutableList.of(
+                            new TypeSignatureProvider(VARCHAR.getTypeSignature())));
+
+            assertThat(query("SELECT reverse_col, concat_col FROM (SELECT reverse(cola) AS reverse_col, CONCAT(reverse(cola), colb) AS concat_col FROM " + table.getName() + ") WHERE concat_col = 'cbadef'"))
+                    .skippingTypesCheck()
+                    .matches("VALUES ('cba', 'cbadef')")
+                    .hasPlan(
+                            output(
+                                    project(
+                                            ImmutableMap.of(
+                                                    "reverse_col", expression(new Call(reverseFunction, ImmutableList.of(new Reference(VARCHAR, "cola")))),
+                                                    "concat_col", expression(new Call(
+                                                            concatFunction,
+                                                            ImmutableList.of(
+                                                                    new Call(reverseFunction, ImmutableList.of(new Reference(VARCHAR, "cola"))),
+                                                                    new Reference(VARCHAR, "colb"))))),
+                                            filter(
+                                                    new Comparison(
+                                                            Comparison.Operator.EQUAL,
+                                                            new Call(
+                                                                    concatFunction,
+                                                                    ImmutableList.of(
+                                                                            new Call(reverseFunction, ImmutableList.of(new Reference(VARCHAR, "cola"))),
+                                                                            new Reference(VARCHAR, "colb"))),
+                                                            new Constant(VARCHAR, Slices.utf8Slice("cbadef"))),
+                                                    tableScan(
+                                                            table.getName(),
+                                                            ImmutableMap.of(
+                                                                    "cola", "cola",
+                                                                    "colb", "colb"))))));
+        }
+    }
+
+    @Test
+    public void testReverseFunctionOnSpecialColumn()
+    {
+        String enumType = "test_enum_" + randomNameSuffix();
+        onRemoteDatabase().execute("CREATE TYPE " + enumType + " AS ENUM ('abc')");
+        try (TestTable table = new TestTable(
+                onRemoteDatabase(),
+                "table_with_special_column",
+                "(id BIGINT, col_money money, col_enum %s)".formatted(enumType),
+                ImmutableList.of("1, 10.0, 'abc'"))) {
+            assertThat(query("SELECT reverse(col_money) AS reverse_col_money, reverse(col_enum) AS reverse_col_enum FROM " + table.getName()))
+                    .skippingTypesCheck()
+                    .matches("VALUES ('00.01$', 'cba')")
+                    .isNotFullyPushedDown(ProjectNode.class)
+                    .hasPlan(output(
+                            project(
+                                    ImmutableMap.of(
+                                            "reverse_col_money",
+                                            expression(
+                                                    new Call(
+                                                            FUNCTIONS.resolveFunction(
+                                                                    "reverse",
+                                                                    ImmutableList.of(new TypeSignatureProvider(VARCHAR.getTypeSignature()))),
+                                                            ImmutableList.of(new Reference(VARCHAR, "col_money")))),
+                                            "reverse_col_enum",
+                                            expression(
+                                                    new Call(
+                                                            FUNCTIONS.resolveFunction(
+                                                                    "reverse",
+                                                                    ImmutableList.of(new TypeSignatureProvider(VARCHAR.getTypeSignature()))),
+                                                            ImmutableList.of(new Reference(VARCHAR, "col_enum"))))),
+                                    tableScan(
+                                            table.getName(),
+                                            ImmutableMap.of(
+                                                    "col_money", "col_money",
+                                                    "col_enum", "col_enum")))));
+        }
+        finally {
+            onRemoteDatabase().execute("DROP TYPE " + enumType);
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This framework would allow us to pushdown specific functions closer to the JDBC datasource. We use this function to pushdown `reverse` function in case of PostgreSQL connector. In order to push down a specific function to the underlying JDBC datasource, we need two parts
 - Client should implement `convertProjection`
 - Write a `ProjectFunctionRule` specific to the function to be pushed down. 

We also support partial pushdown of expression i.e `LOWER(REVERSE(varchar_col))` will be translated into `LOWER(synthetic_col_from_query)` 

Spl thanks to @SemionPar for inspiring me to use `reverse` function for this framework. 



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Without this change when we try to run a query like this 

```
explain select reverse(name) from nation
```
Current master
```
                                                               Query Plan
-----------------------------------------------------------------------------------------------------------------------------------------
 Trino version: testversion
 Fragment 0 [SOURCE]
     Output layout: [expr]
     Output partitioning: SINGLE []
     Output[columnNames = [_col0]]
     │   Layout: [expr:varchar(25)]
     │   Estimates: {rows: 25 (1.34kB), cpu: 0, memory: 0B, network: 0B}
     │   _col0 := expr
     └─ ScanProject[table = postgresql:tpch.nation tpch.nation columns=[name:varchar(25):varchar]]
            Layout: [expr:varchar(25)]
            Estimates: {rows: 25 (1.34kB), cpu: 1.34k, memory: 0B, network: 0B}/{rows: 25 (1.34kB), cpu: 1.34k, memory: 0B, network: 0B}
            expr := reverse(name)
            name := name:varchar(25):varchar
```


With this optimization

```
trino:tpch> explain select reverse(name) from nation;
                                                                    Query Plan
--------------------------------------------------------------------------------------------------------------------------------------------------
 Trino version: testversion
 Fragment 0 [SOURCE]
     Output layout: [pfgnrtd]
     Output partitioning: SINGLE []
     Output[columnNames = [_col0]]
     │   Layout: [pfgnrtd:varchar(25)]
     │   Estimates: {rows: ? (?), cpu: 0, memory: 0B, network: 0B}
     │   _col0 := pfgnrtd
     └─ TableScan[table = postgresql:Query[SELECT REVERSE("name") AS "_pfgnrtd_0" FROM "tpch"."nation"] columns=[_pfgnrtd_0:varchar(25):varchar]]
            Layout: [pfgnrtd:varchar(25)]
            Estimates: {rows: ? (?), cpu: ?, memory: 0B, network: 0B}
            pfgnrtd := _pfgnrtd_0:varchar(25):varchar
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# PostgreSQL
* Pushdown `reverse` function to the datasource when applied as a projection expression 
```
