### PR TITLE
Always show plugin path when service provider is missing on plugin load

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/PluginManager.java
+++ b/core/trino-main/src/main/java/io/trino/server/PluginManager.java
@@ -157,17 +157,17 @@ public class PluginManager
 
         handleResolver.registerClassLoader(pluginClassLoader);
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(pluginClassLoader)) {
-            loadPlugin(pluginClassLoader);
+            loadPlugin(plugin, pluginClassLoader);
         }
 
         log.info("-- Finished loading plugin %s --", plugin);
     }
 
-    private void loadPlugin(PluginClassLoader pluginClassLoader)
+    private void loadPlugin(String pluginPath, PluginClassLoader pluginClassLoader)
     {
         ServiceLoader<Plugin> serviceLoader = ServiceLoader.load(Plugin.class, pluginClassLoader);
         List<Plugin> plugins = ImmutableList.copyOf(serviceLoader);
-        checkState(!plugins.isEmpty(), "No service providers of type %s in the classpath: %s", Plugin.class.getName(), asList(pluginClassLoader.getURLs()));
+        checkState(!plugins.isEmpty(), "%s - No service providers of type %s in the classpath: %s", pluginPath, Plugin.class.getName(), asList(pluginClassLoader.getURLs()));
 
         for (Plugin plugin : plugins) {
             log.info("Installing %s", plugin.getClass().getName());


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

When a plugin fails to load, the exception is batched and only shown after all plugin loading has completed. 
Normally, it should be obvious from the classpath which plugin has failed to load. However if the folder is empty this array will also be empty. This can occur if something has gone wrong during the build. 

This is quite confusing when new to trino.

This is a small PR that modifies the stacktrace to ensure that it _always_ includes the plugin path.

Before...

```
2024-06-08T20:48:53.399Z	INFO	main	io.trino.server.PluginManager	-- Loading plugin /data/trino/plugin/an-invalid-plugin --
2024-06-08T20:48:53.961Z	INFO	main	io.trino.server.PluginManager	-- Loading plugin /data/trino/plugin/tpch --
2024-06-08T20:48:53.964Z	INFO	main	io.trino.server.PluginManager	Installing io.trino.plugin.tpch.TpchPlugin
2024-06-08T20:48:53.966Z	INFO	main	io.trino.server.PluginManager	Registering connector tpch
2024-06-08T20:48:53.966Z	INFO	main	io.trino.server.PluginManager	-- Finished loading plugin /data/trino/plugin/tpch --
2024-06-08T20:48:53.967Z	ERROR	main	io.trino.server.Server	No service providers of type io.trino.spi.Plugin in the classpath: []
java.lang.IllegalStateException: No service providers of type io.trino.spi.Plugin in the classpath: []
	at com.google.common.base.Preconditions.checkState(Preconditions.java:857)
	at io.trino.server.PluginManager.loadPlugin(PluginManager.java:170)
	at io.trino.server.PluginManager.loadPlugin(PluginManager.java:160)
	at io.trino.server.ServerPluginsProvider.lambda$loadPlugins$1(ServerPluginsProvider.java:57)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at com.google.common.util.concurrent.DirectExecutor.execute(DirectExecutor.java:31)
	at java.base/java.util.concurrent.ExecutorCompletionService.submit(ExecutorCompletionService.java:186)
	at io.trino.util.Executors.executeUntilFailure(Executors.java:46)
	at io.trino.server.ServerPluginsProvider.loadPlugins(ServerPluginsProvider.java:52)
	at io.trino.server.PluginManager.loadPlugins(PluginManager.java:142)
	at io.trino.server.Server.doStart(Server.java:147)
	at io.trino.server.Server.lambda$start$0(Server.java:93)
	at io.trino.$gen.Trino_449____20240608_204849_1.run(Unknown Source)
	at io.trino.server.Server.start(Server.java:93)
	at io.trino.server.TrinoServer.main(TrinoServer.java:37)

```

After...

```
2024-06-08T20:48:53.399Z	INFO	main	io.trino.server.PluginManager	-- Loading plugin /data/trino/plugin/an-invalid-plugin --
2024-06-08T20:48:53.961Z	INFO	main	io.trino.server.PluginManager	-- Loading plugin /data/trino/plugin/tpch --
2024-06-08T20:48:53.964Z	INFO	main	io.trino.server.PluginManager	Installing io.trino.plugin.tpch.TpchPlugin
2024-06-08T20:48:53.966Z	INFO	main	io.trino.server.PluginManager	Registering connector tpch
2024-06-08T20:48:53.966Z	INFO	main	io.trino.server.PluginManager	-- Finished loading plugin /data/trino/plugin/tpch --
2024-06-08T20:48:53.967Z	ERROR	main	io.trino.server.Server	/data/trino/plugin/an-invalid-plugin - No service providers of type io.trino.spi.Plugin in the classpath: []
java.lang.IllegalStateException: /data/trino/plugin/an-invalid-plugin No service providers of type io.trino.spi.Plugin in the classpath: []
	at com.google.common.base.Preconditions.checkState(Preconditions.java:857)
	at io.trino.server.PluginManager.loadPlugin(PluginManager.java:170)
	at io.trino.server.PluginManager.loadPlugin(PluginManager.java:160)
	at io.trino.server.ServerPluginsProvider.lambda$loadPlugins$1(ServerPluginsProvider.java:57)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at com.google.common.util.concurrent.DirectExecutor.execute(DirectExecutor.java:31)
	at java.base/java.util.concurrent.ExecutorCompletionService.submit(ExecutorCompletionService.java:186)
	at io.trino.util.Executors.executeUntilFailure(Executors.java:46)
	at io.trino.server.ServerPluginsProvider.loadPlugins(ServerPluginsProvider.java:52)
	at io.trino.server.PluginManager.loadPlugins(PluginManager.java:142)
	at io.trino.server.Server.doStart(Server.java:147)
	at io.trino.server.Server.lambda$start$0(Server.java:93)
	at io.trino.$gen.Trino_449____20240608_204849_1.run(Unknown Source)
	at io.trino.server.Server.start(Server.java:93)
	at io.trino.server.TrinoServer.main(TrinoServer.java:37)
```


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
