### PR TITLE
Install plugins in testing server before startup completes

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
@@ -268,10 +268,12 @@ public class DistributedQueryRunner
                 SimpleSpanProcessor.create(spanExporter),
                 systemAccessControlConfiguration,
                 systemAccessControls,
-                eventListeners));
+                eventListeners,
+                newServer -> {
+                    functionBundles.forEach(newServer::addFunctions);
+                    plugins.forEach(newServer::installPlugin);
+                }));
         servers.add(server);
-        functionBundles.forEach(server::addFunctions);
-        plugins.forEach(server::installPlugin);
         return server;
     }
 
@@ -297,7 +299,8 @@ public class DistributedQueryRunner
             SpanProcessor spanProcessor,
             Optional<FactoryConfiguration> systemAccessControlConfiguration,
             Optional<List<SystemAccessControl>> systemAccessControls,
-            List<EventListener> eventListeners)
+            List<EventListener> eventListeners,
+            Consumer<TestingTrinoServer> additionalConfiguration)
     {
         long start = System.nanoTime();
         ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.<String, String>builder()
@@ -333,6 +336,7 @@ public class DistributedQueryRunner
                 .setSystemAccessControlConfiguration(systemAccessControlConfiguration)
                 .setSystemAccessControls(systemAccessControls)
                 .setEventListeners(eventListeners)
+                .setAdditionalConfiguration(additionalConfiguration)
                 .build();
 
         String nodeRole = coordinator ? "coordinator" : "worker";


### PR DESCRIPTION
When startup completes (`StartupStatus.startupComplete()`), a worker will accept tasks (`TaskResource.failRequestIfInvalid`). The plugins and functions need to be installed before that happens.

Fixes https://github.com/trinodb/trino/issues/22437 