### PR TITLE
Fix typo in GRANT roles sql docs

### DIFF
--- a/docs/src/main/sphinx/sql/grant-roles.md
+++ b/docs/src/main/sphinx/sql/grant-roles.md
@@ -4,7 +4,7 @@
 
 ```text
 GRANT role_name [, ...]
-TO ( user | USER user_mame | ROLE role_name) [, ...]
+TO ( user | USER user_name | ROLE role_name) [, ...]
 [ GRANTED BY ( user | USER user | ROLE role | CURRENT_USER | CURRENT_ROLE ) ]
 [ WITH ADMIN OPTION ]
 [ IN catalog ]


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

* Fixed a typo on the GRANT roles SQL docs page. USER user_mame -> user_name.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
