### PR TITLE
Improve SQL Server column statistics

### DIFF
--- a/plugin/trino-sqlserver/pom.xml
+++ b/plugin/trino-sqlserver/pom.xml
@@ -19,6 +19,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
@@ -107,12 +112,6 @@
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>error_prone_annotations</artifactId>
-            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClientModule.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClientModule.java
@@ -50,6 +50,7 @@ public class SqlServerClientModule
     {
         configBinder(binder).bindConfig(SqlServerConfig.class);
         configBinder(binder).bindConfig(JdbcStatisticsConfig.class);
+        binder.bind(SqlServerStatsCollector.class).in(Scopes.SINGLETON);
         binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class).to(SqlServerClient.class).in(Scopes.SINGLETON);
         bindTablePropertiesProvider(binder, SqlServerTableProperties.class);
         bindSessionPropertiesProvider(binder, SqlServerSessionProperties.class);

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerStatsCollector.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerStatsCollector.java
@@ -1,0 +1,237 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.sqlserver;
+
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+import io.trino.plugin.jdbc.ConnectionFactory;
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcTableHandle;
+import io.trino.plugin.jdbc.RemoteTableName;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.statistics.ColumnStatistics;
+import io.trino.spi.statistics.Estimate;
+import io.trino.spi.statistics.TableStatistics;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.MoreCollectors.toOptional;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class SqlServerStatsCollector
+{
+    private static final Logger log = Logger.get(SqlServerStatsCollector.class);
+
+    private final ConnectionFactory connectionFactory;
+
+    @Inject
+    public SqlServerStatsCollector(ConnectionFactory connectionFactory)
+    {
+        this.connectionFactory = requireNonNull(connectionFactory, "connectionFactory is null");
+    }
+
+    TableStatistics readTableStatistics(ConnectorSession session, JdbcTableHandle table, SqlServerClient sqlServerClient)
+            throws SQLException
+    {
+        checkArgument(table.isNamedRelation(), "Relation is not a table: %s", table);
+
+        try (Connection connection = connectionFactory.openConnection(session);
+                Handle handle = Jdbi.open(connection)) {
+            RemoteTableName remoteTableName = table.getRequiredNamedRelation().getRemoteTableName();
+            String catalog = remoteTableName.getCatalogName().orElse(null);
+            String schema = remoteTableName.getSchemaName().orElse(null);
+            String tableName = remoteTableName.getTableName();
+
+            StatisticsDao statisticsDao = new StatisticsDao(handle);
+            Long tableObjectId = statisticsDao.getTableObjectId(catalog, schema, tableName);
+            if (tableObjectId == null) {
+                // Table not found
+                return TableStatistics.empty();
+            }
+
+            Long rowCount = statisticsDao.getRowCount(tableObjectId);
+            if (rowCount == null) {
+                // Table disappeared
+                return TableStatistics.empty();
+            }
+
+            if (rowCount == 0) {
+                return TableStatistics.empty();
+            }
+
+            TableStatistics.Builder tableStatistics = TableStatistics.builder();
+            tableStatistics.setRowCount(Estimate.of(rowCount));
+
+            Map<String, String> columnNameToStatisticsName = getColumnNameToStatisticsName(table, statisticsDao, tableObjectId);
+
+            for (JdbcColumnHandle column : sqlServerClient.getColumns(session, table)) {
+                String statisticName = columnNameToStatisticsName.get(column.getColumnName());
+                if (statisticName == null) {
+                    // No statistic for column
+                    continue;
+                }
+
+                double averageColumnLength;
+                long notNullValues = 0;
+                long nullValues = 0;
+                long distinctValues = 0;
+
+                try (CallableStatement showStatistics = handle.getConnection().prepareCall("DBCC SHOW_STATISTICS (?, ?)")) {
+                    showStatistics.setString(1, format("%s.%s.%s", catalog, schema, tableName));
+                    showStatistics.setString(2, statisticName);
+
+                    boolean isResultSet = showStatistics.execute();
+                    checkState(isResultSet, "Expected SHOW_STATISTICS to return a result set");
+                    try (ResultSet resultSet = showStatistics.getResultSet()) {
+                        checkState(resultSet.next(), "No rows in result set");
+
+                        averageColumnLength = resultSet.getDouble("Average Key Length"); // NULL values are accounted for with length 0
+
+                        checkState(!resultSet.next(), "More than one row in result set");
+                    }
+
+                    isResultSet = showStatistics.getMoreResults();
+                    checkState(isResultSet, "Expected SHOW_STATISTICS to return second result set");
+                    showStatistics.getResultSet().close();
+
+                    isResultSet = showStatistics.getMoreResults();
+                    checkState(isResultSet, "Expected SHOW_STATISTICS to return third result set");
+                    try (ResultSet resultSet = showStatistics.getResultSet()) {
+                        while (resultSet.next()) {
+                            resultSet.getObject("RANGE_HI_KEY");
+                            if (resultSet.wasNull()) {
+                                // Null fraction
+                                checkState(resultSet.getLong("RANGE_ROWS") == 0, "Unexpected RANGE_ROWS for null fraction");
+                                checkState(resultSet.getLong("DISTINCT_RANGE_ROWS") == 0, "Unexpected DISTINCT_RANGE_ROWS for null fraction");
+                                checkState(nullValues == 0, "Multiple null fraction entries");
+                                nullValues += resultSet.getLong("EQ_ROWS");
+                            }
+                            else {
+                                // TODO discover min/max from resultSet.getXxx("RANGE_HI_KEY")
+                                notNullValues += resultSet.getLong("RANGE_ROWS") // rows strictly within a bucket
+                                        + resultSet.getLong("EQ_ROWS"); // rows equal to RANGE_HI_KEY
+                                distinctValues += resultSet.getLong("DISTINCT_RANGE_ROWS") // NDV strictly within a bucket
+                                        + (resultSet.getLong("EQ_ROWS") > 0 ? 1 : 0);
+                            }
+                        }
+                    }
+                }
+
+                ColumnStatistics statistics = ColumnStatistics.builder()
+                        .setNullsFraction(Estimate.of(
+                                (notNullValues + nullValues == 0)
+                                        ? 1
+                                        : (1.0 * nullValues / (notNullValues + nullValues))))
+                        .setDistinctValuesCount(Estimate.of(distinctValues))
+                        .setDataSize(Estimate.of(rowCount * averageColumnLength))
+                        .build();
+
+                tableStatistics.setColumnStatistics(column, statistics);
+            }
+
+            return tableStatistics.build();
+        }
+    }
+
+    private static class StatisticsDao
+    {
+        private final Handle handle;
+
+        public StatisticsDao(Handle handle)
+        {
+            this.handle = requireNonNull(handle, "handle is null");
+        }
+
+        Long getTableObjectId(String catalog, String schema, String tableName)
+        {
+            return handle.createQuery("SELECT object_id(:table)")
+                    .bind("table", format("%s.%s.%s", catalog, schema, tableName))
+                    .mapTo(Long.class)
+                    .one();
+        }
+
+        Long getRowCount(long tableObjectId)
+        {
+            return handle.createQuery("" +
+                            "SELECT sum(rows) row_count " +
+                            "FROM sys.partitions " +
+                            "WHERE object_id = :object_id " +
+                            "AND index_id IN (0, 1)") // 0 = heap, 1 = clustered index, 2 or greater = non-clustered index
+                    .bind("object_id", tableObjectId)
+                    .mapTo(Long.class)
+                    .one();
+        }
+
+        List<String> getSingleColumnStatistics(long tableObjectId)
+        {
+            return handle.createQuery("" +
+                            "SELECT s.name " +
+                            "FROM sys.stats AS s " +
+                            "JOIN sys.stats_columns AS sc ON s.object_id = sc.object_id AND s.stats_id = sc.stats_id " +
+                            "WHERE s.object_id = :object_id " +
+                            "GROUP BY s.name " +
+                            "HAVING count(*) = 1 " +
+                            "ORDER BY s.name")
+                    .bind("object_id", tableObjectId)
+                    .mapTo(String.class)
+                    .list();
+        }
+
+        String getSingleColumnStatisticsColumnName(long tableObjectId, String statisticsName)
+        {
+            return handle.createQuery("" +
+                            "SELECT c.name " +
+                            "FROM sys.stats AS s " +
+                            "JOIN sys.stats_columns AS sc ON s.object_id = sc.object_id AND s.stats_id = sc.stats_id " +
+                            "JOIN sys.columns AS c ON sc.object_id = c.object_id AND c.column_id = sc.column_id " +
+                            "WHERE s.object_id = :object_id " +
+                            "AND s.name = :statistics_name")
+                    .bind("object_id", tableObjectId)
+                    .bind("statistics_name", statisticsName)
+                    .mapTo(String.class)
+                    .collect(toOptional()) // verify there is no more than 1 column name returned
+                    .orElse(null);
+        }
+    }
+
+    private static Map<String, String> getColumnNameToStatisticsName(JdbcTableHandle table, StatisticsDao statisticsDao, Long tableObjectId)
+    {
+        List<String> singleColumnStatistics = statisticsDao.getSingleColumnStatistics(tableObjectId);
+
+        Map<String, String> columnNameToStatisticsName = new HashMap<>();
+        for (String statisticName : singleColumnStatistics) {
+            String columnName = statisticsDao.getSingleColumnStatisticsColumnName(tableObjectId, statisticName);
+            if (columnName == null) {
+                // Table or statistics disappeared
+                continue;
+            }
+
+            if (columnNameToStatisticsName.putIfAbsent(columnName, statisticName) != null) {
+                log.debug("Multiple statistics for %s in %s: %s and %s", columnName, table, columnNameToStatisticsName.get(columnName), statisticName);
+            }
+        }
+        return columnNameToStatisticsName;
+    }
+}

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerStatsCollector.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerStatsCollector.java
@@ -13,6 +13,9 @@
  */
 package io.trino.plugin.sqlserver;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
 import io.trino.plugin.jdbc.ConnectionFactory;
@@ -33,9 +36,13 @@ import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.MoreCollectors.toOptional;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -57,6 +64,31 @@ public class SqlServerStatsCollector
     {
         checkArgument(table.isNamedRelation(), "Relation is not a table: %s", table);
 
+        if (isNewStatisticsSupported(session)) {
+            log.info("Using new table statistics");
+            return readNewTableStatistics(session, table, sqlServerClient);
+        }
+        else {
+            log.info("Using legacy table statistics");
+            return readLegacyTableStatistics(session, table, sqlServerClient);
+        }
+    }
+
+    @VisibleForTesting
+    boolean isNewStatisticsSupported(ConnectorSession session)
+            throws SQLException
+    {
+        try (Connection connection = connectionFactory.openConnection(session);
+                Handle handle = Jdbi.open(connection)) {
+            return handle.createQuery("SELECT object_id(N'sys.dm_db_stats_histogram')")
+                    .mapTo(Long.class)
+                    .one() != null;
+        }
+    }
+
+    private TableStatistics readLegacyTableStatistics(ConnectorSession session, JdbcTableHandle table, SqlServerClient sqlServerClient)
+            throws SQLException
+    {
         try (Connection connection = connectionFactory.openConnection(session);
                 Handle handle = Jdbi.open(connection)) {
             RemoteTableName remoteTableName = table.getRequiredNamedRelation().getRemoteTableName();
@@ -64,7 +96,7 @@ public class SqlServerStatsCollector
             String schema = remoteTableName.getSchemaName().orElse(null);
             String tableName = remoteTableName.getTableName();
 
-            StatisticsDao statisticsDao = new StatisticsDao(handle);
+            LegacyStatisticsDao statisticsDao = new LegacyStatisticsDao(handle);
             Long tableObjectId = statisticsDao.getTableObjectId(catalog, schema, tableName);
             if (tableObjectId == null) {
                 // Table not found
@@ -155,11 +187,11 @@ public class SqlServerStatsCollector
         }
     }
 
-    private static class StatisticsDao
+    private static class LegacyStatisticsDao
     {
         private final Handle handle;
 
-        public StatisticsDao(Handle handle)
+        public LegacyStatisticsDao(Handle handle)
         {
             this.handle = requireNonNull(handle, "handle is null");
         }
@@ -216,7 +248,7 @@ public class SqlServerStatsCollector
         }
     }
 
-    private static Map<String, String> getColumnNameToStatisticsName(JdbcTableHandle table, StatisticsDao statisticsDao, Long tableObjectId)
+    private static Map<String, String> getColumnNameToStatisticsName(JdbcTableHandle table, LegacyStatisticsDao statisticsDao, Long tableObjectId)
     {
         List<String> singleColumnStatistics = statisticsDao.getSingleColumnStatistics(tableObjectId);
 
@@ -233,5 +265,176 @@ public class SqlServerStatsCollector
             }
         }
         return columnNameToStatisticsName;
+    }
+
+    private TableStatistics readNewTableStatistics(ConnectorSession session, JdbcTableHandle table, SqlServerClient sqlServerClient)
+            throws SQLException
+    {
+        try (Connection connection = connectionFactory.openConnection(session);
+                Handle handle = Jdbi.open(connection)) {
+            RemoteTableName remoteTableName = table.getRequiredNamedRelation().getRemoteTableName();
+            String catalog = remoteTableName.getCatalogName().orElse(null);
+            String schema = remoteTableName.getSchemaName().orElse(null);
+            String tableName = remoteTableName.getTableName();
+
+            NewStatisticsDao statisticsDao = new NewStatisticsDao(handle);
+            Optional<TableLevelInfo> tableLevelInfo = statisticsDao.getTableLevelInfo(catalog, schema, tableName);
+            if (tableLevelInfo.isEmpty() || tableLevelInfo.get().rowCount() == 0L) {
+                return TableStatistics.empty();
+            }
+            long tableObjectId = tableLevelInfo.get().objectId();
+            long rowCount = tableLevelInfo.get().rowCount();
+
+            TableStatistics.Builder tableStatistics = TableStatistics.builder();
+            tableStatistics.setRowCount(Estimate.of(rowCount));
+
+            ImmutableMap<String, JdbcColumnHandle> columns = sqlServerClient.getColumns(session, table)
+                    .stream().collect(toImmutableMap(JdbcColumnHandle::getColumnName, c -> c));
+
+            ConcurrentHashMap<String, ColumnStatsBuilder> columnStats = new ConcurrentHashMap<>();
+            statisticsDao.getColumnStatRanges(tableObjectId).forEach(columnStatsRange -> {
+                JdbcColumnHandle column = columns.get(columnStatsRange.columnName);
+                if (column != null) {
+                    log.info(columnStatsRange.toString());
+                    ColumnStatsBuilder builder = columnStats.computeIfAbsent(columnStatsRange.columnName, ignored ->
+                            new ColumnStatsBuilder(column, rowCount));
+                    builder.add(columnStatsRange);
+                }
+                else {
+                    log.warn("No column for %s: %s", columnStatsRange, columns.keySet());
+                }
+            });
+
+            columnStats.values().forEach(builder ->
+                    tableStatistics.setColumnStatistics(builder.getColumn(), builder.build()));
+
+            return tableStatistics.build();
+        }
+    }
+
+    private record NewStatisticsDao(Handle handle)
+    {
+        public NewStatisticsDao
+        {
+            requireNonNull(handle, "handle is null");
+        }
+
+        private static final String TABLE_LEVEL_QUERY = """
+                SELECT object_id, sum(rows) as row_count
+                FROM sys.partitions
+                WHERE object_id = object_id(:table)
+                  AND index_id IN (0, 1) -- 0 = heap, 1 = clustered index, 2 or greater = non-clustered index
+                GROUP BY object_id
+                """;
+
+        private static final String HISTOGRAM_QUERY = """
+                SELECT c.name as column_name,
+                       h.step_number,
+                       h.range_high_key,
+                       h.range_rows,
+                       h.equal_rows,
+                       h.distinct_range_rows
+                FROM (
+                    SELECT s.object_id, sc.column_id, s.name as stats_name
+                    FROM sys.stats AS s
+                    JOIN sys.stats_columns as sc
+                      ON s.object_id = sc.object_id AND s.stats_id = sc.stats_id
+                    WHERE s.object_id = :object_id
+                    GROUP BY s.object_id, sc.column_id, s.name
+                    HAVING count(*) = 1
+                ) AS ocn
+                JOIN sys.stats AS s
+                  ON ocn.object_id = s.object_id AND ocn.stats_name = s.name
+                JOIN sys.columns AS c
+                  ON ocn.object_id = c.object_id AND ocn.column_id = c.column_id
+                CROSS APPLY sys.dm_db_stats_histogram(s.object_id, s.stats_id) h
+                """;
+
+        Optional<TableLevelInfo> getTableLevelInfo(String catalog, String schema, String tableName)
+        {
+            return Optional.ofNullable(handle.createQuery(TABLE_LEVEL_QUERY)
+                    .bind("table", format("%s.%s.%s", catalog, schema, tableName))
+                    .map((rs, _) -> new TableLevelInfo(rs.getLong("object_id"), rs.getLong("row_count")))
+                    .one());
+        }
+
+        Stream<ColumnStatsRange> getColumnStatRanges(long tableObjectId)
+        {
+            return handle.createQuery(HISTOGRAM_QUERY)
+                    .bind("object_id", tableObjectId)
+                    .map((rs, _) -> {
+                        Object rangeHighKey = rs.getObject("range_high_key");
+                        boolean rangeIsNull = rs.wasNull();
+                        return new ColumnStatsRange(
+                                rs.getString("column_name"),
+                                rs.getLong("step_number"),
+                                rangeHighKey,
+                                rangeIsNull,
+                                rs.getLong("range_rows"),
+                                rs.getLong("equal_rows"),
+                                rs.getLong("distinct_range_rows"));
+                    })
+                    .stream();
+        }
+    }
+
+    private record TableLevelInfo(long objectId, long rowCount) {}
+
+    private record ColumnStatsRange(String columnName,
+                                    long stepNumber,
+                                    Object rangeHighKey,
+                                    boolean rangeIsNull,
+                                    long rangeRows,
+                                    long equalRows,
+                                    long distinctRangeRows) {}
+
+    private static class ColumnStatsBuilder
+    {
+        private final long rowCount;
+        private final JdbcColumnHandle column;
+
+        private long nullValues = 0;
+        private long notNullValues = 0;
+        private long distinctValues = 0;
+
+        ColumnStatsBuilder(JdbcColumnHandle column, long rowCount)
+        {
+            this.column = requireNonNull(column, "column is null");
+            this.rowCount = rowCount;
+        }
+
+        JdbcColumnHandle getColumn()
+        {
+            return this.column;
+        }
+
+        @CanIgnoreReturnValue
+        ColumnStatsBuilder add(ColumnStatsRange range)
+        {
+            if (range.rangeIsNull) {
+                checkState(range.rangeRows == 0, "Unexpected RANGE_ROWS for null fraction");
+                checkState(range.distinctRangeRows == 0, "Unexpected DISTINCT_RANGE_ROWS for null fraction");
+                checkState(nullValues == 0, "Multiple range fraction entries");
+                nullValues += range.equalRows;
+            }
+            else {
+                notNullValues += range.rangeRows + range.equalRows;
+                distinctValues += range.distinctRangeRows + (range.equalRows > 0 ? 1 : 0);
+            }
+            return this;
+        }
+
+        ColumnStatistics build()
+        {
+            ColumnStatistics.Builder builder = ColumnStatistics.builder()
+                    .setNullsFraction(Estimate.of(
+                            (notNullValues + nullValues == 0)
+                                    ? 1
+                                    : (1.0 * nullValues / (notNullValues + nullValues))))
+                    .setDistinctValuesCount(Estimate.of(distinctValues));
+            column.getJdbcTypeHandle().columnSize()
+                    .ifPresent(size -> builder.setDataSize(Estimate.of(rowCount * size)));
+            return builder.build();
+        }
     }
 }

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerClient.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerClient.java
@@ -16,6 +16,7 @@ package io.trino.plugin.sqlserver;
 import io.trino.plugin.base.mapping.DefaultIdentifierMapping;
 import io.trino.plugin.jdbc.BaseJdbcConfig;
 import io.trino.plugin.jdbc.ColumnMapping;
+import io.trino.plugin.jdbc.ConnectionFactory;
 import io.trino.plugin.jdbc.DefaultQueryBuilder;
 import io.trino.plugin.jdbc.JdbcClient;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
@@ -56,14 +57,17 @@ public class TestSqlServerClient
                     .setJdbcTypeHandle(new JdbcTypeHandle(Types.DOUBLE, Optional.of("double"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()))
                     .build();
 
+    private static final ConnectionFactory CONNECTION_FACTORY = session -> {
+        throw new UnsupportedOperationException();
+    };
+
     private static final JdbcClient JDBC_CLIENT = new SqlServerClient(
             new BaseJdbcConfig(),
             new JdbcStatisticsConfig(),
-            session -> {
-                throw new UnsupportedOperationException();
-            },
+            CONNECTION_FACTORY,
             new DefaultQueryBuilder(RemoteQueryModifier.NONE),
             new DefaultIdentifierMapping(),
+            new SqlServerStatsCollector(CONNECTION_FACTORY),
             RemoteQueryModifier.NONE);
 
     @Test

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerStatsCollector.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerStatsCollector.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.sqlserver;
+
+import io.airlift.log.Logger;
+import io.trino.plugin.base.mapping.DefaultIdentifierMapping;
+import io.trino.plugin.jdbc.BaseJdbcConfig;
+import io.trino.plugin.jdbc.ConnectionFactory;
+import io.trino.plugin.jdbc.DefaultQueryBuilder;
+import io.trino.plugin.jdbc.JdbcStatisticsConfig;
+import io.trino.plugin.jdbc.JdbcTableHandle;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.statistics.ColumnStatistics;
+import io.trino.spi.statistics.Estimate;
+import io.trino.spi.statistics.TableStatistics;
+import io.trino.spi.type.IntegerType;
+import io.trino.spi.type.VarcharType;
+import io.trino.testing.TestingConnectorSession;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
+
+@TestInstance(PER_CLASS)
+@Execution(SAME_THREAD)
+public class TestSqlServerStatsCollector
+{
+    private static final Logger log = Logger.get(TestSqlServerStatsCollector.class);
+    private static final String SCHEMA = "test";
+    private static final String TABLE = "foo";
+
+    private TestingSqlServer sqlServer;
+    private ConnectionFactory connectionFactory;
+    private SqlServerStatsCollector statsCollector;
+    private SqlServerClient sqlServerClient;
+    private ConnectorSession session;
+    private JdbcTableHandle table;
+
+    @BeforeAll
+    public void init()
+            throws Exception
+    {
+        this.sqlServer = new TestingSqlServer("2022-latest");
+        this.connectionFactory = ignoredSession -> sqlServer.createConnection();
+        this.statsCollector = new SqlServerStatsCollector(connectionFactory);
+        this.sqlServerClient = new SqlServerClient(
+                new BaseJdbcConfig(),
+                new JdbcStatisticsConfig(),
+                connectionFactory,
+                new DefaultQueryBuilder(RemoteQueryModifier.NONE),
+                new DefaultIdentifierMapping(),
+                statsCollector,
+                RemoteQueryModifier.NONE);
+        this.session = TestingConnectorSession.builder().build();
+        table = createTable();
+    }
+
+    private JdbcTableHandle createTable()
+    {
+        sqlServer.execute("CREATE SCHEMA %s".formatted(SCHEMA));
+
+        SchemaTableName schemaTableName = new SchemaTableName(SCHEMA, TABLE);
+        ImmutableList.Builder<ColumnMetadata> columnsBuilder = ImmutableList.builder();
+        StringBuilder insertValues = new StringBuilder();
+        for (int i = 0; i < 10; ++i) {
+            columnsBuilder.add(new ColumnMetadata("c_int_" + i, IntegerType.INTEGER));
+            columnsBuilder.add(new ColumnMetadata("c_varchar_" + i, VarcharType.createVarcharType(10)));
+            if (i > 0) {
+                insertValues.append(',');
+            }
+            insertValues.append(i).append(',').append("'a").append(i).append("'");
+        }
+        ImmutableList<ColumnMetadata> columns = columnsBuilder.build();
+        ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(schemaTableName, columns);
+
+        sqlServerClient.createTable(session, tableMetadata);
+
+        sqlServer.execute("INSERT INTO %s.%s (%s) VALUES (%s)".formatted(
+                SCHEMA,
+                TABLE,
+                columns.stream().map(ColumnMetadata::getName).collect(Collectors.joining(",")),
+                insertValues.toString()));
+
+        for (ColumnMetadata column : columns) {
+            sqlServer.execute("CREATE STATISTICS %1$s ON %2$s.%3$s (%1$s)".formatted(column.getName(), SCHEMA, TABLE));
+        }
+        sqlServer.execute("UPDATE STATISTICS %s.%s".formatted(SCHEMA, TABLE));
+
+        return sqlServerClient.getTableHandle(session, schemaTableName).orElseThrow();
+    }
+
+    @Test
+    public void testIsNewStatisticsSupported()
+            throws SQLException
+    {
+        // This ensures that we can use the new statistics for testing
+        assertThat(statsCollector.isNewStatisticsSupported(session)).isTrue();
+    }
+
+    @Test
+    public void testLegacyStatsCollection()
+            throws SQLException
+    {
+        testStatistics(false);
+    }
+
+    @Test
+    public void testNewStatsCollection()
+            throws SQLException
+    {
+        testStatistics(true);
+    }
+
+    private void testStatistics(boolean newStats)
+            throws SQLException
+    {
+        TestingSqlServerStatsCollector testingStatsCollector = new TestingSqlServerStatsCollector(newStats, connectionFactory);
+        TableStatistics statistics = testingStatsCollector.readTableStatistics(session, table, sqlServerClient);
+        assertThat(statistics.getRowCount().getValue()).isEqualTo(1.0);
+        sqlServerClient.getColumns(session, table).forEach(columnHandle -> {
+            ColumnStatistics columnStatistics = statistics.getColumnStatistics().get(columnHandle);
+//            log.info("newStats: %s, stats: %s", newStats, statistics.getColumnStatistics());
+            assertThat(columnStatistics.getNullsFraction().getValue()).isEqualTo(0.0);
+            Estimate dataSize = columnStatistics.getDataSize();
+            switch (columnHandle.getJdbcTypeHandle().jdbcType()) {
+                case Types.INTEGER:
+                    assertThat(dataSize.getValue()).isEqualTo(4.0);
+                    break;
+                case Types.NVARCHAR:
+                case Types.VARCHAR:
+                    if (newStats) {
+                        assertThat(dataSize.isUnknown()).isTrue();
+                    }
+                    else {
+                        assertThat(dataSize.getValue()).isEqualTo(4.0);
+                    }
+                    break;
+                default:
+                    throw new RuntimeException("Added columns of different types to the test but didn't update the switch: " + columnHandle.getJdbcTypeHandle().jdbcType());
+            }
+        });
+    }
+
+    private static class TestingSqlServerStatsCollector
+            extends SqlServerStatsCollector
+    {
+        private final boolean supportNewStats;
+
+        public TestingSqlServerStatsCollector(boolean supportNewStats,
+                                              ConnectionFactory connectionFactory)
+        {
+            super(connectionFactory);
+            this.supportNewStats = supportNewStats;
+        }
+
+        @Override
+        boolean isNewStatisticsSupported(ConnectorSession session)
+                throws SQLException
+        {
+            return supportNewStats;
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Marking temporarily as draft so i can see CI build what i have so far.

This addresses an issue with how we currently collect column-level statistics on SQL Server. 

Currently, we have to iterate over every column of the table and one-by-one call [DBCC SHOW_STATISTICS](https://learn.microsoft.com/en-us/sql/t-sql/database-console-commands/dbcc-show-statistics-transact-sql?view=sql-server-ver16) which returns a histogram of the data in the column, which we aggregate to collect the statistics we want. For tables with very many columns, this can be incredibly slow due to all the round-trips.

This PR uses the newer [sys.dm_db_stats_histogram](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-stats-histogram-transact-sql?view=sql-server-ver16) function when available, utilizing the `CROSS APPLY` join to eliminate the round-trip per-column.

Unfortunately, this means we lose the `dataSize` estimate for non-fixed-width columns, as the new function does not return the average value length in the histogram, and there appears to be no other way of getting it. I've instead opted to using the column type's `columnSize` if present.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

I can provide more context around this but it links to internal starburst repositories.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
