### PR TITLE
Update cloud SDKs

### DIFF
--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -509,6 +509,16 @@
                                     <code>java.method.visibilityIncreased</code>
                                     <new>method int io.trino.spi.block.ByteArrayBlock::getRawValuesOffset()</new>
                                 </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.class.externalClassExposedInAPI</code>
+                                    <new>interface io.opentelemetry.api.metrics.DoubleGauge</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.class.externalClassExposedInAPI</code>
+                                    <new>interface io.opentelemetry.api.metrics.LongGauge</new>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/plugin/trino-elasticsearch/pom.xml
+++ b/plugin/trino-elasticsearch/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.elasticsearch.version>7.17.21</dep.elasticsearch.version>
+        <dep.elasticsearch.version>7.17.22</dep.elasticsearch.version>
     </properties>
 
     <dependencies>

--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <!-- Nessie version (compatible with Iceberg release) must be bumped along with Iceberg version bump to avoid compatibility issues -->
-        <dep.nessie.version>0.90.2</dep.nessie.version>
+        <dep.nessie.version>0.90.4</dep.nessie.version>
     </properties>
 
     <dependencies>

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/containers/NessieContainer.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/containers/NessieContainer.java
@@ -28,7 +28,7 @@ public class NessieContainer
 {
     private static final Logger log = Logger.get(NessieContainer.class);
 
-    public static final String DEFAULT_IMAGE = "ghcr.io/projectnessie/nessie:0.90.2";
+    public static final String DEFAULT_IMAGE = "ghcr.io/projectnessie/nessie:0.90.4";
     public static final String DEFAULT_HOST_NAME = "nessie";
     public static final String VERSION_STORE_TYPE = "IN_MEMORY";
 

--- a/pom.xml
+++ b/pom.xml
@@ -596,7 +596,7 @@
             <dependency>
                 <groupId>com.nimbusds</groupId>
                 <artifactId>nimbus-jose-jwt</artifactId>
-                <version>9.39.3</version>
+                <version>9.40</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
         <dep.drift.version>1.22</dep.drift.version>
         <dep.errorprone.version>2.28.0</dep.errorprone.version>
         <dep.flyway.version>10.15.0</dep.flyway.version>
-        <dep.google.http.client.version>1.44.1</dep.google.http.client.version>
+        <dep.google.http.client.version>1.44.2</dep.google.http.client.version>
         <dep.guava.version>33.2.0-jre</dep.guava.version>
         <dep.iceberg.version>1.5.2</dep.iceberg.version>
         <dep.jackson.version>2.17.1</dep.jackson.version>
@@ -202,6 +202,8 @@
         <dep.jsonwebtoken.version>0.12.5</dep.jsonwebtoken.version>
         <dep.kafka-clients.version>3.7.0</dep.kafka-clients.version>
         <dep.okio.version>3.9.0</dep.okio.version>
+        <!-- temporary: required to be in sync with version pulled by libraries-bom -->
+        <dep.opentelemetry.version>1.38.0</dep.opentelemetry.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.parquet.version>1.14.0</dep.parquet.version>
         <dep.plugin.failsafe.version>${dep.plugin.surefire.version}</dep.plugin.failsafe.version>
@@ -229,7 +231,7 @@
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>libraries-bom</artifactId>
-                <version>26.40.0</version>
+                <version>26.41.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -311,7 +311,7 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.26.0</version>
+                <version>2.26.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -461,7 +461,7 @@
             <dependency>
                 <groupId>com.clickhouse</groupId>
                 <artifactId>clickhouse-jdbc</artifactId>
-                <version>0.6.0-patch4</version>
+                <version>0.6.1</version>
                 <classifier>all</classifier>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
         <dep.alluxio.version>2.9.5</dep.alluxio.version>
         <dep.antlr.version>4.13.1</dep.antlr.version>
         <dep.avro.version>1.11.3</dep.avro.version>
-        <dep.aws-sdk.version>1.12.741</dep.aws-sdk.version>
+        <dep.aws-sdk.version>1.12.742</dep.aws-sdk.version>
         <dep.cassandra.version>4.17.0</dep.cassandra.version>
         <dep.confluent.version>7.5.1</dep.confluent.version>
         <dep.docker.images.version>96</dep.docker.images.version>

--- a/pom.xml
+++ b/pom.xml
@@ -516,7 +516,7 @@
             <dependency>
                 <groupId>com.google.cloud.bigdataoss</groupId>
                 <artifactId>gcs-connector</artifactId>
-                <version>hadoop3-2.2.22</version>
+                <version>hadoop3-2.2.23</version>
                 <classifier>shaded</classifier>
                 <exclusions>
                     <exclusion>

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeSparkIcebergNessie.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeSparkIcebergNessie.java
@@ -43,7 +43,7 @@ public class EnvSinglenodeSparkIcebergNessie
 
     private static final int SPARK_THRIFT_PORT = 10213;
     private static final int NESSIE_PORT = 19120;
-    private static final String NESSIE_VERSION = "0.90.2";
+    private static final String NESSIE_VERSION = "0.90.4";
     private static final String SPARK = "spark";
 
     private final DockerFiles dockerFiles;


### PR DESCRIPTION
google cloud SDK requires an override for the opentelemetry-version (this will be updated in airbase and removed latter on).