### PR TITLE
Make AsyncResponse aware of the client disconnection

### DIFF
--- a/core/trino-main/src/main/java/io/trino/dispatcher/QueuedStatementResource.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/QueuedStatementResource.java
@@ -31,6 +31,7 @@ import io.trino.client.StatementStats;
 import io.trino.execution.ExecutionFailureInfo;
 import io.trino.execution.QueryManagerConfig;
 import io.trino.execution.QueryState;
+import io.trino.server.DisconnectionAwareAsyncResponse;
 import io.trino.server.HttpRequestSessionContextFactory;
 import io.trino.server.ServerConfig;
 import io.trino.server.SessionContext;
@@ -46,6 +47,7 @@ import jakarta.annotation.Nullable;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
@@ -54,7 +56,6 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.WebApplicationException;
-import jakarta.ws.rs.container.AsyncResponse;
 import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
@@ -81,9 +82,9 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.util.concurrent.Futures.nonCancellationPropagating;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
-import static io.airlift.jaxrs.AsyncResponseHandler.bindAsyncResponse;
 import static io.trino.execution.QueryState.FAILED;
 import static io.trino.execution.QueryState.QUEUED;
+import static io.trino.server.DisconnectionAwareAsyncResponse.bindDisconnectionAwareAsyncResponse;
 import static io.trino.server.ServletSecurityUtils.authenticatedIdentity;
 import static io.trino.server.ServletSecurityUtils.clearAuthenticatedIdentity;
 import static io.trino.server.protocol.QueryInfoUrlFactory.getQueryInfoUri;
@@ -202,12 +203,12 @@ public class QueuedStatementResource
             @PathParam("token") long token,
             @QueryParam("maxWait") Duration maxWait,
             @Context UriInfo uriInfo,
-            @Suspended AsyncResponse asyncResponse)
+            @Suspended @BeanParam DisconnectionAwareAsyncResponse asyncResponse)
     {
         Query query = getQuery(queryId, slug, token);
 
         ListenableFuture<Response> future = getStatus(query, token, maxWait, uriInfo);
-        bindAsyncResponse(asyncResponse, future, responseExecutor);
+        bindDisconnectionAwareAsyncResponse(asyncResponse, future, responseExecutor);
     }
 
     private ListenableFuture<Response> getStatus(Query query, long token, Duration maxWait, UriInfo uriInfo)

--- a/core/trino-main/src/main/java/io/trino/server/DisconnectionAwareAsyncResponse.java
+++ b/core/trino-main/src/main/java/io/trino/server/DisconnectionAwareAsyncResponse.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.jaxrs.AsyncResponseHandler;
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.AsyncEvent;
+import jakarta.servlet.AsyncListener;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.TimeoutHandler;
+import jakarta.ws.rs.core.Context;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
+import static io.airlift.jaxrs.AsyncResponseHandler.bindAsyncResponse;
+import static java.util.Objects.requireNonNull;
+
+public class DisconnectionAwareAsyncResponse
+        implements AsyncResponse
+{
+    // Guards against calling AsyncResponse methods when client is no longer interested in consuming a response
+    private final AtomicBoolean clientDisconnected = new AtomicBoolean();
+
+    private final AsyncContext asyncContext;
+    private final AsyncResponse delegate;
+    private final AtomicReference<ListenableFuture<?>> cancellableFuture = new AtomicReference<>(null);
+
+    public DisconnectionAwareAsyncResponse(@Context HttpServletRequest request, AsyncResponse delegate)
+    {
+        requireNonNull(request, "request is null");
+        requireNonNull(delegate, "delegate is null");
+        verify(request.isAsyncStarted(), "AsyncContext is not started, did you forget @Suspended?");
+
+        this.delegate = delegate;
+        this.asyncContext = request.getAsyncContext();
+
+        request.getAsyncContext().addListener(new AsyncListener()
+        {
+            @Override
+            public void onComplete(AsyncEvent event) {}
+
+            @Override
+            public void onTimeout(AsyncEvent event) {}
+
+            @Override
+            public void onError(AsyncEvent event)
+            {
+                if (wasRequestTerminated(event.getThrowable())) {
+                    if (clientDisconnected.compareAndSet(false, true)) {
+                        asyncContext.complete();
+                        ListenableFuture<?> future = cancellableFuture.getAndSet(null);
+                        if (future != null) {
+                            future.cancel(true);
+                        }
+                    }
+                }
+            }
+
+            @Override
+            public void onStartAsync(AsyncEvent event) {}
+        });
+    }
+
+    public DisconnectionAwareAsyncResponse withCancellableFuture(ListenableFuture<?> future)
+    {
+        checkState(cancellableFuture.compareAndSet(null, future), "Cancellable future already set");
+        return this;
+    }
+
+    @Override
+    public boolean resume(Object response)
+    {
+        if (clientDisconnected.get()) {
+            return true;
+        }
+        return delegate.resume(response);
+    }
+
+    @Override
+    public boolean resume(Throwable response)
+    {
+        if (clientDisconnected.get()) {
+            return true;
+        }
+        return delegate.resume(response);
+    }
+
+    @Override
+    public boolean cancel()
+    {
+        if (clientDisconnected.get()) {
+            return true;
+        }
+        return delegate.cancel();
+    }
+
+    @Override
+    public boolean cancel(int retryAfter)
+    {
+        if (clientDisconnected.get()) {
+            return true;
+        }
+        return delegate.cancel(retryAfter);
+    }
+
+    @Override
+    public boolean cancel(Date retryAfter)
+    {
+        if (clientDisconnected.get()) {
+            return true;
+        }
+        return delegate.cancel(retryAfter);
+    }
+
+    @Override
+    public boolean isSuspended()
+    {
+        return delegate.isSuspended();
+    }
+
+    @Override
+    public boolean isCancelled()
+    {
+        return delegate.isCancelled();
+    }
+
+    @Override
+    public boolean isDone()
+    {
+        if (clientDisconnected.get()) {
+            return true;
+        }
+        return delegate.isDone();
+    }
+
+    @Override
+    public boolean setTimeout(long time, TimeUnit unit)
+    {
+        return delegate.setTimeout(time, unit);
+    }
+
+    @Override
+    public void setTimeoutHandler(TimeoutHandler handler)
+    {
+        delegate.setTimeoutHandler(handler);
+    }
+
+    @Override
+    public Collection<Class<?>> register(Class<?> callback)
+    {
+        return delegate.register(callback);
+    }
+
+    @Override
+    public Map<Class<?>, Collection<Class<?>>> register(Class<?> callback, Class<?>... callbacks)
+    {
+        return delegate.register(callback, callbacks);
+    }
+
+    @Override
+    public Collection<Class<?>> register(Object callback)
+    {
+        return delegate.register(callback);
+    }
+
+    @Override
+    public Map<Class<?>, Collection<Class<?>>> register(Object callback, Object... callbacks)
+    {
+        return delegate.register(callback, callbacks);
+    }
+
+    private static boolean wasRequestTerminated(Throwable throwable)
+    {
+        // Jetty's detected that client disconnected
+        return throwable instanceof IOException ioException && ioException.getMessage().contains("cancel_stream_error");
+    }
+
+    public static AsyncResponseHandler bindDisconnectionAwareAsyncResponse(DisconnectionAwareAsyncResponse asyncResponse, ListenableFuture<?> futureResponse, Executor httpResponseExecutor)
+    {
+        return bindAsyncResponse(asyncResponse.withCancellableFuture(futureResponse), futureResponse, httpResponseExecutor);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResource.java
@@ -26,12 +26,14 @@ import io.trino.client.ProtocolHeaders;
 import io.trino.exchange.ExchangeManagerRegistry;
 import io.trino.execution.QueryManager;
 import io.trino.operator.DirectExchangeClientSupplier;
+import io.trino.server.DisconnectionAwareAsyncResponse;
 import io.trino.server.ForStatementResource;
 import io.trino.server.ServerConfig;
 import io.trino.server.security.ResourceSecurity;
 import io.trino.spi.QueryId;
 import io.trino.spi.block.BlockEncodingSerde;
 import jakarta.annotation.PreDestroy;
+import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -39,7 +41,6 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.WebApplicationException;
-import jakarta.ws.rs.container.AsyncResponse;
 import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
@@ -56,8 +57,8 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.Threads.threadsNamed;
-import static io.airlift.jaxrs.AsyncResponseHandler.bindAsyncResponse;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static io.trino.server.DisconnectionAwareAsyncResponse.bindDisconnectionAwareAsyncResponse;
 import static io.trino.server.protocol.Slug.Context.EXECUTING_QUERY;
 import static io.trino.server.security.ResourceSecurity.AccessType.PUBLIC;
 import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
@@ -161,7 +162,7 @@ public class ExecutingStatementResource
             @QueryParam("maxWait") Duration maxWait,
             @QueryParam("targetResultSize") DataSize targetResultSize,
             @Context UriInfo uriInfo,
-            @Suspended AsyncResponse asyncResponse)
+            @Suspended @BeanParam DisconnectionAwareAsyncResponse asyncResponse)
     {
         Query query = getQuery(queryId, slug, token);
         asyncQueryResults(query, token, maxWait, targetResultSize, uriInfo, asyncResponse);
@@ -210,7 +211,7 @@ public class ExecutingStatementResource
             Duration maxWait,
             DataSize targetResultSize,
             UriInfo uriInfo,
-            AsyncResponse asyncResponse)
+            DisconnectionAwareAsyncResponse asyncResponse)
     {
         Duration wait = WAIT_ORDERING.min(MAX_WAIT_TIME, maxWait);
         if (targetResultSize == null) {
@@ -223,7 +224,7 @@ public class ExecutingStatementResource
 
         ListenableFuture<Response> response = Futures.transform(queryResultsFuture, this::toResponse, directExecutor());
 
-        bindAsyncResponse(asyncResponse, response, responseExecutor);
+        bindDisconnectionAwareAsyncResponse(asyncResponse, response, responseExecutor);
     }
 
     private Response toResponse(QueryResultsResponse resultsResponse)


### PR DESCRIPTION
With the current Jersey and Jetty implementations @Suspended AsyncResponse can generate a lot of warnings that are caused by the fact that Jetty eagerly recycles request/response objects when the HTTP/2 RST_STREAM frame is sent by the client during request aborting.

We abort in-flight requests for different reasons: either timeout is reached or when the client is closed during cleanup.

For HTTP/1 that doesn't matter, but for HTTP/2 this will cause the AsyncResponse.resume to log an error, since the underlying request/response objects are already recycled and there is no client listening for the response.

This change also cancels Future<?> bound to the AsyncContext since there is no point in processing it anymore.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
