### PR TITLE
Use more compact representation of AssignmentResult in diagnostics

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
@@ -640,6 +640,7 @@ public class EventDrivenFaultTolerantQueryScheduler
                     // Also empty events can push important events out of recorded debug information - making debug logs less useful.
                     return Optional.empty();
                 }
+                return Optional.of(splitAssignmentEvent.debugInfo());
             }
 
             return Optional.of(event.toString());
@@ -3402,6 +3403,15 @@ public class EventDrivenFaultTolerantQueryScheduler
             return toStringHelper(this)
                     .add("stageId", getStageId())
                     .add("assignmentResult", assignmentResult)
+                    .toString();
+        }
+
+        public String debugInfo()
+        {
+            // toString is too verbose
+            return toStringHelper(this)
+                    .add("stageId", getStageId())
+                    .add("assignmentResult", assignmentResult.debugInfo())
                     .toString();
         }
     }


### PR DESCRIPTION
Previously we used toString but it transitively calls out to
ConnectorSplit.toString which may be very verbose. We observed memory
pressure problems while logging diagnostics.