### PR TITLE
Fix handling of non-deterministic expressions in GROUP BY

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/AggregationAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/AggregationAnalyzer.java
@@ -487,6 +487,11 @@ class AggregationAnalyzer
                     return false;
                 }
             }
+            else {
+                if (!expressions.contains(scopeAwareKey(node, analysis, sourceScope))) {
+                    throw semanticException(EXPRESSION_NOT_AGGREGATE, node, "'%s' must be an aggregate expression or appear in GROUP BY clause", node);
+                }
+            }
 
             return node.getArguments().stream().allMatch(expression -> process(expression, context));
         }


### PR DESCRIPTION
Non-deterministic expressions that look like constant invocations are not functionally dependent on GROUP BY keys, so they need to be referenced in the GROUP BY clause.

Additionally, since each occurrence is a separate invocation, they can't be referenced by syntax similiarity, so they require the use of ordinals in the GROUP BY clause, or performing the GROUP BY in an outer query.

Fixes https://github.com/trinodb/trino/issues/22691
<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# General
* TBD. ({issue}`22691`)
```
