### PR TITLE
Add support for reading `vector` type in PostgreSQL

### DIFF
--- a/docs/src/main/sphinx/connector/postgresql.md
+++ b/docs/src/main/sphinx/connector/postgresql.md
@@ -201,6 +201,9 @@ this table:
 * - `JSONB`
   - `JSON`
   -
+* - `VECTOR`
+  - `ARRAY(REAL)`
+  -
 * - `HSTORE`
   - `MAP(VARCHAR, VARCHAR)`
   -

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -1447,7 +1447,7 @@ public class PostgreSqlClient
         return ColumnMapping.sliceMapping(
                 jsonType,
                 arrayAsJsonReadFunction(session, baseElementMapping),
-                (statement, index, block) -> { throw new UnsupportedOperationException(); },
+                (statement, index, block) -> { throw new TrinoException(NOT_SUPPORTED, "Writing to array type is unsupported"); },
                 DISABLE_PUSHDOWN);
     }
 

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -571,6 +571,12 @@ public class PostgreSqlClient
                 return Optional.of(timestampWithTimeZoneColumnMapping(decimalDigits));
             case "hstore":
                 return Optional.of(hstoreColumnMapping(session));
+            case "vector":
+                return Optional.of(vectorColumnMapping());
+        }
+        if (jdbcTypeName.endsWith("\"vector\"")) {
+            // TODO: Find more reliable way to detect vector type. The type name can be "schema-name"."vector"
+            return Optional.of(vectorColumnMapping());
         }
 
         switch (typeHandle.jdbcType()) {
@@ -1590,6 +1596,42 @@ public class PostgreSqlClient
                 uuidType,
                 (resultSet, columnIndex) -> javaUuidToTrinoUuid((UUID) resultSet.getObject(columnIndex)),
                 uuidWriteFunction());
+    }
+
+    private static ColumnMapping vectorColumnMapping()
+    {
+        return ColumnMapping.objectMapping(
+                new ArrayType(REAL),
+                vectorReadFunction(),
+                vectorWriteFunction(),
+                DISABLE_PUSHDOWN);
+    }
+
+    private static ObjectReadFunction vectorReadFunction()
+    {
+        return ObjectReadFunction.of(Block.class, (resultSet, columnIndex) -> {
+            // getArray is unsupported for vectors type
+            String result = resultSet.getString(columnIndex);
+            if (result == null) {
+                BlockBuilder builder = REAL.createBlockBuilder(null, 1);
+                builder.appendNull();
+                return builder.build();
+            }
+            verify(result.charAt(0) == '[' && result.charAt(result.length() - 1) == ']', "vector must be enclosed in square brackets: %s", result);
+            String[] vectors = result.substring(1, result.length() - 1).split(",");
+            BlockBuilder builder = REAL.createBlockBuilder(null, vectors.length);
+            for (String vector : vectors) {
+                REAL.writeFloat(builder, Float.parseFloat(vector));
+            }
+            return builder.build();
+        });
+    }
+
+    private static ObjectWriteFunction vectorWriteFunction()
+    {
+        return ObjectWriteFunction.of(Block.class, (_, _, _) -> {
+            throw new TrinoException(NOT_SUPPORTED, "Writing to vector type is unsupported");
+        });
     }
 
     private static class StatisticsDao

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlVectorType.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlVectorType.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.postgresql;
+
+import io.trino.Session;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.sql.TestTable;
+import io.trino.testing.sql.TestView;
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.IntStream;
+
+import static io.trino.plugin.postgresql.PostgreSqlConfig.ArrayMapping.AS_ARRAY;
+import static io.trino.plugin.postgresql.PostgreSqlConfig.ArrayMapping.AS_JSON;
+import static io.trino.plugin.postgresql.PostgreSqlSessionProperties.ARRAY_MAPPING;
+import static java.util.stream.Collectors.joining;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+final class TestPostgreSqlVectorType
+        extends AbstractTestQueryFramework
+{
+    private TestingPostgreSqlServer postgreSqlServer;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        postgreSqlServer = closeAfterClass(new TestingPostgreSqlServer("pgvector/pgvector:0.7.2-pg16", false));
+        postgreSqlServer.execute("CREATE EXTENSION vector");
+        return PostgreSqlQueryRunner.builder(postgreSqlServer).build();
+    }
+
+    @Test
+    void testVector()
+    {
+        try (TestTable table = new TestTable(postgreSqlServer::execute, "test_vector", "(v vector(1))")) {
+            postgreSqlServer.execute("INSERT INTO " + table.getName() + " VALUES ('[1]')");
+            assertThat(query("SELECT * FROM " + table.getName()))
+                    .matches("VALUES ARRAY[REAL '1.0']");
+            assertThat(query("SELECT * FROM " + table.getName() + " WHERE v = ARRAY[REAL '1.0']"))
+                    .matches("VALUES ARRAY[REAL '1.0']");
+            assertQueryReturnsEmptyResult("SELECT * FROM " + table.getName() + " WHERE v = ARRAY[REAL '2.0']");
+
+            assertThatThrownBy(() -> postgreSqlServer.execute("INSERT INTO " + table.getName() + " VALUES ('[NaN]')"))
+                    .hasMessageContaining("NaN not allowed in vector");
+            assertThatThrownBy(() -> postgreSqlServer.execute("INSERT INTO " + table.getName() + " VALUES ('[-Infinity]')"))
+                    .hasMessageContaining("infinite value not allowed in vector");
+            assertThatThrownBy(() -> postgreSqlServer.execute("INSERT INTO " + table.getName() + " VALUES ('[+Infinity]')"))
+                    .hasMessageContaining("infinite value not allowed in vector");
+        }
+
+        try (TestTable table = new TestTable(postgreSqlServer::execute, "test_vector", "(v vector(2))")) {
+            postgreSqlServer.execute("INSERT INTO " + table.getName() + " VALUES ('[1.1,2.2]')");
+            assertThat(query("SELECT * FROM " + table.getName()))
+                    .matches("VALUES ARRAY[REAL '1.1', REAL '2.2']");
+        }
+
+        try (TestTable table = new TestTable(postgreSqlServer::execute, "test_vector", "(v vector(3))")) {
+            postgreSqlServer.execute("INSERT INTO " + table.getName() + " VALUES ('[1.11,2.22,3.33]')");
+            assertThat(query("SELECT * FROM " + table.getName()))
+                    .matches("VALUES ARRAY[REAL '1.11', REAL '2.22', REAL '3.33']");
+        }
+    }
+
+    @Test
+    void testVectorArray()
+    {
+        Session arrayAsArray = arrayMappingSession(AS_ARRAY);
+        Session arrayAsJson = arrayMappingSession(AS_JSON);
+
+        try (TestTable table = new TestTable(postgreSqlServer::execute, "test_vector_array", "(v vector(1)[])")) {
+            postgreSqlServer.execute("INSERT INTO " + table.getName() + " VALUES (array['[1]'::vector])");
+
+            assertQueryFails(
+                    arrayAsArray,
+                    "INSERT INTO " + table.getName() + " VALUES ARRAY[ARRAY[REAL '2']]",
+                    "(?s).*invalid input syntax for type vector.*");
+            assertThat(query(arrayAsArray, "SELECT * FROM " + table.getName()))
+                    .matches("VALUES ARRAY[ARRAY[REAL '1.0']]");
+
+            assertQueryFails(
+                    arrayAsJson,
+                    "INSERT INTO " + table.getName() + " VALUES JSON '[[2]]'",
+                    "Writing to array type is unsupported");
+            assertThat(query(arrayAsJson, "SELECT * FROM " + table.getName()))
+                    .matches("VALUES JSON '[[1.0]]'");
+        }
+    }
+
+    private Session arrayMappingSession(PostgreSqlConfig.ArrayMapping arrayMapping)
+    {
+        return Session.builder(getSession())
+                .setCatalogSessionProperty("postgresql", ARRAY_MAPPING, arrayMapping.name())
+                .build();
+    }
+
+    @Test
+    void testVectorUnsupportedWrite()
+    {
+        try (TestTable table = new TestTable(postgreSqlServer::execute, "test_vector_writes", "(v vector(1))")) {
+            assertQueryFails("INSERT INTO " + table.getName() + " VALUES ARRAY[REAL '1.0']", "Writing to vector type is unsupported");
+            assertQueryFails("INSERT INTO " + table.getName() + " VALUES ARRAY[REAL '1.0', REAL '2.0']", "Writing to vector type is unsupported");
+            assertQueryFails("INSERT INTO " + table.getName() + " VALUES ARRAY[]", "Writing to vector type is unsupported");
+            assertQueryFails("INSERT INTO " + table.getName() + " VALUES ARRAY[nan()]", "Writing to vector type is unsupported");
+            assertQueryFails("INSERT INTO " + table.getName() + " VALUES ARRAY[-infinity()]", "Writing to vector type is unsupported");
+            assertQueryFails("INSERT INTO " + table.getName() + " VALUES ARRAY[+infinity()]", "Writing to vector type is unsupported");
+
+            assertQueryReturnsEmptyResult("SELECT * FROM " + table.getName());
+        }
+    }
+
+    @Test
+    void testVectorNull()
+    {
+        try (TestTable table = new TestTable(postgreSqlServer::execute, "test_vector_null", "(id int, v1 vector(1), v2 vector(2))")) {
+            postgreSqlServer.execute("INSERT INTO " + table.getName() + " VALUES (1, NULL, NULL), (2, '[1]', '[1,2]')");
+            assertThat(query("SELECT v1 FROM " + table.getName()))
+                    .matches("VALUES CAST(NULL AS ARRAY(REAL)), ARRAY[REAL '1.0']");
+            assertThat(query("SELECT id FROM " + table.getName() + " WHERE v1 IS NULL"))
+                    .matches("VALUES 1");
+            assertThat(query("SELECT id FROM " + table.getName() + " WHERE v1 IS NOT NULL"))
+                    .matches("VALUES 2");
+        }
+    }
+
+    @Test
+    void testVectorArbitraryDimension()
+    {
+        try (TestTable table = new TestTable(postgreSqlServer::execute, "test_vector_arbitrary", "(id int, v vector)")) {
+            postgreSqlServer.execute("INSERT INTO " + table.getName() + " VALUES (1, '[1]'), (2, '[1,2]'), (3, '[1,2,3]')");
+            assertThat(query("SELECT v FROM " + table.getName()))
+                    .matches("VALUES ARRAY[REAL '1.0'], ARRAY[REAL '1.0', REAL '2.0'], ARRAY[REAL '1.0', REAL '2.0', REAL '3.0']");
+
+            postgreSqlServer.execute("SELECT v <-> '[4,5,6]' FROM " + table.getName() + " WHERE id = 3");
+
+            assertThatThrownBy(() -> postgreSqlServer.execute("SELECT v <-> '[4,5,6]' FROM " + table.getName()))
+                    .hasMessageContaining("different vector dimensions");
+            assertThatThrownBy(() -> postgreSqlServer.execute("INSERT INTO " + table.getName() + " VALUES (4, '[]')"))
+                    .hasMessageContaining("vector must have at least 1 dimension");
+        }
+    }
+
+    @Test
+    void testVectorMaxDimension()
+    {
+        try (TestTable table = new TestTable(postgreSqlServer::execute, "test_vector_max", "(v vector(16000))")) {
+            String postgresValue = IntStream.rangeClosed(1, 16000).mapToObj(String::valueOf).collect(joining(","));
+            postgreSqlServer.execute("INSERT INTO " + table.getName() + " VALUES ('[" + postgresValue + "]')");
+
+            String trinoValue = IntStream.rangeClosed(1, 16000).mapToObj("REAL '%s'"::formatted).collect(joining(","));
+            assertThat(query("SELECT v FROM " + table.getName()))
+                    .matches("VALUES ARRAY[" + trinoValue + "]");
+        }
+    }
+
+    @Test
+    void testVectorUnsupportedDimension()
+    {
+        assertThatThrownBy(() -> postgreSqlServer.execute("CREATE TABLE test_vector_unsupported (v vector(-1))"))
+                .hasMessageContaining("dimensions for type vector must be at least 1");
+        assertThatThrownBy(() -> postgreSqlServer.execute("CREATE TABLE test_vector_unsupported (v vector(0))"))
+                .hasMessageContaining("dimensions for type vector must be at least 1");
+        assertThatThrownBy(() -> postgreSqlServer.execute("CREATE TABLE test_vector_unsupported (v vector(16001))"))
+                .hasMessageContaining("dimensions for type vector cannot exceed 16000");
+    }
+
+    @Test
+    void testEuclideanDistanceCompatibility()
+    {
+        // Verify compatibility between Trino euclidean_distance function and pgvector <-> operator
+        try (TestTable table = new TestTable(postgreSqlServer::execute, "test_vector", "(v vector(3))");
+                TestView view = new TestView(postgreSqlServer::execute, "test_euclidean_distance", "SELECT v <-> '[4,5,6]' FROM " + table.getName())) {
+            postgreSqlServer.execute("INSERT INTO " + table.getName() + " VALUES ('[1,2,3]')");
+
+            assertThat(query("SELECT euclidean_distance(v, ARRAY[4,5,6]) FROM " + table.getName()))
+                    .matches("SELECT * FROM tpch." + view.getName());
+
+            assertThatThrownBy(() -> postgreSqlServer.execute("SELECT v <-> '[NaN]' FROM " + table.getName()))
+                    .hasMessageContaining("NaN not allowed in vector");
+            assertThatThrownBy(() -> postgreSqlServer.execute("SELECT v <-> '[-Infinity]' FROM " + table.getName()))
+                    .hasMessageContaining("infinite value not allowed in vector");
+            assertThatThrownBy(() -> postgreSqlServer.execute("SELECT v <-> '[+Infinity]' FROM " + table.getName()))
+                    .hasMessageContaining("infinite value not allowed in vector");
+        }
+    }
+
+    @Test
+    void testDotProductCompatibility()
+    {
+        // Verify compatibility between Trino dot_product function and pgvector <#> operator
+        try (TestTable table = new TestTable(postgreSqlServer::execute, "test_vector", "(v vector(3))");
+                TestView view = new TestView(postgreSqlServer::execute, "test_dot_product", "SELECT v <#> '[4,5,6]' FROM " + table.getName())) {
+            postgreSqlServer.execute("INSERT INTO " + table.getName() + " VALUES ('[1,2,3]')");
+
+            // The minus sign is needed because <#> returns the negative inner product. Postgres only supports ASC order index scans on operators.
+            assertThat(query("SELECT -dot_product(v, ARRAY[4,5,6]) FROM " + table.getName()))
+                    .matches("SELECT * FROM tpch." + view.getName());
+
+            assertThatThrownBy(() -> postgreSqlServer.execute("SELECT v <#> '[NaN]' FROM " + table.getName()))
+                    .hasMessageContaining("NaN not allowed in vector");
+            assertThatThrownBy(() -> postgreSqlServer.execute("SELECT v <#> '[-Infinity]' FROM " + table.getName()))
+                    .hasMessageContaining("infinite value not allowed in vector");
+            assertThatThrownBy(() -> postgreSqlServer.execute("SELECT v <#> '[+Infinity]' FROM " + table.getName()))
+                    .hasMessageContaining("infinite value not allowed in vector");
+        }
+    }
+
+    @Test
+    void testCosineDistanceCompatibility()
+    {
+        // Verify compatibility between Trino cosine_distance function and pgvector <=> operator
+        try (TestTable table = new TestTable(postgreSqlServer::execute, "test_vector", "(v vector(3))");
+                TestView view = new TestView(postgreSqlServer::execute, "test_cosine_distance", "SELECT v <=> '[4,5,6]' FROM " + table.getName())) {
+            postgreSqlServer.execute("INSERT INTO " + table.getName() + " VALUES ('[1,2,3]')");
+
+            assertThat(query("SELECT cosine_distance(v, ARRAY[4,5,6]) FROM " + table.getName()))
+                    .matches("SELECT * FROM tpch." + view.getName());
+
+            assertThatThrownBy(() -> postgreSqlServer.execute("SELECT v <=> '[NaN]' FROM " + table.getName()))
+                    .hasMessageContaining("NaN not allowed in vector");
+            assertThatThrownBy(() -> postgreSqlServer.execute("SELECT v <=> '[-Infinity]' FROM " + table.getName()))
+                    .hasMessageContaining("infinite value not allowed in vector");
+            assertThatThrownBy(() -> postgreSqlServer.execute("SELECT v <=> '[+Infinity]' FROM " + table.getName()))
+                    .hasMessageContaining("infinite value not allowed in vector");
+        }
+    }
+}

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestingPostgreSqlServer.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestingPostgreSqlServer.java
@@ -77,7 +77,12 @@ public class TestingPostgreSqlServer
     public TestingPostgreSqlServer(boolean shouldExposeFixedPorts)
     {
         // Use the oldest supported PostgreSQL version
-        dockerContainer = new PostgreSQLContainer<>("postgres:11")
+        this("postgres:11", shouldExposeFixedPorts);
+    }
+
+    public TestingPostgreSqlServer(String dockerImageName, boolean shouldExposeFixedPorts)
+    {
+        dockerContainer = new PostgreSQLContainer<>(dockerImageName)
                 .withStartupAttempts(3)
                 .withDatabaseName(DATABASE)
                 .withUsername(USER)


### PR DESCRIPTION
## Description

Add support for [pgvector](https://github.com/pgvector/pgvector) in PostgreSQL connector.
pgvector is a famous extension (10k favorites) for vector similarity search. 

This PR maps PostgreSQL `vector` type to Trino `array(real)`

Depends on https://github.com/trinodb/trino/pull/22397

## Release notes

```markdown
# PostgreSQL
* Add support for reading `vector` type on pgvector. ({issue}`22630`)
```
