### PR TITLE
Opensearch Connector - Fix list table to exclude inaccessible indices 

### DIFF
--- a/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/OpenSearchMetadata.java
+++ b/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/OpenSearchMetadata.java
@@ -452,8 +452,11 @@ public class OpenSearchMetadata
                     }
                     catch (TrinoException e) {
                         // this may happen when table is being deleted concurrently
-                        if (e.getCause() instanceof ResponseException cause && cause.getResponse().getStatusLine().getStatusCode() == 404) {
-                            return Stream.empty();
+                        if (e.getCause() instanceof ResponseException cause) {
+                            int statusCode = cause.getResponse().getStatusLine().getStatusCode();
+                            if (statusCode == 403 || statusCode == 404) {
+                                return Stream.empty();
+                            }
                         }
                         throw e;
                     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

We had a restrictive AWS role allowing users to query only certain indexes. We noticed that indexes that are not accessible are still listed down in Trino or Starburst, though they can not be queried as permission denied. We are planning a multitenant system and can't afford to show one tenant's index/table to other tenants.



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
