### PR TITLE
Fix failure when reading non-primitive Parquet fields in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -1421,6 +1421,7 @@ public class IcebergPageSourceProvider
         }
 
         Map<Integer, ColumnDescriptor> descriptorsById = descriptorsByPath.values().stream()
+                .filter(descriptor -> descriptor.getPrimitiveType().getId() != null)
                 .collect(toImmutableMap(descriptor -> descriptor.getPrimitiveType().getId().intValue(), identity()));
         ImmutableMap.Builder<ColumnDescriptor, Domain> predicate = ImmutableMap.builder();
         effectivePredicate.getDomains().orElseThrow().forEach((columnHandle, domain) -> {


### PR DESCRIPTION
## Description

We were getting the value from `descriptorsByPath` only when it's a primitive type before https://github.com/trinodb/trino/pull/19066.

Fixes #22347 

## Release notes

```markdown
# Iceberg
* Fix failure when reading Parquet files that don't have `field-id` on structured types. ({issue}`22347`)
```
