### PR TITLE
Fix incorrect pushdown involving aggregations and unnest

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/query/TestIssue22731.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestIssue22731.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestIssue22731
+{
+    @Test
+    public void test()
+    {
+        try (QueryAssertions assertions = new QueryAssertions()) {
+            assertThat(assertions.query(
+                    """
+                    WITH t(a) as (
+                      VALUES ARRAY[ARRAY['a']]
+                    ),
+                    u as (
+                        SELECT
+                          e[cardinality(e)] AS v1,
+                          cardinality(e) AS v2
+                        FROM t CROSS JOIN UNNEST(t.a) AS z(e)
+                        GROUP BY e
+                    )
+                    SELECT *
+                    FROM u
+                    WHERE v2 = 2 AND v1 = ''
+                    """))
+                    .returnsEmptyResult();
+        }
+    }
+}


### PR DESCRIPTION
Complex conjuncts that might fails were being reordered before simpler conjuncts.

Fixes #22731 


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix potential failure for queries involving `GROUP BY`, `UNNEST`, and filters over expressions that may produce an error for certain inputs. ({issue}`22731`)
```
