### PR TITLE
Clarify log annotation docs

### DIFF
--- a/docs/src/main/sphinx/admin/properties-logging.md
+++ b/docs/src/main/sphinx/admin/properties-logging.md
@@ -4,10 +4,11 @@
 
 - **Type:** {ref}`prop-type-string`
 
-An optional properties file that contains annotations to be included with
-each log message. This can be used to include machine-specific or
-environment-specific information into logs which are centrally aggregated.
-The annotation values can contain references to environment variables.
+An optional properties file that contains annotations to include with each log
+message for TCP output or file output in JSON format, defined with `log.path`
+and `log.format`. This can be used to include machine-specific or
+environment-specific information into logs which are centrally aggregated. The
+annotation values can contain references to environment variables.
 
 ```properties
 environment=production


### PR DESCRIPTION
## Description

See title, not sure we need to call out that it does not work for stdout.

And also .. maybe we should change how it works @electrum ?

## Additional context and related issues

https://trinodb.slack.com/archives/C059KUNPTSP/p1719430408571069

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
