### PR TITLE
Enable query and task retries in MariaDbClient

### DIFF
--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.md
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.md
@@ -44,6 +44,7 @@ connector. The following connectors support fault-tolerant execution:
 - {ref}`Delta Lake connector <delta-lake-fte-support>`
 - {ref}`Hive connector <hive-fte-support>`
 - {ref}`Iceberg connector <iceberg-fte-support>`
+- {ref}`MariaDB connector <mariadb-fte-support>`
 - {ref}`MongoDB connector <mongodb-fte-support>`
 - {ref}`MySQL connector <mysql-fte-support>`
 - {ref}`Oracle connector <oracle-fte-support>`

--- a/docs/src/main/sphinx/connector/mariadb.md
+++ b/docs/src/main/sphinx/connector/mariadb.md
@@ -299,6 +299,12 @@ statements, the connector supports the following features:
 ```{include} sql-delete-limitation.fragment
 ```
 
+(mariadb-fte-support)=
+## Fault-tolerant execution support
+
+The connector supports {doc}`/admin/fault-tolerant-execution` of query
+processing. Read and write operations are both supported with any retry policy.
+
 ## Table functions
 
 The connector provides specific {doc}`table functions </functions/table>` to

--- a/plugin/trino-mariadb/pom.xml
+++ b/plugin/trino-mariadb/pom.xml
@@ -132,6 +132,12 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-exchange-filesystem</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-main</artifactId>
             <scope>test</scope>
         </dependency>

--- a/plugin/trino-mariadb/src/main/java/io/trino/plugin/mariadb/MariaDbClient.java
+++ b/plugin/trino-mariadb/src/main/java/io/trino/plugin/mariadb/MariaDbClient.java
@@ -187,7 +187,7 @@ public class MariaDbClient
             IdentifierMapping identifierMapping,
             RemoteQueryModifier queryModifier)
     {
-        super("`", connectionFactory, queryBuilder, config.getJdbcTypesMappedToVarchar(), identifierMapping, queryModifier, false);
+        super("`", connectionFactory, queryBuilder, config.getJdbcTypesMappedToVarchar(), identifierMapping, queryModifier, true);
 
         JdbcTypeHandle bigintTypeHandle = new JdbcTypeHandle(Types.BIGINT, Optional.of("bigint"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
         this.connectorExpressionRewriter = JdbcConnectorExpressionRewriterBuilder.newBuilder()

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/BaseMariaDbFailureRecoveryTest.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/BaseMariaDbFailureRecoveryTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mariadb;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.operator.RetryPolicy;
+import io.trino.plugin.exchange.filesystem.FileSystemExchangePlugin;
+import io.trino.plugin.jdbc.BaseJdbcFailureRecoveryTest;
+import io.trino.testing.QueryRunner;
+import io.trino.tpch.TpchTable;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.abort;
+
+public abstract class BaseMariaDbFailureRecoveryTest
+        extends BaseJdbcFailureRecoveryTest
+{
+    public BaseMariaDbFailureRecoveryTest(RetryPolicy retryPolicy)
+    {
+        super(retryPolicy);
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner(List<TpchTable<?>> requiredTpchTables, Map<String, String> configProperties, Map<String, String> coordinatorProperties)
+            throws Exception
+    {
+        TestingMariaDbServer server = closeAfterClass(new TestingMariaDbServer());
+        return MariaDbQueryRunner.builder(server)
+                .setInitialTables(requiredTpchTables)
+                .setExtraProperties(configProperties)
+                .setCoordinatorProperties(coordinatorProperties)
+                .setAdditionalSetup(runner -> {
+                    runner.installPlugin(new FileSystemExchangePlugin());
+                    runner.loadExchangeManager("filesystem", ImmutableMap.of(
+                            "exchange.base-directories", System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager"));
+                })
+                .build();
+    }
+
+    @Test
+    @Override
+    protected void testUpdateWithSubquery()
+    {
+        assertThatThrownBy(super::testUpdateWithSubquery).hasMessageContaining("Unexpected Join over for-update table scan");
+        abort("skipped");
+    }
+
+    @Test
+    @Override
+    protected void testUpdate()
+    {
+        // This simple update on JDBC ends up as a very simple, single-fragment, coordinator-only plan,
+        // which has no ability to recover from errors. This test simply verifies that's still the case.
+        Optional<String> setupQuery = Optional.of("CREATE TABLE <table> AS SELECT * FROM orders");
+        String testQuery = "UPDATE <table> SET shippriority = 101 WHERE custkey = 1";
+        Optional<String> cleanupQuery = Optional.of("DROP TABLE <table>");
+
+        assertThatQuery(testQuery)
+                .withSetupQuery(setupQuery)
+                .withCleanupQuery(cleanupQuery)
+                .isCoordinatorOnly();
+    }
+}

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbQueryFailureRecovery.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbQueryFailureRecovery.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mariadb;
+
+import io.trino.operator.RetryPolicy;
+
+public class TestMariaDbQueryFailureRecovery
+        extends BaseMariaDbFailureRecoveryTest
+{
+    public TestMariaDbQueryFailureRecovery()
+    {
+        super(RetryPolicy.QUERY);
+    }
+}

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbTaskFailureRecovery.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbTaskFailureRecovery.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mariadb;
+
+import io.trino.operator.RetryPolicy;
+
+public class TestMariaDbTaskFailureRecovery
+        extends BaseMariaDbFailureRecoveryTest
+{
+    public TestMariaDbTaskFailureRecovery()
+    {
+        super(RetryPolicy.TASK);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

MariaDBClient is capable of supporting retried tasks and queries, so set that flag to `true`.  Add appropriate retry tests for it.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

5579e701e126051ec34d50ba37d9d586a1015263 turned on this flag for MySQLClient but not MariaDBClient.  It added several tests to ensure that the affected clients behave correctly.  It turns out that MariaDB can also pass those tests, so it makes sense to mark it as `supportsRetries=true`.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Connectors
* The MariaDB JDBC client now supports both QUERY and TASK retry policies.
```