### PR TITLE
Fix the issue of empty Symbol name when the column name is Chinese.

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/SymbolAllocator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/SymbolAllocator.java
@@ -60,7 +60,11 @@ public class SymbolAllocator
         requireNonNull(nameHint, "nameHint is null");
         requireNonNull(type, "type is null");
 
+        String tmpNameHint = nameHint;
         nameHint = EXCLUDED_CHARACTERS.trimAndCollapseFrom(nameHint.toLowerCase(ENGLISH), '_');
+        if (nameHint.isEmpty()) {
+            nameHint = tmpNameHint;
+        }
 
         // don't strip the tail if the only _ is the first character
         int index = nameHint.lastIndexOf("_");


### PR DESCRIPTION
when the column name is Chinese，query will failed,  cause io.trino.sql.planner.Symbol.name is empty

java.lang.IllegalArgumentException: name is empty
	at io.trino.spi.expression.Variable.<init>(Variable.java:35)
	at io.trino.sql.planner.iterative.rule.PruneTableScanColumns.lambda$pruneColumns$0(PruneTableScanColumns.java:75)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:1024)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at io.trino.sql.planner.iterative.rule.PruneTableScanColumns.pruneColumns(PruneTableScanColumns.java:76)
	at io.trino.sql.planner.iterative.rule.PruneTableScanColumns.pushDownProjectOff(PruneTableScanColumns.java:63)
	at io.trino.sql.planner.iterative.rule.PruneTableScanColumns.pushDownProjectOff(PruneTableScanColumns.java:48)
	at io.trino.sql.planner.iterative.rule.ProjectOffPushDownRule.lambda$apply$0(ProjectOffPushDownRule.java:63)
	at java.base/java.util.Optional.flatMap(Optional.java:289)
	at io.trino.sql.planner.iterative.rule.ProjectOffPushDownRule.apply(ProjectOffPushDownRule.java:63)
	at io.trino.sql.planner.iterative.rule.ProjectOffPushDownRule.apply(ProjectOffPushDownRule.java:38)
	at io.trino.sql.planner.iterative.IterativeOptimizer.transform(IterativeOptimizer.java:216)
	at io.trino.sql.planner.iterative.IterativeOptimizer.exploreNode(IterativeOptimizer.java:181)
	at io.trino.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:144)
	at io.trino.sql.planner.iterative.IterativeOptimizer.exploreChildren(IterativeOptimizer.java:264)
	at io.trino.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:146)
	at io.trino.sql.planner.iterative.IterativeOptimizer.exploreChildren(IterativeOptimizer.java:264)
	at io.trino.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:146)
	at io.trino.sql.planner.iterative.IterativeOptimizer.exploreChildren(IterativeOptimizer.java:264)
	at io.trino.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:146)
	at io.trino.sql.planner.iterative.IterativeOptimizer.optimizeAndMarkPlanChanges(IterativeOptimizer.java:129)
	at io.trino.sql.planner.optimizations.AdaptivePlanOptimizer.optimize(AdaptivePlanOptimizer.java:33)
	at io.trino.sql.planner.LogicalPlanner.runOptimizer(LogicalPlanner.java:301)
	at io.trino.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:264)
	at io.trino.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:236)
	at io.trino.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:231)
	at io.trino.execution.SqlQueryExecution.doPlanQuery(SqlQueryExecution.java:498)
	at io.trino.execution.SqlQueryExecution.planQuery(SqlQueryExecution.java:478)
	at io.trino.execution.SqlQueryExecution.start(SqlQueryExecution.java:416)
	at io.trino.execution.SqlQueryManager.createQuery(SqlQueryManager.java:272)
	at io.trino.dispatcher.LocalDispatchQuery.startExecution(LocalDispatchQuery.java:145)
	at io.trino.dispatcher.LocalDispatchQuery.lambda$waitForMinimumWorkers$2(LocalDispatchQuery.java:129)
	at io.airlift.concurrent.MoreFutures.lambda$addSuccessCallback$12(MoreFutures.java:570)
	at io.airlift.concurrent.MoreFutures$3.onSuccess(MoreFutures.java:545)
	at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1137)
	at io.trino.$gen.Trino_444_qiyi_2_SNAPSHOT____20240704_065458_2.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)