### PR TITLE
Use Identifier.getValue when analyzing table function arguments

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -1991,8 +1991,11 @@ class StatementAnalyzer
                     }
                 });
                 argumentBuilder.partitionBy(partitionBy.stream()
-                        // each expression is either an Identifier or a DereferenceExpression
-                        .map(Expression::toString)
+                        .map(expression -> switch (expression) {
+                            case Identifier identifier -> identifier.getValue();
+                            case DereferenceExpression dereferenceExpression -> dereferenceExpression.toString();
+                            default -> throw new IllegalStateException("Unexpected partitionBy expression: " + expression);
+                        })
                         .collect(toImmutableList()));
             }
 
@@ -2013,8 +2016,12 @@ class StatementAnalyzer
                             }
                         });
                 argumentBuilder.orderBy(orderBy.getSortItems().stream()
-                        // each sort key is either an Identifier or a DereferenceExpression
-                        .map(sortItem -> sortItem.getSortKey().toString())
+                        .map(SortItem::getSortKey)
+                        .map(expression -> switch (expression) {
+                            case Identifier identifier -> identifier.getValue();
+                            case DereferenceExpression dereferenceExpression -> dereferenceExpression.toString();
+                            default -> throw new IllegalStateException("Unexpected orderBy expression: " + expression);
+                        })
                         .collect(toImmutableList()));
             }
 

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -6373,6 +6373,20 @@ public class TestAnalyzer
                                       ORDER BY b))
                 """);
 
+        analyze("SELECT * FROM TABLE(system.table_argument_function(input => TABLE(t1) PARTITION BY \"a\"))");
+
+        analyze("SELECT * FROM TABLE(system.table_argument_function(input => TABLE(t1) ORDER BY \"a\"))");
+
+        // TODO Fix failure when partitioning by a nested field
+        assertFails("SELECT * FROM TABLE(system.table_argument_function(input => TABLE(SELECT CAST(ROW(1) AS ROW(x BIGINT)) a) PARTITION BY a.x))")
+                .hasErrorCode(COLUMN_NOT_FOUND)
+                .hasMessage("line 1:120: Column a.x is not present in the input relation");
+
+        // TODO Fix failure when ordering by a nested field
+        assertFails("SELECT * FROM TABLE(system.table_argument_function(input => TABLE(SELECT CAST(ROW(1) AS ROW(x BIGINT)) a) ORDER BY a.x))")
+                .hasErrorCode(COLUMN_NOT_FOUND)
+                .hasMessage("line 1:116: Column a.x is not present in the input relation");
+
         assertFails("SELECT * FROM TABLE(system.table_argument_row_semantics_function(input => TABLE(t1) PARTITION BY a))")
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
                 .hasMessage("line 1:66: Invalid argument INPUT. Partitioning specified for table argument with row semantics");


### PR DESCRIPTION
## Description

Otherwise, getPartitionBy and getOrderBy methods in TableArgument SPI returns quoted column names.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
