### PR TITLE
Always cleanup node in Maven check jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { java-version: 22, cache: 'true', cleanup-node: false }
-          - { java-version: 23-ea, cache: 'restore', cleanup-node: true }
+          - { java-version: 22, cache: 'true' }
+          - { java-version: 23-ea, cache: 'restore' }
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
@@ -72,7 +72,7 @@ jobs:
         with:
           cache: ${{ matrix.cache }}
           java-version: ${{ matrix.java-version }}
-          cleanup-node: ${{ matrix.cleanup-node }}
+          cleanup-node: true
       - name: Check SPI backward compatibility
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The JDK 22 job started failing recently in the post-setup step with a `System.IO.IOException: No space left on device` error.

Fixes #22615


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
