### PR TITLE
Enable enableNullHandling query options in Pinot

### DIFF
--- a/plugin/trino-pinot/pom.xml
+++ b/plugin/trino-pinot/pom.xml
@@ -398,6 +398,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.roaringbitmap</groupId>
+            <artifactId>RoaringBitmap</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.weakref</groupId>
             <artifactId>jmxutils</artifactId>
         </dependency>

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotTableHandle.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotTableHandle.java
@@ -32,19 +32,26 @@ public class PinotTableHandle
 {
     private final String schemaName;
     private final String tableName;
+    private final boolean enableNullHandling;
     private final TupleDomain<ColumnHandle> constraint;
     private final OptionalLong limit;
     private final Optional<DynamicTable> query;
 
     public PinotTableHandle(String schemaName, String tableName)
     {
-        this(schemaName, tableName, TupleDomain.all(), OptionalLong.empty(), Optional.empty());
+        this(schemaName, tableName, false, TupleDomain.all(), OptionalLong.empty(), Optional.empty());
+    }
+
+    public PinotTableHandle(String schemaName, String tableName, boolean enableNullHandling)
+    {
+        this(schemaName, tableName, enableNullHandling, TupleDomain.all(), OptionalLong.empty(), Optional.empty());
     }
 
     @JsonCreator
     public PinotTableHandle(
             @JsonProperty("schemaName") String schemaName,
             @JsonProperty("tableName") String tableName,
+            @JsonProperty("enableNullHandling") boolean enableNullHandling,
             @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint,
             @JsonProperty("limit") OptionalLong limit,
             @JsonProperty("query") Optional<DynamicTable> query)
@@ -52,6 +59,7 @@ public class PinotTableHandle
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
+        this.enableNullHandling = enableNullHandling;
         this.constraint = requireNonNull(constraint, "constraint is null");
         this.limit = requireNonNull(limit, "limit is null");
         this.query = requireNonNull(query, "query is null");
@@ -67,6 +75,12 @@ public class PinotTableHandle
     public String getTableName()
     {
         return tableName;
+    }
+
+    @JsonProperty
+    public boolean isEnableNullHandling()
+    {
+        return enableNullHandling;
     }
 
     @JsonProperty
@@ -113,6 +127,7 @@ public class PinotTableHandle
         return toStringHelper(this)
                 .add("schemaName", schemaName)
                 .add("tableName", tableName)
+                .add("enableNullHandling", enableNullHandling)
                 .add("constraint", constraint)
                 .add("limit", limit)
                 .add("query", query)

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/PinotQueryBuilder.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/PinotQueryBuilder.java
@@ -57,6 +57,9 @@ public final class PinotQueryBuilder
     {
         requireNonNull(tableHandle, "tableHandle is null");
         StringBuilder pqlBuilder = new StringBuilder();
+        if (tableHandle.isEnableNullHandling()) {
+            pqlBuilder.append("SET enableNullHandling = true;\n");
+        }
         List<String> quotedColumnNames;
         if (columnHandles.isEmpty()) {
             // This occurs when the query is SELECT COUNT(*) FROM pinotTable ...

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotSplitManager.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotSplitManager.java
@@ -52,7 +52,7 @@ public class TestPinotSplitManager
         SchemaTableName schemaTableName = new SchemaTableName("default", format("SELECT %s, %s FROM %s LIMIT %d", "AirlineID", "OriginStateName", "airlineStats", 100));
         DynamicTable dynamicTable = buildFromPql(pinotMetadata, schemaTableName, mockClusterInfoFetcher, TESTING_TYPE_CONVERTER);
 
-        PinotTableHandle pinotTableHandle = new PinotTableHandle("default", dynamicTable.tableName(), TupleDomain.all(), OptionalLong.empty(), Optional.of(dynamicTable));
+        PinotTableHandle pinotTableHandle = new PinotTableHandle("default", dynamicTable.tableName(), false, TupleDomain.all(), OptionalLong.empty(), Optional.of(dynamicTable));
         List<PinotSplit> splits = getSplitsHelper(pinotTableHandle, 1, false);
         assertSplits(splits, 1, BROKER);
     }

--- a/plugin/trino-pinot/src/test/resources/alltypes_nullable_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/alltypes_nullable_realtimeSpec.json
@@ -1,0 +1,74 @@
+{
+    "tableName": "alltypes_nullable",
+    "tableType": "REALTIME",
+    "segmentsConfig": {
+        "timeColumnName": "updated_at_seconds",
+        "timeType": "SECONDS",
+        "retentionTimeUnit": "DAYS",
+        "retentionTimeValue": "365",
+        "segmentPushType": "APPEND",
+        "segmentPushFrequency": "daily",
+        "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
+        "schemaName": "alltypes_nullable",
+        "replicasPerPartition": "1"
+    },
+    "tenants": {
+        "broker": "DefaultTenant",
+        "server": "DefaultTenant"
+    },
+    "tableIndexConfig": {
+        "loadMode": "MMAP",
+        "invertedIndexColumns": ["string_col"],
+        "noDictionaryColumns": ["int_col"],
+        "sortedColumn": ["updated_at_seconds"],
+        "starTreeIndexConfigs": [
+            {
+                "dimensionsSplitOrder": ["string_col"],
+                "functionColumnPairs": [
+                    "COUNT__int_col",
+                    "COUNT__float_col",
+                    "COUNT__double_col",
+                    "COUNT__long_col",
+                    "MIN__int_col",
+                    "MIN__float_col",
+                    "MIN__double_col",
+                    "MIN__long_col",
+                    "MIN__timestamp_col",
+                    "MAX__int_col",
+                    "MAX__float_col",
+                    "MAX__double_col",
+                    "MAX__long_col",
+                    "MAX__timestamp_col",
+                    "AVG__int_col",
+                    "AVG__float_col",
+                    "AVG__double_col",
+                    "AVG__long_col",
+                    "SUM__int_col",
+                    "SUM__float_col",
+                    "SUM__double_col",
+                    "SUM__long_col"
+                ]
+            }
+        ],
+        "nullHandlingEnabled": "true",
+        "streamConfigs": {
+            "streamType": "kafka",
+            "stream.kafka.consumer.type": "LowLevel",
+            "stream.kafka.topic.name": "alltypes_nullable",
+            "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.avro.confluent.KafkaConfluentSchemaRegistryAvroMessageDecoder",
+            "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+            "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
+            "stream.kafka.zk.broker.url": "zookeeper:2181/",
+            "stream.kafka.broker.list": "kafka:9092",
+            "realtime.segment.flush.threshold.time": "24h",
+            "realtime.segment.flush.threshold.size": "0",
+            "realtime.segment.flush.desired.size": "1M",
+            "isolation.level": "read_committed",
+            "stream.kafka.consumer.prop.auto.offset.reset": "smallest",
+            "stream.kafka.consumer.prop.group.id": "pinot_alltypes_nullable"
+        }
+    },
+    "metadata": {
+        "customConfigs": {}
+    }
+}

--- a/plugin/trino-pinot/src/test/resources/alltypes_nullable_schema.json
+++ b/plugin/trino-pinot/src/test/resources/alltypes_nullable_schema.json
@@ -1,0 +1,96 @@
+{
+    "schemaName": "alltypes_nullable",
+    "enableColumnBasedNullHandling": true,
+    "dimensionFieldSpecs": [
+        {
+            "name": "string_col",
+            "dataType": "STRING",
+            "notNull": false
+        },
+        {
+            "name": "bool_col",
+            "dataType": "BOOLEAN"
+        },
+        {
+            "name": "bytes_col",
+            "dataType": "BYTES"
+        },
+        {
+            "name": "string_array_col",
+            "dataType": "STRING",
+            "singleValueField": false
+        },
+        {
+            "name": "int_array_col",
+            "dataType": "INT",
+            "singleValueField": false
+        },
+        {
+            "name": "int_array_col_with_pinot_default",
+            "dataType": "INT",
+            "singleValueField": false,
+            "defaultNullValue": 7
+        },
+        {
+            "name": "float_array_col",
+            "dataType": "FLOAT",
+            "singleValueField": false
+        },
+        {
+            "name": "double_array_col",
+            "dataType": "DOUBLE",
+            "singleValueField": false
+        },
+        {
+            "name": "long_array_col",
+            "dataType": "LONG",
+            "singleValueField": false
+        },
+        {
+            "name": "timestamp_col",
+            "dataType": "TIMESTAMP"
+        }
+    ],
+    "metricFieldSpecs": [
+        {
+            "name": "int_col",
+            "dataType": "INT"
+        },
+        {
+            "name": "float_col",
+            "dataType": "FLOAT"
+        },
+        {
+            "name": "double_col",
+            "dataType": "DOUBLE"
+        },
+        {
+            "name": "long_col",
+            "dataType": "LONG"
+        }
+    ],
+    "dateTimeFieldSpecs": [
+        {
+            "name": "updated_at_seconds",
+            "dataType": "LONG",
+            "defaultNullValue" : 0,
+            "format": "1:SECONDS:EPOCH",
+            "transformFunction": "toEpochSeconds(updated_at)",
+            "granularity" : "1:SECONDS"
+        },
+        {
+            "name": "updated_at_hours",
+            "dataType": "LONG",
+            "defaultNullValue" : 0,
+            "format": "1:SECONDS:EPOCH",
+            "transformFunction": "toEpochSecondsRounded(updated_at, 3600)",
+            "granularity" : "1:SECONDS"
+        },
+        {
+            "name": "ts",
+            "dataType": "TIMESTAMP",
+            "format": "1:MILLISECONDS:TIMESTAMP",
+            "granularity": "1:SECONDS"
+        }
+    ]
+}


### PR DESCRIPTION
## Description

Enable enableNullHandling query options in Pinot. 
* https://docs.pinot.apache.org/developers/advanced/null-value-support
* https://docs.pinot.apache.org/users/user-guide-query/query-options

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Pinot
* Fix some things. ({issue}`issuenumber`)
```
