### PR TITLE
Update Azure SDK

### DIFF
--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystem.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystem.java
@@ -46,7 +46,6 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 
-import static com.azure.storage.common.Utility.urlEncode;
 import static com.azure.storage.common.implementation.Constants.HeaderConstants.ETAG_WILDCARD;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -178,8 +177,7 @@ public class AzureFileSystem
         BlobContainerClient blobContainerClient = createBlobContainerClient(location);
         PagedIterable<BlobItem> blobItems = blobContainerClient.listBlobs(new ListBlobsOptions().setPrefix(location.directoryPath()), null);
         for (BlobItem item : blobItems) {
-            String blobUrl = urlEncode(item.getName());
-            blobContainerClient.getBlobClient(blobUrl).deleteIfExists();
+            blobContainerClient.getBlobClient(item.getName()).deleteIfExists();
         }
     }
 
@@ -216,7 +214,7 @@ public class AzureFileSystem
             createDirectoryIfNotExists(fileSystemClient, target.location().parentDirectory().path());
             dataLakeFileClient.renameWithResponse(
                     null,
-                    urlEncode(target.path()),
+                    target.path(),
                     null,
                     new DataLakeRequestConditions().setIfNoneMatch(ETAG_WILDCARD),
                     null,
@@ -353,7 +351,7 @@ public class AzureFileSystem
             if (!directoryClient.getProperties().isDirectory()) {
                 throw new IOException("Source is not a directory: " + source);
             }
-            directoryClient.rename(null, urlEncode(targetLocation.path()));
+            directoryClient.rename(null, targetLocation.path());
         }
         catch (RuntimeException e) {
             throw new IOException("Rename directory from %s to %s failed".formatted(source, target), e);
@@ -453,7 +451,7 @@ public class AzureFileSystem
 
     private BlobClient createBlobClient(AzureLocation location)
     {
-        return createBlobContainerClient(location).getBlobClient(urlEncode(location.path()));
+        return createBlobContainerClient(location).getBlobClient(location.path());
     }
 
     private BlobContainerClient createBlobContainerClient(AzureLocation location)
@@ -488,16 +486,16 @@ public class AzureFileSystem
 
     private static DataLakeDirectoryClient createDirectoryClient(DataLakeFileSystemClient fileSystemClient, String directoryName)
     {
-        return fileSystemClient.getDirectoryClient(urlEncode(directoryName));
+        return fileSystemClient.getDirectoryClient(directoryName);
     }
 
     private static DataLakeFileClient createFileClient(DataLakeFileSystemClient fileSystemClient, String fileName)
     {
-        return fileSystemClient.getFileClient(urlEncode(fileName));
+        return fileSystemClient.getFileClient(fileName);
     }
 
     private static DataLakeDirectoryClient createDirectoryIfNotExists(DataLakeFileSystemClient fileSystemClient, String name)
     {
-        return fileSystemClient.createDirectoryIfNotExists(urlEncode(name));
+        return fileSystemClient.createDirectoryIfNotExists(name);
     }
 }

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/AbstractTestAzureFileSystem.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/AbstractTestAzureFileSystem.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import java.io.IOException;
 
-import static com.azure.storage.common.Utility.urlEncode;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Locale.ROOT;
 import static java.util.Objects.requireNonNull;
@@ -158,7 +157,7 @@ public abstract class AbstractTestAzureFileSystem
             }
         }
         else {
-            blobContainerClient.listBlobs().forEach(item -> blobContainerClient.getBlobClient(urlEncode(item.getName())).deleteIfExists());
+            blobContainerClient.listBlobs().forEach(item -> blobContainerClient.getBlobClient(item.getName()).deleteIfExists());
         }
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAdlsConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAdlsConnectorSmokeTest.java
@@ -144,10 +144,7 @@ public class TestDeltaLakeAdlsConnectorSmokeTest
                     .collect(toImmutableList());
             for (ClassPath.ResourceInfo resourceInfo : resources) {
                 String fileName = resourceInfo.getResourceName()
-                        .replaceFirst("^" + Pattern.quote(resourcePath), quoteReplacement(targetDirectory))
-                        // Replace '%' (corresponding to '%' character url encoded) with '%25' in order
-                        // to maintain also after URL decoding from the Azure client the original '%'
-                        .replace("%", "%25");
+                        .replaceFirst("^" + Pattern.quote(resourcePath), quoteReplacement(targetDirectory));
                 ByteSource byteSource = resourceInfo.asByteSource();
                 azureContainerClient.getBlobClient(fileName).upload(byteSource.openBufferedStream(), byteSource.size());
             }

--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-sdk-bom</artifactId>
-                <version>1.2.23</version>
+                <version>1.2.24</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Azure SDK version 1.2.24 includes [Azure Storage Blob 12.26](https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/storage/azure-storage-blob/CHANGELOG.md#12260-beta1-2024-04-15), which introduces a breaking change (https://github.com/Azure/azure-sdk-for-java/pull/37711/), where blob names used to create a new blob client should not be URL-encoded anymore. Blob URLs in the storage don't change, so after adjusting the API usage, data written by older Trino versions should be readable by new Trino versions.

In https://github.com/trinodb/trino/pull/21586 we added tests for special characters.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
