### PR TITLE
Fix bug on `query_partition_filter_required_schemas` config property in Hive connector

### DIFF
--- a/docs/src/main/sphinx/connector/hive.md
+++ b/docs/src/main/sphinx/connector/hive.md
@@ -240,6 +240,15 @@ Hive connector documentation.
     `query_partition_filter_required` catalog session property for temporary,
     catalog specific use.
   - `false`
+* - `hive.query-partition-filter-required-schemas`
+  - Allow specifying the list of schemas for which Trino will enforce that
+    queries use a filter on partition keys for source tables. The list can be
+    specified using the `hive.query-partition-filter-required-schemas`,
+    or the `query_partition_filter_required_schemas` session property. The list
+    is taken into consideration only if the `hive.query-partition-filter-required`
+    configuration property or the `query_partition_filter_required` session
+    property is set to `true`.
+  - `[]`
 * - `hive.table-statistics-enabled`
   - Enables [](/optimizer/statistics). The equivalent [catalog session
     property](/sql/set-session) is `statistics_enabled` for session specific

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -4033,6 +4033,6 @@ public class HiveMetadata
         Set<String> requiredSchemas = getQueryPartitionFilterRequiredSchemas(session);
         // If query_partition_filter_required_schemas is empty, then we would apply partition filter for all tables.
         return isQueryPartitionFilterRequired(session) &&
-                requiredSchemas.isEmpty() || requiredSchemas.contains(schemaTableName.getSchemaName());
+                (requiredSchemas.isEmpty() || requiredSchemas.contains(schemaTableName.getSchemaName()));
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -549,6 +549,26 @@ public abstract class BaseHiveConnectorTest
     }
 
     @Test
+    public void testIgnoreQueryPartitionFilterRequiredSchemas()
+    {
+        String schemaName = "test_partition_filter_" + randomNameSuffix();
+        String tableName = schemaName + ".test_partition_filter" + randomNameSuffix();
+
+        Session session = Session.builder(getSession())
+                .setCatalogSessionProperty("hive", "query_partition_filter_required", "false")
+                .setCatalogSessionProperty("hive", "query_partition_filter_required_schemas", format("[\"%s\"]", schemaName))
+                .build();
+
+        assertUpdate(session, "CREATE SCHEMA " + schemaName);
+        assertUpdate(session, "CREATE TABLE " + tableName + " (id integer, part varchar) WITH (partitioned_by = ARRAY['part'])");
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES (1, 'test')", 1);
+
+        assertQuerySucceeds(session, "SELECT * FROM " + tableName + " WHERE id = 1");
+
+        assertUpdate(session, "DROP SCHEMA " + schemaName + " CASCADE");
+    }
+
+    @Test
     public void testInvalidValueForQueryPartitionFilterRequiredSchemas()
     {
         assertQueryFails(


### PR DESCRIPTION
## Description
- fix minor bug on `query-partition-filter-required-schemas` option to be compatible with `query-partition-filter-required`
- add minor test case for this fix
- add missing description about that config on Hive connector docs, copied from v362 release note. (REF: https://trino.io/docs/current/release/release-362.html )

## Additional context and related issues
- related PR: https://github.com/trinodb/trino/pull/9106 by @Praveen2112 
- I need to declare `query-partition-filter-required-schemas` on catalog configuration, and switch on/off `query-partition-filter-required` option, depending on source/session by using session property manager
- But, I found that `query-partition-filter-required-schemas` option is always applied even though `query-partition-filter-required=false`.
- It is just a minor matter of boolean equation execution order of java

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
