### PR TITLE
Push one side of BETWEEN if full pushdown not possible

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestJoinQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestJoinQueries.java
@@ -2369,6 +2369,23 @@ public abstract class AbstractTestJoinQueries
                 2);
     }
 
+    @Test
+    public void testBetweenPredicatePushdown()
+    {
+        // join build side, min between value pushed down
+        assertQuery("SELECT p.name, l.comment FROM lineitem l JOIN part p ON l.partkey = p.partkey WHERE p.name BETWEEN 'f' AND l.comment");
+        // join build side, max between value pushed down
+        assertQuery("SELECT p.name, l.comment FROM lineitem l JOIN part p ON l.partkey = p.partkey WHERE p.name BETWEEN l.comment AND 'f'");
+        // join probe side, min between value pushed down
+        assertQuery("SELECT p.name, l.comment FROM lineitem l JOIN part p ON l.partkey = p.partkey WHERE l.comment BETWEEN 'f' AND p.name");
+        // join probe side, max between value pushed down
+        assertQuery("SELECT p.name, l.comment FROM lineitem l JOIN part p ON l.partkey = p.partkey WHERE l.comment BETWEEN p.name AND 'f'");
+        // between with subquery
+        assertQuery("SELECT p.name, l.comment FROM lineitem l JOIN part p ON l.partkey = p.partkey WHERE p.name BETWEEN 'f'  AND (select max(name) from part)");
+        // neither side is pushed down
+        assertQuery("SELECT p.name, l.comment FROM lineitem l JOIN part p ON l.partkey = p.partkey WHERE p.name BETWEEN l.linestatus  AND l.comment");
+    }
+
     private void assertJoinOutputPositions(@Language("SQL") String sql, int expectedJoinOutputPositions)
     {
         MaterializedResultWithPlan result = getDistributedQueryRunner().executeWithPlan(


### PR DESCRIPTION


<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Since `value BETWEEN min AND max` is equivalent to value >= min AND value <= max, we can try to push one of the expressions down if the entire BETWEEN cannot be pushed down, leaving the other one as part of the join filter.
We do it only if the value expression is cheap to evaluate since we are going to evaluate it twice if the pushdown is successful.

fixes: https://github.com/trinodb/trino/issues/9399

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( X) Release notes are required, with the following suggested text:

```markdown
# General
* Improve performance of queries with JOIN and BETWEEN predicate. ({issue}`9399`)
```
