### PR TITLE
Add support for path prefix routing using "X-Forwarded-Prefix" header

### DIFF
--- a/core/trino-main/src/main/java/io/trino/dispatcher/CoordinatorLocation.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/CoordinatorLocation.java
@@ -13,11 +13,10 @@
  */
 package io.trino.dispatcher;
 
-import jakarta.ws.rs.core.UriInfo;
-
-import java.net.URI;
+import io.trino.server.ExternalUriInfo;
+import io.trino.server.ExternalUriInfo.ExternalUriBuilder;
 
 public interface CoordinatorLocation
 {
-    URI getUri(UriInfo uriInfo);
+    ExternalUriBuilder getUri(ExternalUriInfo externalUriInfo);
 }

--- a/core/trino-main/src/main/java/io/trino/dispatcher/LocalCoordinatorLocation.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/LocalCoordinatorLocation.java
@@ -13,19 +13,15 @@
  */
 package io.trino.dispatcher;
 
-import jakarta.ws.rs.core.UriInfo;
-
-import java.net.URI;
+import io.trino.server.ExternalUriInfo;
+import io.trino.server.ExternalUriInfo.ExternalUriBuilder;
 
 public class LocalCoordinatorLocation
         implements CoordinatorLocation
 {
     @Override
-    public URI getUri(UriInfo uriInfo)
+    public ExternalUriBuilder getUri(ExternalUriInfo externalUriInfo)
     {
-        return uriInfo.getRequestUriBuilder()
-                .replacePath("")
-                .replaceQuery("")
-                .build();
+        return externalUriInfo.baseUriBuilder();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/dispatcher/QueuedStatementResource.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/QueuedStatementResource.java
@@ -32,6 +32,7 @@ import io.trino.execution.ExecutionFailureInfo;
 import io.trino.execution.QueryManagerConfig;
 import io.trino.execution.QueryState;
 import io.trino.server.DisconnectionAwareAsyncResponse;
+import io.trino.server.ExternalUriInfo;
 import io.trino.server.HttpRequestSessionContextFactory;
 import io.trino.server.ServerConfig;
 import io.trino.server.SessionContext;
@@ -62,8 +63,6 @@ import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
-import jakarta.ws.rs.core.UriBuilder;
-import jakarta.ws.rs.core.UriInfo;
 
 import java.net.URI;
 import java.util.Optional;
@@ -162,7 +161,7 @@ public class QueuedStatementResource
             String statement,
             @Context HttpServletRequest servletRequest,
             @Context HttpHeaders httpHeaders,
-            @Context UriInfo uriInfo)
+            @BeanParam ExternalUriInfo externalUriInfo)
     {
         if (isNullOrEmpty(statement)) {
             throw badRequest(BAD_REQUEST, "SQL statement is empty");
@@ -170,7 +169,7 @@ public class QueuedStatementResource
 
         Query query = registerQuery(statement, servletRequest, httpHeaders);
 
-        return createQueryResultsResponse(query.getQueryResults(query.getLastToken(), uriInfo));
+        return createQueryResultsResponse(query.getQueryResults(query.getLastToken(), externalUriInfo));
     }
 
     private Query registerQuery(String statement, HttpServletRequest servletRequest, HttpHeaders httpHeaders)
@@ -202,16 +201,16 @@ public class QueuedStatementResource
             @PathParam("slug") String slug,
             @PathParam("token") long token,
             @QueryParam("maxWait") Duration maxWait,
-            @Context UriInfo uriInfo,
+            @BeanParam ExternalUriInfo externalUriInfo,
             @Suspended @BeanParam DisconnectionAwareAsyncResponse asyncResponse)
     {
         Query query = getQuery(queryId, slug, token);
 
-        ListenableFuture<Response> future = getStatus(query, token, maxWait, uriInfo);
+        ListenableFuture<Response> future = getStatus(query, token, maxWait, externalUriInfo);
         bindDisconnectionAwareAsyncResponse(asyncResponse, future, responseExecutor);
     }
 
-    private ListenableFuture<Response> getStatus(Query query, long token, Duration maxWait, UriInfo uriInfo)
+    private ListenableFuture<Response> getStatus(Query query, long token, Duration maxWait, ExternalUriInfo externalUriInfo)
     {
         long waitMillis = WAIT_ORDERING.min(MAX_WAIT_TIME, maxWait).toMillis();
 
@@ -220,7 +219,7 @@ public class QueuedStatementResource
                 .withTimeout(waitMillis, MILLISECONDS, timeoutExecutor)
                 .catching(TimeoutException.class, _ -> null, directExecutor())
                 // when state changes, fetch the next result
-                .transform(_ -> query.getQueryResults(token, uriInfo), responseExecutor)
+                .transform(_ -> query.getQueryResults(token, externalUriInfo), responseExecutor)
                 .transform(this::createQueryResultsResponse, directExecutor());
     }
 
@@ -256,14 +255,13 @@ public class QueuedStatementResource
         return builder.build();
     }
 
-    private static URI getQueuedUri(QueryId queryId, Slug slug, long token, UriInfo uriInfo)
+    private static URI getQueuedUri(QueryId queryId, Slug slug, long token, ExternalUriInfo externalUriInfo)
     {
-        return uriInfo.getBaseUriBuilder()
-                .replacePath("/v1/statement/queued/")
+        return externalUriInfo.baseUriBuilder()
+                .path("/v1/statement/queued/")
                 .path(queryId.toString())
                 .path(slug.makeSlug(QUEUED_QUERY, token))
                 .path(String.valueOf(token))
-                .replaceQuery("")
                 .build();
     }
 
@@ -271,7 +269,7 @@ public class QueuedStatementResource
             QueryId queryId,
             URI nextUri,
             Optional<QueryError> queryError,
-            UriInfo uriInfo,
+            ExternalUriInfo externalUriInfo,
             Optional<URI> queryInfoUrl,
             Duration elapsedTime,
             Duration queuedTime)
@@ -279,7 +277,7 @@ public class QueuedStatementResource
         QueryState state = queryError.map(error -> FAILED).orElse(QUEUED);
         return new QueryResults(
                 queryId.toString(),
-                getQueryInfoUri(queryInfoUrl, queryId, uriInfo),
+                getQueryInfoUri(queryInfoUrl, queryId, externalUriInfo),
                 null,
                 nextUri,
                 null,
@@ -384,7 +382,7 @@ public class QueuedStatementResource
             }
         }
 
-        public QueryResults getQueryResults(long token, UriInfo uriInfo)
+        public QueryResults getQueryResults(long token, ExternalUriInfo externalUriInfo)
         {
             long lastToken = this.lastToken.get();
             // token should be the last token or the next token
@@ -398,7 +396,7 @@ public class QueuedStatementResource
             if (!creationFuture.isDone()) {
                 return createQueryResults(
                         token + 1,
-                        uriInfo,
+                        externalUriInfo,
                         DispatchInfo.queued(NO_DURATION, NO_DURATION));
             }
 
@@ -408,7 +406,7 @@ public class QueuedStatementResource
                             .status(NOT_FOUND)
                             .build()));
 
-            return createQueryResults(token + 1, uriInfo, dispatchInfo);
+            return createQueryResults(token + 1, externalUriInfo, dispatchInfo);
         }
 
         public void cancel()
@@ -422,9 +420,9 @@ public class QueuedStatementResource
             sessionContext.getIdentity().destroy();
         }
 
-        private QueryResults createQueryResults(long token, UriInfo uriInfo, DispatchInfo dispatchInfo)
+        private QueryResults createQueryResults(long token, ExternalUriInfo externalUriInfo, DispatchInfo dispatchInfo)
         {
-            URI nextUri = getNextUri(token, uriInfo, dispatchInfo);
+            URI nextUri = getNextUri(token, externalUriInfo, dispatchInfo);
 
             Optional<QueryError> queryError = dispatchInfo.getFailureInfo()
                     .map(this::toQueryError);
@@ -433,13 +431,13 @@ public class QueuedStatementResource
                     queryId,
                     nextUri,
                     queryError,
-                    uriInfo,
+                    externalUriInfo,
                     queryInfoUrl,
                     dispatchInfo.getElapsedTime(),
                     dispatchInfo.getQueuedTime());
         }
 
-        private URI getNextUri(long token, UriInfo uriInfo, DispatchInfo dispatchInfo)
+        private URI getNextUri(long token, ExternalUriInfo externalUriInfo, DispatchInfo dispatchInfo)
         {
             // if failed, query is complete
             if (dispatchInfo.getFailureInfo().isPresent()) {
@@ -447,15 +445,14 @@ public class QueuedStatementResource
             }
             // if dispatched, redirect to new uri
             return dispatchInfo.getCoordinatorLocation()
-                    .map(coordinatorLocation -> getRedirectUri(coordinatorLocation, uriInfo))
-                    .orElseGet(() -> getQueuedUri(queryId, slug, token, uriInfo));
+                    .map(coordinatorLocation -> getRedirectUri(coordinatorLocation, externalUriInfo))
+                    .orElseGet(() -> getQueuedUri(queryId, slug, token, externalUriInfo));
         }
 
-        private URI getRedirectUri(CoordinatorLocation coordinatorLocation, UriInfo uriInfo)
+        private URI getRedirectUri(CoordinatorLocation coordinatorLocation, ExternalUriInfo externalUriInfo)
         {
-            URI coordinatorUri = coordinatorLocation.getUri(uriInfo);
-            return UriBuilder.fromUri(coordinatorUri)
-                    .replacePath("/v1/statement/executing")
+            return coordinatorLocation.getUri(externalUriInfo)
+                    .path("/v1/statement/executing")
                     .path(queryId.toString())
                     .path(slug.makeSlug(EXECUTING_QUERY, 0))
                     .path("0")

--- a/core/trino-main/src/main/java/io/trino/server/ExternalUriInfo.java
+++ b/core/trino-main/src/main/java/io/trino/server/ExternalUriInfo.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server;
+
+import com.google.common.net.UrlEscapers;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.UriBuilderException;
+import jakarta.ws.rs.core.UriInfo;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
+
+/**
+ * Provides external URI information for the current request. The external URI may have a path prefix when behind a reverse proxy.
+ * The path prefix is extracted from the {@code X-Forwarded-Prefix} header.
+ */
+public class ExternalUriInfo
+{
+    private static final String X_FORWARDED_PREFIX = "X-Forwarded-Prefix";
+
+    private final UriInfo uriInfo;
+    private final String forwardedPrefix;
+
+    public ExternalUriInfo(@Context UriInfo uriInfo, @HeaderParam(X_FORWARDED_PREFIX) String forwardedPrefix)
+    {
+        this.uriInfo = requireNonNull(uriInfo, "uriInfo is null");
+        this.forwardedPrefix = UrlEscapers.urlPathSegmentEscaper().escape(requireNonNullElse(forwardedPrefix, ""));
+    }
+
+    public static ExternalUriInfo from(ContainerRequestContext requestContext)
+    {
+        return new ExternalUriInfo(requestContext.getUriInfo(), requestContext.getHeaderString(X_FORWARDED_PREFIX));
+    }
+
+    /**
+     * Returns an external URI builder with the forwarded path prefix and no query parameters.
+     */
+    public ExternalUriBuilder baseUriBuilder()
+    {
+        return new ExternalUriBuilder(uriInfo.getBaseUriBuilder()
+                .replacePath(forwardedPrefix)
+                .replaceQuery(""));
+    }
+
+    /**
+     * Returns an external URI to the specified path prefixed with forwarded path prefix, and no query parameters.
+     */
+    public URI absolutePath(String path)
+    {
+        return baseUriBuilder().path(path).build();
+    }
+
+    /**
+     * Returns the full request URI with the forwarded path prefix, and all query parameters.
+     */
+    public URI fullRequestUri()
+    {
+        return uriInfo.getRequestUriBuilder()
+                .replacePath(forwardedPrefix)
+                .path(uriInfo.getPath())
+                .build();
+    }
+
+    public static class ExternalUriBuilder
+    {
+        private final UriBuilder uriBuilder;
+
+        private ExternalUriBuilder(UriBuilder uriBuilder)
+        {
+            this.uriBuilder = requireNonNull(uriBuilder, "uriBuilder is null");
+        }
+
+        public ExternalUriBuilder path(String path)
+        {
+            uriBuilder.path(path);
+            return this;
+        }
+
+        public ExternalUriBuilder replaceQuery(String query)
+        {
+            uriBuilder.replaceQuery(query);
+            return this;
+        }
+
+        public ExternalUriBuilder rawReplaceQuery(String rawEncodedQuery)
+        {
+            // this is a hack - the replaceQuery method encodes the value where the uri method just copies the value
+            try {
+                uriBuilder.uri(new URI(null, null, null, rawEncodedQuery, null));
+            }
+            catch (URISyntaxException _) {
+            }
+            return this;
+        }
+
+        public URI build()
+                throws IllegalArgumentException, UriBuilderException
+        {
+            return uriBuilder.build();
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResource.java
@@ -27,6 +27,7 @@ import io.trino.exchange.ExchangeManagerRegistry;
 import io.trino.execution.QueryManager;
 import io.trino.operator.DirectExchangeClientSupplier;
 import io.trino.server.DisconnectionAwareAsyncResponse;
+import io.trino.server.ExternalUriInfo;
 import io.trino.server.ForStatementResource;
 import io.trino.server.ServerConfig;
 import io.trino.server.security.ResourceSecurity;
@@ -42,11 +43,9 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.container.Suspended;
-import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.ResponseBuilder;
-import jakarta.ws.rs.core.UriInfo;
 
 import java.net.URLEncoder;
 import java.util.Map.Entry;
@@ -161,11 +160,11 @@ public class ExecutingStatementResource
             @PathParam("token") long token,
             @QueryParam("maxWait") Duration maxWait,
             @QueryParam("targetResultSize") DataSize targetResultSize,
-            @Context UriInfo uriInfo,
+            @BeanParam ExternalUriInfo externalUriInfo,
             @Suspended @BeanParam DisconnectionAwareAsyncResponse asyncResponse)
     {
         Query query = getQuery(queryId, slug, token);
-        asyncQueryResults(query, token, maxWait, targetResultSize, uriInfo, asyncResponse);
+        asyncQueryResults(query, token, maxWait, targetResultSize, externalUriInfo, asyncResponse);
     }
 
     protected Query getQuery(QueryId queryId, String slug, long token)
@@ -210,7 +209,7 @@ public class ExecutingStatementResource
             long token,
             Duration maxWait,
             DataSize targetResultSize,
-            UriInfo uriInfo,
+            ExternalUriInfo externalUriInfo,
             DisconnectionAwareAsyncResponse asyncResponse)
     {
         Duration wait = WAIT_ORDERING.min(MAX_WAIT_TIME, maxWait);
@@ -220,7 +219,7 @@ public class ExecutingStatementResource
         else {
             targetResultSize = Ordering.natural().min(targetResultSize, MAX_TARGET_RESULT_SIZE);
         }
-        ListenableFuture<QueryResultsResponse> queryResultsFuture = query.waitForResults(token, uriInfo, wait, targetResultSize);
+        ListenableFuture<QueryResultsResponse> queryResultsFuture = query.waitForResults(token, externalUriInfo, wait, targetResultSize);
 
         ListenableFuture<Response> response = Futures.transform(queryResultsFuture, this::toResponse, directExecutor());
 

--- a/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
@@ -44,6 +44,7 @@ import io.trino.execution.buffer.PageDeserializer;
 import io.trino.execution.buffer.PagesSerdeFactory;
 import io.trino.memory.context.SimpleLocalMemoryContext;
 import io.trino.operator.DirectExchangeClientSupplier;
+import io.trino.server.ExternalUriInfo;
 import io.trino.server.ResultQueryInfo;
 import io.trino.spi.ErrorCode;
 import io.trino.spi.Page;
@@ -56,7 +57,6 @@ import io.trino.transaction.TransactionId;
 import io.trino.util.Ciphers;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.UriInfo;
 
 import java.net.URI;
 import java.util.List;
@@ -278,7 +278,7 @@ class Query
         return queryManager.getFullQueryInfo(queryId);
     }
 
-    public ListenableFuture<QueryResultsResponse> waitForResults(long token, UriInfo uriInfo, Duration wait, DataSize targetResultSize)
+    public ListenableFuture<QueryResultsResponse> waitForResults(long token, ExternalUriInfo externalUriInfo, Duration wait, DataSize targetResultSize)
     {
         ListenableFuture<Void> futureStateChange;
         synchronized (this) {
@@ -296,7 +296,7 @@ class Query
             futureStateChange = addTimeout(futureStateChange, () -> null, wait, timeoutExecutor);
         }
         // when state changes, fetch the next result
-        return Futures.transform(futureStateChange, _ -> getNextResult(token, uriInfo, targetResultSize), resultsProcessorExecutor);
+        return Futures.transform(futureStateChange, _ -> getNextResult(token, externalUriInfo, targetResultSize), resultsProcessorExecutor);
     }
 
     public void markResultsConsumedIfReady()
@@ -399,7 +399,7 @@ class Query
         return Optional.empty();
     }
 
-    private synchronized QueryResultsResponse getNextResult(long token, UriInfo uriInfo, DataSize targetResultSize)
+    private synchronized QueryResultsResponse getNextResult(long token, ExternalUriInfo externalUriInfo, DataSize targetResultSize)
     {
         // check if the result for the token have already been created
         Optional<QueryResults> cachedResult = getCachedResult(token);
@@ -459,9 +459,9 @@ class Query
         URI partialCancelUri = null;
         if (nextToken.isPresent()) {
             long nextToken = this.nextToken.getAsLong();
-            nextResultsUri = createNextResultsUri(uriInfo, nextToken);
+            nextResultsUri = createNextResultsUri(externalUriInfo, nextToken);
             partialCancelUri = findCancelableLeafStage(queryInfo)
-                    .map(stage -> createPartialCancelUri(stage, uriInfo, nextToken))
+                    .map(stage -> createPartialCancelUri(stage, externalUriInfo, nextToken))
                     .orElse(null);
         }
 
@@ -492,7 +492,7 @@ class Query
         // first time through, self is null
         QueryResults queryResults = new QueryResults(
                 queryId.toString(),
-                getQueryInfoUri(queryInfoUrl, queryId, uriInfo),
+                getQueryInfoUri(queryInfoUrl, queryId, externalUriInfo),
                 partialCancelUri,
                 nextResultsUri,
                 resultRows.getColumns().orElse(null),
@@ -631,26 +631,24 @@ class Query
         return Futures.transformAsync(queryManager.getStateChange(queryId, currentState), this::queryDoneFuture, directExecutor());
     }
 
-    private URI createNextResultsUri(UriInfo uriInfo, long nextToken)
+    private URI createNextResultsUri(ExternalUriInfo externalUriInfo, long nextToken)
     {
-        return uriInfo.getBaseUriBuilder()
-                .replacePath("/v1/statement/executing")
+        return externalUriInfo.baseUriBuilder()
+                .path("/v1/statement/executing")
                 .path(queryId.toString())
                 .path(slug.makeSlug(EXECUTING_QUERY, nextToken))
                 .path(String.valueOf(nextToken))
-                .replaceQuery("")
                 .build();
     }
 
-    private URI createPartialCancelUri(int stage, UriInfo uriInfo, long nextToken)
+    private URI createPartialCancelUri(int stage, ExternalUriInfo externalUriInfo, long nextToken)
     {
-        return uriInfo.getBaseUriBuilder()
-                .replacePath("/v1/statement/executing/partialCancel")
+        return externalUriInfo.baseUriBuilder()
+                .path("/v1/statement/executing/partialCancel")
                 .path(queryId.toString())
                 .path(String.valueOf(stage))
                 .path(slug.makeSlug(EXECUTING_QUERY, nextToken))
                 .path(String.valueOf(nextToken))
-                .replaceQuery("")
                 .build();
     }
 

--- a/core/trino-main/src/main/java/io/trino/server/protocol/QueryInfoUrlFactory.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/QueryInfoUrlFactory.java
@@ -14,9 +14,9 @@
 package io.trino.server.protocol;
 
 import com.google.inject.Inject;
+import io.trino.server.ExternalUriInfo;
 import io.trino.server.ServerConfig;
 import io.trino.spi.QueryId;
-import jakarta.ws.rs.core.UriInfo;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -49,11 +49,11 @@ public class QueryInfoUrlFactory
                 .map(URI::create);
     }
 
-    public static URI getQueryInfoUri(Optional<URI> queryInfoUrl, QueryId queryId, UriInfo uriInfo)
+    public static URI getQueryInfoUri(Optional<URI> queryInfoUrl, QueryId queryId, ExternalUriInfo externalUriInfo)
     {
         return queryInfoUrl.orElseGet(() ->
-                uriInfo.getRequestUriBuilder()
-                        .replacePath("ui/query.html")
+                externalUriInfo.baseUriBuilder()
+                        .path("ui/query.html")
                         .replaceQuery(queryId.toString())
                         .build());
     }

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2CallbackResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2CallbackResource.java
@@ -15,16 +15,16 @@ package io.trino.server.security.oauth2;
 
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
+import io.trino.server.ExternalUriInfo;
 import io.trino.server.security.ResourceSecurity;
+import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.CookieParam;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Cookie;
 import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.UriInfo;
 
 import java.net.URLEncoder;
 
@@ -61,7 +61,7 @@ public class OAuth2CallbackResource
             @QueryParam("error_description") String errorDescription,
             @QueryParam("error_uri") String errorUri,
             @CookieParam(NONCE_COOKIE) Cookie nonce,
-            @Context UriInfo uriInfo)
+            @BeanParam ExternalUriInfo externalUriInfo)
     {
         if (error != null) {
             return service.handleOAuth2Error(state, URLEncoder.encode(error, UTF_8), errorDescription, errorUri);
@@ -70,7 +70,7 @@ public class OAuth2CallbackResource
         try {
             requireNonNull(state, "state is null");
             requireNonNull(code, "code is null");
-            return service.finishOAuth2Challenge(state, code, uriInfo.getBaseUri().resolve(CALLBACK_ENDPOINT), NonceCookie.read(nonce));
+            return service.finishOAuth2Challenge(state, code, externalUriInfo, NonceCookie.read(nonce));
         }
         catch (RuntimeException e) {
             LOG.debug(e, "Authentication response could not be verified: state=%s", state);

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Service.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Service.java
@@ -18,6 +18,7 @@ import com.google.inject.Inject;
 import io.airlift.log.Logger;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtParser;
+import io.trino.server.ExternalUriInfo;
 import io.trino.server.ui.OAuth2WebUiInstalled;
 import io.trino.server.ui.OAuthIdTokenCookie;
 import io.trino.server.ui.OAuthWebUiCookie;
@@ -41,6 +42,7 @@ import static com.google.common.hash.Hashing.sha256;
 import static io.jsonwebtoken.security.Keys.hmacShaKeyFor;
 import static io.trino.server.security.jwt.JwtUtil.newJwtBuilder;
 import static io.trino.server.security.jwt.JwtUtil.newJwtParserBuilder;
+import static io.trino.server.security.oauth2.OAuth2CallbackResource.CALLBACK_ENDPOINT;
 import static io.trino.server.security.oauth2.TokenPairSerializer.TokenPair.fromOAuth2Response;
 import static io.trino.server.ui.FormWebUiAuthenticationFilter.UI_LOCATION;
 import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
@@ -119,6 +121,7 @@ public class OAuth2Service
                 .compact();
 
         OAuth2Client.Request request = client.createAuthorizationRequest(state, callbackUri);
+        // redirect the user to the OAuth2 server
         Response.ResponseBuilder response = Response.seeOther(request.getAuthorizationUri());
         request.getNonce().ifPresent(nce -> response.cookie(NonceCookie.create(nce, challengeExpiration)));
         return response.build();
@@ -149,7 +152,7 @@ public class OAuth2Service
                 .build();
     }
 
-    public Response finishOAuth2Challenge(String state, String code, URI callbackUri, Optional<String> nonce)
+    public Response finishOAuth2Challenge(String state, String code, ExternalUriInfo externalUriInfo, Optional<String> nonce)
     {
         Optional<String> handlerState;
         try {
@@ -167,14 +170,14 @@ public class OAuth2Service
         // Note: the Web UI may be disabled, so REST requests can not redirect to a success or error page inside of the Web UI
         try {
             // fetch access token
-            OAuth2Client.Response oauth2Response = client.getOAuth2Response(code, callbackUri, nonce);
+            OAuth2Client.Response oauth2Response = client.getOAuth2Response(code, externalUriInfo.absolutePath(CALLBACK_ENDPOINT), nonce);
 
             Instant cookieExpirationTime = tokenExpiration
                     .map(expiration -> Instant.now().plus(expiration))
                     .orElse(oauth2Response.getExpiration());
             if (handlerState.isEmpty()) {
                 Response.ResponseBuilder builder = Response
-                        .seeOther(URI.create(UI_LOCATION))
+                        .seeOther(externalUriInfo.absolutePath(UI_LOCATION))
                         .cookie(OAuthWebUiCookie.create(tokenPairSerializer.serialize(fromOAuth2Response(oauth2Response)), cookieExpirationTime))
                         .cookie(NonceCookie.delete());
                 if (oauth2Response.getIdToken().isPresent()) {

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2TokenExchangeResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2TokenExchangeResource.java
@@ -23,6 +23,7 @@ import io.airlift.json.JsonCodec;
 import io.airlift.json.JsonCodecFactory;
 import io.trino.dispatcher.DispatchExecutor;
 import io.trino.server.DisconnectionAwareAsyncResponse;
+import io.trino.server.ExternalUriInfo;
 import io.trino.server.security.ResourceSecurity;
 import io.trino.server.security.oauth2.OAuth2TokenExchange.TokenPoll;
 import jakarta.servlet.http.HttpServletRequest;
@@ -37,7 +38,6 @@ import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.UriInfo;
 
 import java.util.Map;
 import java.util.Optional;
@@ -74,9 +74,9 @@ public class OAuth2TokenExchangeResource
     @Path("initiate/{authIdHash}")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public Response initiateTokenExchange(@PathParam("authIdHash") String authIdHash, @Context UriInfo uriInfo)
+    public Response initiateTokenExchange(@PathParam("authIdHash") String authIdHash, @BeanParam ExternalUriInfo externalUriInfo)
     {
-        return service.startOAuth2Challenge(uriInfo.getBaseUri().resolve(CALLBACK_ENDPOINT), Optional.ofNullable(authIdHash));
+        return service.startOAuth2Challenge(externalUriInfo.absolutePath(CALLBACK_ENDPOINT), Optional.ofNullable(authIdHash));
     }
 
     @ResourceSecurity(PUBLIC)

--- a/core/trino-main/src/main/java/io/trino/server/ui/DisabledWebUiAuthenticationFilter.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/DisabledWebUiAuthenticationFilter.java
@@ -13,10 +13,11 @@
  */
 package io.trino.server.ui;
 
+import io.trino.server.ExternalUriInfo;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.core.Response;
 
-import static io.trino.server.ui.FormWebUiAuthenticationFilter.DISABLED_LOCATION_URI;
+import static io.trino.server.ui.FormWebUiAuthenticationFilter.DISABLED_LOCATION;
 import static jakarta.ws.rs.core.Response.Status.UNAUTHORIZED;
 
 public class DisabledWebUiAuthenticationFilter
@@ -27,12 +28,12 @@ public class DisabledWebUiAuthenticationFilter
     {
         String path = request.getUriInfo().getRequestUri().getPath();
         if (path.equals("/")) {
-            request.abortWith(Response.seeOther(DISABLED_LOCATION_URI).build());
+            request.abortWith(Response.seeOther(ExternalUriInfo.from(request).absolutePath(DISABLED_LOCATION)).build());
             return;
         }
 
         // disabled page is always visible
-        if (path.equals(FormWebUiAuthenticationFilter.DISABLED_LOCATION)) {
+        if (path.equals(DISABLED_LOCATION)) {
             return;
         }
 
@@ -42,7 +43,7 @@ public class DisabledWebUiAuthenticationFilter
         }
         else {
             // redirect to disabled page
-            request.abortWith(Response.seeOther(DISABLED_LOCATION_URI).build());
+            request.abortWith(Response.seeOther(ExternalUriInfo.from(request).absolutePath(DISABLED_LOCATION)).build());
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/ui/FormWebUiAuthenticationFilter.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/FormWebUiAuthenticationFilter.java
@@ -152,8 +152,6 @@ public class FormWebUiAuthenticationFilter
         }
 
         // redirect to login page
-        request.abortWith(Response.seeOther(LOGIN_FORM_URI).build());
-
         request.abortWith(Response.seeOther(buildLoginFormURI(request.getUriInfo())).build());
     }
 

--- a/core/trino-main/src/main/java/io/trino/server/ui/OAuth2WebUiAuthenticationFilter.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/OAuth2WebUiAuthenticationFilter.java
@@ -16,6 +16,7 @@ package io.trino.server.ui;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
+import io.trino.server.ExternalUriInfo;
 import io.trino.server.security.UserMapping;
 import io.trino.server.security.UserMappingException;
 import io.trino.server.security.oauth2.ChallengeFailedException;
@@ -43,7 +44,6 @@ import static io.trino.server.ServletSecurityUtils.sendWwwAuthenticate;
 import static io.trino.server.ServletSecurityUtils.setAuthenticatedIdentity;
 import static io.trino.server.security.oauth2.OAuth2CallbackResource.CALLBACK_ENDPOINT;
 import static io.trino.server.ui.FormWebUiAuthenticationFilter.DISABLED_LOCATION;
-import static io.trino.server.ui.FormWebUiAuthenticationFilter.DISABLED_LOCATION_URI;
 import static io.trino.server.ui.FormWebUiAuthenticationFilter.TRINO_FORM_LOGIN;
 import static jakarta.ws.rs.core.Response.Status.UNAUTHORIZED;
 import static java.util.Objects.requireNonNull;
@@ -89,7 +89,7 @@ public class OAuth2WebUiAuthenticationFilter
                 sendWwwAuthenticate(request, "Unauthorized", ImmutableSet.of(TRINO_FORM_LOGIN));
                 return;
             }
-            request.abortWith(Response.seeOther(DISABLED_LOCATION_URI).build());
+            request.abortWith(Response.seeOther(ExternalUriInfo.from(request).absolutePath(DISABLED_LOCATION)).build());
             return;
         }
         Optional<TokenPair> tokenPair = getTokenPair(request);
@@ -163,7 +163,7 @@ public class OAuth2WebUiAuthenticationFilter
         OAuth2Client.Response response = client.refreshTokens(refreshToken);
         String serializedToken = tokenPairSerializer.serialize(TokenPair.fromOAuth2Response(response));
         Instant newExpirationTime = tokenExpiration.map(expiration -> Instant.now().plus(expiration)).orElse(response.getExpiration());
-        Response.ResponseBuilder builder = Response.temporaryRedirect(request.getUriInfo().getRequestUri())
+        Response.ResponseBuilder builder = Response.temporaryRedirect(ExternalUriInfo.from(request).fullRequestUri())
                 .cookie(OAuthWebUiCookie.create(serializedToken, newExpirationTime));
 
         OAuthIdTokenCookie.read(request.getCookies())

--- a/core/trino-main/src/main/java/io/trino/server/ui/WebUiStaticResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/WebUiStaticResource.java
@@ -13,8 +13,10 @@
  */
 package io.trino.server.ui;
 
+import io.trino.server.ExternalUriInfo;
 import io.trino.server.security.ResourceSecurity;
 import jakarta.servlet.ServletContext;
+import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -36,17 +38,17 @@ public class WebUiStaticResource
 {
     @ResourceSecurity(PUBLIC)
     @GET
-    public Response getRoot()
+    public Response getRoot(@BeanParam ExternalUriInfo externalUriInfo)
     {
-        return Response.seeOther(URI.create("/ui/")).build();
+        return Response.seeOther(externalUriInfo.absolutePath("/ui/")).build();
     }
 
     @ResourceSecurity(PUBLIC)
     @GET
     @Path("/ui")
-    public Response getUi()
+    public Response getUi(@BeanParam ExternalUriInfo externalUriInfo)
     {
-        return Response.seeOther(URI.create("/ui/")).build();
+        return Response.seeOther(externalUriInfo.absolutePath("/ui/")).build();
     }
 
     @ResourceSecurity(WEB_UI)


### PR DESCRIPTION
## Description

This change allows the server to support routing with a path prefix,
enabling better compatibility with reverse proxies and load balancers
that use the "X-Forwarded-Prefix" header.

This feature is only enabled when `http-server.process-forwarded` is
true

NOTE: this does not add support to any of the client implementations, and may not work with any existing clients.

## Additional context and related issues

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Add suppot for processing `X-Forwarded-Prefix` header when `http-server.process-forwarded` is enabled. ({issue}`issuenumber`)
```
