### PR TITLE
Bump default value of max split count per task for FTE

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/QueryManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryManagerConfig.java
@@ -132,7 +132,7 @@ public class QueryManagerConfig
     private int faultTolerantExecutionHashDistributionWriteTaskTargetMaxCount = 2000;
 
     private DataSize faultTolerantExecutionStandardSplitSize = DataSize.of(64, MEGABYTE);
-    private int faultTolerantExecutionMaxTaskSplitCount = 256;
+    private int faultTolerantExecutionMaxTaskSplitCount = 2048;
     private DataSize faultTolerantExecutionTaskDescriptorStorageMaxMemory = DataSize.ofBytes(round(AVAILABLE_HEAP_MEMORY * 0.15));
     private int faultTolerantExecutionMaxPartitionCount = 50;
     private int faultTolerantExecutionMinPartitionCount = 4;

--- a/core/trino-main/src/test/java/io/trino/execution/TestQueryManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestQueryManagerConfig.java
@@ -98,7 +98,7 @@ public class TestQueryManagerConfig
                 .setFaultTolerantExecutionHashDistributionWriteTasksToNodesMinRatio(2.0)
                 .setFaultTolerantExecutionHashDistributionWriteTaskTargetMaxCount(2000)
                 .setFaultTolerantExecutionStandardSplitSize(DataSize.of(64, MEGABYTE))
-                .setFaultTolerantExecutionMaxTaskSplitCount(256)
+                .setFaultTolerantExecutionMaxTaskSplitCount(2048)
                 .setFaultTolerantExecutionTaskDescriptorStorageMaxMemory(DataSize.ofBytes(round(AVAILABLE_HEAP_MEMORY * 0.15)))
                 .setFaultTolerantExecutionMaxPartitionCount(50)
                 .setFaultTolerantExecutionMinPartitionCount(4)

--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.md
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.md
@@ -242,7 +242,7 @@ properties only apply to a `TASK` retry policy.
     May be overridden for the current session with the
     `fault_tolerant_execution_max_task_split_count` [session
     property](session-properties-definition).
-  - `256`
+  - `2048`
 * - `fault-tolerant-execution-arbitrary-distribution-compute-task-target-size-growth-period`
   - The number of tasks created for any given non-writer stage of arbitrary
     distribution before task size is increased.


### PR DESCRIPTION
With limit of 256 splits per task it was possible to end up with very small tasks and possibly even reach limit of number of tasks per stage (2^^15). The problem appeared when splits were very small. Task sizing should be mostly done based on split size; max number of splits should be treated as extra limit to be reached only in rare situations. This PR bumps default value 8x to 2048.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
