### PR TITLE
Upgrade Reactable to 1.1.0

### DIFF
--- a/core/trino-main/src/main/resources/webapp/src/package.json
+++ b/core/trino-main/src/main/resources/webapp/src/package.json
@@ -18,7 +18,7 @@
     "dagre-d3": "^0.6.1",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
-    "reactable": "^1.0.2"
+    "reactable": "^1.1.0"
   },
   "babel": {
     "presets": [

--- a/core/trino-main/src/main/resources/webapp/src/yarn.lock
+++ b/core/trino-main/src/main/resources/webapp/src/yarn.lock
@@ -1914,9 +1914,9 @@ react@^16.4.1:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-reactable@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/reactable/-/reactable-1.0.2.tgz#67a579fee3af68b991b5f04df921a4a40ece0b72"
+reactable@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/reactable/-/reactable-1.1.0.tgz#67a579fee3af68b991b5f04df921a4a40ece0b72"
 
 rechoir@^0.8.0:
   version "0.8.0"


### PR DESCRIPTION
Reactable is a flexible and customizable drag and drop table library that works well with both desktop and mobile devices. This library is used in React applications for creating interactive tables with features like sorting, filtering, pagination, and more. It helps improve the user interface (UI) by providing a more organized and user-friendly way to display data.

upgraded the reactable library to 1.1.0.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
