### PR TITLE
Test H2C/HTTP/2 for internal communication

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/OkHttpUtil.java
+++ b/client/trino-client/src/main/java/io/trino/client/OkHttpUtil.java
@@ -15,7 +15,6 @@ package io.trino.client;
 
 import com.google.common.base.CharMatcher;
 import com.google.common.base.StandardSystemProperty;
-import com.google.common.collect.ImmutableList;
 import com.google.common.net.HostAndPort;
 import io.trino.client.auth.kerberos.DelegatedConstrainedContextProvider;
 import io.trino.client.auth.kerberos.DelegatedUnconstrainedContextProvider;
@@ -26,7 +25,6 @@ import okhttp3.Credentials;
 import okhttp3.Interceptor;
 import okhttp3.JavaNetCookieJar;
 import okhttp3.OkHttpClient;
-import okhttp3.Protocol;
 import okhttp3.internal.tls.LegacyHostnameVerifier;
 import org.ietf.jgss.GSSCredential;
 
@@ -111,12 +109,6 @@ public final class OkHttpUtil
     public static void setupCookieJar(OkHttpClient.Builder clientBuilder)
     {
         clientBuilder.cookieJar(new JavaNetCookieJar(new CookieManager()));
-    }
-
-    public static void disableHttp2(OkHttpClient.Builder clientBuilder)
-    {
-        // Disable HTTP/2 as it's not tested nor supported
-        clientBuilder.protocols(ImmutableList.of(Protocol.HTTP_1_1, Protocol.HTTP_1_1));
     }
 
     public static void setupSocksProxy(OkHttpClient.Builder clientBuilder, Optional<HostAndPort> socksProxy)

--- a/client/trino-client/src/main/java/io/trino/client/uri/TrinoUri.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/TrinoUri.java
@@ -53,7 +53,6 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.client.KerberosUtil.defaultCredentialCachePath;
 import static io.trino.client.OkHttpUtil.basicAuth;
-import static io.trino.client.OkHttpUtil.disableHttp2;
 import static io.trino.client.OkHttpUtil.setupAlternateHostnameVerification;
 import static io.trino.client.OkHttpUtil.setupCookieJar;
 import static io.trino.client.OkHttpUtil.setupHttpProxy;
@@ -604,7 +603,6 @@ public class TrinoUri
             throws SQLException
     {
         try {
-            disableHttp2(builder);
             setupCookieJar(builder);
             setupSocksProxy(builder, socksProxy);
             setupHttpProxy(builder, httpProxy);

--- a/core/trino-main/src/main/java/io/trino/server/InternalCommunicationConfig.java
+++ b/core/trino-main/src/main/java/io/trino/server/InternalCommunicationConfig.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 public class InternalCommunicationConfig
 {
     private String sharedSecret;
-    private boolean http2Enabled;
+    private boolean http2Enabled = true;
     private boolean httpsRequired;
     private String keyStorePath;
     private String keyStorePassword;

--- a/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtAuthenticatorSupportModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtAuthenticatorSupportModule.java
@@ -55,7 +55,9 @@ public class JwtAuthenticatorSupportModule
         @Override
         public void configure(Binder binder)
         {
-            httpClientBinder(binder).bindHttpClient("jwk", ForJwt.class);
+            httpClientBinder(binder)
+                    .bindHttpClient("jwk", ForJwt.class)
+                    .withConfigDefaults(config -> config.setHttp2Enabled(false)); // temporary - reverted in Airlift
         }
 
         @Provides

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2ServiceModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2ServiceModule.java
@@ -55,6 +55,7 @@ public class OAuth2ServiceModule
         httpClientBinder(binder)
                 .bindHttpClient("oauth2-jwk", ForOAuth2.class)
                 .withConfigDefaults(clientConfig -> clientConfig
+                        .setHttp2Enabled(false) // temporary - reverted in Airlift
                         .setRequestBufferSize(DataSize.of(32, KILOBYTE))
                         .setResponseBufferSize(DataSize.of(32, KILOBYTE)));
     }

--- a/core/trino-main/src/test/java/io/trino/server/TestInternalCommunicationConfig.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestInternalCommunicationConfig.java
@@ -32,7 +32,7 @@ public class TestInternalCommunicationConfig
     {
         assertRecordedDefaults(recordDefaults(InternalCommunicationConfig.class)
                 .setSharedSecret(null)
-                .setHttp2Enabled(false)
+                .setHttp2Enabled(true)
                 .setHttpsRequired(false)
                 .setKeyStorePath(null)
                 .setKeyStorePassword(null)
@@ -50,7 +50,7 @@ public class TestInternalCommunicationConfig
 
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("internal-communication.shared-secret", "secret")
-                .put("internal-communication.http2.enabled", "true")
+                .put("internal-communication.http2.enabled", "false")
                 .put("internal-communication.https.required", "true")
                 .put("internal-communication.https.keystore.path", keystoreFile.toString())
                 .put("internal-communication.https.keystore.key", "key-key")
@@ -61,7 +61,7 @@ public class TestInternalCommunicationConfig
 
         InternalCommunicationConfig expected = new InternalCommunicationConfig()
                 .setSharedSecret("secret")
-                .setHttp2Enabled(true)
+                .setHttp2Enabled(false)
                 .setHttpsRequired(true)
                 .setKeyStorePath(keystoreFile.toString())
                 .setKeyStorePassword("key-key")

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/BaseOAuth2WebUiAuthenticationFilterTest.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/BaseOAuth2WebUiAuthenticationFilterTest.java
@@ -371,7 +371,8 @@ public abstract class BaseOAuth2WebUiAuthenticationFilterTest
     protected Jws<Claims> parseJwsClaims(String claimsJws)
     {
         HttpClientConfig httpClientConfig = new HttpClientConfig()
-                .setTrustStorePath(Resources.getResource("cert/localhost.pem").getPath());
+                .setTrustStorePath(Resources.getResource("cert/localhost.pem").getPath())
+                .setHttp2Enabled(false); // temporary - reverted in Airlift;
         try (JettyHttpClient httpClient = new JettyHttpClient(httpClientConfig)) {
             return newJwtParserBuilder()
                     .keyLocator(new JwkSigningKeyLocator(new JwkService(

--- a/plugin/trino-http-event-listener/src/main/java/io/trino/plugin/httpquery/HttpEventListenerFactory.java
+++ b/plugin/trino-http-event-listener/src/main/java/io/trino/plugin/httpquery/HttpEventListenerFactory.java
@@ -47,7 +47,9 @@ public class HttpEventListenerFactory
                     jsonCodecBinder(binder).bindJsonCodec(QueryCreatedEvent.class);
                     jsonCodecBinder(binder).bindJsonCodec(SplitCompletedEvent.class);
                     configBinder(binder).bindConfig(HttpEventListenerConfig.class);
-                    httpClientBinder(binder).bindHttpClient("http-event-listener", ForHttpEventListener.class);
+                    httpClientBinder(binder)
+                            .bindHttpClient("http-event-listener", ForHttpEventListener.class)
+                            .withConfigDefaults(clientConfig -> clientConfig.setHttp2Enabled(false)); // temporary - reverted in Airlift
                     binder.bind(HttpEventListener.class).in(Scopes.SINGLETON);
                 });
 

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaAccessControlFactory.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaAccessControlFactory.java
@@ -77,7 +77,10 @@ public class OpaAccessControlFactory
                     jsonCodecBinder(binder).bindJsonCodec(OpaColumnMaskQueryResult.class);
                     httpClient.ifPresentOrElse(
                             client -> binder.bind(Key.get(HttpClient.class, ForOpa.class)).toInstance(client),
-                            () -> httpClientBinder(binder).bindHttpClient("opa", ForOpa.class));
+                            () -> httpClientBinder(binder)
+                                    .bindHttpClient("opa", ForOpa.class)
+                                    .withConfigDefaults(httpClientConfig -> httpClientConfig
+                                            .setHttp2Enabled(false))); // temporary - reverted in Airlift
                     context.ifPresentOrElse(
                             actualContext -> binder.bind(OpaPluginContext.class).toInstance(new OpaPluginContext(actualContext.getVersion())),
                             () -> binder.bind(OpaPluginContext.class).toInstance(new OpaPluginContext("UNKNOWN")));

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotModule.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotModule.java
@@ -79,6 +79,7 @@ public class PinotModule
         binder.bind(PinotNodePartitioningProvider.class).in(Scopes.SINGLETON);
         httpClientBinder(binder).bindHttpClient("pinot", ForPinot.class)
                 .withConfigDefaults(cfg -> {
+                    cfg.setHttp2Enabled(false); // temporary - reverted in Airlift
                     cfg.setIdleTimeout(new Duration(300, SECONDS));
                     cfg.setConnectTimeout(new Duration(300, SECONDS));
                     cfg.setRequestTimeout(new Duration(300, SECONDS));

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestingPinotCluster.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestingPinotCluster.java
@@ -21,6 +21,7 @@ import com.google.common.io.Closer;
 import com.google.common.net.HostAndPort;
 import com.google.common.net.HttpHeaders;
 import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.HttpClientConfig;
 import io.airlift.http.client.Request;
 import io.airlift.http.client.StaticBodyGenerator;
 import io.airlift.http.client.jetty.JettyHttpClient;
@@ -88,7 +89,7 @@ public class TestingPinotCluster
 
     public TestingPinotCluster(Network network, boolean secured)
     {
-        httpClient = closer.register(new JettyHttpClient());
+        httpClient = closer.register(new JettyHttpClient(new HttpClientConfig().setHttp2Enabled(false)));  // temporary - reverted in Airlift
         zookeeper = new GenericContainer<>(parse("zookeeper:3.9"))
                 .withStartupAttempts(3)
                 .withNetwork(network)

--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
         <!-- keep dependency properties sorted -->
         <dep.accumulo-hadoop.version>2.7.7-1</dep.accumulo-hadoop.version>
         <dep.accumulo.version>3.0.0</dep.accumulo.version>
-        <dep.airlift.version>248</dep.airlift.version>
+        <dep.airlift.version>249-SNAPSHOT</dep.airlift.version>
         <dep.alluxio.version>312</dep.alluxio.version>
         <dep.antlr.version>4.13.1</dep.antlr.version>
         <dep.avro.version>1.11.3</dep.avro.version>

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestWorkerRestart.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestWorkerRestart.java
@@ -99,7 +99,8 @@ public class TestWorkerRestart
                 assertThatThrownBy(future::get)
                         .isInstanceOf(ExecutionException.class)
                         .cause().hasMessageFindingMatch("^Expected response code from \\S+ to be 200, but was 500" +
-                                                        "|Error fetching \\S+: Expected response code to be 200, but was 500");
+                                                        "|Error fetching \\S+: Expected response code to be 200, but was 500" +
+                                                        "|Could not communicate with the remote task");
 
                 // Ensure that the restarted worker is able to serve queries.
                 assertThat((long) queryRunner.execute("SELECT count(*) FROM tpch.tiny.lineitem").getOnlyValue())


### PR DESCRIPTION
Just a test that enabled HTTP/2 over TLS or H2C for internal communication by default