### PR TITLE
Fix infinite optimization loop on PreAggregateCaseAggregations

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPreAggregateCaseAggregations.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPreAggregateCaseAggregations.java
@@ -424,6 +424,19 @@ public class TestPreAggregateCaseAggregations
                         "GROUP BY col_varchar");
     }
 
+    @Test
+    public void testInfiniteOptimizeLoop()
+    {
+        assertFires("""
+                         SELECT
+                             SUM(IF(col_varchar != 'V', col_bigint + col_decimal)),
+                             SUM(IF(col_varchar != 'V', col_decimal + col_tinyint)),
+                             SUM(IF(col_varchar != 'V', col_tinyint + col_double)),
+                             SUM(IF(col_varchar != 'V', col_double + col_bigint))
+                         FROM t
+                         """);
+    }
+
     private void assertFires(@Language("SQL") String query)
     {
         assertThat(countOfMatchingNodes(plan(query), AggregationNode.class::isInstance)).isEqualTo(2);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
In some case, preAggregateCaseAggregations may keep the original case when expression. (like [this condition](https://github.com/trinodb/trino/blob/1c07e6cd5ee87cbe71a21a99e048378cfc04dad6/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PreAggregateCaseAggregations.java#L301))

The optimized `Aggregation1 -> project1 -> Aggregation2 -> project2` may trigger another optimization on Aggregation2. eventually cause stackoverflow.

Fixing this bug by adding a check to make sure not producing same mappings. 
Added unit test with example query that can trigger the bug.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
