### PR TITLE
Improve test coverage for assumeNullCatalogMeansCurrent

### DIFF
--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
@@ -1104,7 +1104,12 @@ public class TestTrinoDatabaseMetaData
                     list(),
                     ImmutableMultiset.of());
         }
+    }
 
+    @Test
+    public void testGetSchemasMetadataCallsWithNullCatalogMeansCurrent()
+            throws Exception
+    {
         try (Connection connection = createConnectionWithNullCatalogMeansCurrent()) {
             // should list all schemas as the catalog is not set
             assertMetadataCalls(
@@ -1325,7 +1330,12 @@ public class TestTrinoDatabaseMetaData
                     list(),
                     ImmutableMultiset.of());
         }
+    }
 
+    @Test
+    public void testGetTablesMetadataCallsWithNullCatalogMeansCurrent()
+            throws Exception
+    {
         try (Connection connection = createConnectionWithNullCatalogMeansCurrent()) {
             assertMetadataCalls(
                     connection,
@@ -1610,7 +1620,12 @@ public class TestTrinoDatabaseMetaData
                     list(),
                     ImmutableMultiset.of("ConnectorMetadata.streamRelationColumns"));
         }
+    }
 
+    @Test
+    public void testGetColumnsMetadataCallsWithNullCatalogMeansCurrent()
+            throws Exception
+    {
         try (Connection connection = createConnectionWithNullCatalogMeansCurrent()) {
             assertMetadataCalls(
                     connection,

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
@@ -1031,78 +1031,7 @@ public class TestTrinoDatabaseMetaData
             throws Exception
     {
         try (Connection connection = createConnection()) {
-            verify(connection.getMetaData().getSearchStringEscape().equals("\\")); // this test uses escape inline for readability
-
-            // No filter
-            assertMetadataCalls(
-                    connection,
-                    readMetaData(
-                            databaseMetaData -> databaseMetaData.getSchemas(null, null),
-                            list("TABLE_CATALOG", "TABLE_SCHEM")),
-                    ImmutableMultiset.of("ConnectorMetadata.listSchemaNames"));
-
-            // Equality predicate on catalog name
-            assertMetadataCalls(
-                    connection,
-                    readMetaData(
-                            databaseMetaData -> databaseMetaData.getSchemas(COUNTING_CATALOG, null),
-                            list("TABLE_CATALOG", "TABLE_SCHEM")),
-                    list(
-                            list(COUNTING_CATALOG, "information_schema"),
-                            list(COUNTING_CATALOG, "test_schema1"),
-                            list(COUNTING_CATALOG, "test_schema2"),
-                            list(COUNTING_CATALOG, "test_schema3_empty"),
-                            list(COUNTING_CATALOG, "test_schema4_empty")),
-                    ImmutableMultiset.of("ConnectorMetadata.listSchemaNames"));
-
-            // Equality predicate on schema name
-            assertMetadataCalls(
-                    connection,
-                    readMetaData(
-                            databaseMetaData -> databaseMetaData.getSchemas(COUNTING_CATALOG, "test\\_schema%"),
-                            list("TABLE_CATALOG", "TABLE_SCHEM")),
-                    list(
-                            list(COUNTING_CATALOG, "test_schema1"),
-                            list(COUNTING_CATALOG, "test_schema2"),
-                            list(COUNTING_CATALOG, "test_schema3_empty"),
-                            list(COUNTING_CATALOG, "test_schema4_empty")),
-                    ImmutableMultiset.of("ConnectorMetadata.listSchemaNames"));
-
-            // LIKE predicate on schema name
-            assertMetadataCalls(
-                    connection,
-                    readMetaData(
-                            databaseMetaData -> databaseMetaData.getSchemas(COUNTING_CATALOG, "test_sch_ma1"),
-                            list("TABLE_CATALOG", "TABLE_SCHEM")),
-                    list(list(COUNTING_CATALOG, "test_schema1")),
-                    ImmutableMultiset.of("ConnectorMetadata.listSchemaNames"));
-
-            // Empty schema name
-            assertMetadataCalls(
-                    connection,
-                    readMetaData(
-                            databaseMetaData -> databaseMetaData.getSchemas(COUNTING_CATALOG, ""),
-                            list("TABLE_CATALOG", "TABLE_SCHEM")),
-                    list(),
-                    ImmutableMultiset.of());
-
-            // catalog does not exist
-            assertMetadataCalls(
-                    connection,
-                    readMetaData(
-                            databaseMetaData -> databaseMetaData.getSchemas("wrong", null),
-                            list("TABLE_CATALOG", "TABLE_SCHEM")),
-                    list(),
-                    ImmutableMultiset.of());
-
-            // empty catalog name (means null filter)
-            assertMetadataCalls(
-                    connection,
-                    readMetaData(
-                            databaseMetaData -> databaseMetaData.getSchemas("", null),
-                            list("TABLE_CATALOG", "TABLE_SCHEM")),
-                    list(),
-                    ImmutableMultiset.of());
+            testGetSchemasMetadataCalls(connection);
         }
     }
 
@@ -1176,6 +1105,83 @@ public class TestTrinoDatabaseMetaData
                             list("blackhole", "test_schema1")),
                     ImmutableMultiset.of());
         }
+    }
+
+    private void testGetSchemasMetadataCalls(Connection connection)
+            throws Exception
+    {
+        verify(connection.getMetaData().getSearchStringEscape().equals("\\")); // this test uses escape inline for readability
+
+        // No filter
+        assertMetadataCalls(
+                connection,
+                readMetaData(
+                        databaseMetaData -> databaseMetaData.getSchemas(null, null),
+                        list("TABLE_CATALOG", "TABLE_SCHEM")),
+                ImmutableMultiset.of("ConnectorMetadata.listSchemaNames"));
+
+        // Equality predicate on catalog name
+        assertMetadataCalls(
+                connection,
+                readMetaData(
+                        databaseMetaData -> databaseMetaData.getSchemas(COUNTING_CATALOG, null),
+                        list("TABLE_CATALOG", "TABLE_SCHEM")),
+                list(
+                        list(COUNTING_CATALOG, "information_schema"),
+                        list(COUNTING_CATALOG, "test_schema1"),
+                        list(COUNTING_CATALOG, "test_schema2"),
+                        list(COUNTING_CATALOG, "test_schema3_empty"),
+                        list(COUNTING_CATALOG, "test_schema4_empty")),
+                ImmutableMultiset.of("ConnectorMetadata.listSchemaNames"));
+
+        // Equality predicate on schema name
+        assertMetadataCalls(
+                connection,
+                readMetaData(
+                        databaseMetaData -> databaseMetaData.getSchemas(COUNTING_CATALOG, "test\\_schema%"),
+                        list("TABLE_CATALOG", "TABLE_SCHEM")),
+                list(
+                        list(COUNTING_CATALOG, "test_schema1"),
+                        list(COUNTING_CATALOG, "test_schema2"),
+                        list(COUNTING_CATALOG, "test_schema3_empty"),
+                        list(COUNTING_CATALOG, "test_schema4_empty")),
+                ImmutableMultiset.of("ConnectorMetadata.listSchemaNames"));
+
+        // LIKE predicate on schema name
+        assertMetadataCalls(
+                connection,
+                readMetaData(
+                        databaseMetaData -> databaseMetaData.getSchemas(COUNTING_CATALOG, "test_sch_ma1"),
+                        list("TABLE_CATALOG", "TABLE_SCHEM")),
+                list(list(COUNTING_CATALOG, "test_schema1")),
+                ImmutableMultiset.of("ConnectorMetadata.listSchemaNames"));
+
+        // Empty schema name
+        assertMetadataCalls(
+                connection,
+                readMetaData(
+                        databaseMetaData -> databaseMetaData.getSchemas(COUNTING_CATALOG, ""),
+                        list("TABLE_CATALOG", "TABLE_SCHEM")),
+                list(),
+                ImmutableMultiset.of());
+
+        // catalog does not exist
+        assertMetadataCalls(
+                connection,
+                readMetaData(
+                        databaseMetaData -> databaseMetaData.getSchemas("wrong", null),
+                        list("TABLE_CATALOG", "TABLE_SCHEM")),
+                list(),
+                ImmutableMultiset.of());
+
+        // empty catalog name (means null filter)
+        assertMetadataCalls(
+                connection,
+                readMetaData(
+                        databaseMetaData -> databaseMetaData.getSchemas("", null),
+                        list("TABLE_CATALOG", "TABLE_SCHEM")),
+                list(),
+                ImmutableMultiset.of());
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This adds tests to ensure that when explicit filters are provided the driver behaves the same with or without assumeNullCatalogMeansCurrent.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Follow up to https://github.com/trinodb/trino/pull/20866

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.