### PR TITLE
Add more http proxy configs for native S3 filesystem implementation

### DIFF
--- a/docs/src/main/sphinx/object-storage/file-system-s3.md
+++ b/docs/src/main/sphinx/object-storage/file-system-s3.md
@@ -69,6 +69,15 @@ support:
   - URL of a HTTP proxy server to use for connecting to S3.
 * - `s3.http-proxy.secure`
   - Set to `true` to enable HTTPS for the proxy server.
+* - `s3.http-proxy.username`
+  - Proxy username to use if connecting through a proxy server.
+* - `s3.http-proxy.password`
+  - Proxy password to use if connecting through a proxy server.
+* - `s3.http-proxy.non-proxy-hosts`
+  - Hosts list to access without going through the proxy server.
+* - `s3.http-proxy.preemptive-basic-auth`
+  - Whether to attempt to authenticate preemptively against proxy server
+    when using base authorization, defaults to `false`.
 * - `s3.retry-mode`
   - Specifies how the AWS SDK attempts retries. Default value is `LEGACY`.
     Other allowed values are `STANDARD` and `ADAPTIVE`. The `STANDARD` mode

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
@@ -13,6 +13,8 @@
  */
 package io.trino.filesystem.s3;
 
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HostAndPort;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
@@ -26,7 +28,9 @@ import jakarta.validation.constraints.NotNull;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 
 import java.util.Optional;
+import java.util.Set;
 
+import static com.google.common.base.Strings.nullToEmpty;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
 public class S3FileSystemConfig
@@ -98,6 +102,10 @@ public class S3FileSystemConfig
     private boolean tcpKeepAlive;
     private HostAndPort httpProxy;
     private boolean httpProxySecure;
+    private String httpProxyUsername;
+    private String httpProxyPassword;
+    private boolean preemptiveBasicProxyAuth;
+    private Set<String> nonProxyHosts = ImmutableSet.of();
     private ObjectCannedAcl objectCannedAcl = ObjectCannedAcl.NONE;
     private RetryMode retryMode = RetryMode.LEGACY;
     private int maxErrorRetries = 10;
@@ -421,6 +429,55 @@ public class S3FileSystemConfig
     public S3FileSystemConfig setHttpProxySecure(boolean httpProxySecure)
     {
         this.httpProxySecure = httpProxySecure;
+        return this;
+    }
+
+    public String getHttpProxyUsername()
+    {
+        return httpProxyUsername;
+    }
+
+    @Config("s3.http-proxy.username")
+    public S3FileSystemConfig setHttpProxyUsername(String httpProxyUsername)
+    {
+        this.httpProxyUsername = httpProxyUsername;
+        return this;
+    }
+
+    public String getHttpProxyPassword()
+    {
+        return httpProxyPassword;
+    }
+
+    @Config("s3.http-proxy.password")
+    @ConfigSecuritySensitive
+    public S3FileSystemConfig setHttpProxyPassword(String httpProxyPassword)
+    {
+        this.httpProxyPassword = httpProxyPassword;
+        return this;
+    }
+
+    public boolean getHttpProxyPreemptiveBasicProxyAuth()
+    {
+        return preemptiveBasicProxyAuth;
+    }
+
+    @Config("s3.http-proxy.preemptive-basic-auth")
+    public S3FileSystemConfig setHttpProxyPreemptiveBasicProxyAuth(boolean preemptiveBasicProxyAuth)
+    {
+        this.preemptiveBasicProxyAuth = preemptiveBasicProxyAuth;
+        return this;
+    }
+
+    public Set<String> getNonProxyHosts()
+    {
+        return nonProxyHosts;
+    }
+
+    @Config("s3.http-proxy.non-proxy-hosts")
+    public S3FileSystemConfig setNonProxyHosts(String nonProxyHosts)
+    {
+        this.nonProxyHosts = ImmutableSet.copyOf(Splitter.on(',').omitEmptyStrings().trimResults().split(nullToEmpty(nonProxyHosts)));
         return this;
     }
 }

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemFactory.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemFactory.java
@@ -106,6 +106,10 @@ public final class S3FileSystemFactory
                     config.getHttpProxy()));
             httpClient.proxyConfiguration(ProxyConfiguration.builder()
                     .endpoint(endpoint)
+                    .username(config.getHttpProxyUsername())
+                    .password(config.getHttpProxyPassword())
+                    .nonProxyHosts(config.getNonProxyHosts())
+                    .preemptiveBasicAuthenticationEnabled(config.getHttpProxyPreemptiveBasicProxyAuth())
                     .build());
         }
 

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemConfig.java
@@ -61,7 +61,11 @@ public class TestS3FileSystemConfig
                 .setSocketReadTimeout(null)
                 .setTcpKeepAlive(false)
                 .setHttpProxy(null)
-                .setHttpProxySecure(false));
+                .setHttpProxySecure(false)
+                .setNonProxyHosts(null)
+                .setHttpProxyUsername(null)
+                .setHttpProxyPassword(null)
+                .setHttpProxyPreemptiveBasicProxyAuth(false));
     }
 
     @Test
@@ -93,6 +97,10 @@ public class TestS3FileSystemConfig
                 .put("s3.tcp-keep-alive", "true")
                 .put("s3.http-proxy", "localhost:8888")
                 .put("s3.http-proxy.secure", "true")
+                .put("s3.http-proxy.non-proxy-hosts", "test1,test2,test3")
+                .put("s3.http-proxy.username", "test")
+                .put("s3.http-proxy.password", "test")
+                .put("s3.http-proxy.preemptive-basic-auth", "true")
                 .buildOrThrow();
 
         S3FileSystemConfig expected = new S3FileSystemConfig()
@@ -120,7 +128,11 @@ public class TestS3FileSystemConfig
                 .setSocketReadTimeout(new Duration(4, MINUTES))
                 .setTcpKeepAlive(true)
                 .setHttpProxy(HostAndPort.fromParts("localhost", 8888))
-                .setHttpProxySecure(true);
+                .setHttpProxySecure(true)
+                .setNonProxyHosts("test1, test2, test3")
+                .setHttpProxyUsername("test")
+                .setHttpProxyPassword("test")
+                .setHttpProxyPreemptiveBasicProxyAuth(true);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
To make the http proxy config options in parity with legacy implementation

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
