### PR TITLE
Add view support for iceberg jdbc catalog

### DIFF
--- a/docs/src/main/sphinx/object-storage/metastores.md
+++ b/docs/src/main/sphinx/object-storage/metastores.md
@@ -550,8 +550,7 @@ iceberg.jdbc-catalog.connection-password=test
 iceberg.jdbc-catalog.default-warehouse-dir=s3://bucket
 ```
 
-The JDBC catalog does not support [view management](sql-view-management) or
-[materialized view management](sql-materialized-view-management).
+The JDBC catalog does not support [materialized view management](sql-materialized-view-management).
 
 (iceberg-nessie-catalog)=
 ### Nessie catalog

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
@@ -126,7 +126,7 @@ public abstract class AbstractTrinoCatalog
     protected static final String TRINO_QUERY_ID_NAME = HiveMetadata.TRINO_QUERY_ID_NAME;
 
     private final CatalogName catalogName;
-    private final TypeManager typeManager;
+    protected final TypeManager typeManager;
     protected final IcebergTableOperationsProvider tableOperationsProvider;
     private final TrinoFileSystemFactory fileSystemFactory;
     private final boolean useUniqueTableLocation;

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -173,7 +173,6 @@ public class TrinoGlueCatalog
     private static final int PER_QUERY_CACHES_SIZE = 1000;
 
     private final String trinoVersion;
-    private final TypeManager typeManager;
     private final boolean cacheTableMetadata;
     private final TrinoFileSystemFactory fileSystemFactory;
     private final Optional<String> defaultSchemaLocation;
@@ -213,7 +212,6 @@ public class TrinoGlueCatalog
     {
         super(catalogName, typeManager, tableOperationsProvider, fileSystemFactory, useUniqueTableLocation);
         this.trinoVersion = requireNonNull(trinoVersion, "trinoVersion is null");
-        this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.cacheTableMetadata = cacheTableMetadata;
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.glueClient = requireNonNull(glueClient, "glueClient is null");

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/IcebergJdbcCatalogConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/IcebergJdbcCatalogConfig.java
@@ -23,12 +23,18 @@ import java.util.Optional;
 
 public class IcebergJdbcCatalogConfig
 {
+    public enum SchemaVersion
+    {
+        V0, V1
+    }
+
     private String driverClass;
     private String connectionUrl;
     private String connectionUser;
     private String connectionPassword;
     private String catalogName;
     private String defaultWarehouseDir;
+    private SchemaVersion schemaVersion = SchemaVersion.V1;
 
     @NotNull
     public String getDriverClass()
@@ -112,6 +118,20 @@ public class IcebergJdbcCatalogConfig
     public IcebergJdbcCatalogConfig setDefaultWarehouseDir(String defaultWarehouseDir)
     {
         this.defaultWarehouseDir = defaultWarehouseDir;
+        return this;
+    }
+
+    @NotNull
+    public SchemaVersion getSchemaVersion()
+    {
+        return schemaVersion;
+    }
+
+    @Config("iceberg.jdbc-catalog.schema-version")
+    @ConfigDescription("JDBC catalog schema version")
+    public IcebergJdbcCatalogConfig setSchemaVersion(SchemaVersion schemaVersion)
+    {
+        this.schemaVersion = schemaVersion;
         return this;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/IcebergJdbcCatalogModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/IcebergJdbcCatalogModule.java
@@ -64,6 +64,7 @@ public class IcebergJdbcCatalogModule
         }
         return new IcebergJdbcClient(
                 new IcebergJdbcConnectionFactory(driver, config.getConnectionUrl(), config.getConnectionUser(), config.getConnectionPassword()),
-                config.getCatalogName());
+                config.getCatalogName(),
+                config.getSchemaVersion());
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
@@ -21,6 +21,7 @@ import io.airlift.log.Logger;
 import io.trino.cache.EvictableCacheBuilder;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.metastore.TableInfo;
+import io.trino.plugin.iceberg.IcebergUtil;
 import io.trino.plugin.iceberg.catalog.AbstractTrinoCatalog;
 import io.trino.plugin.iceberg.catalog.IcebergTableOperationsProvider;
 import io.trino.spi.TrinoException;
@@ -34,6 +35,7 @@ import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableNotFoundException;
+import io.trino.spi.connector.ViewNotFoundException;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.type.TypeManager;
 import org.apache.iceberg.BaseTable;
@@ -47,6 +49,13 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.jdbc.JdbcCatalog;
+import org.apache.iceberg.view.ReplaceViewVersion;
+import org.apache.iceberg.view.SQLViewRepresentation;
+import org.apache.iceberg.view.UpdateViewProperties;
+import org.apache.iceberg.view.View;
+import org.apache.iceberg.view.ViewBuilder;
+import org.apache.iceberg.view.ViewRepresentation;
+import org.apache.iceberg.view.ViewVersion;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -65,6 +74,7 @@ import static io.trino.cache.CacheUtils.uncheckedCacheGet;
 import static io.trino.filesystem.Locations.appendPath;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_CATALOG_ERROR;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
+import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_UNSUPPORTED_VIEW_DIALECT;
 import static io.trino.plugin.iceberg.IcebergSchemaProperties.LOCATION_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergUtil.getIcebergTableWithMetadata;
 import static io.trino.plugin.iceberg.IcebergUtil.loadIcebergTable;
@@ -74,6 +84,7 @@ import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.CatalogUtil.dropTableData;
+import static org.apache.iceberg.view.ViewProperties.COMMENT;
 
 public class TrinoJdbcCatalog
         extends AbstractTrinoCatalog
@@ -173,17 +184,32 @@ public class TrinoJdbcCatalog
         Map<SchemaTableName, TableInfo> tablesListBuilder = new HashMap<>();
         for (String schemaName : namespaces) {
             try {
-                for (TableIdentifier table : jdbcCatalog.listTables(Namespace.of(schemaName))) {
-                    SchemaTableName tableName = new SchemaTableName(schemaName, table.name());
-                    // views and materialized views are currently not supported, so everything is a table
-                    tablesListBuilder.put(tableName, new TableInfo(tableName, TableInfo.ExtendedRelationType.TABLE));
-                }
+                jdbcCatalog.listTables(Namespace.of(schemaName)).stream()
+                        .map(tableId -> SchemaTableName.schemaTableName(schemaName, tableId.name()))
+                        .forEach(schemaTableName -> tablesListBuilder.put(schemaTableName, new TableInfo(schemaTableName, TableInfo.ExtendedRelationType.TABLE)));
+                jdbcCatalog.listViews(Namespace.of(schemaName)).stream()
+                        .map(tableId -> SchemaTableName.schemaTableName(schemaName, tableId.name()))
+                        .forEach(schemaTableName -> tablesListBuilder.put(schemaTableName, new TableInfo(schemaTableName, TableInfo.ExtendedRelationType.OTHER_VIEW)));
             }
             catch (NoSuchNamespaceException e) {
                 // Namespace may have been deleted
             }
         }
         return ImmutableList.copyOf(tablesListBuilder.values());
+    }
+
+    @Override
+    public List<SchemaTableName> listViews(ConnectorSession session, Optional<String> namespace)
+    {
+        List<String> namespaces = listNamespaces(session, namespace);
+
+        ImmutableList.Builder<SchemaTableName> viewNames = ImmutableList.builder();
+        for (String ns : namespaces) {
+            jdbcCatalog.listViews(Namespace.of(ns)).stream()
+                    .map(id -> SchemaTableName.schemaTableName(id.namespace().toString(), id.name()))
+                    .forEach(viewNames::add);
+        }
+        return viewNames.build();
     }
 
     @Override
@@ -345,13 +371,33 @@ public class TrinoJdbcCatalog
     @Override
     public void updateViewComment(ConnectorSession session, SchemaTableName schemaViewName, Optional<String> comment)
     {
-        throw new TrinoException(NOT_SUPPORTED, "updateViewComment is not supported for Iceberg JDBC catalogs");
+        View view = Optional.ofNullable(jdbcCatalog.loadView(toIdentifier(schemaViewName))).orElseThrow(() -> new ViewNotFoundException(schemaViewName));
+        UpdateViewProperties updateViewProperties = view.updateProperties();
+        comment.ifPresentOrElse(
+                value -> updateViewProperties.set(COMMENT, value),
+                () -> updateViewProperties.remove(COMMENT));
+        updateViewProperties.commit();
     }
 
     @Override
     public void updateViewColumnComment(ConnectorSession session, SchemaTableName schemaViewName, String columnName, Optional<String> comment)
     {
-        throw new TrinoException(NOT_SUPPORTED, "updateViewColumnComment is not supported for Iceberg JDBC catalogs");
+        View view = Optional.ofNullable(jdbcCatalog.loadView(toIdentifier(schemaViewName)))
+                .orElseThrow(() -> new ViewNotFoundException(schemaViewName));
+
+        ViewVersion current = view.currentVersion();
+        Schema updatedSchema = IcebergUtil.updateColumnComment(view.schema(), columnName, comment.orElse(null));
+        ReplaceViewVersion replaceViewVersion = view.replaceVersion()
+                .withSchema(updatedSchema)
+                .withDefaultCatalog(current.defaultCatalog())
+                .withDefaultNamespace(current.defaultNamespace());
+        for (ViewRepresentation representation : view.currentVersion().representations()) {
+            if (representation instanceof SQLViewRepresentation sqlViewRepresentation) {
+                replaceViewVersion.withQuery(sqlViewRepresentation.dialect(), sqlViewRepresentation.sql());
+            }
+        }
+
+        replaceViewVersion.commit();
     }
 
     @Override
@@ -380,13 +426,30 @@ public class TrinoJdbcCatalog
     @Override
     public void createView(ConnectorSession session, SchemaTableName schemaViewName, ConnectorViewDefinition definition, boolean replace)
     {
-        throw new TrinoException(NOT_SUPPORTED, "createView is not supported for Iceberg JDBC catalogs");
+        ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
+        definition.getOwner().ifPresent(owner -> properties.put(ICEBERG_VIEW_RUN_AS_OWNER, owner));
+        definition.getComment().ifPresent(comment -> properties.put(COMMENT, comment));
+        Schema schema = IcebergUtil.schemaFromViewColumns(typeManager, definition.getColumns());
+        ViewBuilder viewBuilder = jdbcCatalog.buildView(toIdentifier(schemaViewName));
+        viewBuilder = viewBuilder.withSchema(schema)
+                .withQuery("trino", definition.getOriginalSql())
+                .withDefaultNamespace(Namespace.of(schemaViewName.getSchemaName()))
+                .withDefaultCatalog(definition.getCatalog().orElse(null))
+                .withProperties(properties.buildOrThrow())
+                .withLocation(defaultTableLocation(session, schemaViewName));
+
+        if (replace) {
+            viewBuilder.createOrReplace();
+        }
+        else {
+            viewBuilder.create();
+        }
     }
 
     @Override
     public void renameView(ConnectorSession session, SchemaTableName source, SchemaTableName target)
     {
-        throw new TrinoException(NOT_SUPPORTED, "renameView is not supported for Iceberg JDBC catalogs");
+        jdbcCatalog.renameView(toIdentifier(source), toIdentifier(target));
     }
 
     @Override
@@ -398,19 +461,57 @@ public class TrinoJdbcCatalog
     @Override
     public void dropView(ConnectorSession session, SchemaTableName schemaViewName)
     {
-        throw new TrinoException(NOT_SUPPORTED, "dropView is not supported for Iceberg JDBC catalogs");
+        jdbcCatalog.dropView(toIdentifier(schemaViewName));
     }
 
     @Override
     public Map<SchemaTableName, ConnectorViewDefinition> getViews(ConnectorSession session, Optional<String> namespace)
     {
-        return ImmutableMap.of();
+        ImmutableMap.Builder<SchemaTableName, ConnectorViewDefinition> views = ImmutableMap.builder();
+        for (Namespace ns : jdbcCatalog.listNamespaces()) {
+            for (TableIdentifier restView : jdbcCatalog.listViews(ns)) {
+                SchemaTableName schemaTableName = SchemaTableName.schemaTableName(restView.namespace().toString(), restView.name());
+                try {
+                    getView(session, schemaTableName).ifPresent(view -> views.put(schemaTableName, view));
+                }
+                catch (TrinoException e) {
+                    if (e.getErrorCode().equals(ICEBERG_UNSUPPORTED_VIEW_DIALECT.toErrorCode())) {
+                        LOG.debug(e, "Skip unsupported view dialect: %s", schemaTableName);
+                        continue;
+                    }
+                    throw e;
+                }
+            }
+        }
+
+        return views.buildOrThrow();
     }
 
     @Override
     public Optional<ConnectorViewDefinition> getView(ConnectorSession session, SchemaTableName viewIdentifier)
     {
-        return Optional.empty();
+        if (!jdbcCatalog.viewExists(toIdentifier(viewIdentifier))) {
+            return Optional.empty();
+        }
+
+        return Optional.of(jdbcCatalog.loadView(toIdentifier(viewIdentifier))).flatMap(view -> {
+            SQLViewRepresentation sqlView = view.sqlFor("trino");
+            if (!sqlView.dialect().equalsIgnoreCase("trino")) {
+                throw new TrinoException(ICEBERG_UNSUPPORTED_VIEW_DIALECT, "Cannot read unsupported dialect '%s' for view '%s'".formatted(sqlView.dialect(), viewIdentifier));
+            }
+
+            Optional<String> comment = Optional.ofNullable(view.properties().get(COMMENT));
+            List<ConnectorViewDefinition.ViewColumn> viewColumns = IcebergUtil.viewColumnsFromSchema(typeManager, view.schema());
+            ViewVersion currentVersion = view.currentVersion();
+            Optional<String> catalog = Optional.ofNullable(currentVersion.defaultCatalog());
+            Optional<String> schema = Optional.empty();
+            if (catalog.isPresent() && !currentVersion.defaultNamespace().isEmpty()) {
+                schema = Optional.of(currentVersion.defaultNamespace().toString());
+            }
+
+            Optional<String> owner = Optional.ofNullable(view.properties().get(ICEBERG_VIEW_RUN_AS_OWNER));
+            return Optional.of(new ConnectorViewDefinition(sqlView.sql(), catalog, schema, viewColumns, comment, owner, owner.isEmpty(), null));
+        });
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalogFactory.java
@@ -71,6 +71,7 @@ public class TrinoJdbcCatalogFactory
         ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
         properties.put(URI, jdbcConfig.getConnectionUrl());
         properties.put(WAREHOUSE_LOCATION, defaultWarehouseDir);
+        properties.put(PROPERTY_PREFIX + "schema-version", jdbcConfig.getSchemaVersion().toString());
         jdbcConfig.getConnectionUser().ifPresent(user -> properties.put(PROPERTY_PREFIX + "user", user));
         jdbcConfig.getConnectionPassword().ifPresent(password -> properties.put(PROPERTY_PREFIX + "password", password));
         this.catalogProperties = properties.buildOrThrow();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogConfig.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.iceberg.catalog.jdbc;
 
 import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.iceberg.catalog.jdbc.IcebergJdbcCatalogConfig.SchemaVersion;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -33,7 +34,8 @@ public class TestIcebergJdbcCatalogConfig
                 .setConnectionUser(null)
                 .setConnectionPassword(null)
                 .setCatalogName(null)
-                .setDefaultWarehouseDir(null));
+                .setDefaultWarehouseDir(null)
+                .setSchemaVersion(SchemaVersion.V1));
     }
 
     @Test
@@ -46,6 +48,7 @@ public class TestIcebergJdbcCatalogConfig
                 .put("iceberg.jdbc-catalog.connection-password", "bar")
                 .put("iceberg.jdbc-catalog.catalog-name", "test")
                 .put("iceberg.jdbc-catalog.default-warehouse-dir", "s3://bucket")
+                .put("iceberg.jdbc-catalog.schema-version", "V0")
                 .buildOrThrow();
 
         IcebergJdbcCatalogConfig expected = new IcebergJdbcCatalogConfig()
@@ -54,7 +57,8 @@ public class TestIcebergJdbcCatalogConfig
                 .setConnectionUser("foo")
                 .setConnectionPassword("bar")
                 .setCatalogName("test")
-                .setDefaultWarehouseDir("s3://bucket");
+                .setDefaultWarehouseDir("s3://bucket")
+                .setSchemaVersion(SchemaVersion.V0);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogConnectorSmokeTest.java
@@ -18,12 +18,16 @@ import io.trino.filesystem.Location;
 import io.trino.plugin.iceberg.BaseIcebergConnectorSmokeTest;
 import io.trino.plugin.iceberg.IcebergConfig;
 import io.trino.plugin.iceberg.IcebergQueryRunner;
+import io.trino.plugin.iceberg.catalog.jdbc.IcebergJdbcCatalogConfig.SchemaVersion;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.jdbc.JdbcCatalog;
+import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -40,6 +44,7 @@ import static io.trino.plugin.iceberg.IcebergTestUtils.checkOrcFileSorting;
 import static io.trino.plugin.iceberg.IcebergTestUtils.checkParquetFileSorting;
 import static io.trino.plugin.iceberg.catalog.jdbc.TestingIcebergJdbcServer.PASSWORD;
 import static io.trino.plugin.iceberg.catalog.jdbc.TestingIcebergJdbcServer.USER;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static org.apache.iceberg.CatalogProperties.CATALOG_IMPL;
 import static org.apache.iceberg.CatalogProperties.URI;
@@ -47,6 +52,8 @@ import static org.apache.iceberg.CatalogProperties.WAREHOUSE_LOCATION;
 import static org.apache.iceberg.CatalogUtil.buildIcebergCatalog;
 import static org.apache.iceberg.FileFormat.PARQUET;
 import static org.apache.iceberg.jdbc.JdbcCatalog.PROPERTY_PREFIX;
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
@@ -66,10 +73,7 @@ public class TestIcebergJdbcCatalogConnectorSmokeTest
     protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
     {
         return switch (connectorBehavior) {
-            case SUPPORTS_COMMENT_ON_VIEW,
-                 SUPPORTS_COMMENT_ON_VIEW_COLUMN,
-                 SUPPORTS_CREATE_MATERIALIZED_VIEW,
-                 SUPPORTS_CREATE_VIEW,
+            case SUPPORTS_CREATE_MATERIALIZED_VIEW,
                  SUPPORTS_RENAME_MATERIALIZED_VIEW,
                  SUPPORTS_RENAME_SCHEMA -> false;
             default -> super.hasBehavior(connectorBehavior);
@@ -88,6 +92,7 @@ public class TestIcebergJdbcCatalogConnectorSmokeTest
                         .put(URI, server.getJdbcUrl())
                         .put(PROPERTY_PREFIX + "user", USER)
                         .put(PROPERTY_PREFIX + "password", PASSWORD)
+                        .put(PROPERTY_PREFIX + "schema-version", SchemaVersion.V1.toString())
                         .put(WAREHOUSE_LOCATION, warehouseLocation.getAbsolutePath())
                         .buildOrThrow(),
                 new Configuration(false));
@@ -117,11 +122,64 @@ public class TestIcebergJdbcCatalogConnectorSmokeTest
     }
 
     @Test
-    @Override
-    public void testView()
+    void testDropSchemaCascadeWithViews()
     {
-        assertThatThrownBy(super::testView)
-                .hasMessageContaining("createView is not supported for Iceberg JDBC catalogs");
+        String schemaName = "test_drop_schema_cascade" + randomNameSuffix();
+
+        assertUpdate("CREATE SCHEMA " + schemaName);
+
+        TableIdentifier sparkViewIdentifier = TableIdentifier.of(schemaName, "test_spark_views" + randomNameSuffix());
+        jdbcCatalog.buildView(sparkViewIdentifier)
+                .withDefaultNamespace(Namespace.of(schemaName))
+                .withDefaultCatalog("iceberg")
+                .withQuery("spark", "SELECT 1 x")
+                .withSchema(new Schema(required(1, "x", Types.LongType.get())))
+                .create();
+
+        TableIdentifier trinoViewIdentifier = TableIdentifier.of(schemaName, "test_trino_views" + randomNameSuffix());
+        jdbcCatalog.buildView(trinoViewIdentifier)
+                .withDefaultNamespace(Namespace.of(schemaName))
+                .withDefaultCatalog("iceberg")
+                .withQuery("trino", "SELECT 1 x")
+                .withSchema(new Schema(required(1, "x", Types.LongType.get())))
+                .create();
+
+        assertThat(jdbcCatalog.viewExists(sparkViewIdentifier)).isTrue();
+        assertThat(jdbcCatalog.viewExists(trinoViewIdentifier)).isTrue();
+
+        assertUpdate("DROP SCHEMA " + schemaName + " CASCADE");
+
+        assertThat(jdbcCatalog.viewExists(sparkViewIdentifier)).isFalse();
+        assertThat(jdbcCatalog.viewExists(trinoViewIdentifier)).isFalse();
+    }
+
+    @Test
+    void testUnsupportedViewDialect()
+    {
+        String viewName = "test_unsupported_dialect" + randomNameSuffix();
+        TableIdentifier identifier = TableIdentifier.of("tpch", viewName);
+
+        jdbcCatalog.buildView(identifier)
+                .withDefaultNamespace(Namespace.of("tpch"))
+                .withDefaultCatalog("iceberg")
+                .withQuery("spark", "SELECT 1 x")
+                .withSchema(new Schema(required(1, "x", Types.LongType.get())))
+                .create();
+
+        assertThat(computeActual("SHOW TABLES FROM iceberg.tpch").getOnlyColumnAsSet())
+                .contains(viewName);
+
+        assertThat(computeActual("SELECT table_name FROM information_schema.views WHERE table_schema = 'tpch'").getOnlyColumnAsSet())
+                .doesNotContain(viewName);
+
+        assertThat(computeActual("SELECT table_name FROM information_schema.columns WHERE table_schema = 'tpch'").getOnlyColumnAsSet())
+                .doesNotContain(viewName);
+
+        assertQueryReturnsEmptyResult("SELECT * FROM information_schema.columns WHERE table_schema = 'tpch' AND table_name = '" + viewName + "'");
+
+        assertQueryFails("SELECT * FROM " + viewName, "Cannot read unsupported dialect 'spark' for view '.*'");
+
+        jdbcCatalog.dropView(identifier);
     }
 
     @Test


### PR DESCRIPTION
## Description
Add view support for iceberg JDBC catalog.

## Additional context and related issues
Iceberg now supports views. The iceberg REST catalog already supports views. This just brings things to parity.

## Release notes

```markdown
# Iceberg
* Add support for views in JDBC catalog. ({issue}`22576`)
* Upgrade `jdbc.schema-version` to `V1` in JDBC catalog. ({issue}`22576`)
```
