### PR TITLE
Set Azure read block size to ranged read size

### DIFF
--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureInput.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureInput.java
@@ -23,7 +23,6 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.util.OptionalLong;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.filesystem.azure.AzureUtils.handleAzureException;
 import static java.util.Objects.checkFromIndexSize;
 import static java.util.Objects.requireNonNull;
@@ -33,16 +32,13 @@ class AzureInput
 {
     private final AzureLocation location;
     private final BlobClient blobClient;
-    private final int readBlockSize;
     private OptionalLong length;
     private boolean closed;
 
-    public AzureInput(AzureLocation location, BlobClient blobClient, int readBlockSize, OptionalLong length)
+    public AzureInput(AzureLocation location, BlobClient blobClient, OptionalLong length)
     {
         this.location = requireNonNull(location, "location is null");
         this.blobClient = requireNonNull(blobClient, "blobClient is null");
-        checkArgument(readBlockSize >= 0, "readBlockSize is negative");
-        this.readBlockSize = readBlockSize;
         this.length = requireNonNull(length, "length is null");
     }
 
@@ -61,7 +57,7 @@ class AzureInput
 
         BlobInputStreamOptions options = new BlobInputStreamOptions()
                 .setRange(new BlobRange(position, (long) bufferLength))
-                .setBlockSize(readBlockSize);
+                .setBlockSize(bufferLength);
         try (BlobInputStream blobInputStream = blobClient.openInputStream(options)) {
             long fileSize = blobInputStream.getProperties().getBlobSize();
             if (position >= fileSize) {
@@ -91,7 +87,7 @@ class AzureInput
             }
             BlobInputStreamOptions options = new BlobInputStreamOptions()
                     .setRange(new BlobRange(length.orElseThrow() - bufferLength))
-                    .setBlockSize(readBlockSize);
+                    .setBlockSize(bufferLength);
             try (BlobInputStream blobInputStream = blobClient.openInputStream(options)) {
                 return blobInputStream.readNBytes(buffer, bufferOffset, bufferLength);
             }

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureInputFile.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureInputFile.java
@@ -73,7 +73,7 @@ class AzureInputFile
             throws IOException
     {
         try {
-            return new AzureInput(location, blobClient, readBlockSizeBytes, length);
+            return new AzureInput(location, blobClient, length);
         }
         catch (RuntimeException e) {
             throw handleAzureException(e, "opening file", location);


### PR DESCRIPTION
## Description
Read block size should be needed only for sequential reads.
For positioned range reads from ORC/Parquet, we should use same read size as the buffer.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
