### PR TITLE
Update SQL support docs for memory connector

### DIFF
--- a/docs/src/main/sphinx/connector/memory.md
+++ b/docs/src/main/sphinx/connector/memory.md
@@ -66,6 +66,7 @@ statements, the connector supports the following features:
 - {doc}`/sql/create-schema`
 - {doc}`/sql/drop-schema`
 - {doc}`/sql/comment`
+- [](sql-view-management)
 - [](sql-routine-management)
 
 ### TRUNCATE and DROP TABLE


### PR DESCRIPTION
## Description

- Add view mgt

Update for https://github.com/trinodb/trino/issues/22208 after testing view mgt with 451 locally.

## Additional context and related issues

Sort of related questions for @martint and others - when testing I noticed that there is no `SHOW VIEWS` command and instead the `SHOW TABLES` command lists the view. Is that a bug or a feature - if a feature .. we should probably update the docs for show tables and other sections.

Also @ebyhr .. if desired I can update other parts here for any ongoing PRs or any other issues.



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
