### PR TITLE
Update docker-images version to 98

### DIFF
--- a/plugin/trino-password-authenticators/src/test/java/io/trino/plugin/password/ldap/TestingOpenLdapServer.java
+++ b/plugin/trino-password-authenticators/src/test/java/io/trino/plugin/password/ldap/TestingOpenLdapServer.java
@@ -54,7 +54,7 @@ public class TestingOpenLdapServer
 
     public TestingOpenLdapServer(Network network)
     {
-        openLdapServer = new GenericContainer<>("ghcr.io/trinodb/testing/centos7-oj17-openldap:" + TestingProperties.getDockerImagesVersion())
+        openLdapServer = new GenericContainer<>("ghcr.io/trinodb/testing/almalinux9-oj17-openldap:" + TestingProperties.getDockerImagesVersion())
                 .withNetwork(network)
                 .withExposedPorts(LDAP_PORT)
                 .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
         <dep.aws-sdk.version>1.12.756</dep.aws-sdk.version>
         <dep.cassandra.version>4.17.0</dep.cassandra.version>
         <dep.confluent.version>7.5.1</dep.confluent.version>
-        <dep.docker.images.version>97</dep.docker.images.version>
+        <dep.docker.images.version>98</dep.docker.images.version>
         <dep.drift.version>1.22</dep.drift.version>
         <dep.errorprone.version>2.28.0</dep.errorprone.version>
         <dep.flyway.version>10.15.2</dep.flyway.version>

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Standard.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Standard.java
@@ -167,7 +167,7 @@ public final class Standard
     private DockerContainer createTrinoCoordinator()
     {
         DockerContainer container =
-                createTrinoContainer(dockerFiles, serverPackage, jdkProvider, debug, tracing, "ghcr.io/trinodb/testing/centos7-oj17:" + imagesVersion, COORDINATOR)
+                createTrinoContainer(dockerFiles, serverPackage, jdkProvider, debug, tracing, "ghcr.io/trinodb/testing/almalinux9-oj17:" + imagesVersion, COORDINATOR)
                         .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("common/standard/access-control.properties")), CONTAINER_TRINO_ACCESS_CONTROL_PROPERTIES)
                         .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("common/standard/config.properties")), CONTAINER_TRINO_CONFIG_PROPERTIES);
 
@@ -178,7 +178,7 @@ public final class Standard
     @SuppressWarnings("resource")
     private DockerContainer createTestsContainer()
     {
-        return new DockerContainer("ghcr.io/trinodb/testing/centos7-oj17:" + imagesVersion, TESTS)
+        return new DockerContainer("ghcr.io/trinodb/testing/almalinux9-oj17:" + imagesVersion, TESTS)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath()), "/docker/presto-product-tests")
                 .withCommand("bash", "-xeuc", "echo 'No command provided' >&2; exit 69")
                 .waitingFor(new WaitAllStrategy()) // don't wait

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/StandardMultinode.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/StandardMultinode.java
@@ -85,7 +85,7 @@ public class StandardMultinode
     @SuppressWarnings("resource")
     private DockerContainer createTrinoWorker()
     {
-        return createTrinoContainer(dockerFiles, serverPackage, jdkProvider, debug, tracing, "ghcr.io/trinodb/testing/centos7-oj17:" + imagesVersion, WORKER)
+        return createTrinoContainer(dockerFiles, serverPackage, jdkProvider, debug, tracing, "ghcr.io/trinodb/testing/almalinux9-oj17:" + imagesVersion, WORKER)
                 .withCopyFileToContainer(forHostPath(configDir.getPath("multinode-worker-config.properties")), CONTAINER_TRINO_CONFIG_PROPERTIES);
     }
 }

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/AbstractEnvSinglenodeLdap.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/AbstractEnvSinglenodeLdap.java
@@ -86,7 +86,7 @@ public abstract class AbstractEnvSinglenodeLdap
 
     protected String getBaseImage()
     {
-        return "centos7-oj17-openldap";
+        return "almalinux9-oj17-openldap";
     }
 
     protected abstract String getPasswordAuthenticatorConfigPath();

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodeTls.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodeTls.java
@@ -97,7 +97,7 @@ public final class EnvMultinodeTls
 
     private DockerContainer createTrinoWorker(String workerName)
     {
-        return createTrinoContainer(dockerFiles, serverPackage, jdkProvider, debug, tracing, "ghcr.io/trinodb/testing/centos7-oj17:" + imagesVersion, workerName)
+        return createTrinoContainer(dockerFiles, serverPackage, jdkProvider, debug, tracing, "ghcr.io/trinodb/testing/almalinux9-oj17:" + imagesVersion, workerName)
                 .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withDomainName("docker.cluster"))
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/multinode-tls/config-worker.properties")), CONTAINER_TRINO_CONFIG_PROPERTIES)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("common/hadoop/hive.properties")), CONTAINER_TRINO_HIVE_PROPERTIES)

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeLdapReferrals.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeLdapReferrals.java
@@ -41,6 +41,6 @@ public class EnvSinglenodeLdapReferrals
     @Override
     protected String getBaseImage()
     {
-        return "centos7-oj17-openldap-referrals";
+        return "almalinux9-oj17-openldap-referrals";
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This update allows to run the PTs and other tests on a Alma linux based instead of deprecated CentOS. 
Fixes https://github.com/trinodb/trino/issues/18824

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

