### PR TITLE
Fix failure when reading signed timestamp with time zone stats in Delta Lake

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogParser.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogParser.java
@@ -119,6 +119,11 @@ public final class TransactionLogParser
             .withResolverStyle(ResolverStyle.STRICT);
     public static final DateTimeFormatter JSON_STATISTICS_TIMESTAMP_FORMATTER = new DateTimeFormatterBuilder()
             .parseCaseInsensitive()
+            // Using optional format because the format differ among Delta Lake versions.
+            // For instance, newer versions use '+' sign when year is more than 4 digits, but older versions don't write the sign.
+            .optionalStart()
+            .appendLiteral('+')
+            .optionalEnd()
             .appendValue(YEAR, 4, 10, SignStyle.NORMAL)
             .appendLiteral('-')
             .appendValue(MONTH_OF_YEAR, 2)


### PR DESCRIPTION
## Description

Fixes #22184

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Delta Lake
* TBD. ({issue}`22184`)
```
