### PR TITLE
Avoid org.locationtech.jts:jts-core exclusion in Pinot

### DIFF
--- a/plugin/trino-pinot/pom.xml
+++ b/plugin/trino-pinot/pom.xml
@@ -341,10 +341,6 @@
                     <artifactId>jersey-container-grizzly2-http</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.locationtech.jts</groupId>
-                    <artifactId>jts-core</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
@@ -365,12 +361,6 @@
             <groupId>org.apache.pinot</groupId>
             <artifactId>pinot-segment-spi</artifactId>
             <version>${dep.pinot.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.locationtech.jts</groupId>
-                    <artifactId>jts-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Description

https://trinodb.slack.com/archives/CGB0QHWSW/p1717675311599239

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Pinot
* Fix failure when using dynamic tables. ({issue}`22301`)
```
