### PR TITLE
Improve determinism by preserving split order

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/SplitAssignment.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SplitAssignment.java
@@ -22,6 +22,8 @@ import java.util.Set;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.Comparator.comparingLong;
 import static java.util.Objects.requireNonNull;
 
 public class SplitAssignment
@@ -37,7 +39,10 @@ public class SplitAssignment
             @JsonProperty("noMoreSplits") boolean noMoreSplits)
     {
         this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
-        this.splits = ImmutableSet.copyOf(requireNonNull(splits, "splits is null"));
+        // Sort the splits to make sure that the order of scheduling splits is deterministic
+        this.splits = requireNonNull(splits, "splits is null").stream()
+                .sorted(comparingLong(ScheduledSplit::getSequenceId))
+                .collect(toImmutableSet());
         this.noMoreSplits = noMoreSplits;
     }
 

--- a/core/trino-main/src/main/java/io/trino/execution/SqlTaskExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTaskExecution.java
@@ -50,7 +50,7 @@ import jakarta.annotation.Nullable;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -551,7 +551,7 @@ public class SqlTaskExecution
     @NotThreadSafe
     private static class PendingSplitsForPlanNode
     {
-        private Set<ScheduledSplit> splits = new HashSet<>();
+        private Set<ScheduledSplit> splits = new LinkedHashSet<>();
         private SplitsState state = ADDING_SPLITS;
         private boolean noMoreSplits;
 
@@ -581,7 +581,7 @@ public class SqlTaskExecution
         {
             checkState(state == ADDING_SPLITS || state == NO_MORE_SPLITS);
             Set<ScheduledSplit> result = splits;
-            splits = new HashSet<>();
+            splits = new LinkedHashSet<>();
             return result;
         }
 

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeScheduler.java
@@ -13,9 +13,9 @@
  */
 package io.trino.execution.scheduler;
 
-import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -162,7 +162,7 @@ public class NodeScheduler
             List<RemoteTask> existingTasks,
             BucketNodeMap bucketNodeMap)
     {
-        Multimap<InternalNode, Split> assignments = HashMultimap.create();
+        Multimap<InternalNode, Split> assignments = LinkedHashMultimap.create();
         NodeAssignmentStats assignmentStats = new NodeAssignmentStats(nodeTaskMap, nodeMap, existingTasks);
 
         Set<InternalNode> blockedNodes = new HashSet<>();

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/SourcePartitionedScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/SourcePartitionedScheduler.java
@@ -31,7 +31,7 @@ import io.trino.split.SplitSource.SplitBatch;
 import io.trino.sql.planner.plan.PlanNodeId;
 
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -92,7 +92,7 @@ public class SourcePartitionedScheduler
     private final BooleanSupplier anySourceTaskBlocked;
     private final PartitionIdAllocator partitionIdAllocator;
     private final Map<InternalNode, RemoteTask> scheduledTasks;
-    private final Set<Split> pendingSplits = new HashSet<>();
+    private final Set<Split> pendingSplits = new LinkedHashSet<>();
 
     private ListenableFuture<SplitBatch> nextSplitBatchFuture;
     private ListenableFuture<Void> placementFuture = immediateVoidFuture();

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/TopologyAwareNodeSelector.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/TopologyAwareNodeSelector.java
@@ -14,7 +14,7 @@
 package io.trino.execution.scheduler;
 
 import com.google.common.base.Suppliers;
-import com.google.common.collect.HashMultimap;
+import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.log.Logger;
@@ -119,7 +119,7 @@ public class TopologyAwareNodeSelector
     public SplitPlacementResult computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks)
     {
         NodeMap nodeMap = this.nodeMap.get().get();
-        Multimap<InternalNode, Split> assignment = HashMultimap.create();
+        Multimap<InternalNode, Split> assignment = LinkedHashMultimap.create();
         NodeAssignmentStats assignmentStats = new NodeAssignmentStats(nodeTaskMap, nodeMap, existingTasks);
 
         int[] topologicCounters = new int[topologicalSplitCounters.size()];

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/UniformNodeSelector.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/UniformNodeSelector.java
@@ -16,9 +16,9 @@ package io.trino.execution.scheduler;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
 import com.google.common.base.Ticker;
-import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.log.Logger;
@@ -152,7 +152,7 @@ public class UniformNodeSelector
     @Override
     public SplitPlacementResult computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks)
     {
-        Multimap<InternalNode, Split> assignment = HashMultimap.create();
+        Multimap<InternalNode, Split> assignment = LinkedHashMultimap.create();
         NodeMap nodeMap = this.nodeMap.get().get();
         NodeAssignmentStats assignmentStats = new NodeAssignmentStats(nodeTaskMap, nodeMap, existingTasks);
         queueSizeAdjuster.update(existingTasks, assignmentStats);

--- a/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
@@ -15,8 +15,8 @@ package io.trino.server.remotetask;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
-import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.SetMultimap;
 import com.google.common.net.HttpHeaders;
@@ -159,7 +159,7 @@ public final class HttpRemoteTask
     private final AtomicReference<Future<?>> currentRequest = new AtomicReference<>();
 
     @GuardedBy("this")
-    private final SetMultimap<PlanNodeId, ScheduledSplit> pendingSplits = HashMultimap.create();
+    private final SetMultimap<PlanNodeId, ScheduledSplit> pendingSplits = LinkedHashMultimap.create();
     private final int maxUnacknowledgedSplits;
     @GuardedBy("this")
     private volatile int pendingSourceSplitCount;


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

```
In this we improve query execution determinism by
preserving split order when scheduling
in pipeline execution mode.

This is essentially needed such that splits coming out of CacheSplitSource preserve the order
between coordinator and workers. This way we
prevent scheduling two splits with same
CacheSplitId to reuse cache within a query.
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
