### PR TITLE
Rename `createDestinationTable` to `buildDestinationTable`

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ViewMaterializationCache.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ViewMaterializationCache.java
@@ -64,10 +64,10 @@ public class ViewMaterializationCache
 
     public TableInfo getCachedTable(BigQueryClient client, String query, Duration viewExpiration, TableInfo remoteTableId)
     {
-        return uncheckedCacheGet(destinationTableCache, query, new DestinationTableBuilder(client, viewExpiration, query, createDestinationTable(remoteTableId.getTableId())));
+        return uncheckedCacheGet(destinationTableCache, query, new DestinationTableBuilder(client, viewExpiration, query, buildDestinationTable(remoteTableId.getTableId())));
     }
 
-    private TableId createDestinationTable(TableId remoteTableId)
+    private TableId buildDestinationTable(TableId remoteTableId)
     {
         String project = viewMaterializationProject.orElseGet(remoteTableId::getProject);
         String dataset = viewMaterializationDataset.orElseGet(remoteTableId::getDataset);


### PR DESCRIPTION
`createDestinationTable` looks a little misleading because it doesn't create tables actually
