### PR TITLE
Add support for writing Parquet Bloom filters in Delta Lake connector

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.md
+++ b/docs/src/main/sphinx/connector/delta-lake.md
@@ -663,6 +663,10 @@ The following table properties are available for use:
     * `NONE`
 
     Defaults to `NONE`.
+* - `parquet_bloom_filter_columns`
+  - Comma-separated list of columns to use for Parquet bloom filter. It improves
+    the performance of queries using Equality and IN predicates when reading
+    Parquet files. Defaults to `[]`.
 :::
 
 The following example uses all available table properties:

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeCdfPageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeCdfPageSink.java
@@ -21,6 +21,7 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.type.TypeOperators;
 
 import java.util.List;
+import java.util.Set;
 
 import static io.trino.plugin.deltalake.DataFileInfo.DataFileType.CHANGE_DATA_FEED;
 
@@ -43,7 +44,8 @@ public class DeltaLakeCdfPageSink
             ConnectorSession session,
             DeltaLakeWriterStats stats,
             String trinoVersion,
-            DeltaLakeParquetSchemaMapping parquetSchemaMapping)
+            DeltaLakeParquetSchemaMapping parquetSchemaMapping,
+            Set<String> bloomFilterColumns)
     {
         super(
                 typeOperators,
@@ -58,7 +60,8 @@ public class DeltaLakeCdfPageSink
                 session,
                 stats,
                 trinoVersion,
-                parquetSchemaMapping);
+                parquetSchemaMapping,
+                bloomFilterColumns);
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
@@ -71,6 +71,7 @@ import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getCompressio
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterBlockSize;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterPageSize;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterPageValueCount;
+import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.useParquetBloomFilter;
 import static io.trino.plugin.deltalake.DeltaLakeTypes.toParquetType;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogParser.deserializePartitionValue;
 import static io.trino.spi.block.RowBlock.getRowFieldsFromBlock;
@@ -512,7 +513,7 @@ public class DeltaLakeMergeSink
                 true,
                 parquetDateTimeZone,
                 new FileFormatDataSourceStats(),
-                new ParquetReaderOptions().withBloomFilter(false),
+                new ParquetReaderOptions().withBloomFilter(useParquetBloomFilter(session)),
                 Optional.empty(),
                 domainCompactionThreshold,
                 OptionalLong.of(fileSize));

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -1244,7 +1244,7 @@ public class DeltaLakeMetadata
             setRollback(() -> deleteRecursivelyIfExists(fileSystemFactory.create(session), finalLocation));
             protocolEntry = protocolEntryForNewTable(containsTimestampType, tableMetadata.getProperties());
         }
-
+        Map<String, String> configuration = configurationForNewTable(getCheckpointInterval(tableMetadata.getProperties()), getChangeDataFeedEnabled(tableMetadata.getProperties()), columnMappingMode, maxFieldId);
         return new DeltaLakeOutputTableHandle(
                 schemaName,
                 tableName,
@@ -1253,13 +1253,12 @@ public class DeltaLakeMetadata
                 getCheckpointInterval(tableMetadata.getProperties()),
                 external,
                 tableMetadata.getComment(),
-                getChangeDataFeedEnabled(tableMetadata.getProperties()),
                 serializeSchemaAsJson(deltaTable.build()),
                 columnMappingMode,
-                maxFieldId,
                 replace,
                 readVersion,
-                protocolEntry);
+                protocolEntry,
+                configuration);
     }
 
     private Optional<String> getSchemaLocation(Database database)
@@ -1432,7 +1431,7 @@ public class DeltaLakeMetadata
                             .setDescription(handle.comment())
                             .setSchemaString(schemaString)
                             .setPartitionColumns(handle.partitionedBy())
-                            .setConfiguration(configurationForNewTable(handle.checkpointInterval(), handle.changeDataFeedEnabled(), columnMappingMode, handle.maxColumnId())));
+                            .setConfiguration(handle.configuration()));
             appendAddFileEntries(transactionLogWriter, dataFileInfos, physicalPartitionNames, columnNames, true);
             if (handle.readVersion().isPresent()) {
                 long writeTimestamp = Instant.now().toEpochMilli();

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeOutputTableHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeOutputTableHandle.java
@@ -19,8 +19,8 @@ import io.trino.plugin.deltalake.transactionlog.ProtocolEntry;
 import io.trino.spi.connector.ConnectorOutputTableHandle;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.OptionalLong;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -35,13 +35,12 @@ public record DeltaLakeOutputTableHandle(
         Optional<Long> checkpointInterval,
         boolean external,
         Optional<String> comment,
-        Optional<Boolean> changeDataFeedEnabled,
         String schemaString,
         ColumnMappingMode columnMappingMode,
-        OptionalInt maxColumnId,
         boolean replace,
         OptionalLong readVersion,
-        ProtocolEntry protocolEntry)
+        ProtocolEntry protocolEntry,
+        Map<String, String> configuration)
         implements ConnectorOutputTableHandle
 {
     public DeltaLakeOutputTableHandle
@@ -52,12 +51,11 @@ public record DeltaLakeOutputTableHandle(
         requireNonNull(location, "location is null");
         requireNonNull(checkpointInterval, "checkpointInterval is null");
         requireNonNull(comment, "comment is null");
-        requireNonNull(changeDataFeedEnabled, "changeDataFeedEnabled is null");
         requireNonNull(schemaString, "schemaString is null");
         requireNonNull(columnMappingMode, "columnMappingMode is null");
-        requireNonNull(maxColumnId, "maxColumnId is null");
         requireNonNull(readVersion, "readVersion is null");
         requireNonNull(protocolEntry, "protocolEntry is null");
+        requireNonNull(configuration, "configuration is null");
     }
 
     public List<String> partitionedBy()

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSink.java
@@ -21,6 +21,7 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.type.TypeOperators;
 
 import java.util.List;
+import java.util.Set;
 
 import static io.trino.plugin.deltalake.DataFileInfo.DataFileType.DATA;
 
@@ -39,7 +40,8 @@ public class DeltaLakePageSink
             ConnectorSession session,
             DeltaLakeWriterStats stats,
             String trinoVersion,
-            DeltaLakeParquetSchemaMapping parquetSchemaMapping)
+            DeltaLakeParquetSchemaMapping parquetSchemaMapping,
+            Set<String> bloomFilterColumns)
     {
         super(
                 typeOperators,
@@ -54,7 +56,8 @@ public class DeltaLakePageSink
                 session,
                 stats,
                 trinoVersion,
-                parquetSchemaMapping);
+                parquetSchemaMapping,
+                bloomFilterColumns);
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSourceProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSourceProvider.java
@@ -91,6 +91,7 @@ import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetSma
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.isParquetIgnoreStatistics;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.isParquetUseColumnIndex;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.isParquetVectorizedDecodingEnabled;
+import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.useParquetBloomFilter;
 import static io.trino.plugin.deltalake.DeltaLakeSplitManager.partitionMatchesPredicate;
 import static io.trino.plugin.deltalake.delete.DeletionVectors.readDeletionVectors;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.extractSchema;
@@ -128,7 +129,7 @@ public class DeltaLakePageSourceProvider
     {
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.fileFormatDataSourceStats = requireNonNull(fileFormatDataSourceStats, "fileFormatDataSourceStats is null");
-        this.parquetReaderOptions = parquetReaderConfig.toParquetReaderOptions().withBloomFilter(false);
+        this.parquetReaderOptions = parquetReaderConfig.toParquetReaderOptions();
         this.domainCompactionThreshold = deltaLakeConfig.getDomainCompactionThreshold();
         this.parquetDateTimeZone = deltaLakeConfig.getParquetDateTimeZone();
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
@@ -221,7 +222,8 @@ public class DeltaLakePageSourceProvider
                 .withSmallFileThreshold(getParquetSmallFileThreshold(session))
                 .withUseColumnIndex(isParquetUseColumnIndex(session))
                 .withIgnoreStatistics(isParquetIgnoreStatistics(session))
-                .withVectorizedDecodingEnabled(isParquetVectorizedDecodingEnabled(session));
+                .withVectorizedDecodingEnabled(isParquetVectorizedDecodingEnabled(session))
+                .withBloomFilter(useParquetBloomFilter(session));
 
         Map<Integer, String> parquetFieldIdToName = columnMappingMode == ColumnMappingMode.ID ? loadParquetIdAndNameMapping(inputFile, options) : ImmutableMap.of();
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSessionProperties.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSessionProperties.java
@@ -62,6 +62,7 @@ public final class DeltaLakeSessionProperties
     private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
     private static final String PARQUET_WRITER_PAGE_VALUE_COUNT = "parquet_writer_page_value_count";
+    private static final String PARQUET_USE_BLOOM_FILTER = "parquet_use_bloom_filter";
     private static final String TARGET_MAX_FILE_SIZE = "target_max_file_size";
     private static final String IDLE_WRITER_MIN_FILE_SIZE = "idle_writer_min_file_size";
     private static final String COMPRESSION_CODEC = "compression_codec";
@@ -139,6 +140,11 @@ public final class DeltaLakeSessionProperties
                         PARQUET_VECTORIZED_DECODING_ENABLED,
                         "Enable using Java Vector API for faster decoding of parquet files",
                         parquetReaderConfig.isVectorizedDecodingEnabled(),
+                        false),
+                booleanProperty(
+                        PARQUET_USE_BLOOM_FILTER,
+                        "Use Parquet Bloom filters",
+                        parquetReaderConfig.isUseBloomFilter(),
                         false),
                 dataSizeProperty(
                         PARQUET_WRITER_BLOCK_SIZE,
@@ -282,6 +288,11 @@ public final class DeltaLakeSessionProperties
     public static boolean isParquetVectorizedDecodingEnabled(ConnectorSession session)
     {
         return session.getProperty(PARQUET_VECTORIZED_DECODING_ENABLED, Boolean.class);
+    }
+
+    public static boolean useParquetBloomFilter(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_USE_BLOOM_FILTER, Boolean.class);
     }
 
     public static DataSize getParquetWriterBlockSize(ConnectorSession session)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTableProperties.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTableProperties.java
@@ -42,6 +42,7 @@ public class DeltaLakeTableProperties
     public static final String CHECKPOINT_INTERVAL_PROPERTY = "checkpoint_interval";
     public static final String CHANGE_DATA_FEED_ENABLED_PROPERTY = "change_data_feed_enabled";
     public static final String COLUMN_MAPPING_MODE_PROPERTY = "column_mapping_mode";
+    public static final String PARQUET_BLOOM_FILTER_COLUMNS_PROPERTY = "parquet_bloom_filter_columns";
 
     private final List<PropertyMetadata<?>> tableProperties;
 
@@ -88,6 +89,18 @@ public class DeltaLakeTableProperties
                             }
                         },
                         false))
+                .add(new PropertyMetadata<>(
+                        PARQUET_BLOOM_FILTER_COLUMNS_PROPERTY,
+                        "Parquet Bloom filter index columns",
+                        new ArrayType(VARCHAR),
+                        List.class,
+                        ImmutableList.of(),
+                        false,
+                        value -> ((List<?>) value).stream()
+                                .map(String.class::cast)
+                                .map(name -> name.toLowerCase(ENGLISH))
+                                .collect(toImmutableList()),
+                        value -> value))
                 .build();
     }
 
@@ -127,5 +140,11 @@ public class DeltaLakeTableProperties
     public static ColumnMappingMode getColumnMappingMode(Map<String, Object> tableProperties)
     {
         return ColumnMappingMode.valueOf(tableProperties.get(COLUMN_MAPPING_MODE_PROPERTY).toString().toUpperCase(ENGLISH));
+    }
+
+    public static List<String> getParquetBloomFilterColumns(Map<String, Object> tableProperties)
+    {
+        List<String> parquetBloomFilterColumns = (List<String>) tableProperties.get(PARQUET_BLOOM_FILTER_COLUMNS_PROPERTY);
+        return parquetBloomFilterColumns == null ? ImmutableList.of() : ImmutableList.copyOf(parquetBloomFilterColumns);
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/MetadataEntry.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/MetadataEntry.java
@@ -32,6 +32,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_INVALID_SCHEMA;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.COLUMN_MAPPING_MODE_CONFIGURATION_KEY;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.MAX_COLUMN_ID_CONFIGURATION_KEY;
+import static io.trino.plugin.deltalake.util.DeltaLakeWriteUtils.PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX;
 import static java.lang.Long.parseLong;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
@@ -168,7 +169,8 @@ public class MetadataEntry
             Optional<Long> checkpointInterval,
             Optional<Boolean> changeDataFeedEnabled,
             ColumnMappingMode columnMappingMode,
-            OptionalInt maxFieldId)
+            OptionalInt maxFieldId,
+            List<String> bloomFilterColumns)
     {
         ImmutableMap.Builder<String, String> configurationMapBuilder = ImmutableMap.builder();
         checkpointInterval.ifPresent(interval -> configurationMapBuilder.put(DELTA_CHECKPOINT_INTERVAL_PROPERTY, String.valueOf(interval)));
@@ -181,6 +183,7 @@ public class MetadataEntry
             }
             case UNKNOWN -> throw new UnsupportedOperationException();
         }
+        bloomFilterColumns.forEach(column -> configurationMapBuilder.put(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + column, "true"));
         return configurationMapBuilder.buildOrThrow();
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
@@ -60,6 +60,7 @@ import static io.trino.plugin.deltalake.DeltaTestingConnectorSession.SESSION;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.ColumnMappingMode.NONE;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.serializeColumnType;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.serializeSchemaAsJson;
+import static io.trino.plugin.deltalake.transactionlog.MetadataEntry.configurationForNewTable;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_FILE_SYSTEM_STATS;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -171,13 +172,12 @@ public class TestDeltaLakePageSink
                 Optional.of(deltaLakeConfig.getDefaultCheckpointWritingInterval()),
                 true,
                 Optional.empty(),
-                Optional.of(false),
                 schemaString,
                 NONE,
-                OptionalInt.empty(),
                 false,
                 OptionalLong.empty(),
-                new ProtocolEntry(DEFAULT_READER_VERSION, DEFAULT_WRITER_VERSION, Optional.empty(), Optional.empty()));
+                new ProtocolEntry(DEFAULT_READER_VERSION, DEFAULT_WRITER_VERSION, Optional.empty(), Optional.empty()),
+                configurationForNewTable(Optional.of(deltaLakeConfig.getDefaultCheckpointWritingInterval()), Optional.of(false), NONE, OptionalInt.empty()));
 
         DeltaLakePageSinkProvider provider = new DeltaLakePageSinkProvider(
                 new GroupByHashPageIndexerFactory(new FlatHashStrategyCompiler(new TypeOperators())),

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
@@ -177,7 +177,7 @@ public class TestDeltaLakePageSink
                 false,
                 OptionalLong.empty(),
                 new ProtocolEntry(DEFAULT_READER_VERSION, DEFAULT_WRITER_VERSION, Optional.empty(), Optional.empty()),
-                configurationForNewTable(Optional.of(deltaLakeConfig.getDefaultCheckpointWritingInterval()), Optional.of(false), NONE, OptionalInt.empty()));
+                configurationForNewTable(Optional.of(deltaLakeConfig.getDefaultCheckpointWritingInterval()), Optional.of(false), NONE, OptionalInt.empty(), ImmutableList.of()));
 
         DeltaLakePageSinkProvider provider = new DeltaLakePageSinkProvider(
                 new GroupByHashPageIndexerFactory(new FlatHashStrategyCompiler(new TypeOperators())),

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeParquetWithBloomFilters.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeParquetWithBloomFilters.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import com.google.common.base.Joiner;
+import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.testing.BaseTestParquetWithBloomFilters;
+import io.trino.testing.MaterializedResult;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.trino.testing.MaterializedResult.resultBuilder;
+import static io.trino.testing.QueryAssertions.assertContains;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestDeltaLakeParquetWithBloomFilters
+        extends BaseTestParquetWithBloomFilters
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return DeltaLakeQueryRunner.builder().build();
+    }
+
+    @Override
+    protected CatalogSchemaTableName createParquetTableWithBloomFilter(String columnName, List<Integer> testValues)
+    {
+        // create the managed table
+        String tableName = "parquet_with_bloom_filters_" + randomNameSuffix();
+        CatalogSchemaTableName catalogSchemaTableName = new CatalogSchemaTableName("delta", new SchemaTableName("tpch", tableName));
+        assertUpdate(format("CREATE TABLE %s WITH (parquet_bloom_filter_columns = ARRAY['%s']) AS SELECT * FROM (VALUES %s) t(%s)", catalogSchemaTableName, columnName, Joiner.on(", ").join(testValues), columnName), testValues.size());
+
+        return catalogSchemaTableName;
+    }
+
+    @Test
+    public void testBloomFilterPropertiesArePersistedDuringCreate()
+    {
+        String tableName = "test_metadata_write_properties_" + randomNameSuffix();
+        assertQuerySucceeds("CREATE TABLE " + tableName + " (A bigint, b bigint, c bigint) WITH (" +
+                "parquet_bloom_filter_columns = array['a','B'])");
+
+        MaterializedResult actualProperties = computeActual("SELECT * FROM \"" + tableName + "$properties\"");
+        assertThat(actualProperties).isNotNull();
+        MaterializedResult expectedProperties = resultBuilder(getSession())
+                .row("write.parquet.bloom-filter-enabled.column.a", "true")
+                .row("write.parquet.bloom-filter-enabled.column.b", "true")
+                .build();
+        assertContains(actualProperties, expectedProperties);
+
+        assertThat((String) computeScalar("SHOW CREATE TABLE " + tableName))
+                .contains("parquet_bloom_filter_columns");
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -309,7 +309,7 @@ public final class IcebergUtil
         // iceberg Parquet format bloom filter properties
         Set<String> parquetBloomFilterColumns = getParquetBloomFilterColumns(icebergTable.properties());
         if (!parquetBloomFilterColumns.isEmpty()) {
-            properties.put(PARQUET_BLOOM_FILTER_COLUMNS_PROPERTY, ImmutableList.copyOf(parquetBloomFilterColumns));
+            properties.put(PARQUET_BLOOM_FILTER_COLUMNS_PROPERTY, ImmutableList.sortedCopyOf(parquetBloomFilterColumns));
         }
 
         return properties.buildOrThrow();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This PR adds support for writing Bloom filters to the Parquet file of Delta tables when certain table properties are defined. This PR uses the same properties as Iceberg.

Which table properties to use to control writing of Parquet Bloom filters is not part of the Delta protocol. There is an open issue to get it into the protocol at https://github.com/delta-io/delta/issues/2751.

The PR is an adaption of https://github.com/trinodb/trino/commit/2edfe096efbde37ef8a24479552927950df669f6 to Delta Lake.

If the approach looks good I'll add a product test.

We should also extend `BaseTestParquetWithBloomFilters` to test different ways of writing to a table (CTAS, INSERT INTO, MERGE INTO, OPTIMIZE).

Fixes https://github.com/trinodb/trino/issues/21570.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Support writing Parquet Bloom filters in Delta Lake connector. ({issue}`21570`)
```
