### PR TITLE
Fix argument order in ST_Point() function docs

### DIFF
--- a/docs/src/main/sphinx/functions/geospatial.md
+++ b/docs/src/main/sphinx/functions/geospatial.md
@@ -86,7 +86,7 @@ Array elements must not be `NULL` or empty.
 The returned geometry may not be simple and may contain duplicate points if input array has duplicates.
 :::
 
-:::{function} ST_Point(lat: double, lon: double) -> Point
+:::{function} ST_Point(lon: double, lat: double) -> Point
 Returns a geometry type point object with the given coordinate values.
 :::
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Fix misleading argument order in [ST_Point()](https://trino.io/docs/current/functions/geospatial.html#ST_Point) docs when creating a point from geographical coordinates.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

I ended up swapping the latitude and the longitude when computing the centroid of various coordinates due to the misleading argument order in the documentation.

The order should match the one documented in [PostGis/ST_Point()](https://postgis.net/docs/ST_Point.html).

Fixes https://github.com/trinodb/trino/issues/22419

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
