### PR TITLE
Fix NullPointerException when adding decimal columns in Kudu

### DIFF
--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduClientSession.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduClientSession.java
@@ -326,12 +326,12 @@ public class KuduClientSession
             String rawName = schemaEmulation.toRawName(schemaTableName);
             AlterTableOptions alterOptions = new AlterTableOptions();
             Type type = TypeHelper.toKuduClientType(column.getType());
-            alterOptions.addColumn(
-                    new ColumnSchemaBuilder(column.getName(), type)
-                            .nullable(true)
-                            .defaultValue(null)
-                            .comment(nullToEmpty(column.getComment())) // Kudu doesn't allow null comment
-                            .build());
+            ColumnSchemaBuilder builder = new ColumnSchemaBuilder(column.getName(), type)
+                    .nullable(true)
+                    .defaultValue(null)
+                    .comment(nullToEmpty(column.getComment())); // Kudu doesn't allow null comment
+            setTypeAttributes(column, builder);
+            alterOptions.addColumn(builder.build());
             client.alterTable(rawName, alterOptions);
         }
         catch (KuduException e) {

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduConnectorTest.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduConnectorTest.java
@@ -536,6 +536,28 @@ public class TestKuduConnectorTest
     }
 
     @Test
+    public void testAddColumnWithDecimal()
+    {
+        String tableName = "test_add_column_with_decimal" + randomNameSuffix();
+
+        assertUpdate("CREATE TABLE " + tableName + "(" +
+                "id INT WITH (primary_key=true), " +
+                "a_varchar VARCHAR" +
+                ") WITH (" +
+                " partition_by_hash_columns = ARRAY['id'], " +
+                " partition_by_hash_buckets = 2" +
+                ")");
+
+        assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN b_decimal decimal(14,5)");
+        assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN c_decimal decimal(35,5)");
+
+        assertThat(getColumnType(tableName, "b_decimal")).isEqualTo("decimal(14,5)");
+        assertThat(getColumnType(tableName, "c_decimal")).isEqualTo("decimal(35,5)");
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
     public void testInsertIntoTableHavingRowUuid()
     {
         try (TestTable table = new TestTable(getQueryRunner()::execute, "test_insert_", " AS SELECT * FROM region WITH NO DATA")) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Trino: 451
When I try to add column, which type is decimal(14,4), to the kudu table, I encountered a java.lang.NullPointerException.
I found that when adding a decimal type field, **precision and scale were not passed in**, resulting in a java.lang.NullPointerException.
Then I fix this.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
```
trino> ALTER TABLE catalog.default.table ADD COLUMN buyer_order_pay_price_2 DECIMAL(14,4);
Query 20240701_083955_00002_ysg8b failed: Cannot invoke "org.apache.kudu.ColumnTypeAttributes.getPrecision()" because "typeAttributes" is null
java.lang.NullPointerException: Cannot invoke "org.apache.kudu.ColumnTypeAttributes.getPrecision()" because "typeAttributes" is null
	at org.apache.kudu.Type.getDataType(Type.java:97)
	at org.apache.kudu.ColumnSchema$ColumnSchemaBuilder.build(ColumnSchema.java:492)
	at io.trino.plugin.kudu.KuduClientSession.addColumn(KuduClientSession.java:334)
	at io.trino.plugin.kudu.KuduMetadata.addColumn(KuduMetadata.java:301)
	at io.trino.tracing.TracingConnectorMetadata.addColumn(TracingConnectorMetadata.java:476)
	at io.trino.metadata.MetadataManager.addColumn(MetadataManager.java:928)
	at io.trino.tracing.TracingMetadata.addColumn(TracingMetadata.java:491)
	at io.trino.execution.AddColumnTask.execute(AddColumnTask.java:151)
	at io.trino.execution.AddColumnTask.execute(AddColumnTask.java:63)
	at io.trino.execution.DataDefinitionExecution.start(DataDefinitionExecution.java:146)
	at io.trino.execution.SqlQueryManager.createQuery(SqlQueryManager.java:272)
	at io.trino.dispatcher.LocalDispatchQuery.startExecution(LocalDispatchQuery.java:150)
	at io.trino.dispatcher.LocalDispatchQuery.lambda$waitForMinimumWorkers$2(LocalDispatchQuery.java:134)
	at io.airlift.concurrent.MoreFutures.lambda$addSuccessCallback$12(MoreFutures.java:570)
	at io.airlift.concurrent.MoreFutures$3.onSuccess(MoreFutures.java:545)
	at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1137)
	at io.trino.$gen.Trino_451____20240701_083835_2.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1570)
```


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

```markdown
# Kudu
* Fix NullPointerException when adding new columns with `decimal` type. 
```
