### PR TITLE
Remove HiveMetastoreClosure

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -1004,7 +1004,7 @@ public class HiveMetadata
             // Commit and then drop the database with raw metastore because exclusive operation after dropping object is disallowed in SemiTransactionalHiveMetastore
             metastore.commit();
             boolean deleteData = metastore.shouldDeleteDatabaseData(session, schemaName);
-            metastore.unsafeGetRawHiveMetastoreClosure().dropDatabase(schemaName, deleteData);
+            metastore.unsafeGetRawHiveMetastore().dropDatabase(schemaName, deleteData);
         }
         else {
             metastore.dropDatabase(session, schemaName);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadataFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadataFactory.java
@@ -222,10 +222,12 @@ public class HiveMetadataFactory
     public TransactionalMetadata create(ConnectorIdentity identity, boolean autoCommit)
     {
         CachingHiveMetastore cachingHiveMetastore = createPerTransactionCache(metastoreFactory.createMetastore(Optional.of(identity)), perTransactionCacheMaximumSize);
-        HiveMetastoreClosure hiveMetastoreClosure = new HiveMetastoreClosure(cachingHiveMetastore, typeManager, partitionProjectionEnabled);
+        HiveMetastoreClosure hiveMetastoreClosure = new HiveMetastoreClosure(cachingHiveMetastore);
 
         DirectoryLister directoryLister = transactionScopeCachingDirectoryListerFactory.get(this.directoryLister);
         SemiTransactionalHiveMetastore metastore = new SemiTransactionalHiveMetastore(
+                typeManager,
+                partitionProjectionEnabled,
                 fileSystemFactory,
                 hiveMetastoreClosure,
                 fileSystemExecutor,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadataFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadataFactory.java
@@ -19,12 +19,12 @@ import io.airlift.concurrent.BoundedExecutor;
 import io.airlift.json.JsonCodec;
 import io.airlift.units.Duration;
 import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.metastore.HiveMetastore;
 import io.trino.plugin.hive.fs.DirectoryLister;
 import io.trino.plugin.hive.fs.TransactionScopeCachingDirectoryListerFactory;
 import io.trino.plugin.hive.metastore.HiveMetastoreConfig;
 import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
 import io.trino.plugin.hive.metastore.SemiTransactionalHiveMetastore;
-import io.trino.plugin.hive.metastore.cache.CachingHiveMetastore;
 import io.trino.plugin.hive.security.AccessControlMetadataFactory;
 import io.trino.plugin.hive.statistics.MetastoreHiveStatisticsProvider;
 import io.trino.spi.catalog.CatalogName;
@@ -221,15 +221,14 @@ public class HiveMetadataFactory
     @Override
     public TransactionalMetadata create(ConnectorIdentity identity, boolean autoCommit)
     {
-        CachingHiveMetastore cachingHiveMetastore = createPerTransactionCache(metastoreFactory.createMetastore(Optional.of(identity)), perTransactionCacheMaximumSize);
-        HiveMetastoreClosure hiveMetastoreClosure = new HiveMetastoreClosure(cachingHiveMetastore);
+        HiveMetastore hiveMetastore = createPerTransactionCache(metastoreFactory.createMetastore(Optional.of(identity)), perTransactionCacheMaximumSize);
 
         DirectoryLister directoryLister = transactionScopeCachingDirectoryListerFactory.get(this.directoryLister);
         SemiTransactionalHiveMetastore metastore = new SemiTransactionalHiveMetastore(
                 typeManager,
                 partitionProjectionEnabled,
                 fileSystemFactory,
-                hiveMetastoreClosure,
+                hiveMetastore,
                 fileSystemExecutor,
                 dropExecutor,
                 updateExecutor,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
@@ -33,7 +33,6 @@ import io.trino.metastore.TableInfo;
 import io.trino.plugin.hive.projection.PartitionProjection;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.SchemaTableName;
-import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.function.LanguageFunction;
 import io.trino.spi.function.SchemaFunctionName;
 import io.trino.spi.predicate.TupleDomain;
@@ -79,12 +78,6 @@ public class HiveMetastoreClosure
         return delegate.getAllDatabases();
     }
 
-    private Table getExistingTable(String databaseName, String tableName)
-    {
-        return delegate.getTable(databaseName, tableName)
-                .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(databaseName, tableName)));
-    }
-
     public Optional<Table> getTable(String databaseName, String tableName)
     {
         return delegate.getTable(databaseName, tableName);
@@ -114,9 +107,8 @@ public class HiveMetastoreClosure
         delegate.updateTableStatistics(databaseName, tableName, acidWriteId, mode, statisticsUpdate);
     }
 
-    public void updatePartitionStatistics(String databaseName, String tableName, StatisticsUpdateMode mode, Map<String, PartitionStatistics> partitionUpdates)
+    public void updatePartitionStatistics(Table table, StatisticsUpdateMode mode, Map<String, PartitionStatistics> partitionUpdates)
     {
-        Table table = getExistingTable(databaseName, tableName);
         delegate.updatePartitionStatistics(table, mode, partitionUpdates);
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
@@ -30,14 +30,11 @@ import io.trino.metastore.PrincipalPrivileges;
 import io.trino.metastore.StatisticsUpdateMode;
 import io.trino.metastore.Table;
 import io.trino.metastore.TableInfo;
-import io.trino.plugin.hive.projection.PartitionProjection;
-import io.trino.spi.TrinoException;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.function.LanguageFunction;
 import io.trino.spi.function.SchemaFunctionName;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.security.RoleGrant;
-import io.trino.spi.type.TypeManager;
 
 import java.util.Collection;
 import java.util.List;
@@ -46,26 +43,19 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static io.trino.plugin.hive.HiveErrorCode.HIVE_TABLE_DROPPED_DURING_QUERY;
-import static io.trino.plugin.hive.projection.PartitionProjectionProperties.getPartitionProjectionFromTable;
 import static java.util.Objects.requireNonNull;
 
 public class HiveMetastoreClosure
 {
     private final HiveMetastore delegate;
-    private final TypeManager typeManager;
-    private final boolean partitionProjectionEnabled;
 
     /**
      * Do not use this directly.  Instead, the closure should be fetched from the current SemiTransactionalHiveMetastore,
      * which can be fetched from the current HiveMetadata.
      */
-    public HiveMetastoreClosure(HiveMetastore delegate, TypeManager typeManager, boolean partitionProjectionEnabled)
+    public HiveMetastoreClosure(HiveMetastore delegate)
     {
         this.delegate = requireNonNull(delegate, "delegate is null");
-        this.typeManager = requireNonNull(typeManager, "typeManager is null");
-        this.partitionProjectionEnabled = partitionProjectionEnabled;
     }
 
     public Optional<Database> getDatabase(String databaseName)
@@ -199,34 +189,11 @@ public class HiveMetastoreClosure
             List<String> columnNames,
             TupleDomain<String> partitionKeysFilter)
     {
-        if (partitionProjectionEnabled) {
-            Table table = getTable(databaseName, tableName)
-                    .orElseThrow(() -> new TrinoException(HIVE_TABLE_DROPPED_DURING_QUERY, "Table does not exists: " + tableName));
-
-            Optional<PartitionProjection> projection = getPartitionProjectionFromTable(table, typeManager);
-            if (projection.isPresent()) {
-                return projection.get().getProjectedPartitionNamesByFilter(columnNames, partitionKeysFilter);
-            }
-        }
         return delegate.getPartitionNamesByFilter(databaseName, tableName, columnNames, partitionKeysFilter);
     }
 
-    public Map<String, Optional<Partition>> getPartitionsByNames(String databaseName, String tableName, List<String> partitionNames)
+    public Map<String, Optional<Partition>> getPartitionsByNames(Table table, List<String> partitionNames)
     {
-        return delegate.getTable(databaseName, tableName)
-                .map(table -> getPartitionsByNames(table, partitionNames))
-                .orElseGet(() -> partitionNames.stream()
-                        .collect(toImmutableMap(name -> name, name -> Optional.empty())));
-    }
-
-    private Map<String, Optional<Partition>> getPartitionsByNames(Table table, List<String> partitionNames)
-    {
-        if (partitionProjectionEnabled) {
-            Optional<PartitionProjection> projection = getPartitionProjectionFromTable(table, typeManager);
-            if (projection.isPresent()) {
-                return projection.get().getProjectedPartitionsByNames(table, partitionNames);
-            }
-        }
         return delegate.getPartitionsByNames(table, partitionNames);
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSinkProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSinkProvider.java
@@ -172,7 +172,7 @@ public class HivePageSinkProvider
                 handle.getLocationHandle(),
                 locationService,
                 session.getQueryId(),
-                new HivePageSinkMetadataProvider(handle.getPageSinkMetadata(), new HiveMetastoreClosure(cachingHiveMetastore, typeManager, false)),
+                new HivePageSinkMetadataProvider(handle.getPageSinkMetadata(), new HiveMetastoreClosure(cachingHiveMetastore)),
                 typeManager,
                 pageSorter,
                 writerSortBufferSize,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSinkProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSinkProvider.java
@@ -172,7 +172,7 @@ public class HivePageSinkProvider
                 handle.getLocationHandle(),
                 locationService,
                 session.getQueryId(),
-                new HivePageSinkMetadataProvider(handle.getPageSinkMetadata(), new HiveMetastoreClosure(cachingHiveMetastore)),
+                new HivePageSinkMetadataProvider(handle.getPageSinkMetadata(), cachingHiveMetastore),
                 typeManager,
                 pageSorter,
                 writerSortBufferSize,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HivePageSinkMetadataProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HivePageSinkMetadataProvider.java
@@ -13,9 +13,9 @@
  */
 package io.trino.plugin.hive.metastore;
 
+import io.trino.metastore.HiveMetastore;
 import io.trino.metastore.Partition;
 import io.trino.metastore.Table;
-import io.trino.plugin.hive.HiveMetastoreClosure;
 import io.trino.spi.connector.SchemaTableName;
 
 import java.util.List;
@@ -27,12 +27,12 @@ import static java.util.Objects.requireNonNull;
 
 public class HivePageSinkMetadataProvider
 {
-    private final HiveMetastoreClosure delegate;
+    private final HiveMetastore delegate;
     private final SchemaTableName schemaTableName;
     private final Optional<Table> table;
     private final Map<List<String>, Optional<Partition>> modifiedPartitions;
 
-    public HivePageSinkMetadataProvider(HivePageSinkMetadata pageSinkMetadata, HiveMetastoreClosure delegate)
+    public HivePageSinkMetadataProvider(HivePageSinkMetadata pageSinkMetadata, HiveMetastore delegate)
     {
         requireNonNull(pageSinkMetadata, "pageSinkMetadata is null");
         this.delegate = delegate;
@@ -54,7 +54,7 @@ public class HivePageSinkMetadataProvider
         }
         Optional<Partition> modifiedPartition = modifiedPartitions.get(partitionValues);
         if (modifiedPartition == null) {
-            return delegate.getPartition(schemaTableName.getSchemaName(), schemaTableName.getTableName(), partitionValues);
+            return delegate.getPartition(table.get(), partitionValues);
         }
         return modifiedPartition;
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveTransaction.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveTransaction.java
@@ -15,8 +15,8 @@ package io.trino.plugin.hive.metastore;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.metastore.AcidTransactionOwner;
+import io.trino.metastore.HiveMetastore;
 import io.trino.metastore.HivePartition;
-import io.trino.plugin.hive.HiveMetastoreClosure;
 import io.trino.plugin.hive.HiveTableHandle;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.plugin.hive.util.ValidTxnWriteIdList;
@@ -63,7 +63,7 @@ public class HiveTransaction
 
     public ValidTxnWriteIdList getValidWriteIds(
             AcidTransactionOwner transactionOwner,
-            HiveMetastoreClosure metastore,
+            HiveMetastore metastore,
             HiveTableHandle tableHandle)
     {
         List<SchemaTableName> lockedTables;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/CreateEmptyPartitionProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/CreateEmptyPartitionProcedure.java
@@ -19,10 +19,10 @@ import com.google.inject.Provider;
 import io.airlift.json.JsonCodec;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import io.trino.metastore.HiveMetastore;
 import io.trino.plugin.base.util.UncheckedCloseable;
 import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.plugin.hive.HiveInsertTableHandle;
-import io.trino.plugin.hive.HiveMetastoreClosure;
 import io.trino.plugin.hive.HiveTableHandle;
 import io.trino.plugin.hive.LocationService;
 import io.trino.plugin.hive.LocationService.WriteInfo;
@@ -127,8 +127,8 @@ public class CreateEmptyPartitionProcedure
                 throw new TrinoException(INVALID_PROCEDURE_ARGUMENT, "Provided partition column names do not match actual partition column names: " + actualPartitionColumnNames);
             }
 
-            HiveMetastoreClosure metastore = hiveMetadata.getMetastore().unsafeGetRawHiveMetastoreClosure();
-            if (metastore.getPartition(schemaName, tableName, partitionValues).isPresent()) {
+            HiveMetastore metastore = hiveMetadata.getMetastore().unsafeGetRawHiveMetastore();
+            if (metastore.getTable(schemaName, tableName).flatMap(table -> metastore.getPartition(table, partitionValues)).isPresent()) {
                 throw new TrinoException(ALREADY_EXISTS, "Partition already exists");
             }
             HiveInsertTableHandle hiveInsertTableHandle = (HiveInsertTableHandle) hiveMetadata.beginInsert(session, tableHandle, ImmutableList.of(), NO_RETRIES);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/DropStatsProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/DropStatsProcedure.java
@@ -150,7 +150,7 @@ public class DropStatsProcedure
                 }
                 else {
                     // the table is partitioned; remove stats for every partition
-                    metastore.getPartitionNamesByFilter(handle.getSchemaName(), handle.getTableName(), partitionColumns, TupleDomain.all())
+                    hiveMetadata.getMetastore().getPartitionNamesByFilter(handle.getSchemaName(), handle.getTableName(), partitionColumns, TupleDomain.all())
                             .ifPresent(partitions -> partitions.forEach(partitionName -> metastore.updatePartitionStatistics(
                                     metastore.getTable(schema, table)
                                             .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(schema, table))),

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/DropStatsProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/DropStatsProcedure.java
@@ -17,10 +17,10 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+import io.trino.metastore.HiveMetastore;
 import io.trino.metastore.PartitionStatistics;
 import io.trino.plugin.base.util.UncheckedCloseable;
 import io.trino.plugin.hive.HiveColumnHandle;
-import io.trino.plugin.hive.HiveMetastoreClosure;
 import io.trino.plugin.hive.HiveTableHandle;
 import io.trino.plugin.hive.TransactionalMetadata;
 import io.trino.plugin.hive.TransactionalMetadataFactory;
@@ -121,7 +121,7 @@ public class DropStatsProcedure
                     .map(HiveColumnHandle::getName)
                     .collect(toImmutableList());
 
-            HiveMetastoreClosure metastore = hiveMetadata.getMetastore().unsafeGetRawHiveMetastoreClosure();
+            HiveMetastore metastore = hiveMetadata.getMetastore().unsafeGetRawHiveMetastore();
             if (partitionValues != null) {
                 // drop stats for specified partitions
                 List<List<String>> partitionStringValues = partitionValues.stream()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/RegisterPartitionProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/RegisterPartitionProcedure.java
@@ -130,7 +130,7 @@ public class RegisterPartitionProcedure
             checkIsPartitionedTable(table);
             checkPartitionColumns(table, partitionColumns);
 
-            Optional<Partition> partition = metastore.unsafeGetRawHiveMetastoreClosure().getPartition(schemaName, tableName, partitionValues);
+            Optional<Partition> partition = metastore.unsafeGetRawHiveMetastore().getPartition(table, partitionValues);
             if (partition.isPresent()) {
                 String partitionName = makePartName(partitionColumns, partitionValues);
                 throw new TrinoException(ALREADY_EXISTS, format("Partition [%s] is already registered with location %s", partitionName, partition.get().getStorage().getLocation()));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/UnregisterPartitionProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/UnregisterPartitionProcedure.java
@@ -111,7 +111,7 @@ public class UnregisterPartitionProcedure
 
             String partitionName = makePartName(partitionColumns, partitionValues);
 
-            Partition partition = metastore.unsafeGetRawHiveMetastoreClosure().getPartition(schemaName, tableName, partitionValues)
+            Partition partition = metastore.unsafeGetRawHiveMetastore().getPartition(table, partitionValues)
                     .orElseThrow(() -> new TrinoException(NOT_FOUND, format("Partition '%s' does not exist", partitionName)));
 
             metastore.dropPartition(

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
@@ -33,7 +33,6 @@ import io.trino.metastore.Table;
 import io.trino.metastore.TableInfo;
 import io.trino.plugin.base.util.AutoCloseableCloser;
 import io.trino.plugin.hive.HiveColumnHandle;
-import io.trino.plugin.hive.HiveMetastoreClosure;
 import io.trino.plugin.hive.metastore.thrift.BridgingHiveMetastore;
 import io.trino.plugin.hive.metastore.thrift.MockThriftMetastoreClient;
 import io.trino.plugin.hive.metastore.thrift.ThriftHiveMetastore;
@@ -899,12 +898,10 @@ public class TestCachingHiveMetastore
     {
         assertThat(mockClient.getAccessCount()).isEqualTo(0);
 
-        HiveMetastoreClosure hiveMetastoreClosure = new HiveMetastoreClosure(metastore);
-
-        Table table = hiveMetastoreClosure.getTable(TEST_DATABASE, TEST_TABLE).orElseThrow();
+        Table table = metastore.getTable(TEST_DATABASE, TEST_TABLE).orElseThrow();
         assertThat(mockClient.getAccessCount()).isEqualTo(1);
 
-        hiveMetastoreClosure.updatePartitionStatistics(table, MERGE_INCREMENTAL, Map.of(TEST_PARTITION1, TEST_STATS));
+        metastore.updatePartitionStatistics(table, MERGE_INCREMENTAL, Map.of(TEST_PARTITION1, TEST_STATS));
         assertThat(mockClient.getAccessCount()).isEqualTo(5);
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
@@ -96,7 +96,6 @@ import static io.trino.plugin.hive.metastore.thrift.MockThriftMetastoreClient.TE
 import static io.trino.spi.predicate.TupleDomain.withColumnDomains;
 import static io.trino.spi.security.PrincipalType.USER;
 import static io.trino.spi.type.VarcharType.VARCHAR;
-import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static java.lang.String.format;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -900,7 +899,7 @@ public class TestCachingHiveMetastore
     {
         assertThat(mockClient.getAccessCount()).isEqualTo(0);
 
-        HiveMetastoreClosure hiveMetastoreClosure = new HiveMetastoreClosure(metastore, TESTING_TYPE_MANAGER, false);
+        HiveMetastoreClosure hiveMetastoreClosure = new HiveMetastoreClosure(metastore);
 
         Table table = hiveMetastoreClosure.getTable(TEST_DATABASE, TEST_TABLE).orElseThrow();
         assertThat(mockClient.getAccessCount()).isEqualTo(1);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
@@ -905,7 +905,7 @@ public class TestCachingHiveMetastore
         Table table = hiveMetastoreClosure.getTable(TEST_DATABASE, TEST_TABLE).orElseThrow();
         assertThat(mockClient.getAccessCount()).isEqualTo(1);
 
-        hiveMetastoreClosure.updatePartitionStatistics(table.getDatabaseName(), table.getTableName(), MERGE_INCREMENTAL, Map.of(TEST_PARTITION1, TEST_STATS));
+        hiveMetastoreClosure.updatePartitionStatistics(table, MERGE_INCREMENTAL, Map.of(TEST_PARTITION1, TEST_STATS));
         assertThat(mockClient.getAccessCount()).isEqualTo(5);
     }
 


### PR DESCRIPTION
## Description
`HiveMetastoreClosure` abstraction is no longer needed.  This interface was needed to handle the old statistics system.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
