### PR TITLE
Clarify required configuration for fs caching

### DIFF
--- a/docs/src/main/sphinx/object-storage/file-system-cache.md
+++ b/docs/src/main/sphinx/object-storage/file-system-cache.md
@@ -112,16 +112,17 @@ enable and configure caching for the specific catalogs.
     and set the values for `fs.cache.max-sizes` or
     `fs.cache.max-disk-usage-percentages` accordingly.
 * - `fs.cache.max-sizes`
-  - Optional, comma-separated list of maximum [data sizes](prop-type-data-size)
-    for each caching directory. Order of values must be identical to the
-    directories list. Can not be used together with
-    `fs.cache.max-disk-usage-percentages`.
+  - Comma-separated list of maximum [data sizes](prop-type-data-size) for each
+    caching directory. Order of values must be identical to the directories
+    list. Configuring either `fs.cache.max-sizes` or
+    `fs.cache.max-disk-usage-percentages` is required.
 * - `fs.cache.max-disk-usage-percentages`
-  - Optional, comma-separated list of maximum percentage values of the used disk
-    for each directory. Each value is an integer between 1 and 100. Order of
-    values must be identical to the directories list. If multiple directories
-    use the same disk, ensure that total percentages per drive remains below 100
-    percent. Can not be used together with `fs.cache.max-sizes`.
+  - Comma-separated list of maximum percentage values of the used disk for each
+    directory. Each value is an integer between 1 and 100. Order of values must
+    be identical to the directories list. If multiple directories use the same
+    disk, ensure that total percentages per drive remains below 100 percent.
+    Configuring either `fs.cache.max-sizes` or
+    `fs.cache.max-disk-usage-percentages` is required.
 * - `fs.cache.ttl`
   -  The maximum [duration](prop-type-duration) for objects to remain in the cache
      before eviction. Defaults to `7d`. The minimum value of `0s` means that caching


### PR DESCRIPTION
## Description

Reported by Tom Nats on slack

## Additional context and related issues

```
Caused by: IllegalArgumentException: Either fs.cache.max-sizes or fs.cache.max-disk-usage-percentages must be specified
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
