### PR TITLE
Avoid redundant null check before sizeOf()

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/AbstractMapAggregationState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/AbstractMapAggregationState.java
@@ -203,7 +203,7 @@ public abstract class AbstractMapAggregationState
                 sizeOf(control) +
                 (sizeOf(recordGroups[0]) * recordGroups.length) +
                 (variableWidthData == null ? 0 : variableWidthData.getRetainedSizeBytes()) +
-                (groupRecordIndex == null ? 0 : sizeOf(groupRecordIndex));
+                sizeOf(groupRecordIndex);
     }
 
     public void setMaxGroupId(int maxGroupId)

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/arrayagg/FlatArrayBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/arrayagg/FlatArrayBuilder.java
@@ -132,7 +132,7 @@ public class FlatArrayBuilder
         return INSTANCE_SIZE +
                 sizeOfObjectArray(closedRecordGroups.size()) +
                 ((long) closedRecordGroups.size() * RECORDS_PER_GROUP * recordSize) +
-                (openRecordGroup == null ? 0 : sizeOf(openRecordGroup)) +
+                sizeOf(openRecordGroup) +
                 (variableWidthData == null ? 0 : variableWidthData.getRetainedSizeBytes());
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/histogram/TypedHistogram.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/histogram/TypedHistogram.java
@@ -155,7 +155,7 @@ public final class TypedHistogram
                 sizeOf(control) +
                 (sizeOf(recordGroups[0]) * recordGroups.length) +
                 (variableWidthData == null ? 0 : variableWidthData.getRetainedSizeBytes()) +
-                (groupRecordIndex == null ? 0 : sizeOf(groupRecordIndex));
+                sizeOf(groupRecordIndex);
     }
 
     public void setMaxGroupId(int maxGroupId)

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/listagg/AbstractListaggAggregationState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/listagg/AbstractListaggAggregationState.java
@@ -119,7 +119,7 @@ public abstract class AbstractListaggAggregationState
         return INSTANCE_SIZE +
                 sizeOfObjectArray(closedRecordGroups.size()) +
                 ((long) closedRecordGroups.size() * RECORDS_PER_GROUP * recordSize) +
-                (openRecordGroup == null ? 0 : sizeOf(openRecordGroup)) +
+                sizeOf(openRecordGroup) +
                 (variableWidthData == null ? 0 : variableWidthData.getRetainedSizeBytes());
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/multimapagg/AbstractMultimapAggregationState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/multimapagg/AbstractMultimapAggregationState.java
@@ -208,7 +208,7 @@ public abstract class AbstractMultimapAggregationState
                 sizeOf(control) +
                 (sizeOf(recordGroups[0]) * recordGroups.length) +
                 (variableWidthData == null ? 0 : variableWidthData.getRetainedSizeBytes()) +
-                (groupRecordIndex == null ? 0 : sizeOf(groupRecordIndex));
+                sizeOf(groupRecordIndex);
     }
 
     public void setMaxGroupId(int maxGroupId)

--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/AbstractDiskOrcDataReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/AbstractDiskOrcDataReader.java
@@ -53,7 +53,7 @@ public abstract class AbstractDiskOrcDataReader
     @Override
     public long getRetainedSize()
     {
-        return buffer == null ? 0 : SizeOf.sizeOf(buffer);
+        return SizeOf.sizeOf(buffer);
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Checking null before calling `sizeOf()` is redundant because it's checked inside `sizeOf()`.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
