### PR TITLE
Cleanup in LDAP Product Tests

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/ImmutableLdapObjectDefinitions.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/ImmutableLdapObjectDefinitions.java
@@ -15,7 +15,9 @@ package io.trino.tests.product;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.trino.tempto.Requirement;
 import io.trino.tempto.fulfillment.ldap.LdapObjectDefinition;
+import io.trino.tempto.fulfillment.ldap.LdapObjectRequirement;
 
 import java.util.Arrays;
 import java.util.List;
@@ -64,6 +66,15 @@ public final class ImmutableLdapObjectDefinitions
     public static final LdapObjectDefinition USER_IN_EUROPE = buildLdapUserObject("EuropeUser", EUROPE_DISTINGUISHED_NAME, Optional.of(ImmutableList.of(DEFAULT_GROUP)), LDAP_PASSWORD);
 
     public static final LdapObjectDefinition USER_IN_AMERICA = buildLdapUserObject("AmericanUser", AMERICA_DISTINGUISHED_NAME, Optional.of(ImmutableList.of(DEFAULT_GROUP)), LDAP_PASSWORD);
+
+    public static Requirement getLdapRequirement()
+    {
+        return new LdapObjectRequirement(
+                ImmutableList.of(
+                        AMERICA_ORG, ASIA_ORG, EUROPE_ORG,
+                        DEFAULT_GROUP, PARENT_GROUP, CHILD_GROUP,
+                        DEFAULT_GROUP_USER, PARENT_GROUP_USER, CHILD_GROUP_USER, ORPHAN_USER, SPECIAL_USER, USER_IN_MULTIPLE_GROUPS, USER_IN_AMERICA, USER_IN_EUROPE));
+    }
 
     public static LdapObjectDefinition buildLdapOrganizationObject(String id, String distinguishedName, String unit)
     {

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/ImmutableLdapObjectDefinitions.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/ImmutableLdapObjectDefinitions.java
@@ -13,14 +13,15 @@
  */
 package io.trino.tests.product;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.tempto.fulfillment.ldap.LdapObjectDefinition;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
 
 public final class ImmutableLdapObjectDefinitions
@@ -42,27 +43,27 @@ public final class ImmutableLdapObjectDefinitions
 
     public static final LdapObjectDefinition EUROPE_ORG = buildLdapOrganizationObject("Europe", EUROPE_DISTINGUISHED_NAME, "Europe");
 
-    public static final LdapObjectDefinition DEFAULT_GROUP = buildLdapGroupObject("DefaultGroup", "DefaultGroupUser", Optional.of(Arrays.asList("ChildGroup")));
-
-    public static final LdapObjectDefinition PARENT_GROUP = buildLdapGroupObject("ParentGroup", "ParentGroupUser", Optional.of(Arrays.asList("DefaultGroup")));
-
     public static final LdapObjectDefinition CHILD_GROUP = buildLdapGroupObject("ChildGroup", "ChildGroupUser", Optional.empty());
 
-    public static final LdapObjectDefinition DEFAULT_GROUP_USER = buildLdapUserObject("DefaultGroupUser", Optional.of(Arrays.asList("DefaultGroup")), LDAP_PASSWORD);
+    public static final LdapObjectDefinition DEFAULT_GROUP = buildLdapGroupObject("DefaultGroup", "DefaultGroupUser", Optional.of(ImmutableList.of(CHILD_GROUP)));
 
-    public static final LdapObjectDefinition PARENT_GROUP_USER = buildLdapUserObject("ParentGroupUser", Optional.of(Arrays.asList("ParentGroup")), LDAP_PASSWORD);
+    public static final LdapObjectDefinition PARENT_GROUP = buildLdapGroupObject("ParentGroup", "ParentGroupUser", Optional.of(ImmutableList.of(DEFAULT_GROUP)));
 
-    public static final LdapObjectDefinition CHILD_GROUP_USER = buildLdapUserObject("ChildGroupUser", Optional.of(Arrays.asList("ChildGroup")), LDAP_PASSWORD);
+    public static final LdapObjectDefinition DEFAULT_GROUP_USER = buildLdapUserObject("DefaultGroupUser", Optional.of(ImmutableList.of(DEFAULT_GROUP)), LDAP_PASSWORD);
+
+    public static final LdapObjectDefinition PARENT_GROUP_USER = buildLdapUserObject("ParentGroupUser", Optional.of(ImmutableList.of(PARENT_GROUP)), LDAP_PASSWORD);
+
+    public static final LdapObjectDefinition CHILD_GROUP_USER = buildLdapUserObject("ChildGroupUser", Optional.of(ImmutableList.of(CHILD_GROUP)), LDAP_PASSWORD);
 
     public static final LdapObjectDefinition ORPHAN_USER = buildLdapUserObject("OrphanUser", Optional.empty(), LDAP_PASSWORD);
 
-    public static final LdapObjectDefinition SPECIAL_USER = buildLdapUserObject("User WithSpecialPwd", Optional.of(Arrays.asList("DefaultGroup")), "LDAP:Pass ~!@#$%^&*()_+{}|:\"<>?/.,';\\][=-`");
+    public static final LdapObjectDefinition SPECIAL_USER = buildLdapUserObject("User WithSpecialPwd", Optional.of(ImmutableList.of(DEFAULT_GROUP)), "LDAP:Pass ~!@#$%^&*()_+{}|:\"<>?/.,';\\][=-`");
 
-    public static final LdapObjectDefinition USER_IN_MULTIPLE_GROUPS = buildLdapUserObject("UserInMultipleGroups", Optional.of(Arrays.asList("DefaultGroup", "ParentGroup")), LDAP_PASSWORD);
+    public static final LdapObjectDefinition USER_IN_MULTIPLE_GROUPS = buildLdapUserObject("UserInMultipleGroups", Optional.of(ImmutableList.of(DEFAULT_GROUP, PARENT_GROUP)), LDAP_PASSWORD);
 
-    public static final LdapObjectDefinition USER_IN_EUROPE = buildLdapUserObject("EuropeUser", EUROPE_DISTINGUISHED_NAME, Optional.of(Arrays.asList("DefaultGroup")), Optional.of(AMERICA_DISTINGUISHED_NAME), LDAP_PASSWORD);
+    public static final LdapObjectDefinition USER_IN_EUROPE = buildLdapUserObject("EuropeUser", EUROPE_DISTINGUISHED_NAME, Optional.of(ImmutableList.of(DEFAULT_GROUP)), LDAP_PASSWORD);
 
-    public static final LdapObjectDefinition USER_IN_AMERICA = buildLdapUserObject("AmericanUser", AMERICA_DISTINGUISHED_NAME, Optional.of(Arrays.asList("DefaultGroup")), Optional.of(AMERICA_DISTINGUISHED_NAME), LDAP_PASSWORD);
+    public static final LdapObjectDefinition USER_IN_AMERICA = buildLdapUserObject("AmericanUser", AMERICA_DISTINGUISHED_NAME, Optional.of(ImmutableList.of(DEFAULT_GROUP)), LDAP_PASSWORD);
 
     public static LdapObjectDefinition buildLdapOrganizationObject(String id, String distinguishedName, String unit)
     {
@@ -73,25 +74,29 @@ public final class ImmutableLdapObjectDefinitions
                 .build();
     }
 
-    public static LdapObjectDefinition buildLdapGroupObject(String groupName, String userName, Optional<List<String>> childGroupNames)
+    public static LdapObjectDefinition buildLdapGroupObject(String groupName, String userName, Optional<List<LdapObjectDefinition>> childGroups)
     {
-        if (childGroupNames.isPresent()) {
-            return buildLdapGroupObject(groupName, AMERICA_DISTINGUISHED_NAME, userName, ASIA_DISTINGUISHED_NAME, childGroupNames, Optional.of(AMERICA_DISTINGUISHED_NAME));
-        }
-        return buildLdapGroupObject(groupName, AMERICA_DISTINGUISHED_NAME, userName, ASIA_DISTINGUISHED_NAME,
-                Optional.empty(), Optional.empty());
+        return buildLdapGroupObject(groupName, AMERICA_DISTINGUISHED_NAME, userName, ASIA_DISTINGUISHED_NAME, childGroups);
     }
 
-    public static LdapObjectDefinition buildLdapGroupObject(String groupName, String groupOrganizationName,
-            String userName, String userOrganizationName, Optional<List<String>> childGroupNames, Optional<String> childGroupOrganizationName)
+    public static LdapObjectDefinition buildLdapGroupObject(
+            String groupName,
+            String groupOrganizationName,
+            String userName,
+            String userOrganizationName,
+            Optional<List<LdapObjectDefinition>> childGroups)
     {
-        if (childGroupNames.isPresent() && childGroupOrganizationName.isPresent()) {
+        if (childGroups.isPresent()) {
             return LdapObjectDefinition.builder(groupName)
                     .setDistinguishedName(format("cn=%s,%s", groupName, groupOrganizationName))
                     .setAttributes(ImmutableMap.of(
                             "cn", groupName,
                             "member", format("uid=%s,%s", userName, userOrganizationName)))
-                    .setModificationAttributes(getAttributes(childGroupNames.get(), childGroupOrganizationName.get(), MEMBER))
+                    .setModificationAttributes(ImmutableMap.of(
+                            MEMBER,
+                            childGroups.get().stream()
+                                    .map(LdapObjectDefinition::getDistinguishedName)
+                                    .collect(toImmutableList())))
                     .setObjectClasses(Arrays.asList("groupOfNames"))
                     .build();
         }
@@ -104,20 +109,18 @@ public final class ImmutableLdapObjectDefinitions
                 .build();
     }
 
-    public static LdapObjectDefinition buildLdapUserObject(String userName, Optional<List<String>> groupNames, String password)
+    public static LdapObjectDefinition buildLdapUserObject(String userName, Optional<List<LdapObjectDefinition>> groups, String password)
     {
-        if (groupNames.isPresent()) {
-            return buildLdapUserObject(userName, ASIA_DISTINGUISHED_NAME,
-                    groupNames, Optional.of(AMERICA_DISTINGUISHED_NAME), password);
-        }
-        return buildLdapUserObject(userName, ASIA_DISTINGUISHED_NAME,
-                Optional.empty(), Optional.empty(), password);
+        return buildLdapUserObject(userName, ASIA_DISTINGUISHED_NAME, groups, password);
     }
 
-    public static LdapObjectDefinition buildLdapUserObject(String userName, String userOrganizationName,
-            Optional<List<String>> groupNames, Optional<String> groupOrganizationName, String password)
+    public static LdapObjectDefinition buildLdapUserObject(
+            String userName,
+            String userOrganizationName,
+            Optional<List<LdapObjectDefinition>> groups,
+            String password)
     {
-        if (groupNames.isPresent() && groupOrganizationName.isPresent()) {
+        if (groups.isPresent()) {
             return LdapObjectDefinition.builder(userName)
                     .setDistinguishedName(format("uid=%s,%s", userName, userOrganizationName))
                     .setAttributes(ImmutableMap.of(
@@ -125,7 +128,11 @@ public final class ImmutableLdapObjectDefinitions
                             "sn", userName,
                             "userPassword", password))
                     .setObjectClasses(Arrays.asList("person", "inetOrgPerson"))
-                    .setModificationAttributes(getAttributes(groupNames.get(), groupOrganizationName.get(), MEMBER_OF))
+                    .setModificationAttributes(ImmutableMap.of(
+                            MEMBER_OF,
+                            groups.get().stream()
+                                    .map(LdapObjectDefinition::getDistinguishedName)
+                                    .collect(toImmutableList())))
                     .build();
         }
         return LdapObjectDefinition.builder(userName)
@@ -136,12 +143,5 @@ public final class ImmutableLdapObjectDefinitions
                         "userPassword", password))
                 .setObjectClasses(Arrays.asList("person", "inetOrgPerson"))
                 .build();
-    }
-
-    private static ImmutableMap<String, List<String>> getAttributes(List<String> groupNames, String groupOrganizationName, String relation)
-    {
-        return ImmutableMap.of(relation, groupNames.stream()
-                .map(groupName -> format("cn=%s,%s", groupName, groupOrganizationName))
-                .collect(Collectors.toList()));
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/ImmutableLdapObjectDefinitions.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/ImmutableLdapObjectDefinitions.java
@@ -21,7 +21,6 @@ import io.trino.tempto.fulfillment.ldap.LdapObjectRequirement;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
@@ -33,7 +32,6 @@ public final class ImmutableLdapObjectDefinitions
     private static final String ASIA_DISTINGUISHED_NAME = format("ou=Asia,%s", DOMAIN);
     private static final String EUROPE_DISTINGUISHED_NAME = format("ou=Europe,%s", DOMAIN);
     private static final String LDAP_PASSWORD = "LDAPPass123";
-    private static final String MEMBER_OF = "memberOf";
     private static final String MEMBER = "member";
 
     private ImmutableLdapObjectDefinitions()
@@ -45,35 +43,41 @@ public final class ImmutableLdapObjectDefinitions
 
     public static final LdapObjectDefinition EUROPE_ORG = buildLdapOrganizationObject("Europe", EUROPE_DISTINGUISHED_NAME, "Europe");
 
-    public static final LdapObjectDefinition CHILD_GROUP = buildLdapGroupObject("ChildGroup", "ChildGroupUser", Optional.empty());
+    public static final LdapObjectDefinition DEFAULT_GROUP_USER = buildLdapUserObject("DefaultGroupUser", LDAP_PASSWORD);
 
-    public static final LdapObjectDefinition DEFAULT_GROUP = buildLdapGroupObject("DefaultGroup", "DefaultGroupUser", Optional.of(ImmutableList.of(CHILD_GROUP)));
+    public static final LdapObjectDefinition PARENT_GROUP_USER = buildLdapUserObject("ParentGroupUser", LDAP_PASSWORD);
 
-    public static final LdapObjectDefinition PARENT_GROUP = buildLdapGroupObject("ParentGroup", "ParentGroupUser", Optional.of(ImmutableList.of(DEFAULT_GROUP)));
+    public static final LdapObjectDefinition CHILD_GROUP_USER = buildLdapUserObject("ChildGroupUser", LDAP_PASSWORD);
 
-    public static final LdapObjectDefinition DEFAULT_GROUP_USER = buildLdapUserObject("DefaultGroupUser", Optional.of(ImmutableList.of(DEFAULT_GROUP)), LDAP_PASSWORD);
+    public static final LdapObjectDefinition ORPHAN_USER = buildLdapUserObject("OrphanUser", LDAP_PASSWORD);
 
-    public static final LdapObjectDefinition PARENT_GROUP_USER = buildLdapUserObject("ParentGroupUser", Optional.of(ImmutableList.of(PARENT_GROUP)), LDAP_PASSWORD);
+    public static final LdapObjectDefinition SPECIAL_USER = buildLdapUserObject("User WithSpecialPwd", "LDAP:Pass ~!@#$%^&*()_+{}|:\"<>?/.,';\\][=-`");
 
-    public static final LdapObjectDefinition CHILD_GROUP_USER = buildLdapUserObject("ChildGroupUser", Optional.of(ImmutableList.of(CHILD_GROUP)), LDAP_PASSWORD);
+    public static final LdapObjectDefinition USER_IN_MULTIPLE_GROUPS = buildLdapUserObject("UserInMultipleGroups", LDAP_PASSWORD);
 
-    public static final LdapObjectDefinition ORPHAN_USER = buildLdapUserObject("OrphanUser", Optional.empty(), LDAP_PASSWORD);
+    public static final LdapObjectDefinition USER_IN_EUROPE = buildLdapUserObject("EuropeUser", EUROPE_DISTINGUISHED_NAME, LDAP_PASSWORD);
 
-    public static final LdapObjectDefinition SPECIAL_USER = buildLdapUserObject("User WithSpecialPwd", Optional.of(ImmutableList.of(DEFAULT_GROUP)), "LDAP:Pass ~!@#$%^&*()_+{}|:\"<>?/.,';\\][=-`");
+    public static final LdapObjectDefinition USER_IN_AMERICA = buildLdapUserObject("AmericanUser", AMERICA_DISTINGUISHED_NAME, LDAP_PASSWORD);
 
-    public static final LdapObjectDefinition USER_IN_MULTIPLE_GROUPS = buildLdapUserObject("UserInMultipleGroups", Optional.of(ImmutableList.of(DEFAULT_GROUP, PARENT_GROUP)), LDAP_PASSWORD);
+    public static final LdapObjectDefinition CHILD_GROUP = buildLdapGroupObject("ChildGroup", "ChildGroupUser", ImmutableList.of());
 
-    public static final LdapObjectDefinition USER_IN_EUROPE = buildLdapUserObject("EuropeUser", EUROPE_DISTINGUISHED_NAME, Optional.of(ImmutableList.of(DEFAULT_GROUP)), LDAP_PASSWORD);
+    public static final LdapObjectDefinition DEFAULT_GROUP = buildLdapGroupObject(
+            "DefaultGroup",
+            "DefaultGroupUser",
+            ImmutableList.of(CHILD_GROUP, SPECIAL_USER, USER_IN_MULTIPLE_GROUPS, USER_IN_EUROPE, USER_IN_AMERICA));
 
-    public static final LdapObjectDefinition USER_IN_AMERICA = buildLdapUserObject("AmericanUser", AMERICA_DISTINGUISHED_NAME, Optional.of(ImmutableList.of(DEFAULT_GROUP)), LDAP_PASSWORD);
+    public static final LdapObjectDefinition PARENT_GROUP = buildLdapGroupObject(
+            "ParentGroup",
+            "ParentGroupUser",
+            ImmutableList.of(DEFAULT_GROUP, USER_IN_MULTIPLE_GROUPS));
 
     public static Requirement getLdapRequirement()
     {
         return new LdapObjectRequirement(
                 ImmutableList.of(
                         AMERICA_ORG, ASIA_ORG, EUROPE_ORG,
-                        DEFAULT_GROUP, PARENT_GROUP, CHILD_GROUP,
-                        DEFAULT_GROUP_USER, PARENT_GROUP_USER, CHILD_GROUP_USER, ORPHAN_USER, SPECIAL_USER, USER_IN_MULTIPLE_GROUPS, USER_IN_AMERICA, USER_IN_EUROPE));
+                        DEFAULT_GROUP_USER, PARENT_GROUP_USER, CHILD_GROUP_USER, ORPHAN_USER, SPECIAL_USER, USER_IN_MULTIPLE_GROUPS, USER_IN_AMERICA, USER_IN_EUROPE,
+                        DEFAULT_GROUP, PARENT_GROUP, CHILD_GROUP));
     }
 
     public static LdapObjectDefinition buildLdapOrganizationObject(String id, String distinguishedName, String unit)
@@ -85,9 +89,9 @@ public final class ImmutableLdapObjectDefinitions
                 .build();
     }
 
-    public static LdapObjectDefinition buildLdapGroupObject(String groupName, String userName, Optional<List<LdapObjectDefinition>> childGroups)
+    public static LdapObjectDefinition buildLdapGroupObject(String groupName, String userName, List<LdapObjectDefinition> memberAttributes)
     {
-        return buildLdapGroupObject(groupName, AMERICA_DISTINGUISHED_NAME, userName, ASIA_DISTINGUISHED_NAME, childGroups);
+        return buildLdapGroupObject(groupName, AMERICA_DISTINGUISHED_NAME, userName, ASIA_DISTINGUISHED_NAME, memberAttributes);
     }
 
     public static LdapObjectDefinition buildLdapGroupObject(
@@ -95,57 +99,29 @@ public final class ImmutableLdapObjectDefinitions
             String groupOrganizationName,
             String userName,
             String userOrganizationName,
-            Optional<List<LdapObjectDefinition>> childGroups)
+            List<LdapObjectDefinition> memberAttributes)
     {
-        if (childGroups.isPresent()) {
-            return LdapObjectDefinition.builder(groupName)
-                    .setDistinguishedName(format("cn=%s,%s", groupName, groupOrganizationName))
-                    .setAttributes(ImmutableMap.of(
-                            "cn", groupName,
-                            "member", format("uid=%s,%s", userName, userOrganizationName)))
-                    .setModificationAttributes(ImmutableMap.of(
-                            MEMBER,
-                            childGroups.get().stream()
-                                    .map(LdapObjectDefinition::getDistinguishedName)
-                                    .collect(toImmutableList())))
-                    .setObjectClasses(Arrays.asList("groupOfNames"))
-                    .build();
-        }
         return LdapObjectDefinition.builder(groupName)
                 .setDistinguishedName(format("cn=%s,%s", groupName, groupOrganizationName))
                 .setAttributes(ImmutableMap.of(
                         "cn", groupName,
                         "member", format("uid=%s,%s", userName, userOrganizationName)))
+                .setModificationAttributes(ImmutableMap.of(
+                        MEMBER,
+                        memberAttributes.stream()
+                                .map(LdapObjectDefinition::getDistinguishedName)
+                                .collect(toImmutableList())))
                 .setObjectClasses(Arrays.asList("groupOfNames"))
                 .build();
     }
 
-    public static LdapObjectDefinition buildLdapUserObject(String userName, Optional<List<LdapObjectDefinition>> groups, String password)
+    public static LdapObjectDefinition buildLdapUserObject(String userName, String password)
     {
-        return buildLdapUserObject(userName, ASIA_DISTINGUISHED_NAME, groups, password);
+        return buildLdapUserObject(userName, ASIA_DISTINGUISHED_NAME, password);
     }
 
-    public static LdapObjectDefinition buildLdapUserObject(
-            String userName,
-            String userOrganizationName,
-            Optional<List<LdapObjectDefinition>> groups,
-            String password)
+    public static LdapObjectDefinition buildLdapUserObject(String userName, String userOrganizationName, String password)
     {
-        if (groups.isPresent()) {
-            return LdapObjectDefinition.builder(userName)
-                    .setDistinguishedName(format("uid=%s,%s", userName, userOrganizationName))
-                    .setAttributes(ImmutableMap.of(
-                            "cn", userName,
-                            "sn", userName,
-                            "userPassword", password))
-                    .setObjectClasses(Arrays.asList("person", "inetOrgPerson"))
-                    .setModificationAttributes(ImmutableMap.of(
-                            MEMBER_OF,
-                            groups.get().stream()
-                                    .map(LdapObjectDefinition::getDistinguishedName)
-                                    .collect(toImmutableList())))
-                    .build();
-        }
         return LdapObjectDefinition.builder(userName)
                 .setDistinguishedName(format("uid=%s,%s", userName, userOrganizationName))
                 .setAttributes(ImmutableMap.of(

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/cli/TestTrinoLdapCli.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/cli/TestTrinoLdapCli.java
@@ -20,32 +20,24 @@ import io.trino.tempto.AfterMethodWithContext;
 import io.trino.tempto.Requirement;
 import io.trino.tempto.RequirementsProvider;
 import io.trino.tempto.configuration.Configuration;
-import io.trino.tempto.fulfillment.ldap.LdapObjectRequirement;
 import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.Arrays;
 
 import static io.trino.tempto.Requirements.compose;
 import static io.trino.tempto.fulfillment.table.TableRequirements.immutableTable;
 import static io.trino.tempto.fulfillment.table.hive.tpch.TpchTableDefinitions.NATION;
 import static io.trino.tempto.process.CliProcess.trimLines;
-import static io.trino.tests.product.ImmutableLdapObjectDefinitions.AMERICA_ORG;
-import static io.trino.tests.product.ImmutableLdapObjectDefinitions.ASIA_ORG;
-import static io.trino.tests.product.ImmutableLdapObjectDefinitions.CHILD_GROUP;
 import static io.trino.tests.product.ImmutableLdapObjectDefinitions.CHILD_GROUP_USER;
-import static io.trino.tests.product.ImmutableLdapObjectDefinitions.DEFAULT_GROUP;
-import static io.trino.tests.product.ImmutableLdapObjectDefinitions.DEFAULT_GROUP_USER;
-import static io.trino.tests.product.ImmutableLdapObjectDefinitions.EUROPE_ORG;
 import static io.trino.tests.product.ImmutableLdapObjectDefinitions.ORPHAN_USER;
-import static io.trino.tests.product.ImmutableLdapObjectDefinitions.PARENT_GROUP;
 import static io.trino.tests.product.ImmutableLdapObjectDefinitions.PARENT_GROUP_USER;
 import static io.trino.tests.product.ImmutableLdapObjectDefinitions.SPECIAL_USER;
 import static io.trino.tests.product.ImmutableLdapObjectDefinitions.USER_IN_AMERICA;
 import static io.trino.tests.product.ImmutableLdapObjectDefinitions.USER_IN_EUROPE;
 import static io.trino.tests.product.ImmutableLdapObjectDefinitions.USER_IN_MULTIPLE_GROUPS;
+import static io.trino.tests.product.ImmutableLdapObjectDefinitions.getLdapRequirement;
 import static io.trino.tests.product.TestGroups.LDAP;
 import static io.trino.tests.product.TestGroups.LDAP_AND_FILE_CLI;
 import static io.trino.tests.product.TestGroups.LDAP_CLI;
@@ -104,12 +96,7 @@ public class TestTrinoLdapCli
     @Override
     public Requirement getRequirements(Configuration configuration)
     {
-        return compose(new LdapObjectRequirement(
-                        Arrays.asList(
-                                AMERICA_ORG, ASIA_ORG, EUROPE_ORG,
-                                DEFAULT_GROUP, PARENT_GROUP, CHILD_GROUP,
-                                DEFAULT_GROUP_USER, PARENT_GROUP_USER, CHILD_GROUP_USER, ORPHAN_USER, SPECIAL_USER, USER_IN_MULTIPLE_GROUPS, USER_IN_AMERICA, USER_IN_EUROPE)),
-                immutableTable(NATION));
+        return compose(getLdapRequirement(), immutableTable(NATION));
     }
 
     @Test(groups = {LDAP, LDAP_CLI, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/jdbc/BaseLdapJdbcTest.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/jdbc/BaseLdapJdbcTest.java
@@ -19,7 +19,6 @@ import io.trino.tempto.ProductTest;
 import io.trino.tempto.Requirement;
 import io.trino.tempto.RequirementsProvider;
 import io.trino.tempto.configuration.Configuration;
-import io.trino.tempto.fulfillment.ldap.LdapObjectRequirement;
 import io.trino.tempto.query.QueryResult;
 
 import java.sql.Connection;
@@ -27,21 +26,9 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.Arrays;
 
 import static com.google.common.base.Preconditions.checkState;
-import static io.trino.tests.product.ImmutableLdapObjectDefinitions.AMERICA_ORG;
-import static io.trino.tests.product.ImmutableLdapObjectDefinitions.ASIA_ORG;
-import static io.trino.tests.product.ImmutableLdapObjectDefinitions.CHILD_GROUP;
-import static io.trino.tests.product.ImmutableLdapObjectDefinitions.CHILD_GROUP_USER;
-import static io.trino.tests.product.ImmutableLdapObjectDefinitions.DEFAULT_GROUP;
-import static io.trino.tests.product.ImmutableLdapObjectDefinitions.DEFAULT_GROUP_USER;
-import static io.trino.tests.product.ImmutableLdapObjectDefinitions.EUROPE_ORG;
-import static io.trino.tests.product.ImmutableLdapObjectDefinitions.ORPHAN_USER;
-import static io.trino.tests.product.ImmutableLdapObjectDefinitions.PARENT_GROUP;
-import static io.trino.tests.product.ImmutableLdapObjectDefinitions.PARENT_GROUP_USER;
-import static io.trino.tests.product.ImmutableLdapObjectDefinitions.USER_IN_AMERICA;
-import static io.trino.tests.product.ImmutableLdapObjectDefinitions.USER_IN_EUROPE;
+import static io.trino.tests.product.ImmutableLdapObjectDefinitions.getLdapRequirement;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -76,11 +63,7 @@ public abstract class BaseLdapJdbcTest
     @Override
     public Requirement getRequirements(Configuration configuration)
     {
-        return new LdapObjectRequirement(
-                Arrays.asList(
-                        AMERICA_ORG, ASIA_ORG, EUROPE_ORG,
-                        DEFAULT_GROUP, PARENT_GROUP, CHILD_GROUP,
-                        DEFAULT_GROUP_USER, PARENT_GROUP_USER, CHILD_GROUP_USER, ORPHAN_USER, USER_IN_AMERICA, USER_IN_EUROPE));
+        return getLdapRequirement();
     }
 
     protected void expectQueryToFail(String user, String password, String message)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
 As a part of [this effort](https://github.com/trinodb/docker-images/pull/202) we are trying to move from CentOS to AlmaLinux and the OpenLDAP server is also updated - This PR cleans up the LDAP specific code (for testing) so as to be compatible with the OpenLDAP 2.6


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:


