### PR TITLE
Handle Delta Lake vacuum file system error

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/VacuumProcedure.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/VacuumProcedure.java
@@ -62,6 +62,7 @@ import static com.google.common.base.Predicates.alwaysFalse;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.plugin.base.util.Procedures.checkProcedureArgument;
+import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_FILESYSTEM_ERROR;
 import static io.trino.plugin.deltalake.DeltaLakeMetadata.MAX_WRITER_VERSION;
 import static io.trino.plugin.deltalake.DeltaLakeMetadata.checkUnsupportedUniversalFormat;
 import static io.trino.plugin.deltalake.DeltaLakeMetadata.checkValidTableHandle;
@@ -139,7 +140,10 @@ public class VacuumProcedure
         catch (TrinoException e) {
             throw e;
         }
-        catch (Exception e) {
+        catch (IOException e) {
+            throw new TrinoException(DELTA_LAKE_FILESYSTEM_ERROR, format("Failure when vacuuming %s.%s with retention %s: %s", schema, table, retention, e), e);
+        }
+        catch (RuntimeException e) {
             // This is not categorized as TrinoException. All possible external failures should be handled explicitly.
             throw new RuntimeException(format("Failure when vacuuming %s.%s with retention %s: %s", schema, table, retention, e), e);
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Error when deleting S3 files should be catagorized as file system error for accounting purposes.

Stack trace:

```
{
  "type": "io.trino.spi.TrinoException",
  "message": "Failure when vacuuming <table> with retention 7d: java.io.IOException: Exception while batch deleting paths",
  "cause": {
    "type": "java.lang.RuntimeException",
    "message": "Failure when vacuuming <table> with retention 7d: java.io.IOException: Exception while batch deleting paths",
    "cause": {
      "type": "java.io.IOException",
      "message": "Exception while batch deleting paths",
      "cause": {
        "type": "com.amazonaws.services.s3.model.MultiObjectDeleteException",
        "message": "One or more objects could not be deleted (Service: null; Status Code: 200; Error Code: null; Request ID: <request_id>; S3 Extended Request ID: <request_id> ; Proxy: null)",
        "suppressed": [],
        "stack": [
          "com.amazonaws.services.s3.AmazonS3Client.deleteObjects(AmazonS3Client.java:2388)",
          "io.trino.hdfs.s3.TrinoS3FileSystem.deletePaths(TrinoS3FileSystem.java:819)",
          "io.trino.hdfs.s3.TrinoS3FileSystem.deleteFiles(TrinoS3FileSystem.java:799)",
          "io.trino.filesystem.hdfs.HdfsFileSystem.lambda$deleteFiles$2(HdfsFileSystem.java:139)",
          "io.trino.hdfs.authentication.NoHdfsAuthentication.doAs(NoHdfsAuthentication.java:25)",
          "io.trino.hdfs.HdfsEnvironment.doAs(HdfsEnvironment.java:134)",
          "io.trino.filesystem.hdfs.HdfsFileSystem.deleteFiles(HdfsFileSystem.java:137)",
          "io.trino.filesystem.manager.SwitchingFileSystem.deleteFiles(SwitchingFileSystem.java:88)",
          "io.trino.filesystem.tracing.TracingFileSystem.lambda$deleteFiles$1(TracingFileSystem.java:79)",
          "io.trino.filesystem.tracing.Tracing.lambda$withTracing$1(Tracing.java:38)",
          "io.trino.filesystem.tracing.Tracing.withTracing(Tracing.java:47)",
          "io.trino.filesystem.tracing.Tracing.withTracing(Tracing.java:37)",
          "io.trino.filesystem.tracing.TracingFileSystem.deleteFiles(TracingFileSystem.java:79)",
          "io.trino.plugin.deltalake.procedure.VacuumProcedure.doVacuum(VacuumProcedure.java:296)",
          "io.trino.plugin.deltalake.procedure.VacuumProcedure.vacuum(VacuumProcedure.java:135)",
          "io.trino.plugin.objectstore.MethodHandles$Translate.invoke(MethodHandles.java:83)",
          "java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:733)",
          "java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:758)",
          "io.trino.execution.CallTask.execute(CallTask.java:210)",
          "io.trino.execution.CallTask.execute(CallTask.java:70)",
...
```


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
