### PR TITLE
Allow varbinary to varchar coercion for hive tables

### DIFF
--- a/docs/src/main/sphinx/connector/hive.md
+++ b/docs/src/main/sphinx/connector/hive.md
@@ -631,6 +631,8 @@ type conversions.
   - `VARCHAR`
 * - `TIMESTAMP`
   - `VARCHAR`, `DATE`
+* - `VARBINARY`
+  - `VARCHAR` 
 :::
 
 Any conversion failure results in null, which is the same behavior

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceProvider.java
@@ -57,7 +57,6 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.Maps.uniqueIndex;
-import static io.trino.hive.formats.HiveClassNames.ORC_SERDE_CLASS;
 import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
 import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.SYNTHESIZED;
@@ -67,6 +66,7 @@ import static io.trino.plugin.hive.HivePageSourceProvider.ColumnMapping.toColumn
 import static io.trino.plugin.hive.HivePageSourceProvider.ColumnMappingKind.PREFILLED;
 import static io.trino.plugin.hive.HiveSessionProperties.getTimestampPrecision;
 import static io.trino.plugin.hive.coercions.CoercionUtils.createTypeFromCoercer;
+import static io.trino.plugin.hive.coercions.CoercionUtils.extractHiveStorageFormat;
 import static io.trino.plugin.hive.util.HiveBucketing.HiveBucketFilter;
 import static io.trino.plugin.hive.util.HiveBucketing.getHiveBucketFilter;
 import static io.trino.plugin.hive.util.HiveUtil.getDeserializerClassName;
@@ -191,8 +191,7 @@ public class HivePageSourceProvider
         Optional<BucketAdaptation> bucketAdaptation = createBucketAdaptation(bucketConversion, tableBucketNumber, regularAndInterimColumnMappings);
         Optional<BucketValidator> bucketValidator = createBucketValidator(path, bucketValidation, tableBucketNumber, regularAndInterimColumnMappings);
 
-        boolean isOrcFile = ORC_SERDE_CLASS.equals(getDeserializerClassName(schema));
-        CoercionContext coercionContext = new CoercionContext(getTimestampPrecision(session), isOrcFile);
+        CoercionContext coercionContext = new CoercionContext(getTimestampPrecision(session), extractHiveStorageFormat(getDeserializerClassName(schema)));
 
         for (HivePageSourceFactory pageSourceFactory : pageSourceFactories) {
             List<HiveColumnHandle> desiredColumns = toColumnHandles(regularAndInterimColumnMappings, typeManager, coercionContext);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/CoercionUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/CoercionUtils.java
@@ -53,6 +53,7 @@ import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.TinyintType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
+import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
 
 import java.util.List;
@@ -79,6 +80,7 @@ import static io.trino.plugin.hive.coercions.DecimalCoercers.createIntegerNumber
 import static io.trino.plugin.hive.coercions.DecimalCoercers.createRealToDecimalCoercer;
 import static io.trino.plugin.hive.coercions.DoubleToVarcharCoercers.createDoubleToVarcharCoercer;
 import static io.trino.plugin.hive.coercions.FloatToVarcharCoercers.createFloatToVarcharCoercer;
+import static io.trino.plugin.hive.coercions.VarbinaryToVarcharCoercers.createVarbinaryToVarcharCoercer;
 import static io.trino.plugin.hive.coercions.VarcharToIntegralNumericCoercers.createVarcharToIntegerNumberCoercer;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.block.ColumnarArray.toColumnarArray;
@@ -271,6 +273,10 @@ public final class CoercionUtils
                     (StructTypeInfo) fromHiveTypeStruct.getTypeInfo(),
                     (StructTypeInfo) toHiveTypeStruct.getTypeInfo(),
                     coercionContext);
+        }
+
+        if (fromType instanceof VarbinaryType && toType instanceof VarcharType varcharType) {
+            return Optional.of(createVarbinaryToVarcharCoercer(varcharType, coercionContext.storageFormat()));
         }
 
         throw new TrinoException(NOT_SUPPORTED, format("Unsupported coercion from %s to %s", fromHiveType, toHiveType));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/CoercionUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/CoercionUtils.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.hive.coercions;
 
 import com.google.common.collect.ImmutableList;
+import io.trino.plugin.hive.HiveStorageFormat;
 import io.trino.plugin.hive.HiveTimestampPrecision;
 import io.trino.plugin.hive.HiveType;
 import io.trino.plugin.hive.coercions.BooleanCoercer.BooleanToVarcharCoercer;
@@ -58,6 +59,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.plugin.hive.HiveErrorCode.HIVE_UNSUPPORTED_FORMAT;
+import static io.trino.plugin.hive.HiveStorageFormat.ORC;
 import static io.trino.plugin.hive.HiveType.HIVE_BOOLEAN;
 import static io.trino.plugin.hive.HiveType.HIVE_BYTE;
 import static io.trino.plugin.hive.HiveType.HIVE_DOUBLE;
@@ -105,21 +108,22 @@ public final class CoercionUtils
 
         Type fromType = fromHiveType.getType(typeManager, coercionContext.timestampPrecision());
         Type toType = toHiveType.getType(typeManager, coercionContext.timestampPrecision());
+        boolean isOrcFile = coercionContext.storageFormat() == ORC;
 
         if (toType instanceof VarcharType toVarcharType && (fromHiveType.equals(HIVE_BYTE) || fromHiveType.equals(HIVE_SHORT) || fromHiveType.equals(HIVE_INT) || fromHiveType.equals(HIVE_LONG))) {
             return Optional.of(new IntegerNumberToVarcharCoercer<>(fromType, toVarcharType));
         }
         if (fromType instanceof VarcharType fromVarcharType && (toHiveType.equals(HIVE_BYTE) || toHiveType.equals(HIVE_SHORT) || toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG))) {
-            return Optional.of(createVarcharToIntegerNumberCoercer(fromVarcharType, toType, coercionContext.isOrcFile));
+            return Optional.of(createVarcharToIntegerNumberCoercer(fromVarcharType, toType, isOrcFile));
         }
         if (fromType instanceof VarcharType fromVarcharType && toHiveType.equals(HIVE_BOOLEAN)) {
-            return Optional.of(createVarcharToBooleanCoercer(fromVarcharType, coercionContext.isOrcFile()));
+            return Optional.of(createVarcharToBooleanCoercer(fromVarcharType, isOrcFile));
         }
         if (fromType instanceof VarcharType varcharType && toHiveType.equals(HIVE_DOUBLE)) {
-            return Optional.of(new VarcharToDoubleCoercer(varcharType, coercionContext.isOrcFile()));
+            return Optional.of(new VarcharToDoubleCoercer(varcharType, isOrcFile));
         }
         if (fromType instanceof VarcharType varcharType && toHiveType.equals(HIVE_FLOAT)) {
-            return Optional.of(new VarcharToFloatCoercer(varcharType, coercionContext.isOrcFile()));
+            return Optional.of(new VarcharToFloatCoercer(varcharType, isOrcFile));
         }
         if (fromType instanceof VarcharType varcharType && toType instanceof TimestampType timestampType) {
             if (timestampType.isShort()) {
@@ -239,10 +243,10 @@ public final class CoercionUtils
             return Optional.of(new DateToVarcharCoercer(toVarcharType));
         }
         if (fromType == REAL && toType instanceof VarcharType toVarcharType) {
-            return Optional.of(createFloatToVarcharCoercer(toVarcharType, coercionContext.isOrcFile));
+            return Optional.of(createFloatToVarcharCoercer(toVarcharType, isOrcFile));
         }
         if (fromType == DOUBLE && toType instanceof VarcharType toVarcharType) {
-            return Optional.of(createDoubleToVarcharCoercer(toVarcharType, coercionContext.isOrcFile));
+            return Optional.of(createDoubleToVarcharCoercer(toVarcharType, isOrcFile));
         }
         if ((fromType instanceof ArrayType) && (toType instanceof ArrayType)) {
             return createCoercerForList(
@@ -525,11 +529,22 @@ public final class CoercionUtils
         }
     }
 
-    public record CoercionContext(HiveTimestampPrecision timestampPrecision, boolean isOrcFile)
+    public record CoercionContext(HiveTimestampPrecision timestampPrecision, HiveStorageFormat storageFormat)
     {
         public CoercionContext
         {
+            requireNonNull(storageFormat, "storageFormat is null");
             requireNonNull(timestampPrecision, "timestampPrecision is null");
         }
+    }
+
+    public static HiveStorageFormat extractHiveStorageFormat(String deserializedClass)
+    {
+        for (HiveStorageFormat format : HiveStorageFormat.values()) {
+            if (format.getSerde().equals(deserializedClass)) {
+                return format;
+            }
+        }
+        throw new TrinoException(HIVE_UNSUPPORTED_FORMAT, format("SerDe %s is not supported", deserializedClass));
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/VarbinaryToVarcharCoercers.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/VarbinaryToVarcharCoercers.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.coercions;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.plugin.hive.HiveStorageFormat;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.type.VarbinaryType;
+import io.trino.spi.type.VarcharType;
+
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CharsetDecoder;
+import java.util.HexFormat;
+
+import static io.trino.plugin.hive.HiveStorageFormat.ORC;
+import static io.trino.plugin.hive.HiveStorageFormat.PARQUET;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static io.trino.spi.type.Varchars.truncateToLength;
+import static java.nio.charset.CodingErrorAction.REPLACE;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class VarbinaryToVarcharCoercers
+{
+    private VarbinaryToVarcharCoercers() {}
+
+    public static TypeCoercer<VarbinaryType, VarcharType> createVarbinaryToVarcharCoercer(VarcharType toType, HiveStorageFormat storageFormat)
+    {
+        if (storageFormat == ORC) {
+            return new OrcVarbinaryToVarcharCoercer(toType);
+        }
+        if (storageFormat == PARQUET) {
+            return new ParquetVarbinaryToVarcharCoercer(toType);
+        }
+        return new VarbinaryToVarcharCoercer(toType);
+    }
+
+    private static class VarbinaryToVarcharCoercer
+            extends TypeCoercer<VarbinaryType, VarcharType>
+    {
+        public VarbinaryToVarcharCoercer(VarcharType toType)
+        {
+            super(VARBINARY, toType);
+        }
+
+        @Override
+        protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+        {
+            try {
+                Slice decodedValue = fromType.getSlice(block, position);
+                if (toType.isUnbounded()) {
+                    toType.writeSlice(blockBuilder, decodedValue);
+                    return;
+                }
+                toType.writeSlice(blockBuilder, truncateToLength(decodedValue, toType.getBoundedLength()));
+            }
+            catch (RuntimeException e) {
+                blockBuilder.appendNull();
+            }
+        }
+    }
+
+    private static class ParquetVarbinaryToVarcharCoercer
+            extends TypeCoercer<VarbinaryType, VarcharType>
+    {
+        public ParquetVarbinaryToVarcharCoercer(VarcharType toType)
+        {
+            super(VARBINARY, toType);
+        }
+
+        @Override
+        protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+        {
+            // Hive's coercion logic for Varbinary to Varchar
+            // https://github.com/apache/hive/blob/8190d2be7b7165effa62bd21b7d60ef81fb0e4af/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/PrimitiveObjectInspectorUtils.java#L911
+            // It uses Hadoop's Text#decode replaces malformed input with a substitution character i.e U+FFFD
+            // https://github.com/apache/hadoop/blob/706d88266abcee09ed78fbaa0ad5f74d818ab0e9/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/Text.java#L414
+            CharsetDecoder decoder = UTF_8.newDecoder()
+                    .onMalformedInput(REPLACE)
+                    .onUnmappableCharacter(REPLACE);
+
+            try {
+                Slice decodedValue = Slices.utf8Slice(decoder.decode(fromType.getSlice(block, position).toByteBuffer()).toString());
+                if (toType.isUnbounded()) {
+                    toType.writeSlice(blockBuilder, decodedValue);
+                    return;
+                }
+                toType.writeSlice(blockBuilder, truncateToLength(decodedValue, toType.getBoundedLength()));
+            }
+            catch (CharacterCodingException e) {
+                blockBuilder.appendNull();
+            }
+        }
+    }
+
+    private static class OrcVarbinaryToVarcharCoercer
+            extends TypeCoercer<VarbinaryType, VarcharType>
+    {
+        private static final HexFormat HEX_FORMAT = HexFormat.of().withDelimiter(" ");
+
+        public OrcVarbinaryToVarcharCoercer(VarcharType toType)
+        {
+            super(VARBINARY, toType);
+        }
+
+        @Override
+        protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+        {
+            Slice value = fromType.getSlice(block, position);
+            Slice hexValue = Slices.utf8Slice(HEX_FORMAT.formatHex(value.byteArray(), value.byteArrayOffset(), value.length()));
+            if (toType.isUnbounded()) {
+                toType.writeSlice(blockBuilder, hexValue);
+                return;
+            }
+            toType.writeSlice(blockBuilder, truncateToLength(hexValue, toType.getBoundedLength()));
+        }
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcTypeTranslator.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcTypeTranslator.java
@@ -59,6 +59,7 @@ import java.util.Optional;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.orc.metadata.OrcType.OrcTypeKind.BINARY;
 import static io.trino.orc.metadata.OrcType.OrcTypeKind.BOOLEAN;
 import static io.trino.orc.metadata.OrcType.OrcTypeKind.BYTE;
 import static io.trino.orc.metadata.OrcType.OrcTypeKind.DATE;
@@ -74,6 +75,7 @@ import static io.trino.orc.metadata.OrcType.OrcTypeKind.STRING;
 import static io.trino.orc.metadata.OrcType.OrcTypeKind.STRUCT;
 import static io.trino.orc.metadata.OrcType.OrcTypeKind.TIMESTAMP;
 import static io.trino.orc.metadata.OrcType.OrcTypeKind.VARCHAR;
+import static io.trino.plugin.hive.HiveStorageFormat.ORC;
 import static io.trino.plugin.hive.coercions.DecimalCoercers.createDecimalToDecimalCoercer;
 import static io.trino.plugin.hive.coercions.DecimalCoercers.createDecimalToDoubleCoercer;
 import static io.trino.plugin.hive.coercions.DecimalCoercers.createDecimalToInteger;
@@ -84,6 +86,7 @@ import static io.trino.plugin.hive.coercions.DecimalCoercers.createIntegerNumber
 import static io.trino.plugin.hive.coercions.DecimalCoercers.createRealToDecimalCoercer;
 import static io.trino.plugin.hive.coercions.DoubleToVarcharCoercers.createDoubleToVarcharCoercer;
 import static io.trino.plugin.hive.coercions.FloatToVarcharCoercers.createFloatToVarcharCoercer;
+import static io.trino.plugin.hive.coercions.VarbinaryToVarcharCoercers.createVarbinaryToVarcharCoercer;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.SmallintType.SMALLINT;
@@ -283,6 +286,10 @@ public final class OrcTypeTranslator
                 return Optional.of(new MapCoercer(fromType, toType, keyCoercer, valueCoercer));
             }
             return Optional.empty();
+        }
+
+        if (fromOrcTypeKind == BINARY && toTrinoType instanceof VarcharType varcharType) {
+            return Optional.of(createVarbinaryToVarcharCoercer(varcharType, ORC));
         }
         return Optional.empty();
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveCoercionPolicy.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveCoercionPolicy.java
@@ -23,6 +23,7 @@ import io.trino.spi.type.CharType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
+import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
 
 import java.util.List;
@@ -87,7 +88,8 @@ public final class HiveCoercionPolicy
                     fromHiveType.equals(HIVE_FLOAT) ||
                     fromHiveType.equals(HIVE_DOUBLE) ||
                     fromHiveType.equals(HIVE_DATE) ||
-                    fromType instanceof DecimalType;
+                    fromType instanceof DecimalType ||
+                    fromType instanceof VarbinaryType;
         }
         if (toHiveType.equals(HIVE_DATE)) {
             return fromHiveType.equals(HIVE_TIMESTAMP);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestBooleanCoercer.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestBooleanCoercer.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.hive.coercions;
 
 import io.airlift.slice.Slice;
+import io.trino.plugin.hive.HiveStorageFormat;
 import io.trino.plugin.hive.coercions.CoercionUtils.CoercionContext;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
@@ -21,6 +22,8 @@ import io.trino.spi.type.Type;
 import org.junit.jupiter.api.Test;
 
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.hive.HiveStorageFormat.ORC;
+import static io.trino.plugin.hive.HiveStorageFormat.PARQUET;
 import static io.trino.plugin.hive.HiveTimestampPrecision.DEFAULT_PRECISION;
 import static io.trino.plugin.hive.HiveType.toHiveType;
 import static io.trino.plugin.hive.coercions.CoercionUtils.createCoercer;
@@ -91,27 +94,27 @@ public class TestBooleanCoercer
     public void testVarcharToBooleanForOrc()
     {
         // Valid false values
-        assertVarcharToBooleanCoercion("0", true, false);
-        assertVarcharToBooleanCoercion("-0", true, false);
-        assertVarcharToBooleanCoercion("00", true, false);
+        assertVarcharToBooleanCoercion("0", ORC, false);
+        assertVarcharToBooleanCoercion("-0", ORC, false);
+        assertVarcharToBooleanCoercion("00", ORC, false);
 
         // True values
-        assertVarcharToBooleanCoercion("1", true, true);
-        assertVarcharToBooleanCoercion("-1", true, true);
-        assertVarcharToBooleanCoercion("-123", true, true);
-        assertVarcharToBooleanCoercion("123", true, true);
+        assertVarcharToBooleanCoercion("1", ORC, true);
+        assertVarcharToBooleanCoercion("-1", ORC, true);
+        assertVarcharToBooleanCoercion("-123", ORC, true);
+        assertVarcharToBooleanCoercion("123", ORC, true);
 
         // Non numeric values
-        assertVarcharToBooleanCoercion("FALSE", true, null);
-        assertVarcharToBooleanCoercion("OFF", true, null);
-        assertVarcharToBooleanCoercion("NO", true, null);
-        assertVarcharToBooleanCoercion("T", true, null);
-        assertVarcharToBooleanCoercion("Y", true, null);
+        assertVarcharToBooleanCoercion("FALSE", ORC, null);
+        assertVarcharToBooleanCoercion("OFF", ORC, null);
+        assertVarcharToBooleanCoercion("NO", ORC, null);
+        assertVarcharToBooleanCoercion("T", ORC, null);
+        assertVarcharToBooleanCoercion("Y", ORC, null);
     }
 
     private void assertBooleanToVarcharCoercion(Type toType, boolean valueToBeCoerced, Slice expectedValue)
     {
-        Block coercedValue = createCoercer(TESTING_TYPE_MANAGER, toHiveType(BOOLEAN), toHiveType(toType), new CoercionContext(DEFAULT_PRECISION, false)).orElseThrow()
+        Block coercedValue = createCoercer(TESTING_TYPE_MANAGER, toHiveType(BOOLEAN), toHiveType(toType), new CoercionContext(DEFAULT_PRECISION, PARQUET)).orElseThrow()
                 .apply(nativeValueToBlock(BOOLEAN, valueToBeCoerced));
         assertThat(blockToNativeValue(toType, coercedValue))
                 .isEqualTo(expectedValue);
@@ -119,12 +122,12 @@ public class TestBooleanCoercer
 
     private void assertVarcharToBooleanCoercion(String valueToBeCoerced, Boolean expectedValue)
     {
-        assertVarcharToBooleanCoercion(valueToBeCoerced, false, expectedValue);
+        assertVarcharToBooleanCoercion(valueToBeCoerced, PARQUET, expectedValue);
     }
 
-    private void assertVarcharToBooleanCoercion(String valueToBeCoerced, boolean isOrcFile, Boolean expectedValue)
+    private void assertVarcharToBooleanCoercion(String valueToBeCoerced, HiveStorageFormat storageFormat, Boolean expectedValue)
     {
-        Block coercedValue = createCoercer(TESTING_TYPE_MANAGER, toHiveType(createUnboundedVarcharType()), toHiveType(BOOLEAN), new CoercionContext(DEFAULT_PRECISION, isOrcFile)).orElseThrow()
+        Block coercedValue = createCoercer(TESTING_TYPE_MANAGER, toHiveType(createUnboundedVarcharType()), toHiveType(BOOLEAN), new CoercionContext(DEFAULT_PRECISION, storageFormat)).orElseThrow()
                 .apply(nativeValueToBlock(createUnboundedVarcharType(), utf8Slice(valueToBeCoerced)));
         assertThat(blockToNativeValue(BOOLEAN, coercedValue))
                 .isEqualTo(expectedValue);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestCharToVarcharCoercer.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestCharToVarcharCoercer.java
@@ -19,6 +19,7 @@ import io.trino.spi.type.Type;
 import org.junit.jupiter.api.Test;
 
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.hive.HiveStorageFormat.PARQUET;
 import static io.trino.plugin.hive.HiveTimestampPrecision.DEFAULT_PRECISION;
 import static io.trino.plugin.hive.HiveType.toHiveType;
 import static io.trino.plugin.hive.coercions.CoercionUtils.createCoercer;
@@ -46,7 +47,7 @@ public class TestCharToVarcharCoercer
 
     private static void assertCharToVarcharCoercion(String actualValue, Type fromType, String expectedValue, Type toType)
     {
-        Block coercedBlock = createCoercer(TESTING_TYPE_MANAGER, toHiveType(fromType), toHiveType(toType), new CoercionContext(DEFAULT_PRECISION, false)).orElseThrow()
+        Block coercedBlock = createCoercer(TESTING_TYPE_MANAGER, toHiveType(fromType), toHiveType(toType), new CoercionContext(DEFAULT_PRECISION, PARQUET)).orElseThrow()
                 .apply(nativeValueToBlock(fromType, utf8Slice(actualValue)));
         assertThat(blockToNativeValue(toType, coercedBlock))
                 .isEqualTo(utf8Slice(expectedValue));

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestDateCoercer.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestDateCoercer.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDate;
 
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.hive.HiveStorageFormat.PARQUET;
 import static io.trino.plugin.hive.HiveTimestampPrecision.DEFAULT_PRECISION;
 import static io.trino.plugin.hive.HiveType.toHiveType;
 import static io.trino.plugin.hive.coercions.CoercionUtils.createCoercer;
@@ -98,7 +99,7 @@ public class TestDateCoercer
 
     private void assertVarcharToDateCoercion(Type fromType, String date, Long expected)
     {
-        Block coercedValue = createCoercer(TESTING_TYPE_MANAGER, toHiveType(fromType), toHiveType(DATE), new CoercionContext(DEFAULT_PRECISION, false)).orElseThrow()
+        Block coercedValue = createCoercer(TESTING_TYPE_MANAGER, toHiveType(fromType), toHiveType(DATE), new CoercionContext(DEFAULT_PRECISION, PARQUET)).orElseThrow()
                 .apply(nativeValueToBlock(fromType, utf8Slice(date)));
         assertThat(blockToNativeValue(DATE, coercedValue))
                 .isEqualTo(expected);
@@ -106,7 +107,7 @@ public class TestDateCoercer
 
     private void assertDateToVarcharCoercion(Type toType, LocalDate date, String expected)
     {
-        Block coercedValue = createCoercer(TESTING_TYPE_MANAGER, toHiveType(DATE), toHiveType(toType), new CoercionContext(DEFAULT_PRECISION, false)).orElseThrow()
+        Block coercedValue = createCoercer(TESTING_TYPE_MANAGER, toHiveType(DATE), toHiveType(toType), new CoercionContext(DEFAULT_PRECISION, PARQUET)).orElseThrow()
                 .apply(nativeValueToBlock(DATE, date.toEpochDay()));
         assertThat(blockToNativeValue(VARCHAR, coercedValue))
                 .isEqualTo(utf8Slice(expected));

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestDecimalCoercers.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestDecimalCoercers.java
@@ -20,6 +20,7 @@ import io.trino.spi.type.Int128;
 import io.trino.spi.type.Type;
 import org.junit.jupiter.api.Test;
 
+import static io.trino.plugin.hive.HiveStorageFormat.PARQUET;
 import static io.trino.plugin.hive.HiveTimestampPrecision.DEFAULT_PRECISION;
 import static io.trino.plugin.hive.HiveType.toHiveType;
 import static io.trino.plugin.hive.coercions.CoercionUtils.createCoercer;
@@ -157,7 +158,7 @@ public class TestDecimalCoercers
 
     private static void assertCoercion(Type fromType, Object valueToBeCoerced, Type toType, Object expectedValue)
     {
-        Block coercedValue = createCoercer(TESTING_TYPE_MANAGER, toHiveType(fromType), toHiveType(toType), new CoercionUtils.CoercionContext(DEFAULT_PRECISION, false)).orElseThrow()
+        Block coercedValue = createCoercer(TESTING_TYPE_MANAGER, toHiveType(fromType), toHiveType(toType), new CoercionUtils.CoercionContext(DEFAULT_PRECISION, PARQUET)).orElseThrow()
                 .apply(nativeValueToBlock(fromType, valueToBeCoerced));
         assertThat(blockToNativeValue(toType, coercedValue))
                 .isEqualTo(expectedValue);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestDoubleToVarcharCoercions.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestDoubleToVarcharCoercions.java
@@ -14,12 +14,15 @@
 package io.trino.plugin.hive.coercions;
 
 import io.airlift.slice.Slices;
+import io.trino.plugin.hive.HiveStorageFormat;
 import io.trino.plugin.hive.coercions.CoercionUtils.CoercionContext;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
 import org.junit.jupiter.api.Test;
 
+import static io.trino.plugin.hive.HiveStorageFormat.ORC;
+import static io.trino.plugin.hive.HiveStorageFormat.PARQUET;
 import static io.trino.plugin.hive.HiveTimestampPrecision.DEFAULT_PRECISION;
 import static io.trino.plugin.hive.HiveType.toHiveType;
 import static io.trino.plugin.hive.coercions.CoercionUtils.createCoercer;
@@ -52,7 +55,7 @@ public class TestDoubleToVarcharCoercions
 
     private void testDoubleToVarcharCoercions(Double doubleValue, boolean treatNaNAsNull)
     {
-        assertCoercions(DOUBLE, doubleValue, createUnboundedVarcharType(), Slices.utf8Slice(doubleValue.toString()), treatNaNAsNull);
+        assertCoercions(DOUBLE, doubleValue, createUnboundedVarcharType(), Slices.utf8Slice(doubleValue.toString()), treatNaNAsNull ? ORC : PARQUET);
     }
 
     @Test
@@ -73,7 +76,7 @@ public class TestDoubleToVarcharCoercions
 
     private void testDoubleSmallerVarcharCoercions(Double doubleValue, boolean treatNaNAsNull)
     {
-        assertThatThrownBy(() -> assertCoercions(DOUBLE, doubleValue, createVarcharType(1), doubleValue.toString(), treatNaNAsNull))
+        assertThatThrownBy(() -> assertCoercions(DOUBLE, doubleValue, createVarcharType(1), doubleValue.toString(), treatNaNAsNull ? ORC : PARQUET))
                 .isInstanceOf(TrinoException.class)
                 .hasMessageContaining("Varchar representation of %s exceeds varchar(1) bounds", doubleValue);
     }
@@ -81,17 +84,17 @@ public class TestDoubleToVarcharCoercions
     @Test
     public void testNaNToVarcharCoercions()
     {
-        assertCoercions(DOUBLE, Double.NaN, createUnboundedVarcharType(), null, true);
+        assertCoercions(DOUBLE, Double.NaN, createUnboundedVarcharType(), null, ORC);
 
-        assertCoercions(DOUBLE, Double.NaN, createUnboundedVarcharType(), Slices.utf8Slice("NaN"), false);
-        assertThatThrownBy(() -> assertCoercions(DOUBLE, Double.NaN, createVarcharType(1), "NaN", false))
+        assertCoercions(DOUBLE, Double.NaN, createUnboundedVarcharType(), Slices.utf8Slice("NaN"), PARQUET);
+        assertThatThrownBy(() -> assertCoercions(DOUBLE, Double.NaN, createVarcharType(1), "NaN", PARQUET))
                 .isInstanceOf(TrinoException.class)
                 .hasMessageContaining("Varchar representation of NaN exceeds varchar(1) bounds");
     }
 
-    public static void assertCoercions(Type fromType, Object valueToBeCoerced, Type toType, Object expectedValue, boolean isOrcFile)
+    public static void assertCoercions(Type fromType, Object valueToBeCoerced, Type toType, Object expectedValue, HiveStorageFormat storageFormat)
     {
-        Block coercedValue = createCoercer(TESTING_TYPE_MANAGER, toHiveType(fromType), toHiveType(toType), new CoercionContext(DEFAULT_PRECISION, isOrcFile)).orElseThrow()
+        Block coercedValue = createCoercer(TESTING_TYPE_MANAGER, toHiveType(fromType), toHiveType(toType), new CoercionContext(DEFAULT_PRECISION, storageFormat)).orElseThrow()
                 .apply(nativeValueToBlock(fromType, valueToBeCoerced));
         assertThat(blockToNativeValue(toType, coercedValue))
                 .isEqualTo(expectedValue);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestIntegerNumberToDoubleCoercer.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestIntegerNumberToDoubleCoercer.java
@@ -17,6 +17,7 @@ import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
 import org.junit.jupiter.api.Test;
 
+import static io.trino.plugin.hive.HiveStorageFormat.PARQUET;
 import static io.trino.plugin.hive.HiveTimestampPrecision.DEFAULT_PRECISION;
 import static io.trino.plugin.hive.HiveType.toHiveType;
 import static io.trino.plugin.hive.coercions.CoercionUtils.createCoercer;
@@ -95,7 +96,7 @@ public class TestIntegerNumberToDoubleCoercer
 
     private static Block createIntegerToDoubleCoercer(Type fromType, Object valueToBeCoerced)
     {
-        return createCoercer(TESTING_TYPE_MANAGER, toHiveType(fromType), toHiveType(DOUBLE), new CoercionUtils.CoercionContext(DEFAULT_PRECISION, false)).orElseThrow()
+        return createCoercer(TESTING_TYPE_MANAGER, toHiveType(fromType), toHiveType(DOUBLE), new CoercionUtils.CoercionContext(DEFAULT_PRECISION, PARQUET)).orElseThrow()
                 .apply(nativeValueToBlock(fromType, valueToBeCoerced));
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestTimestampCoercer.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestTimestampCoercer.java
@@ -28,6 +28,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.hive.HiveStorageFormat.PARQUET;
 import static io.trino.plugin.hive.HiveTimestampPrecision.MICROSECONDS;
 import static io.trino.plugin.hive.HiveTimestampPrecision.NANOSECONDS;
 import static io.trino.plugin.hive.HiveType.toHiveType;
@@ -309,7 +310,7 @@ public class TestTimestampCoercer
 
     public static void assertCoercions(Type fromType, Object valueToBeCoerced, Type toType, Object expectedValue, HiveTimestampPrecision timestampPrecision)
     {
-        Block coercedValue = createCoercer(TESTING_TYPE_MANAGER, toHiveType(fromType), toHiveType(toType), new CoercionContext(timestampPrecision, false)).orElseThrow()
+        Block coercedValue = createCoercer(TESTING_TYPE_MANAGER, toHiveType(fromType), toHiveType(toType), new CoercionContext(timestampPrecision, PARQUET)).orElseThrow()
                 .apply(nativeValueToBlock(fromType, valueToBeCoerced));
         assertThat(blockToNativeValue(toType, coercedValue))
                 .isEqualTo(expectedValue);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestVarbinaryToVarcharCoercer.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestVarbinaryToVarcharCoercer.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.coercions;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.plugin.hive.HiveStorageFormat;
+import io.trino.plugin.hive.coercions.CoercionUtils.CoercionContext;
+import io.trino.spi.block.Block;
+import io.trino.spi.type.Type;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.plugin.hive.HiveStorageFormat.ORC;
+import static io.trino.plugin.hive.HiveStorageFormat.PARQUET;
+import static io.trino.plugin.hive.HiveStorageFormat.RCTEXT;
+import static io.trino.plugin.hive.HiveTimestampPrecision.DEFAULT_PRECISION;
+import static io.trino.plugin.hive.HiveType.toHiveType;
+import static io.trino.plugin.hive.coercions.CoercionUtils.createCoercer;
+import static io.trino.spi.predicate.Utils.blockToNativeValue;
+import static io.trino.spi.predicate.Utils.nativeValueToBlock;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestVarbinaryToVarcharCoercer
+{
+    private static final byte CONTINUATION_BYTE = (byte) 0b1011_1111;
+    private static final byte START_4_BYTE = (byte) 0b1111_0111;
+    private static final byte X_CHAR = (byte) 'X';
+
+    // Test cases are copied from https://github.com/airlift/slice/blob/master/src/test/java/io/airlift/slice/TestSliceUtf8.java
+
+    @Test
+    public void testVarbinaryToVarcharCoercion()
+    {
+        assertVarbinaryToVarcharCoercion(Slices.utf8Slice("abc"), VARBINARY, Slices.utf8Slice("abc"), VARCHAR);
+        assertVarbinaryToVarcharCoercion(Slices.utf8Slice("abc"), VARBINARY, Slices.utf8Slice("ab"), createVarcharType(2));
+        // Invalid UTF-8 encoding
+        assertVarbinaryToVarcharCoercion(Slices.wrappedBuffer(X_CHAR, CONTINUATION_BYTE), VARBINARY, Slices.wrappedBuffer(X_CHAR, CONTINUATION_BYTE), VARCHAR);
+        assertVarbinaryToVarcharCoercion(
+                Slices.wrappedBuffer(X_CHAR, START_4_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE),
+                VARBINARY,
+                Slices.wrappedBuffer(X_CHAR, START_4_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE),
+                VARCHAR);
+        assertVarbinaryToVarcharCoercion(
+                Slices.wrappedBuffer(X_CHAR, START_4_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE, X_CHAR),
+                VARBINARY,
+                Slices.wrappedBuffer(X_CHAR, START_4_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE, X_CHAR),
+                VARCHAR);
+        assertVarbinaryToVarcharCoercion(
+                Slices.wrappedBuffer(X_CHAR, (byte) 0b11101101, (byte) 0xA0, (byte) 0x80),
+                VARBINARY,
+                Slices.wrappedBuffer(X_CHAR, (byte) 0b11101101, (byte) 0xA0, (byte) 0x80),
+                VARCHAR);
+        assertVarbinaryToVarcharCoercion(
+                Slices.wrappedBuffer(X_CHAR, (byte) 0b11101101, (byte) 0xBF, (byte) 0xBF),
+                VARBINARY,
+                Slices.wrappedBuffer(X_CHAR, (byte) 0b11101101, (byte) 0xBF, (byte) 0xBF),
+                VARCHAR);
+    }
+
+    @Test
+    public void testVarbinaryToVarcharCoercionForParquet()
+    {
+        assertVarbinaryToVarcharCoercionForParquet(Slices.utf8Slice("abc"), VARBINARY, "abc", VARCHAR);
+        assertVarbinaryToVarcharCoercionForParquet(Slices.utf8Slice("abc"), VARBINARY, "ab", createVarcharType(2));
+        // Invalid UTF-8 encoding
+        assertVarbinaryToVarcharCoercionForParquet(Slices.wrappedBuffer(X_CHAR, CONTINUATION_BYTE), VARBINARY, "X\uFFFD", VARCHAR);
+        assertVarbinaryToVarcharCoercionForParquet(Slices.wrappedBuffer(X_CHAR, START_4_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE), VARBINARY, "X\uFFFD\uFFFD\uFFFD\uFFFD", VARCHAR);
+        assertVarbinaryToVarcharCoercionForParquet(Slices.wrappedBuffer(X_CHAR, START_4_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE, X_CHAR), VARBINARY, "X\uFFFD\uFFFD\uFFFD\uFFFDX", VARCHAR);
+        assertVarbinaryToVarcharCoercionForParquet(Slices.wrappedBuffer(X_CHAR, (byte) 0b11101101, (byte) 0xA0, (byte) 0x80), VARBINARY, "X\uFFFD", VARCHAR);
+        assertVarbinaryToVarcharCoercionForParquet(Slices.wrappedBuffer(X_CHAR, (byte) 0b11101101, (byte) 0xBF, (byte) 0xBF), VARBINARY, "X\uFFFD", VARCHAR);
+    }
+
+    @Test
+    public void testVarbinaryToVarcharCoercionForOrc()
+    {
+        assertVarbinaryToVarcharCoercionForOrc(Slices.utf8Slice("abc"), VARBINARY, "61 62 63", VARCHAR);
+        assertVarbinaryToVarcharCoercionForOrc(Slices.utf8Slice("abc"), VARBINARY, "61", createVarcharType(2));
+        // Invalid UTF-8 encoding
+        assertVarbinaryToVarcharCoercionForOrc(Slices.wrappedBuffer(X_CHAR, CONTINUATION_BYTE), VARBINARY, "58 bf", VARCHAR);
+        assertVarbinaryToVarcharCoercionForOrc(Slices.wrappedBuffer(X_CHAR, START_4_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE), VARBINARY, "58 f7 bf bf bf", VARCHAR);
+        assertVarbinaryToVarcharCoercionForOrc(Slices.wrappedBuffer(X_CHAR, START_4_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE, X_CHAR), VARBINARY, "58 f7 bf bf bf 58", VARCHAR);
+        assertVarbinaryToVarcharCoercionForOrc(Slices.wrappedBuffer(X_CHAR, (byte) 0b11101101, (byte) 0xA0, (byte) 0x80), VARBINARY, "58 ed a0 80", VARCHAR);
+        assertVarbinaryToVarcharCoercionForOrc(Slices.wrappedBuffer(X_CHAR, (byte) 0b11101101, (byte) 0xBF, (byte) 0xBF), VARBINARY, "58 ed bf bf", VARCHAR);
+    }
+
+    private static void assertVarbinaryToVarcharCoercion(Slice actualValue, Type fromType, Slice expectedValue, Type toType)
+    {
+        assertVarbinaryToVarcharCoercion(actualValue, fromType, expectedValue, toType, RCTEXT);
+    }
+
+    private static void assertVarbinaryToVarcharCoercionForOrc(Slice actualValue, Type fromType, String expectedValue, Type toType)
+    {
+        assertVarbinaryToVarcharCoercion(actualValue, fromType, Slices.utf8Slice(expectedValue), toType, ORC);
+    }
+
+    private static void assertVarbinaryToVarcharCoercionForParquet(Slice actualValue, Type fromType, String expectedValue, Type toType)
+    {
+        assertVarbinaryToVarcharCoercion(actualValue, fromType, Slices.utf8Slice(expectedValue), toType, PARQUET);
+    }
+
+    private static void assertVarbinaryToVarcharCoercion(Slice actualValue, Type fromType, Slice expectedValue, Type toType, HiveStorageFormat storageFormat)
+    {
+        Block coercedBlock = createCoercer(TESTING_TYPE_MANAGER, toHiveType(fromType), toHiveType(toType), new CoercionContext(DEFAULT_PRECISION, storageFormat)).orElseThrow()
+                .apply(nativeValueToBlock(fromType, actualValue));
+        assertThat(blockToNativeValue(toType, coercedBlock))
+                .isEqualTo(expectedValue);
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestVarcharToCharCoercer.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestVarcharToCharCoercer.java
@@ -19,6 +19,7 @@ import io.trino.spi.type.Type;
 import org.junit.jupiter.api.Test;
 
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.hive.HiveStorageFormat.PARQUET;
 import static io.trino.plugin.hive.HiveTimestampPrecision.DEFAULT_PRECISION;
 import static io.trino.plugin.hive.HiveType.toHiveType;
 import static io.trino.plugin.hive.coercions.CoercionUtils.createCoercer;
@@ -48,7 +49,7 @@ public class TestVarcharToCharCoercer
 
     private static void assertVarcharToCharCoercion(String actualValue, Type fromType, String expectedValue, Type toType)
     {
-        Block coercedBlock = createCoercer(TESTING_TYPE_MANAGER, toHiveType(fromType), toHiveType(toType), new CoercionContext(DEFAULT_PRECISION, false)).orElseThrow()
+        Block coercedBlock = createCoercer(TESTING_TYPE_MANAGER, toHiveType(fromType), toHiveType(toType), new CoercionContext(DEFAULT_PRECISION, PARQUET)).orElseThrow()
                 .apply(nativeValueToBlock(fromType, utf8Slice(actualValue)));
         assertThat(blockToNativeValue(toType, coercedBlock))
                 .isEqualTo(utf8Slice(expectedValue));

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestVarcharToDoubleCoercer.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestVarcharToDoubleCoercer.java
@@ -13,11 +13,14 @@
  */
 package io.trino.plugin.hive.coercions;
 
+import io.trino.plugin.hive.HiveStorageFormat;
 import io.trino.plugin.hive.coercions.CoercionUtils.CoercionContext;
 import io.trino.spi.block.Block;
 import org.junit.jupiter.api.Test;
 
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.hive.HiveStorageFormat.ORC;
+import static io.trino.plugin.hive.HiveStorageFormat.PARQUET;
 import static io.trino.plugin.hive.HiveTimestampPrecision.DEFAULT_PRECISION;
 import static io.trino.plugin.hive.HiveType.toHiveType;
 import static io.trino.plugin.hive.coercions.CoercionUtils.createCoercer;
@@ -53,18 +56,18 @@ public class TestVarcharToDoubleCoercer
     @Test
     public void testNaNToVarcharCoercions()
     {
-        assertVarcharToDoubleCoercion("NaN", true, null);
-        assertVarcharToDoubleCoercion("NaN", false, NaN);
+        assertVarcharToDoubleCoercion("NaN", ORC, null);
+        assertVarcharToDoubleCoercion("NaN", PARQUET, NaN);
     }
 
     private static void assertVarcharToDoubleCoercion(String actualValue, Double expectedValue)
     {
-        assertVarcharToDoubleCoercion(actualValue, false, expectedValue);
+        assertVarcharToDoubleCoercion(actualValue, PARQUET, expectedValue);
     }
 
-    private static void assertVarcharToDoubleCoercion(String actualValue, boolean isOrcFile, Double expectedValue)
+    private static void assertVarcharToDoubleCoercion(String actualValue, HiveStorageFormat storageFormat, Double expectedValue)
     {
-        Block coercedBlock = createCoercer(TESTING_TYPE_MANAGER, toHiveType(createUnboundedVarcharType()), toHiveType(DOUBLE), new CoercionContext(DEFAULT_PRECISION, isOrcFile)).orElseThrow()
+        Block coercedBlock = createCoercer(TESTING_TYPE_MANAGER, toHiveType(createUnboundedVarcharType()), toHiveType(DOUBLE), new CoercionContext(DEFAULT_PRECISION, storageFormat)).orElseThrow()
                 .apply(nativeValueToBlock(createUnboundedVarcharType(), utf8Slice(actualValue)));
         assertThat(blockToNativeValue(DOUBLE, coercedBlock))
                 .isEqualTo(expectedValue);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestVarcharToFloatCoercer.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestVarcharToFloatCoercer.java
@@ -13,11 +13,14 @@
  */
 package io.trino.plugin.hive.coercions;
 
+import io.trino.plugin.hive.HiveStorageFormat;
 import io.trino.plugin.hive.coercions.CoercionUtils.CoercionContext;
 import io.trino.spi.block.Block;
 import org.junit.jupiter.api.Test;
 
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.hive.HiveStorageFormat.ORC;
+import static io.trino.plugin.hive.HiveStorageFormat.PARQUET;
 import static io.trino.plugin.hive.HiveTimestampPrecision.DEFAULT_PRECISION;
 import static io.trino.plugin.hive.HiveType.toHiveType;
 import static io.trino.plugin.hive.coercions.CoercionUtils.createCoercer;
@@ -68,18 +71,18 @@ public class TestVarcharToFloatCoercer
     @Test
     public void testVarcharToFloatNaNCoercions()
     {
-        assertVarcharToFloatCoercion("NaN", true, null);
-        assertVarcharToFloatCoercion("NaN", false, NaN);
+        assertVarcharToFloatCoercion("NaN", ORC, null);
+        assertVarcharToFloatCoercion("NaN", PARQUET, NaN);
     }
 
     private static void assertVarcharToFloatCoercion(String actualValue, Float expectedValue)
     {
-        assertVarcharToFloatCoercion(actualValue, false, expectedValue);
+        assertVarcharToFloatCoercion(actualValue, PARQUET, expectedValue);
     }
 
-    private static void assertVarcharToFloatCoercion(String actualValue, boolean isOrcFile, Float expectedValue)
+    private static void assertVarcharToFloatCoercion(String actualValue, HiveStorageFormat storageFormat, Float expectedValue)
     {
-        Block coercedBlock = createCoercer(TESTING_TYPE_MANAGER, toHiveType(createUnboundedVarcharType()), toHiveType(REAL), new CoercionContext(DEFAULT_PRECISION, isOrcFile)).orElseThrow()
+        Block coercedBlock = createCoercer(TESTING_TYPE_MANAGER, toHiveType(createUnboundedVarcharType()), toHiveType(REAL), new CoercionContext(DEFAULT_PRECISION, storageFormat)).orElseThrow()
                 .apply(nativeValueToBlock(createUnboundedVarcharType(), utf8Slice(actualValue)));
         Float coercedValue = coercedBlock.isNull(0) ? null : REAL.getFloat(coercedBlock, 0);
         assertThat(coercedValue).isEqualTo(expectedValue);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestVarcharToIntegralNumericCoercer.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestVarcharToIntegralNumericCoercer.java
@@ -13,12 +13,15 @@
  */
 package io.trino.plugin.hive.coercions;
 
+import io.trino.plugin.hive.HiveStorageFormat;
 import io.trino.plugin.hive.coercions.CoercionUtils.CoercionContext;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
 import org.junit.jupiter.api.Test;
 
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.hive.HiveStorageFormat.ORC;
+import static io.trino.plugin.hive.HiveStorageFormat.PARQUET;
 import static io.trino.plugin.hive.HiveTimestampPrecision.DEFAULT_PRECISION;
 import static io.trino.plugin.hive.HiveType.toHiveType;
 import static io.trino.plugin.hive.coercions.CoercionUtils.createCoercer;
@@ -180,17 +183,17 @@ public class TestVarcharToIntegralNumericCoercer
 
     private static void assertVarcharToIntegralCoercion(String actualValue, Type expectedType, Object expectedValue)
     {
-        assertVarcharToIntegralCoercion(actualValue, false, expectedType, expectedValue);
+        assertVarcharToIntegralCoercion(actualValue, PARQUET, expectedType, expectedValue);
     }
 
     private static void assertVarcharToIntegralCoercionForOrc(String actualValue, Type expectedType, Object expectedValue)
     {
-        assertVarcharToIntegralCoercion(actualValue, true, expectedType, expectedValue);
+        assertVarcharToIntegralCoercion(actualValue, ORC, expectedType, expectedValue);
     }
 
-    private static void assertVarcharToIntegralCoercion(String actualValue, boolean isOrcFile, Type expectedType, Object expectedValue)
+    private static void assertVarcharToIntegralCoercion(String actualValue, HiveStorageFormat storageFormat, Type expectedType, Object expectedValue)
     {
-        Block coercedBlock = createCoercer(TESTING_TYPE_MANAGER, toHiveType(createUnboundedVarcharType()), toHiveType(expectedType), new CoercionContext(DEFAULT_PRECISION, isOrcFile)).orElseThrow()
+        Block coercedBlock = createCoercer(TESTING_TYPE_MANAGER, toHiveType(createUnboundedVarcharType()), toHiveType(expectedType), new CoercionContext(DEFAULT_PRECISION, storageFormat)).orElseThrow()
                 .apply(nativeValueToBlock(createUnboundedVarcharType(), utf8Slice(actualValue)));
         Object coercedValue = coercedBlock.isNull(0) ? null : expectedType.getObjectValue(SESSION, coercedBlock, 0);
         assertThat(coercedValue).isEqualTo(expectedValue);

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnPartitionedTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnPartitionedTable.java
@@ -202,7 +202,9 @@ public class TestHiveCoercionOnPartitionedTable
                         "    timestamp_to_bounded_varchar       TIMESTAMP," +
                         "    timestamp_to_smaller_varchar       TIMESTAMP," +
                         "    smaller_varchar_to_timestamp       VARCHAR(4)," +
-                        "    varchar_to_timestamp               STRING" +
+                        "    varchar_to_timestamp               STRING," +
+                        "    binary_to_string                   BINARY," +
+                        "    binary_to_smaller_varchar          BINARY" +
                         ") " +
                         "PARTITIONED BY (id BIGINT) " +
                         rowFormat.map(s -> format("ROW FORMAT %s ", s)).orElse("") +

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnUnpartitionedTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnUnpartitionedTable.java
@@ -158,6 +158,8 @@ public class TestHiveCoercionOnUnpartitionedTable
                             timestamp_to_smaller_varchar       TIMESTAMP,
                             smaller_varchar_to_timestamp       VARCHAR(4),
                             varchar_to_timestamp               STRING,
+                            binary_to_string                   BINARY,
+                            binary_to_smaller_varchar          BINARY,
                             id                                 BIGINT)
                        STORED AS\s""" + fileFormat);
     }
@@ -351,6 +353,8 @@ public class TestHiveCoercionOnUnpartitionedTable
                 .put(columnContext("3.1", "parquet", "string_to_timestamp"), "org.apache.hadoop.io.Text cannot be cast to org.apache.hadoop.hive.serde2.io.TimestampWritableV2")
                 .put(columnContext("3.1", "parquet", "timestamp_to_date"), "org.apache.hadoop.io.Text cannot be cast to org.apache.hadoop.hive.serde2.io.TimestampWritableV2")
                 .put(columnContext("3.1", "parquet", "double_to_float"), "org.apache.hadoop.hive.serde2.io.DoubleWritable cannot be cast to org.apache.hadoop.io.FloatWritable")
+                .put(columnContext("3.1", "parquet", "binary_to_string"), "org.apache.hadoop.io.BytesWritable cannot be cast to org.apache.hadoop.hive.serde2.io.HiveVarcharWritable")
+                .put(columnContext("3.1", "parquet", "binary_to_smaller_varchar"), "org.apache.hadoop.io.BytesWritable cannot be cast to org.apache.hadoop.hive.serde2.io.HiveVarcharWritable")
                 .buildOrThrow();
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Allow varbinary to varchar coercion for hive tables
```
