### PR TITLE
Update airbase to 157

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>156</version>
+        <version>157</version>
     </parent>
 
     <groupId>io.trino</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2308,7 +2308,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.3.0</version>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
There is one breaking change in the update library that caused some trouble in the Airlift: https://github.com/google/guava/commit/3f61870ac6e5b18dbb74ce6f6cb2930ad8750a43. 

Let's see whether this affects Trino tests