### PR TITLE
Fix uncheckedCacheGet javadoc

### DIFF
--- a/lib/trino-cache/src/main/java/io/trino/cache/CacheUtils.java
+++ b/lib/trino-cache/src/main/java/io/trino/cache/CacheUtils.java
@@ -14,6 +14,7 @@
 package io.trino.cache;
 
 import com.google.common.cache.Cache;
+import com.google.common.util.concurrent.ExecutionError;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 
 import java.util.List;
@@ -29,7 +30,8 @@ public final class CacheUtils
 
     /**
      * @throws UncheckedExecutionException when {@code loader} throws an unchecked exception
-     * @throws RuntimeException when{@code loader} throws a checked exception (which should not happen) or an {@link Error}
+     * @throws ExecutionError when {@code loader} throws an {@link Error}
+     * @throws RuntimeException when {@code loader} throws a checked exception (which should not happen)
      */
     public static <K, V> V uncheckedCacheGet(Cache<K, V> cache, K key, Supplier<V> loader)
     {


### PR DESCRIPTION
The `uncheckedCacheGet` will propagate `ExecutionError` if `Cache.get` throws it.

This reverts commit 3d0632d8a63ee5acd135984ddccda98ad6ebcbc2.
