### PR TITLE
Gracefully handle missing spooling output stats in FTE scheduler

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/RemoteTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RemoteTask.java
@@ -21,6 +21,8 @@ import io.trino.execution.buffer.SpoolingOutputStats;
 import io.trino.metadata.Split;
 import io.trino.sql.planner.plan.PlanNodeId;
 
+import java.util.Optional;
+
 public interface RemoteTask
 {
     TaskId getTaskId();
@@ -88,5 +90,5 @@ public interface RemoteTask
      *
      * @return spooling output statistics
      */
-    SpoolingOutputStats.Snapshot retrieveAndDropSpoolingOutputStats();
+    Optional<SpoolingOutputStats.Snapshot> retrieveAndDropSpoolingOutputStats();
 }

--- a/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
@@ -556,7 +556,7 @@ public final class HttpRemoteTask
     }
 
     @Override
-    public SpoolingOutputStats.Snapshot retrieveAndDropSpoolingOutputStats()
+    public Optional<SpoolingOutputStats.Snapshot> retrieveAndDropSpoolingOutputStats()
     {
         return taskInfoFetcher.retrieveAndDropSpoolingOutputStats();
     }

--- a/core/trino-main/src/test/java/io/trino/execution/MockRemoteTaskFactory.java
+++ b/core/trino-main/src/test/java/io/trino/execution/MockRemoteTaskFactory.java
@@ -521,7 +521,7 @@ public class MockRemoteTaskFactory
         }
 
         @Override
-        public SpoolingOutputStats.Snapshot retrieveAndDropSpoolingOutputStats()
+        public Optional<SpoolingOutputStats.Snapshot> retrieveAndDropSpoolingOutputStats()
         {
             throw new UnsupportedOperationException();
         }

--- a/core/trino-main/src/test/java/io/trino/execution/TestingRemoteTaskFactory.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestingRemoteTaskFactory.java
@@ -322,7 +322,7 @@ public class TestingRemoteTaskFactory
         }
 
         @Override
-        public SpoolingOutputStats.Snapshot retrieveAndDropSpoolingOutputStats()
+        public Optional<SpoolingOutputStats.Snapshot> retrieveAndDropSpoolingOutputStats()
         {
             throw new UnsupportedOperationException();
         }


### PR DESCRIPTION
It is rare but possible to get empty spooling output stats for task which completed successfully. This may happen if we observe FINISHED task state based on received TaskStatus but are later on unable to successfully retrieve TaskInfo. In such case we are building final TaskInfo based on last known taskInfo, just updating the taskState field. The spooling output stats will not be present. As we need this information in FTE mode we need to fail such task artificially

