### PR TITLE
Make AsyncResponse aware of the client disconnection

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/ConnectionAwareAsyncResponse.java
+++ b/core/trino-main/src/main/java/io/trino/server/ConnectionAwareAsyncResponse.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.AsyncEvent;
+import jakarta.servlet.AsyncListener;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.TimeoutHandler;
+import jakarta.ws.rs.core.Context;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
+import static java.util.Objects.requireNonNull;
+
+public class ConnectionAwareAsyncResponse
+        implements AsyncResponse
+{
+    private final AsyncResponse delegate;
+    private final AtomicBoolean clientDisconnected = new AtomicBoolean();
+    private final AtomicReference<ListenableFuture<?>> future = new AtomicReference<>(null);
+    private final AsyncContext asyncContext;
+
+    public ConnectionAwareAsyncResponse(@Context HttpServletRequest request, AsyncResponse delegate)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        requireNonNull(request, "request is null");
+        verify(request.isAsyncStarted(), "AsyncContext is not started, did you forget @Suspended?");
+        this.asyncContext = request.getAsyncContext();
+
+        request.getAsyncContext().addListener(new AsyncListener()
+        {
+            @Override
+            public void onComplete(AsyncEvent event) {}
+
+            @Override
+            public void onTimeout(AsyncEvent event) {}
+
+            @Override
+            public void onError(AsyncEvent event)
+            {
+                // Jetty's detected that client disconnected
+                if (event.getThrowable() instanceof IOException ioException && ioException.getMessage().contains("cancel_stream_error")) {
+                    clientDisconnected.set(true);
+                    asyncContext.complete();
+                    ListenableFuture<?> listenableFuture = future.get();
+                    if (listenableFuture != null) {
+                        if (future.compareAndSet(listenableFuture, null)) {
+                            listenableFuture.cancel(true);
+                        }
+                    }
+                }
+            }
+
+            @Override
+            public void onStartAsync(AsyncEvent event) {}
+        });
+    }
+
+    public ConnectionAwareAsyncResponse withCancellableFuture(ListenableFuture<?> future)
+    {
+        checkState(this.future.compareAndSet(null, future), "Future to cancel already set");
+        return this;
+    }
+
+    @Override
+    public boolean resume(Object response)
+    {
+        if (clientDisconnected.get()) {
+            return true;
+        }
+        return delegate.resume(response);
+    }
+
+    @Override
+    public boolean resume(Throwable response)
+    {
+        if (clientDisconnected.get()) {
+            return true;
+        }
+        return delegate.resume(response);
+    }
+
+    @Override
+    public boolean cancel()
+    {
+        return delegate.cancel();
+    }
+
+    @Override
+    public boolean cancel(int retryAfter)
+    {
+        return delegate.cancel(retryAfter);
+    }
+
+    @Override
+    public boolean cancel(Date retryAfter)
+    {
+        return delegate.cancel(retryAfter);
+    }
+
+    @Override
+    public boolean isSuspended()
+    {
+        return delegate.isSuspended();
+    }
+
+    @Override
+    public boolean isCancelled()
+    {
+        return delegate.isCancelled();
+    }
+
+    @Override
+    public boolean isDone()
+    {
+        if (clientDisconnected.get()) {
+            return true;
+        }
+        return delegate.isDone();
+    }
+
+    @Override
+    public boolean setTimeout(long time, TimeUnit unit)
+    {
+        return delegate.setTimeout(time, unit);
+    }
+
+    @Override
+    public void setTimeoutHandler(TimeoutHandler handler)
+    {
+        delegate.setTimeoutHandler(handler);
+    }
+
+    @Override
+    public Collection<Class<?>> register(Class<?> callback)
+    {
+        return delegate.register(callback);
+    }
+
+    @Override
+    public Map<Class<?>, Collection<Class<?>>> register(Class<?> callback, Class<?>... callbacks)
+    {
+        return delegate.register(callback, callbacks);
+    }
+
+    @Override
+    public Collection<Class<?>> register(Object callback)
+    {
+        return delegate.register(callback);
+    }
+
+    @Override
+    public Map<Class<?>, Collection<Class<?>>> register(Object callback, Object... callbacks)
+    {
+        return delegate.register(callback, callbacks);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/TaskResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/TaskResource.java
@@ -37,6 +37,7 @@ import io.trino.execution.buffer.PipelinedOutputBuffers;
 import io.trino.metadata.SessionPropertyManager;
 import io.trino.server.security.ResourceSecurity;
 import io.trino.spi.connector.CatalogHandle;
+import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.DefaultValue;
@@ -48,7 +49,6 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.container.AsyncResponse;
-import jakarta.ws.rs.container.CompletionCallback;
 import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.GenericEntity;
@@ -143,7 +143,7 @@ public class TaskResource
             @PathParam("taskId") TaskId taskId,
             TaskUpdateRequest taskUpdateRequest,
             @Context UriInfo uriInfo,
-            @Suspended AsyncResponse asyncResponse)
+            @Suspended @BeanParam ConnectionAwareAsyncResponse asyncResponse)
     {
         requireNonNull(taskUpdateRequest, "taskUpdateRequest is null");
         if (failRequestIfInvalid(asyncResponse)) {
@@ -182,7 +182,7 @@ public class TaskResource
             @HeaderParam(TRINO_CURRENT_VERSION) Long currentVersion,
             @HeaderParam(TRINO_MAX_WAIT) Duration maxWait,
             @Context UriInfo uriInfo,
-            @Suspended AsyncResponse asyncResponse)
+            @Suspended @BeanParam ConnectionAwareAsyncResponse asyncResponse)
     {
         requireNonNull(taskId, "taskId is null");
         if (failRequestIfInvalid(asyncResponse)) {
@@ -218,7 +218,7 @@ public class TaskResource
 
         // For hard timeout, add an additional time to max wait for thread scheduling contention and GC
         Duration timeout = new Duration(waitTime.toMillis() + ADDITIONAL_WAIT_TIME.toMillis(), MILLISECONDS);
-        bindAsyncResponse(asyncResponse, futureTaskInfo, responseExecutor)
+        bindAsyncResponse(asyncResponse.withCancellableFuture(futureTaskInfo), futureTaskInfo, responseExecutor)
                 .withTimeout(timeout);
     }
 
@@ -230,7 +230,7 @@ public class TaskResource
             @PathParam("taskId") TaskId taskId,
             @HeaderParam(TRINO_CURRENT_VERSION) Long currentVersion,
             @HeaderParam(TRINO_MAX_WAIT) Duration maxWait,
-            @Suspended AsyncResponse asyncResponse)
+            @Suspended @BeanParam ConnectionAwareAsyncResponse asyncResponse)
     {
         requireNonNull(taskId, "taskId is null");
         if (failRequestIfInvalid(asyncResponse)) {
@@ -262,7 +262,7 @@ public class TaskResource
 
         // For hard timeout, add an additional time to max wait for thread scheduling contention and GC
         Duration timeout = new Duration(waitTime.toMillis() + ADDITIONAL_WAIT_TIME.toMillis(), MILLISECONDS);
-        bindAsyncResponse(asyncResponse, futureTaskStatus, responseExecutor)
+        bindAsyncResponse(asyncResponse.withCancellableFuture(futureTaskStatus), futureTaskStatus, responseExecutor)
                 .withTimeout(timeout);
     }
 
@@ -273,7 +273,7 @@ public class TaskResource
     public void acknowledgeAndGetNewDynamicFilterDomains(
             @PathParam("taskId") TaskId taskId,
             @HeaderParam(TRINO_CURRENT_VERSION) Long currentDynamicFiltersVersion,
-            @Suspended AsyncResponse asyncResponse)
+            @Suspended @BeanParam ConnectionAwareAsyncResponse asyncResponse)
     {
         requireNonNull(taskId, "taskId is null");
         requireNonNull(currentDynamicFiltersVersion, "currentDynamicFiltersVersion is null");
@@ -336,7 +336,7 @@ public class TaskResource
             @PathParam("bufferId") PipelinedOutputBuffers.OutputBufferId bufferId,
             @PathParam("token") long token,
             @HeaderParam(TRINO_MAX_SIZE) DataSize maxSize,
-            @Suspended AsyncResponse asyncResponse)
+            @Suspended @BeanParam ConnectionAwareAsyncResponse asyncResponse)
     {
         requireNonNull(taskId, "taskId is null");
         requireNonNull(bufferId, "bufferId is null");
@@ -363,11 +363,10 @@ public class TaskResource
 
         // For hard timeout, add an additional time to max wait for thread scheduling contention and GC
         Duration timeout = new Duration(waitTime.toMillis() + ADDITIONAL_WAIT_TIME.toMillis(), MILLISECONDS);
-        bindAsyncResponse(asyncResponse, responseFuture, responseExecutor)
+        bindAsyncResponse(asyncResponse.withCancellableFuture(responseFuture), responseFuture, responseExecutor)
                 .withTimeout(timeout, () -> createBufferResultResponse(taskWithResults, emptyBufferResults));
 
         responseFuture.addListener(() -> readFromOutputBufferTime.add(Duration.nanosSince(start)), directExecutor());
-        asyncResponse.register((CompletionCallback) throwable -> resultsRequestTime.add(Duration.nanosSince(start)));
     }
 
     @ResourceSecurity(INTERNAL_ONLY)


### PR DESCRIPTION
With the current Jersey and Jetty implementations @Suspended AsyncResponse can generate a lot of warnings that are caused by the fact that Jetty eagerly recycles request/response objects when the HTTP/2 RST_STREAM frame is sent by the client during request aborting.

We abort in-flight requests for different reasons: either timeout is reached or when the client is closed during cleanup.

For HTTP/1 that doesn't matter, but for HTTP/2 this will cause the AsyncResponse.resume to log an error, since the underlying request/response objects are already recycled and there is no client listening for the response.

This change also cancels Future<?> bound to the AsyncContext since there is no point in processing it anymore.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
