### PR TITLE
Add `exchange.azure.endpoint` configuration option

### DIFF
--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.md
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.md
@@ -485,8 +485,14 @@ the property may be configured for:
     together with `exchange.gcs.json-key-file-path`
   -
   - GCS
+* - `exchange.azure.endpoint`
+  - Azure blob endpoint used to access the spooling container. Not to be set
+    together with `exchange.azure.connection-string`
+  - 
+  - Azure Blob Storage
 * - `exchange.azure.connection-string`
-  - Connection string used to access the spooling container.
+  - Connection string used to access the spooling container. Not to be set
+    together with `exchange.azure.endpoint`
   -
   - Azure Blob Storage
 * - `exchange.azure.block-size`

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/azure/AzureBlobFileSystemExchangeStorage.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/azure/AzureBlobFileSystemExchangeStorage.java
@@ -99,12 +99,20 @@ public class AzureBlobFileSystemExchangeStorage
         BlobServiceClientBuilder blobServiceClientBuilder = new BlobServiceClientBuilder()
                 .retryOptions(new RequestRetryOptions(RetryPolicyType.EXPONENTIAL, config.getMaxErrorRetries(), (Integer) null, null, null, null));
         Optional<String> connectionString = config.getAzureStorageConnectionString();
+        Optional<String> endpoint = config.getAzureStorageEndpoint();
+
+        if ((connectionString.isEmpty() && endpoint.isEmpty()) || (connectionString.isPresent() && endpoint.isPresent())) {
+            throw new IllegalArgumentException("Exactly one of exchange.azure.endpoint or exchange.azure.connection-string must be provided");
+        }
+
         if (connectionString.isPresent()) {
             blobServiceClientBuilder.connectionString(connectionString.get());
         }
         else {
+            blobServiceClientBuilder.endpoint(endpoint.get());
             blobServiceClientBuilder.credential(new DefaultAzureCredentialBuilder().build());
         }
+
         this.blobServiceAsyncClient = blobServiceClientBuilder.buildAsyncClient();
     }
 

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/azure/ExchangeAzureConfig.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/azure/ExchangeAzureConfig.java
@@ -29,6 +29,7 @@ import static io.airlift.units.DataSize.Unit.MEGABYTE;
 public class ExchangeAzureConfig
 {
     private Optional<String> azureStorageConnectionString = Optional.empty();
+    private Optional<String> azureStorageEndpoint = Optional.empty();
     private DataSize azureStorageBlockSize = DataSize.of(4, MEGABYTE);
     private int maxErrorRetries = 10;
 
@@ -37,11 +38,24 @@ public class ExchangeAzureConfig
         return azureStorageConnectionString;
     }
 
+    public Optional<String> getAzureStorageEndpoint()
+    {
+        return azureStorageEndpoint;
+    }
+
     @Config("exchange.azure.connection-string")
     @ConfigSecuritySensitive
     public ExchangeAzureConfig setAzureStorageConnectionString(String azureStorageConnectionString)
     {
         this.azureStorageConnectionString = Optional.ofNullable(azureStorageConnectionString);
+        return this;
+    }
+
+    @Config("exchange.azure.endpoint")
+    @ConfigSecuritySensitive
+    public ExchangeAzureConfig setAzureStorageEndpoint(String azureStorageEndpoint)
+    {
+        this.azureStorageEndpoint = Optional.ofNullable(azureStorageEndpoint);
         return this;
     }
 

--- a/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/azure/TestExchangeAzureConfig.java
+++ b/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/azure/TestExchangeAzureConfig.java
@@ -30,6 +30,7 @@ public class TestExchangeAzureConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(ExchangeAzureConfig.class)
+                .setAzureStorageEndpoint(null)
                 .setAzureStorageConnectionString(null)
                 .setAzureStorageBlockSize(DataSize.of(4, MEGABYTE))
                 .setMaxErrorRetries(10));
@@ -40,12 +41,14 @@ public class TestExchangeAzureConfig
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("exchange.azure.connection-string", "connection")
+                .put("exchange.azure.endpoint", "endpoint")
                 .put("exchange.azure.block-size", "8MB")
                 .put("exchange.azure.max-error-retries", "8")
                 .buildOrThrow();
 
         ExchangeAzureConfig expected = new ExchangeAzureConfig()
                 .setAzureStorageConnectionString("connection")
+                .setAzureStorageEndpoint("endpoint")
                 .setAzureStorageBlockSize(DataSize.of(8, MEGABYTE))
                 .setMaxErrorRetries(8);
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This option can be used instead of `exchange.azure.connection-string` and will use the default azure credentials when set.

If a user attempts to set up an ABFS-backed exchange manager without specifying a connection string, the plugin will fail when calling `blobServiceClientBuilder.buildAsyncClient()` as the builder does not have an endpoint set. That also means one cannot use the `DefaultAzureCredential` and is only able to use authentication methods allowed via connection strings (SAS Tokens and Account Keys). This PR aims to fix that code path by adding a configuration to supply an endpoint to be injected into the builder, and makes it mutually exclusive with `exchange.azure.connection-string`. 

Generally the use-cases would be like this: 

* Use `exchange.azure.connection-string` if you're using SAS Tokens/Account Keys
* Use `exchange.azure.endpoint` if you're using anything else (Managed Identity, Workload Identity, Service Principals, etc.)

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
