### PR TITLE
Allow portless URIs in the client/jdbc/cli

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
@@ -42,7 +42,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.nullToEmpty;
@@ -325,10 +324,9 @@ public class ClientOptions
 
     public ClientSession toClientSession(TrinoUri uri)
     {
-        ClientSession clientSession = uri.toClientSession();
-        return ClientSession
-                .builder(clientSession)
-                .source(firstNonNull(clientSession.getSource(), SOURCE_DEFAULT))
+        return uri
+                .toClientSessionBuilder()
+                .source(uri.getSource().orElse(SOURCE_DEFAULT))
                 .build();
     }
 

--- a/client/trino-cli/src/main/java/io/trino/cli/QueryRunner.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/QueryRunner.java
@@ -23,7 +23,6 @@ import okhttp3.OkHttpClient;
 import java.io.Closeable;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static io.trino.client.ClientSession.stripTransactionId;
 import static io.trino.client.StatementClientFactory.newStatementClient;
 import static java.util.Objects.requireNonNull;
@@ -38,7 +37,7 @@ public class QueryRunner
     public QueryRunner(TrinoUri uri, ClientSession session, boolean debug)
     {
         this.session = new AtomicReference<>(requireNonNull(session, "session is null"));
-        this.httpClient = HttpClientFactory.toHttpClientBuilder(uri, firstNonNull(session.getSource(), uri.getSource().orElse(null))).build();
+        this.httpClient = HttpClientFactory.toHttpClientBuilder(uri, session.getSource()).build();
         this.debug = debug;
     }
 

--- a/client/trino-client/src/main/java/io/trino/client/ClientSession.java
+++ b/client/trino-client/src/main/java/io/trino/client/ClientSession.java
@@ -99,7 +99,7 @@ public class ClientSession
         this.principal = requireNonNull(principal, "principal is null");
         this.user = requireNonNull(user, "user is null");
         this.authorizationUser = requireNonNull(authorizationUser, "authorizationUser is null");
-        this.source = source;
+        this.source = requireNonNull(source, "source is null");
         this.traceToken = requireNonNull(traceToken, "traceToken is null");
         this.clientTags = ImmutableSet.copyOf(requireNonNull(clientTags, "clientTags is null"));
         this.clientInfo = clientInfo;

--- a/client/trino-client/src/main/java/io/trino/client/ClientSession.java
+++ b/client/trino-client/src/main/java/io/trino/client/ClientSession.java
@@ -277,6 +277,10 @@ public class ClientSession
                 .add("locale", locale)
                 .add("properties", properties)
                 .add("transactionId", transactionId)
+                .add("source", source)
+                .add("resourceEstimates", resourceEstimates)
+                .add("clientRequestTimeout", clientRequestTimeout)
+                .add("compressionDisabled", compressionDisabled)
                 .omitNullValues()
                 .toString();
     }

--- a/client/trino-client/src/main/java/io/trino/client/uri/TrinoUri.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/TrinoUri.java
@@ -470,7 +470,7 @@ public class TrinoUri
         return uri.getScheme().equals("https") || (uri.getScheme().equals("trino") && uri.getPort() == 443);
     }
 
-    public ClientSession toClientSession()
+    public ClientSession.Builder toClientSessionBuilder()
     {
         return ClientSession.builder()
                 .server(getHttpUri())
@@ -488,8 +488,7 @@ public class TrinoUri
                 .credentials(getExtraCredentials())
                 .transactionId(null)
                 .resourceEstimates(getResourceEstimates())
-                .compressionDisabled(isCompressionDisabled())
-                .build();
+                .compressionDisabled(isCompressionDisabled());
     }
 
     protected static Set<ConnectionProperty<?, ?>> allProperties()

--- a/client/trino-client/src/main/java/io/trino/client/uri/TrinoUri.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/TrinoUri.java
@@ -547,14 +547,10 @@ public class TrinoUri
     {
         validatePrefix(url);
         URI uri = parseUrl(url);
-
         if (isNullOrEmpty(uri.getHost())) {
             throw new RuntimeException("No host specified: " + url);
         }
-        if (uri.getPort() == -1) {
-            throw new RuntimeException("No port number specified: " + url);
-        }
-        if ((uri.getPort() < 1) || (uri.getPort() > 65535)) {
+        if (uri.getPort() == 0 || uri.getPort() > 65535) {
             throw new RuntimeException("Invalid port number: " + url);
         }
         return uri;

--- a/client/trino-client/src/test/java/io/trino/client/TestRetry.java
+++ b/client/trino-client/src/test/java/io/trino/client/TestRetry.java
@@ -80,6 +80,7 @@ public class TestRetry
         ClientSession session = ClientSession.builder()
                 .server(URI.create("http://" + server.getHostName() + ":" + server.getPort()))
                 .timeZone(ZoneId.of("UTC"))
+                .source("test")
                 .clientRequestTimeout(Duration.valueOf("2s"))
                 .build();
 
@@ -109,6 +110,7 @@ public class TestRetry
         ClientSession session = ClientSession.builder()
                 .server(URI.create("http://" + server.getHostName() + ":" + server.getPort()))
                 .timeZone(ZoneId.of("UTC"))
+                .source("test")
                 .clientRequestTimeout(Duration.valueOf("2s"))
                 .build();
 

--- a/client/trino-client/src/test/java/io/trino/client/uri/TestTrinoUri.java
+++ b/client/trino-client/src/test/java/io/trino/client/uri/TestTrinoUri.java
@@ -53,8 +53,9 @@ public class TestTrinoUri
         // invalid scheme
         assertInvalid("mysql://localhost", "Invalid Trino URL: mysql://localhost");
 
-        // missing port
-        assertInvalid("trino://localhost/", "No port number specified:");
+        // invalid port
+        assertInvalid("trino://localhost:0/", "Invalid port number:");
+        assertInvalid("trino://localhost:70000/", "Invalid port number:");
 
         // extra path segments
         assertInvalid("trino://localhost:8080/hive/default/abc", "Invalid path segments in URL:");
@@ -434,6 +435,16 @@ public class TestTrinoUri
                 .collect(toImmutableSet());
 
         assertThat(allProperties).hasSameElementsAs(setters);
+    }
+
+    @Test
+    public void testDefaultPorts()
+    {
+        TrinoUri uri = createTrinoUri("trino://localhost");
+        assertThat(uri.getHttpUri()).isEqualTo(URI.create("http://localhost:80"));
+
+        TrinoUri secureUri = createTrinoUri("trino://localhost?SSL=true");
+        assertThat(secureUri.getHttpUri()).isEqualTo(URI.create("https://localhost:443"));
     }
 
     private static boolean isBuilderHelperMethod(String name)

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
@@ -65,10 +65,7 @@ public final class TrinoDriverUri
         if (isNullOrEmpty(uri.getHost())) {
             throw new SQLException("No host specified: " + url);
         }
-        if (uri.getPort() == -1) {
-            throw new SQLException("No port number specified: " + url);
-        }
-        if ((uri.getPort() < 1) || (uri.getPort() > 65535)) {
+        if (uri.getPort() == 0 || uri.getPort() > 65535) {
             throw new SQLException("Invalid port number: " + url);
         }
         return uri;

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriverUri.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriverUri.java
@@ -55,8 +55,9 @@ public class TestTrinoDriverUri
         // invalid scheme
         assertInvalid("jdbc:http://localhost", "Invalid JDBC URL: jdbc:http://localhost");
 
-        // missing port
-        assertInvalid("jdbc:trino://localhost/", "No port number specified:");
+        // invalid port
+        assertInvalid("jdbc:trino://localhost:0/", "Invalid port number:");
+        assertInvalid("jdbc:trino://localhost:70000/", "Invalid port number:");
 
         // extra path segments
         assertInvalid("jdbc:trino://localhost:8080/hive/default/abc", "Invalid path segments in URL:");
@@ -450,6 +451,17 @@ public class TestTrinoDriverUri
                 .hasMessage("Connection property timezone value is invalid: Asia/NOT_FOUND")
                 .hasRootCauseInstanceOf(ZoneRulesException.class)
                 .hasRootCauseMessage("Unknown time-zone ID: Asia/NOT_FOUND");
+    }
+
+    @Test
+    public void testDefaultPorts()
+            throws SQLException
+    {
+        TrinoDriverUri uri = createDriverUri("jdbc:trino://localhost");
+        assertThat(uri.getHttpUri()).isEqualTo(URI.create("http://localhost:80"));
+
+        TrinoDriverUri secureUri = createDriverUri("jdbc:trino://localhost?SSL=true");
+        assertThat(secureUri.getHttpUri()).isEqualTo(URI.create("https://localhost:443"));
     }
 
     private static void assertUriPortScheme(TrinoDriverUri parameters, int port, String scheme)

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestingTrinoClient.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestingTrinoClient.java
@@ -160,7 +160,7 @@ public abstract class AbstractTestingTrinoClient<T>
         return ClientSession.builder()
                 .server(server)
                 .principal(Optional.of(session.getIdentity().getUser()))
-                .source(session.getSource().orElse(null))
+                .source(session.getSource().orElse("test"))
                 .traceToken(session.getTraceToken())
                 .clientTags(session.getClientTags())
                 .clientInfo(session.getClientInfo().orElse(null))


### PR DESCRIPTION
80/443 are standard HTTP ports Trino use. If the port is missing in the URI - assume default ones.