### PR TITLE
Fix flaky TestIcebergMinioOrcConnectorTest

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMinioOrcConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMinioOrcConnectorTest.java
@@ -72,7 +72,7 @@ public class TestIcebergMinioOrcConnectorTest
                                 .put("s3.endpoint", minio.getMinioAddress())
                                 .put("s3.path-style-access", "true")
                                 .put("s3.streaming.part-size", "5MB") // minimize memory usage
-                                .put("s3.max-connections", "2") // verify no leaks
+                                .put("s3.max-connections", "8") // verify no leaks
                                 .put("iceberg.register-table-procedure.enabled", "true")
                                 // Allows testing the sorting writer flushing to the file system with smaller tables
                                 .put("iceberg.writer-sort-buffer-size", "1MB")

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMinioOrcConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMinioOrcConnectorTest.java
@@ -21,6 +21,7 @@ import io.trino.testing.QueryRunner;
 import io.trino.testing.containers.Minio;
 import io.trino.testing.sql.TestTable;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 
 import java.util.List;
 import java.util.Map;
@@ -36,10 +37,12 @@ import static io.trino.testing.containers.Minio.MINIO_REGION;
 import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
 /**
  * Iceberg connector test ORC and with S3-compatible storage (but without real metastore).
  */
+@Execution(SAME_THREAD)
 public class TestIcebergMinioOrcConnectorTest
         extends BaseIcebergConnectorTest
 {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

`TestIcebergMinioOrcConnectorTest.testOptimizeTimePartitionedTable` is failing intermittently, where there's a congestion on HTTP connections in the S3 client. Slightly increasing the number of available connections should fix it.

Switching to a single thread doesn't make the tests slower.

Fixes #21736

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
