### PR TITLE
Fix failure when hidden partition column name conflicted in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1922,9 +1922,8 @@ public class IcebergMetadata
             difference(existingPartitionFields, partitionFields).stream()
                     .map(PartitionField::name)
                     .forEach(updatePartitionSpec::removeField);
-            difference(partitionFields, existingPartitionFields).stream()
-                    .map(partitionField -> toIcebergTerm(schema, partitionField))
-                    .forEach(updatePartitionSpec::addField);
+            difference(partitionFields, existingPartitionFields)
+                    .forEach(partitionField -> updatePartitionSpec.addField(partitionField.name(), toIcebergTerm(schema, partitionField)));
         }
 
         try {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionFields.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionFields.java
@@ -61,7 +61,7 @@ public final class PartitionFields
         try {
             PartitionSpec.Builder builder = PartitionSpec.builderFor(schema);
             for (String field : fields) {
-                parsePartitionField(builder, field);
+                parsePartitionFields(schema, fields, builder, field);
             }
             return builder.build();
         }
@@ -70,16 +70,59 @@ public final class PartitionFields
         }
     }
 
-    public static void parsePartitionField(PartitionSpec.Builder builder, String field)
+    private static void parsePartitionFields(Schema schema, List<String> fields, PartitionSpec.Builder builder, String field)
     {
-        boolean matched = tryMatch(field, IDENTITY_PATTERN, match -> builder.identity(fromIdentifierToColumn(match.group()))) ||
-                tryMatch(field, YEAR_PATTERN, match -> builder.year(fromIdentifierToColumn(match.group(1)))) ||
-                tryMatch(field, MONTH_PATTERN, match -> builder.month(fromIdentifierToColumn(match.group(1)))) ||
-                tryMatch(field, DAY_PATTERN, match -> builder.day(fromIdentifierToColumn(match.group(1)))) ||
-                tryMatch(field, HOUR_PATTERN, match -> builder.hour(fromIdentifierToColumn(match.group(1)))) ||
-                tryMatch(field, BUCKET_PATTERN, match -> builder.bucket(fromIdentifierToColumn(match.group(1)), parseInt(match.group(2)))) ||
-                tryMatch(field, TRUNCATE_PATTERN, match -> builder.truncate(fromIdentifierToColumn(match.group(1)), parseInt(match.group(2)))) ||
-                tryMatch(field, VOID_PATTERN, match -> builder.alwaysNull(fromIdentifierToColumn(match.group(1))));
+        for (int i = 1; i < schema.columns().size() + fields.size(); i++) {
+            try {
+                parsePartitionField(builder, field, i == 1 ? "" : "_" + i);
+                return;
+            }
+            catch (IllegalArgumentException e) {
+                if (e.getMessage().contains("Cannot create partition from name that exists in schema")
+                        || e.getMessage().contains("Cannot create identity partition sourced from different field in schema")) {
+                    continue;
+                }
+                throw e;
+            }
+        }
+        throw new IllegalArgumentException("Cannot resolve partition field: " + field);
+    }
+
+    public static void parsePartitionField(PartitionSpec.Builder builder, String field, String suffix)
+    {
+        boolean matched =
+                tryMatch(field, IDENTITY_PATTERN, match -> {
+                    // identity doesn't allow specifying an alias
+                    builder.identity(fromIdentifierToColumn(match.group()));
+                }) ||
+                tryMatch(field, YEAR_PATTERN, match -> {
+                    String column = fromIdentifierToColumn(match.group(1));
+                    builder.year(column, column + "_year" + suffix);
+                }) ||
+                tryMatch(field, MONTH_PATTERN, match -> {
+                    String column = fromIdentifierToColumn(match.group(1));
+                    builder.month(column, column + "_month" + suffix);
+                }) ||
+                tryMatch(field, DAY_PATTERN, match -> {
+                    String column = fromIdentifierToColumn(match.group(1));
+                    builder.day(column, column + "_day" + suffix);
+                }) ||
+                tryMatch(field, HOUR_PATTERN, match -> {
+                    String column = fromIdentifierToColumn(match.group(1));
+                    builder.hour(column, column + "_hour" + suffix);
+                }) ||
+                tryMatch(field, BUCKET_PATTERN, match -> {
+                    String column = fromIdentifierToColumn(match.group(1));
+                    builder.bucket(column, parseInt(match.group(2)), column + "_bucket" + suffix);
+                }) ||
+                tryMatch(field, TRUNCATE_PATTERN, match -> {
+                    String column = fromIdentifierToColumn(match.group(1));
+                    builder.truncate(column, parseInt(match.group(2)), column + "_trunc" + suffix);
+                }) ||
+                tryMatch(field, VOID_PATTERN, match -> {
+                    String column = fromIdentifierToColumn(match.group(1));
+                    builder.alwaysNull(column, column + "_null" + suffix);
+                });
         if (!matched) {
             throw new IllegalArgumentException("Invalid partition field declaration: " + field);
         }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -1316,6 +1316,29 @@ public abstract class BaseIcebergConnectorTest
     }
 
     @Test
+    public void testPartitionColumnNameConflict()
+    {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_conflict_partition", "(ts timestamp, ts_day int) WITH (partitioning = ARRAY['day(ts)'])")) {
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (TIMESTAMP '2021-07-24 03:43:57.987654', 1)", 1);
+
+            assertThat(query("SELECT * FROM " + table.getName()))
+                    .matches("VALUES (TIMESTAMP '2021-07-24 03:43:57.987654', 1)");
+            assertThat(query("SELECT partition.ts_day_2 FROM \"" + table.getName() + "$partitions\""))
+                    .matches("VALUES DATE '2021-07-24'");
+        }
+
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_conflict_partition", "(ts timestamp, ts_day int)")) {
+            assertUpdate("ALTER TABLE " + table.getName() + " SET PROPERTIES partitioning = ARRAY['day(ts)']");
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (TIMESTAMP '2021-07-24 03:43:57.987654', 1)", 1);
+
+            assertThat(query("SELECT * FROM " + table.getName()))
+                    .matches("VALUES (TIMESTAMP '2021-07-24 03:43:57.987654', 1)");
+            assertThat(query("SELECT partition.ts_day_2 FROM \"" + table.getName() + "$partitions\""))
+                    .matches("VALUES DATE '2021-07-24'");
+        }
+    }
+
+    @Test
     public void testSortByAllTypes()
     {
         String tableName = "test_sort_by_all_types_" + randomNameSuffix();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestPartitionFields.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestPartitionFields.java
@@ -13,9 +13,12 @@
  */
 package io.trino.plugin.iceberg;
 
+import com.google.common.collect.ImmutableList;
+import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.DoubleType;
 import org.apache.iceberg.types.Types.ListType;
@@ -25,10 +28,12 @@ import org.apache.iceberg.types.Types.StringType;
 import org.apache.iceberg.types.Types.TimestampType;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.function.Consumer;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.plugin.iceberg.PartitionFields.parsePartitionField;
+import static io.trino.plugin.iceberg.PartitionFields.parsePartitionFields;
 import static io.trino.plugin.iceberg.PartitionFields.toPartitionFields;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -96,6 +101,35 @@ public class TestPartitionFields
         assertInvalid("\"nested.list\"", "Cannot partition by non-primitive source field: list<string>");
     }
 
+    @Test
+    public void testConflicts()
+    {
+        assertParseName(List.of("col", "col_year"), TimestampType.withZone(), List.of("year(col)"), List.of("col_year_2"));
+        assertParseName(List.of("col", "col_month"), TimestampType.withZone(), List.of("month(col)"), List.of("col_month_2"));
+        assertParseName(List.of("col", "col_day"), TimestampType.withZone(), List.of("day(col)"), List.of("col_day_2"));
+        assertParseName(List.of("col", "col_hour"), TimestampType.withZone(), List.of("hour(col)"), List.of("col_hour_2"));
+        assertParseName(List.of("col", "col_bucket"), TimestampType.withZone(), List.of("bucket(col,10)"), List.of("col_bucket_2"));
+        assertParseName(List.of("col", "col_trunc"), StringType.get(), List.of("truncate(col,10)"), List.of("col_trunc_2"));
+        assertParseName(List.of("col", "col_null"), TimestampType.withZone(), List.of("void(col)"), List.of("col_null_2"));
+
+        assertParseName(List.of("col", "col_year", "col_year_2"), TimestampType.withZone(), List.of("year(col)"), List.of("col_year_3"));
+        assertParseName(List.of("col", "col_year", "col_year_3"), TimestampType.withZone(), List.of("year(col)"), List.of("col_year_2"));
+
+        assertParseName(List.of("col", "col_year", "col_year_2"), TimestampType.withZone(), List.of("year(col)", "col_year_2"), List.of("col_year_3", "col_year_2"));
+    }
+
+    private static void assertParseName(List<String> columnNames, Type type, List<String> partitions, List<String> expected)
+    {
+        ImmutableList.Builder<NestedField> columns = ImmutableList.builderWithExpectedSize(columnNames.size());
+        int i = 1;
+        for (String name : columnNames) {
+            columns.add(NestedField.required(i++, name, type));
+        }
+        PartitionSpec spec = parsePartitionFields(new Schema(columns.build()), partitions);
+        assertThat(spec.fields()).extracting(PartitionField::name)
+                .containsExactlyElementsOf(expected);
+    }
+
     private static void assertParse(String value, PartitionSpec expected, String canonicalRepresentation)
     {
         assertThat(expected.fields().size()).isEqualTo(1);
@@ -120,7 +154,7 @@ public class TestPartitionFields
 
     private static PartitionSpec parseField(String value)
     {
-        return partitionSpec(builder -> parsePartitionField(builder, value));
+        return partitionSpec(builder -> parsePartitionField(builder, value, ""));
     }
 
     private static PartitionSpec partitionSpec(Consumer<PartitionSpec.Builder> consumer)


### PR DESCRIPTION
## Description

Iceberg connector caused query failure when the hidden partition column name conflicts with other columns.

The approach is different from Spark. They throw an exception when conflicts happen:
```sql
CREATE TABLE test (ts timestamp, ts_day int) USING iceberg PARTITIONED BY (day(ts));
Failed in [create table test (ts timestamp, ts_day int) using iceberg partitioned by (day(ts))]
java.lang.IllegalArgumentException: Cannot create partition from name that exists in schema: ts_day
```

Fixes #22351

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Fix failure when hidden partition name conflicted. ({issue}`22351`)
```
