### PR TITLE
Never precalculate stats for LIMIT pushdown

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaMetadata.java
@@ -181,8 +181,7 @@ public class InformationSchemaMetadata
 
         return Optional.of(new LimitApplicationResult<>(
                 new InformationSchemaTableHandle(table.getCatalogName(), table.getTable(), table.getPrefixes(), OptionalLong.of(limit)),
-                true,
-                false));
+                true));
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -1977,8 +1977,7 @@ public final class MetadataManager
         return metadata.applyLimit(connectorSession, table.connectorHandle(), limit)
                 .map(result -> new LimitApplicationResult<>(
                         new TableHandle(catalogHandle, result.getHandle(), table.transaction()),
-                        result.isLimitGuaranteed(),
-                        result.isPrecalculateStatistics()));
+                        result.isLimitGuaranteed()));
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushLimitIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushLimitIntoTableScan.java
@@ -27,7 +27,6 @@ import java.util.Optional;
 
 import static io.trino.SystemSessionProperties.isAllowPushdownIntoConnectors;
 import static io.trino.matching.Capture.newCapture;
-import static io.trino.sql.planner.iterative.rule.Rules.deriveTableStatisticsForPushdown;
 import static io.trino.sql.planner.plan.Patterns.Limit.requiresPreSortedInputs;
 import static io.trino.sql.planner.plan.Patterns.limit;
 import static io.trino.sql.planner.plan.Patterns.source;
@@ -76,11 +75,7 @@ public class PushLimitIntoTableScan
                             tableScan.getOutputSymbols(),
                             tableScan.getAssignments(),
                             tableScan.getEnforcedConstraint(),
-                            deriveTableStatisticsForPushdown(
-                                    context.getStatsProvider(),
-                                    context.getSession(),
-                                    result.isPrecalculateStatistics(),
-                                    result.isLimitGuaranteed() ? limit : tableScan),
+                            Optional.empty(), // calculating stats isn't beneficial for LIMIT
                             tableScan.isUpdateTarget(),
                             // table scan partitioning might have changed with new table handle
                             Optional.empty());

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/LimitApplicationResult.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/LimitApplicationResult.java
@@ -19,17 +19,20 @@ public class LimitApplicationResult<T>
 {
     private final T handle;
     private final boolean limitGuaranteed;
-    private final boolean precalculateStatistics;
 
     /**
-     * @param precalculateStatistics Indicates whether engine should consider calculating statistics based on the plan before pushdown,
-     * as the connector may be unable to provide good table statistics for {@code handle}.
+     * @param precalculateStatistics is no longer used
      */
+    @Deprecated
     public LimitApplicationResult(T handle, boolean limitGuaranteed, boolean precalculateStatistics)
+    {
+        this(handle, limitGuaranteed);
+    }
+
+    public LimitApplicationResult(T handle, boolean limitGuaranteed)
     {
         this.handle = requireNonNull(handle, "handle is null");
         this.limitGuaranteed = limitGuaranteed;
-        this.precalculateStatistics = precalculateStatistics;
     }
 
     public T getHandle()
@@ -44,6 +47,6 @@ public class LimitApplicationResult<T>
 
     public boolean isPrecalculateStatistics()
     {
-        return precalculateStatistics;
+        return false;
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
@@ -775,7 +775,7 @@ public class DefaultJdbcMetadata
                 handle.getAuthorization(),
                 handle.getUpdateAssignments());
 
-        return Optional.of(new LimitApplicationResult<>(handle, jdbcClient.isLimitGuaranteed(session), precalculateStatisticsForPushdown));
+        return Optional.of(new LimitApplicationResult<>(handle, jdbcClient.isLimitGuaranteed(session)));
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcTableStatisticsTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcTableStatisticsTest.java
@@ -219,27 +219,6 @@ public abstract class BaseJdbcTableStatisticsTest
     }
 
     @Test
-    public void testStatsWithLimitPushdown()
-    {
-        // Just limit, should be eligible for pushdown.
-        String query = "SELECT regionkey, nationkey FROM nation LIMIT 2";
-
-        // Verify query can be pushed down, that's the situation we want to test for.
-        // it's important that we test with LIMIT value smaller than table row count, hence need to skip results check
-        assertThat(query(query)).skipResultsCorrectnessCheckForPushdown().isFullyPushedDown();
-
-        assertThat(query("SHOW STATS FOR (" + query + ")"))
-                .result()
-                // Not testing average length and min/max, as this would make the test less reusable and is not that important to test.
-                .exceptColumns("data_size", "low_value", "high_value")
-                .skippingTypesCheck()
-                .matches("VALUES " +
-                        "('regionkey', 2e0, 0e0, null)," +
-                        "('nationkey', 2e0, 0e0, null)," +
-                        "(null, null, null, 2e0)");
-    }
-
-    @Test
     public void testStatsWithTopNPushdown()
     {
         // TopN on a numeric column, should be eligible for pushdown.

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
@@ -503,7 +503,7 @@ public class ElasticsearchMetadata
                 handle.query(),
                 OptionalLong.of(limit));
 
-        return Optional.of(new LimitApplicationResult<>(handle, false, false));
+        return Optional.of(new LimitApplicationResult<>(handle, false));
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -2602,7 +2602,7 @@ public class IcebergMetadata
                 table.getConstraintColumns(),
                 table.getForAnalyze());
 
-        return Optional.of(new LimitApplicationResult<>(table, false, false));
+        return Optional.of(new LimitApplicationResult<>(table, false));
     }
 
     @Override

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduMetadata.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduMetadata.java
@@ -573,6 +573,6 @@ public class KuduMetadata
                 handle.getBucketCount(),
                 OptionalLong.of(limit));
 
-        return Optional.of(new LimitApplicationResult<>(handle, false, false));
+        return Optional.of(new LimitApplicationResult<>(handle, false));
     }
 }

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/BaseMariaDbTableIndexStatisticsTest.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/BaseMariaDbTableIndexStatisticsTest.java
@@ -70,14 +70,6 @@ public abstract class BaseMariaDbTableIndexStatisticsTest
 
     @Test
     @Override
-    public void testStatsWithLimitPushdown()
-    {
-        // TODO (https://github.com/trinodb/trino/issues/11664) implement the test for MariaDB, with permissive approximate assertions
-        abort("Test to be implemented");
-    }
-
-    @Test
-    @Override
     public void testStatsWithTopNPushdown()
     {
         // TODO (https://github.com/trinodb/trino/issues/11664) implement the test for MariaDB, with permissive approximate assertions

--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryMetadata.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryMetadata.java
@@ -520,7 +520,6 @@ public class MemoryMetadata
 
         return Optional.of(new LimitApplicationResult<>(
                 new MemoryTableHandle(table.id(), OptionalLong.of(limit), OptionalDouble.empty()),
-                true,
                 true));
     }
 

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
@@ -618,8 +618,7 @@ public class MongoMetadata
                         handle.constraint(),
                         handle.projectedColumns(),
                         OptionalInt.of(toIntExact(limit))),
-                true,
-                false));
+                true));
     }
 
     @Override

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlTableStatisticsIndexStatisticsTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlTableStatisticsIndexStatisticsTest.java
@@ -69,14 +69,6 @@ public abstract class BaseMySqlTableStatisticsIndexStatisticsTest
 
     @Test
     @Override
-    public void testStatsWithLimitPushdown()
-    {
-        // TODO (https://github.com/trinodb/trino/issues/11664) implement the test for MySQL, with permissive approximate assertions
-        abort("Test to be implemented");
-    }
-
-    @Test
-    @Override
     public void testStatsWithTopNPushdown()
     {
         // TODO (https://github.com/trinodb/trino/issues/11664) implement the test for MySQL, with permissive approximate assertions

--- a/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/OpenSearchMetadata.java
+++ b/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/OpenSearchMetadata.java
@@ -496,7 +496,7 @@ public class OpenSearchMetadata
                 handle.query(),
                 OptionalLong.of(limit));
 
-        return Optional.of(new LimitApplicationResult<>(handle, false, false));
+        return Optional.of(new LimitApplicationResult<>(handle, false));
     }
 
     @Override

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotMetadata.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotMetadata.java
@@ -284,7 +284,7 @@ public class PinotMetadata
                 OptionalLong.of(limit),
                 dynamicTable);
         boolean singleSplit = dynamicTable.isPresent();
-        return Optional.of(new LimitApplicationResult<>(handle, singleSplit, false));
+        return Optional.of(new LimitApplicationResult<>(handle, singleSplit));
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This removes the ability to precalc stats for a LIMIT pushdown. I am unaware of a situation where the stats would be useful for a simple LIMIT pushdown. We could obviously make this specific to sql server only if requested, but I don't see value in this regardless.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This came out of a complaint from a starburst customer. In SQL Server, because the statistics are gathered on a per-column basis, this causes `SELECT * FROM foo LIMIT 3` to be much, much slower than `SELECT * FROM foo`. I attempted to improve the performance of that procedure using `dm_db_stats_histogram`, but this proved to not have all the same information. The only other remediation would be to not precalculate stats for LIMIT pushdown on sql server specifically, but i don't believe a simple limited table scan could possibly benefit from stats, hence this PR to remove it entirely.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
