### PR TITLE
Run TestPhoenixConnectorTest in parallel

### DIFF
--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
@@ -26,7 +26,6 @@ import io.trino.testing.sql.SqlExecutor;
 import io.trino.testing.sql.TestTable;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Isolated;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -65,7 +64,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.abort;
 
-@Isolated
 public class TestPhoenixConnectorTest
         extends BaseJdbcConnectorTest
 {


### PR DESCRIPTION
## Description

Phoenix connector tests take [40 minutes](https://github.com/trinodb/trino/actions/runs/9486286121/job/26141094953) on average. This is the slowest plugin except for SaaS connectors. 

Test results:
1. 18m: https://github.com/trinodb/trino/actions/runs/9491852065/job/26158062589?pr=22372
2. 18m: https://github.com/trinodb/trino/actions/runs/9491852065/job/26159720377?pr=22372
3. 18m: https://github.com/trinodb/trino/actions/runs/9491852065/job/26160159614?pr=22372

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
