### PR TITLE
Verify body in doScheduleAsyncCleanupRequest

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
@@ -975,6 +975,10 @@ public final class HttpRemoteTask
             public void onSuccess(JsonResponse<TaskInfo> result)
             {
                 try {
+                    if (!result.hasValue()) {
+                        log.warn("TaskInfo result did not contain JSON payload; payload=" + result.getResponseBody());
+                        throw new IllegalArgumentException("TaskInfo result did not contain JSON payload");
+                    }
                     updateTaskInfo(result.getValue());
                 }
                 finally {


### PR DESCRIPTION
We observed rare cases when we got non-JSON result in doScheduleAsyncCleanupRequest and current logging does not provide enough information to understand the root cause.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
