### PR TITLE
Add junit-extensions to OpenLineage

### DIFF
--- a/plugin/trino-openlineage/pom.xml
+++ b/plugin/trino-openlineage/pom.xml
@@ -118,6 +118,12 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>junit-extensions</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>testing</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
## Description

Fix CI failure: https://github.com/trinodb/trino/actions/runs/9325542244/job/25672737398
```
Error:  Failures: 
Error:    TestTestSetup.testSetupOfTests:45 Errors: 
		Missing dependency on io.airlift:junit-extensions in /home/runner/work/trino/trino/plugin/trino-openlineage/pom.xml
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
