### PR TITLE
Add Exasol connector to release notes

### DIFF
--- a/docs/release-template.md
+++ b/docs/release-template.md
@@ -32,6 +32,8 @@
 
 ## Elasticsearch connector
 
+## Exasol connector
+
 ## Google Sheets connector
 
 ## Hive connector

--- a/docs/src/main/sphinx/release/release-452.md
+++ b/docs/src/main/sphinx/release/release-452.md
@@ -2,6 +2,7 @@
 
 ## General
 
+* Add [](/connector/exasol). ({issue}`16083`)
 * Add support for processing the `X-Forwarded-Prefix` header when the
   `http-server.process-forwarded` property is enabled. ({issue}`22227`)
 * Add support for the {func}`euclidean_distance`, {func}`dot_product`, and


### PR DESCRIPTION
## Description

Accidentally missed in 452 release


## Additional context and related issues



## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
