### PR TITLE
Use static lambda in WorkProcessorOperatorAdapter

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorOperatorAdapter.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorOperatorAdapter.java
@@ -17,6 +17,8 @@ import com.google.common.util.concurrent.ListenableFuture;
 import io.trino.memory.context.MemoryTrackingContext;
 import io.trino.spi.Page;
 
+import java.util.function.Supplier;
+
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -101,7 +103,13 @@ public class WorkProcessorOperatorAdapter
         memoryTrackingContext.initializeLocalMemoryContexts(workProcessorOperatorFactory.getOperatorType());
         this.workProcessorOperator = workProcessorOperatorFactory.createAdapterOperator(new ProcessorContext(operatorContext.getSession(), memoryTrackingContext, operatorContext));
         this.pages = workProcessorOperator.getOutputPages();
-        operatorContext.setInfoSupplier(() -> workProcessorOperator.getOperatorInfo().orElse(null));
+        operatorContext.setInfoSupplier(createInfoSupplier(workProcessorOperator));
+    }
+
+    // static method to avoid capturing a reference to "this"
+    private static Supplier<OperatorInfo> createInfoSupplier(AdapterWorkProcessorOperator workProcessorOperator)
+    {
+        return () -> workProcessorOperator.getOperatorInfo().orElse(null);
     }
 
     @Override


### PR DESCRIPTION
## Description
Avoid capturing a local reference to "this" which can retain memory in the operator info supplier longer than intended.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
