### PR TITLE
Fix failure when reading nested partition in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -250,6 +250,7 @@ import static io.trino.plugin.iceberg.IcebergUtil.firstSnapshotAfter;
 import static io.trino.plugin.iceberg.IcebergUtil.getColumnHandle;
 import static io.trino.plugin.iceberg.IcebergUtil.getColumnMetadatas;
 import static io.trino.plugin.iceberg.IcebergUtil.getColumns;
+import static io.trino.plugin.iceberg.IcebergUtil.getColumnsWithNested;
 import static io.trino.plugin.iceberg.IcebergUtil.getFileFormat;
 import static io.trino.plugin.iceberg.IcebergUtil.getIcebergTableProperties;
 import static io.trino.plugin.iceberg.IcebergUtil.getPartitionKeys;
@@ -606,7 +607,7 @@ public class IcebergMetadata
         DiscretePredicates discretePredicates = null;
         if (!partitionSourceIds.isEmpty()) {
             // Extract identity partition columns
-            Map<Integer, IcebergColumnHandle> columns = getColumns(icebergTable.schema(), typeManager).stream()
+            Map<Integer, IcebergColumnHandle> columns = getColumnsWithNested(icebergTable.schema(), typeManager).stream()
                     .filter(column -> partitionSourceIds.contains(column.getId()))
                     .collect(toImmutableMap(IcebergColumnHandle::getId, identity()));
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -296,6 +296,13 @@ public final class IcebergUtil
                 .collect(toImmutableList());
     }
 
+    public static List<IcebergColumnHandle> getColumnsWithNested(Schema schema, TypeManager typeManager)
+    {
+        return schema.idToName().keySet().stream()
+                .map(id -> getColumnHandle(schema.findField(id), typeManager))
+                .collect(toImmutableList());
+    }
+
     public static List<ColumnMetadata> getColumnMetadatas(Schema schema, TypeManager typeManager)
     {
         List<NestedField> icebergColumns = schema.columns();

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
@@ -502,6 +502,13 @@ public class TestIcebergSparkCompatibility
                         "  TBLPROPERTIES ('format-version'=2)",
                 sparkTableName));
 
+        onSpark().executeQuery(format(
+                        "INSERT INTO %s SELECT 1, named_struct('nested','aa','nested_another','bb')",
+                sparkTableName));
+
+        assertThat(onTrino().executeQuery("SELECT id, parent.nested, parent.nested_another FROM " + trinoTableName))
+                .containsOnly(row(1, "aa", "bb"));
+
         assertQueryFailure(() -> onTrino().executeQuery("INSERT INTO " + trinoTableName + " VALUES (2, ROW('b'))"))
                 .hasMessageContaining("Partitioning by nested field is unsupported: parent.nested");
         assertQueryFailure(() -> onTrino().executeQuery("UPDATE " + trinoTableName + " SET id = 2"))


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

when the iceberg partitions field is the sub field of the struct,  we query the table, it will throw an exception , 

for example .
1. create table by spark , like this,
```
  CREATE TABLE mytest (
  id INT,
  parent STRUCT<nested:STRING, nested_another:STRING>)
  USING ICEBERG
  PARTITIONED BY (parent.nested)
  TBLPROPERTIES ('format-version'=2)

```
2. insert data to mytest table by spark
3. query the table by trino. 

it will throw exception:
<img width="584" alt="image" src="https://github.com/trinodb/trino/assets/25563794/42aa73b2-1d1f-4ea2-86fe-bd71fcbac195">



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
