### PR TITLE
Add support for `list_files` table function to Hive

### DIFF
--- a/docs/src/main/sphinx/connector/hive.md
+++ b/docs/src/main/sphinx/connector/hive.md
@@ -580,6 +580,36 @@ The following procedures are available:
   Flush Hive metadata cache entries connected with selected partition.
   Procedure requires named parameters to be passed.
 
+## Table functions
+
+The connector provides specific {doc}`table functions </functions/table>` to
+access storages.
+
+(hive-list-files-function)=
+### `list_files(varchar) -> table`
+
+The `list_files` function allows you to list files in the specified location.
+
+For example, query the `example` catalog and list files in the `employees` directory 
+in the `test-bucket` bucket on S3:
+
+```sql
+SELECT
+  *
+FROM
+  TABLE(
+    example.system.list_files(
+      path => 's3://test-bucket/employees'
+    )
+  );
+```
+
+```
+         file_modified_time         | size  |                name
+------------------------------------+-------+-------------------------------------
+ 2024-06-22 16:59:40.300 Asia/Tokyo |   456 | s3://test-bucket/employees/data.orc
+```
+
 (hive-data-management)=
 ### Data management
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveModule.java
@@ -27,6 +27,7 @@ import io.trino.plugin.hive.avro.AvroPageSourceFactory;
 import io.trino.plugin.hive.fs.CachingDirectoryLister;
 import io.trino.plugin.hive.fs.DirectoryLister;
 import io.trino.plugin.hive.fs.TransactionScopeCachingDirectoryListerFactory;
+import io.trino.plugin.hive.functions.ListFilesTableFunction;
 import io.trino.plugin.hive.line.CsvFileWriterFactory;
 import io.trino.plugin.hive.line.CsvPageSourceFactory;
 import io.trino.plugin.hive.line.JsonFileWriterFactory;
@@ -151,7 +152,7 @@ public class HiveModule
         fileWriterFactoryBinder.addBinding().to(ParquetFileWriterFactory.class).in(Scopes.SINGLETON);
 
         newOptionalBinder(binder, FunctionProvider.class).setDefault().toInstance(new NoopFunctionProvider());
-        newSetBinder(binder, ConnectorTableFunction.class);
+        newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(ListFilesTableFunction.class).in(Scopes.SINGLETON);
 
         closingBinder(binder).registerExecutor(ExecutorService.class);
         closingBinder(binder).registerExecutor(Key.get(ScheduledExecutorService.class, ForHiveTransactionHeartbeats.class));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitManager.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitManager.java
@@ -33,6 +33,8 @@ import io.trino.metastore.HiveTypeName;
 import io.trino.metastore.Partition;
 import io.trino.metastore.SortingColumn;
 import io.trino.metastore.Table;
+import io.trino.plugin.hive.functions.HiveListFilesTableHandle;
+import io.trino.plugin.hive.functions.ListFilesSplit;
 import io.trino.plugin.hive.metastore.SemiTransactionalHiveMetastore;
 import io.trino.plugin.hive.util.HiveBucketing.HiveBucketFilter;
 import io.trino.plugin.hive.util.HiveUtil;
@@ -197,6 +199,10 @@ public class HiveSplitManager
             DynamicFilter dynamicFilter,
             Constraint constraint)
     {
+        if (tableHandle instanceof HiveListFilesTableHandle hiveListFunctionTableHandle) {
+            return new FixedSplitSource(new ListFilesSplit(hiveListFunctionTableHandle.path()));
+        }
+
         HiveTableHandle hiveTable = (HiveTableHandle) tableHandle;
         SchemaTableName tableName = hiveTable.getSchemaTableName();
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/functions/HiveListFilesTableHandle.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/functions/HiveListFilesTableHandle.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.functions;
+
+import io.trino.spi.connector.ConnectorTableHandle;
+
+import static java.util.Objects.requireNonNull;
+
+public record HiveListFilesTableHandle(String path)
+        implements ConnectorTableHandle
+{
+    public HiveListFilesTableHandle
+    {
+        requireNonNull(path, "path is null");
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/functions/ListFilesPageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/functions/ListFilesPageSource.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.functions;
+
+import io.trino.filesystem.FileEntry;
+import io.trino.filesystem.FileIterator;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.plugin.hive.HiveColumnHandle;
+import io.trino.spi.Page;
+import io.trino.spi.PageBuilder;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.type.TimeZoneKey;
+import io.trino.spi.type.Type;
+
+import java.io.IOException;
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
+import static io.trino.plugin.hive.functions.ListFilesTableFunction.LIST_FILES_COLUMNS;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.util.Objects.requireNonNull;
+
+public final class ListFilesPageSource
+        implements ConnectorPageSource
+{
+    private static final List<Type> COLUMN_TYPES = LIST_FILES_COLUMNS.stream()
+            .map(column -> ((HiveColumnHandle) column).getType())
+            .collect(toImmutableList());
+
+    private final FileIterator fileIterator;
+    private final TimeZoneKey timeZoneKey;
+    private final long readTimeNanos;
+
+    private boolean done;
+
+    public ListFilesPageSource(TrinoFileSystem fileSystem, String path, TimeZoneKey timeZoneKey)
+    {
+        requireNonNull(fileSystem, "fileSystem is null");
+        requireNonNull(path, "path is null");
+        requireNonNull(timeZoneKey, "timeZoneKey is null");
+
+        long start = System.nanoTime();
+        try {
+            fileIterator = fileSystem.listFiles(Location.of(path));
+        }
+        catch (IOException e) {
+            throw new TrinoException(HIVE_FILESYSTEM_ERROR, "Failed listing files: " + path, e);
+        }
+        this.timeZoneKey = timeZoneKey;
+        readTimeNanos = System.nanoTime() - start;
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getMemoryUsage()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return readTimeNanos;
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return done;
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        if (done) {
+            return null;
+        }
+
+        done = true;
+
+        PageBuilder page = new PageBuilder(COLUMN_TYPES);
+        try {
+            while (fileIterator.hasNext()) {
+                FileEntry status = fileIterator.next();
+                page.declarePosition();
+                BIGINT.writeLong(page.getBlockBuilder(0), packDateTimeWithZone(status.lastModified().toEpochMilli(), timeZoneKey));
+                BIGINT.writeLong(page.getBlockBuilder(1), status.length());
+                VARCHAR.writeSlice(page.getBlockBuilder(2), utf8Slice(status.location().toString()));
+            }
+        }
+        catch (IOException e) {
+            throw new TrinoException(HIVE_FILESYSTEM_ERROR, "Failed listing files", e);
+        }
+        return page.build();
+    }
+
+    @Override
+    public void close() {}
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/functions/ListFilesSplit.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/functions/ListFilesSplit.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.functions;
+
+import io.trino.spi.connector.ConnectorSplit;
+
+import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
+import static java.util.Objects.requireNonNull;
+
+public record ListFilesSplit(String path)
+        implements ConnectorSplit
+{
+    private static final int INSTANCE_SIZE = instanceSize(ListFilesSplit.class);
+
+    public ListFilesSplit
+    {
+        requireNonNull(path, "path is null");
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE
+                + estimatedSizeOf(path);
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/functions/ListFilesTableFunction.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/functions/ListFilesTableFunction.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.functions;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import io.airlift.slice.Slice;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.plugin.hive.HiveColumnHandle;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorAccessControl;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.function.table.AbstractConnectorTableFunction;
+import io.trino.spi.function.table.Argument;
+import io.trino.spi.function.table.ArgumentSpecification;
+import io.trino.spi.function.table.ConnectorTableFunction;
+import io.trino.spi.function.table.ConnectorTableFunctionHandle;
+import io.trino.spi.function.table.Descriptor;
+import io.trino.spi.function.table.ScalarArgument;
+import io.trino.spi.function.table.ScalarArgumentSpecification;
+import io.trino.spi.function.table.TableFunctionAnalysis;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.metastore.HiveType.HIVE_LONG;
+import static io.trino.metastore.HiveType.HIVE_STRING;
+import static io.trino.metastore.HiveType.HIVE_TIMESTAMP;
+import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static io.trino.plugin.hive.HiveColumnHandle.createBaseColumn;
+import static io.trino.plugin.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
+import static io.trino.spi.StandardErrorCode.NOT_FOUND;
+import static io.trino.spi.function.table.ReturnTypeSpecification.GenericTable.GENERIC_TABLE;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.util.Objects.requireNonNull;
+
+public final class ListFilesTableFunction
+        implements Provider<ConnectorTableFunction>
+{
+    public static final List<ColumnHandle> LIST_FILES_COLUMNS = ImmutableList.<ColumnHandle>builder()
+            .add(createBaseColumn("file_modified_time", 1, HIVE_TIMESTAMP, TIMESTAMP_TZ_MILLIS, REGULAR, Optional.empty()))
+            .add(createBaseColumn("size", 2, HIVE_LONG, BIGINT, REGULAR, Optional.empty()))
+            .add(createBaseColumn("location", 3, HIVE_STRING, VARCHAR, REGULAR, Optional.empty()))
+            .build();
+
+    private final TrinoFileSystemFactory fileSystemFactory;
+
+    @Inject
+    public ListFilesTableFunction(TrinoFileSystemFactory fileSystemFactory)
+    {
+        this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
+    }
+
+    @Override
+    public ConnectorTableFunction get()
+    {
+        return new ListFilesFunction(fileSystemFactory);
+    }
+
+    public static class ListFilesFunction
+            extends AbstractConnectorTableFunction
+    {
+        private final TrinoFileSystemFactory fileSystemFactory;
+
+        public ListFilesFunction(TrinoFileSystemFactory fileSystemFactory)
+        {
+            super(
+                    "system",
+                    "list_files",
+                    ImmutableList.<ArgumentSpecification>builder()
+                            .add(ScalarArgumentSpecification.builder()
+                                    .name("PATH")
+                                    .type(VARCHAR)
+                                    .build())
+                            .build(),
+                    GENERIC_TABLE);
+            this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
+        }
+
+        @Override
+        public TableFunctionAnalysis analyze(
+                ConnectorSession session,
+                ConnectorTransactionHandle transaction,
+                Map<String, Argument> arguments,
+                ConnectorAccessControl accessControl)
+        {
+            String pathArgument = ((Slice) ((ScalarArgument) arguments.get("PATH")).getValue()).toStringUtf8();
+            Location path = Location.of(pathArgument);
+
+            TrinoFileSystem fileSystem = fileSystemFactory.create(session);
+            try {
+                if (!fileSystem.directoryExists(path).orElse(false)) {
+                    throw new TrinoException(NOT_FOUND, "Directory not found: " + path);
+                }
+            }
+            catch (IOException e) {
+                throw new TrinoException(HIVE_FILESYSTEM_ERROR, "Failed checking directory path: " + path, e);
+            }
+
+            Descriptor returnedType = new Descriptor(LIST_FILES_COLUMNS.stream()
+                    .map(column -> (HiveColumnHandle) column)
+                    .map(column -> new Descriptor.Field(column.getName(), Optional.of(column.getType())))
+                    .collect(toImmutableList()));
+
+            ListFilesTableFunctionHandle handle = new ListFilesTableFunctionHandle(new HiveListFilesTableHandle(path.toString()));
+
+            return TableFunctionAnalysis.builder()
+                    .returnedType(returnedType)
+                    .handle(handle)
+                    .build();
+        }
+    }
+
+    public record ListFilesTableFunctionHandle(HiveListFilesTableHandle tableHandle)
+            implements ConnectorTableFunctionHandle
+    {
+        public ListFilesTableFunctionHandle
+        {
+            requireNonNull(tableHandle, "tableHandle is null");
+        }
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSink.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSink.java
@@ -353,6 +353,7 @@ public class TestHivePageSink
                 SplitWeight.standard());
         ConnectorTableHandle table = new HiveTableHandle(SCHEMA_NAME, TABLE_NAME, ImmutableMap.of(), ImmutableList.of(), ImmutableList.of(), Optional.empty());
         HivePageSourceProvider provider = new HivePageSourceProvider(
+                HDFS_FILE_SYSTEM_FACTORY,
                 TESTING_TYPE_MANAGER,
                 config,
                 getDefaultHivePageSourceFactories(fileSystemFactory, config));

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestNodeLocalDynamicSplitPruning.java
@@ -46,6 +46,7 @@ import java.util.concurrent.CompletableFuture;
 import static io.trino.metastore.HiveType.HIVE_INT;
 import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
 import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static io.trino.plugin.hive.HiveTestUtils.HDFS_FILE_SYSTEM_FACTORY;
 import static io.trino.plugin.hive.HiveTestUtils.getDefaultHivePageSourceFactories;
 import static io.trino.plugin.hive.util.HiveBucketing.BucketingVersion.BUCKETING_V1;
 import static io.trino.plugin.hive.util.SerdeConstants.SERIALIZATION_LIB;
@@ -157,6 +158,7 @@ class TestNodeLocalDynamicSplitPruning
                 transaction);
 
         HivePageSourceProvider provider = new HivePageSourceProvider(
+                HDFS_FILE_SYSTEM_FACTORY,
                 TESTING_TYPE_MANAGER,
                 hiveConfig,
                 getDefaultHivePageSourceFactories(fileSystemFactory, hiveConfig));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This PR adds `list_files` table function that is similar to [LIST](https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-aux-list.html) statement in Databricks.
This is helpful to inspect file status in the specified location. 

The function takes a `path` argument and returns `file_modified_time`, `size` and `location` columns. 
Example on S3HiveQueryRunner:
```sql
trino:tpch> SELECT * FROM TABLE(system.list_files('s3a://tpch/tpch'));
         file_modified_time         |  size   |                                         location
------------------------------------+---------+-------------------------------------------------------------------------------------------
 2024-06-22 18:21:47.725 Asia/Tokyo |   81477 | s3a://tpch/tpch/customer/20240622_092144_00000_5xpbr_6cbe4d8e-1c8e-44e4-b952-4140689a20a1
 2024-06-22 18:21:50.837 Asia/Tokyo | 1445487 | s3a://tpch/tpch/lineitem/20240622_092150_00007_5xpbr_f031175e-3a34-4fd9-93d3-fdad370e7cfe
 2024-06-22 18:21:53.396 Asia/Tokyo |    1665 | s3a://tpch/tpch/nation/20240622_092153_00019_5xpbr_95c3835c-4c11-40c7-9870-9a934edd4af5
 2024-06-22 18:21:49.589 Asia/Tokyo |  339698 | s3a://tpch/tpch/orders/20240622_092149_00003_5xpbr_d0da6aab-2f6d-49f3-bc72-2e0efe031851
 2024-06-22 18:21:51.706 Asia/Tokyo |   51785 | s3a://tpch/tpch/part/20240622_092151_00010_5xpbr_c7c3883d-3e87-4f5d-8603-bc56f86d4b48
 2024-06-22 18:21:52.351 Asia/Tokyo |  263624 | s3a://tpch/tpch/partsupp/20240622_092152_00013_5xpbr_6844f2a7-588d-4ad0-9668-d2ccef406552
 2024-06-22 18:21:53.791 Asia/Tokyo |     952 | s3a://tpch/tpch/region/20240622_092153_00022_5xpbr_e4879e58-f87b-40ae-9210-57c9b60f5ce2
 2024-06-22 18:21:52.957 Asia/Tokyo |    7004 | s3a://tpch/tpch/supplier/20240622_092152_00016_5xpbr_aa7e388f-f21f-4824-b112-d1b96343a240
(8 rows)
```

## Release notes

```markdown
# Hive
* Add support for `list_files` table function. ({issue}`issuenumber`)
```
