### PR TITLE
Add TopN pushdown support for mongo connector

### DIFF
--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoTableHandle.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoTableHandle.java
@@ -13,12 +13,15 @@
  */
 package io.trino.plugin.mongodb;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.SortItem;
 import io.trino.spi.predicate.TupleDomain;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
@@ -31,12 +34,13 @@ public record MongoTableHandle(
         Optional<String> filter,
         TupleDomain<ColumnHandle> constraint,
         Set<MongoColumnHandle> projectedColumns,
-        OptionalInt limit)
+        OptionalInt limit,
+        List<SortItem> sortItems)
         implements ConnectorTableHandle
 {
     public MongoTableHandle(SchemaTableName schemaTableName, RemoteTableName remoteTableName, Optional<String> filter)
     {
-        this(schemaTableName, remoteTableName, filter, TupleDomain.all(), ImmutableSet.of(), OptionalInt.empty());
+        this(schemaTableName, remoteTableName, filter, TupleDomain.all(), ImmutableSet.of(), OptionalInt.empty(), ImmutableList.of());
     }
 
     public MongoTableHandle
@@ -47,6 +51,7 @@ public record MongoTableHandle(
         requireNonNull(constraint, "constraint is null");
         projectedColumns = ImmutableSet.copyOf(requireNonNull(projectedColumns, "projectedColumns is null"));
         requireNonNull(limit, "limit is null");
+        sortItems = ImmutableList.copyOf(requireNonNull(sortItems, "sortItems is null"));
     }
 
     public MongoTableHandle withProjectedColumns(Set<MongoColumnHandle> projectedColumns)
@@ -57,7 +62,8 @@ public record MongoTableHandle(
                 filter,
                 constraint,
                 projectedColumns,
-                limit);
+                limit,
+                sortItems);
     }
 
     public MongoTableHandle withConstraint(TupleDomain<ColumnHandle> constraint)
@@ -68,6 +74,7 @@ public record MongoTableHandle(
                 filter,
                 constraint,
                 projectedColumns,
-                limit);
+                limit,
+                sortItems);
     }
 }

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
@@ -142,10 +142,34 @@ public class TestMongoConnectorTest
     public void testSortItemsReflectedInExplain()
     {
         // The format of the string representation of what gets shown in the table scan is connector-specific
-        // and there's no requirement that the conform to a specific shape or contain certain keywords.
+        // and there's no requirement that the connector should conform to a specific shape or contain certain keywords.
         assertExplain(
-                "EXPLAIN SELECT name FROM nation ORDER BY nationkey DESC NULLS LAST LIMIT 5",
+                "EXPLAIN SELECT name FROM nation ORDER BY nationkey DESC NULLS FIRST LIMIT 5",
                 "TopNPartial\\[count = 5, orderBy = \\[nationkey DESC");
+    }
+
+    @Test
+    public void testSortItemWithDescendingNullsLastReflectedInExplain()
+    {
+        assertExplainDoesNotContain(
+                "EXPLAIN SELECT name FROM nation ORDER BY nationkey DESC NULLS LAST LIMIT 5",
+                "TopNPartial");
+    }
+
+    @Test
+    public void testSortItemWithAscendingNullsLastReflectedInExplain()
+    {
+        assertExplain(
+                "EXPLAIN SELECT name FROM nation ORDER BY nationkey ASC NULLS LAST LIMIT 5",
+                "TopNPartial\\[count = 5, orderBy = \\[nationkey ASC");
+    }
+
+    @Test
+    public void testSortItemWithAscendingNullsFirstReflectedInExplain()
+    {
+        assertExplainDoesNotContain(
+                "EXPLAIN SELECT name FROM nation ORDER BY nationkey ASC NULLS FIRST LIMIT 5",
+                "TopNPartial");
     }
 
     @Override

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoSession.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoSession.java
@@ -16,6 +16,8 @@ package io.trino.plugin.mongodb;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.SortItem;
+import io.trino.spi.connector.SortOrder;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.predicate.ValueSet;
@@ -237,6 +239,25 @@ public class TestMongoSession
         assertThat(output)
                 .containsExactly(col9)
                 .hasSize(1);
+    }
+
+    @Test
+    public void testBuildSortCriteria()
+    {
+        List<SortItem> sortItems = ImmutableList.of(
+                new SortItem("id", SortOrder.ASC_NULLS_FIRST),
+                new SortItem("address", SortOrder.DESC_NULLS_LAST),
+                new SortItem("user", SortOrder.ASC_NULLS_FIRST),
+                new SortItem("creator", SortOrder.DESC_NULLS_LAST));
+
+        Document output = MongoSession.buildSortCriteria(sortItems);
+        Document expected = new Document()
+                .append("id", 1)
+                .append("address", -1)
+                .append("user", 1)
+                .append("creator", -1);
+        assertThat(output)
+                .isEqualTo(expected);
     }
 
     private static MongoColumnHandle createColumnHandle(String baseName, Type type, String... dereferenceNames)

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoTableHandle.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoTableHandle.java
@@ -20,12 +20,15 @@ import io.airlift.json.JsonCodec;
 import io.airlift.json.JsonCodecFactory;
 import io.airlift.json.ObjectMapperProvider;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.SortItem;
+import io.trino.spi.connector.SortOrder;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.type.TypeDeserializer;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
@@ -125,7 +128,34 @@ public class TestMongoTableHandle
                 Optional.empty(),
                 TupleDomain.all(),
                 projectedColumns,
-                OptionalInt.empty());
+                OptionalInt.empty(),
+                ImmutableList.of());
+
+        String json = codec.toJson(expected);
+        MongoTableHandle actual = codec.fromJson(json);
+
+        assertThat(actual)
+                .isEqualTo(expected);
+    }
+
+    @Test
+    public void testRoundTripWithSortItems()
+    {
+        SchemaTableName schemaTableName = new SchemaTableName("schema", "table");
+        RemoteTableName remoteTableName = new RemoteTableName("Schema", "Table");
+        List<SortItem> sortItems = ImmutableList.of(
+                new SortItem("id", SortOrder.ASC_NULLS_FIRST),
+                new SortItem("address", SortOrder.DESC_NULLS_LAST),
+                new SortItem("user", SortOrder.ASC_NULLS_FIRST),
+                new SortItem("creator", SortOrder.DESC_NULLS_LAST));
+        MongoTableHandle expected = new MongoTableHandle(
+                schemaTableName,
+                remoteTableName,
+                Optional.empty(),
+                TupleDomain.all(),
+                ImmutableSet.of(),
+                OptionalInt.empty(),
+                sortItems);
 
         String json = codec.toJson(expected);
         MongoTableHandle actual = codec.fromJson(json);

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
@@ -564,6 +564,20 @@ public abstract class AbstractTestQueryFramework
         }
     }
 
+    protected void assertExplainDoesNotContain(@Language("SQL") String query, @Language("RegExp") String... unexpectedExplainRegExps)
+    {
+        assertExplainDoesNotContain(getSession(), query, unexpectedExplainRegExps);
+    }
+
+    private void assertExplainDoesNotContain(Session session, @Language("SQL") String query, @Language("RegExp") String... unexpectedExplainRegExps)
+    {
+        String value = (String) computeActual(session, query).getOnlyValue();
+
+        for (String unexpectedExplainRegExp : unexpectedExplainRegExps) {
+            assertThat(value).doesNotContainPattern(unexpectedExplainRegExp);
+        }
+    }
+
     protected void assertQueryStats(
             Session session,
             @Language("SQL") String query,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Implemented TopN pushdown for the Mongo connector.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Pushdown happens when all the SortItems have a SortOrder of either `ASC_NULLS_FIRST` or `DESC_NULLS_LAST`, since these are the only two sort orders supported by MongoDB and hence the Java Mongo Driver.
Added tests for the same along with comments in the code explaining the above limitations and references to the relevant sections in the MongoDB docs.
 
<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
