### PR TITLE
Optimize BETWEEN predicate to include both the sides.

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/SortExpressionExtractor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/SortExpressionExtractor.java
@@ -22,14 +22,12 @@ import io.trino.sql.ir.IrUtils;
 import io.trino.sql.ir.IrVisitor;
 import io.trino.sql.ir.Reference;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static java.util.Collections.singletonList;
 import static java.util.Comparator.comparing;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
@@ -65,8 +63,6 @@ public final class SortExpressionExtractor
         List<SortExpressionContext> sortExpressionCandidates = ImmutableList.copyOf(filterConjuncts.stream()
                 .filter(DeterminismEvaluator::isDeterministic)
                 .map(visitor::process)
-                .filter(Optional::isPresent)
-                .map(Optional::get)
                 .flatMap(List::stream)
                 .collect(toMap(SortExpressionContext::getSortExpression, identity(), SortExpressionExtractor::merge))
                 .values());
@@ -88,7 +84,7 @@ public final class SortExpressionExtractor
     }
 
     private static class SortExpressionVisitor
-            extends IrVisitor<Optional<List<SortExpressionContext>>, Void>
+            extends IrVisitor<List<SortExpressionContext>, Void>
     {
         private final Set<Symbol> buildSymbols;
 
@@ -98,13 +94,13 @@ public final class SortExpressionExtractor
         }
 
         @Override
-        protected Optional<List<SortExpressionContext>> visitExpression(Expression expression, Void context)
+        protected List<SortExpressionContext> visitExpression(Expression expression, Void context)
         {
-            return Optional.empty();
+            return List.of();
         }
 
         @Override
-        protected Optional<List<SortExpressionContext>> visitComparison(Comparison comparison, Void context)
+        protected List<SortExpressionContext> visitComparison(Comparison comparison, Void context)
         {
             return switch (comparison.operator()) {
                 case GREATER_THAN, GREATER_THAN_OR_EQUAL, LESS_THAN, LESS_THAN_OR_EQUAL -> {
@@ -115,29 +111,22 @@ public final class SortExpressionExtractor
                         hasBuildReferencesOnOtherSide = hasBuildSymbolReference(buildSymbols, comparison.right());
                     }
                     if (sortChannel.isPresent() && !hasBuildReferencesOnOtherSide) {
-                        yield sortChannel.map(symbolReference -> singletonList(new SortExpressionContext(symbolReference, singletonList(comparison))));
+                        yield ImmutableList.of(new SortExpressionContext(sortChannel.get(), ImmutableList.of(comparison)));
                     }
-                    yield Optional.empty();
+                    yield List.of();
                 }
-                default -> Optional.empty();
+                default -> List.of();
             };
         }
 
         @Override
-        protected Optional<List<SortExpressionContext>> visitBetween(Between node, Void context)
+        protected List<SortExpressionContext> visitBetween(Between node, Void context)
         {
             // Handle both side of BETWEEN as `GREATER_THAN_OR_EQUAL` expression and `LESS_THAN_OR_EQUAL` expression.
-            Optional<List<SortExpressionContext>> betweenLeftResult = visitComparison(new Comparison(Comparison.Operator.GREATER_THAN_OR_EQUAL, node.value(), node.min()), context);
-            Optional<List<SortExpressionContext>> betweenRightResult = visitComparison(new Comparison(Comparison.Operator.LESS_THAN_OR_EQUAL, node.value(), node.max()), context);
-            if (betweenLeftResult.isPresent() && betweenRightResult.isPresent()) {
-                return Optional.of(Arrays.asList(betweenLeftResult.get().getFirst(), betweenRightResult.get().getFirst()));
-            }
-            else if (betweenLeftResult.isPresent()) {
-                return betweenLeftResult;
-            }
-            else {
-                return betweenRightResult;
-            }
+            return ImmutableList.<SortExpressionContext>builder()
+                    .addAll(visitComparison(new Comparison(Comparison.Operator.GREATER_THAN_OR_EQUAL, node.value(), node.min()), context))
+                    .addAll(visitComparison(new Comparison(Comparison.Operator.LESS_THAN_OR_EQUAL, node.value(), node.max()), context))
+                    .build();
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestSortExpressionExtractor.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestSortExpressionExtractor.java
@@ -93,9 +93,20 @@ public class TestSortExpressionExtractor
                 new Comparison(GREATER_THAN, new Reference(BIGINT, "b2"), new Reference(BIGINT, "p2")));
 
         assertGetSortExpression(
-                new Between(new Reference(BIGINT, "p1"), new Reference(BIGINT, "b1"), new Reference(BIGINT, "b2")),
+                new Between(new Reference(BIGINT, "b1"), new Reference(BIGINT, "p1"), new Reference(BIGINT, "p2")),
                 "b1",
-                new Comparison(GREATER_THAN_OR_EQUAL, new Reference(BIGINT, "p1"), new Reference(BIGINT, "b1")));
+                new Comparison(GREATER_THAN_OR_EQUAL, new Reference(BIGINT, "b1"), new Reference(BIGINT, "p1")),
+                new Comparison(LESS_THAN_OR_EQUAL, new Reference(BIGINT, "b1"), new Reference(BIGINT, "p2")));
+
+        assertGetSortExpression(
+                new Logical(AND, ImmutableList.of(
+                        new Between(new Reference(BIGINT, "p1"), new Reference(BIGINT, "b1"), new Reference(BIGINT, "b2")),
+                        new Comparison(LESS_THAN, new Reference(BIGINT, "b2"),
+                                new Call(ADD_BIGINT, ImmutableList.of(new Reference(BIGINT, "p2"), new Constant(BIGINT, 1L)))))),
+                "b2",
+                new Comparison(LESS_THAN_OR_EQUAL, new Reference(BIGINT, "p1"), new Reference(BIGINT, "b2")),
+                new Comparison(LESS_THAN, new Reference(BIGINT, "b2"),
+                        new Call(ADD_BIGINT, ImmutableList.of(new Reference(BIGINT, "p2"), new Constant(BIGINT, 1L)))));
 
         assertGetSortExpression(
                 new Between(new Reference(BIGINT, "p1"), new Reference(BIGINT, "p2"), new Reference(BIGINT, "b1")),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestSortExpressionExtractor.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestSortExpressionExtractor.java
@@ -93,12 +93,6 @@ public class TestSortExpressionExtractor
                 new Comparison(GREATER_THAN, new Reference(BIGINT, "b2"), new Reference(BIGINT, "p2")));
 
         assertGetSortExpression(
-                new Between(new Reference(BIGINT, "b1"), new Reference(BIGINT, "p1"), new Reference(BIGINT, "p2")),
-                "b1",
-                new Comparison(GREATER_THAN_OR_EQUAL, new Reference(BIGINT, "b1"), new Reference(BIGINT, "p1")),
-                new Comparison(LESS_THAN_OR_EQUAL, new Reference(BIGINT, "b1"), new Reference(BIGINT, "p2")));
-
-        assertGetSortExpression(
                 new Logical(AND, ImmutableList.of(
                         new Between(new Reference(BIGINT, "p1"), new Reference(BIGINT, "b1"), new Reference(BIGINT, "b2")),
                         new Comparison(LESS_THAN, new Reference(BIGINT, "b2"),
@@ -116,7 +110,8 @@ public class TestSortExpressionExtractor
         assertGetSortExpression(
                 new Between(new Reference(BIGINT, "b1"), new Reference(BIGINT, "p1"), new Reference(BIGINT, "p2")),
                 "b1",
-                new Comparison(GREATER_THAN_OR_EQUAL, new Reference(BIGINT, "b1"), new Reference(BIGINT, "p1")));
+                new Comparison(GREATER_THAN_OR_EQUAL, new Reference(BIGINT, "b1"), new Reference(BIGINT, "p1")),
+                new Comparison(LESS_THAN_OR_EQUAL, new Reference(BIGINT, "b1"), new Reference(BIGINT, "p2")));
 
         assertGetSortExpression(
                 new Logical(AND, ImmutableList.of(new Comparison(GREATER_THAN, new Reference(BIGINT, "b1"), new Reference(BIGINT, "p1")), new Between(new Reference(BIGINT, "p1"), new Reference(BIGINT, "b1"), new Reference(BIGINT, "b2")))),


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

reviving this [old PR](https://github.com/trinodb/trino/pull/14598)

visitBetweenPredicate  in SortExpressionVisitor can only handle one side of BETWEEN (GREATER_THAN_OR_EQUAL or LESS_THAN_OR_EQUAL), this pr optimize it and let it handle both sides of BETWEEN as conjunct expressions
Fixes one par of this issue: https://github.com/trinodb/trino/issues/22520


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
