### PR TITLE
Use Scan#includeColumnStats to restrict metadata in IcebergSplitSource

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -2279,6 +2279,9 @@ public abstract class BaseConnectorTest
             assertQuery(
                     "SELECT * FROM " + table.getName(),
                     "VALUES ('first', NULL)");
+            assertQuery(
+                    "SELECT * FROM " + table.getName() + " WHERE a IS NULL",
+                    "VALUES ('first', NULL)");
             assertUpdate("INSERT INTO " + table.getName() + " SELECT 'second', 'xxx'", 1);
             assertQuery(
                     "SELECT x, a FROM " + table.getName(),


### PR DESCRIPTION
## Description
We need column nulls/min/max only for columns with predicate in IcebergSplitSource

## Additional context and related issues
Potentially reduces memory used by iceberg metadata objects during splits generation

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
