### PR TITLE
Make catalog management configurable in TestingTrinoServer

### DIFF
--- a/core/trino-main/src/test/java/io/trino/server/testing/TestTestingTrinoServer.java
+++ b/core/trino-main/src/test/java/io/trino/server/testing/TestTestingTrinoServer.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.testing;
+
+import com.google.inject.Key;
+import io.trino.connector.CoordinatorDynamicCatalogManager;
+import io.trino.connector.InMemoryCatalogStore;
+import io.trino.connector.StaticCatalogManager;
+import io.trino.connector.WorkerDynamicCatalogManager;
+import io.trino.metadata.CatalogManager;
+import io.trino.spi.catalog.CatalogStore;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static io.trino.connector.CatalogManagerConfig.CatalogMangerKind.STATIC;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestTestingTrinoServer
+{
+    @Test
+    public void testDefaultCatalogManagement()
+            throws IOException
+    {
+        try (TestingTrinoServer server = TestingTrinoServer.builder().build()) {
+            if (server.isCoordinator()) {
+                assertThat(server.getInstance(Key.get(CatalogManager.class)))
+                        .isInstanceOf(CoordinatorDynamicCatalogManager.class);
+                assertThat(server.getInstance(Key.get(CatalogStore.class)))
+                        .isInstanceOf(InMemoryCatalogStore.class);
+            }
+            else {
+                assertThat(server.getInstance(Key.get(CatalogManager.class)))
+                        .isInstanceOf(WorkerDynamicCatalogManager.class);
+            }
+        }
+    }
+
+    @Test
+    public void testSetCatalogManagementToStatic()
+            throws IOException
+    {
+        try (TestingTrinoServer server = TestingTrinoServer.builder()
+                .setCatalogMangerKind(STATIC)
+                .build()) {
+            assertThat(server.getInstance(Key.get(CatalogManager.class)))
+                    .isInstanceOf(StaticCatalogManager.class);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Currently, `TestingTrinoServer` hardcodes the catalog management strategy. This PR aims to make it configurable so that it can be set to `static`.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
