### PR TITLE
Exclude logback backend from benchto

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1519,6 +1519,12 @@
                 <groupId>io.trino.benchto</groupId>
                 <artifactId>benchto-driver</artifactId>
                 <version>0.29</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-classic</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
It conflicts with the JUL backend:

    SLF4J(W): Class path contains multiple SLF4J providers.
    SLF4J(W): Found provider [org.slf4j.jul.JULServiceProvider@69ec706d]
    SLF4J(W): Found provider [ch.qos.logback.classic.spi.LogbackServiceProvider@a9f57d0]
    SLF4J(W): See https://www.slf4j.org/codes.html#multiple_bindings for an explanation.
    SLF4J(I): Actual provider is of type [org.slf4j.jul.JULServiceProvider@69ec706d]

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
