### PR TITLE
Add encoding to error code in OAuth2 callback handler

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2CallbackResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2CallbackResource.java
@@ -26,11 +26,14 @@ import jakarta.ws.rs.core.Cookie;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
+import java.net.URLEncoder;
+
 import static io.trino.server.security.ResourceSecurity.AccessType.PUBLIC;
 import static io.trino.server.security.oauth2.NonceCookie.NONCE_COOKIE;
 import static io.trino.server.security.oauth2.OAuth2CallbackResource.CALLBACK_ENDPOINT;
 import static jakarta.ws.rs.core.MediaType.TEXT_HTML;
 import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
 @Path(CALLBACK_ENDPOINT)
@@ -61,7 +64,7 @@ public class OAuth2CallbackResource
             @Context UriInfo uriInfo)
     {
         if (error != null) {
-            return service.handleOAuth2Error(state, error, errorDescription, errorUri);
+            return service.handleOAuth2Error(state, URLEncoder.encode(error, UTF_8), errorDescription, errorUri);
         }
 
         try {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This PR adds add encoding to error code in OAuth2 callback handler. Error code that is passed as query parameter to `/oauth2/callback` endpoint is used in plain html. So if error contains malicious code it will be included in error page.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Add encoding to error code in OAuth2 callback handler
```
