### PR TITLE
Optimize lookups of ColumnChunkMetadata in large parquet schema

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/BloomFilterStore.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/BloomFilterStore.java
@@ -56,7 +56,7 @@ public class BloomFilterStore
         requireNonNull(columnsFiltered, "columnsFiltered is null");
 
         ImmutableMap.Builder<ColumnPath, Long> bloomFilterOffsetBuilder = ImmutableMap.builder();
-        for (ColumnChunkMetadata column : block.getColumns()) {
+        for (ColumnChunkMetadata column : block.columns()) {
             ColumnPath path = column.getPath();
             if (hasBloomFilter(column) && columnsFiltered.contains(path)) {
                 bloomFilterOffsetBuilder.put(path, column.getBloomFilterOffset());
@@ -106,7 +106,7 @@ public class BloomFilterStore
             return Optional.empty();
         }
 
-        boolean hasBloomFilter = blockMetadata.getColumns().stream().anyMatch(BloomFilterStore::hasBloomFilter);
+        boolean hasBloomFilter = blockMetadata.columns().stream().anyMatch(BloomFilterStore::hasBloomFilter);
         if (!hasBloomFilter) {
             return Optional.empty();
         }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetWriteValidation.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetWriteValidation.java
@@ -138,14 +138,14 @@ public class ParquetWriteValidation
             BlockMetadata block = rowGroupInfos.get(rowGroupIndex).blockMetaData();
             RowGroup rowGroup = rowGroups.get(rowGroupIndex);
             validateParquet(
-                    block.getRowCount() == rowGroup.getNum_rows(),
+                    block.rowCount() == rowGroup.getNum_rows(),
                     dataSourceId,
                     "Number of rows %d in row group %d did not match %d",
-                    block.getRowCount(),
+                    block.rowCount(),
                     rowGroupIndex,
                     rowGroup.getNum_rows());
 
-            List<ColumnChunkMetadata> columnChunkMetaData = block.getColumns();
+            List<ColumnChunkMetadata> columnChunkMetaData = block.columns();
             validateParquet(
                     columnChunkMetaData.size() == rowGroup.getColumnsSize(),
                     dataSourceId,
@@ -358,7 +358,7 @@ public class ParquetWriteValidation
     public void validateRowGroupStatistics(ParquetDataSourceId dataSourceId, BlockMetadata blockMetaData, List<ColumnStatistics> actualColumnStatistics)
             throws ParquetCorruptionException
     {
-        List<ColumnChunkMetadata> columnChunks = blockMetaData.getColumns();
+        List<ColumnChunkMetadata> columnChunks = blockMetaData.columns();
         checkArgument(
                 columnChunks.size() == actualColumnStatistics.size(),
                 "Column chunk metadata count %s did not match column fields count %s",

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetWriteValidation.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetWriteValidation.java
@@ -18,9 +18,9 @@ import io.airlift.slice.SizeOf;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.airlift.slice.XxHash64;
-import io.trino.parquet.metadata.BlockMetadata;
 import io.trino.parquet.metadata.ColumnChunkMetadata;
 import io.trino.parquet.metadata.IndexReference;
+import io.trino.parquet.metadata.PrunedBlockMetadata;
 import io.trino.parquet.reader.RowGroupInfo;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
@@ -135,17 +135,17 @@ public class ParquetWriteValidation
                 rowGroupInfos.size(),
                 rowGroups.size());
         for (int rowGroupIndex = 0; rowGroupIndex < rowGroupInfos.size(); rowGroupIndex++) {
-            BlockMetadata block = rowGroupInfos.get(rowGroupIndex).blockMetaData();
+            PrunedBlockMetadata block = rowGroupInfos.get(rowGroupIndex).prunedBlockMetadata();
             RowGroup rowGroup = rowGroups.get(rowGroupIndex);
             validateParquet(
-                    block.rowCount() == rowGroup.getNum_rows(),
+                    block.getRowCount() == rowGroup.getNum_rows(),
                     dataSourceId,
                     "Number of rows %d in row group %d did not match %d",
-                    block.rowCount(),
+                    block.getRowCount(),
                     rowGroupIndex,
                     rowGroup.getNum_rows());
 
-            List<ColumnChunkMetadata> columnChunkMetaData = block.columns();
+            List<ColumnChunkMetadata> columnChunkMetaData = block.getColumns();
             validateParquet(
                     columnChunkMetaData.size() == rowGroup.getColumnsSize(),
                     dataSourceId,
@@ -355,10 +355,10 @@ public class ParquetWriteValidation
         }
     }
 
-    public void validateRowGroupStatistics(ParquetDataSourceId dataSourceId, BlockMetadata blockMetaData, List<ColumnStatistics> actualColumnStatistics)
+    public void validateRowGroupStatistics(ParquetDataSourceId dataSourceId, PrunedBlockMetadata blockMetaData, List<ColumnStatistics> actualColumnStatistics)
             throws ParquetCorruptionException
     {
-        List<ColumnChunkMetadata> columnChunks = blockMetaData.columns();
+        List<ColumnChunkMetadata> columnChunks = blockMetaData.getColumns();
         checkArgument(
                 columnChunks.size() == actualColumnStatistics.size(),
                 "Column chunk metadata count %s did not match column fields count %s",

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/metadata/BlockMetadata.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/metadata/BlockMetadata.java
@@ -13,100 +13,12 @@
  */
 package io.trino.parquet.metadata;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
-public class BlockMetadata
+public record BlockMetadata(long rowCount, List<ColumnChunkMetadata> columns)
 {
-    private final List<ColumnChunkMetadata> columns = new ArrayList<>();
-    private long rowCount;
-    private long totalByteSize;
-    private String path;
-    private int ordinal;
-    private long rowIndexOffset = -1;
-
-    public void setPath(String path)
-    {
-        this.path = path;
-    }
-
-    public String getPath()
-    {
-        return path;
-    }
-
-    public long getRowCount()
-    {
-        return rowCount;
-    }
-
-    public void setRowCount(long rowCount)
-    {
-        this.rowCount = rowCount;
-    }
-
-    public long getRowIndexOffset()
-    {
-        return rowIndexOffset;
-    }
-
-    public void setRowIndexOffset(long rowIndexOffset)
-    {
-        this.rowIndexOffset = rowIndexOffset;
-    }
-
-    public long getTotalByteSize()
-    {
-        return totalByteSize;
-    }
-
-    public void setTotalByteSize(long totalByteSize)
-    {
-        this.totalByteSize = totalByteSize;
-    }
-
-    public void addColumn(ColumnChunkMetadata column)
-    {
-        columns.add(column);
-    }
-
-    public List<ColumnChunkMetadata> getColumns()
-    {
-        return Collections.unmodifiableList(columns);
-    }
-
     public long getStartingPos()
     {
-        return getColumns().getFirst().getStartingPos();
-    }
-
-    @Override
-    public String toString()
-    {
-        String rowIndexOffsetString = "";
-        if (rowIndexOffset != -1) {
-            rowIndexOffsetString = ", rowIndexOffset = " + rowIndexOffset;
-        }
-        return "BlockMetaData{" + rowCount + ", " + totalByteSize + rowIndexOffsetString + " " + columns + "}";
-    }
-
-    public long getCompressedSize()
-    {
-        long totalSize = 0;
-        for (ColumnChunkMetadata col : getColumns()) {
-            totalSize += col.getTotalSize();
-        }
-        return totalSize;
-    }
-
-    public int getOrdinal()
-    {
-        return ordinal;
-    }
-
-    public void setOrdinal(int ordinal)
-    {
-        this.ordinal = ordinal;
+        return columns().getFirst().getStartingPos();
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/metadata/PrunedBlockMetadata.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/metadata/PrunedBlockMetadata.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.metadata;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.parquet.ParquetCorruptionException;
+import io.trino.parquet.ParquetDataSourceId;
+import org.apache.parquet.column.ColumnDescriptor;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.Arrays.asList;
+import static java.util.function.Function.identity;
+
+public final class PrunedBlockMetadata
+{
+    /**
+     * Stores only the necessary columns metadata from BlockMetadata and indexes them by path for efficient look-ups
+     */
+    public static PrunedBlockMetadata createPrunedColumnsMetadata(BlockMetadata blockMetadata, ParquetDataSourceId dataSourceId, Map<List<String>, ColumnDescriptor> descriptorsByPath)
+            throws ParquetCorruptionException
+    {
+        Set<List<String>> requiredPaths = descriptorsByPath.keySet();
+        Map<List<String>, ColumnChunkMetadata> columnMetadataByPath = blockMetadata.columns().stream()
+                .collect(toImmutableMap(column -> asList(column.getPath().toArray()), identity()));
+        ImmutableMap.Builder<List<String>, ColumnChunkMetadata> columnMetadataByPathBuilder = ImmutableMap.builderWithExpectedSize(requiredPaths.size());
+        for (Map.Entry<List<String>, ColumnDescriptor> entry : descriptorsByPath.entrySet()) {
+            List<String> requiredPath = entry.getKey();
+            ColumnDescriptor columnDescriptor = entry.getValue();
+            ColumnChunkMetadata columnChunkMetadata = columnMetadataByPath.get(requiredPath);
+            if (columnChunkMetadata == null) {
+                throw new ParquetCorruptionException(dataSourceId, "Metadata is missing for column: %s", columnDescriptor);
+            }
+            columnMetadataByPathBuilder.put(requiredPath, columnChunkMetadata);
+        }
+        return new PrunedBlockMetadata(blockMetadata.rowCount(), dataSourceId, columnMetadataByPathBuilder.buildOrThrow());
+    }
+
+    private final long rowCount;
+    private final ParquetDataSourceId dataSourceId;
+    private final Map<List<String>, ColumnChunkMetadata> columnMetadataByPath;
+
+    private PrunedBlockMetadata(long rowCount, ParquetDataSourceId dataSourceId, Map<List<String>, ColumnChunkMetadata> columnMetadataByPath)
+    {
+        this.rowCount = rowCount;
+        this.dataSourceId = dataSourceId;
+        this.columnMetadataByPath = columnMetadataByPath;
+    }
+
+    public long getRowCount()
+    {
+        return rowCount;
+    }
+
+    public List<ColumnChunkMetadata> getColumns()
+    {
+        return ImmutableList.copyOf(columnMetadataByPath.values());
+    }
+
+    public ColumnChunkMetadata getColumnChunkMetaData(ColumnDescriptor columnDescriptor)
+            throws ParquetCorruptionException
+    {
+        ColumnChunkMetadata columnChunkMetadata = columnMetadataByPath.get(asList(columnDescriptor.getPath()));
+        if (columnChunkMetadata == null) {
+            throw new ParquetCorruptionException(dataSourceId, "Metadata is missing for column: %s", columnDescriptor);
+        }
+        return columnChunkMetadata;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("rowCount", rowCount)
+                .add("columnMetadataByPath", columnMetadataByPath)
+                .toString();
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/PredicateUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/PredicateUtils.java
@@ -141,7 +141,7 @@ public final class PredicateUtils
             int domainCompactionThreshold)
             throws IOException
     {
-        if (block.getRowCount() == 0) {
+        if (block.rowCount() == 0) {
             return false;
         }
         Map<ColumnDescriptor, Statistics<?>> columnStatistics = getStatistics(block, descriptorsByPath);
@@ -192,7 +192,7 @@ public final class PredicateUtils
         long fileRowCount = 0;
         ImmutableList.Builder<RowGroupInfo> rowGroupInfoBuilder = ImmutableList.builder();
         for (BlockMetadata block : blocksMetaData) {
-            long blockStart = block.getColumns().getFirst().getStartingPos();
+            long blockStart = block.getStartingPos();
             boolean splitContainsBlock = splitStart <= blockStart && blockStart < splitStart + splitLength;
             if (splitContainsBlock) {
                 for (int i = 0; i < parquetTupleDomains.size(); i++) {
@@ -215,7 +215,7 @@ public final class PredicateUtils
                     }
                 }
             }
-            fileRowCount += block.getRowCount();
+            fileRowCount += block.rowCount();
         }
         return rowGroupInfoBuilder.build();
     }
@@ -223,7 +223,7 @@ public final class PredicateUtils
     private static Map<ColumnDescriptor, Statistics<?>> getStatistics(BlockMetadata blockMetadata, Map<List<String>, ColumnDescriptor> descriptorsByPath)
     {
         ImmutableMap.Builder<ColumnDescriptor, Statistics<?>> statistics = ImmutableMap.builder();
-        for (ColumnChunkMetadata columnMetaData : blockMetadata.getColumns()) {
+        for (ColumnChunkMetadata columnMetaData : blockMetadata.columns()) {
             Statistics<?> columnStatistics = columnMetaData.getStatistics();
             if (columnStatistics != null) {
                 ColumnDescriptor descriptor = descriptorsByPath.get(Arrays.asList(columnMetaData.getPath().toArray()));
@@ -238,7 +238,7 @@ public final class PredicateUtils
     private static Map<ColumnDescriptor, Long> getColumnValueCounts(BlockMetadata blockMetadata, Map<List<String>, ColumnDescriptor> descriptorsByPath)
     {
         ImmutableMap.Builder<ColumnDescriptor, Long> columnValueCounts = ImmutableMap.builder();
-        for (ColumnChunkMetadata columnMetaData : blockMetadata.getColumns()) {
+        for (ColumnChunkMetadata columnMetaData : blockMetadata.columns()) {
             ColumnDescriptor descriptor = descriptorsByPath.get(Arrays.asList(columnMetaData.getPath().toArray()));
             if (descriptor != null) {
                 columnValueCounts.put(descriptor, columnMetaData.getValueCount());
@@ -256,7 +256,7 @@ public final class PredicateUtils
             Optional<ColumnIndexStore> columnIndexStore)
             throws IOException
     {
-        for (ColumnChunkMetadata columnMetaData : blockMetadata.getColumns()) {
+        for (ColumnChunkMetadata columnMetaData : blockMetadata.columns()) {
             ColumnDescriptor descriptor = descriptorsByPath.get(Arrays.asList(columnMetaData.getPath().toArray()));
             if (descriptor == null || !candidateColumns.contains(descriptor)) {
                 continue;

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/PredicateUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/PredicateUtils.java
@@ -20,12 +20,14 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.SliceInput;
 import io.trino.parquet.BloomFilterStore;
 import io.trino.parquet.DictionaryPage;
+import io.trino.parquet.ParquetCorruptionException;
 import io.trino.parquet.ParquetDataSource;
 import io.trino.parquet.ParquetDataSourceId;
 import io.trino.parquet.ParquetEncoding;
 import io.trino.parquet.ParquetReaderOptions;
 import io.trino.parquet.metadata.BlockMetadata;
 import io.trino.parquet.metadata.ColumnChunkMetadata;
+import io.trino.parquet.metadata.PrunedBlockMetadata;
 import io.trino.parquet.reader.RowGroupInfo;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.DecimalType;
@@ -56,6 +58,7 @@ import static io.trino.parquet.BloomFilterStore.getBloomFilterStore;
 import static io.trino.parquet.ParquetCompressionUtils.decompress;
 import static io.trino.parquet.ParquetReaderUtils.isOnlyDictionaryEncodingPages;
 import static io.trino.parquet.ParquetTypeUtils.getParquetEncoding;
+import static io.trino.parquet.metadata.PrunedBlockMetadata.createPrunedColumnsMetadata;
 import static io.trino.parquet.reader.TrinoColumnIndexStore.getColumnIndexStore;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DateType.DATE;
@@ -131,7 +134,7 @@ public final class PredicateUtils
 
     public static boolean predicateMatches(
             TupleDomainParquetPredicate parquetPredicate,
-            BlockMetadata block,
+            PrunedBlockMetadata columnsMetadata,
             ParquetDataSource dataSource,
             Map<List<String>, ColumnDescriptor> descriptorsByPath,
             TupleDomain<ColumnDescriptor> parquetTupleDomain,
@@ -141,11 +144,11 @@ public final class PredicateUtils
             int domainCompactionThreshold)
             throws IOException
     {
-        if (block.rowCount() == 0) {
+        if (columnsMetadata.getRowCount() == 0) {
             return false;
         }
-        Map<ColumnDescriptor, Statistics<?>> columnStatistics = getStatistics(block, descriptorsByPath);
-        Map<ColumnDescriptor, Long> columnValueCounts = getColumnValueCounts(block, descriptorsByPath);
+        Map<ColumnDescriptor, Statistics<?>> columnStatistics = getStatistics(columnsMetadata, descriptorsByPath);
+        Map<ColumnDescriptor, Long> columnValueCounts = getColumnValueCounts(columnsMetadata, descriptorsByPath);
         Optional<List<ColumnDescriptor>> candidateColumns = parquetPredicate.getIndexLookupCandidates(columnValueCounts, columnStatistics, dataSource.getId());
         if (candidateColumns.isEmpty()) {
             return false;
@@ -169,7 +172,7 @@ public final class PredicateUtils
 
         return dictionaryPredicatesMatch(
                 indexPredicate,
-                block,
+                columnsMetadata,
                 dataSource,
                 descriptorsByPath,
                 ImmutableSet.copyOf(candidateColumns.get()),
@@ -200,9 +203,10 @@ public final class PredicateUtils
                     TupleDomainParquetPredicate parquetPredicate = parquetPredicates.get(i);
                     Optional<ColumnIndexStore> columnIndex = getColumnIndexStore(dataSource, block, descriptorsByPath, parquetTupleDomain, options);
                     Optional<BloomFilterStore> bloomFilterStore = getBloomFilterStore(dataSource, block, parquetTupleDomain, options);
+                    PrunedBlockMetadata columnsMetadata = createPrunedColumnsMetadata(block, dataSource.getId(), descriptorsByPath);
                     if (predicateMatches(
                             parquetPredicate,
-                            block,
+                            columnsMetadata,
                             dataSource,
                             descriptorsByPath,
                             parquetTupleDomain,
@@ -210,7 +214,7 @@ public final class PredicateUtils
                             bloomFilterStore,
                             timeZone,
                             domainCompactionThreshold)) {
-                        rowGroupInfoBuilder.add(new RowGroupInfo(block, fileRowCount, columnIndex));
+                        rowGroupInfoBuilder.add(new RowGroupInfo(columnsMetadata, fileRowCount, columnIndex));
                         break;
                     }
                 }
@@ -220,45 +224,43 @@ public final class PredicateUtils
         return rowGroupInfoBuilder.build();
     }
 
-    private static Map<ColumnDescriptor, Statistics<?>> getStatistics(BlockMetadata blockMetadata, Map<List<String>, ColumnDescriptor> descriptorsByPath)
+    private static Map<ColumnDescriptor, Statistics<?>> getStatistics(PrunedBlockMetadata columnsMetadata, Map<List<String>, ColumnDescriptor> descriptorsByPath)
+            throws ParquetCorruptionException
     {
-        ImmutableMap.Builder<ColumnDescriptor, Statistics<?>> statistics = ImmutableMap.builder();
-        for (ColumnChunkMetadata columnMetaData : blockMetadata.columns()) {
+        ImmutableMap.Builder<ColumnDescriptor, Statistics<?>> statistics = ImmutableMap.builderWithExpectedSize(descriptorsByPath.size());
+        for (ColumnDescriptor descriptor : descriptorsByPath.values()) {
+            ColumnChunkMetadata columnMetaData = columnsMetadata.getColumnChunkMetaData(descriptor);
             Statistics<?> columnStatistics = columnMetaData.getStatistics();
             if (columnStatistics != null) {
-                ColumnDescriptor descriptor = descriptorsByPath.get(Arrays.asList(columnMetaData.getPath().toArray()));
-                if (descriptor != null) {
-                    statistics.put(descriptor, columnStatistics);
-                }
+                statistics.put(descriptor, columnStatistics);
             }
         }
         return statistics.buildOrThrow();
     }
 
-    private static Map<ColumnDescriptor, Long> getColumnValueCounts(BlockMetadata blockMetadata, Map<List<String>, ColumnDescriptor> descriptorsByPath)
+    private static Map<ColumnDescriptor, Long> getColumnValueCounts(PrunedBlockMetadata columnsMetadata, Map<List<String>, ColumnDescriptor> descriptorsByPath)
+            throws ParquetCorruptionException
     {
-        ImmutableMap.Builder<ColumnDescriptor, Long> columnValueCounts = ImmutableMap.builder();
-        for (ColumnChunkMetadata columnMetaData : blockMetadata.columns()) {
-            ColumnDescriptor descriptor = descriptorsByPath.get(Arrays.asList(columnMetaData.getPath().toArray()));
-            if (descriptor != null) {
-                columnValueCounts.put(descriptor, columnMetaData.getValueCount());
-            }
+        ImmutableMap.Builder<ColumnDescriptor, Long> columnValueCounts = ImmutableMap.builderWithExpectedSize(descriptorsByPath.size());
+        for (ColumnDescriptor descriptor : descriptorsByPath.values()) {
+            ColumnChunkMetadata columnMetaData = columnsMetadata.getColumnChunkMetaData(descriptor);
+            columnValueCounts.put(descriptor, columnMetaData.getValueCount());
         }
         return columnValueCounts.buildOrThrow();
     }
 
     private static boolean dictionaryPredicatesMatch(
             TupleDomainParquetPredicate parquetPredicate,
-            BlockMetadata blockMetadata,
+            PrunedBlockMetadata columnsMetadata,
             ParquetDataSource dataSource,
             Map<List<String>, ColumnDescriptor> descriptorsByPath,
             Set<ColumnDescriptor> candidateColumns,
             Optional<ColumnIndexStore> columnIndexStore)
             throws IOException
     {
-        for (ColumnChunkMetadata columnMetaData : blockMetadata.columns()) {
-            ColumnDescriptor descriptor = descriptorsByPath.get(Arrays.asList(columnMetaData.getPath().toArray()));
-            if (descriptor == null || !candidateColumns.contains(descriptor)) {
+        for (ColumnDescriptor descriptor : descriptorsByPath.values()) {
+            ColumnChunkMetadata columnMetaData = columnsMetadata.getColumnChunkMetaData(descriptor);
+            if (!candidateColumns.contains(descriptor)) {
                 continue;
             }
             if (isOnlyDictionaryEncodingPages(columnMetaData)) {

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
@@ -183,7 +183,7 @@ public class ParquetReader
                 int columnId = field.getId();
                 ColumnChunkMetadata chunkMetadata = getColumnChunkMetaData(metadata, field.getDescriptor());
                 ColumnPath columnPath = chunkMetadata.getPath();
-                long rowGroupRowCount = metadata.getRowCount();
+                long rowGroupRowCount = metadata.rowCount();
                 long startingPosition = chunkMetadata.getStartingPos();
                 long totalLength = chunkMetadata.getTotalSize();
                 long totalDataSize = 0;
@@ -299,7 +299,7 @@ public class ParquetReader
         RowGroupInfo rowGroupInfo = rowGroups.get(currentRowGroup);
         currentBlockMetadata = rowGroupInfo.blockMetaData();
         firstRowIndexInGroup = rowGroupInfo.fileRowOffset();
-        currentGroupRowCount = currentBlockMetadata.getRowCount();
+        currentGroupRowCount = currentBlockMetadata.rowCount();
         FilteredRowRanges currentGroupRowRanges = blockRowRanges[currentRowGroup];
         log.debug("advanceToNextRowGroup dataSource %s, currentRowGroup %d, rowRanges %s, currentBlockMetadata %s", dataSource.getId(), currentRowGroup, currentGroupRowRanges, currentBlockMetadata);
         if (currentGroupRowRanges != null) {
@@ -448,12 +448,12 @@ public class ParquetReader
         int fieldId = field.getId();
         ColumnReader columnReader = columnReaders.get(fieldId);
         if (!columnReader.hasPageReader()) {
-            validateParquet(currentBlockMetadata.getRowCount() > 0, dataSource.getId(), "Row group has 0 rows");
+            validateParquet(currentBlockMetadata.rowCount() > 0, dataSource.getId(), "Row group has 0 rows");
             ColumnChunkMetadata metadata = getColumnChunkMetaData(currentBlockMetadata, columnDescriptor);
             FilteredRowRanges rowRanges = blockRowRanges[currentRowGroup];
             OffsetIndex offsetIndex = null;
             if (rowRanges != null) {
-                offsetIndex = getFilteredOffsetIndex(rowRanges, currentRowGroup, currentBlockMetadata.getRowCount(), metadata.getPath());
+                offsetIndex = getFilteredOffsetIndex(rowRanges, currentRowGroup, currentBlockMetadata.rowCount(), metadata.getPath());
             }
             ChunkedInputStream columnChunkInputStream = chunkReaders.get(new ChunkKey(fieldId, currentRowGroup));
             columnReader.setPageReader(
@@ -493,7 +493,7 @@ public class ParquetReader
     private ColumnChunkMetadata getColumnChunkMetaData(BlockMetadata blockMetaData, ColumnDescriptor columnDescriptor)
             throws IOException
     {
-        for (ColumnChunkMetadata metadata : blockMetaData.getColumns()) {
+        for (ColumnChunkMetadata metadata : blockMetaData.columns()) {
             // Column paths for nested structures have common root, so we compare in reverse to find mismatch sooner
             if (arrayEqualsReversed(metadata.getPath().toArray(), columnDescriptor.getPath())) {
                 return metadata;
@@ -585,7 +585,7 @@ public class ParquetReader
                 continue;
             }
             BlockMetadata metadata = rowGroupInfo.blockMetaData();
-            long rowGroupRowCount = metadata.getRowCount();
+            long rowGroupRowCount = metadata.rowCount();
             FilteredRowRanges rowRanges = new FilteredRowRanges(ColumnIndexFilter.calculateRowRanges(
                     FilterCompat.get(filter.get()),
                     rowGroupColumnIndexStore.get(),

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
@@ -30,8 +30,8 @@ import io.trino.parquet.ParquetDataSource;
 import io.trino.parquet.ParquetReaderOptions;
 import io.trino.parquet.ParquetWriteValidation;
 import io.trino.parquet.PrimitiveField;
-import io.trino.parquet.metadata.BlockMetadata;
 import io.trino.parquet.metadata.ColumnChunkMetadata;
+import io.trino.parquet.metadata.PrunedBlockMetadata;
 import io.trino.parquet.predicate.TupleDomainParquetPredicate;
 import io.trino.parquet.reader.FilteredOffsetIndex.OffsetRange;
 import io.trino.plugin.base.metrics.LongCount;
@@ -101,7 +101,7 @@ public class ParquetReader
     private final AggregatedMemoryContext memoryContext;
 
     private int currentRowGroup = -1;
-    private BlockMetadata currentBlockMetadata;
+    private PrunedBlockMetadata currentBlockMetadata;
     private long currentGroupRowCount;
     /**
      * Index in the Parquet file of the first row of the current group
@@ -178,12 +178,13 @@ public class ParquetReader
         ListMultimap<ChunkKey, DiskRange> ranges = ArrayListMultimap.create();
         Map<String, LongCount> codecMetrics = new HashMap<>();
         for (int rowGroup = 0; rowGroup < rowGroups.size(); rowGroup++) {
-            BlockMetadata metadata = rowGroups.get(rowGroup).blockMetaData();
+            PrunedBlockMetadata blockMetadata = rowGroups.get(rowGroup).prunedBlockMetadata();
+            long rowGroupRowCount = blockMetadata.getRowCount();
             for (PrimitiveField field : primitiveFields) {
                 int columnId = field.getId();
-                ColumnChunkMetadata chunkMetadata = getColumnChunkMetaData(metadata, field.getDescriptor());
+                ColumnChunkMetadata chunkMetadata = blockMetadata.getColumnChunkMetaData(field.getDescriptor());
                 ColumnPath columnPath = chunkMetadata.getPath();
-                long rowGroupRowCount = metadata.rowCount();
+
                 long startingPosition = chunkMetadata.getStartingPos();
                 long totalLength = chunkMetadata.getTotalSize();
                 long totalDataSize = 0;
@@ -297,9 +298,9 @@ public class ParquetReader
             return false;
         }
         RowGroupInfo rowGroupInfo = rowGroups.get(currentRowGroup);
-        currentBlockMetadata = rowGroupInfo.blockMetaData();
+        currentBlockMetadata = rowGroupInfo.prunedBlockMetadata();
         firstRowIndexInGroup = rowGroupInfo.fileRowOffset();
-        currentGroupRowCount = currentBlockMetadata.rowCount();
+        currentGroupRowCount = currentBlockMetadata.getRowCount();
         FilteredRowRanges currentGroupRowRanges = blockRowRanges[currentRowGroup];
         log.debug("advanceToNextRowGroup dataSource %s, currentRowGroup %d, rowRanges %s, currentBlockMetadata %s", dataSource.getId(), currentRowGroup, currentGroupRowRanges, currentBlockMetadata);
         if (currentGroupRowRanges != null) {
@@ -448,12 +449,12 @@ public class ParquetReader
         int fieldId = field.getId();
         ColumnReader columnReader = columnReaders.get(fieldId);
         if (!columnReader.hasPageReader()) {
-            validateParquet(currentBlockMetadata.rowCount() > 0, dataSource.getId(), "Row group has 0 rows");
-            ColumnChunkMetadata metadata = getColumnChunkMetaData(currentBlockMetadata, columnDescriptor);
+            validateParquet(currentBlockMetadata.getRowCount() > 0, dataSource.getId(), "Row group has 0 rows");
+            ColumnChunkMetadata metadata = currentBlockMetadata.getColumnChunkMetaData(columnDescriptor);
             FilteredRowRanges rowRanges = blockRowRanges[currentRowGroup];
             OffsetIndex offsetIndex = null;
             if (rowRanges != null) {
-                offsetIndex = getFilteredOffsetIndex(rowRanges, currentRowGroup, currentBlockMetadata.rowCount(), metadata.getPath());
+                offsetIndex = getFilteredOffsetIndex(rowRanges, currentRowGroup, currentBlockMetadata.getRowCount(), metadata.getPath());
             }
             ChunkedInputStream columnChunkInputStream = chunkReaders.get(new ChunkKey(fieldId, currentRowGroup));
             columnReader.setPageReader(
@@ -488,18 +489,6 @@ public class ParquetReader
         }
 
         return new Metrics(metrics.buildOrThrow());
-    }
-
-    private ColumnChunkMetadata getColumnChunkMetaData(BlockMetadata blockMetaData, ColumnDescriptor columnDescriptor)
-            throws IOException
-    {
-        for (ColumnChunkMetadata metadata : blockMetaData.columns()) {
-            // Column paths for nested structures have common root, so we compare in reverse to find mismatch sooner
-            if (arrayEqualsReversed(metadata.getPath().toArray(), columnDescriptor.getPath())) {
-                return metadata;
-            }
-        }
-        throw new ParquetCorruptionException(dataSource.getId(), "Metadata is missing for column: %s", columnDescriptor);
     }
 
     private void initializeColumnReaders()
@@ -584,8 +573,7 @@ public class ParquetReader
             if (rowGroupColumnIndexStore.isEmpty()) {
                 continue;
             }
-            BlockMetadata metadata = rowGroupInfo.blockMetaData();
-            long rowGroupRowCount = metadata.rowCount();
+            long rowGroupRowCount = rowGroupInfo.prunedBlockMetadata().getRowCount();
             FilteredRowRanges rowRanges = new FilteredRowRanges(ColumnIndexFilter.calculateRowRanges(
                     FilterCompat.get(filter.get()),
                     rowGroupColumnIndexStore.get(),
@@ -623,18 +611,5 @@ public class ParquetReader
         if (writeValidation.isPresent() && !test.test(writeValidation.get())) {
             throw new ParquetCorruptionException(dataSource.getId(), "Write validation failed: " + messageFormat, args);
         }
-    }
-
-    private static boolean arrayEqualsReversed(String[] a, String[] b)
-    {
-        if (a.length != b.length) {
-            return false;
-        }
-        for (int i = a.length - 1; i >= 0; i--) {
-            if (!a[i].equals(b[i])) {
-                return false;
-            }
-        }
-        return true;
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/RowGroupInfo.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/RowGroupInfo.java
@@ -13,9 +13,9 @@
  */
 package io.trino.parquet.reader;
 
-import io.trino.parquet.metadata.BlockMetadata;
+import io.trino.parquet.metadata.PrunedBlockMetadata;
 import org.apache.parquet.internal.filter2.columnindex.ColumnIndexStore;
 
 import java.util.Optional;
 
-public record RowGroupInfo(BlockMetadata blockMetaData, long fileRowOffset, Optional<ColumnIndexStore> columnIndexStore) {}
+public record RowGroupInfo(PrunedBlockMetadata prunedBlockMetadata, long fileRowOffset, Optional<ColumnIndexStore> columnIndexStore) {}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/TrinoColumnIndexStore.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/TrinoColumnIndexStore.java
@@ -84,7 +84,7 @@ public class TrinoColumnIndexStore
 
         ImmutableList.Builder<ColumnIndexMetadata> columnIndexBuilder = ImmutableList.builderWithExpectedSize(columnsFiltered.size());
         ImmutableList.Builder<ColumnIndexMetadata> offsetIndexBuilder = ImmutableList.builderWithExpectedSize(columnsRead.size());
-        for (ColumnChunkMetadata column : block.getColumns()) {
+        for (ColumnChunkMetadata column : block.columns()) {
             ColumnPath path = column.getPath();
             if (column.getColumnIndexReference() != null && columnsFiltered.contains(path)) {
                 columnIndexBuilder.add(new ColumnIndexMetadata(
@@ -149,7 +149,7 @@ public class TrinoColumnIndexStore
         }
 
         boolean hasColumnIndex = false;
-        for (ColumnChunkMetadata column : blockMetadata.getColumns()) {
+        for (ColumnChunkMetadata column : blockMetadata.columns()) {
             if (column.getColumnIndexReference() != null && column.getOffsetIndexReference() != null) {
                 hasColumnIndex = true;
                 break;

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
@@ -274,7 +274,7 @@ public class ParquetWriter
         ImmutableList.Builder<RowGroupInfo> rowGroupInfoBuilder = ImmutableList.builder();
         for (BlockMetadata block : parquetMetadata.getBlocks()) {
             rowGroupInfoBuilder.add(new RowGroupInfo(block, nextStart, Optional.empty()));
-            nextStart += block.getRowCount();
+            nextStart += block.rowCount();
         }
         return new ParquetReader(
                 Optional.ofNullable(fileMetaData.getCreatedBy()),

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReader.java
@@ -83,9 +83,9 @@ public class TestParquetReader
         assertThat(parquetMetadata.getBlocks().size()).isGreaterThan(1);
         // Verify file has only non-dictionary encodings as dictionary memory usage is already tested in TestFlatColumnReader#testMemoryUsage
         parquetMetadata.getBlocks().forEach(block -> {
-            block.getColumns()
+            block.columns()
                     .forEach(columnChunkMetaData -> assertThat(columnChunkMetaData.getEncodingStats().hasDictionaryEncodedPages()).isFalse());
-            assertThat(block.getRowCount()).isEqualTo(100);
+            assertThat(block.rowCount()).isEqualTo(100);
         });
 
         AggregatedMemoryContext memoryContext = newSimpleAggregatedMemoryContext();
@@ -105,7 +105,7 @@ public class TestParquetReader
         assertThat(currentMemoryUsage).isGreaterThan(initialMemoryUsage);
 
         // Memory usage does not change until next row group (1 page per row-group)
-        long rowGroupRowCount = parquetMetadata.getBlocks().get(0).getRowCount();
+        long rowGroupRowCount = parquetMetadata.getBlocks().get(0).rowCount();
         int rowsRead = page.getPositionCount();
         while (rowsRead < rowGroupRowCount) {
             rowsRead += reader.nextPage().getPositionCount();
@@ -153,7 +153,7 @@ public class TestParquetReader
             assertThat(metrics).containsKey(COLUMN_INDEX_ROWS_FILTERED);
             // Column index should filter at least the first row group
             assertThat(((Count<?>) metrics.get(COLUMN_INDEX_ROWS_FILTERED)).getTotal())
-                    .isGreaterThanOrEqualTo(parquetMetadata.getBlocks().get(0).getRowCount());
+                    .isGreaterThanOrEqualTo(parquetMetadata.getBlocks().get(0).rowCount());
         }
     }
 

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriter.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriter.java
@@ -129,9 +129,9 @@ public class TestParquetWriter
                 new ParquetReaderOptions());
         ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
         assertThat(parquetMetadata.getBlocks().size()).isEqualTo(1);
-        assertThat(parquetMetadata.getBlocks().get(0).getRowCount()).isEqualTo(100 * 1000);
+        assertThat(parquetMetadata.getBlocks().get(0).rowCount()).isEqualTo(100 * 1000);
 
-        ColumnChunkMetadata chunkMetaData = parquetMetadata.getBlocks().get(0).getColumns().get(0);
+        ColumnChunkMetadata chunkMetaData = parquetMetadata.getBlocks().get(0).columns().get(0);
         DiskRange range = new DiskRange(chunkMetaData.getStartingPos(), chunkMetaData.getTotalSize());
         Map<Integer, ChunkedInputStream> chunkReader = dataSource.planRead(ImmutableListMultimap.of(0, range), newSimpleAggregatedMemoryContext());
 
@@ -178,10 +178,10 @@ public class TestParquetWriter
                 new ParquetReaderOptions());
         ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
         assertThat(parquetMetadata.getBlocks().size()).isEqualTo(1);
-        assertThat(parquetMetadata.getBlocks().get(0).getRowCount()).isEqualTo(100 * 1000);
+        assertThat(parquetMetadata.getBlocks().get(0).rowCount()).isEqualTo(100 * 1000);
 
-        ColumnChunkMetadata columnAMetaData = parquetMetadata.getBlocks().get(0).getColumns().get(0);
-        ColumnChunkMetadata columnBMetaData = parquetMetadata.getBlocks().get(0).getColumns().get(1);
+        ColumnChunkMetadata columnAMetaData = parquetMetadata.getBlocks().get(0).columns().get(0);
+        ColumnChunkMetadata columnBMetaData = parquetMetadata.getBlocks().get(0).columns().get(1);
         Map<Integer, ChunkedInputStream> chunkReader = dataSource.planRead(
                 ImmutableListMultimap.of(
                         0, new DiskRange(columnAMetaData.getStartingPos(), columnAMetaData.getTotalSize()),
@@ -260,12 +260,12 @@ public class TestParquetWriter
         ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
         BlockMetadata blockMetaData = getOnlyElement(parquetMetadata.getBlocks());
 
-        ColumnChunkMetadata chunkMetaData = blockMetaData.getColumns().get(0);
+        ColumnChunkMetadata chunkMetaData = blockMetaData.columns().get(0);
         assertThat(chunkMetaData.getStatistics().getMinBytes()).isEqualTo(minA.getBytes());
         Slice truncatedMax = Slices.utf8Slice("y".repeat(1023) + "z");
         assertThat(chunkMetaData.getStatistics().getMaxBytes()).isEqualTo(truncatedMax.getBytes());
 
-        chunkMetaData = blockMetaData.getColumns().get(1);
+        chunkMetaData = blockMetaData.columns().get(1);
         Slice truncatedMin = varcharToVarcharSaturatedFloorCast(1024, minB);
         assertThat(chunkMetaData.getStatistics().getMinBytes()).isEqualTo(truncatedMin.getBytes());
         truncatedMax = Slices.utf8Slice(maxCodePoint + "d".repeat(1016) + "e");
@@ -294,7 +294,7 @@ public class TestParquetWriter
         assertThat(parquetMetadata.getBlocks().size()).isGreaterThanOrEqualTo(10);
         for (BlockMetadata blockMetaData : parquetMetadata.getBlocks()) {
             // Verify that the columns are stored in the same order as the metadata
-            List<Long> offsets = blockMetaData.getColumns().stream()
+            List<Long> offsets = blockMetaData.columns().stream()
                     .map(ColumnChunkMetadata::getFirstDataPageOffset)
                     .collect(toImmutableList());
             assertThat(offsets).isSorted();
@@ -350,7 +350,7 @@ public class TestParquetWriter
         ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
         assertThat(parquetMetadata.getBlocks().size()).isGreaterThanOrEqualTo(1);
         for (BlockMetadata blockMetaData : parquetMetadata.getBlocks()) {
-            ColumnChunkMetadata chunkMetaData = getOnlyElement(blockMetaData.getColumns());
+            ColumnChunkMetadata chunkMetaData = getOnlyElement(blockMetaData.columns());
             assertThat(chunkMetaData.getDictionaryPageOffset()).isGreaterThan(0);
             int dictionaryPageSize = toIntExact(chunkMetaData.getFirstDataPageOffset() - chunkMetaData.getDictionaryPageOffset());
             assertThat(dictionaryPageSize).isGreaterThan(0);
@@ -397,9 +397,9 @@ public class TestParquetWriter
         // Check that bloom filters are right after each other
         int bloomFilterSize = Integer.highestOneBit(BlockSplitBloomFilter.optimalNumOfBits(BLOOM_FILTER_EXPECTED_ENTRIES, DEFAULT_BLOOM_FILTER_FPP) / 8) << 1;
         for (BlockMetadata block : parquetMetadata.getBlocks()) {
-            for (int i = 1; i < block.getColumns().size(); i++) {
-                assertThat(block.getColumns().get(i - 1).getBloomFilterOffset() + bloomFilterSize + 17) // + 17 bytes for Bloom filter metadata
-                        .isEqualTo(block.getColumns().get(i).getBloomFilterOffset());
+            for (int i = 1; i < block.columns().size(); i++) {
+                assertThat(block.columns().get(i - 1).getBloomFilterOffset() + bloomFilterSize + 17) // + 17 bytes for Bloom filter metadata
+                        .isEqualTo(block.columns().get(i).getBloomFilterOffset());
             }
         }
         int rowGroupCount = parquetMetadata.getBlocks().size();

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeWriter.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeWriter.java
@@ -201,7 +201,7 @@ public final class DeltaLakeWriter
 
         ImmutableMultimap.Builder<String, ColumnChunkMetadata> metadataForColumn = ImmutableMultimap.builder();
         for (BlockMetadata blockMetaData : parquetMetadata.getBlocks()) {
-            for (ColumnChunkMetadata columnChunkMetaData : blockMetaData.getColumns()) {
+            for (ColumnChunkMetadata columnChunkMetaData : blockMetaData.columns()) {
                 if (columnChunkMetaData.getPath().size() != 1) {
                     continue; // Only base column stats are supported
                 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestBloomFilterStore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestBloomFilterStore.java
@@ -309,7 +309,7 @@ public class TestBloomFilterStore
         TrinoParquetDataSource dataSource = new TrinoParquetDataSource(inputFile, new ParquetReaderOptions(), new FileFormatDataSourceStats());
 
         ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
-        ColumnChunkMetadata columnChunkMetaData = getOnlyElement(getOnlyElement(parquetMetadata.getBlocks()).getColumns());
+        ColumnChunkMetadata columnChunkMetaData = getOnlyElement(getOnlyElement(parquetMetadata.getBlocks()).columns());
 
         return new BloomFilterStore(dataSource, getOnlyElement(parquetMetadata.getBlocks()), Set.of(columnChunkMetaData.getPath()));
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -953,7 +953,7 @@ public class IcebergPageSourceProvider
             if (!rowGroups.isEmpty()) {
                 startRowPosition = Optional.of(rowGroups.getFirst().fileRowOffset());
                 RowGroupInfo lastRowGroup = rowGroups.getLast();
-                endRowPosition = Optional.of(lastRowGroup.fileRowOffset() + lastRowGroup.blockMetaData().rowCount());
+                endRowPosition = Optional.of(lastRowGroup.fileRowOffset() + lastRowGroup.prunedBlockMetadata().getRowCount());
             }
 
             MessageColumnIO messageColumnIO = getColumnIO(fileSchema, requestedSchema);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -953,7 +953,7 @@ public class IcebergPageSourceProvider
             if (!rowGroups.isEmpty()) {
                 startRowPosition = Optional.of(rowGroups.getFirst().fileRowOffset());
                 RowGroupInfo lastRowGroup = rowGroups.getLast();
-                endRowPosition = Optional.of(lastRowGroup.fileRowOffset() + lastRowGroup.blockMetaData().getRowCount());
+                endRowPosition = Optional.of(lastRowGroup.fileRowOffset() + lastRowGroup.blockMetaData().rowCount());
             }
 
             MessageColumnIO messageColumnIO = getColumnIO(fileSchema, requestedSchema);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/util/ParquetUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/util/ParquetUtil.java
@@ -97,8 +97,8 @@ public final class ParquetUtil
 
         List<BlockMetadata> blocks = metadata.getBlocks();
         for (BlockMetadata block : blocks) {
-            rowCount += block.getRowCount();
-            for (ColumnChunkMetadata column : block.getColumns()) {
+            rowCount += block.rowCount();
+            for (ColumnChunkMetadata column : block.columns()) {
                 Integer fieldId = fileSchema.aliasToId(column.getPath().toDotString());
                 if (fieldId == null) {
                     // fileSchema may contain a subset of columns present in the file

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergTestUtils.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergTestUtils.java
@@ -140,7 +140,7 @@ public final class IcebergTestUtils
         Comparable previousMax = null;
         verify(parquetMetadata.getBlocks().size() > 1, "Test must produce at least two row groups");
         for (BlockMetadata blockMetaData : parquetMetadata.getBlocks()) {
-            ColumnChunkMetadata columnMetadata = blockMetaData.getColumns().stream()
+            ColumnChunkMetadata columnMetadata = blockMetaData.columns().stream()
                     .filter(column -> getOnlyElement(column.getPath().iterator()).equalsIgnoreCase(sortColumnName))
                     .collect(onlyElement());
             if (previousMax != null) {


### PR DESCRIPTION
## Description
Reduces memory usage by keeping only the required columns metadata in memory.
Look-up of ColumnChunkMetadata is now through a Map rather than repeatedly
iterating over all columns metadata in the footer

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes https://github.com/trinodb/trino/issues/22434

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Hudi, Delta, Iceberg
* Improve performance of reading from parquet files with large schemas. ({issue}`22434`)
```
