### PR TITLE
Add date data type support for Kudu 

### DIFF
--- a/docs/src/main/sphinx/connector/kudu.md
+++ b/docs/src/main/sphinx/connector/kudu.md
@@ -217,6 +217,8 @@ this table:
   - `VARCHAR`
 * - `BINARY`
   - `VARBINARY`
+* - `DATE`
+  - `DATE`
 * - `UNIXTIME_MICROS`
   - `TIMESTAMP(3)`
 :::
@@ -266,7 +268,7 @@ this table:
   - `BINARY`
   -
 * - `DATE`
-  - `STRING`
+  - `DATE`
   -
 * - `TIMESTAMP(3)`
   - `UNIXTIME_MICROS`

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduPageSink.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduPageSink.java
@@ -16,6 +16,7 @@ package io.trino.plugin.kudu;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import io.trino.spi.Page;
+import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.connector.ConnectorMergeSink;
 import io.trino.spi.connector.ConnectorPageSink;
@@ -47,6 +48,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateType.DATE;
@@ -138,8 +140,8 @@ public class KuduPageSink
             }
             return NOT_BLOCKED;
         }
-        catch (KuduException e) {
-            throw new RuntimeException(e);
+        catch (KuduException | RuntimeException e) {
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, e);
         }
     }
 
@@ -228,8 +230,8 @@ public class KuduPageSink
                     try {
                         operationApplier.applyOperationAsync(delete);
                     }
-                    catch (KuduException e) {
-                        throw new RuntimeException(e);
+                    catch (KuduException | RuntimeException e) {
+                        throw new TrinoException(GENERIC_INTERNAL_ERROR, e);
                     }
                 }
 
@@ -248,14 +250,14 @@ public class KuduPageSink
                     try {
                         operationApplier.applyOperationAsync(insert);
                     }
-                    catch (KuduException e) {
-                        throw new RuntimeException(e);
+                    catch (KuduException | RuntimeException e) {
+                        throw new TrinoException(GENERIC_INTERNAL_ERROR, e);
                     }
                 }
             }
         }
-        catch (KuduException e) {
-            throw new RuntimeException(e);
+        catch (KuduException | RuntimeException e) {
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, e);
         }
     }
 

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduPageSink.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduPageSink.java
@@ -63,6 +63,7 @@ import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.apache.kudu.util.DateUtil.epochDaysToSqlDate;
 
 public class KuduPageSink
         implements ConnectorPageSink, ConnectorMergeSink
@@ -151,6 +152,9 @@ public class KuduPageSink
         Type type = columnTypes.get(destChannel);
         if (block.isNull(position)) {
             row.setNull(destChannel);
+        }
+        else if (DATE.equals(type)) {
+            row.addDate(destChannel, epochDaysToSqlDate(INTEGER.getInt(block, position)));
         }
         else if (TIMESTAMP_MILLIS.equals(type)) {
             row.addLong(destChannel, truncateEpochMicrosToMillis(TIMESTAMP_MILLIS.getLong(block, position)));

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/TypeHelper.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/TypeHelper.java
@@ -84,7 +84,7 @@ public final class TypeHelper
             return org.apache.kudu.Type.BINARY;
         }
         if (type == DateType.DATE) {
-            return org.apache.kudu.Type.STRING;
+            return org.apache.kudu.Type.DATE;
         }
         if (type.equals(TIMESTAMP_MILLIS)) {
             return org.apache.kudu.Type.UNIXTIME_MICROS;
@@ -116,15 +116,16 @@ public final class TypeHelper
                 return DoubleType.DOUBLE;
             case DECIMAL:
                 return DecimalType.createDecimalType(attributes.getPrecision(), attributes.getScale());
-            // TODO: add support for varchar and date types: https://github.com/trinodb/trino/issues/11009
             case STRING:
                 return VarcharType.VARCHAR;
             case BINARY:
                 return VarbinaryType.VARBINARY;
+            case DATE:
+                return DateType.DATE;
             case UNIXTIME_MICROS:
                 return TIMESTAMP_MILLIS;
+            // TODO: add support for varchar types: https://github.com/trinodb/trino/issues/11009
             case VARCHAR:
-            case DATE:
                 break;
         }
         throw new IllegalStateException("Kudu type not implemented for " + ktype);
@@ -166,6 +167,9 @@ public final class TypeHelper
         if (type instanceof VarbinaryType) {
             return ((Slice) nativeValue).toByteBuffer();
         }
+        if (type.equals(DateType.DATE)) {
+            return nativeValue;
+        }
         if (type.equals(TIMESTAMP_MILLIS)) {
             // Kudu's native format is in microseconds
             return nativeValue;
@@ -203,6 +207,9 @@ public final class TypeHelper
                 return row.getDecimal(field).unscaledValue().longValue();
             }
             throw new IllegalStateException("getLong not supported for long decimal: " + type);
+        }
+        if (type.equals(DateType.DATE)) {
+            return row.getInt(field);
         }
         if (type.equals(TIMESTAMP_MILLIS)) {
             return truncateEpochMicrosToMillis(row.getLong(field));

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduConnectorTest.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduConnectorTest.java
@@ -173,7 +173,7 @@ public class TestKuduConnectorTest
                 .row("custkey", "bigint", extra, "")
                 .row("orderstatus", "varchar", extra, "")
                 .row("totalprice", "double", extra, "")
-                .row("orderdate", "varchar", extra, "")
+                .row("orderdate", "date", extra, "")
                 .row("orderpriority", "varchar", extra, "")
                 .row("clerk", "varchar", extra, "")
                 .row("shippriority", "integer", extra, "")
@@ -198,7 +198,7 @@ public class TestKuduConnectorTest
                         "   custkey bigint COMMENT '' WITH (nullable = true),\n" +
                         "   orderstatus varchar COMMENT '' WITH (nullable = true),\n" +
                         "   totalprice double COMMENT '' WITH (nullable = true),\n" +
-                        "   orderdate varchar COMMENT '' WITH (nullable = true),\n" +
+                        "   orderdate date COMMENT '' WITH (nullable = true),\n" +
                         "   orderpriority varchar COMMENT '' WITH (nullable = true),\n" +
                         "   clerk varchar COMMENT '' WITH (nullable = true),\n" +
                         "   shippriority integer COMMENT '' WITH (nullable = true),\n" +
@@ -601,8 +601,6 @@ public class TestKuduConnectorTest
     public void testInsertNegativeDate()
     {
         // TODO Remove this overriding test once kudu connector can create tables with default partitions
-        // TODO Update this test once kudu connector supports DATE type: https://github.com/trinodb/trino/issues/11009
-        // DATE type is not supported by Kudu connector
         try (TestTable table = new TestTable(getQueryRunner()::execute, "insert_date",
                 "(dt DATE WITH (primary_key=true)) " +
                         "WITH (partition_by_hash_columns = ARRAY['dt'], partition_by_hash_buckets = 2)")) {
@@ -613,7 +611,7 @@ public class TestKuduConnectorTest
     @Override
     protected String errorMessageForInsertNegativeDate(String date)
     {
-        return "Insert query has mismatched column types: Table: \\[varchar\\], Query: \\[date\\]";
+        return "Date value <-719893>} is out of range '0001-01-01':'9999-12-31'";
     }
 
     @Test
@@ -731,37 +729,24 @@ public class TestKuduConnectorTest
 
     @Test
     @Override
-    public void testCreateTableAsSelectNegativeDate()
-    {
-        // Map date column type to varchar
-        String tableName = "negative_date_" + randomNameSuffix();
-
-        try {
-            assertUpdate(format("CREATE TABLE %s AS SELECT DATE '-0001-01-01' AS dt", tableName), 1);
-            assertQuery("SELECT * FROM " + tableName, "VALUES '-0001-01-01'");
-            assertQuery(format("SELECT * FROM %s WHERE dt = '-0001-01-01'", tableName), "VALUES '-0001-01-01'");
-        }
-        finally {
-            assertUpdate("DROP TABLE IF EXISTS " + tableName);
-        }
-    }
-
-    @Test
-    @Override
-    public void testDateYearOfEraPredicate()
-    {
-        assertThatThrownBy(super::testDateYearOfEraPredicate)
-                .hasStackTraceContaining("Cannot apply operator: varchar = date");
-    }
-
-    @Test
-    @Override
     public void testVarcharCastToDateInPredicate()
     {
         assertThatThrownBy(super::testVarcharCastToDateInPredicate)
                 .hasStackTraceContaining("Table partitioning must be specified using setRangePartitionColumns or addHashPartitions");
 
         abort("TODO: implement the test for Kudu");
+    }
+
+    @Test
+    @Override
+    @SuppressWarnings("deprecation")
+    public void testDateYearOfEraPredicate()
+    {
+        // Override because the connector throws an exception instead of an empty result when the value is out of supported range
+        assertQuery("SELECT orderdate FROM orders WHERE orderdate = DATE '1997-09-14'", "VALUES DATE '1997-09-14'");
+        // TODO Replace failure with a TrinoException
+        assertThat(query("SELECT * FROM orders WHERE orderdate = DATE '-1996-09-14'"))
+                .nonTrinoExceptionFailure().hasMessageContaining("integer value out of range for Type: date column: -1448295");
     }
 
     @Test
@@ -1011,10 +996,14 @@ public class TestKuduConnectorTest
             return Optional.of(dataMappingTestSetup.asUnsupported());
         }
 
-        if (typeName.equals("date") // date gets stored as varchar
-                || typeName.equals("varbinary") // TODO (https://github.com/trinodb/trino/issues/3416)
+        if (typeName.equals("varbinary") // TODO (https://github.com/trinodb/trino/issues/3416)
                 || (typeName.startsWith("char") && dataMappingTestSetup.getSampleValueLiteral().contains(" "))) { // TODO: https://github.com/trinodb/trino/issues/3597
             // TODO this should either work or fail cleanly
+            return Optional.empty();
+        }
+
+        if (typeName.equals("date") && dataMappingTestSetup.getSampleValueLiteral().equals("DATE '1582-10-05'")) {
+            // Kudu connector returns +10 days during julian->gregorian switch. The test case exists in TestKuduTypeMapping.testDate().
             return Optional.empty();
         }
 
@@ -1063,6 +1052,12 @@ public class TestKuduConnectorTest
     protected void verifyColumnNameLengthFailurePermissible(Throwable e)
     {
         assertThat(e).hasMessageContaining("invalid column name: identifier");
+    }
+
+    @Override
+    protected String errorMessageForCreateTableAsSelectNegativeDate(String date)
+    {
+        return ".*Date value <-719893>} is out of range '0001-01-01':'9999-12-31'.*";
     }
 
     private void assertTableProperty(String tableProperties, String key, String regexValue)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Previously Date type was mapped to `VARCHAR` and Kudu has natively added supported for `DATE` from 1.15. This PR maps Kudu Date type to Trino's Date type.

Partially fixes https://github.com/trinodb/trino/issues/11009


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
This PR depends on https://github.com/trinodb/trino/pull/22496


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Add date data type support for Kudu ({issue}`issuenumber`)
```
