### PR TITLE
Fix BucketValidator to validate on data page

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
@@ -180,6 +180,11 @@ public class HivePageSource
                     return null;
                 }
             }
+            else {
+                // bucket adaptation already validates that data is in the right bucket
+                final Page dataPageRef = dataPage;
+                bucketValidator.ifPresent(validator -> validator.validate(dataPageRef));
+            }
 
             int batchSize = dataPage.getPositionCount();
             List<Block> blocks = new ArrayList<>();
@@ -207,14 +212,7 @@ public class HivePageSource
                 }
             }
 
-            Page page = new Page(batchSize, blocks.toArray(new Block[0]));
-
-            // bucket adaptation already validates that data is in the right bucket
-            if (bucketAdapter.isEmpty()) {
-                bucketValidator.ifPresent(validator -> validator.validate(page));
-            }
-
-            return page;
+            return new Page(batchSize, blocks.toArray(new Block[0]));
         }
         catch (TrinoException e) {
             closeAllSuppress(e, this);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceProvider.java
@@ -599,7 +599,7 @@ public class HivePageSourceProvider
         }
     }
 
-    private static Optional<BucketValidator> createBucketValidator(Location path, Optional<BucketValidation> bucketValidation, OptionalInt bucketNumber, List<ColumnMapping> columnMappings)
+    static Optional<BucketValidator> createBucketValidator(Location path, Optional<BucketValidation> bucketValidation, OptionalInt bucketNumber, List<ColumnMapping> columnMappings)
     {
         return bucketValidation.flatMap(validation -> {
             Map<Integer, ColumnMapping> baseHiveColumnToBlockIndex = columnMappings.stream()

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSource.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSource.java
@@ -13,10 +13,37 @@
  */
 package io.trino.plugin.hive;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.filesystem.Location;
+import io.trino.operator.TestScanFilterAndProjectOperator;
+import io.trino.plugin.hive.coercions.CoercionUtils;
+import io.trino.spi.Page;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.Block;
 import io.trino.spi.connector.ConnectorPageSource;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.metastore.HiveType.HIVE_LONG;
+import static io.trino.metastore.HiveType.HIVE_STRING;
+import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
+import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static io.trino.plugin.hive.HivePageSourceProvider.createBucketValidator;
+import static io.trino.plugin.hive.HiveStorageFormat.PARQUET;
+import static io.trino.plugin.hive.HiveTimestampPrecision.DEFAULT_PRECISION;
+import static io.trino.plugin.hive.util.HiveBucketing.BucketingVersion.BUCKETING_V1;
+import static io.trino.spi.predicate.Utils.nativeValueToBlock;
 import static io.trino.spi.testing.InterfaceTestUtils.assertAllMethodsOverridden;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestHivePageSource
 {
@@ -24,5 +51,74 @@ public class TestHivePageSource
     public void testEverythingImplemented()
     {
         assertAllMethodsOverridden(ConnectorPageSource.class, HivePageSource.class);
+    }
+
+    @Test
+    public void testGetNextPageSucceedsWhenHiveBucketingEnabled()
+            throws IOException
+    {
+        testGetNextPageWhenHiveBucketingEnabled(OptionalInt.of(1));
+    }
+
+    @Test
+    public void testGetNextPageThrowsExceptionWhenHiveBucketingEnabled()
+    {
+        assertThatThrownBy(() -> testGetNextPageWhenHiveBucketingEnabled(OptionalInt.of(-1)))
+                .isInstanceOf(TrinoException.class)
+                .hasMessageContaining("Hive table is corrupt.");
+    }
+
+    private void testGetNextPageWhenHiveBucketingEnabled(OptionalInt tableBucketNumber)
+            throws IOException
+    {
+        String partitionColumnName = "partition_col";
+        String bucketColumnName = "bucket_col";
+
+        List<HiveColumnHandle> columns = ImmutableList.of(
+                new HiveColumnHandle(partitionColumnName, 0, HIVE_STRING, VARCHAR, Optional.empty(), PARTITION_KEY, Optional.empty()),
+                new HiveColumnHandle("regular_col", 1, HIVE_STRING, VARCHAR, Optional.empty(), REGULAR, Optional.empty()),
+                new HiveColumnHandle(bucketColumnName, 2, HIVE_LONG, BIGINT, Optional.empty(), REGULAR, Optional.empty()));
+
+        String partitionColumnValue = "1";
+        List<HivePartitionKey> partitionKeys = ImmutableList.of(new HivePartitionKey(partitionColumnName, partitionColumnValue));
+        List<HivePageSourceProvider.ColumnMapping> columnMappings = HivePageSourceProvider.ColumnMapping.buildColumnMappings(
+                partitionColumnValue,
+                partitionKeys,
+                columns,
+                ImmutableList.of(),
+                ImmutableMap.of(),
+                null,
+                tableBucketNumber,
+                0,
+                0);
+
+        List<HivePageSourceProvider.ColumnMapping> regularAndInterimColumnMappings = HivePageSourceProvider.ColumnMapping.extractRegularAndInterimColumnMappings(columnMappings);
+
+        List<HiveColumnHandle> bucketColumns = columns.stream().filter(c -> c.getName().equals(bucketColumnName)).toList();
+        Optional<HiveSplit.BucketValidation> bucketValidation = Optional.of(new HiveSplit.BucketValidation(BUCKETING_V1, 8, bucketColumns));
+        Optional<HivePageSource.BucketValidator> bucketValidator = createBucketValidator(
+                Location.of("memory:///test"),
+                bucketValidation,
+                tableBucketNumber,
+                regularAndInterimColumnMappings);
+
+        Block[] blocks = new Block[] {
+                nativeValueToBlock(VARCHAR, utf8Slice("a")),
+                nativeValueToBlock(BIGINT, 1L)
+        };
+        Page page = new Page(1, blocks);
+
+        try (
+                ConnectorPageSource pageSource = new TestScanFilterAndProjectOperator.SinglePagePageSource(page);
+                HivePageSource hivePageSource = new HivePageSource(
+                        columnMappings,
+                        Optional.empty(),
+                        bucketValidator,
+                        Optional.empty(),
+                        TESTING_TYPE_MANAGER,
+                        new CoercionUtils.CoercionContext(DEFAULT_PRECISION, PARQUET),
+                        pageSource)) {
+            hivePageSource.getNextPage();
+        }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
A bug related to [BucketValidator](https://github.com/trinodb/trino/blob/b63e75eb9e06a0018dc0c720e6696479cc5869e5/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java#L365) was causing select queries on certain column combination on Hive V1 bucketed table failed with HIVE_CURSOR_ERROR while it succeeded in the other column combination. 

### Minimal example
**DDL of bucketed table**

```
CREATE EXTERNAL TABLE `example_table`(
  `input_key` varchar(1), 
  `metrics` struct<gauges:array<struct<name:string,value:bigint>>>)
PARTITIONED BY ( 
  `run_id` varchar(1))
CLUSTERED BY ( 
  input_key) 
INTO 8 BUCKETS
ROW FORMAT SERDE 
  'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe' 
STORED AS INPUTFORMAT 
  'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat' 
OUTPUTFORMAT 
  'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
LOCATION
  '<S3_PATH_TO_TABLE>'
TBLPROPERTIES ( 
  'bucketing_format'='hive', 
  'bucketing_version'='1', 
)
```

**Failed select query with HIVE_CURSOR_ERROR**

```
select run_id, input_key, metrics.gauges from example_table
```

**Succeeded select queries**

```
select run_id, input_key, metrics from example_table
select * from example_table
```

### Root cause
In HivePageSource.java > [getNextPage](https://github.com/trinodb/trino/blob/b63e75eb9e06a0018dc0c720e6696479cc5869e5/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java#L163) method, BucketValidator and BucketAdapter validate if the data is in the right bucket. (BucketValidator - [here](https://github.com/trinodb/trino/blob/b63e75eb9e06a0018dc0c720e6696479cc5869e5/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java#L212), BucketAdapter - [here](https://github.com/trinodb/trino/blob/b63e75eb9e06a0018dc0c720e6696479cc5869e5/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java#L175)). This validation is done only once by either BucketValidator or BucketAdapter depending on if bucketAdapter is empty.

The root cause of the query failure is that BucketValidator and BucketAdapter were validating different page while they should have validated the same data page. BucketValidator was validating on output page instead of data page in [here](https://github.com/trinodb/trino/blob/6ce4e83aaf545e959fdcde7e9f81f12591805eed/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java#L212) while BucketAdapter was validating on data page in [here](https://github.com/trinodb/trino/blob/6ce4e83aaf545e959fdcde7e9f81f12591805eed/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java#L176). 

Output page includes PREFILLED type column which is for partition or synthesized column while data page doesn't include that column type. BucketAdapter and BucketValidator both use the same bucketColumnIndices based on column mapping index which only accounts for regular or interim column type in [here](https://github.com/trinodb/trino/blob/6ce4e83aaf545e959fdcde7e9f81f12591805eed/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceProvider.java#L397-L461). 

Thus when BucketValidator calls page.getColumns in validate method in [here](https://github.com/trinodb/trino/blob/6ce4e83aaf545e959fdcde7e9f81f12591805eed/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java#L365), in an edge case where in the column order, prefilled(partition) column precedes regular/interim columns, it returns wrong column as bucket column. This is because bucketColumnIndices is based only on regular or interim column while the output page contains blocks from columns including not only regular/interim column, but prefilled one causing mismatch between bucketColumnIndex and the block (indices of blocks got pushed by 1). 
The wrong bucket column caused HIVE_CURSOR_ERROR and failed select queries. 

BucketAdapter didn't have this issue because both data page being validated and the bucketColumnIndices being using in page.getColumns [here](https://github.com/trinodb/trino/blob/6ce4e83aaf545e959fdcde7e9f81f12591805eed/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java#L311) both doesn't include prefilled column type.



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Fix potential query failures caused by incorrect bucket column validation in some cases
```