### PR TITLE
Add support for `euclidean_distance`, `dot_product`, `cosine_distance` functions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
@@ -117,6 +117,7 @@ import io.trino.operator.scalar.ArraySortFunction;
 import io.trino.operator.scalar.ArrayToArrayCast;
 import io.trino.operator.scalar.ArrayTrimFunction;
 import io.trino.operator.scalar.ArrayUnionFunction;
+import io.trino.operator.scalar.ArrayVectorFunctions;
 import io.trino.operator.scalar.ArraysOverlapFunction;
 import io.trino.operator.scalar.BitwiseFunctions;
 import io.trino.operator.scalar.CharacterStringCasts;
@@ -476,6 +477,7 @@ public final class SystemFunctionBundle
                 .scalar(ArrayContainsSequence.class)
                 .scalar(ArrayFilterFunction.class)
                 .scalar(ArrayPositionFunction.class)
+                .scalars(ArrayVectorFunctions.class)
                 .scalars(CombineHashFunction.class)
                 .scalars(JsonOperators.class)
                 .scalars(FailureFunction.class)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayVectorFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayVectorFunctions.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import io.trino.spi.block.Block;
+import io.trino.spi.function.Description;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.type.StandardTypes;
+
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.util.Failures.checkCondition;
+
+public final class ArrayVectorFunctions
+{
+    private ArrayVectorFunctions() {}
+
+    @Description("Calculates the euclidean distance between two vectors")
+    @ScalarFunction
+    @SqlType(StandardTypes.DOUBLE)
+    public static double euclideanDistance(@SqlType("array(double)") Block first, @SqlType("array(double)") Block second)
+    {
+        checkCondition(first.getPositionCount() == second.getPositionCount(), INVALID_FUNCTION_ARGUMENT, "The arguments must have the same length");
+
+        double sum = 0.0;
+        for (int i = 0; i < first.getPositionCount(); i++) {
+            double diff = DOUBLE.getDouble(first, i) - DOUBLE.getDouble(second, i);
+            sum += diff * diff;
+        }
+        return Math.sqrt(sum);
+    }
+
+    @Description("Calculates the dot product between two vectors")
+    @ScalarFunction
+    @SqlType(StandardTypes.DOUBLE)
+    public static double dotProduct(@SqlType("array(double)") Block first, @SqlType("array(double)") Block second)
+    {
+        checkCondition(first.getPositionCount() == second.getPositionCount(), INVALID_FUNCTION_ARGUMENT, "The arguments must have the same length");
+
+        double dotProduct = 0.0;
+        for (int i = 0; i < first.getPositionCount(); i++) {
+            dotProduct += DOUBLE.getDouble(first, i) * DOUBLE.getDouble(second, i);
+        }
+        return dotProduct;
+    }
+
+    @Description("Calculates the cosine distance between two vectors")
+    @ScalarFunction
+    @SqlType(StandardTypes.DOUBLE)
+    public static double cosineDistance(@SqlType("array(double)") Block first, @SqlType("array(double)") Block second)
+    {
+        checkCondition(first.getPositionCount() == second.getPositionCount(), INVALID_FUNCTION_ARGUMENT, "The arguments must have the same length");
+
+        double firstMagnitude = 0.0;
+        double secondMagnitude = 0.0;
+        double dotProduct = 0.0;
+        for (int i = 0; i < first.getPositionCount(); i++) {
+            double firstValue = DOUBLE.getDouble(first, i);
+            double secondValue = DOUBLE.getDouble(second, i);
+            firstMagnitude += firstValue * firstValue;
+            secondMagnitude += secondValue * secondValue;
+            dotProduct += firstValue * secondValue;
+        }
+        firstMagnitude = Math.sqrt(firstMagnitude);
+        secondMagnitude = Math.sqrt(secondMagnitude);
+
+        checkCondition(firstMagnitude != 0 && secondMagnitude != 0, INVALID_FUNCTION_ARGUMENT, "Vector magnitude cannot be zero");
+        double cosineSimilarity = dotProduct / (firstMagnitude * secondMagnitude);
+        return 1.0 - cosineSimilarity;
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArrayDotProduct.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArrayDotProduct.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.operator.DriverYieldSignal;
+import io.trino.operator.project.PageProcessor;
+import io.trino.spi.Page;
+import io.trino.spi.block.ArrayBlockBuilder;
+import io.trino.spi.block.Block;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.Type;
+import io.trino.sql.gen.ExpressionCompiler;
+import io.trino.sql.relational.CallExpression;
+import io.trino.sql.relational.RowExpression;
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import static io.trino.jmh.Benchmarks.benchmark;
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static io.trino.sql.relational.Expressions.field;
+import static io.trino.testing.TestingConnectorSession.SESSION;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+@Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkArrayDotProduct
+{
+    private static final int POSITIONS = 1_000;
+
+    @Benchmark
+    @OperationsPerInvocation(POSITIONS)
+    public List<Optional<Page>> arrayIntersect(BenchmarkData data)
+    {
+        return ImmutableList.copyOf(data.getPageProcessor().process(
+                SESSION,
+                new DriverYieldSignal(),
+                newSimpleAggregatedMemoryContext().newLocalMemoryContext(PageProcessor.class.getSimpleName()),
+                data.getPage()));
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        private String name = "dot_product";
+
+        @Param({"10", "100", "1000"})
+        private int arraySize = 10;
+
+        private Page page;
+        private PageProcessor pageProcessor;
+
+        @Setup
+        public void setup()
+        {
+            Type elementType = DOUBLE;
+            TestingFunctionResolution functionResolution = new TestingFunctionResolution();
+            ArrayType arrayType = new ArrayType(elementType);
+            ImmutableList<RowExpression> projections = ImmutableList.of(new CallExpression(
+                    functionResolution.resolveFunction(name, fromTypes(arrayType, arrayType)),
+                    ImmutableList.of(field(0, arrayType), field(1, arrayType))));
+
+            ExpressionCompiler compiler = functionResolution.getExpressionCompiler();
+            pageProcessor = compiler.compilePageProcessor(Optional.empty(), projections).get();
+
+            page = new Page(createChannel(POSITIONS, arraySize, elementType), createChannel(POSITIONS, arraySize, elementType));
+        }
+
+        private static Block createChannel(int positionCount, int arraySize, Type elementType)
+        {
+            ArrayType arrayType = new ArrayType(elementType);
+            ArrayBlockBuilder blockBuilder = arrayType.createBlockBuilder(null, positionCount);
+            for (int position = 0; position < positionCount; position++) {
+                blockBuilder.buildEntry(elementBuilder -> {
+                    for (int i = 0; i < arraySize; i++) {
+                        if (elementType.getJavaType() == double.class) {
+                            elementType.writeDouble(elementBuilder, ThreadLocalRandom.current().nextDouble() % arraySize);
+                        }
+                        else {
+                            throw new UnsupportedOperationException();
+                        }
+                    }
+                });
+            }
+            return blockBuilder.build();
+        }
+
+        public PageProcessor getPageProcessor()
+        {
+            return pageProcessor;
+        }
+
+        public Page getPage()
+        {
+            return page;
+        }
+    }
+
+    @Test
+    public void verify()
+    {
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        new BenchmarkArrayDotProduct().arrayIntersect(data);
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        // assure the benchmarks are valid before running
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        new BenchmarkArrayDotProduct().arrayIntersect(data);
+
+        benchmark(BenchmarkArrayDotProduct.class).run();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestArrayVectorFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestArrayVectorFunctions.java
@@ -1,0 +1,335 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import io.trino.sql.query.QueryAssertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
+import static java.lang.Double.NEGATIVE_INFINITY;
+import static java.lang.Double.NaN;
+import static java.lang.Double.POSITIVE_INFINITY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+final class TestArrayVectorFunctions
+{
+    private final QueryAssertions assertions = new QueryAssertions();
+
+    @AfterAll
+    void teardown()
+    {
+        assertions.close();
+    }
+
+    @Test
+    void testEuclideanDistance()
+    {
+        assertThat(assertions.function("euclidean_distance", "ARRAY[1]", "ARRAY[2]"))
+                .hasType(DOUBLE)
+                .isEqualTo(1.0);
+        assertThat(assertions.function("euclidean_distance", "ARRAY[1, 2]", "ARRAY[3, 4]"))
+                .hasType(DOUBLE)
+                .isEqualTo(2.8284271247461903);
+        assertThat(assertions.function("euclidean_distance", "ARRAY[REAL '1.1', REAL '2.2', REAL '3.3']", "ARRAY[REAL '4.4', REAL '5.5', REAL '6.6']"))
+                .hasType(DOUBLE)
+                .isEqualTo(5.715767651212193);
+        assertThat(assertions.function("euclidean_distance", "ARRAY[DOUBLE '1.1', DOUBLE '2.2', DOUBLE '3.3']", "ARRAY[DOUBLE '4.4', DOUBLE '5.5', DOUBLE '6.6']"))
+                .hasType(DOUBLE)
+                .isEqualTo(5.715767664977295);
+        assertThat(assertions.function("euclidean_distance", "ARRAY[1.1, 2.2, 3.3]", "ARRAY[4.4, 5.5, 6.6]"))
+                .hasType(DOUBLE)
+                .isEqualTo(5.715767664977295);
+        assertThat(assertions.function("euclidean_distance", "ARRAY[]", "ARRAY[]"))
+                .hasType(DOUBLE)
+                .isEqualTo(0.0);
+
+        // real type's min and max
+        assertThat(assertions.function("euclidean_distance", "ARRAY[REAL '3.4028235e+38f']", "ARRAY[REAL '3.4028235e+38f']"))
+                .hasType(DOUBLE)
+                .isEqualTo(0.0);
+        assertThat(assertions.function("euclidean_distance", "ARRAY[REAL '-3.4028235e+38f']", "ARRAY[REAL '-3.4028235e+38f']"))
+                .hasType(DOUBLE)
+                .isEqualTo(0.0);
+        assertThat(assertions.function("euclidean_distance", "ARRAY[REAL '3.4028235e+38f']", "ARRAY[REAL '-3.4028235e+38f']"))
+                .hasType(DOUBLE)
+                .isEqualTo(6.805646932770577E38);
+        assertThat(assertions.function("euclidean_distance", "ARRAY[REAL '-3.4028235e+38f']", "ARRAY[REAL '3.4028235e+38f']"))
+                .hasType(DOUBLE)
+                .isEqualTo(6.805646932770577E38);
+        assertThat(assertions.function("euclidean_distance", "ARRAY[REAL '1.4E-45']", "ARRAY[REAL '1.4E-45']"))
+                .hasType(DOUBLE)
+                .isEqualTo(0.0);
+        assertThat(assertions.function("euclidean_distance", "ARRAY[REAL '-1.4E-45']", "ARRAY[REAL '-1.4E-45']"))
+                .hasType(DOUBLE)
+                .isEqualTo(0.0);
+        assertThat(assertions.function("euclidean_distance", "ARRAY[REAL '1.4E-45']", "ARRAY[REAL '-1.4E-45']"))
+                .hasType(DOUBLE)
+                .isEqualTo(2.802596928649634E-45);
+        assertThat(assertions.function("euclidean_distance", "ARRAY[REAL '-1.4E-45']", "ARRAY[REAL '1.4E-45']"))
+                .hasType(DOUBLE)
+                .isEqualTo(2.802596928649634E-45);
+        assertThat(assertions.function("euclidean_distance", "ARRAY[REAL '3.4028235e+38f']", "ARRAY[REAL '1.4E-45']"))
+                .hasType(DOUBLE)
+                .isEqualTo(3.4028234663852886E38);
+        assertThat(assertions.function("euclidean_distance", "ARRAY[REAL '1.4E-45']", "ARRAY[REAL '3.4028235e+38f']"))
+                .hasType(DOUBLE)
+                .isEqualTo(3.4028234663852886E38);
+
+        // double type's min and max
+        assertThat(assertions.function("euclidean_distance", "ARRAY[DOUBLE '1.7976931348623157E+309']", "ARRAY[DOUBLE '1.7976931348623157E+309']"))
+                .hasType(DOUBLE)
+                .isEqualTo(NaN);
+        assertThat(assertions.function("euclidean_distance", "ARRAY[DOUBLE '-1.7976931348623157E+308']", "ARRAY[DOUBLE '-1.7976931348623157E+308']"))
+                .hasType(DOUBLE)
+                .isEqualTo(0.0);
+        assertThat(assertions.function("euclidean_distance", "ARRAY[DOUBLE '1.7976931348623157E+309']", "ARRAY[DOUBLE '-1.7976931348623157E+308']"))
+                .hasType(DOUBLE)
+                .isEqualTo(POSITIVE_INFINITY);
+        assertThat(assertions.function("euclidean_distance", "ARRAY[DOUBLE '-1.7976931348623157E+308']", "ARRAY[DOUBLE '1.7976931348623157E+309']"))
+                .hasType(DOUBLE)
+                .isEqualTo(POSITIVE_INFINITY);
+
+        // NaN and infinity
+        assertThat(assertions.function("euclidean_distance", "ARRAY[1]", "ARRAY[nan()]"))
+                .hasType(DOUBLE)
+                .isEqualTo(NaN);
+        assertThat(assertions.function("euclidean_distance", "ARRAY[nan()]", "ARRAY[1]"))
+                .hasType(DOUBLE)
+                .isEqualTo(NaN);
+        assertThat(assertions.function("euclidean_distance", "ARRAY[1]", "ARRAY[-infinity()]"))
+                .hasType(DOUBLE)
+                .isEqualTo(POSITIVE_INFINITY);
+        assertThat(assertions.function("euclidean_distance", "ARRAY[-infinity()]", "ARRAY[1]"))
+                .hasType(DOUBLE)
+                .isEqualTo(POSITIVE_INFINITY);
+        assertThat(assertions.function("euclidean_distance", "ARRAY[1]", "ARRAY[infinity()]"))
+                .hasType(DOUBLE)
+                .isEqualTo(POSITIVE_INFINITY);
+        assertThat(assertions.function("euclidean_distance", "ARRAY[infinity()]", "ARRAY[1]"))
+                .hasType(DOUBLE)
+                .isEqualTo(POSITIVE_INFINITY);
+
+        assertTrinoExceptionThrownBy(assertions.function("euclidean_distance", "ARRAY[]", "ARRAY[1]")::evaluate)
+                .hasMessage("The arguments must have the same length");
+        assertTrinoExceptionThrownBy(assertions.function("euclidean_distance", "ARRAY[1]", "ARRAY[]")::evaluate)
+                .hasMessage("The arguments must have the same length");
+        assertTrinoExceptionThrownBy(assertions.function("euclidean_distance", "ARRAY[1]", "ARRAY[1, 2]")::evaluate)
+                .hasMessage("The arguments must have the same length");
+        assertTrinoExceptionThrownBy(assertions.function("euclidean_distance", "ARRAY[1, 2]", "ARRAY[1]")::evaluate)
+                .hasMessage("The arguments must have the same length");
+    }
+
+    @Test
+    void testDotProduct()
+    {
+        assertThat(assertions.function("dot_product", "ARRAY[1]", "ARRAY[2]"))
+                .hasType(DOUBLE)
+                .isEqualTo(2.0);
+        assertThat(assertions.function("dot_product", "ARRAY[1, 2]", "ARRAY[3, 4]"))
+                .hasType(DOUBLE)
+                .isEqualTo(11.0);
+        assertThat(assertions.function("dot_product", "ARRAY[REAL '1.1', REAL '2.2', REAL '3.3']", "ARRAY[REAL '4.4', REAL '5.5', REAL '6.6']"))
+                .hasType(DOUBLE)
+                .isEqualTo(38.719999842643745);
+        assertThat(assertions.function("dot_product", "ARRAY[DOUBLE '1.1', DOUBLE '2.2', DOUBLE '3.3']", "ARRAY[DOUBLE '4.4', DOUBLE '5.5', DOUBLE '6.6']"))
+                .hasType(DOUBLE)
+                .isEqualTo(38.72);
+        assertThat(assertions.function("dot_product", "ARRAY[1.1, 2.2, 3.3]", "ARRAY[4.4, 5.5, 6.6]"))
+                .hasType(DOUBLE)
+                .isEqualTo(38.72);
+        assertThat(assertions.function("dot_product", "ARRAY[]", "ARRAY[]"))
+                .hasType(DOUBLE)
+                .isEqualTo(0.0);
+
+        // real type's min and max
+        assertThat(assertions.function("dot_product", "ARRAY[REAL '3.4028235e+38f']", "ARRAY[REAL '3.4028235e+38f']"))
+                .hasType(DOUBLE)
+                .isEqualTo(1.1579207543382391E77);
+        assertThat(assertions.function("dot_product", "ARRAY[REAL '-3.4028235e+38f']", "ARRAY[REAL '-3.4028235e+38f']"))
+                .hasType(DOUBLE)
+                .isEqualTo(1.1579207543382391E77);
+        assertThat(assertions.function("dot_product", "ARRAY[REAL '3.4028235e+38f']", "ARRAY[REAL '-3.4028235e+38f']"))
+                .hasType(DOUBLE)
+                .isEqualTo(-1.1579207543382391E77);
+        assertThat(assertions.function("dot_product", "ARRAY[REAL '-3.4028235e+38f']", "ARRAY[REAL '3.4028235e+38f']"))
+                .hasType(DOUBLE)
+                .isEqualTo(-1.1579207543382391E77);
+        assertThat(assertions.function("dot_product", "ARRAY[REAL '1.4E-45']", "ARRAY[REAL '1.4E-45']"))
+                .hasType(DOUBLE)
+                .isEqualTo(1.9636373861190906E-90);
+        assertThat(assertions.function("dot_product", "ARRAY[REAL '-1.4E-45']", "ARRAY[REAL '-1.4E-45']"))
+                .hasType(DOUBLE)
+                .isEqualTo(1.9636373861190906E-90);
+        assertThat(assertions.function("dot_product", "ARRAY[REAL '1.4E-45']", "ARRAY[REAL '-1.4E-45']"))
+                .hasType(DOUBLE)
+                .isEqualTo(-1.9636373861190906E-90);
+        assertThat(assertions.function("dot_product", "ARRAY[REAL '-1.4E-45']", "ARRAY[REAL '1.4E-45']"))
+                .hasType(DOUBLE)
+                .isEqualTo(-1.9636373861190906E-90);
+        assertThat(assertions.function("dot_product", "ARRAY[REAL '3.4028235e+38f']", "ARRAY[REAL '1.4E-45']"))
+                .hasType(DOUBLE)
+                .isEqualTo(4.7683712978141557E-7);
+        assertThat(assertions.function("dot_product", "ARRAY[REAL '1.4E-45']", "ARRAY[REAL '3.4028235e+38f']"))
+                .hasType(DOUBLE)
+                .isEqualTo(4.7683712978141557E-7);
+
+        // double type's min and max
+        assertThat(assertions.function("dot_product", "ARRAY[DOUBLE '1.7976931348623157E+309']", "ARRAY[DOUBLE '1.7976931348623157E+309']"))
+                .hasType(DOUBLE)
+                .isEqualTo(POSITIVE_INFINITY);
+        assertThat(assertions.function("dot_product", "ARRAY[DOUBLE '-1.7976931348623157E+308']", "ARRAY[DOUBLE '-1.7976931348623157E+308']"))
+                .hasType(DOUBLE)
+                .isEqualTo(POSITIVE_INFINITY);
+        assertThat(assertions.function("dot_product", "ARRAY[DOUBLE '1.7976931348623157E+309']", "ARRAY[DOUBLE '-1.7976931348623157E+308']"))
+                .hasType(DOUBLE)
+                .isEqualTo(NEGATIVE_INFINITY);
+        assertThat(assertions.function("dot_product", "ARRAY[DOUBLE '-1.7976931348623157E+308']", "ARRAY[DOUBLE '1.7976931348623157E+309']"))
+                .hasType(DOUBLE)
+                .isEqualTo(NEGATIVE_INFINITY);
+
+        // NaN and infinity
+        assertThat(assertions.function("dot_product", "ARRAY[1]", "ARRAY[nan()]"))
+                .hasType(DOUBLE)
+                .isEqualTo(NaN);
+        assertThat(assertions.function("dot_product", "ARRAY[nan()]", "ARRAY[1]"))
+                .hasType(DOUBLE)
+                .isEqualTo(NaN);
+        assertThat(assertions.function("dot_product", "ARRAY[1]", "ARRAY[-infinity()]"))
+                .hasType(DOUBLE)
+                .isEqualTo(NEGATIVE_INFINITY);
+        assertThat(assertions.function("dot_product", "ARRAY[-infinity()]", "ARRAY[1]"))
+                .hasType(DOUBLE)
+                .isEqualTo(NEGATIVE_INFINITY);
+        assertThat(assertions.function("dot_product", "ARRAY[1]", "ARRAY[+infinity()]"))
+                .hasType(DOUBLE)
+                .isEqualTo(POSITIVE_INFINITY);
+        assertThat(assertions.function("dot_product", "ARRAY[infinity()]", "ARRAY[1]"))
+                .hasType(DOUBLE)
+                .isEqualTo(POSITIVE_INFINITY);
+
+        assertTrinoExceptionThrownBy(assertions.function("dot_product", "ARRAY[]", "ARRAY[1]")::evaluate)
+                .hasMessage("The arguments must have the same length");
+        assertTrinoExceptionThrownBy(assertions.function("dot_product", "ARRAY[1]", "ARRAY[]")::evaluate)
+                .hasMessage("The arguments must have the same length");
+        assertTrinoExceptionThrownBy(assertions.function("dot_product", "ARRAY[1]", "ARRAY[1, 2]")::evaluate)
+                .hasMessage("The arguments must have the same length");
+        assertTrinoExceptionThrownBy(assertions.function("dot_product", "ARRAY[1, 2]", "ARRAY[1]")::evaluate)
+                .hasMessage("The arguments must have the same length");
+    }
+
+    @Test
+    void testCosineDistance()
+    {
+        assertThat(assertions.function("cosine_distance", "ARRAY[1]", "ARRAY[2]"))
+                .hasType(DOUBLE)
+                .isEqualTo(0.0);
+        assertThat(assertions.function("cosine_distance", "ARRAY[1, 2]", "ARRAY[3, 4]"))
+                .hasType(DOUBLE)
+                .isEqualTo(0.01613008990009257);
+        assertThat(assertions.function("cosine_distance", "ARRAY[REAL '1.1', REAL '2.2', REAL '3.3']", "ARRAY[REAL '4.4', REAL '5.5', REAL '6.6']"))
+                .hasType(DOUBLE)
+                .isEqualTo(0.025368154060122383);
+        assertThat(assertions.function("cosine_distance", "ARRAY[DOUBLE '1.1', DOUBLE '2.2', DOUBLE '3.3']", "ARRAY[DOUBLE '4.4', DOUBLE '5.5', DOUBLE '6.6']"))
+                .hasType(DOUBLE)
+                .isEqualTo(0.025368153802923676);
+        assertThat(assertions.function("cosine_distance", "ARRAY[1.1, 2.2, 3.3]", "ARRAY[4.4, 5.5, 6.6]"))
+                .hasType(DOUBLE)
+                .isEqualTo(0.025368153802923676);
+
+        // real type's min and max
+        assertThat(assertions.function("cosine_distance", "ARRAY[REAL '3.4028235e+38f']", "ARRAY[REAL '3.4028235e+38f']"))
+                .hasType(DOUBLE)
+                .isEqualTo(0.0);
+        assertThat(assertions.function("cosine_distance", "ARRAY[REAL '-3.4028235e+38f']", "ARRAY[REAL '-3.4028235e+38f']"))
+                .hasType(DOUBLE)
+                .isEqualTo(0.0);
+        assertThat(assertions.function("cosine_distance", "ARRAY[REAL '3.4028235e+38f']", "ARRAY[REAL '-3.4028235e+38f']"))
+                .hasType(DOUBLE)
+                .isEqualTo(2.0);
+        assertThat(assertions.function("cosine_distance", "ARRAY[REAL '-3.4028235e+38f']", "ARRAY[REAL '3.4028235e+38f']"))
+                .hasType(DOUBLE)
+                .isEqualTo(2.0);
+        assertThat(assertions.function("cosine_distance", "ARRAY[REAL '1.4E-45']", "ARRAY[REAL '1.4E-45']"))
+                .hasType(DOUBLE)
+                .isEqualTo(0.0);
+        assertThat(assertions.function("cosine_distance", "ARRAY[REAL '-1.4E-45']", "ARRAY[REAL '-1.4E-45']"))
+                .hasType(DOUBLE)
+                .isEqualTo(0.0);
+        assertThat(assertions.function("cosine_distance", "ARRAY[REAL '1.4E-45']", "ARRAY[REAL '-1.4E-45']"))
+                .hasType(DOUBLE)
+                .isEqualTo(2.0);
+        assertThat(assertions.function("cosine_distance", "ARRAY[REAL '-1.4E-45']", "ARRAY[REAL '1.4E-45']"))
+                .hasType(DOUBLE)
+                .isEqualTo(2.0);
+        assertThat(assertions.function("cosine_distance", "ARRAY[REAL '3.4028235e+38f']", "ARRAY[REAL '1.4E-45']"))
+                .hasType(DOUBLE)
+                .isEqualTo(0.0);
+        assertThat(assertions.function("cosine_distance", "ARRAY[REAL '1.4E-45']", "ARRAY[REAL '3.4028235e+38f']"))
+                .hasType(DOUBLE)
+                .isEqualTo(0.0);
+
+        // double type's min and max
+        assertThat(assertions.function("cosine_distance", "ARRAY[DOUBLE '1.7976931348623157E+309']", "ARRAY[DOUBLE '1.7976931348623157E+309']"))
+                .hasType(DOUBLE)
+                .isEqualTo(NaN);
+        assertThat(assertions.function("cosine_distance", "ARRAY[DOUBLE '-1.7976931348623157E+308']", "ARRAY[DOUBLE '-1.7976931348623157E+308']"))
+                .hasType(DOUBLE)
+                .isEqualTo(NaN);
+        assertThat(assertions.function("cosine_distance", "ARRAY[DOUBLE '1.7976931348623157E+309']", "ARRAY[DOUBLE '-1.7976931348623157E+308']"))
+                .hasType(DOUBLE)
+                .isEqualTo(NaN);
+        assertThat(assertions.function("cosine_distance", "ARRAY[DOUBLE '-1.7976931348623157E+308']", "ARRAY[DOUBLE '1.7976931348623157E+309']"))
+                .hasType(DOUBLE)
+                .isEqualTo(NaN);
+
+        // NaN and infinity
+        assertThat(assertions.function("cosine_distance", "ARRAY[1]", "ARRAY[nan()]"))
+                .hasType(DOUBLE)
+                .isEqualTo(NaN);
+        assertThat(assertions.function("cosine_distance", "ARRAY[nan()]", "ARRAY[1]"))
+                .hasType(DOUBLE)
+                .isEqualTo(NaN);
+        assertThat(assertions.function("cosine_distance", "ARRAY[1]", "ARRAY[-infinity()]"))
+                .hasType(DOUBLE)
+                .isEqualTo(NaN);
+        assertThat(assertions.function("cosine_distance", "ARRAY[-infinity()]", "ARRAY[1]"))
+                .hasType(DOUBLE)
+                .isEqualTo(NaN);
+        assertThat(assertions.function("cosine_distance", "ARRAY[1]", "ARRAY[infinity()]"))
+                .hasType(DOUBLE)
+                .isEqualTo(NaN);
+        assertThat(assertions.function("cosine_distance", "ARRAY[infinity()]", "ARRAY[1]"))
+                .hasType(DOUBLE)
+                .isEqualTo(NaN);
+
+        assertTrinoExceptionThrownBy(assertions.function("cosine_distance", "ARRAY[]", "ARRAY[]")::evaluate)
+                .hasMessage("Vector magnitude cannot be zero");
+        assertTrinoExceptionThrownBy(assertions.function("cosine_distance", "ARRAY[]", "ARRAY[1]")::evaluate)
+                .hasMessage("The arguments must have the same length");
+        assertTrinoExceptionThrownBy(assertions.function("cosine_distance", "ARRAY[1]", "ARRAY[]")::evaluate)
+                .hasMessage("The arguments must have the same length");
+        assertTrinoExceptionThrownBy(assertions.function("cosine_distance", "ARRAY[1]", "ARRAY[1, 2]")::evaluate)
+                .hasMessage("The arguments must have the same length");
+        assertTrinoExceptionThrownBy(assertions.function("cosine_distance", "ARRAY[1, 2]", "ARRAY[1]")::evaluate)
+                .hasMessage("The arguments must have the same length");
+    }
+}

--- a/docs/src/main/sphinx/functions/array.md
+++ b/docs/src/main/sphinx/functions/array.md
@@ -392,6 +392,33 @@ SELECT transform(ARRAY[ARRAY[1, NULL, 2], ARRAY[3, NULL]],
 ```
 :::
 
+:::{function} euclidean_distance(array(double), array(double)) -> double
+Calculates the euclidean distance:
+
+```sql
+SELECT euclidean_distance(ARRAY[1.0, 2.0], ARRAY[3.0, 4.0]);
+-- 2.8284271247461903
+```
+:::
+
+:::{function} dot_product(array(double), array(double)) -> double
+Calculates the dot product:
+
+```sql
+SELECT dot_product(ARRAY[1.0, 2.0], ARRAY[3.0, 4.0]);
+-- 11.0
+```
+:::
+
+:::{function} cosine_distance(array(double), array(double)) -> double
+Calculates the cosine distance:
+
+```sql
+SELECT cosine_distance(ARRAY[1.0, 2.0], ARRAY[3.0, 4.0]);
+-- 0.01613008990009257
+```
+:::
+
 :::{function} zip(array1, array2[, ...]) -> array(row)
 Merges the given arrays, element-wise, into a single array of rows. The M-th element of
 the N-th argument will be the N-th field of the M-th output element.


### PR DESCRIPTION
## Description

Adds 3 functions calculating distance:
* euclidean_distance
* dot_product
* cosine_distance

## Release notes

```markdown
# General
* Add support for `euclidean_distance`, `dot_product` and `cosine_distance` functions. ({issue}`22397`)
```
