### PR TITLE
Optimize big query toRemoteTable

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
@@ -36,6 +36,8 @@ import com.google.cloud.http.BaseHttpServiceException;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
@@ -54,6 +56,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.google.cloud.bigquery.JobStatistics.QueryStatistics.StatementType.SELECT;
@@ -88,7 +91,15 @@ public class BigQueryClient
     private static final Logger log = Logger.get(BigQueryClient.class);
     private static final int PAGE_SIZE = 100;
 
-    static final Set<TableDefinition.Type> TABLE_TYPES = ImmutableSet.of(TABLE, VIEW, MATERIALIZED_VIEW, EXTERNAL, SNAPSHOT);
+    // BigQuery has different table_type in `INFORMATION_SCHEMA` than API responses that returns TableDefinition.Type
+    // see https://cloud.google.com/bigquery/docs/information-schema-tables#schema
+    static final Map<TableDefinition.Type, String> TABLE_TYPES = ImmutableMap.<TableDefinition.Type, String>builder()
+            .put(TABLE, "BASE TABLE")
+            .put(VIEW, "VIEW")
+            .put(MATERIALIZED_VIEW, "MATERIALIZED VIEW")
+            .put(EXTERNAL, "EXTERNAL")
+            .put(SNAPSHOT, "SNAPSHOT")
+            .buildOrThrow();
 
     private final BigQuery bigQuery;
     private final BigQueryLabelFactory labelFactory;
@@ -170,9 +181,9 @@ public class BigQueryClient
         }
     }
 
-    public Optional<RemoteDatabaseObject> toRemoteTable(String projectId, String remoteDatasetName, String tableName)
+    public Optional<RemoteDatabaseObject> toRemoteTable(ConnectorSession session, String projectId, String remoteDatasetName, String tableName)
     {
-        return toRemoteTable(projectId, remoteDatasetName, tableName, () -> listTableIds(DatasetId.of(projectId, remoteDatasetName)));
+        return toRemoteTable(projectId, remoteDatasetName, tableName, () -> findTableIdsIgnoreCase(session, DatasetId.of(projectId, remoteDatasetName), tableName));
     }
 
     public Optional<RemoteDatabaseObject> toRemoteTable(String projectId, String remoteDatasetName, String tableName, Iterable<TableId> tableIds)
@@ -300,9 +311,34 @@ public class BigQueryClient
             throw new TrinoException(BIGQUERY_LISTING_TABLE_ERROR, "Failed to retrieve tables from BigQuery", e);
         }
         return stream(allTables)
-                .filter(table -> TABLE_TYPES.contains(table.getDefinition().getType()))
+                .filter(table -> TABLE_TYPES.containsKey(table.getDefinition().getType()))
                 .map(TableInfo::getTableId)
                 .collect(toImmutableList());
+    }
+
+    public Iterable<TableId> findTableIdsIgnoreCase(ConnectorSession session, DatasetId remoteDatasetId, String tableName)
+    {
+        try {
+            TableResult tableNamesMatchingResults = executeQuery(session, """
+                    SELECT table_name
+                    FROM %s.%s.INFORMATION_SCHEMA.TABLES
+                    WHERE LOWER(table_name) = '%s' AND table_type IN (%s)""".formatted(
+                    quote(remoteDatasetId.getProject()),
+                    quote(remoteDatasetId.getDataset()),
+                    tableName.toLowerCase(ENGLISH),
+                    TABLE_TYPES.values().stream().map(value -> "'" + value + "'").collect(Collectors.joining(","))));
+
+            return tableNamesMatchingResults.streamAll()
+                    .map(row -> TableId.of(remoteDatasetId.getProject(), remoteDatasetId.getDataset(), row.getFirst().getStringValue()))
+                    .collect(toImmutableList());
+        }
+        catch (TrinoException e) {
+            if (e.getMessage().contains("Dataset %s:%s was not found".formatted(remoteDatasetId.getProject(), remoteDatasetId.getDataset()))) {
+                // means that schema is missing, let MetadataManager handle it gracefully
+                return ImmutableList.of();
+            }
+            throw e;
+        }
     }
 
     Table update(TableInfo table)

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
@@ -314,7 +314,7 @@ public class BigQueryMetadata
         String remoteSchemaName = client.toRemoteDataset(localDatasetId)
                 .map(RemoteDatabaseObject::getOnlyRemoteName)
                 .orElse(localDatasetId.getDataset());
-        String remoteTableName = client.toRemoteTable(localDatasetId.getProject(), remoteSchemaName, schemaTableName.getTableName())
+        String remoteTableName = client.toRemoteTable(session, localDatasetId.getProject(), remoteSchemaName, schemaTableName.getTableName())
                 .map(RemoteDatabaseObject::getOnlyRemoteName)
                 .orElse(schemaTableName.getTableName());
         Optional<TableInfo> tableInfo = client.getTable(TableId.of(localDatasetId.getProject(), remoteSchemaName, remoteTableName));
@@ -348,7 +348,7 @@ public class BigQueryMetadata
         String remoteSchemaName = client.toRemoteDataset(localDatasetId)
                 .map(RemoteDatabaseObject::getAnyRemoteName)
                 .orElse(localDatasetId.getDataset());
-        String remoteTableName = client.toRemoteTable(localDatasetId.getProject(), remoteSchemaName, schemaTableName.getTableName())
+        String remoteTableName = client.toRemoteTable(session, localDatasetId.getProject(), remoteSchemaName, schemaTableName.getTableName())
                 .map(RemoteDatabaseObject::getAnyRemoteName)
                 .orElse(schemaTableName.getTableName());
         return client.getTable(TableId.of(localDatasetId.getProject(), remoteSchemaName, remoteTableName));
@@ -383,7 +383,7 @@ public class BigQueryMetadata
         String remoteSchemaName = client.toRemoteDataset(localDatasetId)
                 .map(RemoteDatabaseObject::getOnlyRemoteName)
                 .orElseThrow(() -> new TableNotFoundException(viewDefinitionTableName));
-        String remoteTableName = client.toRemoteTable(localDatasetId.getProject(), remoteSchemaName, sourceTableName.getTableName())
+        String remoteTableName = client.toRemoteTable(session, localDatasetId.getProject(), remoteSchemaName, sourceTableName.getTableName())
                 .map(RemoteDatabaseObject::getOnlyRemoteName)
                 .orElseThrow(() -> new TableNotFoundException(viewDefinitionTableName));
         TableInfo tableInfo = client.getTable(TableId.of(localDatasetId.getProject(), remoteSchemaName, remoteTableName))

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitManager.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitManager.java
@@ -204,7 +204,7 @@ public class BigQuerySplitManager
 
     private List<BigQuerySplit> createEmptyProjection(ConnectorSession session, TableDefinition.Type tableType, TableId remoteTableId, Optional<String> filter)
     {
-        if (!TABLE_TYPES.contains(tableType)) {
+        if (!TABLE_TYPES.containsKey(tableType)) {
             throw new TrinoException(NOT_SUPPORTED, "Unsupported table type: " + tableType);
         }
 


### PR DESCRIPTION
Instead of querying big query for all tables, query INFORMATION_SCHEMA only for ones matching name with trino table

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Instead of querying big query for all tables, query
INFORMATION_SCHEMA only for ones matching name with
trino table


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Closes https://github.com/trinodb/trino/issues/22770


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

```markdown
# BigQuery
* Improve performance when getting table definitions
```
