### PR TITLE
Add manifest file caching support for Iceberg Hive Metastore catalog

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -1685,3 +1685,35 @@ The connector supports redirection from Iceberg tables to Hive tables with the
 
 The connector supports configuring and using [file system
 caching](/object-storage/file-system-cache).
+
+### Manifest File Caching
+
+As of Iceberg version 1.1.0, Apache Iceberg provides a mechanism to cache the
+contents of Iceberg manifest files in memory. This feature helps to reduce
+repeated reads of small Iceberg manifest files from remote storage.
+
+Note that currently, manifest file caching is supported for Hive Metastore catalog.
+
+The following configuration properties are available:
+
+:::{list-table} Manifest File Caching configuration properties
+:widths: 30, 58, 12
+:header-rows: 1
+
+* - Property name
+  - Description
+  - Default
+* - `iceberg.hive.manifest.cache-enabled`
+  - Enable or disable the manifest caching feature.
+  - `false`
+* - `iceberg.hive.manifest.cache.max-total-size`
+  - Maximum size of cache size.
+  - `100MB`
+* - `iceberg.hive.manifest.cache.expiration-interval-duration`
+  - Maximum time duration for which an entry stays in the manifest cache.
+  - `60s`
+* - `iceberg.hive.manifest.cache.max-content-length`
+  - Maximum length of a manifest file to be considered for caching. Manifest files
+    with a length exceeding this size will not be cached.
+  - `8MB`
+:::

--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -40,6 +40,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_annotations</artifactId>
             <optional>true</optional>

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/IcebergHiveMetastoreCatalogConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/IcebergHiveMetastoreCatalogConfig.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.hms;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+
+import static io.airlift.units.DataSize.Unit.BYTE;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_EXPIRATION_INTERVAL_MS_DEFAULT;
+import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH_DEFAULT;
+import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_MAX_TOTAL_BYTES_DEFAULT;
+
+public class IcebergHiveMetastoreCatalogConfig
+{
+    private boolean manifestCachingEnabled;
+    private DataSize maxManifestCacheSize = DataSize.of(IO_MANIFEST_CACHE_MAX_TOTAL_BYTES_DEFAULT, BYTE);
+    private Duration manifestCacheExpireDuration = new Duration(IO_MANIFEST_CACHE_EXPIRATION_INTERVAL_MS_DEFAULT, MILLISECONDS);
+    private DataSize manifestCacheMaxContentLength = DataSize.of(IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH_DEFAULT, BYTE);
+
+    public boolean isManifestCachingEnabled()
+    {
+        return manifestCachingEnabled;
+    }
+
+    @Config("iceberg.hive.manifest.cache-enabled")
+    @ConfigDescription("Enable/disable the manifest caching feature in Hive Metastore catalog")
+    public IcebergHiveMetastoreCatalogConfig setManifestCachingEnabled(boolean manifestCachingEnabled)
+    {
+        this.manifestCachingEnabled = manifestCachingEnabled;
+        return this;
+    }
+
+    public DataSize getMaxManifestCacheSize()
+    {
+        return maxManifestCacheSize;
+    }
+
+    @Config("iceberg.hive.manifest.cache.max-total-size")
+    @ConfigDescription("Maximum total amount to cache in the manifest cache of Hive Metastore catalog")
+    public IcebergHiveMetastoreCatalogConfig setMaxManifestCacheSize(DataSize maxManifestCacheSize)
+    {
+        this.maxManifestCacheSize = maxManifestCacheSize;
+        return this;
+    }
+
+    public Duration getManifestCacheExpireDuration()
+    {
+        return manifestCacheExpireDuration;
+    }
+
+    @Config("iceberg.hive.manifest.cache.expiration-interval-duration")
+    @ConfigDescription("Maximum duration for which an entry stays in the manifest cache of Hive Metastore catalog")
+    public IcebergHiveMetastoreCatalogConfig setManifestCacheExpireDuration(Duration manifestCacheExpireDuration)
+    {
+        this.manifestCacheExpireDuration = manifestCacheExpireDuration;
+        return this;
+    }
+
+    public DataSize getManifestCacheMaxContentLength()
+    {
+        return manifestCacheMaxContentLength;
+    }
+
+    @Config("iceberg.hive.manifest.cache.max-content-length")
+    @ConfigDescription("Maximum length of a manifest file to be considered for caching in Hive Metastore catalog")
+    public IcebergHiveMetastoreCatalogConfig setManifestCacheMaxContentLength(DataSize manifestCacheMaxContentLength)
+    {
+        this.manifestCacheMaxContentLength = manifestCacheMaxContentLength;
+        return this;
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/IcebergHiveMetastoreCatalogModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/IcebergHiveMetastoreCatalogModule.java
@@ -44,6 +44,7 @@ public class IcebergHiveMetastoreCatalogModule
     protected void setup(Binder binder)
     {
         install(new ThriftMetastoreModule());
+        configBinder(binder).bindConfig(IcebergHiveMetastoreCatalogConfig.class);
         binder.bind(IcebergTableOperationsProvider.class).to(HiveMetastoreTableOperationsProvider.class).in(Scopes.SINGLETON);
         binder.bind(TrinoCatalogFactory.class).to(TrinoHiveCatalogFactory.class).in(Scopes.SINGLETON);
         binder.bind(MetastoreValidator.class).asEagerSingleton();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/hms/TestIcebergHiveMetastoreCatalogConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/hms/TestIcebergHiveMetastoreCatalogConfig.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.hms;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.airlift.units.DataSize.Unit.BYTE;
+import static io.airlift.units.DataSize.Unit.GIGABYTE;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_EXPIRATION_INTERVAL_MS_DEFAULT;
+import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH_DEFAULT;
+import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_MAX_TOTAL_BYTES_DEFAULT;
+
+public class TestIcebergHiveMetastoreCatalogConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(IcebergHiveMetastoreCatalogConfig.class)
+                .setManifestCachingEnabled(false)
+                .setMaxManifestCacheSize(DataSize.of(IO_MANIFEST_CACHE_MAX_TOTAL_BYTES_DEFAULT, BYTE))
+                .setManifestCacheExpireDuration(new Duration(IO_MANIFEST_CACHE_EXPIRATION_INTERVAL_MS_DEFAULT, MILLISECONDS))
+                .setManifestCacheMaxContentLength(DataSize.of(IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH_DEFAULT, BYTE)));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("iceberg.hive.manifest.cache-enabled", "true")
+                .put("iceberg.hive.manifest.cache.max-total-size", "1GB")
+                .put("iceberg.hive.manifest.cache.expiration-interval-duration", "10m")
+                .put("iceberg.hive.manifest.cache.max-content-length", "10MB")
+                .buildOrThrow();
+
+        IcebergHiveMetastoreCatalogConfig expected = new IcebergHiveMetastoreCatalogConfig()
+                .setManifestCachingEnabled(true)
+                .setMaxManifestCacheSize(DataSize.of(1, GIGABYTE))
+                .setManifestCacheExpireDuration(new Duration(10, MINUTES))
+                .setManifestCacheMaxContentLength(DataSize.of(10, MEGABYTE));
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/hms/TestTrinoHiveCatalogWithHiveMetastore.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/hms/TestTrinoHiveCatalogWithHiveMetastore.java
@@ -130,7 +130,7 @@ public class TestTrinoHiveCatalogWithHiveMetastore
                     {
                         return thriftMetastore;
                     }
-                }),
+                }, new IcebergHiveMetastoreCatalogConfig()),
                 useUniqueTableLocations,
                 false,
                 false,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Iceberg library has a manifest caching feature contributed by Cloudera:  
https://blog.cloudera.com/12-times-faster-query-planning-with-iceberg-manifest-caching-in-impala/  

PrestoDB also has similar configurations to turn on this feature: https://github.com/prestodb/presto/pull/21399  

Iceberg manifest caching can accelerate query planning.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
https://prestodb.io/docs/current/connector/iceberg.html#manifest-file-caching  


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Add manifest file caching support for Iceberg Hive Metastore catalog. ({issue}`22376`)
```
