### PR TITLE
Populate split offsets when writing orc/parquet files in iceberg

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/PredicateUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/PredicateUtils.java
@@ -192,8 +192,8 @@ public final class PredicateUtils
         long fileRowCount = 0;
         ImmutableList.Builder<RowGroupInfo> rowGroupInfoBuilder = ImmutableList.builder();
         for (BlockMetadata block : blocksMetaData) {
-            long firstDataPage = block.getColumns().get(0).getFirstDataPageOffset();
-            boolean splitContainsBlock = splitStart <= firstDataPage && firstDataPage < splitStart + splitLength;
+            long blockStart = block.getColumns().getFirst().getStartingPos();
+            boolean splitContainsBlock = splitStart <= blockStart && blockStart < splitStart + splitLength;
             if (splitContainsBlock) {
                 for (int i = 0; i < parquetTupleDomains.size(); i++) {
                     TupleDomain<ColumnDescriptor> parquetTupleDomain = parquetTupleDomains.get(i);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/CommitTaskData.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/CommitTaskData.java
@@ -15,6 +15,7 @@ package io.trino.plugin.iceberg;
 
 import org.apache.iceberg.FileContent;
 
+import java.util.List;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
@@ -27,7 +28,8 @@ public record CommitTaskData(
         String partitionSpecJson,
         Optional<String> partitionDataJson,
         FileContent content,
-        Optional<String> referencedDataFile)
+        Optional<String> referencedDataFile,
+        Optional<List<Long>> fileSplitOffsets)
 {
     public CommitTaskData
     {
@@ -38,5 +40,6 @@ public record CommitTaskData(
         requireNonNull(partitionDataJson, "partitionDataJson is null");
         requireNonNull(content, "content is null");
         requireNonNull(referencedDataFile, "referencedDataFile is null");
+        requireNonNull(fileSplitOffsets, "fileSplitOffsets is null");
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergAvroFileWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergAvroFileWriter.java
@@ -18,7 +18,6 @@ import io.trino.plugin.hive.HiveCompressionCodec;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
 import io.trino.spi.type.Type;
-import org.apache.iceberg.Metrics;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.data.Record;
@@ -29,6 +28,7 @@ import org.apache.iceberg.io.OutputFile;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.plugin.iceberg.IcebergAvroDataConversion.toIcebergRecords;
@@ -145,8 +145,8 @@ public final class IcebergAvroFileWriter
     }
 
     @Override
-    public Metrics getMetrics()
+    public FileMetrics getFileMetrics()
     {
-        return avroWriter.metrics();
+        return new FileMetrics(avroWriter.metrics(), Optional.empty());
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriter.java
@@ -16,8 +16,13 @@ package io.trino.plugin.iceberg;
 import io.trino.plugin.hive.FileWriter;
 import org.apache.iceberg.Metrics;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface IcebergFileWriter
         extends FileWriter
 {
-    Metrics getMetrics();
+    FileMetrics getFileMetrics();
+
+    record FileMetrics(Metrics metrics, Optional<List<Long>> splitOffsets) {}
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1137,6 +1137,7 @@ public class IcebergMetadata
                     .withFileSizeInBytes(task.fileSizeInBytes())
                     .withFormat(table.getFileFormat().toIceberg())
                     .withMetrics(task.metrics().metrics());
+            task.fileSplitOffsets().ifPresent(builder::withSplitOffsets);
 
             if (!icebergTable.spec().fields().isEmpty()) {
                 String partitionDataJson = task.partitionDataJson()
@@ -2427,6 +2428,7 @@ public class IcebergMetadata
                             .ofPositionDeletes()
                             .withFileSizeInBytes(task.fileSizeInBytes())
                             .withMetrics(task.metrics().metrics());
+                    task.fileSplitOffsets().ifPresent(deleteBuilder::withSplitOffsets);
                     if (!partitionSpec.fields().isEmpty()) {
                         String partitionDataJson = task.partitionDataJson()
                                 .orElseThrow(() -> new VerifyException("No partition data for partitioned table"));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergOrcFileWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergOrcFileWriter.java
@@ -28,7 +28,6 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.type.Type;
-import org.apache.iceberg.Metrics;
 import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.Schema;
 
@@ -110,9 +109,11 @@ public final class IcebergOrcFileWriter
     }
 
     @Override
-    public Metrics getMetrics()
+    public FileMetrics getFileMetrics()
     {
-        return computeMetrics(metricsConfig, icebergSchema, orcColumns, orcWriter.getFileRowCount(), orcWriter.getFileStats());
+        return new FileMetrics(
+                computeMetrics(metricsConfig, icebergSchema, orcColumns, orcWriter.getFileRowCount(), orcWriter.getFileStats()),
+                Optional.of(orcWriter.getStripeOffsets()));
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
@@ -424,11 +424,12 @@ public class IcebergPageSink
                 writeContext.getPath(),
                 fileFormat,
                 writer.getWrittenBytes(),
-                new MetricsWrapper(writer.getMetrics()),
+                new MetricsWrapper(writer.getFileMetrics().metrics()),
                 PartitionSpecParser.toJson(partitionSpec),
                 writeContext.getPartitionData().map(PartitionData::toJson),
                 DATA,
-                Optional.empty());
+                Optional.empty(),
+                writer.getFileMetrics().splitOffsets());
 
         commitTasks.add(wrappedBuffer(jsonCodec.toJsonBytes(task)));
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergParquetFileWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergParquetFileWriter.java
@@ -22,7 +22,6 @@ import io.trino.plugin.hive.parquet.ParquetFileWriter;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
 import io.trino.spi.type.Type;
-import org.apache.iceberg.Metrics;
 import org.apache.iceberg.MetricsConfig;
 import org.apache.parquet.format.CompressionCodec;
 import org.apache.parquet.schema.MessageType;
@@ -36,6 +35,7 @@ import java.util.stream.Stream;
 
 import static io.trino.parquet.reader.MetadataReader.createParquetMetadata;
 import static io.trino.plugin.iceberg.util.ParquetUtil.footerMetrics;
+import static io.trino.plugin.iceberg.util.ParquetUtil.getSplitOffsets;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -79,7 +79,7 @@ public final class IcebergParquetFileWriter
     }
 
     @Override
-    public Metrics getMetrics()
+    public FileMetrics getFileMetrics()
     {
         ParquetMetadata parquetMetadata;
         try {
@@ -88,7 +88,7 @@ public final class IcebergParquetFileWriter
         catch (IOException e) {
             throw new TrinoException(GENERIC_INTERNAL_ERROR, format("Error creating metadata for Parquet file %s", location), e);
         }
-        return footerMetrics(parquetMetadata, Stream.empty(), metricsConfig);
+        return new FileMetrics(footerMetrics(parquetMetadata, Stream.empty(), metricsConfig), Optional.of(getSplitOffsets(parquetMetadata)));
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSortingFileWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSortingFileWriter.java
@@ -23,7 +23,6 @@ import io.trino.spi.PageSorter;
 import io.trino.spi.connector.SortOrder;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
-import org.apache.iceberg.Metrics;
 
 import java.io.Closeable;
 import java.util.List;
@@ -64,9 +63,9 @@ public final class IcebergSortingFileWriter
     }
 
     @Override
-    public Metrics getMetrics()
+    public FileMetrics getFileMetrics()
     {
-        return outputWriter.getMetrics();
+        return outputWriter.getFileMetrics();
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/IcebergPositionDeletePageSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/IcebergPositionDeletePageSink.java
@@ -130,11 +130,12 @@ public class IcebergPositionDeletePageSink
                     outputPath,
                     fileFormat,
                     writer.getWrittenBytes(),
-                    new MetricsWrapper(writer.getMetrics()),
+                    new MetricsWrapper(writer.getFileMetrics().metrics()),
                     PartitionSpecParser.toJson(partitionSpec),
                     partition.map(PartitionData::toJson),
                     FileContent.POSITION_DELETES,
-                    Optional.of(dataFilePath));
+                    Optional.of(dataFilePath),
+                    writer.getFileMetrics().splitOffsets());
             Long recordCount = task.metrics().recordCount();
             if (recordCount != null && recordCount > 0) {
                 commitTasks.add(wrappedBuffer(jsonCodec.toJsonBytes(task)));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/util/ParquetUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/util/ParquetUtil.java
@@ -14,6 +14,7 @@
 
 package io.trino.plugin.iceberg.util;
 
+import com.google.common.collect.ImmutableList;
 import io.trino.parquet.metadata.BlockMetadata;
 import io.trino.parquet.metadata.ColumnChunkMetadata;
 import io.trino.parquet.metadata.ParquetMetadata;
@@ -44,6 +45,8 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -150,6 +153,16 @@ public final class ParquetUtil
                 createNanValueCounts(fieldMetricsMap.values().stream(), metricsConfig, fileSchema),
                 toBufferMap(fileSchema, lowerBounds),
                 toBufferMap(fileSchema, upperBounds));
+    }
+
+    public static List<Long> getSplitOffsets(ParquetMetadata metadata)
+    {
+        List<Long> splitOffsets = new ArrayList<>(metadata.getBlocks().size());
+        for (BlockMetadata blockMetaData : metadata.getBlocks()) {
+            splitOffsets.add(blockMetaData.getStartingPos());
+        }
+        Collections.sort(splitOffsets);
+        return ImmutableList.copyOf(splitOffsets);
     }
 
     private static void updateFromFieldMetrics(

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
@@ -536,7 +536,11 @@ public abstract class BaseIcebergConnectorSmokeTest
     public void testFileSortingWithLargerTable()
     {
         // Using a larger table forces buffered data to be written to disk
-        Session withSmallRowGroups = withSmallRowGroups(getSession());
+        Session withSmallRowGroups = Session.builder(getSession())
+                .setCatalogSessionProperty("iceberg", "orc_writer_max_stripe_rows", "200")
+                .setCatalogSessionProperty("iceberg", "parquet_writer_block_size", "20kB")
+                .setCatalogSessionProperty("iceberg", "parquet_writer_batch_size", "200")
+                .build();
         try (TestTable table = new TestTable(
                 getQueryRunner()::execute,
                 "test_sorted_lineitem_table",

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -1376,17 +1376,15 @@ public abstract class BaseIcebergConnectorTest
         try (TestTable table = new TestTable(
                 getQueryRunner()::execute,
                 "test_sorted_update",
-                "WITH (sorted_by = ARRAY['comment']) AS TABLE tpch.tiny.lineitem WITH NO DATA")) {
+                "WITH (sorted_by = ARRAY['comment']) AS TABLE tpch.tiny.customer WITH NO DATA")) {
             assertUpdate(
                     withSmallRowGroups,
-                    "INSERT INTO " + table.getName() + " TABLE tpch.tiny.lineitem",
-                    "VALUES 60175");
-            assertUpdate(withSmallRowGroups, "UPDATE " + table.getName() + " SET comment = substring(comment, 2)", 60175);
+                    "INSERT INTO " + table.getName() + " TABLE tpch.tiny.customer",
+                    "VALUES 1500");
+            assertUpdate(withSmallRowGroups, "UPDATE " + table.getName() + " SET comment = substring(comment, 2)", 1500);
             assertQuery(
-                    "SELECT orderkey, partkey, suppkey, linenumber, quantity, extendedprice, discount, tax, returnflag, linestatus, shipdate, " +
-                            "commitdate, receiptdate, shipinstruct, shipmode, comment FROM " + table.getName(),
-                    "SELECT orderkey, partkey, suppkey, linenumber, quantity, extendedprice, discount, tax, returnflag, linestatus, shipdate, " +
-                            "commitdate, receiptdate, shipinstruct, shipmode, substring(comment, 2) FROM lineitem");
+                    "SELECT custkey, name, address, nationkey, phone, acctbal, mktsegment, comment FROM " + table.getName(),
+                    "SELECT custkey, name, address, nationkey, phone, acctbal, mktsegment, substring(comment, 2) FROM customer");
             for (Object filePath : computeActual("SELECT file_path from \"" + table.getName() + "$files\"").getOnlyColumnAsSet()) {
                 assertThat(isFileSorted((String) filePath, "comment")).isTrue();
             }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
@@ -13,7 +13,9 @@
  */
 package io.trino.plugin.iceberg;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.trino.spi.type.ArrayType;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.MaterializedResult;
 import io.trino.testing.MaterializedRow;
@@ -31,7 +33,9 @@ import java.util.function.Function;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.plugin.iceberg.IcebergFileFormat.PARQUET;
+import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.testing.MaterializedResult.DEFAULT_PRECISION;
+import static io.trino.testing.MaterializedResult.resultBuilder;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
@@ -348,6 +352,15 @@ public abstract class BaseIcebergSystemTables
                         "('split_offsets', 'array(bigint)', '', '')," +
                         "('equality_ids', 'array(integer)', '', '')");
         assertQuerySucceeds("SELECT * FROM test_schema.\"test_table$files\"");
+
+        long offset = format == PARQUET ? 4L : 3L;
+        assertThat(computeActual("SELECT split_offsets FROM test_schema.\"test_table$files\""))
+                .isEqualTo(resultBuilder(getSession(), ImmutableList.of(new ArrayType(BIGINT)))
+                        .row(ImmutableList.of(offset))
+                        .row(ImmutableList.of(offset))
+                        .row(ImmutableList.of(offset))
+                        .row(ImmutableList.of(offset))
+                        .build());
     }
 
     private Long nanCount(long value)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergTestUtils.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergTestUtils.java
@@ -67,9 +67,9 @@ public final class IcebergTestUtils
     public static Session withSmallRowGroups(Session session)
     {
         return Session.builder(session)
-                .setCatalogSessionProperty("iceberg", "orc_writer_max_stripe_rows", "10")
+                .setCatalogSessionProperty("iceberg", "orc_writer_max_stripe_rows", "20")
                 .setCatalogSessionProperty("iceberg", "parquet_writer_block_size", "1kB")
-                .setCatalogSessionProperty("iceberg", "parquet_writer_batch_size", "10")
+                .setCatalogSessionProperty("iceberg", "parquet_writer_batch_size", "20")
                 .build();
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
@@ -844,7 +844,7 @@ public class TestIcebergV2
                                         JSON '{"1":"0","2":"ALGERIA","3":"0","4":" haggle. careful"}',
                                         JSON '{"1":"24","2":"VIETNAM","3":"4","4":"y final packaget"}',
                                         null,
-                                        null,
+                                        ARRAY[4L],
                                         null),
                                        (0,
                                         'ORC',


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Offsets can be used by readers to align splits with row-group/stripe boundaries.
For data written this change, https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/OffsetsAwareSplitScanTaskIterator.java#L30 will be used to generate 1 split per parquet row-group or orc stripe.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes https://github.com/trinodb/trino/issues/9018


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Populate `split_offsets` in file metadata to allow faster reads. ({issue}`9018`)
```
