### PR TITLE
Add oracle, redshift, postgresql jdbc fetch size

### DIFF
--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleConfig.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleConfig.java
@@ -38,6 +38,7 @@ public class OracleConfig
     private int connectionPoolMinSize = 1;
     private int connectionPoolMaxSize = 30;
     private Duration inactiveConnectionTimeout = new Duration(20, MINUTES);
+    private Integer fetchSize;
 
     public boolean isSynonymsEnabled()
     {
@@ -138,6 +139,19 @@ public class OracleConfig
     public OracleConfig setInactiveConnectionTimeout(Duration inactiveConnectionTimeout)
     {
         this.inactiveConnectionTimeout = inactiveConnectionTimeout;
+        return this;
+    }
+
+    public Optional<@Min(0) Integer> getFetchSize()
+    {
+        return Optional.ofNullable(fetchSize);
+    }
+
+    @Config("oracle.fetch-size")
+    @ConfigDescription("Oracle fetch size, trino specific heuristic is applied if empty")
+    public OracleConfig setFetchSize(Integer fetchSize)
+    {
+        this.fetchSize = fetchSize;
         return this;
     }
 

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleConfig.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleConfig.java
@@ -42,7 +42,8 @@ public class TestOracleConfig
                 .setConnectionPoolEnabled(true)
                 .setConnectionPoolMinSize(1)
                 .setConnectionPoolMaxSize(30)
-                .setInactiveConnectionTimeout(new Duration(20, MINUTES)));
+                .setInactiveConnectionTimeout(new Duration(20, MINUTES))
+                .setFetchSize(null));
     }
 
     @Test
@@ -57,6 +58,7 @@ public class TestOracleConfig
                 .put("oracle.connection-pool.min-size", "10")
                 .put("oracle.connection-pool.max-size", "20")
                 .put("oracle.connection-pool.inactive-timeout", "30s")
+                .put("oracle.fetch-size", "2000")
                 .buildOrThrow();
 
         OracleConfig expected = new OracleConfig()
@@ -67,7 +69,8 @@ public class TestOracleConfig
                 .setConnectionPoolEnabled(false)
                 .setConnectionPoolMinSize(10)
                 .setConnectionPoolMaxSize(20)
-                .setInactiveConnectionTimeout(new Duration(30, SECONDS));
+                .setInactiveConnectionTimeout(new Duration(30, SECONDS))
+                .setFetchSize(2000);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlConfig.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlConfig.java
@@ -14,9 +14,13 @@
 package io.trino.plugin.postgresql;
 
 import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.DefunctConfig;
 import io.airlift.configuration.LegacyConfig;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+
+import java.util.Optional;
 
 @DefunctConfig("postgresql.disable-automatic-fetch-size")
 public class PostgreSqlConfig
@@ -24,6 +28,7 @@ public class PostgreSqlConfig
     private ArrayMapping arrayMapping = ArrayMapping.DISABLED;
     private boolean includeSystemTables;
     private boolean enableStringPushdownWithCollate;
+    private Integer fetchSize;
 
     public enum ArrayMapping
     {
@@ -67,6 +72,19 @@ public class PostgreSqlConfig
     public PostgreSqlConfig setEnableStringPushdownWithCollate(boolean enableStringPushdownWithCollate)
     {
         this.enableStringPushdownWithCollate = enableStringPushdownWithCollate;
+        return this;
+    }
+
+    public Optional<@Min(0) Integer> getFetchSize()
+    {
+        return Optional.ofNullable(fetchSize);
+    }
+
+    @Config("postgresql.fetch-size")
+    @ConfigDescription("Postgresql fetch size, trino specific heuristic is applied if empty")
+    public PostgreSqlConfig setFetchSize(Integer fetchSize)
+    {
+        this.fetchSize = fetchSize;
         return this;
     }
 }

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConfig.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConfig.java
@@ -30,7 +30,8 @@ public class TestPostgreSqlConfig
         assertRecordedDefaults(recordDefaults(PostgreSqlConfig.class)
                 .setArrayMapping(PostgreSqlConfig.ArrayMapping.DISABLED)
                 .setIncludeSystemTables(false)
-                .setEnableStringPushdownWithCollate(false));
+                .setEnableStringPushdownWithCollate(false)
+                .setFetchSize(null));
     }
 
     @Test
@@ -40,12 +41,14 @@ public class TestPostgreSqlConfig
                 .put("postgresql.array-mapping", "AS_ARRAY")
                 .put("postgresql.include-system-tables", "true")
                 .put("postgresql.experimental.enable-string-pushdown-with-collate", "true")
+                .put("postgresql.fetch-size", "2000")
                 .buildOrThrow();
 
         PostgreSqlConfig expected = new PostgreSqlConfig()
                 .setArrayMapping(PostgreSqlConfig.ArrayMapping.AS_ARRAY)
                 .setIncludeSystemTables(true)
-                .setEnableStringPushdownWithCollate(true);
+                .setEnableStringPushdownWithCollate(true)
+                .setFetchSize(2000);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-redshift/pom.xml
+++ b/plugin/trino-redshift/pom.xml
@@ -51,6 +51,11 @@
         </dependency>
 
         <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-core</artifactId>
         </dependency>

--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftConfig.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftConfig.java
@@ -13,7 +13,12 @@
  */
 package io.trino.plugin.redshift;
 
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.DefunctConfig;
+import jakarta.validation.constraints.Min;
+
+import java.util.Optional;
 
 @DefunctConfig({
         "redshift.disable-automatic-fetch-size",
@@ -21,4 +26,18 @@ import io.airlift.configuration.DefunctConfig;
 })
 public class RedshiftConfig
 {
+    private Integer fetchSize;
+
+    public Optional<@Min(0) Integer> getFetchSize()
+    {
+        return Optional.ofNullable(fetchSize);
+    }
+
+    @Config("redshift.fetch-size")
+    @ConfigDescription("Redshift fetch size, trino specific heuristic is applied if empty")
+    public RedshiftConfig setFetchSize(Integer fetchSize)
+    {
+        this.fetchSize = fetchSize;
+        return this;
+    }
 }

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConfig.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConfig.java
@@ -27,16 +27,19 @@ public class TestRedshiftConfig
     @Test
     public void testDefaults()
     {
-        assertRecordedDefaults(recordDefaults(RedshiftConfig.class));
+        assertRecordedDefaults(recordDefaults(RedshiftConfig.class)
+                .setFetchSize(null));
     }
 
     @Test
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("redshift.fetch-size", "2000")
                 .buildOrThrow();
 
-        RedshiftConfig expected = new RedshiftConfig();
+        RedshiftConfig expected = new RedshiftConfig()
+                .setFetchSize(2000);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
trino specific heuristic is applied if empty or zero

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Oracle, Redshift, PostgreSql
* Allow customising fetch size using `oracle.fetch-size`, `redshift.fetch-size` , `postgresql.fetch-size` respectively for each connector. 
```
