### PR TITLE
Fix reading empty files from S3 and GCS

### DIFF
--- a/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsUtils.java
+++ b/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsUtils.java
@@ -49,7 +49,7 @@ public class GcsUtils
             throws IOException
     {
         long fileSize = requireNonNull(blob.getSize(), "blob size is null");
-        if (position >= fileSize) {
+        if (position != 0 && position >= fileSize) {
             throw new IOException("Cannot read at %s. File size is %s: %s".formatted(position, fileSize, location));
         }
         // Enable shouldReturnRawInputStream: currently set by default but just to ensure the behavior is predictable

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3InputStream.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3InputStream.java
@@ -196,6 +196,10 @@ final class S3InputStream
                 rangeRequest = request.toBuilder().range(range).build();
             }
             in = client.getObject(rangeRequest);
+            // a workaround for https://github.com/aws/aws-sdk-java-v2/issues/3538
+            if (in.response().contentLength() == 0) {
+                in = new ResponseInputStream<>(in.response(), nullInputStream());
+            }
             streamPosition = nextReadPosition;
         }
         catch (NoSuchKeyException e) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

When reading an empty file from S3 as a stream, using the AWS SDK v2, it
incorrectly keeps reading the MD5 checksum included at the end of the
response. This has been reported upstream as
https://github.com/aws/aws-sdk-java-v2/issues/3538

For GCS, skip the boundary check for empty files.

> [!IMPORTANT]
> This is a follow-up to #22469 that was not tested with all secrets. Run a workflow with all secrets before merging.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
