### PR TITLE
Add support for XPath functions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
@@ -237,6 +237,7 @@ import io.trino.operator.scalar.timetz.TimeWithTimeZoneToTimeWithTimeZoneCast;
 import io.trino.operator.scalar.timetz.TimeWithTimeZoneToTimestampWithTimeZoneCast;
 import io.trino.operator.scalar.timetz.TimeWithTimeZoneToVarcharCast;
 import io.trino.operator.scalar.timetz.VarcharToTimeWithTimeZoneCast;
+import io.trino.operator.scalar.xpath.XPathFunctions;
 import io.trino.operator.window.CumulativeDistributionFunction;
 import io.trino.operator.window.DenseRankFunction;
 import io.trino.operator.window.FirstValueFunction;
@@ -428,6 +429,7 @@ public final class SystemFunctionBundle
                 .scalar(SplitToMultimapFunction.class)
                 .scalars(VarbinaryFunctions.class)
                 .scalars(UrlFunctions.class)
+                .scalars(XPathFunctions.class)
                 .scalars(MathFunctions.class)
                 .scalar(MathFunctions.Abs.class)
                 .scalar(MathFunctions.Sign.class)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/xpath/XPathFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/xpath/XPathFunctions.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar.xpath;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.function.Description;
+import io.trino.spi.function.LiteralParameters;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlNullable;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.type.StandardTypes;
+import jakarta.annotation.Nullable;
+import org.w3c.dom.Node;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+
+public final class XPathFunctions
+{
+    private XPathFunctions() {}
+
+    @SqlNullable
+    @Description("Returns a string array of values within xml nodes that match the xpath expression")
+    @ScalarFunction
+    @LiteralParameters({"x", "y"})
+    @SqlType("array(varchar)")
+    public static Block xpath(@SqlType("varchar(x)") Slice xml, @SqlType("varchar(y)") Slice path)
+    {
+        XPathHelper xpathHelper = new XPathHelper();
+        List<String> xpathNodeValueList = xpathHelper.evalNodeList(xml.toStringUtf8(), path.toStringUtf8())
+                .map(nodeList -> Stream.iterate(0, i -> i + 1)
+                        .limit(nodeList.getLength())
+                        .map(nodeList::item)
+                        .filter(node -> node.getNodeValue() != null)
+                        .map(Node::getNodeValue)
+                        .collect(toImmutableList()))
+                .orElse(ImmutableList.of());
+
+        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, xpathNodeValueList.size());
+        xpathNodeValueList.stream().forEach(value -> VARCHAR.writeSlice(blockBuilder, utf8Slice(value)));
+        return blockBuilder.build();
+    }
+
+    @SqlNullable
+    @Description("Returns the first node that matches the xpath expression")
+    @ScalarFunction
+    @LiteralParameters({"x", "y"})
+    @SqlType("varchar(x)")
+    public static Slice xpathNode(@SqlType("varchar(x)") Slice xml, @SqlType("varchar(y)") Slice path)
+    {
+        XPathHelper xpathHelper = new XPathHelper();
+        Node xpathNode = xpathHelper.evalNode(xml.toStringUtf8(), path.toStringUtf8());
+        return xpathNode == null ? null : slice(xpathNode.getNodeValue());
+    }
+
+    @SqlNullable
+    @Description("Returns a string from the xml body computed based on the provided path")
+    @ScalarFunction
+    @LiteralParameters({"x", "y"})
+    @SqlType("varchar(x)")
+    public static Slice xpathString(@SqlType("varchar(x)") Slice xml, @SqlType("varchar(y)") Slice path)
+    {
+        XPathHelper xpathHelper = new XPathHelper();
+        return slice(xpathHelper.evalString(xml.toStringUtf8(), path.toStringUtf8()));
+    }
+
+    @SqlNullable
+    @Description("Returns true if the XPath expression evaluates to true, or if a matching node is found")
+    @ScalarFunction
+    @LiteralParameters({"x", "y"})
+    @SqlType(StandardTypes.BOOLEAN)
+    public static Boolean xpathBoolean(@SqlType("varchar(x)") Slice xml, @SqlType("varchar(y)") Slice path)
+    {
+        XPathHelper xPathHelper = new XPathHelper();
+        return xPathHelper.evalBoolean(xml.toStringUtf8(), path.toStringUtf8());
+    }
+
+    @SqlNullable
+    @Description("Return a double value, or the value 0.0 if no match is found, or NaN for non-numeric match")
+    @ScalarFunction
+    @LiteralParameters({"x", "y"})
+    @SqlType(StandardTypes.DOUBLE)
+    public static Double xpathDouble(@SqlType("varchar(x)") Slice xml, @SqlType("varchar(y)") Slice path)
+    {
+        XPathHelper xPathHelper = new XPathHelper();
+        return xPathHelper.evalNumber(xml.toStringUtf8(), path.toStringUtf8());
+    }
+
+    private static Slice slice(@Nullable String data)
+    {
+        return data == null ? null : utf8Slice(data);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/xpath/XPathHelper.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/xpath/XPathHelper.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar.xpath;
+
+import com.google.errorprone.annotations.ThreadSafe;
+import io.trino.spi.TrinoException;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXParseException;
+
+import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.Optional;
+
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static java.lang.String.format;
+import static javax.xml.xpath.XPathConstants.BOOLEAN;
+import static javax.xml.xpath.XPathConstants.NODE;
+import static javax.xml.xpath.XPathConstants.NODESET;
+import static javax.xml.xpath.XPathConstants.NUMBER;
+import static javax.xml.xpath.XPathConstants.STRING;
+
+/**
+ * Utility class for XML processing; borrowed from Hive UDFXPathUtil
+ * https://github.com/apache/hive/blob/master/ql/src/java/org/apache/hadoop/hive/ql/udf/xml/UDFXPathUtil.java
+ */
+final class XPathHelper
+{
+    public static final String SAX_FEATURE_PREFIX = "http://xml.org/sax/features/";
+    public static final String EXTERNAL_GENERAL_ENTITIES_FEATURE = "external-general-entities";
+    public static final String EXTERNAL_PARAMETER_ENTITIES_FEATURE = "external-parameter-entities";
+
+    private DocumentBuilderFactory documentBuilderFactory;
+    private DocumentBuilder documentBuilder;
+    private ReusableStringReader reader;
+    private InputSource inputSource;
+    private XPath xpath;
+    private XPathExpression expression;
+    private String oldPath;
+
+    public XPathHelper()
+    {
+        this.documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        this.reader = new ReusableStringReader();
+        this.inputSource = new InputSource(reader);
+        this.xpath = XPathFactory.newInstance().newXPath();
+    }
+
+    public Object eval(String xml, String path, QName qname)
+    {
+        if (xml == null || path == null || qname == null) {
+            return null;
+        }
+        if (xml.length() == 0 || path.length() == 0) {
+            return null;
+        }
+        if (!path.equals(oldPath)) {
+            try {
+                expression = xpath.compile(path);
+            }
+            catch (XPathExpressionException e) {
+                expression = null;
+            }
+            oldPath = path;
+        }
+        if (expression == null) {
+            return null;
+        }
+        if (documentBuilder == null) {
+            try {
+                documentBuilderFactory.setFeature(SAX_FEATURE_PREFIX + EXTERNAL_GENERAL_ENTITIES_FEATURE, false);
+                documentBuilderFactory.setFeature(SAX_FEATURE_PREFIX + EXTERNAL_PARAMETER_ENTITIES_FEATURE, false);
+                documentBuilder = documentBuilderFactory.newDocumentBuilder();
+            }
+            catch (ParserConfigurationException e) {
+                throw new RuntimeException("Error instantiating DocumentBuilder; cannot build XML parser", e);
+            }
+        }
+
+        reader.set(xml);
+        try {
+            return expression.evaluate(documentBuilder.parse(inputSource), qname);
+        }
+        catch (XPathExpressionException e) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, format("Invalid expression '%s'", oldPath), e);
+        }
+        catch (SAXParseException e) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, format("Error parsing xml data '%s'", xml), e);
+        }
+        catch (Exception e) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, format("Error evaluating expression '%s'", oldPath), e);
+        }
+    }
+
+    public Boolean evalBoolean(String xml, String path)
+    {
+        return (Boolean) eval(xml, path, BOOLEAN);
+    }
+
+    public String evalString(String xml, String path)
+    {
+        return (String) eval(xml, path, STRING);
+    }
+
+    public Double evalNumber(String xml, String path)
+    {
+        return (Double) eval(xml, path, NUMBER);
+    }
+
+    public Node evalNode(String xml, String path)
+    {
+        return (Node) eval(xml, path, NODE);
+    }
+
+    public Optional<NodeList> evalNodeList(String xml, String path)
+    {
+        return Optional.ofNullable((NodeList) eval(xml, path, NODESET));
+    }
+
+    /**
+     * Reusable, threadsafe version of {@link StringReader}.
+     */
+    @ThreadSafe
+    private static final class ReusableStringReader
+            extends Reader
+    {
+        private String streamData;
+        private int length = -1;
+        private int next;
+        private int mark;
+
+        public void set(String streamData)
+        {
+            this.streamData = streamData;
+            this.length = streamData.length();
+            this.next = 0;
+            this.mark = 0;
+        }
+
+        /** Check to make sure that the stream has not been closed */
+        private void ensureOpen()
+                throws IOException
+        {
+            if (streamData == null) {
+                throw new IOException("Stream is closed");
+            }
+        }
+
+        @Override
+        public int read()
+                throws IOException
+        {
+            ensureOpen();
+            if (next >= length) {
+                return -1;
+            }
+            return streamData.charAt(next++);
+        }
+
+        @Override
+        public int read(char[] cbuf, int off, int len)
+                throws IOException
+        {
+            ensureOpen();
+            if (off < 0 || off > cbuf.length || len < 0 || (off + len) > cbuf.length || (off + length) < 0) {
+                throw new IndexOutOfBoundsException();
+            }
+            else if (len == 0) {
+                return 0;
+            }
+
+            if (next >= length) {
+                return -1;
+            }
+
+            int n = Math.min(length - next, len);
+            streamData.getChars(next, next + n, cbuf, off);
+            next += n;
+            return n;
+        }
+
+        @Override
+        public long skip(long ns)
+                throws IOException
+        {
+            ensureOpen();
+            if (next >= length) {
+                return 0;
+            }
+            // Bound skip by beginning and end of the source
+            int n = Long.valueOf(Math.min(length - next, ns)).intValue();
+            n = Math.max(-next, n);
+            next += n;
+            return n;
+        }
+
+        @Override
+        public boolean ready()
+                throws IOException
+        {
+            ensureOpen();
+            return true;
+        }
+
+        @Override
+        public boolean markSupported()
+        {
+            return true;
+        }
+
+        @Override
+        public void mark(int readAheadLimit)
+                throws IOException
+        {
+            if (readAheadLimit < 0) {
+                throw new IllegalArgumentException("Read-ahead limit < 0");
+            }
+            ensureOpen();
+            mark = next;
+        }
+
+        @Override
+        public void reset()
+                throws IOException
+        {
+            ensureOpen();
+            next = mark;
+        }
+
+        @Override
+        public void close()
+        {
+            streamData = null;
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/xpath/TestXPathFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/xpath/TestXPathFunctions.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar.xpath;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.Type;
+import io.trino.sql.query.QueryAssertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public final class TestXPathFunctions
+{
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testXPath()
+    {
+        Type arrayType = new ArrayType(VARCHAR);
+
+        assertThat(assertions.function("xpath", "NULL", "'dummy'")).isNull(arrayType);
+        assertThat(assertions.function("xpath", "'dummy'", "NULL")).isNull(arrayType);
+
+        validateXPathExtract("xpath", "<a><b id=\"foo\">b1</b><b id=\"bar\">b2</b></a>", "//@id", arrayType,
+                ImmutableList.of("foo", "bar"));
+        validateXPathExtract("xpath", "<a><b id=\"1\"><c/></b><b id=\"2\"><c/></b></a>", "/descendant::c/ancestor::b/@id",
+                arrayType, ImmutableList.of("1", "2"));
+        validateXPathExtract("xpath", "<a><b>b1</b><b>b2</b></a>", "a/*", arrayType, ImmutableList.of());
+        validateXPathExtract("xpath", "<a><b>b1</b><b>b2</b></a>", "a/*/text()", arrayType, ImmutableList.of("b1", "b2"));
+        validateXPathExtract("xpath", "<a><b class=\"bb\">b1</b><b>b2</b><b>b3</b><c class=\"bb\">c1</c><c>c2</c></a>",
+                "a/*[@class=\"bb\"]/text()", arrayType, ImmutableList.of("b1", "c1"));
+    }
+
+    @Test
+    public void testXPathNode()
+    {
+        assertThat(assertions.function("xpath_node", "NULL", "'dummy'")).isNull(createVarcharType(0));
+        assertThat(assertions.function("xpath_node", "'dummy'", "NULL")).isNull(createVarcharType(5));
+        assertThat(assertions.function("xpath_node", "'<a><b>bb</b><c>cc</c></a>'", "'d'")).isNull(createVarcharType(25));
+        assertThat(assertions.function("xpath_node", "'<a><b>b1</b><b>b2</b></a>'", "'//b'")).isNull(createVarcharType(25));
+
+        validateXPathExtract("xpath_node", "<a><b><c>test</c></b></a>", "//text()", createVarcharType(25), "test");
+        validateXPathExtract("xpath_node", "<a><b id=\"foo\">b1</b><b id=\"bar\">b2</b></a>", "//@id", createVarcharType(43), "foo");
+        validateXPathExtract("xpath_node", "<a><b class=\"bb\">b1</b><b>b2</b><b>b3</b><c class=\"bb\">c1</c><c>c2</c></a>",
+                "a/*[@class=\"bb\"]/text()", createVarcharType(74), "b1");
+    }
+
+    @Test
+    public void testXPathString()
+    {
+        assertThat(assertions.function("xpath_string", "NULL", "'dummy'")).isNull(createVarcharType(0));
+        assertThat(assertions.function("xpath_string", "'dummy'", "NULL")).isNull(createVarcharType(5));
+
+        Type varcharType = createVarcharType(25);
+        validateXPathExtract("xpath_string", "<a><b>bb</b><c>cc</c></a>", "a/b", varcharType, "bb");
+        validateXPathExtract("xpath_string", "<a><b>bb</b><c>cc</c></a>", "a", varcharType, "bbcc");
+        validateXPathExtract("xpath_string", "<a><b>bb</b><c>cc</c></a>", "a/d", varcharType, "");
+        validateXPathExtract("xpath_string", "<a><b>bb</b><c>cc</c></a>", "d", varcharType, "");
+        validateXPathExtract("xpath_string", "<a><b>b1</b><b>b2</b></a>", "//b", varcharType, "b1");
+        validateXPathExtract("xpath_string", "<a><b>b1</b><b>b2</b></a>", "a/b[2]", varcharType, "b2");
+        validateXPathExtract("xpath_string", "<a><b>b1</b><c>c1</c></a>", "concat(a/b[1], a/c)", varcharType, "b1c1");
+        validateXPathExtract("xpath_string", "<a><b>b1</b><c>c1</c></a>", "a/b[1] + a/c", varcharType, "NaN");
+        validateXPathExtract("xpath_string", "<a><b>b1</b><b id=\"b_2\">b2</b></a>", "a/b[@id=\"b_2\"]", createVarcharType(34), "b2");
+    }
+
+    @Test
+    public void testXPathBoolean()
+    {
+        assertThat(assertions.function("xpath_boolean", "NULL", "'dummy'")).isNull(BOOLEAN);
+        assertThat(assertions.function("xpath_boolean", "'dummy'", "NULL")).isNull(BOOLEAN);
+
+        validateXPathExtract("xpath_boolean", "<a><b>b</b></a>", "a/b", BOOLEAN, true);
+        validateXPathExtract("xpath_boolean", "<a><b>b</b></a>", "a/c", BOOLEAN, false);
+        validateXPathExtract("xpath_boolean", "<a><b>b</b></a>", "a/b = \"b\"", BOOLEAN, true);
+        validateXPathExtract("xpath_boolean", "<a><b>10</b></a>", "a/b < 10", BOOLEAN, false);
+        validateXPathExtract("xpath_boolean", "<a><b>10</b></a>", "d", BOOLEAN, false);
+        validateXPathExtract("xpath_boolean", "<a><b>2</b><c>3</c></a>", "a/b + a/c = 5", BOOLEAN, true);
+    }
+
+    @Test
+    public void testXPathDouble()
+    {
+        assertThat(assertions.function("xpath_double", "NULL", "'dummy'")).isNull(DOUBLE);
+        assertThat(assertions.function("xpath_double", "'dummy'", "NULL")).isNull(DOUBLE);
+
+        validateXPathExtract("xpath_double", "<a>b</a>", "a = 10", DOUBLE, 0d);
+        validateXPathExtract("xpath_double", "<a>this is not a number</a>", "a", DOUBLE, Double.NaN);
+        validateXPathExtract("xpath_double", "<a>2000</a>", "d", DOUBLE, Double.NaN);
+        validateXPathExtract("xpath_double", "<a><b>2000</b><c>not a number</c></a>", "a/b + a/c", DOUBLE, Double.NaN);
+        validateXPathExtract("xpath_double", "<a><b>2000000000</b><c>40000000000</c></a>", "a/b * a/c", DOUBLE, 8e19d);
+    }
+
+    private void validateXPathExtract(String xpathFunctionName, String xml, String path, Type expectedType, Object expectedValue)
+    {
+        assertThat(assertions.function(xpathFunctionName, format("'%s'", xml), format("'%s'", path)))
+                .hasType(expectedType)
+                .isEqualTo(expectedValue);
+    }
+}

--- a/docs/src/main/sphinx/functions.md
+++ b/docs/src/main/sphinx/functions.md
@@ -62,4 +62,5 @@ T-Digest            <functions/tdigest>
 URL                 <functions/url>
 UUID                <functions/uuid>
 Window              <functions/window>
+XPath               <functions/xpath>
 ```

--- a/docs/src/main/sphinx/functions/xpath.md
+++ b/docs/src/main/sphinx/functions/xpath.md
@@ -1,0 +1,21 @@
+# XPath functions
+
+The XPath functions extract elements from an XML body based on a given path.
+The following variations are supported.
+
+:::{function} xpath(xml, path) -> array(varchar)
+Returns an array of string where each string element is the value of node that matches the provided path.
+:::
+
+:::{function} xpath_node(xml, path) -> varchar
+Returns a string whose value is the value of the first node that matches the provided path.
+:::
+
+:::{function} xpath_string(xml, path) -> varchar
+Returns a string whose value is the result computed based on the provided path.
+:::
+
+:::{function} xpath_double(xml, path) -> double
+Returns a double whose value is the result computed based on the provided path. Returns 0.0 if no match is found,
+or NaN if the match is not numeric.
+:::


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
* Fixes #3888
* Supersedes #9219 

## Additional context and related issues
* The case with `XPathConstants.NODE` is not utilized in both Hive and Spark. `xpath_node` may not be needed here. For now the behavior is following that of the case with `NODESET`, returning the content provided by `Node#getNodeValue`


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Add support for XPath functions. ({issue}`3888`)
```
