### PR TITLE
Use the correct scheme for azure native-fs location

### DIFF
--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureLocation.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureLocation.java
@@ -30,13 +30,14 @@ class AzureLocation
     private static final CharMatcher STORAGE_ACCOUNT_VALID_CHARACTERS = CharMatcher.inRange('a', 'z').or(CharMatcher.inRange('0', '9'));
 
     private final Location location;
+    private final String scheme;
     private final String account;
 
     public AzureLocation(Location location)
     {
         this.location = requireNonNull(location, "location is null");
         // abfss is also supported but not documented
-        String scheme = location.scheme().orElseThrow(() -> new IllegalArgumentException(String.format(INVALID_LOCATION_MESSAGE, location)));
+        scheme = location.scheme().orElseThrow(() -> new IllegalArgumentException(String.format(INVALID_LOCATION_MESSAGE, location)));
         checkArgument("abfs".equals(scheme) || "abfss".equals(scheme), INVALID_LOCATION_MESSAGE, location);
 
         // container is interpolated into the URL path, so perform extra checks
@@ -125,7 +126,8 @@ class AzureLocation
 
     public Location baseLocation()
     {
-        return Location.of("abfs://%s%s.dfs.core.windows.net/".formatted(
+        return Location.of("%s://%s%s.dfs.core.windows.net/".formatted(
+                scheme,
                 container().map(container -> container + "@").orElse(""),
                 account()));
     }

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureLocation.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureLocation.java
@@ -27,7 +27,7 @@ class TestAzureLocation
     void test()
     {
         assertValid("abfs://container@account.dfs.core.windows.net/some/path/file", "account", "container", "some/path/file");
-        assertValid("abfss://container@account.dfs.core.windows.net/some/path/file", "account", "container", "some/path/file");
+        assertValid("abfss://container@account.dfs.core.windows.net/some/path/file", "account", "container", "some/path/file", "abfss");
 
         assertValid("abfs://container-stuff@account.dfs.core.windows.net/some/path/file", "account", "container-stuff", "some/path/file");
         assertValid("abfs://container2@account.dfs.core.windows.net/some/path/file", "account", "container2", "some/path/file");
@@ -64,7 +64,7 @@ class TestAzureLocation
         assertInvalid("abfs://container@account.fake.dfs.core.windows.net/some/path/file");
     }
 
-    private static void assertValid(String uri, String expectedAccount, String expectedContainer, String expectedPath)
+    private static void assertValid(String uri, String expectedAccount, String expectedContainer, String expectedPath, String expectedScheme)
     {
         Location location = Location.of(uri);
         AzureLocation azureLocation = new AzureLocation(location);
@@ -72,6 +72,12 @@ class TestAzureLocation
         assertThat(azureLocation.account()).isEqualTo(expectedAccount);
         assertThat(azureLocation.container()).isEqualTo(Optional.ofNullable(expectedContainer));
         assertThat(azureLocation.path()).contains(expectedPath);
+        assertThat(azureLocation.baseLocation().scheme()).isEqualTo(Optional.of(expectedScheme));
+    }
+
+    private static void assertValid(String uri, String expectedAccount, String expectedContainer, String expectedPath)
+    {
+        assertValid(uri, expectedAccount, expectedContainer, expectedPath, "abfs");
     }
 
     private static void assertInvalid(String uri)


### PR DESCRIPTION
The base location scheme was incorrectly set to abfs always, irrespective of the objects' location scheme

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
