### PR TITLE
Support options property in PostgreSQL connector

### DIFF
--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlConfig.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlConfig.java
@@ -29,6 +29,7 @@ public class PostgreSqlConfig
     private boolean includeSystemTables;
     private boolean enableStringPushdownWithCollate;
     private Integer fetchSize;
+    private String jdbcOptions;
 
     public enum ArrayMapping
     {
@@ -85,6 +86,18 @@ public class PostgreSqlConfig
     public PostgreSqlConfig setFetchSize(Integer fetchSize)
     {
         this.fetchSize = fetchSize;
+        return this;
+    }
+
+    public String getJdbcOptions()
+    {
+        return this.jdbcOptions;
+    }
+
+    @Config("postgresql.jdbc.options")
+    public PostgreSqlConfig setJdbcOptions(String jdbcOptions)
+    {
+        this.jdbcOptions = jdbcOptions;
         return this;
     }
 }

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlConnectionFactoryModule.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlConnectionFactoryModule.java
@@ -38,13 +38,22 @@ public class PostgreSqlConnectionFactoryModule
     @Provides
     @Singleton
     @ForBaseJdbc
-    public static ConnectionFactory getConnectionFactory(BaseJdbcConfig config, CredentialProvider credentialProvider, OpenTelemetry openTelemetry)
+    public static ConnectionFactory getConnectionFactory(BaseJdbcConfig config, CredentialProvider credentialProvider, PostgreSqlConfig postgreSqlConfig, OpenTelemetry openTelemetry)
     {
-        Properties connectionProperties = new Properties();
+        Properties connectionProperties = getConnectionProperties(postgreSqlConfig);
         connectionProperties.put(REWRITE_BATCHED_INSERTS.getName(), "true");
         return DriverConnectionFactory.builder(new Driver(), config.getConnectionUrl(), credentialProvider)
                 .setConnectionProperties(connectionProperties)
                 .setOpenTelemetry(openTelemetry)
                 .build();
+    }
+
+    public static Properties getConnectionProperties(PostgreSqlConfig postgreSqlConfig)
+    {
+        Properties connectionProperties = new Properties();
+        if (postgreSqlConfig.getJdbcOptions() != null) {
+            connectionProperties.setProperty("options", postgreSqlConfig.getJdbcOptions());
+        }
+        return connectionProperties;
     }
 }

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConfig.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConfig.java
@@ -31,7 +31,8 @@ public class TestPostgreSqlConfig
                 .setArrayMapping(PostgreSqlConfig.ArrayMapping.DISABLED)
                 .setIncludeSystemTables(false)
                 .setEnableStringPushdownWithCollate(false)
-                .setFetchSize(null));
+                .setFetchSize(null)
+                .setJdbcOptions(null));
     }
 
     @Test
@@ -42,13 +43,15 @@ public class TestPostgreSqlConfig
                 .put("postgresql.include-system-tables", "true")
                 .put("postgresql.experimental.enable-string-pushdown-with-collate", "true")
                 .put("postgresql.fetch-size", "2000")
+                .put("postgresql.jdbc.options", "-c statement_timeout=5min")
                 .buildOrThrow();
 
         PostgreSqlConfig expected = new PostgreSqlConfig()
                 .setArrayMapping(PostgreSqlConfig.ArrayMapping.AS_ARRAY)
                 .setIncludeSystemTables(true)
                 .setEnableStringPushdownWithCollate(true)
-                .setFetchSize(2000);
+                .setFetchSize(2000)
+                .setJdbcOptions("-c statement_timeout=5min");
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
PostgreSQL JDBC driver can take `options` property to send connection initialization parameters to the PostgreSQL server which allows clients to specify the statement timeout, etc.

It would be great if we can specify those parameters for connections from Trino.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

See the Connection Parameters section of the doc below:
https://jdbc.postgresql.org/documentation/use/

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# PostgreSQL connector
* Add `postgresql.jdbc.options` configuration property to specify connection initialization parameters sent to the PostgreSQL server ({issue}`issuenumber`)
```
