### PR TITLE
Add support for Glue catalog-id with catalog routines

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueContext.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueContext.java
@@ -21,11 +21,13 @@ import software.amazon.awssdk.services.glue.model.BatchGetPartitionRequest;
 import software.amazon.awssdk.services.glue.model.BatchUpdatePartitionRequest;
 import software.amazon.awssdk.services.glue.model.CreateDatabaseRequest;
 import software.amazon.awssdk.services.glue.model.CreateTableRequest;
+import software.amazon.awssdk.services.glue.model.CreateUserDefinedFunctionRequest;
 import software.amazon.awssdk.services.glue.model.DeleteColumnStatisticsForPartitionRequest;
 import software.amazon.awssdk.services.glue.model.DeleteColumnStatisticsForTableRequest;
 import software.amazon.awssdk.services.glue.model.DeleteDatabaseRequest;
 import software.amazon.awssdk.services.glue.model.DeletePartitionRequest;
 import software.amazon.awssdk.services.glue.model.DeleteTableRequest;
+import software.amazon.awssdk.services.glue.model.DeleteUserDefinedFunctionRequest;
 import software.amazon.awssdk.services.glue.model.GetColumnStatisticsForPartitionRequest;
 import software.amazon.awssdk.services.glue.model.GetColumnStatisticsForTableRequest;
 import software.amazon.awssdk.services.glue.model.GetDatabaseRequest;
@@ -34,11 +36,14 @@ import software.amazon.awssdk.services.glue.model.GetPartitionRequest;
 import software.amazon.awssdk.services.glue.model.GetPartitionsRequest;
 import software.amazon.awssdk.services.glue.model.GetTableRequest;
 import software.amazon.awssdk.services.glue.model.GetTablesRequest;
+import software.amazon.awssdk.services.glue.model.GetUserDefinedFunctionRequest;
+import software.amazon.awssdk.services.glue.model.GetUserDefinedFunctionsRequest;
 import software.amazon.awssdk.services.glue.model.UpdateColumnStatisticsForPartitionRequest;
 import software.amazon.awssdk.services.glue.model.UpdateColumnStatisticsForTableRequest;
 import software.amazon.awssdk.services.glue.model.UpdateDatabaseRequest;
 import software.amazon.awssdk.services.glue.model.UpdatePartitionRequest;
 import software.amazon.awssdk.services.glue.model.UpdateTableRequest;
+import software.amazon.awssdk.services.glue.model.UpdateUserDefinedFunctionRequest;
 
 import java.util.Optional;
 
@@ -92,6 +97,11 @@ public class GlueContext
             case GetColumnStatisticsForPartitionRequest.Builder builder -> builder.catalogId(catalogId);
             case UpdateColumnStatisticsForPartitionRequest.Builder builder -> builder.catalogId(catalogId);
             case DeleteColumnStatisticsForPartitionRequest.Builder builder -> builder.catalogId(catalogId);
+            case GetUserDefinedFunctionsRequest.Builder builder -> builder.catalogId(catalogId);
+            case GetUserDefinedFunctionRequest.Builder builder -> builder.catalogId(catalogId);
+            case CreateUserDefinedFunctionRequest.Builder builder -> builder.catalogId(catalogId);
+            case UpdateUserDefinedFunctionRequest.Builder builder -> builder.catalogId(catalogId);
+            case DeleteUserDefinedFunctionRequest.Builder builder -> builder.catalogId(catalogId);
             default -> throw new IllegalArgumentException("Unsupported request: " + request);
         }
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/v1/GlueCatalogIdRequestHandler.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/v1/GlueCatalogIdRequestHandler.java
@@ -20,11 +20,13 @@ import com.amazonaws.services.glue.model.BatchGetPartitionRequest;
 import com.amazonaws.services.glue.model.BatchUpdatePartitionRequest;
 import com.amazonaws.services.glue.model.CreateDatabaseRequest;
 import com.amazonaws.services.glue.model.CreateTableRequest;
+import com.amazonaws.services.glue.model.CreateUserDefinedFunctionRequest;
 import com.amazonaws.services.glue.model.DeleteColumnStatisticsForPartitionRequest;
 import com.amazonaws.services.glue.model.DeleteColumnStatisticsForTableRequest;
 import com.amazonaws.services.glue.model.DeleteDatabaseRequest;
 import com.amazonaws.services.glue.model.DeletePartitionRequest;
 import com.amazonaws.services.glue.model.DeleteTableRequest;
+import com.amazonaws.services.glue.model.DeleteUserDefinedFunctionRequest;
 import com.amazonaws.services.glue.model.GetColumnStatisticsForPartitionRequest;
 import com.amazonaws.services.glue.model.GetColumnStatisticsForTableRequest;
 import com.amazonaws.services.glue.model.GetDatabaseRequest;
@@ -33,11 +35,14 @@ import com.amazonaws.services.glue.model.GetPartitionRequest;
 import com.amazonaws.services.glue.model.GetPartitionsRequest;
 import com.amazonaws.services.glue.model.GetTableRequest;
 import com.amazonaws.services.glue.model.GetTablesRequest;
+import com.amazonaws.services.glue.model.GetUserDefinedFunctionRequest;
+import com.amazonaws.services.glue.model.GetUserDefinedFunctionsRequest;
 import com.amazonaws.services.glue.model.UpdateColumnStatisticsForPartitionRequest;
 import com.amazonaws.services.glue.model.UpdateColumnStatisticsForTableRequest;
 import com.amazonaws.services.glue.model.UpdateDatabaseRequest;
 import com.amazonaws.services.glue.model.UpdatePartitionRequest;
 import com.amazonaws.services.glue.model.UpdateTableRequest;
+import com.amazonaws.services.glue.model.UpdateUserDefinedFunctionRequest;
 
 import static java.util.Objects.requireNonNull;
 
@@ -78,6 +83,11 @@ public class GlueCatalogIdRequestHandler
             case GetColumnStatisticsForPartitionRequest request -> request.withCatalogId(catalogId);
             case UpdateColumnStatisticsForPartitionRequest request -> request.withCatalogId(catalogId);
             case DeleteColumnStatisticsForPartitionRequest request -> request.withCatalogId(catalogId);
+            case GetUserDefinedFunctionsRequest request -> request.withCatalogId(catalogId);
+            case GetUserDefinedFunctionRequest request -> request.withCatalogId(catalogId);
+            case CreateUserDefinedFunctionRequest request -> request.withCatalogId(catalogId);
+            case UpdateUserDefinedFunctionRequest request -> request.withCatalogId(catalogId);
+            case DeleteUserDefinedFunctionRequest request -> request.withCatalogId(catalogId);
             default -> throw new IllegalArgumentException("Unsupported request: " + serviceRequest);
         };
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/v1/GlueCatalogIdRequestHandler.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/v1/GlueCatalogIdRequestHandler.java
@@ -52,77 +52,33 @@ public class GlueCatalogIdRequestHandler
     }
 
     @Override
-    public AmazonWebServiceRequest beforeExecution(AmazonWebServiceRequest request)
+    public AmazonWebServiceRequest beforeExecution(AmazonWebServiceRequest serviceRequest)
     {
-        if (request instanceof GetDatabasesRequest) {
-            return ((GetDatabasesRequest) request).withCatalogId(catalogId);
-        }
-        if (request instanceof GetDatabaseRequest) {
-            return ((GetDatabaseRequest) request).withCatalogId(catalogId);
-        }
-        if (request instanceof CreateDatabaseRequest) {
-            return ((CreateDatabaseRequest) request).withCatalogId(catalogId);
-        }
-        if (request instanceof UpdateDatabaseRequest) {
-            return ((UpdateDatabaseRequest) request).withCatalogId(catalogId);
-        }
-        if (request instanceof DeleteDatabaseRequest) {
-            return ((DeleteDatabaseRequest) request).withCatalogId(catalogId);
-        }
-        if (request instanceof GetTablesRequest) {
-            return ((GetTablesRequest) request).withCatalogId(catalogId);
-        }
-        if (request instanceof GetTableRequest) {
-            return ((GetTableRequest) request).withCatalogId(catalogId);
-        }
-        if (request instanceof CreateTableRequest) {
-            return ((CreateTableRequest) request).withCatalogId(catalogId);
-        }
-        if (request instanceof UpdateTableRequest) {
-            return ((UpdateTableRequest) request).withCatalogId(catalogId);
-        }
-        if (request instanceof DeleteTableRequest) {
-            return ((DeleteTableRequest) request).withCatalogId(catalogId);
-        }
-        if (request instanceof GetPartitionsRequest) {
-            return ((GetPartitionsRequest) request).withCatalogId(catalogId);
-        }
-        if (request instanceof GetPartitionRequest) {
-            return ((GetPartitionRequest) request).withCatalogId(catalogId);
-        }
-        if (request instanceof UpdatePartitionRequest) {
-            return ((UpdatePartitionRequest) request).withCatalogId(catalogId);
-        }
-        if (request instanceof DeletePartitionRequest) {
-            return ((DeletePartitionRequest) request).withCatalogId(catalogId);
-        }
-        if (request instanceof BatchGetPartitionRequest) {
-            return ((BatchGetPartitionRequest) request).withCatalogId(catalogId);
-        }
-        if (request instanceof BatchCreatePartitionRequest) {
-            return ((BatchCreatePartitionRequest) request).withCatalogId(catalogId);
-        }
-        if (request instanceof BatchUpdatePartitionRequest) {
-            return ((BatchUpdatePartitionRequest) request).withCatalogId(catalogId);
-        }
-        if (request instanceof GetColumnStatisticsForTableRequest) {
-            return ((GetColumnStatisticsForTableRequest) request).withCatalogId(catalogId);
-        }
-        if (request instanceof UpdateColumnStatisticsForTableRequest) {
-            return ((UpdateColumnStatisticsForTableRequest) request).withCatalogId(catalogId);
-        }
-        if (request instanceof DeleteColumnStatisticsForTableRequest) {
-            return ((DeleteColumnStatisticsForTableRequest) request).withCatalogId(catalogId);
-        }
-        if (request instanceof GetColumnStatisticsForPartitionRequest) {
-            return ((GetColumnStatisticsForPartitionRequest) request).withCatalogId(catalogId);
-        }
-        if (request instanceof UpdateColumnStatisticsForPartitionRequest) {
-            return ((UpdateColumnStatisticsForPartitionRequest) request).withCatalogId(catalogId);
-        }
-        if (request instanceof DeleteColumnStatisticsForPartitionRequest) {
-            return ((DeleteColumnStatisticsForPartitionRequest) request).withCatalogId(catalogId);
-        }
-        throw new IllegalArgumentException("Unsupported request: " + request);
+        return switch (serviceRequest) {
+            case GetDatabasesRequest request -> request.withCatalogId(catalogId);
+            case GetDatabaseRequest request -> request.withCatalogId(catalogId);
+            case CreateDatabaseRequest request -> request.withCatalogId(catalogId);
+            case UpdateDatabaseRequest request -> request.withCatalogId(catalogId);
+            case DeleteDatabaseRequest request -> request.withCatalogId(catalogId);
+            case GetTablesRequest request -> request.withCatalogId(catalogId);
+            case GetTableRequest request -> request.withCatalogId(catalogId);
+            case CreateTableRequest request -> request.withCatalogId(catalogId);
+            case UpdateTableRequest request -> request.withCatalogId(catalogId);
+            case DeleteTableRequest request -> request.withCatalogId(catalogId);
+            case GetPartitionsRequest request -> request.withCatalogId(catalogId);
+            case GetPartitionRequest request -> request.withCatalogId(catalogId);
+            case UpdatePartitionRequest request -> request.withCatalogId(catalogId);
+            case DeletePartitionRequest request -> request.withCatalogId(catalogId);
+            case BatchGetPartitionRequest request -> request.withCatalogId(catalogId);
+            case BatchCreatePartitionRequest request -> request.withCatalogId(catalogId);
+            case BatchUpdatePartitionRequest request -> request.withCatalogId(catalogId);
+            case GetColumnStatisticsForTableRequest request -> request.withCatalogId(catalogId);
+            case UpdateColumnStatisticsForTableRequest request -> request.withCatalogId(catalogId);
+            case DeleteColumnStatisticsForTableRequest request -> request.withCatalogId(catalogId);
+            case GetColumnStatisticsForPartitionRequest request -> request.withCatalogId(catalogId);
+            case UpdateColumnStatisticsForPartitionRequest request -> request.withCatalogId(catalogId);
+            case DeleteColumnStatisticsForPartitionRequest request -> request.withCatalogId(catalogId);
+            default -> throw new IllegalArgumentException("Unsupported request: " + serviceRequest);
+        };
     }
 }


### PR DESCRIPTION
## Release notes

```markdown
# Hive
* Add support for Glue catalog id with [SQL routine management](sql-routine-management). ({issue}`22717`)
```
