### PR TITLE
Add support for reading from Unity catalog with Iceberg REST

### DIFF
--- a/docs/src/main/sphinx/object-storage/metastores.md
+++ b/docs/src/main/sphinx/object-storage/metastores.md
@@ -470,6 +470,9 @@ following properties:
 * - `iceberg.rest-catalog.warehouse`
   - Warehouse identifier/location for the catalog (optional). Example:
     `s3://my_bucket/warehouse_location`
+* - `iceberg.rest-catalog.parent-namespace`
+  - The namespace to use with the REST catalog server. Example:
+    `main`
 * - `iceberg.rest-catalog.security`
   - The type of security to use (default: `NONE`).  `OAUTH2` requires either a
     `token` or `credential`. Example: `OAUTH2`
@@ -495,6 +498,19 @@ REST metadata catalog:
 connector.name=iceberg
 iceberg.catalog.type=rest
 iceberg.rest-catalog.uri=http://iceberg-with-rest:8181
+```
+
+`iceberg.security` must be `read_only` when connecting to Databricks Unity catalog
+using an Iceberg REST catalog:
+
+```properties
+connector.name=iceberg
+iceberg.catalog.type=rest
+iceberg.rest-catalog.uri=https://dbc-12345678-9999.cloud.databricks.com/api/2.1/unity-catalog/iceberg
+iceberg.security=read_only
+iceberg.rest-catalog.security=OAUTH2
+iceberg.rest-catalog.oauth2.token=***
+iceberg.rest-catalog.parent-namespace=test_namespace
 ```
 
 The REST catalog supports [view management](sql-view-management) 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogConfig.java
@@ -16,6 +16,7 @@ package io.trino.plugin.iceberg.catalog.rest;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import jakarta.validation.constraints.NotNull;
+import org.apache.iceberg.catalog.Namespace;
 
 import java.net.URI;
 import java.util.Optional;
@@ -37,6 +38,7 @@ public class IcebergRestCatalogConfig
     private URI restUri;
     private Optional<String> prefix = Optional.empty();
     private Optional<String> warehouse = Optional.empty();
+    private Namespace parentNamespace = Namespace.of();
     private Security security = Security.NONE;
     private SessionType sessionType = SessionType.NONE;
     private boolean vendedCredentialsEnabled;
@@ -80,6 +82,19 @@ public class IcebergRestCatalogConfig
     public IcebergRestCatalogConfig setWarehouse(String warehouse)
     {
         this.warehouse = Optional.ofNullable(warehouse);
+        return this;
+    }
+
+    public Namespace getParentNamespace()
+    {
+        return parentNamespace;
+    }
+
+    @Config("iceberg.rest-catalog.parent-namespace")
+    @ConfigDescription("The parent namespace to use with the REST catalog server")
+    public IcebergRestCatalogConfig setParentNamespace(String parentNamespace)
+    {
+        this.parentNamespace = parentNamespace == null ? Namespace.empty() : Namespace.of(parentNamespace);
         return this;
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
@@ -28,6 +28,7 @@ import io.trino.spi.catalog.CatalogName;
 import io.trino.spi.security.ConnectorIdentity;
 import io.trino.spi.type.TypeManager;
 import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.rest.HTTPClient;
 import org.apache.iceberg.rest.RESTSessionCatalog;
 
@@ -49,6 +50,7 @@ public class TrinoIcebergRestCatalogFactory
     private final URI serverUri;
     private final Optional<String> prefix;
     private final Optional<String> warehouse;
+    private final Namespace parentNamespace;
     private final SessionType sessionType;
     private final boolean vendedCredentialsEnabled;
     private final SecurityProperties securityProperties;
@@ -75,6 +77,7 @@ public class TrinoIcebergRestCatalogFactory
         this.serverUri = restConfig.getBaseUri();
         this.prefix = restConfig.getPrefix();
         this.warehouse = restConfig.getWarehouse();
+        this.parentNamespace = restConfig.getParentNamespace();
         this.sessionType = restConfig.getSessionType();
         this.vendedCredentialsEnabled = restConfig.isVendedCredentialsEnabled();
         this.securityProperties = requireNonNull(securityProperties, "securityProperties is null");
@@ -122,6 +125,7 @@ public class TrinoIcebergRestCatalogFactory
                 catalogName,
                 sessionType,
                 credentials,
+                parentNamespace,
                 trinoVersion,
                 typeManager,
                 uniqueTableLocation);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -69,6 +69,7 @@ import org.apache.iceberg.view.ViewBuilder;
 import org.apache.iceberg.view.ViewRepresentation;
 import org.apache.iceberg.view.ViewVersion;
 
+import java.util.Arrays;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -92,6 +93,7 @@ import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
+import static java.util.stream.Collectors.joining;
 import static org.apache.iceberg.view.ViewProperties.COMMENT;
 
 public class TrinoRestCatalog
@@ -106,6 +108,7 @@ public class TrinoRestCatalog
     private final TypeManager typeManager;
     private final SessionType sessionType;
     private final Map<String, String> credentials;
+    private final Namespace parentNamespace;
     private final String trinoVersion;
     private final boolean useUniqueTableLocation;
 
@@ -118,6 +121,7 @@ public class TrinoRestCatalog
             CatalogName catalogName,
             SessionType sessionType,
             Map<String, String> credentials,
+            Namespace parentNamespace,
             String trinoVersion,
             TypeManager typeManager,
             boolean useUniqueTableLocation)
@@ -126,6 +130,7 @@ public class TrinoRestCatalog
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.sessionType = requireNonNull(sessionType, "sessionType is null");
         this.credentials = ImmutableMap.copyOf(requireNonNull(credentials, "credentials is null"));
+        this.parentNamespace = requireNonNull(parentNamespace, "parentNamespace is null");
         this.trinoVersion = requireNonNull(trinoVersion, "trinoVersion is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.useUniqueTableLocation = useUniqueTableLocation;
@@ -134,14 +139,14 @@ public class TrinoRestCatalog
     @Override
     public boolean namespaceExists(ConnectorSession session, String namespace)
     {
-        return restSessionCatalog.namespaceExists(convert(session), Namespace.of(namespace));
+        return restSessionCatalog.namespaceExists(convert(session), toNamespace(namespace));
     }
 
     @Override
     public List<String> listNamespaces(ConnectorSession session)
     {
-        return restSessionCatalog.listNamespaces(convert(session)).stream()
-                .map(Namespace::toString)
+        return restSessionCatalog.listNamespaces(convert(session), parentNamespace).stream()
+                .map(this::toSchemaName)
                 .collect(toImmutableList());
     }
 
@@ -164,7 +169,7 @@ public class TrinoRestCatalog
     {
         try {
             // Return immutable metadata as direct modifications will not be reflected on the namespace
-            return ImmutableMap.copyOf(restSessionCatalog.loadNamespaceMetadata(convert(session), Namespace.of(namespace)));
+            return ImmutableMap.copyOf(restSessionCatalog.loadNamespaceMetadata(convert(session), toNamespace(namespace)));
         }
         catch (NoSuchNamespaceException e) {
             throw new SchemaNotFoundException(namespace);
@@ -213,10 +218,10 @@ public class TrinoRestCatalog
         ImmutableList.Builder<TableInfo> tables = ImmutableList.builder();
         for (Namespace restNamespace : namespaces) {
             listTableIdentifiers(restNamespace, () -> restSessionCatalog.listTables(sessionContext, restNamespace)).stream()
-                    .map(id -> new TableInfo(SchemaTableName.schemaTableName(id.namespace().toString(), id.name()), TableInfo.ExtendedRelationType.TABLE))
+                    .map(id -> new TableInfo(SchemaTableName.schemaTableName(toSchemaName(id.namespace()), id.name()), TableInfo.ExtendedRelationType.TABLE))
                     .forEach(tables::add);
             listTableIdentifiers(restNamespace, () -> restSessionCatalog.listViews(sessionContext, restNamespace)).stream()
-                    .map(id -> new TableInfo(SchemaTableName.schemaTableName(id.namespace().toString(), id.name()), TableInfo.ExtendedRelationType.OTHER_VIEW))
+                    .map(id -> new TableInfo(SchemaTableName.schemaTableName(toSchemaName(id.namespace()), id.name()), TableInfo.ExtendedRelationType.OTHER_VIEW))
                     .forEach(tables::add);
         }
         return tables.build();
@@ -357,12 +362,15 @@ public class TrinoRestCatalog
     @Override
     public Table loadTable(ConnectorSession session, SchemaTableName schemaTableName)
     {
+        Namespace namespace = toNamespace(schemaTableName.getSchemaName());
         try {
             return uncheckedCacheGet(
                     tableCache,
                     schemaTableName,
                     () -> {
-                        BaseTable baseTable = (BaseTable) restSessionCatalog.loadTable(convert(session), toIdentifier(schemaTableName));
+                        TableIdentifier identifier = TableIdentifier.of(namespace, schemaTableName.getTableName());
+
+                        BaseTable baseTable = (BaseTable) restSessionCatalog.loadTable(convert(session), identifier);
                         // Creating a new base table is necessary to adhere to Trino's expectations for quoted table names
                         return new BaseTable(baseTable.operations(), quotedTableName(schemaTableName));
                     });
@@ -371,7 +379,7 @@ public class TrinoRestCatalog
             if (e.getCause() instanceof NoSuchTableException) {
                 throw new TableNotFoundException(schemaTableName, e.getCause());
             }
-            throw new TrinoException(ICEBERG_CATALOG_ERROR, format("Failed to load table: %s", schemaTableName), e.getCause());
+            throw new TrinoException(ICEBERG_CATALOG_ERROR, format("Failed to load table: %s in %s namespace", schemaTableName.getTableName(), namespace), e.getCause());
         }
     }
 
@@ -653,19 +661,39 @@ public class TrinoRestCatalog
         tableCache.invalidate(schemaTableName);
     }
 
-    private static TableIdentifier toIdentifier(SchemaTableName schemaTableName)
+    private Namespace toNamespace(String schemaName)
     {
-        return TableIdentifier.of(schemaTableName.getSchemaName(), schemaTableName.getTableName());
+        if (parentNamespace.isEmpty()) {
+            return Namespace.of(schemaName);
+        }
+        return Namespace.of(parentNamespace + "." + schemaName);
+    }
+
+    private String toSchemaName(Namespace namespace)
+    {
+        if (this.parentNamespace.isEmpty()) {
+            return namespace.toString();
+        }
+        return Arrays.stream(namespace.levels(), this.parentNamespace.length(), namespace.length())
+                .collect(joining("."));
+    }
+
+    private TableIdentifier toIdentifier(SchemaTableName schemaTableName)
+    {
+        if (parentNamespace.isEmpty()) {
+            return TableIdentifier.of(schemaTableName.getSchemaName(), schemaTableName.getTableName());
+        }
+        return TableIdentifier.of(Namespace.of(parentNamespace + "." + schemaTableName.getSchemaName()), schemaTableName.getTableName());
     }
 
     private List<Namespace> listNamespaces(ConnectorSession session, Optional<String> namespace)
     {
         if (namespace.isEmpty()) {
             return listNamespaces(session).stream()
-                    .map(Namespace::of)
+                    .map(this::toNamespace)
                     .collect(toImmutableList());
         }
 
-        return ImmutableList.of(Namespace.of(namespace.get()));
+        return ImmutableList.of(toNamespace(namespace.get()));
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogConfig.java
@@ -31,6 +31,7 @@ public class TestIcebergRestCatalogConfig
                 .setBaseUri(null)
                 .setPrefix(null)
                 .setWarehouse(null)
+                .setParentNamespace(null)
                 .setSessionType(IcebergRestCatalogConfig.SessionType.NONE)
                 .setSecurity(IcebergRestCatalogConfig.Security.NONE)
                 .setVendedCredentialsEnabled(false));
@@ -43,6 +44,7 @@ public class TestIcebergRestCatalogConfig
                 .put("iceberg.rest-catalog.uri", "http://localhost:1234")
                 .put("iceberg.rest-catalog.prefix", "dev")
                 .put("iceberg.rest-catalog.warehouse", "test_warehouse_identifier")
+                .put("iceberg.rest-catalog.parent-namespace", "main")
                 .put("iceberg.rest-catalog.security", "OAUTH2")
                 .put("iceberg.rest-catalog.session", "USER")
                 .put("iceberg.rest-catalog.vended-credentials-enabled", "true")
@@ -52,6 +54,7 @@ public class TestIcebergRestCatalogConfig
                 .setBaseUri("http://localhost:1234")
                 .setPrefix("dev")
                 .setWarehouse("test_warehouse_identifier")
+                .setParentNamespace("main")
                 .setSessionType(IcebergRestCatalogConfig.SessionType.USER)
                 .setSecurity(IcebergRestCatalogConfig.Security.OAUTH2)
                 .setVendedCredentialsEnabled(true);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergUnityRestCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergUnityRestCatalogConnectorSmokeTest.java
@@ -1,0 +1,523 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import io.trino.filesystem.Location;
+import io.trino.plugin.iceberg.BaseIcebergConnectorSmokeTest;
+import io.trino.plugin.iceberg.IcebergConfig;
+import io.trino.plugin.iceberg.IcebergQueryRunner;
+import io.trino.plugin.iceberg.containers.UnityCatalogContainer;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.TestingConnectorBehavior;
+import org.assertj.core.util.Files;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+final class TestIcebergUnityRestCatalogConnectorSmokeTest
+        extends BaseIcebergConnectorSmokeTest
+{
+    private final File warehouseLocation;
+
+    public TestIcebergUnityRestCatalogConnectorSmokeTest()
+    {
+        super(new IcebergConfig().getFileFormat().toIceberg());
+        warehouseLocation = Files.newTemporaryFolder();
+    }
+
+    @Override
+    protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
+    {
+        return switch (connectorBehavior) {
+            case SUPPORTS_CREATE_MATERIALIZED_VIEW,
+                 SUPPORTS_RENAME_MATERIALIZED_VIEW,
+                 SUPPORTS_RENAME_SCHEMA -> false;
+            default -> super.hasBehavior(connectorBehavior);
+        };
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        closeAfterClass(() -> deleteRecursively(warehouseLocation.toPath(), ALLOW_INSECURE));
+        UnityCatalogContainer unityCatalog = closeAfterClass(new UnityCatalogContainer("unity", "tpch"));
+
+        DistributedQueryRunner queryRunner = IcebergQueryRunner.builder()
+                .setBaseDataDir(Optional.of(warehouseLocation.toPath()))
+                .addIcebergProperty("iceberg.file-format", format.name())
+                .addIcebergProperty("iceberg.security", "read_only")
+                .addIcebergProperty("iceberg.catalog.type", "rest")
+                .addIcebergProperty("iceberg.rest-catalog.uri", unityCatalog.uri() + "/iceberg")
+                .addIcebergProperty("iceberg.rest-catalog.parent-namespace", "unity")
+                .addIcebergProperty("iceberg.register-table-procedure.enabled", "true")
+                .disableSchemaInitializer()
+                .build();
+
+        unityCatalog.copyTpchTables(REQUIRED_TPCH_TABLES);
+
+        return queryRunner;
+    }
+
+    @Override
+    protected void dropTableFromMetastore(String tableName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected String getMetadataLocation(String tableName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected String schemaPath()
+    {
+        return format("%s/%s", warehouseLocation, getSession().getSchema());
+    }
+
+    @Override
+    protected boolean locationExists(String location)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected boolean isFileSorted(Location path, String sortColumnName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void deleteDirectory(String location)
+    {
+        try {
+            deleteRecursively(Path.of(location), ALLOW_INSECURE);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Test
+    @Override
+    public void testView()
+    {
+        assertThatThrownBy(super::testView)
+                .hasStackTraceContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testCommentView()
+    {
+        assertThatThrownBy(super::testCommentView)
+                .hasStackTraceContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testCommentViewColumn()
+    {
+        assertThatThrownBy(super::testCommentViewColumn)
+                .hasStackTraceContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testMaterializedView()
+    {
+        assertThatThrownBy(super::testMaterializedView)
+                .hasStackTraceContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testRenameSchema()
+    {
+        assertThatThrownBy(super::testRenameSchema)
+                .hasStackTraceContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testRenameTable()
+    {
+        assertThatThrownBy(super::testRenameTable)
+                .hasStackTraceContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testRenameTableAcrossSchemas()
+    {
+        assertThatThrownBy(super::testRenameTableAcrossSchemas)
+                .hasStackTraceContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testCreateTable()
+    {
+        assertThatThrownBy(super::testCreateTable)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testCreateTableAsSelect()
+    {
+        assertThatThrownBy(super::testCreateTableAsSelect)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testUpdate()
+    {
+        assertThatThrownBy(super::testUpdate)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testInsert()
+    {
+        assertThatThrownBy(super::testInsert)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testHiddenPathColumn()
+    {
+        assertThatThrownBy(super::testHiddenPathColumn)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testRowLevelDelete()
+    {
+        assertThatThrownBy(super::testRowLevelDelete)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testDeleteAllDataFromTable()
+    {
+        assertThatThrownBy(super::testDeleteAllDataFromTable)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testDeleteRowsConcurrently()
+    {
+        assertThatThrownBy(super::testDeleteRowsConcurrently)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testCreateOrReplaceTable()
+    {
+        assertThatThrownBy(super::testCreateOrReplaceTable)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testCreateOrReplaceTableChangeColumnNamesAndTypes()
+    {
+        assertThatThrownBy(super::testCreateOrReplaceTableChangeColumnNamesAndTypes)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testRegisterTableWithTableLocation()
+    {
+        assertThatThrownBy(super::testRegisterTableWithTableLocation)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testRegisterTableWithComments()
+    {
+        assertThatThrownBy(super::testRegisterTableWithComments)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testRowLevelUpdate()
+    {
+        assertThatThrownBy(super::testRowLevelUpdate)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testMerge()
+    {
+        assertThatThrownBy(super::testMerge)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testCreateSchema()
+    {
+        assertThatThrownBy(super::testCreateSchema)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testCreateSchemaWithNonLowercaseOwnerName()
+    {
+        assertThatThrownBy(super::testCreateSchemaWithNonLowercaseOwnerName)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testRegisterTableWithShowCreateTable()
+    {
+        assertThatThrownBy(super::testRegisterTableWithShowCreateTable)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testRegisterTableWithReInsert()
+    {
+        assertThatThrownBy(super::testRegisterTableWithReInsert)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testRegisterTableWithDroppedTable()
+    {
+        assertThatThrownBy(super::testRegisterTableWithDroppedTable)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testRegisterTableWithDifferentTableName()
+    {
+        assertThatThrownBy(super::testRegisterTableWithDifferentTableName)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testRegisterTableWithMetadataFile()
+    {
+        assertThatThrownBy(super::testRegisterTableWithMetadataFile)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testCreateTableWithTrailingSpaceInLocation()
+    {
+        assertThatThrownBy(super::testCreateTableWithTrailingSpaceInLocation)
+                .hasStackTraceContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testRegisterTableWithTrailingSpaceInLocation()
+    {
+        assertThatThrownBy(super::testRegisterTableWithTrailingSpaceInLocation)
+                .hasStackTraceContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testUnregisterTable()
+    {
+        assertThatThrownBy(super::testUnregisterTable)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testUnregisterBrokenTable()
+    {
+        assertThatThrownBy(super::testUnregisterBrokenTable)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testUnregisterTableNotExistingTable()
+    {
+        assertThatThrownBy(super::testUnregisterTableNotExistingTable)
+                .hasStackTraceContaining("Table .* not found");
+    }
+
+    @Test
+    @Override
+    public void testUnregisterTableNotExistingSchema()
+    {
+        assertThatThrownBy(super::testUnregisterTableNotExistingSchema)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testRepeatUnregisterTable()
+    {
+        assertThatThrownBy(super::testRepeatUnregisterTable)
+                .hasStackTraceContaining("Table .* not found");
+    }
+
+    @Test
+    @Override
+    public void testUnregisterTableAccessControl()
+    {
+        assertThatThrownBy(super::testUnregisterTableAccessControl)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testCreateTableWithNonExistingSchemaVerifyLocation()
+    {
+        assertThatThrownBy(super::testCreateTableWithNonExistingSchemaVerifyLocation)
+                .hasStackTraceContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testSortedNationTable()
+    {
+        assertThatThrownBy(super::testSortedNationTable)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testFileSortingWithLargerTable()
+    {
+        assertThatThrownBy(super::testFileSortingWithLargerTable)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testDropTableWithMissingMetadataFile()
+    {
+        assertThatThrownBy(super::testDropTableWithMissingMetadataFile)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testDropTableWithMissingSnapshotFile()
+    {
+        assertThatThrownBy(super::testDropTableWithMissingSnapshotFile)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testDropTableWithMissingManifestListFile()
+    {
+        assertThatThrownBy(super::testDropTableWithMissingManifestListFile)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testDropTableWithMissingDataFile()
+    {
+        assertThatThrownBy(super::testDropTableWithMissingDataFile)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testDropTableWithNonExistentTableLocation()
+    {
+        assertThatThrownBy(super::testDropTableWithNonExistentTableLocation)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testMetadataTables()
+    {
+        assertThatThrownBy(super::testMetadataTables)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testPartitionFilterRequired()
+    {
+        assertThatThrownBy(super::testPartitionFilterRequired)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testTableChangesFunction()
+    {
+        assertThatThrownBy(super::testTableChangesFunction)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testRowLevelDeletesWithTableChangesFunction()
+    {
+        assertThatThrownBy(super::testRowLevelDeletesWithTableChangesFunction)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testCreateOrReplaceWithTableChangesFunction()
+    {
+        assertThatThrownBy(super::testCreateOrReplaceWithTableChangesFunction)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
+    public void testTruncateTable()
+    {
+        assertThatThrownBy(super::testTruncateTable)
+                .hasMessageContaining("Access Denied");
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
@@ -32,6 +32,7 @@ import io.trino.spi.security.PrincipalType;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.type.TestingTypeManager;
 import io.trino.spi.type.VarcharType;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.rest.DelegatingRestSessionCatalog;
 import org.apache.iceberg.rest.RESTSessionCatalog;
@@ -79,7 +80,15 @@ public class TestTrinoRestCatalog
 
         restSessionCatalog.initialize(catalogName, properties);
 
-        return new TrinoRestCatalog(restSessionCatalog, new CatalogName(catalogName), NONE, ImmutableMap.of(), "test", new TestingTypeManager(), useUniqueTableLocations);
+        return new TrinoRestCatalog(
+                restSessionCatalog,
+                new CatalogName(catalogName),
+                NONE,
+                ImmutableMap.of(),
+                Namespace.empty(),
+                "test",
+                new TestingTypeManager(),
+                useUniqueTableLocations);
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/containers/UnityCatalogContainer.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/containers/UnityCatalogContainer.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.containers;
+
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.jetty.JettyHttpClient;
+import io.trino.plugin.base.util.AutoCloseableCloser;
+import io.trino.plugin.iceberg.IcebergQueryRunner;
+import io.trino.testing.QueryRunner;
+import io.trino.tpch.TpchTable;
+import org.intellij.lang.annotations.Language;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static io.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
+import static io.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
+import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
+import static io.trino.testing.TestingProperties.getDockerImagesVersion;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.Files.createTempDirectory;
+import static java.util.Objects.requireNonNull;
+
+public class UnityCatalogContainer
+        implements AutoCloseable
+{
+    private static final HttpClient HTTP_CLIENT = new JettyHttpClient();
+
+    private final String catalogName;
+    private final String schemaName;
+    private final PostgreSQLContainer<?> postgreSql;
+    private final GenericContainer<?> unityCatalog;
+    private final AutoCloseableCloser closer = AutoCloseableCloser.create();
+
+    public UnityCatalogContainer(String catalogName, String schemaName)
+            throws IOException
+    {
+        this.catalogName = requireNonNull(catalogName, "catalogName is null");
+        this.schemaName = requireNonNull(schemaName, "schema is null");
+
+        Network network = Network.newNetwork();
+        closer.register(network);
+
+        //noinspection resource
+        postgreSql = new PostgreSQLContainer<>(DockerImageName.parse("postgres"))
+                .withNetwork(network)
+                .withNetworkAliases("postgres");
+        postgreSql.start();
+        closer.register(postgreSql);
+
+        String hibernate = """
+                hibernate.connection.driver_class=org.postgresql.Driver
+                hibernate.connection.url=jdbc:postgresql://postgres:5432/test
+                hibernate.connection.username=test
+                hibernate.connection.password=test
+                hibernate.hbm2ddl.auto=update
+                """;
+
+        File hibernateProperties = Files.createTempFile("hibernate", ".properties").toFile();
+        Files.writeString(hibernateProperties.toPath(), hibernate);
+
+        //noinspection resource
+        unityCatalog = new GenericContainer<>(DockerImageName.parse("ghcr.io/trinodb/testing/unity-catalog:" + getDockerImagesVersion()))
+                .withExposedPorts(8080)
+                .withNetwork(network)
+                .withCopyFileToContainer(MountableFile.forHostPath(hibernateProperties.toPath()), "/unity/etc/conf/hibernate.properties");
+        unityCatalog.start();
+        closer.register(unityCatalog);
+
+        createCatalog();
+        createSchema();
+    }
+
+    public String uri()
+    {
+        return "http://%s:%s/api/2.1/unity-catalog".formatted(unityCatalog.getHost(), unityCatalog.getMappedPort(8080));
+    }
+
+    private void createCatalog()
+    {
+        @Language("JSON")
+        String body = "{\"name\": \"" + catalogName + "\"}";
+        Request request = Request.Builder.preparePost()
+                .setUri(URI.create(uri() + "/catalogs"))
+                .setHeader("Content-Type", "application/json")
+                .setBodyGenerator(createStaticBodyGenerator(body, UTF_8))
+                .build();
+        HTTP_CLIENT.execute(request, createStatusResponseHandler());
+    }
+
+    private void createSchema()
+    {
+        @Language("JSON")
+        String body = "{\"name\": \"" + schemaName + "\", \"catalog_name\": \"" + catalogName + "\"}";
+        Request request = Request.Builder.preparePost()
+                .setUri(URI.create(uri() + "/schemas"))
+                .setHeader("Content-Type", "application/json")
+                .setBodyGenerator(createStaticBodyGenerator(body, UTF_8))
+                .build();
+        var execute = HTTP_CLIENT.execute(request, createStringResponseHandler());
+        System.out.println(execute);
+    }
+
+    public void copyTpchTables(Iterable<TpchTable<?>> tpchTables)
+            throws Exception
+    {
+        File metastoreDir = createTempDirectory("iceberg_query_runner").toFile();
+        metastoreDir.deleteOnExit();
+
+        QueryRunner queryRunner = IcebergQueryRunner.builder()
+                .addIcebergProperty("hive.metastore.catalog.dir", metastoreDir.toURI().toString())
+                .build();
+
+        for (TpchTable<?> table : tpchTables) {
+            String tableName = table.getTableName();
+            queryRunner.execute("CREATE TABLE iceberg.tpch." + tableName + " AS SELECT * FROM tpch.tiny." + tableName);
+            String metadataFilePath = (String) queryRunner.execute("SELECT file FROM \"" + tableName + "$metadata_log_entries\" ORDER BY file LIMIT 1").getOnlyValue();
+            createTable(tableName, metadataFilePath);
+        }
+        unityCatalog.copyFileToContainer(MountableFile.forHostPath(metastoreDir.getPath()), metastoreDir.getPath());
+        queryRunner.close();
+    }
+
+    private void createTable(String tableName, String metadataFilePath)
+    {
+        @Language("JSON")
+        String body = "{" +
+                "\"catalog_name\": \"" + catalogName + "\"," +
+                "\"schema_name\": \"" + schemaName + "\"," +
+                "\"name\": \"" + tableName + "\"," +
+                "\"table_type\": \"EXTERNAL\"," +
+                "\"data_source_format\": \"DELTA\"," +
+                "\"storage_location\": \"" + metadataFilePath + "\"" +
+                "}";
+        Request request = Request.Builder.preparePost()
+                .setUri(URI.create(uri() + "/tables"))
+                .setHeader("Content-Type", "application/json")
+                .setBodyGenerator(createStaticBodyGenerator(body, UTF_8))
+                .build();
+        HTTP_CLIENT.execute(request, createStringResponseHandler());
+
+        // TODO https://github.com/unitycatalog/unitycatalog/issues/312 Fix uc_tables directly until the issue is fixed
+        execute("UPDATE uc_tables " +
+                "SET uniform_iceberg_metadata_location = '" + metadataFilePath + "'" +
+                "WHERE name = '" + tableName + "'");
+
+    }
+
+    public void execute(@Language("SQL") String sql)
+    {
+        try (Connection connection = DriverManager.getConnection(postgreSql.getJdbcUrl(), postgreSql.getUsername(), postgreSql.getPassword());
+                Statement statement = connection.createStatement()) {
+            //noinspection SqlSourceToSinkFlow
+            statement.execute(sql);
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void close()
+            throws Exception
+    {
+        closer.close();
+    }
+}


### PR DESCRIPTION
## Description

This PR supports only read operations because Iceberg REST interface in Unity catalog doesn't support creating tables yet. 

Note that Databricks Unity catalog provides HTTP interface, but it doesn’t return Iceberg UniForm tables. 

Example catalog config properties:
```properties
connector.name=iceberg
iceberg.catalog.type=rest
iceberg.rest-catalog.uri=https://dbc-12345678-9999.cloud.databricks.com/api/2.1/unity-catalog/iceberg
iceberg.security=read_only
iceberg.rest-catalog.security=OAUTH2
iceberg.rest-catalog.oauth2.token=***
iceberg.rest-catalog.parent-namespace=test_namespace
```

Fixes #22609

## Release notes

```markdown
# Iceberg
* Add support for reading from Unity catalog with REST catalog. ({issue}`22609`)
```
