### PR TITLE
Remove invalid syntax hint in docs

### DIFF
--- a/docs/src/main/sphinx/security/opa-access-control.md
+++ b/docs/src/main/sphinx/security/opa-access-control.md
@@ -228,7 +228,7 @@ for row filter processing with `opa.policy.row-filters-uri`.
 For example, an OPA policy for row filtering may be defined by the following
 rego script:
 
-```rego
+```text
   package trino
   import future.keywords.in
   import future.keywords.if
@@ -268,7 +268,7 @@ processing with `opa.policy.column-masking-uri` in the opa-plugin configuration.
 For example, a policy configuring column masking may be defined by the following
 rego script:
 
-```rego
+```text
   package trino
   import future.keywords.in
   import future.keywords.if


### PR DESCRIPTION
## Description

Just remove a warning in the docs build process. Fyi @vagaerg .. turns out that rego is not recognized and throws a warning on clean builds - so switching to no syntax highlighting.

## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
