### PR TITLE
Use builderWithExpectedSize in aggregation builder

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
@@ -99,7 +99,7 @@ public class InMemoryHashAggregationBuilder
             UpdateMemory updateMemory)
     {
         if (hashChannel.isPresent()) {
-            this.groupByOutputTypes = ImmutableList.<Type>builder()
+            this.groupByOutputTypes = ImmutableList.<Type>builderWithExpectedSize(groupByTypes.size() + 1)
                     .addAll(groupByTypes)
                     .add(BIGINT)
                     .build();
@@ -126,8 +126,8 @@ public class InMemoryHashAggregationBuilder
         this.updateMemory = requireNonNull(updateMemory, "updateMemory is null");
 
         // wrapper each function with an aggregator
-        ImmutableList.Builder<GroupedAggregator> builder = ImmutableList.builder();
         requireNonNull(aggregatorFactories, "aggregatorFactories is null");
+        ImmutableList.Builder<GroupedAggregator> builder = ImmutableList.builderWithExpectedSize(aggregatorFactories.size());
         for (int i = 0; i < aggregatorFactories.size(); i++) {
             AggregatorFactory accumulatorFactory = aggregatorFactories.get(i);
             if (unspillIntermediateChannelOffset.isPresent()) {
@@ -333,7 +333,7 @@ public class InMemoryHashAggregationBuilder
 
     public static List<Type> toTypes(List<? extends Type> groupByType, List<AggregatorFactory> factories, Optional<Integer> hashChannel)
     {
-        ImmutableList.Builder<Type> types = ImmutableList.builder();
+        ImmutableList.Builder<Type> types = ImmutableList.builderWithExpectedSize(groupByType.size() + (hashChannel.isPresent() ? 1 : 0) + factories.size());
         types.addAll(groupByType);
         if (hashChannel.isPresent()) {
             types.add(BIGINT);

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/builder/MergingHashAggregationBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/builder/MergingHashAggregationBuilder.java
@@ -63,7 +63,7 @@ public class MergingHashAggregationBuilder
             int overwriteIntermediateChannelOffset,
             FlatHashStrategyCompiler hashStrategyCompiler)
     {
-        ImmutableList.Builder<Integer> groupByPartialChannels = ImmutableList.builder();
+        ImmutableList.Builder<Integer> groupByPartialChannels = ImmutableList.builderWithExpectedSize(groupByTypes.size());
         for (int i = 0; i < groupByTypes.size(); i++) {
             groupByPartialChannels.add(i);
         }


### PR DESCRIPTION
## Description
Simple refactoring that prefers using pre-sized `ImmutableList.Builder` instances

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
