### PR TITLE
Add support for prefix configuration in Iceberg REST catalog

### DIFF
--- a/docs/src/main/sphinx/object-storage/metastores.md
+++ b/docs/src/main/sphinx/object-storage/metastores.md
@@ -475,6 +475,9 @@ following properties:
 * - `iceberg.rest-catalog.uri`
   - REST server API endpoint URI (required). Example:
     `http://iceberg-with-rest:8181`
+* - `iceberg.rest-catalog.prefix`
+  - The prefix for the resource path to use with the REST catalog server (optional).
+    Example: `dev`
 * - `iceberg.rest-catalog.warehouse`
   - Warehouse identifier/location for the catalog (optional). Example:
     `s3://my_bucket/warehouse_location`

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogConfig.java
@@ -35,6 +35,7 @@ public class IcebergRestCatalogConfig
     }
 
     private URI restUri;
+    private Optional<String> prefix = Optional.empty();
     private Optional<String> warehouse = Optional.empty();
     private Security security = Security.NONE;
     private SessionType sessionType = SessionType.NONE;
@@ -53,6 +54,19 @@ public class IcebergRestCatalogConfig
         if (uri != null) {
             this.restUri = URI.create(uri);
         }
+        return this;
+    }
+
+    public Optional<String> getPrefix()
+    {
+        return prefix;
+    }
+
+    @Config("iceberg.rest-catalog.prefix")
+    @ConfigDescription("The prefix for the resource path to use with the REST catalog server")
+    public IcebergRestCatalogConfig setPrefix(String prefix)
+    {
+        this.prefix = Optional.ofNullable(prefix);
         return this;
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
@@ -42,6 +42,7 @@ public class TrinoIcebergRestCatalogFactory
     private final CatalogName catalogName;
     private final String trinoVersion;
     private final URI serverUri;
+    private final Optional<String> prefix;
     private final Optional<String> warehouse;
     private final SessionType sessionType;
     private final boolean vendedCredentialsEnabled;
@@ -67,6 +68,7 @@ public class TrinoIcebergRestCatalogFactory
         this.trinoVersion = requireNonNull(nodeVersion, "nodeVersion is null").toString();
         requireNonNull(restConfig, "restConfig is null");
         this.serverUri = restConfig.getBaseUri();
+        this.prefix = restConfig.getPrefix();
         this.warehouse = restConfig.getWarehouse();
         this.sessionType = restConfig.getSessionType();
         this.vendedCredentialsEnabled = restConfig.isVendedCredentialsEnabled();
@@ -85,6 +87,7 @@ public class TrinoIcebergRestCatalogFactory
             ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
             properties.put(CatalogProperties.URI, serverUri.toString());
             warehouse.ifPresent(location -> properties.put(CatalogProperties.WAREHOUSE_LOCATION, location));
+            prefix.ifPresent(prefix -> properties.put("prefix", prefix));
             properties.put("trino-version", trinoVersion);
             properties.putAll(securityProperties.get());
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogConfig.java
@@ -29,6 +29,7 @@ public class TestIcebergRestCatalogConfig
     {
         assertRecordedDefaults(recordDefaults(IcebergRestCatalogConfig.class)
                 .setBaseUri(null)
+                .setPrefix(null)
                 .setWarehouse(null)
                 .setSessionType(IcebergRestCatalogConfig.SessionType.NONE)
                 .setSecurity(IcebergRestCatalogConfig.Security.NONE)
@@ -40,6 +41,7 @@ public class TestIcebergRestCatalogConfig
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("iceberg.rest-catalog.uri", "http://localhost:1234")
+                .put("iceberg.rest-catalog.prefix", "dev")
                 .put("iceberg.rest-catalog.warehouse", "test_warehouse_identifier")
                 .put("iceberg.rest-catalog.security", "OAUTH2")
                 .put("iceberg.rest-catalog.session", "USER")
@@ -48,6 +50,7 @@ public class TestIcebergRestCatalogConfig
 
         IcebergRestCatalogConfig expected = new IcebergRestCatalogConfig()
                 .setBaseUri("http://localhost:1234")
+                .setPrefix("dev")
                 .setWarehouse("test_warehouse_identifier")
                 .setSessionType(IcebergRestCatalogConfig.SessionType.USER)
                 .setSecurity(IcebergRestCatalogConfig.Security.OAUTH2)


### PR DESCRIPTION
## Description
REST catalog supports a `prefix` in the resource path as per the spec. But it is not exposed from Trino `IcebergRestCatalogConfig`. In Spark, this works by default because they accept generic property bag.

## Additional context and related issues
Iceberg side usage:
https://github.com/apache/iceberg/blob/cbd11d7aa54a3b531f59a5e83411a163f9126a0c/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java#L31


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

```md
# Iceberg
* Add support for specifying a resource [prefix](https://github.com/apache/iceberg/blob/a47937c0c1fcafe57d7dc83551d8c9a3ce0ab1b9/open-api/rest-catalog-open-api.yaml#L1449-L1455) in REST catalog. 
```
