### PR TITLE
Extract protoc maven config to pluginManagement

### DIFF
--- a/plugin/trino-kafka/pom.xml
+++ b/plugin/trino-kafka/pom.xml
@@ -361,6 +361,24 @@
     </repositories>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.github.os72</groupId>
+                    <artifactId>protoc-jar-maven-plugin</artifactId>
+                    <version>3.11.4</version>
+                    <configuration>
+                        <protocArtifact>com.google.protobuf:protoc:${dep.protobuf.version}</protocArtifact>
+                        <protocVersion>${dep.protobuf.version}</protocVersion>
+                        <addSources>none</addSources>
+                        <inputDirectories>
+                            <include>src/test/resources/protobuf-sources</include>
+                        </inputDirectories>
+                        <outputDirectory>target/generated-test-sources/</outputDirectory>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>io.trino</groupId>
@@ -387,7 +405,6 @@
             <plugin>
                 <groupId>com.github.os72</groupId>
                 <artifactId>protoc-jar-maven-plugin</artifactId>
-                <version>3.11.4</version>
                 <executions>
                     <execution>
                         <id>generate-test-sources</id>
@@ -395,15 +412,6 @@
                             <goal>run</goal>
                         </goals>
                         <phase>generate-test-sources</phase>
-                        <configuration>
-                            <protocArtifact>com.google.protobuf:protoc:${dep.protobuf.version}</protocArtifact>
-                            <protocVersion>${dep.protobuf.version}</protocVersion>
-                            <addSources>none</addSources>
-                            <inputDirectories>
-                                <include>src/test/resources/protobuf-sources</include>
-                            </inputDirectories>
-                            <outputDirectory>target/generated-test-sources/</outputDirectory>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
This allows to run plugin manually:

./mvnw protoc-jar:3.11.4:run  -pl :trino-kafka

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
