### PR TITLE
Improve accuracy of cosine distance calculation

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayVectorFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayVectorFunctions.java
@@ -73,11 +73,9 @@ public final class ArrayVectorFunctions
             secondMagnitude += secondValue * secondValue;
             dotProduct += firstValue * secondValue;
         }
-        firstMagnitude = Math.sqrt(firstMagnitude);
-        secondMagnitude = Math.sqrt(secondMagnitude);
 
         checkCondition(firstMagnitude != 0 && secondMagnitude != 0, INVALID_FUNCTION_ARGUMENT, "Vector magnitude cannot be zero");
-        double cosineSimilarity = dotProduct / (firstMagnitude * secondMagnitude);
+        double cosineSimilarity = dotProduct / Math.sqrt(firstMagnitude * secondMagnitude);
         return 1.0 - cosineSimilarity;
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestArrayVectorFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestArrayVectorFunctions.java
@@ -49,6 +49,9 @@ final class TestArrayVectorFunctions
         assertThat(assertions.function("euclidean_distance", "ARRAY[1, 2]", "ARRAY[3, 4]"))
                 .hasType(DOUBLE)
                 .isEqualTo(2.8284271247461903);
+        assertThat(assertions.function("euclidean_distance", "ARRAY[4, 5, 6]", "ARRAY[4, 5, 6]"))
+                .hasType(DOUBLE)
+                .isEqualTo(0.0);
         assertThat(assertions.function("euclidean_distance", "ARRAY[REAL '1.1', REAL '2.2', REAL '3.3']", "ARRAY[REAL '4.4', REAL '5.5', REAL '6.6']"))
                 .hasType(DOUBLE)
                 .isEqualTo(5.715767651212193);
@@ -147,6 +150,9 @@ final class TestArrayVectorFunctions
         assertThat(assertions.function("dot_product", "ARRAY[1, 2]", "ARRAY[3, 4]"))
                 .hasType(DOUBLE)
                 .isEqualTo(11.0);
+        assertThat(assertions.function("dot_product", "ARRAY[4, 5, 6]", "ARRAY[4, 5, 6]"))
+                .hasType(DOUBLE)
+                .isEqualTo(77.0);
         assertThat(assertions.function("dot_product", "ARRAY[REAL '1.1', REAL '2.2', REAL '3.3']", "ARRAY[REAL '4.4', REAL '5.5', REAL '6.6']"))
                 .hasType(DOUBLE)
                 .isEqualTo(38.719999842643745);

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestArrayVectorFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestArrayVectorFunctions.java
@@ -245,6 +245,9 @@ final class TestArrayVectorFunctions
         assertThat(assertions.function("cosine_distance", "ARRAY[1, 2]", "ARRAY[3, 4]"))
                 .hasType(DOUBLE)
                 .isEqualTo(0.01613008990009257);
+        assertThat(assertions.function("cosine_distance", "ARRAY[4, 5, 6]", "ARRAY[4, 5, 6]"))
+                .hasType(DOUBLE)
+                .isEqualTo(0.0);
         assertThat(assertions.function("cosine_distance", "ARRAY[REAL '1.1', REAL '2.2', REAL '3.3']", "ARRAY[REAL '4.4', REAL '5.5', REAL '6.6']"))
                 .hasType(DOUBLE)
                 .isEqualTo(0.025368154060122383);


### PR DESCRIPTION
## Description

The cosine similarity between `ARRAY[4, 5, 6]` and `ARRAY[4, 5, 6]` becomes 0.9999999999999998 and `cosine_distance` function returned `2.220446049250313E-16`. 

## Release notes

```markdown
# General
* Improve accuracy of `cosine_distance` function. ({issue}`22761`)
```
