### PR TITLE
Clarify the default value of iceberg.catalog.type in Iceberg docs

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -51,12 +51,10 @@ To configure the Iceberg connector, create a catalog properties file
 `etc/catalog/example.properties` that references the `iceberg`
 connector and defines a metastore type. The Hive metastore catalog is the
 default implementation. To use a {ref}`Hive metastore <hive-thrift-metastore>`,
-`iceberg.catalog.type` must be set to `hive_metastore` and
 `hive.metastore.uri` must be configured:
 
 ```properties
 connector.name=iceberg
-iceberg.catalog.type=hive_metastore
 hive.metastore.uri=thrift://example.net:9083
 ```
 
@@ -85,7 +83,7 @@ implementation is used:
     * `rest`
     * `nessie`
     * `snowflake`
-  -
+  - `hive_metastore`
 * - `iceberg.file-format`
   - Define the data storage file format for Iceberg tables. Possible values are:
 

--- a/docs/src/main/sphinx/object-storage/metastores.md
+++ b/docs/src/main/sphinx/object-storage/metastores.md
@@ -46,7 +46,7 @@ are also available. They are discussed later in this topic.
     You must set this property in all Iceberg catalog property files. Valid
     values are `hive_metastore`, `glue`, `jdbc`, `rest`, `nessie`, and
     `snowflake`.
-  -
+  - `hive_metastore`
 * - `hive.metastore-cache.cache-partitions`
   - Enable caching for partition metadata. You can disable caching to avoid
     inconsistent behavior that results from it.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
The default value of `iceberg.catalog.type` is `hive_metastore` but it isn't mentioned in the docs clearly.
https://github.com/trinodb/trino/blob/7a863b30c1448024feb92bbd6119943d977f80b5/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java#L59

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
