### PR TITLE
Evaluate SkipAggregationBuilder column wise

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/partial/SkipAggregationBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/partial/SkipAggregationBuilder.java
@@ -13,6 +13,7 @@
  */
 package io.trino.operator.aggregation.partial;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.trino.memory.context.LocalMemoryContext;
 import io.trino.operator.CompletedWork;
@@ -30,7 +31,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -42,7 +42,7 @@ public class SkipAggregationBuilder
         implements HashAggregationBuilder
 {
     private final LocalMemoryContext memoryContext;
-    private final List<GroupedAggregator> groupedAggregators;
+    private final List<AggregatorFactory> aggregatorFactories;
     @Nullable
     private Page currentPage;
     private final int[] hashChannels;
@@ -54,9 +54,7 @@ public class SkipAggregationBuilder
             LocalMemoryContext memoryContext)
     {
         this.memoryContext = requireNonNull(memoryContext, "memoryContext is null");
-        this.groupedAggregators = aggregatorFactories.stream()
-                .map(AggregatorFactory::createGroupedAggregator)
-                .collect(toImmutableList());
+        this.aggregatorFactories = ImmutableList.copyOf(requireNonNull(aggregatorFactories, "aggregatorFactories is null"));
         this.hashChannels = new int[groupByChannels.size() + (inputHashChannel.isPresent() ? 1 : 0)];
         for (int i = 0; i < groupByChannels.size(); i++) {
             hashChannels[i] = groupByChannels.get(i);
@@ -117,51 +115,31 @@ public class SkipAggregationBuilder
 
     private Page buildOutputPage(Page page)
     {
-        populateInitialAccumulatorState(page);
-
-        BlockBuilder[] outputBuilders = serializeAccumulatorState(page.getPositionCount());
-
-        return constructOutputPage(page, outputBuilders);
-    }
-
-    private void populateInitialAccumulatorState(Page page)
-    {
-        int[] groupIds = new int[page.getPositionCount()];
-        for (int position = 0; position < page.getPositionCount(); position++) {
-            groupIds[position] = position;
-        }
-
-        for (GroupedAggregator groupedAggregator : groupedAggregators) {
-            groupedAggregator.processPage(page.getPositionCount(), groupIds, page);
-        }
-    }
-
-    private BlockBuilder[] serializeAccumulatorState(int positionCount)
-    {
-        BlockBuilder[] outputBuilders = new BlockBuilder[groupedAggregators.size()];
-        for (int i = 0; i < outputBuilders.length; i++) {
-            outputBuilders[i] = groupedAggregators.get(i).getType().createBlockBuilder(null, positionCount);
-        }
-
-        for (int position = 0; position < positionCount; position++) {
-            for (int i = 0; i < groupedAggregators.size(); i++) {
-                GroupedAggregator groupedAggregator = groupedAggregators.get(i);
-                BlockBuilder output = outputBuilders[i];
-                groupedAggregator.evaluate(position, output);
-            }
-        }
-        return outputBuilders;
-    }
-
-    private Page constructOutputPage(Page page, BlockBuilder[] outputBuilders)
-    {
-        Block[] outputBlocks = new Block[hashChannels.length + outputBuilders.length];
+        // Prefix the output with the hash channels
+        Block[] outputBlocks = new Block[hashChannels.length + aggregatorFactories.size()];
         for (int i = 0; i < hashChannels.length; i++) {
             outputBlocks[i] = page.getBlock(hashChannels[i]);
         }
-        for (int i = 0; i < outputBuilders.length; i++) {
-            outputBlocks[hashChannels.length + i] = outputBuilders[i].build();
+
+        // Create a unique groupId mapping per row
+        int positionCount = page.getPositionCount();
+        int[] groupIds = new int[positionCount];
+        for (int position = 0; position < positionCount; position++) {
+            groupIds[position] = position;
         }
-        return new Page(page.getPositionCount(), outputBlocks);
+
+        // Evaluate each grouped aggregator into its own output block
+        for (int i = 0; i < aggregatorFactories.size(); i++) {
+            GroupedAggregator groupedAggregator = aggregatorFactories.get(i).createGroupedAggregator();
+            groupedAggregator.processPage(positionCount, groupIds, page);
+            BlockBuilder outputBuilder = groupedAggregator.getType().createBlockBuilder(null, positionCount);
+            for (int position = 0; position < positionCount; position++) {
+                groupedAggregator.evaluate(position, outputBuilder);
+            }
+            groupedAggregator = null; // ensure the groupedAggregator is eligible for GC
+            outputBlocks[hashChannels.length + i] = outputBuilder.build();
+        }
+
+        return new Page(positionCount, outputBlocks);
     }
 }


### PR DESCRIPTION
## Description
Since SkipAggregationBuilder creates a unique groupId for each input row of each page, it can create significant ephemeral memory allocations inside of GroupedAggregator instances. This can be especially bad since SkipAggregationBuilder is only used for intermediate aggregations which can occur with very high concurrency.

In an attempt to mitigate the GC pressure that SkipAggregationBuilder can create, this change refactors the logic to evaluate each GroupedAggregator individually and make it eligible for GC immediately after producing its output.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

