### PR TITLE
Remove unsupported procedure from Phoenix docs

### DIFF
--- a/docs/src/main/sphinx/connector/phoenix.md
+++ b/docs/src/main/sphinx/connector/phoenix.md
@@ -55,9 +55,6 @@ The following Phoenix-specific configuration properties are available:
 ```{include} jdbc-domain-compaction-threshold.fragment
 ```
 
-```{include} jdbc-procedures.fragment
-```
-
 ```{include} jdbc-case-insensitive-matching.fragment
 ```
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Phoenix connector doesn't support `flush_metadata_cache` procedure. 
https://trino.io/docs/current/connector/phoenix.html#procedures

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
