### PR TITLE
Add storage api support for reading table for query function in bigquery

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
@@ -20,6 +20,7 @@ import com.google.cloud.bigquery.Dataset;
 import com.google.cloud.bigquery.DatasetId;
 import com.google.cloud.bigquery.DatasetInfo;
 import com.google.cloud.bigquery.Job;
+import com.google.cloud.bigquery.JobConfiguration;
 import com.google.cloud.bigquery.JobException;
 import com.google.cloud.bigquery.JobInfo;
 import com.google.cloud.bigquery.JobStatistics;
@@ -397,6 +398,36 @@ public class BigQueryClient
         }
 
         return requireNonNull(queryStatistics.getSchema(), "Cannot determine schema for query");
+    }
+
+    public boolean useStorageApi(String sql, TableId destinationTable)
+    {
+        JobInfo jobInfo = JobInfo.of(QueryJobConfiguration.newBuilder(sql).setDryRun(true).setDestinationTable(destinationTable).build());
+        try {
+            bigQuery.create(jobInfo);
+        }
+        catch (BigQueryException e) {
+            if (e.getMessage().startsWith("Duplicate column names in the result are not supported when a destination table is present.")) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public TableId getDestinationTable(String sql)
+    {
+        log.debug("Get destination table from query: %s", sql);
+        JobInfo jobInfo = JobInfo.of(QueryJobConfiguration.newBuilder(sql).setDryRun(true).build());
+
+        JobConfiguration jobConfiguration;
+        try {
+            jobConfiguration = bigQuery.create(jobInfo).getConfiguration();
+        }
+        catch (BigQueryException e) {
+            throw new TrinoException(BIGQUERY_INVALID_STATEMENT, "Failed to get destination table for query. " + firstNonNull(e.getMessage(), e), e);
+        }
+
+        return requireNonNull(((QueryJobConfiguration) jobConfiguration).getDestinationTable(), "Cannot determine destination table for query");
     }
 
     public static String selectSql(TableId table, List<String> requiredColumns, Optional<String> filter)

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryQueryRelationHandle.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryQueryRelationHandle.java
@@ -19,16 +19,21 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 
 public class BigQueryQueryRelationHandle
         extends BigQueryRelationHandle
 {
     private final String query;
+    private final RemoteTableName destinationTableName;
+    private final boolean useStorageApi;
 
     @JsonCreator
-    public BigQueryQueryRelationHandle(String query)
+    public BigQueryQueryRelationHandle(String query, RemoteTableName destinationTableName, boolean useStorageApi)
     {
         this.query = query;
+        this.destinationTableName = requireNonNull(destinationTableName, "destinationTableName is null");
+        this.useStorageApi = useStorageApi;
     }
 
     @JsonProperty
@@ -37,10 +42,22 @@ public class BigQueryQueryRelationHandle
         return query;
     }
 
+    @JsonProperty
+    public RemoteTableName getDestinationTableName()
+    {
+        return destinationTableName;
+    }
+
+    @JsonProperty
+    public boolean isUseStorageApi()
+    {
+        return useStorageApi;
+    }
+
     @Override
     public String toString()
     {
-        return format("Query[%s]", query);
+        return format("Query[%s], Destination table[%s], Api[%s]", query, destinationTableName, useStorageApi ? "Storage" : "Rest");
     }
 
     @Override
@@ -53,12 +70,14 @@ public class BigQueryQueryRelationHandle
             return false;
         }
         BigQueryQueryRelationHandle that = (BigQueryQueryRelationHandle) o;
-        return query.equals(that.query);
+        return query.equals(that.query)
+                && destinationTableName.equals(that.destinationTableName)
+                && useStorageApi == that.useStorageApi;
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(query);
+        return Objects.hash(query, destinationTableName, useStorageApi);
     }
 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitManager.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitManager.java
@@ -16,6 +16,7 @@ package io.trino.plugin.bigquery;
 import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.TableDefinition;
 import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.TableResult;
 import com.google.cloud.bigquery.storage.v1.ReadSession;
 import com.google.common.annotations.VisibleForTesting;
@@ -104,9 +105,37 @@ public class BigQuerySplitManager
         TupleDomain<ColumnHandle> tableConstraint = bigQueryTableHandle.constraint();
         Optional<String> filter = BigQueryFilterQueryBuilder.buildFilter(tableConstraint);
 
-        if (!bigQueryTableHandle.isNamedRelation()) {
+        if (bigQueryTableHandle.isQueryRelation()) {
+            BigQueryQueryRelationHandle bigQueryQueryRelationHandle = bigQueryTableHandle.getRequiredQueryRelation();
             List<BigQueryColumnHandle> columns = bigQueryTableHandle.projectedColumns().orElse(ImmutableList.of());
-            return new FixedSplitSource(BigQuerySplit.forViewStream(columns, filter));
+            boolean useStorageApi = bigQueryQueryRelationHandle.isUseStorageApi();
+            List<String> projectedColumnsNames = getProjectedColumnNames(columns);
+
+            // projectedColumnsNames can not be used for generating select sql because the query fails if it does not
+            // include a column name. eg: query => 'SELECT 1'
+            String query = filter
+                    .map(whereClause -> "SELECT * FROM (" + bigQueryQueryRelationHandle.getQuery() + " ) WHERE " + whereClause)
+                    .orElseGet(bigQueryQueryRelationHandle::getQuery);
+
+            if (emptyProjectionIsRequired(bigQueryTableHandle.projectedColumns())) {
+                String sql = "SELECT COUNT(*) FROM (" + query + ")";
+                return new FixedSplitSource(createEmptyProjection(session, sql));
+            }
+
+            if (!useStorageApi) {
+                log.debug("Using Rest API for running query: %s", query);
+                return new FixedSplitSource(BigQuerySplit.forViewStream(columns, filter));
+            }
+
+            TableId destinationTable = bigQueryQueryRelationHandle.getDestinationTableName().toTableId();
+            TableInfo tableInfo = new ViewMaterializationCache.DestinationTableBuilder(bigQueryClientFactory.create(session), viewExpiration, query, destinationTable).get();
+
+            log.debug("Using Storage API for running query: %s", query);
+            // filter is already used while constructing the select query
+            ReadSession readSession = createReadSession(session, tableInfo.getTableId(), ImmutableList.copyOf(projectedColumnsNames), Optional.empty());
+            return new FixedSplitSource(readSession.getStreamsList().stream()
+                    .map(stream -> BigQuerySplit.forStream(stream.getName(), getSchemaAsString(readSession), columns, OptionalInt.of(stream.getSerializedSize())))
+                    .collect(toImmutableList()));
         }
 
         TableId remoteTableId = bigQueryTableHandle.asPlainTable().getRemoteTableName().toTableId();
@@ -134,7 +163,7 @@ public class BigQuerySplitManager
 
         log.debug("readFromBigQuery(tableId=%s, projectedColumns=%s, filter=[%s])", remoteTableId, projectedColumns, filter);
         List<BigQueryColumnHandle> columns = projectedColumns.get();
-        List<String> projectedColumnsNames = new ArrayList<>(columns.stream().map(BigQueryColumnHandle::name).toList());
+        List<String> projectedColumnsNames = new ArrayList<>(getProjectedColumnNames(columns));
 
         if (isWildcardTable(type, remoteTableId.getTable())) {
             // Storage API doesn't support reading wildcard tables
@@ -168,18 +197,28 @@ public class BigQuerySplitManager
         return readSessionCreator.create(session, remoteTableId, projectedColumnsNames, filter, nodeManager.getRequiredWorkerNodes().size());
     }
 
+    private static List<String> getProjectedColumnNames(List<BigQueryColumnHandle> columns)
+    {
+        return columns.stream().map(BigQueryColumnHandle::name).collect(toImmutableList());
+    }
+
     private List<BigQuerySplit> createEmptyProjection(ConnectorSession session, TableDefinition.Type tableType, TableId remoteTableId, Optional<String> filter)
     {
         if (!TABLE_TYPES.contains(tableType)) {
             throw new TrinoException(NOT_SUPPORTED, "Unsupported table type: " + tableType);
         }
 
+        // Note that we cannot use row count from TableInfo because for writes via insertAll/streaming API the number is incorrect until the streaming buffer is flushed
+        // (and there's no mechanism to trigger an on-demand flush). This can lead to incorrect results for queries with empty projections.
+        String sql = selectSql(remoteTableId, "COUNT(*)", filter);
+        return createEmptyProjection(session, sql);
+    }
+
+    private List<BigQuerySplit> createEmptyProjection(ConnectorSession session, String sql)
+    {
         BigQueryClient client = bigQueryClientFactory.create(session);
-        log.debug("createEmptyProjection(tableId=%s, filter=[%s])", remoteTableId, filter);
+        log.debug("createEmptyProjection(sql=%s)", sql);
         try {
-            // Note that we cannot use row count from TableInfo because for writes via insertAll/streaming API the number is incorrect until the streaming buffer is flushed
-            // (and there's no mechanism to trigger an on-demand flush). This can lead to incorrect results for queries with empty projections.
-            String sql = selectSql(remoteTableId, "COUNT(*)", filter);
             TableResult result = client.executeQuery(session, sql);
             long numberOfRows = getOnlyElement(getOnlyElement(result.iterateAll())).getLongValue();
 

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTableHandle.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTableHandle.java
@@ -49,6 +49,13 @@ public record BigQueryTableHandle(
     }
 
     @JsonIgnore
+    public BigQueryQueryRelationHandle getRequiredQueryRelation()
+    {
+        checkState(isQueryRelation(), "The table handle does not represent a query relation: %s", this);
+        return (BigQueryQueryRelationHandle) relationHandle;
+    }
+
+    @JsonIgnore
     public boolean isSynthetic()
     {
         return !isNamedRelation();
@@ -58,6 +65,12 @@ public record BigQueryTableHandle(
     public boolean isNamedRelation()
     {
         return relationHandle instanceof BigQueryNamedRelationHandle;
+    }
+
+    @JsonIgnore
+    public boolean isQueryRelation()
+    {
+        return relationHandle instanceof BigQueryQueryRelationHandle;
     }
 
     public BigQueryNamedRelationHandle asPlainTable()

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ViewMaterializationCache.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ViewMaterializationCache.java
@@ -76,7 +76,7 @@ public class ViewMaterializationCache
         return TableId.of(project, dataset, name);
     }
 
-    private static class DestinationTableBuilder
+    public static class DestinationTableBuilder
             implements Supplier<TableInfo>
     {
         private final BigQueryClient bigQueryClient;

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ptf/Query.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ptf/Query.java
@@ -16,6 +16,7 @@ package io.trino.plugin.bigquery.ptf;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.TableId;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
@@ -27,6 +28,7 @@ import io.trino.plugin.bigquery.BigQueryColumnHandle;
 import io.trino.plugin.bigquery.BigQueryQueryRelationHandle;
 import io.trino.plugin.bigquery.BigQueryTableHandle;
 import io.trino.plugin.bigquery.BigQueryTypeManager;
+import io.trino.plugin.bigquery.RemoteTableName;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorSession;
@@ -48,10 +50,14 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.plugin.bigquery.ViewMaterializationCache.TEMP_TABLE_PREFIX;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.function.table.ReturnTypeSpecification.GenericTable.GENERIC_TABLE;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
+import static java.util.UUID.randomUUID;
 import static java.util.stream.Collectors.toList;
 
 public class Query
@@ -107,9 +113,11 @@ public class Query
             String query = ((Slice) argument.getValue()).toStringUtf8();
 
             BigQueryClient client = clientFactory.create(session);
+            TableId destinationTable = buildDestinationTable(client.getDestinationTable(query));
+            boolean useStorageApi = client.useStorageApi(query, destinationTable);
             Schema schema = client.getSchema(query);
 
-            BigQueryQueryRelationHandle queryRelationHandle = new BigQueryQueryRelationHandle(query);
+            BigQueryQueryRelationHandle queryRelationHandle = new BigQueryQueryRelationHandle(query, new RemoteTableName(destinationTable), useStorageApi);
             BigQueryTableHandle tableHandle = new BigQueryTableHandle(queryRelationHandle, TupleDomain.all(), Optional.empty());
 
             ImmutableList.Builder<BigQueryColumnHandle> columnsBuilder = ImmutableList.builderWithExpectedSize(schema.getFields().size());
@@ -132,6 +140,15 @@ public class Query
                     .handle(handle)
                     .build();
         }
+    }
+
+    private static TableId buildDestinationTable(TableId remoteTableId)
+    {
+        String project = remoteTableId.getProject();
+        String dataset = remoteTableId.getDataset();
+
+        String name = format("%s%s", TEMP_TABLE_PREFIX, randomUUID().toString().toLowerCase(ENGLISH).replace("-", ""));
+        return TableId.of(project, dataset, name);
     }
 
     public static class QueryHandle

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
@@ -983,6 +983,16 @@ public abstract class BaseBigQueryConnectorTest
     }
 
     @Test
+    public void testNativeQueryWithCount()
+    {
+        assertThat(query("SELECT COUNT(*) FROM TABLE(bigquery.system.query(query => 'SELECT 1'))"))
+                .matches("VALUES BIGINT '1'");
+
+        assertThat(query("SELECT COUNT(*) FROM TABLE(bigquery.system.query(query => 'SELECT * FROM tpch.nation'))"))
+                .matches("VALUES BIGINT '25'");
+    }
+
+    @Test
     public void testNativeQueryColumnAliasNotFound()
     {
         assertQueryFails(
@@ -1042,7 +1052,7 @@ public abstract class BaseBigQueryConnectorTest
         assertThat(getQueryRunner().tableExists(getSession(), tableName)).isFalse();
         assertThat(query("SELECT * FROM TABLE(bigquery.system.query(query => 'INSERT INTO test." + tableName + " VALUES (1)'))"))
                 .failure()
-                .hasMessageContaining("Failed to get schema for query")
+                .hasMessageContaining("Failed to get destination table for query")
                 .hasStackTraceContaining("%s was not found", tableName);
     }
 
@@ -1064,7 +1074,7 @@ public abstract class BaseBigQueryConnectorTest
     public void testNativeQueryIncorrectSyntax()
     {
         assertThat(query("SELECT * FROM TABLE(system.query(query => 'some wrong syntax'))"))
-                .failure().hasMessageContaining("Failed to get schema for query");
+                .failure().hasMessageContaining("Failed to get destination table for query");
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This PR now uses the storage api to execute native bigquery query.

~This PR adds an optional parameter `mode` for BigQuery query table function, which indicates which api should be used to run the native bigquery query.~

~By default when mode is not provided It will use `REST_API` to run the native bigquery query.~

~Parameter `mode` can be set as~

~1. `REST_API` (More Details: https://cloud.google.com/bigquery/docs/reference/rest)~
~2. `STORAGE_API` (More Details: https://cloud.google.com/bigquery/docs/reference/storage).~

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

While implementing this feature, we see that when native query result set is small then the `REST_API` performs better than `STORAGE_API`. But when native query result set is large then the `STORAGE_API` performs better than `REST_API`.
~
Here are some numbers:

```
--------------------------------------------------------------------------------------
When the Table has just one single row and calling select on the table 5 times, Then
--------------------------------------------------------------------------------------

testNativeQuerySelectForCaseSensitiveColumnNames (WITH Storage API)
2024-05-20T03:23:59.413-0600 INFO ForkJoinPool-1-worker-1 stdout Time taken in seconds: 48

testNativeQuerySelectForCaseSensitiveColumnNames (With Rest API)
2024-05-20T06:07:00.375-0600 INFO ForkJoinPool-1-worker-1 stdout Time taken in seconds: 20

--------------------------------------------------------------------------------------
When the Table has ~60K row, call select on the table 1 time, Then
--------------------------------------------------------------------------------------
SELECT * FROM lineitem; (WITH Storage API)
2024-05-20T06:17:16.949-0600 INFO ForkJoinPool-1-worker-1 stdout Time taken in seconds: 47

SELECT * FROM lineitem; (With Rest API)
2024-05-20T06:13:18.182-0600 INFO ForkJoinPool-1-worker-1 stdout Time taken in seconds: 141
```

Using Storage API has an overhead of creating a temporary cached table. This approach is similar to how the Materialized view is implemented in Bigquery.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) Release notes are required, with the following suggested text:

```markdown
# Section
* Add storage api support for reading table for query function in bigquery. ({issue}`22432`)
```
