### PR TITLE
Add JsonStringArrayExtractScalar function

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
@@ -291,6 +291,7 @@ import static io.trino.operator.scalar.ElementToArrayConcatFunction.ELEMENT_TO_A
 import static io.trino.operator.scalar.FormatFunction.FORMAT_FUNCTION;
 import static io.trino.operator.scalar.Greatest.GREATEST;
 import static io.trino.operator.scalar.IdentityCast.IDENTITY_CAST;
+import static io.trino.operator.scalar.JsonStringArrayExtractScalar.JSON_STRING_ARRAY_EXTRACT_SCALAR;
 import static io.trino.operator.scalar.JsonStringToArrayCast.JSON_STRING_TO_ARRAY;
 import static io.trino.operator.scalar.JsonStringToMapCast.JSON_STRING_TO_MAP;
 import static io.trino.operator.scalar.JsonStringToRowCast.JSON_STRING_TO_ROW;
@@ -525,7 +526,7 @@ public final class SystemFunctionBundle
                 .function(new MapToMapCast(blockTypeOperators))
                 .function(ARRAY_FLATTEN_FUNCTION)
                 .function(ARRAY_CONCAT_FUNCTION)
-                .functions(ARRAY_SUBSCRIPT, JSON_TO_ARRAY, JSON_STRING_TO_ARRAY)
+                .functions(ARRAY_SUBSCRIPT, JSON_TO_ARRAY, JSON_STRING_TO_ARRAY, JSON_STRING_ARRAY_EXTRACT_SCALAR)
                 .aggregates(ArrayAggregationFunction.class)
                 .aggregates(ListaggAggregationFunction.class)
                 .functions(new MapSubscriptOperator())

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayTransformFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayTransformFunction.java
@@ -84,10 +84,11 @@ public final class ArrayTransformFunction
     }
 
     public static final ArrayTransformFunction ARRAY_TRANSFORM_FUNCTION = new ArrayTransformFunction();
+    public static final String ARRAY_TRANSFORM_NAME = "transform";
 
     private ArrayTransformFunction()
     {
-        super(FunctionMetadata.scalarBuilder("transform")
+        super(FunctionMetadata.scalarBuilder(ARRAY_TRANSFORM_NAME)
                 .signature(Signature.builder()
                         .typeVariable("T")
                         .typeVariable("U")

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/JsonExtract.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/JsonExtract.java
@@ -127,15 +127,23 @@ public final class JsonExtract
     public static <T> T extract(Slice jsonInput, JsonExtractor<T> jsonExtractor)
     {
         requireNonNull(jsonInput, "jsonInput is null");
-        try {
-            try (JsonParser jsonParser = createJsonParser(JSON_FACTORY, jsonInput)) {
-                // Initialize by advancing to first token and make sure it exists
-                if (jsonParser.nextToken() == null) {
-                    return null;
-                }
+        try (JsonParser jsonParser = createJsonParser(JSON_FACTORY, jsonInput)) {
+            return extract(jsonParser, jsonExtractor);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
 
-                return jsonExtractor.extract(jsonParser);
+    public static <T> T extract(JsonParser jsonParser, JsonExtractor<T> jsonExtractor)
+    {
+        requireNonNull(jsonParser, "jsonParser is null");
+        try {
+            // Initialize by advancing to first token and make sure it exists
+            if (jsonParser.nextToken() == null) {
+                return null;
             }
+            return jsonExtractor.extract(jsonParser);
         }
         catch (JsonParseException e) {
             // Return null if we failed to parse something

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringArrayExtractScalar.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringArrayExtractScalar.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.trino.annotation.UsedByGeneratedCode;
+import io.trino.metadata.SqlScalarFunction;
+import io.trino.operator.scalar.JsonExtract.JsonExtractor;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.ArrayBlockBuilder;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.function.BoundSignature;
+import io.trino.spi.function.FunctionMetadata;
+import io.trino.spi.function.Signature;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.TypeSignature;
+import io.trino.type.JsonPathType;
+import io.trino.util.JsonCastException;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+
+import static com.fasterxml.jackson.core.JsonToken.END_ARRAY;
+import static com.fasterxml.jackson.core.JsonToken.START_ARRAY;
+import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
+import static io.trino.spi.type.TypeSignature.arrayType;
+import static io.trino.spi.type.TypeSignatureParameter.typeVariable;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.util.JsonUtil.createJsonFactory;
+import static io.trino.util.JsonUtil.createJsonParser;
+import static io.trino.util.JsonUtil.truncateIfNecessaryForErrorMessage;
+import static io.trino.util.Reflection.methodHandle;
+import static java.lang.String.format;
+
+public final class JsonStringArrayExtractScalar
+        extends SqlScalarFunction
+{
+    public static final JsonStringArrayExtractScalar JSON_STRING_ARRAY_EXTRACT_SCALAR = new JsonStringArrayExtractScalar();
+    public static final String JSON_STRING_ARRAY_EXTRACT_SCALAR_NAME = "$internal$json_string_array_extract_scalar";
+    private static final MethodHandle METHOD_HANDLE = methodHandle(JsonStringArrayExtractScalar.class, "extract", Slice.class, JsonPath.class);
+
+    private static final JsonFactory JSON_FACTORY = createJsonFactory();
+    private static final ArrayType ARRAY_TYPE = new ArrayType(VARCHAR);
+
+    static {
+        // Changes factory. Necessary for JsonParser.readValueAsTree to work.
+        new ObjectMapper(JSON_FACTORY);
+    }
+
+    private JsonStringArrayExtractScalar()
+    {
+        super(FunctionMetadata.scalarBuilder(JSON_STRING_ARRAY_EXTRACT_SCALAR_NAME)
+                .signature(Signature.builder()
+                        .argumentType(new TypeSignature("varchar", typeVariable("N")))
+                        .longVariable("N")
+                        .argumentType(new TypeSignature(JsonPathType.NAME))
+                        .returnType(arrayType(VARCHAR.getTypeSignature()))
+                        .build())
+                .nullable()
+                .hidden()
+                .noDescription()
+                .build());
+    }
+
+    @Override
+    protected SpecializedSqlScalarFunction specialize(BoundSignature boundSignature)
+    {
+        return new ChoicesSpecializedSqlScalarFunction(
+                boundSignature,
+                NULLABLE_RETURN,
+                ImmutableList.of(NEVER_NULL, NEVER_NULL),
+                METHOD_HANDLE);
+    }
+
+    @UsedByGeneratedCode
+    public static Block extract(Slice json, JsonPath jsonPath)
+    {
+        try (JsonParser jsonParser = createJsonParser(JSON_FACTORY, json)) {
+            jsonParser.nextToken();
+            if (jsonParser.getCurrentToken() == JsonToken.VALUE_NULL) {
+                return null;
+            }
+            BlockBuilder blockBuilder = ARRAY_TYPE.createBlockBuilder(null, 1);
+            append(jsonParser, jsonPath.getScalarExtractor(), blockBuilder);
+            Block block = blockBuilder.build();
+            return ARRAY_TYPE.getObject(block, 0);
+        }
+        catch (TrinoException | JsonCastException e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast to %s. %s\n%s", ARRAY_TYPE, e.getMessage(), truncateIfNecessaryForErrorMessage(json)), e);
+        }
+        catch (Exception e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast to %s.\n%s", ARRAY_TYPE, truncateIfNecessaryForErrorMessage(json)), e);
+        }
+    }
+
+    public static void append(JsonParser parser, JsonExtractor<Slice> extractor, BlockBuilder blockBuilder)
+            throws IOException
+    {
+        if (parser.getCurrentToken() == JsonToken.VALUE_NULL) {
+            append(null, blockBuilder);
+            return;
+        }
+
+        if (parser.getCurrentToken() != START_ARRAY) {
+            throw new JsonCastException(format("Expected a json array, but got %s", parser.getText()));
+        }
+
+        ((ArrayBlockBuilder) blockBuilder).buildEntry(elementBuilder -> {
+            while (parser.nextToken() != END_ARRAY) {
+                if (parser.getCurrentToken() == JsonToken.VALUE_NULL) {
+                    append(null, elementBuilder);
+                    continue;
+                }
+                JsonParser jsonParser = parser.readValueAsTree().traverse();
+                append(JsonExtract.extract(jsonParser, extractor), elementBuilder);
+            }
+        });
+    }
+
+    private static void append(Slice slice, BlockBuilder blockBuilder)
+    {
+        if (slice == null) {
+            blockBuilder.appendNull();
+        }
+        else {
+            VARCHAR.writeSlice(blockBuilder, slice);
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionOptimizer.java
@@ -67,6 +67,7 @@ import io.trino.sql.ir.optimizer.rule.SimplifyRedundantCast;
 import io.trino.sql.ir.optimizer.rule.SimplifyStackedArithmeticNegation;
 import io.trino.sql.ir.optimizer.rule.SimplifyStackedNot;
 import io.trino.sql.ir.optimizer.rule.SpecializeCastWithJsonParse;
+import io.trino.sql.ir.optimizer.rule.SpecializeTransformWithJsonParse;
 import io.trino.sql.planner.Symbol;
 
 import java.util.List;
@@ -120,7 +121,8 @@ public class IrExpressionOptimizer
                 new DistributeComparisonOverSwitch(),
                 new DistributeComparisonOverCase(),
                 new SimplifyRedundantCase(context),
-                new SpecializeCastWithJsonParse(context)));
+                new SpecializeCastWithJsonParse(context),
+                new SpecializeTransformWithJsonParse(context)));
     }
 
     /**

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/SpecializeTransformWithJsonParse.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/SpecializeTransformWithJsonParse.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.ir.optimizer.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.Session;
+import io.trino.metadata.Metadata;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.ir.Call;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.Lambda;
+import io.trino.sql.ir.optimizer.IrOptimizerRule;
+import io.trino.sql.planner.Symbol;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.metadata.GlobalFunctionCatalog.builtinFunctionName;
+import static io.trino.operator.scalar.ArrayTransformFunction.ARRAY_TRANSFORM_NAME;
+import static io.trino.operator.scalar.JsonStringArrayExtractScalar.JSON_STRING_ARRAY_EXTRACT_SCALAR_NAME;
+import static io.trino.operator.scalar.JsonStringToArrayCast.JSON_STRING_TO_ARRAY_NAME;
+import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
+
+/**
+ * Optimize case of transformation with cast and json_extract_scalars E.g,
+ *
+ * <ul>
+ *     <li>{@code transform(cast(json_parse(varchar_column) as array<json>), json -> json_extract_scalar(json, jsonPath)) -> $internal$json_string_array_extract_scalar(varchar_column, jsonPath)}</li>
+ * </ul>
+ */
+public class SpecializeTransformWithJsonParse
+        implements IrOptimizerRule
+{
+    private final Metadata metadata;
+
+    public SpecializeTransformWithJsonParse(PlannerContext context)
+    {
+        metadata = context.getMetadata();
+    }
+
+    @Override
+    public Optional<Expression> apply(Expression expression, Session session, Map<Symbol, Expression> bindings)
+    {
+        if (expression instanceof Call call
+                && call.function().name().getFunctionName().equals(ARRAY_TRANSFORM_NAME)) {
+            if (!(call.arguments().getFirst() instanceof Call transformArrayCall
+                    && transformArrayCall.function().name().equals(builtinFunctionName(JSON_STRING_TO_ARRAY_NAME)))) {
+                return Optional.empty();
+            }
+
+            if (call.arguments().getLast() instanceof Lambda transform
+                    && transform.body() instanceof Call transformLambdaCall
+                    && transformLambdaCall.function().name().equals(builtinFunctionName("json_extract_scalar"))) {
+                Expression jsonData = transformArrayCall.arguments().getFirst();
+                Constant jsonPath = (Constant) transformLambdaCall.arguments().getLast();
+                Call newCall = new Call(
+                        metadata.resolveBuiltinFunction(
+                                JSON_STRING_ARRAY_EXTRACT_SCALAR_NAME,
+                                fromTypes(ImmutableList.of(jsonData.type(), jsonPath.type()))),
+                        ImmutableList.of(jsonData, jsonPath));
+                return Optional.of(newCall);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArrayTransform.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArrayTransform.java
@@ -53,6 +53,7 @@ import java.util.stream.Collectors;
 
 import static com.google.common.base.Verify.verify;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static io.trino.operator.scalar.ArrayTransformFunction.ARRAY_TRANSFORM_NAME;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -108,7 +109,7 @@ public class BenchmarkArrayTransform
                 Type elementType = TYPES.get(i);
                 ArrayType arrayType = new ArrayType(elementType);
                 projectionsBuilder.add(new CallExpression(
-                        functionResolution.resolveFunction("transform", fromTypes(arrayType, new FunctionType(ImmutableList.of(BIGINT), BOOLEAN))),
+                        functionResolution.resolveFunction(ARRAY_TRANSFORM_NAME, fromTypes(arrayType, new FunctionType(ImmutableList.of(BIGINT), BOOLEAN))),
                         ImmutableList.of(
                                 new InputReferenceExpression(0, arrayType),
                                 new LambdaDefinitionExpression(

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestJsonStringArrayExtractScalar.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestJsonStringArrayExtractScalar.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import io.trino.metadata.ResolvedFunction;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.spi.function.CatalogSchemaFunctionName;
+import io.trino.spi.type.ArrayType;
+import io.trino.sql.ir.Call;
+import io.trino.sql.query.QueryAssertions;
+import io.trino.sql.query.QueryAssertions.ExpressionAssertProvider.Result;
+import io.trino.type.FunctionType;
+import io.trino.type.JsonPathType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static io.trino.operator.scalar.ArrayTransformFunction.ARRAY_TRANSFORM_NAME;
+import static io.trino.operator.scalar.JsonStringArrayExtractScalar.JSON_STRING_ARRAY_EXTRACT_SCALAR_NAME;
+import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
+import static io.trino.type.JsonType.JSON;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+class TestJsonStringArrayExtractScalar
+{
+    private static final TestingFunctionResolution FUNCTIONS = new TestingFunctionResolution();
+    private static final ResolvedFunction TRANSFORM = FUNCTIONS.resolveFunction(ARRAY_TRANSFORM_NAME, fromTypes(new ArrayType(JSON), new FunctionType(List.of(JSON), VARCHAR)));
+    private static final CatalogSchemaFunctionName JSON_STRING_ARRAY_EXTRACT_SCALAR = FUNCTIONS.getMetadata().resolveBuiltinFunction(JSON_STRING_ARRAY_EXTRACT_SCALAR_NAME, fromTypes(VARCHAR, JsonPathType.JSON_PATH)).name();
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    void testEmptySliceExtract()
+    {
+        assertTrinoExceptionThrownBy(() -> assertions.expression("transform(cast(json_parse(a) as array<json>), x -> json_extract_scalar(\"x\", '$.name'))")
+                .binding("a", "''").evaluate())
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessageContaining("Cannot cast to array(varchar). Expected a json array, but got null");
+    }
+
+    @Test
+    void testEmptyStringExtract()
+    {
+        failedExtract("", "$");
+    }
+
+    @Test
+    void testObjectStringExtract()
+    {
+        failedExtract("{}", "$");
+    }
+
+    @Test
+    void testScalarStringExtract()
+    {
+        failedExtract("1", "$");
+    }
+
+    @Test
+    void testEmptyArrayExtract()
+    {
+        Result result = extract("[]", "$.name");
+        assertThat(result.value()).isEqualTo(ImmutableList.of());
+    }
+
+    @Test
+    void testScalarArrayExtract()
+    {
+        Result result = extract("[1, \"abc\", 2.2]", "$.name");
+        assertThat(result.value()).isEqualTo(asList(null, null, null));
+        result = extract("[1, \"abc\", 2.2]", "$");
+        assertThat(result.value()).isEqualTo(asList("1", "abc", "2.2"));
+    }
+
+    @Test
+    void testEmptyElementsArrayExtract()
+    {
+        Result result = extract("[null, [], {}]", "$.name");
+        assertThat(result.value()).isEqualTo(asList(null, null, null));
+    }
+
+    @Test
+    void testExtract()
+    {
+        Result result = extract("[{\"name\": \"a\"}, {\"name\": \"b\"}, [], {}]", "$.name");
+        assertThat(result.value()).isEqualTo(asList("a", "b", null, null));
+    }
+
+    @Test
+    void testMixedExtract()
+    {
+        Result result = extract("[{\"name\": \"a\"}, 1]", "$.name");
+        assertThat(result.value()).isEqualTo(asList("a", null));
+    }
+
+    @Test
+    void testComplexExtract()
+    {
+        Result result = extract("[{\"name\": [1, 2, 3]}, 1]", "$.name");
+        assertThat(result.value()).isEqualTo(asList(null, null));
+        result = extract("[{\"name\": {}}, 1]", "$.name");
+        assertThat(result.value()).isEqualTo(asList(null, null));
+    }
+
+    private Result extract(String json, String jsonPath)
+    {
+        Result transformationResult = extractTransformationResult(json, jsonPath);
+        Result jsonStringResult = extractJsonStringArrayExtractResult(json, jsonPath);
+        assertThat(transformationResult.value()).isEqualTo(jsonStringResult.value());
+        return jsonStringResult;
+    }
+
+    private Result extractTransformationResult(String json, String jsonPath)
+    {
+        Result result = assertions.expression("transform(cast(json_parse('" + json + "') as array<json>), elem -> json_extract_scalar(\"elem\", '" + jsonPath + "'))")
+                .evaluate();
+        assertThat(result.expression().isPresent()).isTrue();
+        assertThat(result.expression().get()).isInstanceOf(Call.class);
+        assertThat(((Call) result.expression().get()).function()).isEqualTo(TRANSFORM);
+        return result;
+    }
+
+    private Result extractJsonStringArrayExtractResult(String json, String jsonPath)
+    {
+        Result result = assertions.expression("transform(cast(json_parse(json) as array<json>), elem -> json_extract_scalar(\"elem\", '" + jsonPath + "'))")
+                .binding("json", "'" + json + "'")
+                .evaluate();
+        assertThat(result.expression().isPresent()).isTrue();
+        assertThat(result.expression().get()).isInstanceOf(Call.class);
+        assertThat(((Call) result.expression().get()).function().name()).isEqualTo(JSON_STRING_ARRAY_EXTRACT_SCALAR);
+        return result;
+    }
+
+    private void failedExtract(String json, String jsonPath)
+    {
+        assertTrinoExceptionThrownBy(() -> extractTransformationResult(json, jsonPath))
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessageContaining("Cannot cast to array");
+        assertTrinoExceptionThrownBy(() -> extractJsonStringArrayExtractResult(json, jsonPath))
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessageContaining("Cannot cast to array");
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestSpecializeTransformWithJsonParse.java
+++ b/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestSpecializeTransformWithJsonParse.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.ir.optimizer;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.operator.scalar.JsonPath;
+import io.trino.spi.type.ArrayType;
+import io.trino.sql.ir.Call;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.Lambda;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.ir.optimizer.rule.SpecializeTransformWithJsonParse;
+import io.trino.sql.planner.Symbol;
+import io.trino.type.FunctionType;
+import io.trino.type.JsonPathType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.metadata.GlobalFunctionCatalog.builtinFunctionName;
+import static io.trino.operator.scalar.ArrayTransformFunction.ARRAY_TRANSFORM_NAME;
+import static io.trino.operator.scalar.JsonStringArrayExtractScalar.JSON_STRING_ARRAY_EXTRACT_SCALAR_NAME;
+import static io.trino.operator.scalar.JsonStringToArrayCast.JSON_STRING_TO_ARRAY_NAME;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
+import static io.trino.testing.TestingSession.testSession;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestSpecializeTransformWithJsonParse
+{
+    private static final TestingFunctionResolution FUNCTIONS = new TestingFunctionResolution();
+    private static final ResolvedFunction JSON_STRING_TO_ARRAY = FUNCTIONS.getCoercion(builtinFunctionName(JSON_STRING_TO_ARRAY_NAME), VARCHAR, new ArrayType(VARCHAR));
+    private static final ResolvedFunction TRANSFORM = FUNCTIONS.resolveFunction(ARRAY_TRANSFORM_NAME, fromTypes(new ArrayType(VARCHAR), new FunctionType(List.of(VARCHAR), VARCHAR)));
+    private static final ResolvedFunction JSON_EXTRACT_SCALAR = FUNCTIONS.resolveFunction("json_extract_scalar", fromTypes(VARCHAR, JsonPathType.JSON_PATH));
+
+    @Test
+    void testArray()
+    {
+        JsonPath jsonPath = new JsonPath("$");
+        assertThat(optimize(
+                new Call(TRANSFORM,
+                        ImmutableList.of(
+                                new Call(JSON_STRING_TO_ARRAY, ImmutableList.of(new Reference(VARCHAR, "json_string"))),
+                                new Lambda(
+                                        ImmutableList.of(new Symbol(VARCHAR, "json_array")),
+                                        new Call(JSON_EXTRACT_SCALAR, ImmutableList.of(
+                                                new Reference(VARCHAR, "json_array"),
+                                                new Constant(JsonPathType.JSON_PATH, jsonPath))))))))
+                .isEqualTo(Optional.of(
+                        new Call(
+                                PLANNER_CONTEXT.getMetadata().resolveBuiltinFunction(JSON_STRING_ARRAY_EXTRACT_SCALAR_NAME, fromTypes(VARCHAR, JsonPathType.JSON_PATH)),
+                                ImmutableList.of(
+                                        new Reference(VARCHAR, "json_string"),
+                                        new Constant(JsonPathType.JSON_PATH, jsonPath)))));
+    }
+
+    private Optional<Expression> optimize(Expression expression)
+    {
+        return new SpecializeTransformWithJsonParse(PLANNER_CONTEXT).apply(expression, testSession(), ImmutableMap.of());
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
@@ -29,17 +29,20 @@ import io.trino.spi.type.SqlTimeWithTimeZone;
 import io.trino.spi.type.SqlTimestamp;
 import io.trino.spi.type.SqlTimestampWithTimeZone;
 import io.trino.spi.type.Type;
+import io.trino.sql.ir.Expression;
 import io.trino.sql.planner.Plan;
 import io.trino.sql.planner.assertions.PlanMatchPattern;
 import io.trino.sql.planner.optimizations.PlanNodeSearcher;
 import io.trino.sql.planner.plan.JoinNode;
 import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.ProjectNode;
 import io.trino.sql.planner.plan.TableScanNode;
 import io.trino.sql.planner.plan.ValuesNode;
 import io.trino.testing.MaterializedResult;
 import io.trino.testing.MaterializedRow;
 import io.trino.testing.PlanTester;
 import io.trino.testing.QueryRunner;
+import io.trino.testing.QueryRunner.MaterializedResultWithPlan;
 import io.trino.testing.StandaloneQueryRunner;
 import io.trino.testing.assertions.TrinoExceptionAssert;
 import org.assertj.core.api.AbstractAssert;
@@ -67,6 +70,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -818,7 +822,8 @@ public class QueryAssertions
         public Result evaluate()
         {
             if (bindings.isEmpty()) {
-                return run("VALUES ROW(%s)".formatted(expression));
+                return run("VALUES ROW(%s)".formatted(expression),
+                        ExpressionAssertProvider::extractExpressionWithoutBindings);
             }
 
             List<Map.Entry<String, String>> entries = ImmutableList.copyOf(bindings.entrySet());
@@ -845,7 +850,8 @@ public class QueryAssertions
                     .formatted(
                             expression,
                             Joiner.on(",").join(values),
-                            Joiner.on(",").join(columns)));
+                            Joiner.on(",").join(columns)),
+                    ExpressionAssertProvider::extractExpressionWithBindings);
 
             Result withConstantFolding = run("""
                     SELECT %s
@@ -856,8 +862,8 @@ public class QueryAssertions
                     .formatted(
                             expression,
                             Joiner.on(",").join(values),
-                            Joiner.on(",").join(columns)));
-
+                            Joiner.on(",").join(columns)),
+                    _ -> Optional.empty());
             if (!full.type().equals(withConstantFolding.type())) {
                 fail("Mismatched types between interpreter and evaluation engine: %s vs %s".formatted(full.type(), withConstantFolding.type()));
             }
@@ -866,13 +872,30 @@ public class QueryAssertions
                 fail("Mismatched results between interpreter and evaluation engine: %s vs %s".formatted(full.value(), withConstantFolding.value()));
             }
 
-            return new Result(full.type(), full.value);
+            return new Result(full.type(), full.value, full.expression);
         }
 
-        private Result run(String query)
+        private static Optional<Expression> extractExpressionWithBindings(Plan plan)
         {
-            MaterializedResult result = runner.execute(session, query);
-            return new Result(getOnlyElement(result.getTypes()), result.getOnlyColumnAsSet().iterator().next());
+            return PlanNodeSearcher.searchFrom(plan.getRoot())
+                    .whereIsInstanceOfAny(ProjectNode.class)
+                    .findFirst()
+                    .map(ProjectNode.class::cast)
+                    .flatMap(node -> node.getAssignments().getExpressions().stream().findFirst());
+        }
+
+        private static Optional<Expression> extractExpressionWithoutBindings(Plan plan)
+        {
+            return PlanNodeSearcher.searchFrom(plan.getRoot()) .whereIsInstanceOfAny(ValuesNode.class)
+                    .findFirst()
+                    .map(ValuesNode.class::cast)
+                    .map(node -> node.getRows().orElseThrow().getFirst().children().getFirst());
+        }
+
+        private Result run(String query, Function<Plan, Optional<Expression>> expressionExtractor)
+        {
+            MaterializedResultWithPlan result = runner.executeWithPlan(session, query);
+            return new Result(getOnlyElement(result.result().getTypes()), result.result().getOnlyColumnAsSet().iterator().next(), expressionExtractor.apply(result.queryPlan().get()));
         }
 
         @Override
@@ -883,7 +906,7 @@ public class QueryAssertions
                     .withRepresentation(ExpressionAssert.TYPE_RENDERER);
         }
 
-        public record Result(Type type, Object value) {}
+        public record Result(Type type, Object value, Optional<Expression> expression) {}
     }
 
     public static class ExpressionAssert


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Optimize common case of `transform(cast(json_parse), json_extract_scalar)` to be single and more performant call of `JsonStringArrayExtractScalar`.

Example query:
```SQL
WITH t AS (SELECT a.id as id, a.data AS data FROM table_a AS a) 
SELECT b.data FROM table_b AS b, t AS a 
WHERE b.id = a.id AND  
CASE WHEN b.data <> 'second' THEN contains(transform(cast(json_parse(a.data) as array<json>), (x) -> json_extract_scalar("x", '$.name')), b.data) 
ELSE false END;
```


With change:
```
     │   CPU: 8.58s (94.13%), Scheduled: 8.93s (69.96%), Blocked: 1.89s (94.59%), Output: 3492632 rows (34.65MB)                                        
```

Without:
```
     │   CPU: 16.49s (95.06%), Scheduled: 17.24s (82.05%), Blocked: 2.81s (92.72%), Output: 3492632 rows (34.65MB)            
```
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# General
* Improve performance of parsing json array and extracting scalar
```
