### PR TITLE
Improve performance of json functions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
+++ b/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
@@ -63,6 +63,7 @@ import io.trino.type.VarcharOperators;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.io.StringReader;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -105,6 +106,9 @@ import static java.time.ZoneOffset.UTC;
 
 public final class JsonUtil
 {
+    // StringReader outperforms InputStreamReader for small inputs. Limit based on Jackson benchmarks {@link https://github.com/FasterXML/jackson-benchmarks/pull/9}
+    private static final int STRING_READER_LENGTH_LIMIT = 8192;
+
     private JsonUtil() {}
 
     // This object mapper is constructed without .configure(ORDER_MAP_ENTRIES_BY_KEYS, true) because
@@ -124,7 +128,12 @@ public final class JsonUtil
             throws IOException
     {
         // Jackson tries to detect the character encoding automatically when using InputStream
-        // so we pass an InputStreamReader instead.
+        // so we pass StringReader or an InputStreamReader instead.
+        if (json.length() < STRING_READER_LENGTH_LIMIT) {
+            // StringReader is more performant than InputStreamReader for small inputs
+            return factory.createParser(new StringReader(new String(json.getBytes(), UTF_8)));
+        }
+
         return factory.createParser(new InputStreamReader(json.getInput(), UTF_8));
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Avoid allocating heap ByteBuffer used by InputStreamReader and use StringReader for small inputs. (https://github.com/FasterXML/jackson-core/pull/1081)

Before change:

```
FilterProject[filterPredicate = (CASE WHEN (data <> varchar 'second') THEN contains(transform($internal$json_string_to_array_cast(data_0), (x) -> json_extract_scalar(x, JsonPath '$.name')), data) ELSE boolean 'false' END)]
     │   Layout: [data:varchar]                                                                                                          
     │   Estimates: {rows: ? (?), cpu: 216.78G, memory: 0B, network: 0B}/{rows: ? (?), cpu: ?, memory: 0B, network: 0B}                  
     │   CPU: 35.08s (91.80%), Scheduled: 36.97s (87.41%), Blocked: 0.00ns (0.00%), Output: 3492632 rows (34.65MB)          
```

After:

```
FilterProject[filterPredicate = (CASE WHEN (data <> varchar 'second') THEN contains(transform($internal$json_string_to_array_cast(data_0), (x) -> json_extract_scalar(x, JsonPath '$.name')), data) ELSE boolean 'false' END)]
     │   Layout: [data:varchar]                                                                                                          
     │   Estimates: {rows: ? (?), cpu: 216.78G, memory: 0B, network: 0B}/{rows: ? (?), cpu: ?, memory: 0B, network: 0B}                  
     │   CPU: 16.49s (95.06%), Scheduled: 17.24s (82.05%), Blocked: 2.81s (92.72%), Output: 3492632 rows (34.65MB)            
```

Query execution time dropped from 6.40s to 4.29s

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Improve JSON parsing performance. ({issue}`issuenumber`)
```
