### PR TITLE
Support varargs in ConnectorExpression

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/expression/VarArgs.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/expression/VarArgs.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.expression;
+
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+
+import java.util.List;
+import java.util.Objects;
+
+public class VarArgs
+        extends ConnectorExpression
+{
+    private final List<ConnectorExpression> items;
+
+    public VarArgs(List<ConnectorExpression> items, List<Type> types)
+    {
+        super(RowType.anonymous(types));
+        this.items = List.copyOf(items);
+    }
+
+    @Override
+    public List<? extends ConnectorExpression> getChildren()
+    {
+        return items;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(items, getType());
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        VarArgs that = (VarArgs) o;
+        return Objects.equals(items, that.items) &&
+                Objects.equals(getType(), that.getType());
+    }
+
+    @Override
+    public String toString()
+    {
+        return "row(" + String.join(", ", items.stream().map(ConnectorExpression::toString).toList()) + ")";
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Make it possible to pushdown functions that take varargs to connectors.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
