### PR TITLE
Enable JDBC statistics cache by default

### DIFF
--- a/docs/src/main/sphinx/connector/jdbc-common-configurations.fragment
+++ b/docs/src/main/sphinx/connector/jdbc-common-configurations.fragment
@@ -36,7 +36,7 @@ connector:
     Defaults to the value of `metadata.cache-ttl`.
 * - `metadata.statistics.cache-ttl`
   - [Duration](prop-type-duration) for which tables statistics are cached.
-    Defaults to the value of `metadata.cache-ttl`.
+    Defaults to `30m` or the value of `metadata.cache-ttl`, whichever is larger.
 * - `metadata.cache-maximum-size`
   - Maximum number of objects stored in the metadata cache. Defaults to `10000`.
 * - `write.batch-size`

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcConfig.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcConfig.java
@@ -27,12 +27,16 @@ import jakarta.validation.constraints.Pattern;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.google.common.collect.Comparators.max;
 import static jakarta.validation.constraints.Pattern.Flag.CASE_INSENSITIVE;
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 @DefunctConfig("remote-query-async-cancellation.enabled")
 public class BaseJdbcConfig
 {
+    public static final Duration DEFAULT_STATISTICS_CACHE_TTL = new Duration(30, MINUTES);
+
     private static final String METADATA_CACHE_TTL = "metadata.cache-ttl";
     private static final String METADATA_SCHEMAS_CACHE_TTL = "metadata.schemas.cache-ttl";
     private static final String METADATA_TABLES_CACHE_TTL = "metadata.tables.cache-ttl";
@@ -122,7 +126,7 @@ public class BaseJdbcConfig
     @NotNull
     public Duration getStatisticsCacheTtl()
     {
-        return statisticsCacheTtl.orElse(metadataCacheTtl);
+        return statisticsCacheTtl.orElseGet(() -> max(metadataCacheTtl, DEFAULT_STATISTICS_CACHE_TTL));
     }
 
     @Config(METADATA_STATISTICS_CACHE_TTL)
@@ -164,7 +168,7 @@ public class BaseJdbcConfig
     public boolean isCacheMaximumSizeConsistent()
     {
         return !metadataCacheTtl.isZero() ||
-                (statisticsCacheTtl.isPresent() && !statisticsCacheTtl.get().isZero()) ||
+                !getStatisticsCacheTtl().isZero() ||
                 cacheMaximumSize.isEmpty();
     }
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -498,7 +498,10 @@ public class CachingJdbcClient
         // TODO depend on Identity when needed
         TableStatistics cachedStatistics = statisticsCache.getIfPresent(handle);
         if (cachedStatistics != null) {
-            if (cacheMissing || !cachedStatistics.equals(TableStatistics.empty())) {
+            // Don't serve cached stats that have no column statistics (e.g. row count only)
+            // when cacheMissing is disabled, so that column stats are picked up once available
+            // (e.g. after ANALYZE runs in the remote database).
+            if (cacheMissing || !cachedStatistics.getColumnStatistics().isEmpty()) {
                 return cachedStatistics;
             }
             statisticsCache.invalidate(handle);

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestBaseJdbcConfig.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestBaseJdbcConfig.java
@@ -28,6 +28,9 @@ import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static io.airlift.testing.ValidationAssertions.assertFailsValidation;
 import static io.airlift.testing.ValidationAssertions.assertValidates;
 import static io.airlift.units.Duration.ZERO;
+import static io.trino.plugin.jdbc.BaseJdbcConfig.DEFAULT_STATISTICS_CACHE_TTL;
+import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -43,7 +46,7 @@ public class TestBaseJdbcConfig
                 .setMetadataCacheTtl(ZERO)
                 .setSchemaNamesCacheTtl(null)
                 .setTableNamesCacheTtl(null)
-                .setStatisticsCacheTtl(null)
+                .setStatisticsCacheTtl(DEFAULT_STATISTICS_CACHE_TTL)
                 .setCacheMissing(false)
                 .setCacheMaximumSize(10000));
     }
@@ -78,6 +81,27 @@ public class TestBaseJdbcConfig
     }
 
     @Test
+    public void testStatsCacheTtl()
+    {
+        // enabled by default
+        assertThat(new BaseJdbcConfig().getStatisticsCacheTtl()).isEqualTo(DEFAULT_STATISTICS_CACHE_TTL);
+
+        // takes higher of the DEFAULT_STATISTICS_CACHE_TTL or metadataCacheTtl if not set explicitly
+        assertThat(new BaseJdbcConfig()
+                .setMetadataCacheTtl(new Duration(1, SECONDS))
+                .getStatisticsCacheTtl()).isEqualTo(DEFAULT_STATISTICS_CACHE_TTL);
+        assertThat(new BaseJdbcConfig()
+                .setMetadataCacheTtl(new Duration(1111, DAYS))
+                .getStatisticsCacheTtl()).isEqualTo(new Duration(1111, DAYS));
+
+        // explicit configuration is honored
+        assertThat(new BaseJdbcConfig()
+                .setStatisticsCacheTtl(new Duration(135, MILLISECONDS))
+                .setMetadataCacheTtl(new Duration(1111, DAYS))
+                .getStatisticsCacheTtl()).isEqualTo(new Duration(135, MILLISECONDS));
+    }
+
+    @Test
     public void testConnectionUrlIsValid()
     {
         assertThatThrownBy(() -> buildConfig(ImmutableMap.of("connection-url", "jdbc:")))
@@ -107,12 +131,10 @@ public class TestBaseJdbcConfig
                 .setConnectionUrl("jdbc:h2:mem:config")
                 .setMetadataCacheTtl(new Duration(1, SECONDS)));
 
-        assertFailsValidation(
-                new BaseJdbcConfig()
-                        .setCacheMaximumSize(5000),
-                "cacheMaximumSizeConsistent",
-                "metadata.cache-ttl or metadata.statistics.cache-ttl must be set to a non-zero value when metadata.cache-maximum-size is set",
-                AssertTrue.class);
+        // Statistics cache is enabled by default, so setting only cache-maximum-size is valid
+        assertValidates(new BaseJdbcConfig()
+                .setConnectionUrl("jdbc:h2:mem:config")
+                .setCacheMaximumSize(5000));
 
         assertFailsValidation(
                 new BaseJdbcConfig()

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestCachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestCachingJdbcClient.java
@@ -34,6 +34,7 @@ import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.security.ConnectorIdentity;
 import io.trino.spi.session.PropertyMetadata;
+import io.trino.spi.statistics.ColumnStatistics;
 import io.trino.spi.statistics.Estimate;
 import io.trino.spi.statistics.TableStatistics;
 import io.trino.testing.TestingConnectorSession;
@@ -47,6 +48,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Types;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -103,6 +105,20 @@ public class TestCachingJdbcClient
 
     private static final TableStatistics NON_EMPTY_STATS = TableStatistics.builder()
             .setRowCount(Estimate.zero())
+            .setColumnStatistics(
+                    JdbcColumnHandle.builder()
+                            .setJdbcTypeHandle(new JdbcTypeHandle(Types.INTEGER, Optional.of("integer"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()))
+                            .setColumnType(INTEGER)
+                            .setColumnName("test_column")
+                            .build(),
+                    ColumnStatistics.builder()
+                            .setDistinctValuesCount(Estimate.zero())
+                            .setNullsFraction(Estimate.zero())
+                            .build())
+            .build();
+
+    private static final TableStatistics ROW_COUNT_ONLY_STATS = TableStatistics.builder()
+            .setRowCount(Estimate.of(100))
             .build();
 
     private TestingDatabase database;
@@ -777,6 +793,54 @@ public class TestCachingJdbcClient
     }
 
     @Test
+    public void testGetTableStatisticsDoNotCachePartialWhenCachingMissingIsDisabled()
+    {
+        CachingJdbcClient cachingJdbcClient = cachingClientBuilder()
+                .delegate(jdbcClientWithPartialTableStats())
+                .config(enableCache().setCacheMissing(false))
+                .build();
+        ConnectorSession session = createSession("table");
+        JdbcTableHandle table = createTable(new SchemaTableName(schema, "table"));
+
+        // First call loads from delegate - partial stats (row count only, no column stats)
+        assertStatisticsCacheStats(cachingJdbcClient).loads(1).misses(1).afterRunning(() -> {
+            assertThat(cachingJdbcClient.getTableStatistics(session, table)).isEqualTo(ROW_COUNT_ONLY_STATS);
+        });
+
+        // Second call should NOT serve from cache since stats have no column statistics
+        assertStatisticsCacheStats(cachingJdbcClient).loads(1).hits(1).misses(1).afterRunning(() -> {
+            assertThat(cachingJdbcClient.getTableStatistics(session, table)).isEqualTo(ROW_COUNT_ONLY_STATS);
+        });
+
+        // cleanup
+        this.jdbcClient.dropTable(SESSION, table);
+    }
+
+    @Test
+    public void testCachePartialStatisticsWhenCacheMissingEnabled()
+    {
+        CachingJdbcClient cachingJdbcClient = cachingClientBuilder()
+                .delegate(jdbcClientWithPartialTableStats())
+                .config(enableCache().setCacheMissing(true))
+                .build();
+        ConnectorSession session = createSession("table");
+        JdbcTableHandle table = createTable(new SchemaTableName(schema, "table"));
+
+        // First call loads from delegate
+        assertStatisticsCacheStats(cachingJdbcClient).loads(1).misses(1).afterRunning(() -> {
+            assertThat(cachingJdbcClient.getTableStatistics(session, table)).isEqualTo(ROW_COUNT_ONLY_STATS);
+        });
+
+        // Second call SHOULD serve from cache since cacheMissing is enabled
+        assertStatisticsCacheStats(cachingJdbcClient).hits(1).afterRunning(() -> {
+            assertThat(cachingJdbcClient.getTableStatistics(session, table)).isEqualTo(ROW_COUNT_ONLY_STATS);
+        });
+
+        // cleanup
+        this.jdbcClient.dropTable(SESSION, table);
+    }
+
+    @Test
     public void testDifferentIdentityKeys()
     {
         CachingJdbcClient cachingJdbcClient = cachingClientBuilder()
@@ -1206,6 +1270,24 @@ public class TestCachingJdbcClient
             public TableStatistics getTableStatistics(ConnectorSession session, JdbcTableHandle handle)
             {
                 return NON_EMPTY_STATS;
+            }
+        };
+    }
+
+    private JdbcClient jdbcClientWithPartialTableStats()
+    {
+        return new ForwardingJdbcClient()
+        {
+            @Override
+            protected JdbcClient delegate()
+            {
+                return database.getJdbcClient();
+            }
+
+            @Override
+            public TableStatistics getTableStatistics(ConnectorSession session, JdbcTableHandle handle)
+            {
+                return ROW_COUNT_ONLY_STATS;
             }
         };
     }

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlJdbcConnectionAccesses.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlJdbcConnectionAccesses.java
@@ -71,7 +71,12 @@ public class TestPostgreSqlJdbcConnectionAccesses
                             "connection-user", postgreSqlServer.getUser(),
                             "connection-password", postgreSqlServer.getPassword(),
                             // disables connection reuse to approximate number of I/O operations since we almost always open a new connection to execute a query
-                            "query.reuse-connection", "false"));
+                            "query.reuse-connection", "false",
+                            // Disable statistics cache to make connection counts deterministic.
+                            // Whether a table has column-level stats depends on whether PostgreSQL
+                            // auto-vacuum has analyzed it yet. Stats without columns are not cached,
+                            // so auto-vacuum timing affects how many connections are opened.
+                            "metadata.statistics.cache-ttl", "0s"));
                 })
                 .build();
         copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, ImmutableList.of(CUSTOMER, NATION, REGION));

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlJdbcConnectionCreation.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlJdbcConnectionCreation.java
@@ -67,7 +67,12 @@ public class TestPostgreSqlJdbcConnectionCreation
                     runner.createCatalog("counting_postgresql", "counting_postgresql", ImmutableMap.of(
                             "connection-url", postgreSqlServer.getJdbcUrl(),
                             "connection-user", postgreSqlServer.getUser(),
-                            "connection-password", postgreSqlServer.getPassword()));
+                            "connection-password", postgreSqlServer.getPassword(),
+                            // Disable statistics cache to make connection counts deterministic.
+                            // Whether a table has column-level stats depends on whether PostgreSQL
+                            // auto-vacuum has analyzed it yet. Stats without columns are not cached,
+                            // so auto-vacuum timing affects how many connections are opened.
+                            "metadata.statistics.cache-ttl", "0s"));
                 })
                 .build();
         copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, ImmutableList.of(CUSTOMER, NATION, REGION));

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerJdbcConnectionAccesses.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerJdbcConnectionAccesses.java
@@ -108,7 +108,7 @@ public class TestSqlServerJdbcConnectionAccesses
         assertJdbcConnections("DROP TABLE copy_of_nation", 2, Optional.empty());
         assertJdbcConnections("SHOW SCHEMAS", 1, Optional.empty());
         assertJdbcConnections("SHOW TABLES", 2, Optional.empty());
-        assertJdbcConnections("SHOW STATS FOR nation", 4, Optional.empty());
+        assertJdbcConnections("SHOW STATS FOR nation", 2, Optional.empty());
         assertJdbcConnections("SELECT * FROM system.jdbc.columns WHERE table_cat = 'counting_sqlserver'", 1041, Optional.empty());
     }
 

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerJdbcConnectionCreation.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerJdbcConnectionCreation.java
@@ -104,7 +104,7 @@ public class TestSqlServerJdbcConnectionCreation
         assertJdbcConnections("DROP TABLE copy_of_nation", 1, Optional.empty());
         assertJdbcConnections("SHOW SCHEMAS", 1, Optional.empty());
         assertJdbcConnections("SHOW TABLES", 1, Optional.empty());
-        assertJdbcConnections("SHOW STATS FOR nation", 2, Optional.empty());
+        assertJdbcConnections("SHOW STATS FOR nation", 1, Optional.empty());
         assertJdbcConnections("SELECT * FROM system.jdbc.columns WHERE table_cat = 'counting_sqlserver'", 1, Optional.empty());
     }
 


### PR DESCRIPTION
## Description
For JDBC connectors, `metadata.statistics.cache-ttl` will default to 
`30m` or the value of `metadata.cache-ttl`, whichever is larger

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# JDBC
* Improve query planning time for JDBC connectors. ({issue}`22519`)
```
