### PR TITLE
Convert QueryRunner to an ordinary class

### DIFF
--- a/core/trino-server-rpm/src/test/java/io/trino/server/rpm/ServerIT.java
+++ b/core/trino-server-rpm/src/test/java/io/trino/server/rpm/ServerIT.java
@@ -300,11 +300,15 @@ public class ServerIT
         return builder.buildOrThrow();
     }
 
-    private record QueryRunner(String host, int port)
+    private static class QueryRunner
     {
-        private QueryRunner
+        private final String host;
+        private final int port;
+
+        private QueryRunner(String host, int port)
         {
-            requireNonNull(host, "host is null");
+            this.host = requireNonNull(host, "host is null");
+            this.port = port;
         }
 
         public Set<List<String>> execute(String sql)


### PR DESCRIPTION
This reverts commit 459fa066f2b3bb7d70e438c6610cd9101c41a89c. Records should be used for data carriers.