### PR TITLE
Allowing users to provide additional http headers for Prometheus Client.

### DIFF
--- a/docs/src/main/sphinx/connector/prometheus.md
+++ b/docs/src/main/sphinx/connector/prometheus.md
@@ -82,6 +82,13 @@ The following configuration properties are available:
 * - `prometheus.case-insensitive-name-matching`
   - Match Prometheus metric names case insensitively.
   - `false`
+* - `prometheus.http.additional-headers`
+  -  Additional headers to send to Prometheus endpoint. These headers
+     must be comma-separated and delimited using `:`. For example,
+     `header1:value1,header2:value2` sends two headers `header1` and `header2`
+     with the values as `value1` and `value2`. Escape comma (`,`) or colon(`:`)
+     characters in a header name or value with a backslash (`\`).
+  -
 :::
 
 ## Not exhausting your Trino available heap

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusClient.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusClient.java
@@ -75,6 +75,7 @@ public class PrometheusClient
         Builder clientBuilder = new Builder().readTimeout(Duration.ofMillis(config.getReadTimeout().toMillis()));
         setupBasicAuth(clientBuilder, config.getUser(), config.getPassword());
         setupTokenAuth(clientBuilder, getBearerAuthInfoFromFile(config.getBearerTokenFile()), config.getHttpAuthHeaderName());
+        clientBuilder.addInterceptor(addAdditionalHeaders(config.getAdditionalHeaders()));
         this.httpClient = clientBuilder.build();
 
         URI prometheusMetricsUri = getPrometheusMetricsURI(config.getPrometheusURI());
@@ -221,5 +222,14 @@ public class PrometheusClient
         return chain -> chain.proceed(chain.request().newBuilder()
                 .addHeader(httpAuthHeaderName, token)
                 .build());
+    }
+
+    private static Interceptor addAdditionalHeaders(Map<String, String> additionalHeaders)
+    {
+        return chain -> {
+            Request.Builder requestBuilder = chain.request().newBuilder();
+            additionalHeaders.forEach(requestBuilder::addHeader);
+            return chain.proceed(requestBuilder.build());
+        };
     }
 }

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusConnectorConfig.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusConnectorConfig.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.prometheus;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HttpHeaders;
 import com.google.inject.ConfigurationException;
 import com.google.inject.spi.Message;
@@ -27,8 +28,12 @@ import jakarta.validation.constraints.NotNull;
 
 import java.io.File;
 import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+
+import static java.lang.String.format;
 
 public class PrometheusConnectorConfig
 {
@@ -42,6 +47,7 @@ public class PrometheusConnectorConfig
     private String user;
     private String password;
     private boolean caseInsensitiveNameMatching;
+    private Map<String, String> additionalHeaders = ImmutableMap.of();
 
     @NotNull
     public URI getPrometheusURI()
@@ -179,6 +185,37 @@ public class PrometheusConnectorConfig
         return this;
     }
 
+    public Map<String, String> getAdditionalHeaders()
+    {
+        return additionalHeaders;
+    }
+
+    @Config("prometheus.http.additional-headers")
+    @ConfigDescription("Comma separated key:value pairs to be sent with the HTTP request to Prometheus as additional headers")
+    public PrometheusConnectorConfig setAdditionalHeaders(String httpHeaders)
+    {
+        try {
+            // we allow escaping the delimiters like , and : using back-slash.
+            // To support that we create a negative lookbehind of , and : which
+            // are not preceded by a back-slash.
+            String headersDelim = "(?<!\\\\),";
+            String kvDelim = "(?<!\\\\):";
+            Map<String, String> temp = new HashMap<>();
+            if (httpHeaders != null) {
+                for (String kv : httpHeaders.split(headersDelim)) {
+                    String key = kv.split(kvDelim, 2)[0].trim();
+                    String val = kv.split(kvDelim, 2)[1].trim();
+                    temp.put(key, val);
+                }
+                this.additionalHeaders = ImmutableMap.copyOf(temp);
+            }
+        }
+        catch (IndexOutOfBoundsException e) {
+            throw new IllegalArgumentException(format("Invalid format for 'prometheus.http.additional-headers' because %s. Value provided is %s", e.getMessage(), httpHeaders), e);
+        }
+        return this;
+    }
+
     @PostConstruct
     public void checkConfig()
     {
@@ -192,6 +229,9 @@ public class PrometheusConnectorConfig
         }
         if (getUser().isPresent() ^ getPassword().isPresent()) {
             throw new IllegalStateException("Both username and password must be set when using basic authentication");
+        }
+        if (getAdditionalHeaders().containsKey(httpAuthHeaderName)) {
+            throw new IllegalStateException("Additional headers can not include: " + httpAuthHeaderName);
         }
     }
 }

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusConnectorConfig.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusConnectorConfig.java
@@ -45,7 +45,8 @@ public class TestPrometheusConnectorConfig
                 .setUser(null)
                 .setPassword(null)
                 .setReadTimeout(new Duration(10, SECONDS))
-                .setCaseInsensitiveNameMatching(false));
+                .setCaseInsensitiveNameMatching(false)
+                .setAdditionalHeaders(null));
     }
 
     @Test
@@ -62,6 +63,7 @@ public class TestPrometheusConnectorConfig
                 .put("prometheus.auth.password", "password")
                 .put("prometheus.read-timeout", "30s")
                 .put("prometheus.case-insensitive-name-matching", "true")
+                .put("prometheus.http.additional-headers", "key\\:1:value\\,1, key\\,2:value\\:2")
                 .buildOrThrow();
 
         URI uri = URI.create("file://test.json");
@@ -76,6 +78,7 @@ public class TestPrometheusConnectorConfig
         expected.setPassword("password");
         expected.setReadTimeout(new Duration(30, SECONDS));
         expected.setCaseInsensitiveNameMatching(true);
+        expected.setAdditionalHeaders("key\\:1:value\\,1, key\\,2:value\\:2");
 
         assertFullMapping(properties, expected);
     }
@@ -111,5 +114,10 @@ public class TestPrometheusConnectorConfig
         assertThatThrownBy(new PrometheusConnectorConfig().setPassword("test")::checkConfig)
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Both username and password must be set when using basic authentication");
+
+        assertThatThrownBy(new PrometheusConnectorConfig().setAdditionalHeaders("Authorization: test").setHttpAuthHeaderName("Authorization")
+                ::checkConfig)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Additional headers can not include: Authorization");
     }
 }


### PR DESCRIPTION
## Description

Prometheus endpoint may require additional http headers. Adding the configuration properties for the same
Example of additional header "X-Scope-orgID" , "default"

Fixes https://github.com/trinodb/trino/issues/21394

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
