### PR TITLE
Push filter through TopNRankingNode

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/planner/AbstractPredicatePushdownTest.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/AbstractPredicatePushdownTest.java
@@ -33,6 +33,7 @@ import io.trino.sql.planner.optimizations.PlanOptimizer;
 import io.trino.sql.planner.plan.ExchangeNode;
 import io.trino.sql.planner.plan.JoinNode;
 import io.trino.sql.planner.plan.ProjectNode;
+import io.trino.sql.planner.plan.TopNRankingNode;
 import io.trino.sql.planner.plan.WindowNode;
 import org.junit.jupiter.api.Test;
 
@@ -425,7 +426,30 @@ public abstract class AbstractPredicatePushdownTest
     }
 
     @Test
-    public void testPredicateOnNonDeterministicSymbolsPushedDown()
+    public void testPredicateOnPartitionSymbolsPushedThroughTopNRanking()
+    {
+        assertPlan(
+                "SELECT * FROM (" +
+                        "SELECT custkey, orderkey, rank() OVER (PARTITION BY custkey  ORDER BY orderdate ASC) rank " +
+                        "FROM orders " +
+                        ") WHERE rank < 5 AND custkey = 0 AND orderkey > 0 ",
+                anyTree(
+                        filter(
+                                new Comparison(GREATER_THAN, new Reference(BIGINT, "ORDER_KEY"), new Constant(BIGINT, 0L)),
+                                anyTree(
+                                        node(TopNRankingNode.class,
+                                                anyTree(
+                                                        filter(
+                                                                new Comparison(EQUAL, new Reference(BIGINT, "CUST_KEY"), new Constant(BIGINT, 0L)),
+                                                                tableScan(
+                                                                        "orders",
+                                                                        ImmutableMap.of(
+                                                                                "CUST_KEY", "custkey",
+                                                                                "ORDER_KEY", "orderkey")))))))));
+    }
+
+    @Test
+    public void testPredicateOnNonDeterministicSymbolsPushedDownThroughWindow()
     {
         assertPlan(
                 "SELECT * FROM (" +
@@ -444,7 +468,26 @@ public abstract class AbstractPredicatePushdownTest
     }
 
     @Test
-    public void testNonDeterministicPredicateNotPushedDown()
+    public void testPredicateOnNonDeterministicSymbolsPushedDownThroughTopNRanking()
+    {
+        assertPlan(
+                "SELECT * FROM (" +
+                        "SELECT random_column, orderkey, rank() OVER (PARTITION BY random_column  ORDER BY orderdate ASC) rank " +
+                        "FROM (select round(custkey*rand()) random_column, * from orders) " +
+                        ") WHERE rank < 5 AND random_column > 100",
+                anyTree(
+                        node(TopNRankingNode.class,
+                                anyTree(
+                                        filter(
+                                                new Comparison(GREATER_THAN, new Reference(DOUBLE, "ROUND"), new Constant(DOUBLE, 100.0)),
+                                                project(ImmutableMap.of("ROUND", expression(new Call(ROUND, ImmutableList.of(new Call(MULTIPLY_DOUBLE, ImmutableList.of(new Cast(new Reference(BIGINT, "CUST_KEY"), DOUBLE), new Call(RANDOM, ImmutableList.of()))))))),
+                                                        tableScan(
+                                                                "orders",
+                                                                ImmutableMap.of("CUST_KEY", "custkey"))))))));
+    }
+
+    @Test
+    public void testNonDeterministicPredicateNotPushedDownThroughWindow()
     {
         assertPlan(
                 "SELECT * FROM (" +
@@ -456,6 +499,25 @@ public abstract class AbstractPredicatePushdownTest
                                 new Comparison(GREATER_THAN, new Cast(new Reference(BIGINT, "CUST_KEY"), DOUBLE), new Call(MULTIPLY_DOUBLE, ImmutableList.of(new Call(RANDOM, ImmutableList.of()), new Constant(DOUBLE, 100.0)))),
                                 anyTree(
                                         node(WindowNode.class,
+                                                anyTree(
+                                                        tableScan(
+                                                                "orders",
+                                                                ImmutableMap.of("CUST_KEY", "custkey"))))))));
+    }
+
+    @Test
+    public void testNonDeterministicPredicateNotPushedDownThroughTopNRanking()
+    {
+        assertPlan(
+                "SELECT * FROM (" +
+                        "SELECT custkey, orderkey, rank() OVER (PARTITION BY custkey  ORDER BY orderdate ASC) rank " +
+                        "FROM orders" +
+                        ") WHERE rank < 5 AND custkey > 100*rand()",
+                anyTree(
+                        filter(
+                                new Comparison(GREATER_THAN, new Cast(new Reference(BIGINT, "CUST_KEY"), DOUBLE), new Call(MULTIPLY_DOUBLE, ImmutableList.of(new Call(RANDOM, ImmutableList.of()), new Constant(DOUBLE, 100.0)))),
+                                anyTree(
+                                        node(TopNRankingNode.class,
                                                 anyTree(
                                                         tableScan(
                                                                 "orders",


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Push down deterministic filters on partitioning symbols through TopNRankingNode. Based on similar mechanism for WindowNode.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# General
* Improve performance of certain queries involving `row_number`, `rank` or `dense_rank` window functions with partitioning and filter.
```
