### PR TITLE
Nessie: Support APIv2 client

### DIFF
--- a/docs/src/main/sphinx/object-storage/metastores.md
+++ b/docs/src/main/sphinx/object-storage/metastores.md
@@ -545,7 +545,7 @@ properties:
   - Description
 * - `iceberg.nessie-catalog.uri`
   - Nessie API endpoint URI (required). Example:
-    `https://localhost:19120/api/v1`
+    `https://localhost:19120/api/v2`
 * - `iceberg.nessie-catalog.ref`
   - The branch/tag to use for Nessie. Defaults to `main`.
 * - `iceberg.nessie-catalog.default-warehouse-dir`
@@ -566,12 +566,15 @@ properties:
 * - `iceberg.nessie-catalog.authentication.token`
   - The token to use with `BEARER` authentication. Example:
 `SXVLUXUhIExFQ0tFUiEK`
+* - `iceberg.nessie-catalog.client-api-version`
+  - Optional version of the Client API version to use. By default it is inferred from the `iceberg.nessie-catalog.uri` value.
+    Valid values are `V1` or `V2`.
 :::
 
 ```text
 connector.name=iceberg
 iceberg.catalog.type=nessie
-iceberg.nessie-catalog.uri=https://localhost:19120/api/v1
+iceberg.nessie-catalog.uri=https://localhost:19120/api/v2
 iceberg.nessie-catalog.default-warehouse-dir=/tmp
 ```
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPlugin.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPlugin.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.inject.CreationException;
 import io.airlift.bootstrap.ApplicationConfigurationException;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorFactory;
@@ -285,6 +286,7 @@ public class TestIcebergPlugin
                                 "iceberg.catalog.type", "nessie",
                                 "iceberg.nessie-catalog.default-warehouse-dir", "/tmp",
                                 "iceberg.nessie-catalog.uri", "http://foo:1234",
+                                "iceberg.nessie-catalog.client-api-version", "V1",
                                 "bootstrap.quiet", "true"),
                         new TestingConnectorContext())
                 .shutdown();
@@ -301,6 +303,7 @@ public class TestIcebergPlugin
                                 "iceberg.catalog.type", "nessie",
                                 "iceberg.nessie-catalog.default-warehouse-dir", "/tmp",
                                 "iceberg.nessie-catalog.uri", "http://foo:1234",
+                                "iceberg.nessie-catalog.client-api-version", "V2",
                                 "iceberg.nessie-catalog.authentication.type", "BEARER",
                                 "iceberg.nessie-catalog.authentication.token", "someToken"),
                         new TestingConnectorContext())
@@ -341,6 +344,23 @@ public class TestIcebergPlugin
                 .shutdown())
                 .isInstanceOf(ApplicationConfigurationException.class)
                 .hasMessageContaining("'iceberg.nessie-catalog.authentication.token' must be configured with 'iceberg.nessie-catalog.authentication.type' BEARER");
+    }
+
+    @Test
+    public void testNessieCatalogClientAPIVersion()
+    {
+        ConnectorFactory factory = getConnectorFactory();
+
+        assertThatThrownBy(() -> factory.create(
+                        "test",
+                        Map.of(
+                                "iceberg.catalog.type", "nessie",
+                                "iceberg.nessie-catalog.uri", "http://foo:1234",
+                                "iceberg.nessie-catalog.default-warehouse-dir", "/tmp"),
+                        new TestingConnectorContext())
+                .shutdown())
+                .isInstanceOf(CreationException.class)
+                .hasMessageContaining("URI doesn't end with the version: http://foo:1234. Please configure `client-api-version` in the catalog properties explicitly.");
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestIcebergNessieCatalogConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestIcebergNessieCatalogConfig.java
@@ -41,7 +41,8 @@ public class TestIcebergNessieCatalogConfig
                 .setConnectionTimeout(new Duration(DEFAULT_CONNECT_TIMEOUT_MILLIS, MILLISECONDS))
                 .setReadTimeout(new Duration(DEFAULT_READ_TIMEOUT_MILLIS, MILLISECONDS))
                 .setSecurity(null)
-                .setBearerToken(null));
+                .setBearerToken(null)
+                .setClientAPIVersion(null));
     }
 
     @Test
@@ -49,24 +50,26 @@ public class TestIcebergNessieCatalogConfig
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("iceberg.nessie-catalog.default-warehouse-dir", "/tmp")
-                .put("iceberg.nessie-catalog.uri", "http://localhost:xxx/api/v1")
+                .put("iceberg.nessie-catalog.uri", "http://localhost:xxx/api/custom")
                 .put("iceberg.nessie-catalog.ref", "someRef")
                 .put("iceberg.nessie-catalog.enable-compression", "false")
                 .put("iceberg.nessie-catalog.connection-timeout", "2s")
                 .put("iceberg.nessie-catalog.read-timeout", "5m")
                 .put("iceberg.nessie-catalog.authentication.type", "BEARER")
                 .put("iceberg.nessie-catalog.authentication.token", "bearerToken")
+                .put("iceberg.nessie-catalog.client-api-version", "V1")
                 .buildOrThrow();
 
         IcebergNessieCatalogConfig expected = new IcebergNessieCatalogConfig()
                 .setDefaultWarehouseDir("/tmp")
-                .setServerUri(URI.create("http://localhost:xxx/api/v1"))
+                .setServerUri(URI.create("http://localhost:xxx/api/custom"))
                 .setDefaultReferenceName("someRef")
                 .setCompressionEnabled(false)
                 .setConnectionTimeout(new Duration(2, TimeUnit.SECONDS))
                 .setReadTimeout(new Duration(5, TimeUnit.MINUTES))
                 .setSecurity(IcebergNessieCatalogConfig.Security.BEARER)
-                .setBearerToken("bearerToken");
+                .setBearerToken("bearerToken")
+                .setClientAPIVersion(IcebergNessieCatalogConfig.ClientApiVersion.V1);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestTrinoNessieCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestTrinoNessieCatalog.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 import org.projectnessie.client.NessieClientBuilder;
-import org.projectnessie.client.api.NessieApiV1;
+import org.projectnessie.client.api.NessieApiV2;
 
 import java.io.File;
 import java.io.IOException;
@@ -94,9 +94,9 @@ public class TestTrinoNessieCatalog
         TrinoFileSystemFactory fileSystemFactory = new HdfsFileSystemFactory(HDFS_ENVIRONMENT, HDFS_FILE_SYSTEM_STATS);
         IcebergNessieCatalogConfig icebergNessieCatalogConfig = new IcebergNessieCatalogConfig()
                 .setServerUri(URI.create(nessieContainer.getRestApiUri()));
-        NessieApiV1 nessieApi = NessieClientBuilder.createClientBuilderFromSystemSettings()
+        NessieApiV2 nessieApi = NessieClientBuilder.createClientBuilderFromSystemSettings()
                 .withUri(nessieContainer.getRestApiUri())
-                .build(NessieApiV1.class);
+                .build(NessieApiV2.class);
         NessieIcebergClient nessieClient = new NessieIcebergClient(nessieApi, icebergNessieCatalogConfig.getDefaultReferenceName(), null, ImmutableMap.of());
         return new TrinoNessieCatalog(
                 new CatalogName("catalog_name"),
@@ -118,9 +118,9 @@ public class TestTrinoNessieCatalog
         IcebergNessieCatalogConfig icebergNessieCatalogConfig = new IcebergNessieCatalogConfig()
                 .setDefaultWarehouseDir(tmpDirectory.toAbsolutePath().toString())
                 .setServerUri(URI.create(nessieContainer.getRestApiUri()));
-        NessieApiV1 nessieApi = NessieClientBuilder.createClientBuilderFromSystemSettings()
+        NessieApiV2 nessieApi = NessieClientBuilder.createClientBuilderFromSystemSettings()
                 .withUri(nessieContainer.getRestApiUri())
-                .build(NessieApiV1.class);
+                .build(NessieApiV2.class);
         NessieIcebergClient nessieClient = new NessieIcebergClient(nessieApi, icebergNessieCatalogConfig.getDefaultReferenceName(), null, ImmutableMap.of());
         TrinoCatalog catalogWithDefaultLocation = new TrinoNessieCatalog(
                 new CatalogName("catalog_name"),

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/containers/NessieContainer.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/containers/NessieContainer.java
@@ -64,7 +64,7 @@ public class NessieContainer
 
     public String getRestApiUri()
     {
-        return "http://" + getMappedHostAndPortForExposedPort(PORT) + "/api/v1";
+        return "http://" + getMappedHostAndPortForExposedPort(PORT) + "/api/v2";
     }
 
     public static class Builder

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg-nessie/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg-nessie/iceberg.properties
@@ -1,4 +1,4 @@
 connector.name=iceberg
 iceberg.catalog.type=nessie
-iceberg.nessie-catalog.uri=http://nessie-server:19120/api/v1
+iceberg.nessie-catalog.uri=http://nessie-server:19120/api/v2
 iceberg.nessie-catalog.default-warehouse-dir=hdfs://hadoop-master:9000/user/hive/warehouse

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg-nessie/spark-defaults.conf
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg-nessie/spark-defaults.conf
@@ -1,6 +1,6 @@
 spark.sql.catalog.iceberg_test=org.apache.iceberg.spark.SparkCatalog
 spark.sql.catalog.iceberg_test.catalog-impl=org.apache.iceberg.nessie.NessieCatalog
-spark.sql.catalog.iceberg_test.uri=http://nessie-server:19120/api/v1
+spark.sql.catalog.iceberg_test.uri=http://nessie-server:19120/api/v2
 spark.sql.catalog.iceberg_test.authentication.type=NONE
 spark.sql.catalog.iceberg_test.warehouse=hdfs://hadoop-master:9000/user/hive/warehouse
 ; disabling caching allows us to run spark queries interchangeably with trino's


### PR DESCRIPTION
## Description
By default, Nessie API version will be inferred from Nessie URI. If the User has a custom URI which doesn't have version info in the URI, user can configure `iceberg.nessie-catalog.client-api-version`


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Changes at Iceberg repo: https://github.com/apache/iceberg/pull/9459

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
