### PR TITLE
Reduce thread congestion in HashBuilderOperator

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/join/unspilled/HashBuilderOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/unspilled/HashBuilderOperator.java
@@ -17,7 +17,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.errorprone.annotations.ThreadSafe;
-import io.trino.memory.context.LocalMemoryContext;
+import io.trino.memory.context.ThresholdLocalMemoryContext;
 import io.trino.operator.DriverContext;
 import io.trino.operator.HashArraySizeSupplier;
 import io.trino.operator.Operator;
@@ -38,6 +38,7 @@ import java.util.OptionalInt;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
+import static io.trino.memory.context.ThresholdLocalMemoryContext.DEFAULT_SYNC_THRESHOLD;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -159,7 +160,7 @@ public class HashBuilderOperator
     }
 
     private final OperatorContext operatorContext;
-    private final LocalMemoryContext localUserMemoryContext;
+    private final ThresholdLocalMemoryContext localUserMemoryContext;
     private final PartitionedLookupSourceFactory lookupSourceFactory;
     private final ListenableFuture<Void> lookupSourceFactoryDestroyed;
     private final int partitionIndex;
@@ -193,6 +194,25 @@ public class HashBuilderOperator
             PagesIndex.Factory pagesIndexFactory,
             HashArraySizeSupplier hashArraySizeSupplier)
     {
+        this(operatorContext, lookupSourceFactory, partitionIndex, outputChannels, hashChannels, preComputedHashChannel, filterFunctionFactory, sortChannel, searchFunctionFactories, expectedPositions, pagesIndexFactory, hashArraySizeSupplier, DEFAULT_SYNC_THRESHOLD);
+    }
+
+    @VisibleForTesting
+    HashBuilderOperator(
+            OperatorContext operatorContext,
+            PartitionedLookupSourceFactory lookupSourceFactory,
+            int partitionIndex,
+            List<Integer> outputChannels,
+            List<Integer> hashChannels,
+            OptionalInt preComputedHashChannel,
+            Optional<JoinFilterFunctionFactory> filterFunctionFactory,
+            Optional<Integer> sortChannel,
+            List<JoinFilterFunctionFactory> searchFunctionFactories,
+            int expectedPositions,
+            PagesIndex.Factory pagesIndexFactory,
+            HashArraySizeSupplier hashArraySizeSupplier,
+            long memorySyncThreshold)
+    {
         requireNonNull(pagesIndexFactory, "pagesIndexFactory is null");
 
         this.operatorContext = operatorContext;
@@ -200,7 +220,7 @@ public class HashBuilderOperator
         this.filterFunctionFactory = filterFunctionFactory;
         this.sortChannel = sortChannel;
         this.searchFunctionFactories = searchFunctionFactories;
-        this.localUserMemoryContext = operatorContext.localUserMemoryContext();
+        this.localUserMemoryContext = new ThresholdLocalMemoryContext(operatorContext.localUserMemoryContext(), memorySyncThreshold);
 
         this.index = pagesIndexFactory.newPagesIndex(lookupSourceFactory.getTypes(), expectedPositions);
         this.lookupSourceFactory = lookupSourceFactory;
@@ -314,6 +334,7 @@ public class HashBuilderOperator
         }
         LookupSourceSupplier partition = buildLookupSource();
         localUserMemoryContext.setBytes(partition.get().getInMemorySizeInBytes());
+        localUserMemoryContext.sync();
         lookupSourceNotNeeded = Optional.of(lookupSourceFactory.lendPartitionLookupSource(partitionIndex, partition));
 
         index = null;

--- a/core/trino-main/src/test/java/io/trino/operator/join/unspilled/TestHashBuilderOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/unspilled/TestHashBuilderOperator.java
@@ -114,7 +114,9 @@ public class TestHashBuilderOperator
                 ImmutableList.of(),
                 10_000,
                 new PagesIndex.TestingFactory(false),
-                defaultHashArraySizeSupplier())) {
+                defaultHashArraySizeSupplier(),
+                // sync memory usage to delegate memory pool more frequently
+                4096)) {
             assertThat(operator.getState()).isEqualTo(CONSUMING_INPUT);
 
             ListenableFuture<Void> whenBuildFinishes = lookupSourceFactory.whenBuildFinishes();

--- a/lib/trino-memory-context/src/main/java/io/trino/memory/context/ThresholdLocalMemoryContext.java
+++ b/lib/trino-memory-context/src/main/java/io/trino/memory/context/ThresholdLocalMemoryContext.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.memory.context;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class ThresholdLocalMemoryContext
+        implements LocalMemoryContext
+{
+    public static final long DEFAULT_SYNC_THRESHOLD = 65536;
+
+    private final LocalMemoryContext delegate;
+    private final long syncThreshold;
+    private long syncedBytes;
+    private long currentBytes;
+
+    public ThresholdLocalMemoryContext(LocalMemoryContext delegate)
+    {
+        this(delegate, DEFAULT_SYNC_THRESHOLD);
+    }
+
+    public ThresholdLocalMemoryContext(LocalMemoryContext delegate, long syncThreshold)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        checkArgument(syncThreshold > 0, "syncThreshold must be greater than 0");
+        this.syncThreshold = syncThreshold;
+    }
+
+    @Override
+    public long getBytes()
+    {
+        return currentBytes;
+    }
+
+    @Override
+    public ListenableFuture<Void> setBytes(long bytes)
+    {
+        if (bytes < syncedBytes || bytes - syncedBytes > syncThreshold) {
+            currentBytes = bytes;
+            syncedBytes = bytes;
+            return delegate.setBytes(bytes);
+        }
+        // bytes - syncBytes <= syncThreshold
+        currentBytes = bytes;
+        return Futures.immediateVoidFuture();
+    }
+
+    @Override
+    public boolean trySetBytes(long bytes)
+    {
+        if (bytes < syncedBytes || bytes - syncedBytes > syncThreshold) {
+            if (delegate.trySetBytes(bytes)) {
+                currentBytes = bytes;
+                syncedBytes = bytes;
+                return true;
+            }
+            return false;
+        }
+
+        currentBytes = bytes;
+        return true;
+    }
+
+    @Override
+    public void close()
+    {
+        delegate.close();
+        currentBytes = 0;
+        syncedBytes = 0;
+    }
+
+    public void sync()
+    {
+        delegate.setBytes(currentBytes);
+        syncedBytes = currentBytes;
+    }
+}


### PR DESCRIPTION
Memory management in HashBuilderOperator.addInput caused significant
thread congestion. When memory tracking accuracy is traded for calling
delegate.setBytes() less frequently, we are getting better performance
for queries which tend to process tiny pages in HashBuilder operator.

Improvement is very much visible in couple TPC-DS queries run in FTE mode.
Queries run on unpartitioned iceberg, sf1000, 8 nodes cluseter.

![image](https://github.com/user-attachments/assets/f0803f9d-3431-4119-ab04-138778d51ea9)


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

