### PR TITLE
Use the actual partition name from the storage in syncing partition metadata

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/SyncPartitionMetadataProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/SyncPartitionMetadataProcedure.java
@@ -45,6 +45,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Sets.difference;
 import static io.trino.plugin.base.util.Procedures.checkProcedureArgument;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
@@ -137,21 +138,61 @@ public class SyncPartitionMetadataProcedure
                 accessControl.checkCanDeleteFromTable(null, new SchemaTableName(schemaName, tableName));
             }
 
-            Location tableLocation = Location.of(table.getStorage().getLocation());
-
-            Set<String> partitionsInMetastore = metastore.getPartitionNames(schemaName, tableName)
+            Set<String> partitionNamesInMetastore = metastore.getPartitionNames(schemaName, tableName)
                     .map(ImmutableSet::copyOf)
                     .orElseThrow(() -> new TableNotFoundException(schemaTableName));
-            Set<String> partitionsInFileSystem = listPartitions(fileSystemFactory.create(session), tableLocation, table.getPartitionColumns(), caseSensitive);
+            String tableStorageLocation = table.getStorage().getLocation();
+            Set<String> canonicalPartitionNamesInMetastore = metastore.getPartitionsByNames(schemaName, tableName, ImmutableList.copyOf(partitionNamesInMetastore))
+                    .values().stream()
+                    .flatMap(Optional::stream) // disregard partitions which disappeared in the meantime since listing the partition names
+                    // Disregard the partitions which do not have a canonical Hive location (e.g. `ALTER TABLE ... ADD PARTITION (...) LOCATION '...'`)
+                    .flatMap(partition -> getCanonicalPartitionName(partition, table.getPartitionColumns(), tableStorageLocation).stream())
+                    .collect(toImmutableSet());
+
+            Set<String> partitionsInFileSystem = listPartitions(fileSystemFactory.create(session), Location.of(tableStorageLocation), table.getPartitionColumns(), caseSensitive);
 
             // partitions in file system but not in metastore
-            Set<String> partitionsToAdd = difference(partitionsInFileSystem, partitionsInMetastore);
+            Set<String> partitionsToAdd = difference(partitionsInFileSystem, canonicalPartitionNamesInMetastore);
 
             // partitions in metastore but not in file system
-            Set<String> partitionsToDrop = difference(partitionsInMetastore, partitionsInFileSystem);
+            Set<String> partitionsToDrop = difference(canonicalPartitionNamesInMetastore, partitionsInFileSystem);
 
             syncPartitions(partitionsToAdd, partitionsToDrop, syncMode, metastore, session, table);
         }
+    }
+
+    private static Optional<String> getCanonicalPartitionName(Partition partition, List<Column> partitionColumns, String tableLocation)
+    {
+        String partitionStorageLocation = partition.getStorage().getLocation();
+        if (!partitionStorageLocation.startsWith(tableLocation)) {
+            return Optional.empty();
+        }
+
+        String partitionName = partitionStorageLocation.substring(tableLocation.length());
+
+        if (partitionName.startsWith("/")) {
+            // Remove eventual forward slash from the name of the partition
+            partitionName = partitionName.replaceFirst("^/+", "");
+        }
+        if (partitionName.endsWith("/")) {
+            // Remove eventual trailing slash from the name of the partition
+            partitionName = partitionName.replaceFirst("/+$", "");
+        }
+
+        // Ensure that the partition location is corresponding to a canonical Hive partition location
+        String[] partitionDirectories = partitionName.split("/");
+        if (partitionDirectories.length != partitionColumns.size()) {
+            return Optional.empty();
+        }
+        for (int i = 0; i < partitionDirectories.length; i++) {
+            String partitionDirectory = partitionDirectories[i];
+            Column column = partitionColumns.get(i);
+            if (!isValidPartitionPath(partitionDirectory, column, false)) {
+                return Optional.empty();
+            }
+        }
+
+        return Optional.of(partitionName);
     }
 
     private static Set<String> listPartitions(TrinoFileSystem fileSystem, Location directory, List<Column> partitionColumns, boolean caseSensitive)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHive3OnDataLake.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHive3OnDataLake.java
@@ -273,6 +273,10 @@ public class TestHive3OnDataLake
         getQueryRunner().execute("CALL system.sync_partition_metadata(schema_name => '" + HIVE_TEST_SCHEMA + "', table_name => '" + tableName + "', mode => 'FULL', case_sensitive => false)");
         assertQuery("SELECT * FROM " + fullyQualifiedTestTableName, "VALUES ('Trino', 'rocks', 'part_val')");
 
+        // Verify that syncing again the partition metadata has no negative effect (e.g. drop the partition)
+        getQueryRunner().execute("CALL system.sync_partition_metadata(schema_name => '" + HIVE_TEST_SCHEMA + "', table_name => '" + tableName + "', mode => 'FULL', case_sensitive => false)");
+        assertQuery("SELECT * FROM " + fullyQualifiedTestTableName, "VALUES ('Trino', 'rocks', 'part_val')");
+
         assertUpdate("DROP TABLE " + fullyQualifiedTestTableName);
     }
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/BaseTestSyncPartitionMetadata.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/BaseTestSyncPartitionMetadata.java
@@ -196,7 +196,7 @@ public abstract class BaseTestSyncPartitionMetadata
                 .hasMessageMatching(".*mode cannot be null.*");
     }
 
-    private String tableLocation(String tableName)
+    protected String tableLocation(String tableName)
     {
         return schemaLocation() + '/' + tableName;
     }
@@ -239,18 +239,18 @@ public abstract class BaseTestSyncPartitionMetadata
 
     protected abstract void copyOrcFileToHdfsDirectory(String tableName, String targetDirectory);
 
-    private static void cleanup(String tableName)
+    protected static void cleanup(String tableName)
     {
         onTrino().executeQuery("DROP TABLE " + tableName);
     }
 
-    private static void assertPartitions(String tableName, QueryAssert.Row... rows)
+    protected static void assertPartitions(String tableName, QueryAssert.Row... rows)
     {
         QueryResult partitionListResult = onTrino().executeQuery("SELECT * FROM \"" + tableName + "$partitions\" ORDER BY 1, 2");
         assertThat(partitionListResult).containsExactlyInOrder(rows);
     }
 
-    private static void assertData(String tableName, QueryAssert.Row... rows)
+    protected static void assertData(String tableName, QueryAssert.Row... rows)
     {
         QueryResult dataResult = onTrino().executeQuery("SELECT payload, col_x, col_y FROM " + tableName + " ORDER BY 1, 2, 3 ASC");
         assertThat(dataResult).containsExactlyInOrder(rows);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The canonical partition name built from the column name and values of the partition may differ from the actual storage location of the partition. This can lead to inconsistencies when syncing partition metadata, like identifying a partition to add/remove when there is actually nothing to be done.

Rely on the partition name from the storage location for identifying the partitions to sync via the `sync_partition_metadata` procedure call.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This fix applies specifically where  there is a partition name case sensitive variation between the canonical name and the storage location of the partition.

See `io.trino.plugin.hive.TestHive3OnDataLake#testSyncPartitionCaseSensitivePathVariation` for details.

Follow-up from #21168

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Fix `sync_partition_metadata` to cope with case sensitive variations of the partition names on the storage. ({issue}`issuenumber`)
```
