### PR TITLE
Reduce TypedHeap allocations

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/VariableWidthData.java
+++ b/core/trino-main/src/main/java/io/trino/operator/VariableWidthData.java
@@ -40,7 +40,7 @@ public final class VariableWidthData
 {
     private static final int INSTANCE_SIZE = instanceSize(VariableWidthData.class);
 
-    public static final int MIN_CHUNK_SIZE = 1024;
+    public static final int MIN_CHUNK_SIZE = 256;
     public static final int MAX_CHUNK_SIZE = 8 * 1024 * 1024;
 
     public static final int POINTER_SIZE = SIZE_OF_INT + SIZE_OF_INT + SIZE_OF_INT;

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/minmaxbyn/TypedKeyValueHeap.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/minmaxbyn/TypedKeyValueHeap.java
@@ -281,7 +281,7 @@ public final class TypedKeyValueHeap
                 keyVariableWidthLength = keyType.getFlatVariableWidthSize(keyBlock, keyPosition);
             }
             int valueVariableWidthLength = valueType.getFlatVariableWidthSize(valueBlock, valuePosition);
-            variableWidthChunk = variableWidthData.allocate(fixedChunk, recordOffset, keyVariableWidthLength + valueVariableWidthLength);
+            variableWidthChunk = variableWidthData.allocateWithCapacity(fixedChunk, recordOffset, keyVariableWidthLength + valueVariableWidthLength, capacity - positionCount);
             variableWidthChunkOffset = getChunkOffset(fixedChunk, recordOffset);
         }
 

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/minmaxn/TypedHeap.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/minmaxn/TypedHeap.java
@@ -228,7 +228,7 @@ public final class TypedHeap
         int variableWidthChunkOffset = 0;
         if (variableWidthData != null) {
             int variableWidthLength = elementType.getFlatVariableWidthSize(block, position);
-            variableWidthChunk = variableWidthData.allocate(fixedChunk, recordOffset, variableWidthLength);
+            variableWidthChunk = variableWidthData.allocateWithCapacity(fixedChunk, recordOffset, variableWidthLength, capacity - positionCount);
             variableWidthChunkOffset = getChunkOffset(fixedChunk, recordOffset);
         }
 


### PR DESCRIPTION
## Description
Reduces the amount of memory allocated unnecessarily by `TypedHeap` and `TypedKeyValueHeap` instances with small capacities.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
