### PR TITLE
Bulk fetch all columns from all tables in JDBC connectors

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -14,11 +14,13 @@
 package io.trino.plugin.jdbc;
 
 import com.google.common.base.VerifyException;
+import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.io.Closer;
+import dev.failsafe.function.CheckedRunnable;
 import io.airlift.log.Logger;
 import io.trino.plugin.base.mapping.IdentifierMapping;
 import io.trino.plugin.base.mapping.RemoteIdentifiers;
@@ -35,6 +37,7 @@ import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.FixedSplitSource;
 import io.trino.spi.connector.JoinStatistics;
 import io.trino.spi.connector.JoinType;
+import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
 import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
@@ -59,6 +62,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -75,6 +79,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.emptyToNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -92,10 +98,12 @@ import static io.trino.plugin.jdbc.TypeHandlingJdbcSessionProperties.getUnsuppor
 import static io.trino.plugin.jdbc.UnsupportedTypeHandling.IGNORE;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static java.lang.Boolean.TRUE;
 import static java.lang.String.CASE_INSENSITIVE_ORDER;
 import static java.lang.String.format;
 import static java.lang.String.join;
 import static java.sql.DatabaseMetaData.columnNoNulls;
+import static java.util.Collections.emptyIterator;
 import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
@@ -361,6 +369,181 @@ public abstract class BaseJdbcClient
         }
     }
 
+    @Override
+    public Iterator<RelationColumnsMetadata> getAllTableColumns(ConnectorSession session, Optional<String> schema)
+    {
+        Connection connection = null;
+        ResultSet resultSet = null;
+        try {
+            connection = connectionFactory.openConnection(session);
+            Connection connectionFinal = connection;
+            Optional<String> remoteSchema = schema.map(name -> {
+                RemoteIdentifiers remoteIdentifiers = getRemoteIdentifiers(connectionFinal);
+                return identifierMapping.toRemoteSchemaName(remoteIdentifiers, session.getIdentity(), name);
+            });
+            if (remoteSchema.isPresent() && !filterSchema(remoteSchema.get())) {
+                return emptyIterator();
+            }
+
+            // getTables filter tables by table_type. This is not possible to do when reading columns result set.
+            ImmutableSet.Builder<RemoteTableName> visibleTables = ImmutableSet.builder();
+            try (ResultSet tablesResultSet = getTables(connection, remoteSchema, Optional.empty())) {
+                while (tablesResultSet.next()) {
+                    if (filterSchema(getTableSchemaName(tablesResultSet))) {
+                        visibleTables.add(getRemoteTable(tablesResultSet));
+                    }
+                }
+            }
+
+            resultSet = getAllTableColumns(connection, remoteSchema);
+            return new IterateTableColumns(session, connection, visibleTables.build(), resultSet);
+        }
+        catch (RuntimeException | SQLException e) {
+            if (resultSet != null) {
+                ResultSet resultSetFinal = resultSet;
+                Connection connectionFinal = connection;
+                cleanupSuppressing(e, () -> abortReadConnection(connectionFinal, resultSetFinal));
+                cleanupSuppressing(e, resultSet::close);
+            }
+            if (connection != null) {
+                cleanupSuppressing(e, connection::close);
+            }
+            throwIfUnchecked(e);
+            throw new TrinoException(JDBC_ERROR, e);
+        }
+    }
+
+    private class IterateTableColumns
+            extends AbstractIterator<RelationColumnsMetadata>
+    {
+        private final ConnectorSession session;
+        private final Connection connection;
+        private final Set<RemoteTableName> visibleTables;
+        private final ResultSet resultSet;
+
+        private RemoteTableName currentTable;
+        private boolean currentTableVisible;
+        // Not set when current table not visible
+        private SchemaTableName currentTableName;
+        // Not set when current table not visible
+        private ImmutableList.Builder<ColumnMetadata> currentTableColumns;
+
+        public IterateTableColumns(ConnectorSession session, Connection connection, Set<RemoteTableName> visibleTables, ResultSet resultSet)
+        {
+            this.session = requireNonNull(session, "session is null");
+            this.connection = requireNonNull(connection, "connection is null");
+            this.visibleTables = requireNonNull(visibleTables, "visibleTables is null");
+            this.resultSet = requireNonNull(resultSet, "resultSet is null");
+        }
+
+        @Override
+        protected RelationColumnsMetadata computeNext()
+        {
+            try {
+                RelationColumnsMetadata computedNext = null;
+                while (computedNext == null && resultSet.next()) {
+                    RemoteTableName nextTable = getRemoteTable(resultSet);
+                    if (currentTable != null && !currentTable.equals(nextTable)) {
+                        computedNext = finishCurrentTable().orElse(null);
+                    }
+
+                    try {
+                        if (currentTable == null) {
+                            currentTable = nextTable;
+                            String remoteSchemaFromResultSet = getTableSchemaName(resultSet);
+                            currentTableVisible = visibleTables.contains(nextTable);
+                            if (currentTableVisible) {
+                                currentTableName = new SchemaTableName(
+                                        identifierMapping.fromRemoteSchemaName(remoteSchemaFromResultSet),
+                                        identifierMapping.fromRemoteTableName(remoteSchemaFromResultSet, resultSet.getString("TABLE_NAME")));
+                                currentTableColumns = ImmutableList.builder();
+                            }
+                        }
+                        if (!currentTableVisible) {
+                            continue;
+                        }
+
+                        String columnName = resultSet.getString("COLUMN_NAME");
+                        JdbcTypeHandle typeHandle = new JdbcTypeHandle(
+                                getInteger(resultSet, "DATA_TYPE").orElseThrow(() -> new IllegalStateException("DATA_TYPE is null")),
+                                Optional.ofNullable(resultSet.getString("TYPE_NAME")),
+                                getInteger(resultSet, "COLUMN_SIZE"),
+                                getInteger(resultSet, "DECIMAL_DIGITS"),
+                                // arrayDimensions
+                                Optional.<Integer>empty(),
+                                // This code doesn't do getCaseSensitivityForColumns. However, this does not impact the ColumnMetadata returned.
+                                Optional.<CaseSensitivity>empty());
+                        boolean nullable = (resultSet.getInt("NULLABLE") != columnNoNulls);
+                        Optional<String> comment = Optional.ofNullable(emptyToNull(resultSet.getString("REMARKS")));
+                        toColumnMapping(session, connection, typeHandle).ifPresent(columnMapping -> {
+                            currentTableColumns.add(ColumnMetadata.builder()
+                                    .setName(columnName)
+                                    .setType(columnMapping.getType())
+                                    .setNullable(nullable)
+                                    .setComment(comment)
+                                    .build());
+                        });
+                    }
+                    catch (RuntimeException | SQLException e) {
+                        throwIfInstanceOf(e, TrinoException.class);
+                        throw new RuntimeException("Failure when processing column information for table %s: %s".formatted(currentTable, firstNonNull(e.getMessage(), e)), e);
+                    }
+                }
+                if (computedNext == null) {
+                    // Last table
+                    computedNext = finishCurrentTable().orElse(null);
+                }
+                if (computedNext == null) {
+                    // We will not be called again.
+                    resultSet.close();
+                    connection.close();
+                    return endOfData();
+                }
+                return computedNext;
+            }
+            catch (RuntimeException | SQLException e) {
+                cleanupSuppressing(e, () -> abortReadConnection(connection, resultSet));
+                cleanupSuppressing(e, resultSet::close);
+                cleanupSuppressing(e, connection::close);
+                throwIfUnchecked(e);
+                throw new TrinoException(JDBC_ERROR, e);
+            }
+        }
+
+        private Optional<RelationColumnsMetadata> finishCurrentTable()
+        {
+            if (currentTable == null) {
+                return Optional.empty();
+            }
+            Optional<RelationColumnsMetadata> currentTableMetadata = Optional.empty();
+            if (currentTableVisible) {
+                List<ColumnMetadata> columnMetadata = currentTableColumns.build();
+                if (!columnMetadata.isEmpty()) { // Ignore tables with no supported columns
+                    currentTableMetadata = Optional.of(RelationColumnsMetadata.forTable(currentTableName, columnMetadata));
+                }
+            }
+            currentTable = null;
+            currentTableName = null;
+            currentTableColumns = null;
+            return currentTableMetadata;
+        }
+    }
+
+    private static void cleanupSuppressing(Throwable inflight, CheckedRunnable cleanup)
+    {
+        try {
+            cleanup.run();
+        }
+        catch (Throwable cleanupException) {
+            if (cleanupException instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            if (inflight != cleanupException) {
+                inflight.addSuppressed(cleanupException);
+            }
+        }
+    }
+
     protected Map<String, CaseSensitivity> getCaseSensitivityForColumns(ConnectorSession session, Connection connection, JdbcTableHandle tableHandle)
     {
         return ImmutableMap.of();
@@ -384,6 +567,27 @@ public abstract class BaseJdbcClient
                 remoteTableName.getCatalogName().orElse(null),
                 escapeObjectNameForMetadataQuery(remoteTableName.getSchemaName(), metadata.getSearchStringEscape()).orElse(null),
                 escapeObjectNameForMetadataQuery(remoteTableName.getTableName(), metadata.getSearchStringEscape()),
+                null);
+    }
+
+    protected ResultSet getAllTableColumns(Connection connection, Optional<String> remoteSchemaName)
+            throws SQLException
+    {
+        if (TRUE) {
+            // A really compliant database would have the implementation as below.
+            // However, any subclass overriding
+            //  - listing tables (getTables(Connection, ...)) OR
+            //  - listing table's columns (getColumns(..., DatabaseMetaData))
+            // would need to override this method. So, to be on the safe side,
+            // there is no default implementation for this method, and the capability remains opt-in.
+            throw new TrinoException(NOT_SUPPORTED, "The requested column listing mode is not supported");
+        }
+        // Unreachable (see comment above). Kept for illustration purposes.
+        DatabaseMetaData metadata = connection.getMetaData();
+        return metadata.getColumns(
+                metadata.getConnection().getCatalog(),
+                escapeObjectNameForMetadataQuery(remoteSchemaName, metadata.getSearchStringEscape()).orElse(null),
+                null,
                 null);
     }
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -36,6 +36,7 @@ import io.trino.spi.connector.ConnectorSplitSource;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.JoinStatistics;
 import io.trino.spi.connector.JoinType;
+import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SystemTable;
@@ -52,6 +53,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -178,6 +180,15 @@ public class CachingJdbcClient
         }
         ColumnsCacheKey key = new ColumnsCacheKey(getIdentityKey(session), getSessionProperties(session), tableHandle.getRequiredNamedRelation().getSchemaTableName());
         return get(columnsCache, key, () -> delegate.getColumns(session, tableHandle));
+    }
+
+    @Override
+    public Iterator<RelationColumnsMetadata> getAllTableColumns(ConnectorSession session, Optional<String> schema)
+    {
+        // TODO should this cache the list (once iterator is completed)?
+        // TODO should it cache the iterator (smartly) before it's completed? (sharing failures?)
+        // TODO should this put objects into tableCache when iterating?
+        return delegate.getAllTableColumns(session, schema);
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/FailingExecutor.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/FailingExecutor.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import java.util.concurrent.Executor;
+
+public enum FailingExecutor
+        implements Executor
+{
+    INSTANCE;
+
+    @Override
+    public void execute(Runnable command)
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
@@ -23,6 +23,7 @@ import io.trino.spi.connector.ConnectorSplitSource;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.JoinStatistics;
 import io.trino.spi.connector.JoinType;
+import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SystemTable;
@@ -36,6 +37,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -104,6 +106,12 @@ public abstract class ForwardingJdbcClient
     public List<JdbcColumnHandle> getColumns(ConnectorSession session, JdbcTableHandle tableHandle)
     {
         return delegate().getColumns(session, tableHandle);
+    }
+
+    @Override
+    public Iterator<RelationColumnsMetadata> getAllTableColumns(ConnectorSession session, Optional<String> schema)
+    {
+        return delegate().getAllTableColumns(session, schema);
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
@@ -24,6 +24,7 @@ import io.trino.spi.connector.ConnectorSplitSource;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.JoinStatistics;
 import io.trino.spi.connector.JoinType;
+import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SystemTable;
@@ -37,6 +38,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -64,6 +66,8 @@ public interface JdbcClient
     JdbcProcedureHandle getProcedureHandle(ConnectorSession session, ProcedureQuery procedureQuery);
 
     List<JdbcColumnHandle> getColumns(ConnectorSession session, JdbcTableHandle tableHandle);
+
+    Iterator<RelationColumnsMetadata> getAllTableColumns(ConnectorSession session, Optional<String> schema);
 
     List<RelationCommentMetadata> getAllTableComments(ConnectorSession session, Optional<String> schema);
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadataConfig.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadataConfig.java
@@ -15,6 +15,7 @@ package io.trino.plugin.jdbc;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigHidden;
 import io.airlift.configuration.DefunctConfig;
 import io.airlift.configuration.LegacyConfig;
 import jakarta.validation.constraints.Min;
@@ -34,6 +35,8 @@ public class JdbcMetadataConfig
     private boolean aggregationPushdownEnabled = true;
 
     private boolean topNPushdownEnabled = true;
+
+    private boolean bulkListColumns; // default overridden in connectors that support other modes
 
     // Pushed domains are transformed into SQL IN lists
     // (or sequence of range predicates) in JDBC connectors.
@@ -106,6 +109,19 @@ public class JdbcMetadataConfig
     public Boolean isTopNPushdownEnabled()
     {
         return this.topNPushdownEnabled;
+    }
+
+    public boolean isBulkListColumns()
+    {
+        return bulkListColumns;
+    }
+
+    @Config("jdbc.bulk-list-columns.enabled")
+    @ConfigHidden // just a kill switch
+    public JdbcMetadataConfig setBulkListColumns(boolean bulkListColumns)
+    {
+        this.bulkListColumns = bulkListColumns;
+        return this;
     }
 
     @Min(1)

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadataSessionProperties.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadataSessionProperties.java
@@ -36,6 +36,7 @@ public class JdbcMetadataSessionProperties
     public static final String COMPLEX_JOIN_PUSHDOWN_ENABLED = "complex_join_pushdown_enabled";
     public static final String AGGREGATION_PUSHDOWN_ENABLED = "aggregation_pushdown_enabled";
     public static final String TOPN_PUSHDOWN_ENABLED = "topn_pushdown_enabled";
+    public static final String BULK_LIST_COLUMNS = "bulk_list_columns";
     public static final String DOMAIN_COMPACTION_THRESHOLD = "domain_compaction_threshold";
 
     private final List<PropertyMetadata<?>> properties;
@@ -65,6 +66,12 @@ public class JdbcMetadataSessionProperties
                         "Enable aggregation pushdown",
                         jdbcMetadataConfig.isAggregationPushdownEnabled(),
                         false))
+                .add(booleanProperty(
+                        BULK_LIST_COLUMNS,
+                        "Listing tables' columns in bulk",
+                        jdbcMetadataConfig.isBulkListColumns(),
+                        // Hidden because it's really a kill switch. Some connectors do not support it.
+                        true))
                 .add(integerProperty(
                         DOMAIN_COMPACTION_THRESHOLD,
                         "Maximum ranges to allow in a tuple domain without simplifying it",
@@ -108,6 +115,11 @@ public class JdbcMetadataSessionProperties
     public static boolean isTopNPushdownEnabled(ConnectorSession session)
     {
         return session.getProperty(TOPN_PUSHDOWN_ENABLED, Boolean.class);
+    }
+
+    public static boolean isBulkListColumns(ConnectorSession session)
+    {
+        return session.getProperty(BULK_LIST_COLUMNS, Boolean.class);
     }
 
     public static int getDomainCompactionThreshold(ConnectorSession session)

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
@@ -38,6 +38,7 @@ import io.trino.spi.connector.ConnectorSplitSource;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.JoinStatistics;
 import io.trino.spi.connector.JoinType;
+import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SystemTable;
@@ -53,6 +54,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -125,6 +127,13 @@ public final class StatisticsAwareJdbcClient
     public List<JdbcColumnHandle> getColumns(ConnectorSession session, JdbcTableHandle tableHandle)
     {
         return stats.getGetColumns().wrap(() -> delegate().getColumns(session, tableHandle));
+    }
+
+    @Override
+    public Iterator<RelationColumnsMetadata> getAllTableColumns(ConnectorSession session, Optional<String> schema)
+    {
+        // Note: no stats here. As it results an Iterator, the stats would not reflect actual time.
+        return delegate().getAllTableColumns(session, schema);
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcMetadataConfig.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcMetadataConfig.java
@@ -33,6 +33,7 @@ public class TestJdbcMetadataConfig
                 .setComplexJoinPushdownEnabled(true)
                 .setAggregationPushdownEnabled(true)
                 .setTopNPushdownEnabled(true)
+                .setBulkListColumns(false)
                 .setDomainCompactionThreshold(32));
     }
 
@@ -44,6 +45,7 @@ public class TestJdbcMetadataConfig
                 .put("join-pushdown.enabled", "true")
                 .put("join-pushdown.with-expressions", "false")
                 .put("aggregation-pushdown.enabled", "false")
+                .put("jdbc.bulk-list-columns.enabled", "true")
                 .put("domain-compaction-threshold", "42")
                 .put("topn-pushdown.enabled", "false")
                 .buildOrThrow();
@@ -54,6 +56,7 @@ public class TestJdbcMetadataConfig
                 .setComplexJoinPushdownEnabled(false)
                 .setAggregationPushdownEnabled(false)
                 .setTopNPushdownEnabled(false)
+                .setBulkListColumns(true)
                 .setDomainCompactionThreshold(42);
 
         assertFullMapping(properties, expected);

--- a/plugin/trino-mariadb/src/main/java/io/trino/plugin/mariadb/MariaDbClient.java
+++ b/plugin/trino-mariadb/src/main/java/io/trino/plugin/mariadb/MariaDbClient.java
@@ -310,6 +310,19 @@ public class MariaDbClient
     }
 
     @Override
+    protected ResultSet getAllTableColumns(Connection connection, Optional<String> remoteSchemaName)
+            throws SQLException
+    {
+        // MariaDB maps their "database" to SQL catalogs and does not have schemas
+        DatabaseMetaData metadata = connection.getMetaData();
+        return metadata.getColumns(
+                remoteSchemaName.orElse(null),
+                null,
+                null,
+                null);
+    }
+
+    @Override
     protected String getTableSchemaName(ResultSet resultSet)
             throws SQLException
     {

--- a/plugin/trino-mariadb/src/main/java/io/trino/plugin/mariadb/MariaDbClientModule.java
+++ b/plugin/trino-mariadb/src/main/java/io/trino/plugin/mariadb/MariaDbClientModule.java
@@ -25,6 +25,7 @@ import io.trino.plugin.jdbc.DecimalModule;
 import io.trino.plugin.jdbc.DriverConnectionFactory;
 import io.trino.plugin.jdbc.ForBaseJdbc;
 import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.JdbcMetadataConfig;
 import io.trino.plugin.jdbc.JdbcStatisticsConfig;
 import io.trino.plugin.jdbc.credential.CredentialProvider;
 import io.trino.plugin.jdbc.ptf.Query;
@@ -43,6 +44,7 @@ public class MariaDbClientModule
     public void configure(Binder binder)
     {
         binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class).to(MariaDbClient.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfigDefaults(JdbcMetadataConfig.class, config -> config.setBulkListColumns(true));
         configBinder(binder).bindConfig(MariaDbJdbcConfig.class);
         configBinder(binder).bindConfig(JdbcStatisticsConfig.class);
         binder.install(new DecimalModule());

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
@@ -432,6 +432,19 @@ public class MySqlClient
     }
 
     @Override
+    protected ResultSet getAllTableColumns(Connection connection, Optional<String> remoteSchemaName)
+            throws SQLException
+    {
+        // MySQL maps their "database" to SQL catalogs and does not have schemas
+        DatabaseMetaData metadata = connection.getMetaData();
+        return metadata.getColumns(
+                remoteSchemaName.orElse(null),
+                null,
+                null,
+                null);
+    }
+
+    @Override
     public Optional<String> getTableComment(ResultSet resultSet)
             throws SQLException
     {

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClientModule.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClientModule.java
@@ -27,6 +27,7 @@ import io.trino.plugin.jdbc.DriverConnectionFactory;
 import io.trino.plugin.jdbc.ForBaseJdbc;
 import io.trino.plugin.jdbc.JdbcClient;
 import io.trino.plugin.jdbc.JdbcJoinPushdownSupportModule;
+import io.trino.plugin.jdbc.JdbcMetadataConfig;
 import io.trino.plugin.jdbc.JdbcStatisticsConfig;
 import io.trino.plugin.jdbc.TimestampTimeZoneDomain;
 import io.trino.plugin.jdbc.credential.CredentialProvider;
@@ -47,6 +48,7 @@ public class MySqlClientModule
     protected void setup(Binder binder)
     {
         binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class).to(MySqlClient.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfigDefaults(JdbcMetadataConfig.class, config -> config.setBulkListColumns(true));
         newOptionalBinder(binder, TimestampTimeZoneDomain.class).setBinding().toInstance(TimestampTimeZoneDomain.UTC_ONLY);
         configBinder(binder).bindConfig(MySqlJdbcConfig.class);
         configBinder(binder).bindConfig(MySqlConfig.class);

--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftClient.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftClient.java
@@ -294,6 +294,18 @@ public class RedshiftClient
     }
 
     @Override
+    protected ResultSet getAllTableColumns(Connection connection, Optional<String> remoteSchemaName)
+            throws SQLException
+    {
+        DatabaseMetaData metadata = connection.getMetaData();
+        return metadata.getColumns(
+                metadata.getConnection().getCatalog(),
+                escapeObjectNameForMetadataQuery(remoteSchemaName, metadata.getSearchStringEscape()).orElse(null),
+                null,
+                null);
+    }
+
+    @Override
     protected void dropSchema(ConnectorSession session, Connection connection, String remoteSchemaName, boolean cascade)
             throws SQLException
     {

--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftClientModule.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftClientModule.java
@@ -26,6 +26,7 @@ import io.trino.plugin.jdbc.DriverConnectionFactory;
 import io.trino.plugin.jdbc.ForBaseJdbc;
 import io.trino.plugin.jdbc.JdbcClient;
 import io.trino.plugin.jdbc.JdbcJoinPushdownSupportModule;
+import io.trino.plugin.jdbc.JdbcMetadataConfig;
 import io.trino.plugin.jdbc.JdbcStatisticsConfig;
 import io.trino.plugin.jdbc.credential.CredentialProvider;
 import io.trino.plugin.jdbc.ptf.Query;
@@ -45,6 +46,7 @@ public class RedshiftClientModule
     {
         configBinder(binder).bindConfig(RedshiftConfig.class);
         binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class).to(RedshiftClient.class).in(SINGLETON);
+        configBinder(binder).bindConfigDefaults(JdbcMetadataConfig.class, config -> config.setBulkListColumns(true));
         newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(Query.class).in(SINGLETON);
         configBinder(binder).bindConfig(JdbcStatisticsConfig.class);
 

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/RedshiftQueryRunner.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/RedshiftQueryRunner.java
@@ -60,7 +60,7 @@ public final class RedshiftQueryRunner
     private static final String S3_TPCH_TABLES_ROOT = requiredNonEmptySystemProperty("test.redshift.s3.tpch.tables.root");
     private static final String IAM_ROLE = requiredNonEmptySystemProperty("test.redshift.iam.role");
 
-    private static final String TEST_DATABASE = "testdb";
+    static final String TEST_DATABASE = "testdb";
     private static final String TEST_CATALOG = "redshift";
     static final String TEST_SCHEMA = "test_schema";
 

--- a/plugin/trino-singlestore/src/main/java/io/trino/plugin/singlestore/SingleStoreClient.java
+++ b/plugin/trino-singlestore/src/main/java/io/trino/plugin/singlestore/SingleStoreClient.java
@@ -409,6 +409,19 @@ public class SingleStoreClient
     }
 
     @Override
+    protected ResultSet getAllTableColumns(Connection connection, Optional<String> remoteSchemaName)
+            throws SQLException
+    {
+        // SingleStore maps their "database" to SQL catalogs and does not have schemas
+        DatabaseMetaData metadata = connection.getMetaData();
+        return metadata.getColumns(
+                remoteSchemaName.orElse(null),
+                null,
+                null,
+                null);
+    }
+
+    @Override
     public void renameTable(ConnectorSession session, JdbcTableHandle handle, SchemaTableName newTableName)
     {
         RemoteTableName remoteTableName = handle.asPlainTable().getRemoteTableName();

--- a/plugin/trino-singlestore/src/main/java/io/trino/plugin/singlestore/SingleStoreClientModule.java
+++ b/plugin/trino-singlestore/src/main/java/io/trino/plugin/singlestore/SingleStoreClientModule.java
@@ -25,6 +25,7 @@ import io.trino.plugin.jdbc.DecimalModule;
 import io.trino.plugin.jdbc.DriverConnectionFactory;
 import io.trino.plugin.jdbc.ForBaseJdbc;
 import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.JdbcMetadataConfig;
 import io.trino.plugin.jdbc.credential.CredentialProvider;
 import io.trino.plugin.jdbc.ptf.Query;
 import io.trino.spi.function.table.ConnectorTableFunction;
@@ -41,6 +42,7 @@ public class SingleStoreClientModule
     public void configure(Binder binder)
     {
         binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class).to(SingleStoreClient.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfigDefaults(JdbcMetadataConfig.class, config -> config.setBulkListColumns(true));
         configBinder(binder).bindConfig(SingleStoreJdbcConfig.class);
         configBinder(binder).bindConfig(SingleStoreConfig.class);
         binder.install(new DecimalModule());


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Before this change, when listing table columns, JDBC connectors would first list tables and then list columns of a table. Thus, when serving Trino's `information_schema.columns` or `system.jdbc.columns`, we would make O(#tables) calls to the remote database.

With this change, we utilize remote database's bulk column listing facilities to satisfy Trino's bulk column listing requests. This can be viewed as "`information_schema.columns` pass-through", although this works for both Trino's `information_schema.columns` and Trino's `system.jdbc.columns`
(`io.trino.jdbc.TrinoDatabaseMetaData.getColumns`), and does not use remote database's `information_schema.columns` directly. Instead, the commit leverages the fact that `DatabaseMetaData.getColumns` typically used to get columns of a table can be used without a table filter, and then it gets all columns from all tables.

The bulk retrieval is supported for selected JDBC connectors, and by default is not supported (requires `JdbcClient` changes).

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# MariaDB, MySQL, SingleStore, Redshift
* Improve performance of listing table columns. ({issue}`issuenumber`)
```
