### PR TITLE
Fix output symbols of PushFilterThroughBoolOrAggregation optimizer

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushFilterThroughBoolOrAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushFilterThroughBoolOrAggregation.java
@@ -239,7 +239,7 @@ public class PushFilterThroughBoolOrAggregation
                 context.getIdAllocator().getNextId(),
                 newAggregationNode,
                 Assignments.builder()
-                        .putIdentities(source.getOutputSymbols())
+                        .putIdentities(newAggregationNode.getOutputSymbols())
                         .put(boolOrSymbol, TRUE)
                         .build());
 

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestCorrelatedAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestCorrelatedAggregation.java
@@ -489,6 +489,16 @@ public class TestCorrelatedAggregation
                 LATERAL (SELECT bool_or(distinct value), true FROM (VALUES (2, null), (3, false), (4, true)) t2(key, value) WHERE t2.key <= t.key)
                 ON TRUE"""))
                 .matches("VALUES (1, null, true), (2, null, true), (3, false, true), (4, true, true)");
+
+        // with aggregation and filter
+        assertThat(assertions.query("""
+                SELECT * FROM
+                  (SELECT key, BOOL_OR(value) AS bool_or_value
+                   FROM (VALUES (2, null), (3, false), (4, true)) t2(key, value)
+                   GROUP BY key)
+                WHERE bool_or_value = true
+                """))
+                .matches("VALUES (4, true)");
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
PushFilterThroughBoolOrAggregation optimizer may return more output symbol than original plan. 
and cause error

```
java.lang.IllegalArgumentException: io.trino.sql.planner.iterative.rule.PushFilterThroughBoolOrAggregation$PushFilterThroughBoolOrAggregationWithoutProject: transformed expression doesn't produce same outputs: [project::[varchar], bool_or::[boolean]] vs [project::[varchar], is_mocked::[boolean], bool_or::[boolean]]
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:466)
	at io.trino.sql.planner.iterative.Memo.replace(Memo.java:117)
```

Fixing this issue by using output symbols from aggregation node instead of its source.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
example query to reproduce:
```
SELECT *
FROM
  (SELECT project, BOOL_OR(is_mocked) AS has_mocking
   FROM schema.table
   GROUP BY project) AS virtual_table
WHERE has_mocking = true
```

or see new unit test. 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix planning failure for queries with filter on an aggregation. ({issue}`22716`)
```
