### PR TITLE
Add support for uppercase characters in `partitioning` table property

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionFields.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionFields.java
@@ -88,13 +88,6 @@ public final class PartitionFields
     public static String fromIdentifierToColumn(String identifier)
     {
         if (QUOTED_IDENTIFIER_PATTERN.matcher(identifier).matches()) {
-            // We only support lowercase quoted identifiers for now.
-            // See https://github.com/trinodb/trino/issues/12226#issuecomment-1128839259
-            // TODO: Enhance quoted identifiers support in Iceberg partitioning to support mixed case identifiers
-            //  See https://github.com/trinodb/trino/issues/12668
-            if (!identifier.toLowerCase(ENGLISH).equals(identifier)) {
-                throw new IllegalArgumentException(format("Uppercase characters in identifier '%s' are not supported.", identifier));
-            }
             return identifier.substring(1, identifier.length() - 1).replace("\"\"", "\"");
         }
         // Currently, all Iceberg columns are stored in lowercase in the Iceberg metadata files.
@@ -156,7 +149,7 @@ public final class PartitionFields
 
     public static String quotedName(String name)
     {
-        if (UNQUOTED_IDENTIFIER_PATTERN.matcher(name).matches()) {
+        if (UNQUOTED_IDENTIFIER_PATTERN.matcher(name).matches() && name.toLowerCase(ENGLISH).equals(name)) {
             return name;
         }
         return '"' + name.replace("\"", "\"\"") + '"';

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestPartitionFields.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestPartitionFields.java
@@ -76,6 +76,15 @@ public class TestPartitionFields
         assertParse("truncate(\"nested.nested.value\", 13)", partitionSpec(builder -> builder.truncate("nested.nested.value", 13)));
         assertParse("bucket(\"nested.nested.value\", 42)", partitionSpec(builder -> builder.bucket("nested.nested.value", 42)));
         assertParse("void(\"nested.nested.value\")", partitionSpec(builder -> builder.alwaysNull("nested.nested.value")));
+        assertParse("\"MixedTs\"", partitionSpec(builder -> builder.identity("MixedTs")));
+        assertParse("\"MixedNested.MixedValue\"", partitionSpec(builder -> builder.identity("MixedNested.MixedValue")));
+        assertParse("year(\"MixedTs\")", partitionSpec(builder -> builder.year("MixedTs")));
+        assertParse("month(\"MixedTs\")", partitionSpec(builder -> builder.month("MixedTs")));
+        assertParse("day(\"MixedTs\")", partitionSpec(builder -> builder.day("MixedTs")));
+        assertParse("hour(\"MixedTs\")", partitionSpec(builder -> builder.hour("MixedTs")));
+        assertParse("bucket(\"MixedTs\", 42)", partitionSpec(builder -> builder.bucket("MixedTs", 42)));
+        assertParse("truncate(\"MixedString\", 13)", partitionSpec(builder -> builder.truncate("MixedString", 13)));
+        assertParse("void(\"MixedString\")", partitionSpec(builder -> builder.alwaysNull("MixedString")));
 
         assertInvalid("bucket()", "Invalid partition field declaration: bucket()");
         assertInvalid(".nested", "Invalid partition field declaration: .nested");
@@ -90,9 +99,9 @@ public class TestPartitionFields
         assertInvalid("\"test \"with space\"", "Invalid partition field declaration: \"test \"with space\"");
         assertInvalid("\"test \"\"\"with space\"", "Invalid partition field declaration: \"test \"\"\"with space\"");
         assertInvalid("ABC", "Cannot find source column: abc");
-        assertInvalid("\"ABC\"", "Uppercase characters in identifier '\"ABC\"' are not supported.");
+        assertInvalid("\"ABC\"", "Cannot find source column: ABC");
         assertInvalid("year(ABC)", "Cannot find source column: abc");
-        assertInvalid("bucket(\"ABC\", 12)", "Uppercase characters in identifier '\"ABC\"' are not supported.");
+        assertInvalid("bucket(\"ABC\", 12)", "Cannot find source column: ABC");
         assertInvalid("\"nested.list\"", "Cannot partition by non-primitive source field: list<string>");
     }
 
@@ -140,7 +149,11 @@ public class TestPartitionFields
                         NestedField.required(14, "list", ListType.ofRequired(15, StringType.get())),
                         NestedField.required(16, "nested", Types.StructType.of(
                                 NestedField.required(17, "value", StringType.get()),
-                                NestedField.required(18, "ts", TimestampType.withZone()))))));
+                                NestedField.required(18, "ts", TimestampType.withZone()))))),
+                NestedField.required(19, "MixedTs", TimestampType.withoutZone()),
+                NestedField.optional(20, "MixedString", StringType.get()),
+                NestedField.required(21, "MixedNested", Types.StructType.of(
+                        NestedField.required(22, "MixedValue", StringType.get()))));
 
         PartitionSpec.Builder builder = PartitionSpec.builderFor(schema);
         consumer.accept(builder);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestSortFieldUtils.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestSortFieldUtils.java
@@ -51,14 +51,16 @@ public class TestSortFieldUtils
         // uppercase
         assertParse("ORDER_KEY ASC NULLS LAST", sortOrder(builder -> builder.asc("order_key", NullOrder.NULLS_LAST)));
         assertParse("ORDER_KEY DESC NULLS FIRST", sortOrder(builder -> builder.desc("order_key", NullOrder.NULLS_FIRST)));
-        assertDoesNotParse("\"ORDER_KEY\" ASC NULLS LAST", "Uppercase characters in identifier '\"ORDER_KEY\"' are not supported.");
-        assertDoesNotParse("\"ORDER_KEY\" DESC NULLS FIRST", "Uppercase characters in identifier '\"ORDER_KEY\"' are not supported.");
+        assertDoesNotParse("\"ORDER_KEY\" ASC NULLS LAST", "Cannot find field 'ORDER_KEY' .*");
+        assertDoesNotParse("\"ORDER_KEY\" DESC NULLS FIRST", "Cannot find field 'ORDER_KEY' .*");
 
         // mixed case
+        assertParse("\"MixedCase\" ASC NULLS LAST", sortOrder(builder -> builder.asc("MixedCase", NullOrder.NULLS_LAST)));
+        assertParse("\"MixedCase\" DESC NULLS FIRST", sortOrder(builder -> builder.desc("MixedCase", NullOrder.NULLS_FIRST)));
         assertParse("OrDER_keY Asc NullS LAst", sortOrder(builder -> builder.asc("order_key", NullOrder.NULLS_LAST)));
         assertParse("OrDER_keY Desc NullS FIrsT", sortOrder(builder -> builder.desc("order_key", NullOrder.NULLS_FIRST)));
-        assertDoesNotParse("\"OrDER_keY\" Asc NullS LAst", "Uppercase characters in identifier '\"OrDER_keY\"' are not supported.");
-        assertDoesNotParse("\"OrDER_keY\" Desc NullS FIrsT", "Uppercase characters in identifier '\"OrDER_keY\"' are not supported.");
+        assertDoesNotParse("\"OrDER_keY\" Asc NullS LAst", "Cannot find field 'OrDER_keY' .*");
+        assertDoesNotParse("\"OrDER_keY\" Desc NullS FIrsT", "Cannot find field 'OrDER_keY' .*");
 
         assertParse("comment", sortOrder(builder -> builder.asc("comment")));
         assertParse("\"comment\"", sortOrder(builder -> builder.asc("comment")));
@@ -106,13 +108,13 @@ public class TestSortFieldUtils
 
     private static void assertDoesNotParse(@Language("SQL") String value)
     {
-        assertDoesNotParse(value, "Unable to parse sort field: [%s]".formatted(value));
+        assertDoesNotParse(value, "\\QUnable to parse sort field: [%s]".formatted(value));
     }
 
-    private static void assertDoesNotParse(@Language("SQL") String value, String expectedMessage)
+    private static void assertDoesNotParse(@Language("SQL") String value, @Language("RegExp") String expectedMessage)
     {
         assertThatThrownBy(() -> parseField(value))
-                .hasMessage(expectedMessage);
+                .hasMessageMatching(expectedMessage);
     }
 
     private static SortOrder parseField(String value)
@@ -130,7 +132,8 @@ public class TestSortFieldUtils
                 Types.NestedField.optional(5, "notes", Types.ListType.ofRequired(6, Types.StringType.get())),
                 Types.NestedField.optional(7, "quoted field", Types.StringType.get()),
                 Types.NestedField.optional(8, "quoted ts", Types.TimestampType.withoutZone()),
-                Types.NestedField.optional(9, "\"another\" \"quoted\" \"field\"", Types.StringType.get()));
+                Types.NestedField.optional(9, "\"another\" \"quoted\" \"field\"", Types.StringType.get()),
+                Types.NestedField.optional(10, "MixedCase", Types.StringType.get()));
 
         SortOrder.Builder builder = SortOrder.builderFor(schema);
         consumer.accept(builder);


### PR DESCRIPTION
## Description

Fixes #12668

## Release notes

```markdown
# Iceberg
* Add support for uppercase characters in `partitioning` table property. ({issue}`12668`)
```
