### PR TITLE
Fix incorrect case optimization

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/SimplifyRedundantCase.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/SimplifyRedundantCase.java
@@ -17,6 +17,7 @@ import io.trino.Session;
 import io.trino.metadata.Metadata;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.ir.Case;
+import io.trino.sql.ir.Comparison;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.IrExpressions;
 import io.trino.sql.ir.WhenClause;
@@ -53,11 +54,11 @@ public class SimplifyRedundantCase
 
         WhenClause thenClause = caseTerm.whenClauses().getFirst();
         if (thenClause.getResult().equals(TRUE) && caseTerm.defaultValue().equals(FALSE)) {
-            return Optional.of(thenClause.getOperand());
+            return Optional.of(new Comparison(Comparison.Operator.IDENTICAL, thenClause.getOperand(), TRUE));
         }
 
         if (thenClause.getResult().equals(FALSE) && caseTerm.defaultValue().equals(TRUE)) {
-            return Optional.of(IrExpressions.not(metadata, thenClause.getOperand()));
+            return Optional.of(IrExpressions.not(metadata, new Comparison(Comparison.Operator.IDENTICAL, thenClause.getOperand(), TRUE)));
         }
 
         return Optional.empty();

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveRedundantPredicateAboveTableScan.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveRedundantPredicateAboveTableScan.java
@@ -48,6 +48,7 @@ import static io.trino.sql.ir.Booleans.FALSE;
 import static io.trino.sql.ir.Booleans.TRUE;
 import static io.trino.sql.ir.Comparison.Operator.EQUAL;
 import static io.trino.sql.ir.Comparison.Operator.GREATER_THAN;
+import static io.trino.sql.ir.Comparison.Operator.IDENTICAL;
 import static io.trino.sql.ir.Comparison.Operator.LESS_THAN;
 import static io.trino.sql.ir.IrExpressions.ifExpression;
 import static io.trino.sql.ir.Logical.Operator.AND;
@@ -286,7 +287,7 @@ public class TestRemoveRedundantPredicateAboveTableScan
                                         nationKeyColumnHandle, NullableValue.of(BIGINT, (long) 44))))))
                 .matches(
                         filter(
-                                new Comparison(EQUAL, new Reference(VARCHAR, "name"), new Constant(VARCHAR, Slices.utf8Slice("x"))),
+                                new Comparison(IDENTICAL, new Comparison(EQUAL, new Reference(VARCHAR, "name"), new Constant(VARCHAR, Slices.utf8Slice("x"))), TRUE),
                                 constrainedTableScanWithTableLayout(
                                         "nation",
                                         ImmutableMap.of(

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestIssue22530.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestIssue22530.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestIssue22530
+{
+    @Test
+    void test()
+    {
+        try (QueryAssertions assertions = new QueryAssertions()) {
+            assertThat(assertions.query(
+                    """
+                    WITH t(a) AS (VALUES 1, 2, null)
+                    SELECT CASE
+                      WHEN a = 1 THEN true
+                      ELSE false
+                      END
+                    FROM t
+                    """))
+                    .matches("VALUES true, false, false");
+        }
+
+        try (QueryAssertions assertions = new QueryAssertions()) {
+            assertThat(assertions.query(
+                    """
+                    WITH t(a) AS (VALUES 1, 2, null)
+                    SELECT CASE
+                      WHEN a = 1 THEN false
+                      ELSE true
+                      END
+                    FROM t
+                    """))
+                    .matches("VALUES false, true, true");
+        }
+    }
+}


### PR DESCRIPTION
Expressions of the form:

```
CASE
    WHEN <cond> THEN true
    ELSE false
END
```

were being simplified to `<cond>`, which is
incorrect due to null handling. The original
form would return false, while the simplified
form returns null.

The correct transformation is: `<cond> ≡ true`.

Conversely, for an expression such as:

```
CASE
    WHEN <cond> THEN false
    ELSE true
END
```

The correct transformation is: `not(<cond> ≡ true)`.


Fixes #22530 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix incorrect results for CASE expressions of the form `CASE WHEN ... THEN true ELSE false END`. ({issue}`22530`)
```
