### PR TITLE
Fix BaseConnectorTest.testMultipleRangesPredicate

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -538,7 +538,7 @@ public abstract class BaseConnectorTest
         assertQuery("" +
                 "SELECT orderkey, custkey, orderstatus, totalprice, orderdate, orderpriority, clerk, shippriority, comment " +
                 "FROM orders " +
-                "WHERE orderkey BETWEEN 10 AND 50");
+                "WHERE orderkey BETWEEN 10 AND 50 OR orderkey BETWEEN 100 AND 150");
     }
 
     @Test


### PR DESCRIPTION
## Description

It seems OR condition was accidentally deleted in https://github.com/trinodb/trino/commit/964e49609024d17584e96ca77dd213a48496ff96#diff-5ceb726fc5fef567f3ffbcae192ff58b1d00700d285db6369054e05cde0c52d2

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
