### PR TITLE
Use projected columns in iceberg getTableStatistics

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergStatistics.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergStatistics.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.iceberg;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.spi.TrinoException;
 import io.trino.spi.type.TypeManager;
@@ -65,7 +64,6 @@ record IcebergStatistics(
 
     static class Builder
     {
-        private final List<Types.NestedField> columns;
         private final TypeManager typeManager;
         private final Map<Integer, io.trino.spi.type.Type> fieldIdToTrinoType;
 
@@ -81,9 +79,7 @@ record IcebergStatistics(
                 List<Types.NestedField> columns,
                 TypeManager typeManager)
         {
-            this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
             this.typeManager = requireNonNull(typeManager, "typeManager is null");
-
             this.fieldIdToTrinoType = columns.stream()
                     .collect(toImmutableMap(Types.NestedField::fieldId, column -> toTrinoType(column.type(), typeManager)));
         }
@@ -96,11 +92,10 @@ record IcebergStatistics(
 
             Map<Integer, Long> newColumnSizes = dataFile.columnSizes();
             if (newColumnSizes != null) {
-                for (Types.NestedField column : columns) {
-                    int id = column.fieldId();
-                    Long addedSize = newColumnSizes.get(id);
+                for (Map.Entry<Integer, Long> entry : newColumnSizes.entrySet()) {
+                    Long addedSize = entry.getValue();
                     if (addedSize != null) {
-                        columnSizes.merge(id, addedSize, Long::sum);
+                        columnSizes.merge(entry.getKey(), addedSize, Long::sum);
                     }
                 }
             }


### PR DESCRIPTION
## Description
Restrict fetching of iceberg statistics to only the columns projected from a scan.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Relies on https://github.com/trinodb/trino/pull/22739 to cache multiple accesses to filesystem due to different columns being projected from same table through multiple scans

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

