### PR TITLE
Fix failure when dropping schemas with cascade on Iceberg REST catalog

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -2552,10 +2552,7 @@ public class IcebergMetadata
     @Override
     public List<SchemaTableName> listViews(ConnectorSession session, Optional<String> schemaName)
     {
-        return catalog.listTables(session, schemaName).stream()
-                .filter(info -> info.extendedRelationType() == TableInfo.ExtendedRelationType.TRINO_VIEW)
-                .map(TableInfo::tableName)
-                .toList();
+        return catalog.listViews(session, schemaName);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/TrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/TrinoCatalog.java
@@ -41,6 +41,8 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
 /**
  * An interface to allow different Iceberg catalog implementations in IcebergMetadata.
  * <p>
@@ -75,6 +77,14 @@ public interface TrinoCatalog
     void renameNamespace(ConnectorSession session, String source, String target);
 
     List<TableInfo> listTables(ConnectorSession session, Optional<String> namespace);
+
+    default List<SchemaTableName> listViews(ConnectorSession session, Optional<String> namespace)
+    {
+        return listTables(session, namespace).stream()
+                .filter(info -> info.extendedRelationType() == TableInfo.ExtendedRelationType.TRINO_VIEW)
+                .map(TableInfo::tableName)
+                .collect(toImmutableList());
+    }
 
     Optional<Iterator<RelationColumnsMetadata>> streamRelationColumns(
             ConnectorSession session,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -219,6 +219,21 @@ public class TrinoRestCatalog
         return tables.build();
     }
 
+    @Override
+    public List<SchemaTableName> listViews(ConnectorSession session, Optional<String> namespace)
+    {
+        SessionContext sessionContext = convert(session);
+        List<Namespace> namespaces = listNamespaces(session, namespace);
+
+        ImmutableList.Builder<SchemaTableName> viewNames = ImmutableList.builder();
+        for (Namespace restNamespace : namespaces) {
+            listTableIdentifiers(restNamespace, () -> restSessionCatalog.listViews(sessionContext, restNamespace)).stream()
+                    .map(id -> SchemaTableName.schemaTableName(id.namespace().toString(), id.name()))
+                    .forEach(viewNames::add);
+        }
+        return viewNames.build();
+    }
+
     private static List<TableIdentifier> listTableIdentifiers(Namespace restNamespace, Supplier<List<TableIdentifier>> tableIdentifiersProvider)
     {
         try {


### PR DESCRIPTION
## Description

Iceberg REST catalog threw the following an exception when executing `DROP SCHEMA ... CASCADE` statement against schema having views. 

```
io.trino.testing.QueryFailedException: Cannot invoke "io.trino.plugin.iceberg.IcebergTableHandle.getSchemaTableName()" because "tableHandle" is null

	at io.trino.testing.AbstractTestingTrinoClient.execute(AbstractTestingTrinoClient.java:134)
	at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:558)
	at io.trino.testing.DistributedQueryRunner.executeWithPlan(DistributedQueryRunner.java:547)
	at io.trino.testing.QueryAssertions.assertDistributedUpdate(QueryAssertions.java:108)
	at io.trino.testing.QueryAssertions.assertUpdate(QueryAssertions.java:62)
	at io.trino.testing.AbstractTestQueryFramework.assertUpdate(AbstractTestQueryFramework.java:410)
	at io.trino.testing.AbstractTestQueryFramework.assertUpdate(AbstractTestQueryFramework.java:405)
	at io.trino.plugin.iceberg.catalog.rest.TestIcebergTrinoRestCatalogConnectorSmokeTest.testDropSchemaCascadeWithViews(TestIcebergTrinoRestCatalogConnectorSmokeTest.java:142)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.concurrent.RecursiveAction.exec(RecursiveAction.java:194)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:507)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1491)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:2073)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2035)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
	Suppressed: java.lang.Exception: SQL: DROP SCHEMA test_drop_schema_cascadej3suww3p6w CASCADE
		at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:565)
		... 13 more
Caused by: java.lang.NullPointerException: Cannot invoke "io.trino.plugin.iceberg.IcebergTableHandle.getSchemaTableName()" because "tableHandle" is null
	at io.trino.plugin.iceberg.IcebergMetadata.dropTable(IcebergMetadata.java:1844)
	at io.trino.plugin.iceberg.IcebergMetadata.dropSchema(IcebergMetadata.java:875)
	at io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata.dropSchema(ClassLoaderSafeConnectorMetadata.java:418)
	at io.trino.tracing.TracingConnectorMetadata.dropSchema(TracingConnectorMetadata.java:350)
	at io.trino.metadata.MetadataManager.dropSchema(MetadataManager.java:799)
	at io.trino.tracing.TracingMetadata.dropSchema(TracingMetadata.java:383)
	at io.trino.execution.DropSchemaTask.execute(DropSchemaTask.java:79)
	at io.trino.execution.DropSchemaTask.execute(DropSchemaTask.java:37)
	at io.trino.execution.DataDefinitionExecution.start(DataDefinitionExecution.java:146)
	at io.trino.execution.SqlQueryManager.createQuery(SqlQueryManager.java:272)
	at io.trino.dispatcher.LocalDispatchQuery.startExecution(LocalDispatchQuery.java:150)
	at io.trino.dispatcher.LocalDispatchQuery.lambda$waitForMinimumWorkers$2(LocalDispatchQuery.java:134)
	at io.airlift.concurrent.MoreFutures.lambda$addSuccessCallback$12(MoreFutures.java:570)
	at io.airlift.concurrent.MoreFutures$3.onSuccess(MoreFutures.java:545)
	at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1137)
	at io.trino.$gen.Trino_testversion____20240722_220840_71.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1570)
```

https://trinodb.slack.com/archives/C07ABNN828M/p1721663162609879

## Release notes

```markdown
# Iceberg
* Fix failure when executing `DROP SCHEMA ... CASCADE` on schemas with Iceberg views. ({issue}`22758`)
```
