### PR TITLE
Mark source stages as finished when parent finishes

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
@@ -1766,6 +1766,11 @@ public class EventDrivenFaultTolerantQueryScheduler
             TaskId taskId = taskStatus.getTaskId();
             TaskState taskState = taskStatus.getState();
             StageExecution stageExecution = getStageExecution(taskId.getStageId());
+
+            if (stageExecution.getState().isDone()) {
+                return null;
+            }
+
             if (taskState == TaskState.FINISHED) {
                 Optional<List<PrioritizedScheduledTask>> failOverrideReplacementTasks = stageExecution.taskFinished(taskId, taskStatus);
                 failOverrideReplacementTasks.ifPresent(prioritizedScheduledTasks -> prioritizedScheduledTasks.forEach(schedulingQueue::addOrUpdate));
@@ -2325,10 +2330,6 @@ public class EventDrivenFaultTolerantQueryScheduler
          */
         public Optional<List<PrioritizedScheduledTask>> taskFinished(TaskId taskId, TaskStatus taskStatus)
         {
-            if (getState().isDone()) {
-                return Optional.empty();
-            }
-
             int partitionId = taskId.getPartitionId();
             StagePartition partition = getStagePartition(partitionId);
             Optional<SpoolingOutputStats.Snapshot> outputStats = partition.taskFinished(taskId);
@@ -2405,10 +2406,6 @@ public class EventDrivenFaultTolerantQueryScheduler
 
         public List<PrioritizedScheduledTask> taskFailed(TaskId taskId, ExecutionFailureInfo failureInfo, TaskStatus taskStatus)
         {
-            if (getState().isDone()) {
-                return ImmutableList.of();
-            }
-
             int partitionId = taskId.getPartitionId();
             StagePartition partition = getStagePartition(partitionId);
             partition.taskFailed(taskId);


### PR DESCRIPTION
In fault tolerant execution it was not enforced that source stages were marked as finished immediatelly after parent stages completes successfully. As a result the query which essentially compelted successfully could have been marked as failed if one of source stages failed.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix issue when queries could sometimes fail when run with `retry_policy` set to `TASK`. ({issue}`issuenumber`)
```
