### PR TITLE
fix: missing exchange prefix in query-resiliency doc

### DIFF
--- a/docs/src/main/sphinx/installation/query-resiliency.md
+++ b/docs/src/main/sphinx/installation/query-resiliency.md
@@ -74,9 +74,9 @@ fault-tolerant execution with an S3-based exchange:
        base-directories=s3://exchange-spooling-bucket-1,s3://exchange-spooling-bucket-2
 
    additionalExchangeManagerProperties:
-     s3.region=us-west-1
-     s3.aws-access-key=example-access-key
-     s3.aws-secret-key=example-secret-key
+     exchange.s3.region=us-west-1
+     exchange.s3.aws-access-key=example-access-key
+     exchange.s3.aws-secret-key=example-secret-key
    ```
 
    In non-Kubernetes installations, the same properties must be defined in an


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Query resiliency documentation example for configuring exchange manager is missing `exchange.` prefix in properties. 



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Closes https://github.com/trinodb/trino/issues/22229

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( x ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
