### PR TITLE
Use hive.parquet.time-zone when reading INT64 timestamps in hive

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
@@ -205,7 +205,7 @@ public final class ColumnReaderFactory
             }
             if (timestampType.isShort()) {
                 return switch (timestampAnnotation.getUnit()) {
-                    case MILLIS -> createColumnReader(field, valueDecoders::getInt64TimestampMillsToShortTimestampDecoder, LONG_ADAPTER, memoryContext);
+                    case MILLIS -> createColumnReader(field, valueDecoders::getInt64TimestampMillisToShortTimestampDecoder, LONG_ADAPTER, memoryContext);
                     case MICROS -> createColumnReader(field, valueDecoders::getInt64TimestampMicrosToShortTimestampDecoder, LONG_ADAPTER, memoryContext);
                     case NANOS -> createColumnReader(field, valueDecoders::getInt64TimestampNanosToShortTimestampDecoder, LONG_ADAPTER, memoryContext);
                 };

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
@@ -203,17 +203,18 @@ public final class ColumnReaderFactory
             if (!(annotation instanceof TimestampLogicalTypeAnnotation timestampAnnotation)) {
                 throw unsupportedException(type, field);
             }
+            DateTimeZone readTimeZone = timestampAnnotation.isAdjustedToUTC() ? timeZone : DateTimeZone.UTC;
             if (timestampType.isShort()) {
                 return switch (timestampAnnotation.getUnit()) {
-                    case MILLIS -> createColumnReader(field, valueDecoders::getInt64TimestampMillisToShortTimestampDecoder, LONG_ADAPTER, memoryContext);
-                    case MICROS -> createColumnReader(field, valueDecoders::getInt64TimestampMicrosToShortTimestampDecoder, LONG_ADAPTER, memoryContext);
-                    case NANOS -> createColumnReader(field, valueDecoders::getInt64TimestampNanosToShortTimestampDecoder, LONG_ADAPTER, memoryContext);
+                    case MILLIS -> createColumnReader(field, encoding -> valueDecoders.getInt64TimestampMillisToShortTimestampDecoder(encoding, readTimeZone), LONG_ADAPTER, memoryContext);
+                    case MICROS -> createColumnReader(field, encoding -> valueDecoders.getInt64TimestampMicrosToShortTimestampDecoder(encoding, readTimeZone), LONG_ADAPTER, memoryContext);
+                    case NANOS -> createColumnReader(field, encoding -> valueDecoders.getInt64TimestampNanosToShortTimestampDecoder(encoding, readTimeZone), LONG_ADAPTER, memoryContext);
                 };
             }
             return switch (timestampAnnotation.getUnit()) {
-                case MILLIS -> createColumnReader(field, valueDecoders::getInt64TimestampMillisToLongTimestampDecoder, FIXED12_ADAPTER, memoryContext);
-                case MICROS -> createColumnReader(field, valueDecoders::getInt64TimestampMicrosToLongTimestampDecoder, FIXED12_ADAPTER, memoryContext);
-                case NANOS -> createColumnReader(field, valueDecoders::getInt64TimestampNanosToLongTimestampDecoder, FIXED12_ADAPTER, memoryContext);
+                case MILLIS -> createColumnReader(field, encoding -> valueDecoders.getInt64TimestampMillisToLongTimestampDecoder(encoding, readTimeZone), FIXED12_ADAPTER, memoryContext);
+                case MICROS -> createColumnReader(field, encoding -> valueDecoders.getInt64TimestampMicrosToLongTimestampDecoder(encoding, readTimeZone), FIXED12_ADAPTER, memoryContext);
+                case NANOS -> createColumnReader(field, encoding -> valueDecoders.getInt64TimestampNanosToLongTimestampDecoder(encoding, readTimeZone), FIXED12_ADAPTER, memoryContext);
             };
         }
         if (type instanceof TimestampWithTimeZoneType timestampWithTimeZoneType && primitiveType == INT64) {

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
@@ -494,7 +494,7 @@ public final class ValueDecoders
                 });
     }
 
-    public ValueDecoder<long[]> getInt64TimestampMillsToShortTimestampDecoder(ParquetEncoding encoding)
+    public ValueDecoder<long[]> getInt64TimestampMillisToShortTimestampDecoder(ParquetEncoding encoding)
     {
         checkArgument(
                 field.getType() instanceof TimestampType timestampType && timestampType.isShort(),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetUtil.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetUtil.java
@@ -26,6 +26,7 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.security.ConnectorIdentity;
 import io.trino.spi.type.Type;
+import org.joda.time.DateTimeZone;
 
 import java.io.File;
 import java.io.IOException;
@@ -54,7 +55,25 @@ final class ParquetUtil
         return createPageSource(session, parquetFile, getBaseColumns(columnNames, columnTypes), TupleDomain.all());
     }
 
+    public static ConnectorPageSource createPageSource(ConnectorSession session, File parquetFile, List<String> columnNames, List<Type> columnTypes, DateTimeZone timeZone)
+            throws IOException
+    {
+        return createPageSource(session, parquetFile, getBaseColumns(columnNames, columnTypes), TupleDomain.all(), new HiveConfig().setParquetTimeZone(timeZone.toString()));
+    }
+
+    public static ConnectorPageSource createPageSource(ConnectorSession session, File parquetFile, List<HiveColumnHandle> columns, TupleDomain<HiveColumnHandle> domain, DateTimeZone timeZone)
+            throws IOException
+    {
+        return createPageSource(session, parquetFile, columns, domain, new HiveConfig().setParquetTimeZone(timeZone.toString()));
+    }
+
     public static ConnectorPageSource createPageSource(ConnectorSession session, File parquetFile, List<HiveColumnHandle> columns, TupleDomain<HiveColumnHandle> domain)
+            throws IOException
+    {
+        return createPageSource(session, parquetFile, columns, domain, new HiveConfig());
+    }
+
+    private static ConnectorPageSource createPageSource(ConnectorSession session, File parquetFile, List<HiveColumnHandle> columns, TupleDomain<HiveColumnHandle> domain, HiveConfig hiveConfig)
             throws IOException
     {
         // copy the test file into the memory filesystem
@@ -68,7 +87,7 @@ final class ParquetUtil
                 fileSystemFactory,
                 new FileFormatDataSourceStats(),
                 new ParquetReaderConfig(),
-                new HiveConfig());
+                hiveConfig);
 
         return hivePageSourceFactory.createPageSource(
                         session,


### PR DESCRIPTION
## Description

Parquet files having INT96 timestamps support `hive.parquet.time-zone` property for Hive connector. However, for UTC adjusted INT64 timestamps, setting `hive.parquet.time-zone` doesn't have any effect. This PR adds support for parquet reader to adjust INT64 timestamps to timezone defined by `hive.parquet.time-zone` when parquet logical annotation `isAdjustedToUTC` is set to true.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Use `hive.parquet.time-zone` when reading UTC adjusted INT64 timestamps in parquet files. ({issue}`22577`)
```
