### PR TITLE
Support reading INT96 timestamps as LongTimestampWithTimeZoneType

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
@@ -197,7 +197,7 @@ public final class ColumnReaderFactory
             if (timestampWithTimeZoneType.isShort()) {
                 return createColumnReader(field, valueDecoders::getInt96ToShortTimestampWithTimeZoneDecoder, LONG_ADAPTER, memoryContext);
             }
-            throw unsupportedException(type, field);
+            return createColumnReader(field, valueDecoders::getInt96ToLongTimestampWithTimeZoneDecoder, FIXED12_ADAPTER, memoryContext);
         }
         if (type instanceof TimestampType timestampType && primitiveType == INT64) {
             if (!(annotation instanceof TimestampLogicalTypeAnnotation timestampAnnotation)) {

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
@@ -416,17 +416,16 @@ public final class ValueDecoders
                 (values, offset, length) -> {
                     for (int i = offset; i < offset + length; i++) {
                         long epochSeconds = decodeFixed12First(values, i);
-                        long nanosOfSecond = decodeFixed12Second(values, i);
+                        int nanosOfSecond = decodeFixed12Second(values, i);
                         if (timeZone != DateTimeZone.UTC) {
                             epochSeconds = timeZone.convertUTCToLocal(epochSeconds * MILLISECONDS_PER_SECOND) / MILLISECONDS_PER_SECOND;
                         }
                         if (precision < 9) {
                             nanosOfSecond = (int) round(nanosOfSecond, 9 - precision);
                         }
-                        // epochMicros
                         encodeFixed12(
-                                epochSeconds * MICROSECONDS_PER_SECOND + (nanosOfSecond / NANOSECONDS_PER_MICROSECOND),
-                                (int) ((nanosOfSecond * PICOSECONDS_PER_NANOSECOND) % PICOSECONDS_PER_MICROSECOND),
+                                epochSeconds * MICROSECONDS_PER_SECOND + (nanosOfSecond / NANOSECONDS_PER_MICROSECOND), // epochMicros
+                                (nanosOfSecond % NANOSECONDS_PER_MICROSECOND) * PICOSECONDS_PER_NANOSECOND, // picosOfMicro
                                 values,
                                 i);
                     }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestingColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestingColumnReader.java
@@ -39,6 +39,7 @@ import io.trino.spi.type.LongTimestamp;
 import io.trino.spi.type.LongTimestampWithTimeZone;
 import io.trino.spi.type.TimeType;
 import io.trino.spi.type.TimeZoneKey;
+import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.Timestamps;
 import io.trino.spi.type.Type;
 import jakarta.annotation.Nullable;
@@ -89,8 +90,14 @@ import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_NANOS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_PICOS;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MICROS;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_NANOS;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_PICOS;
+import static io.trino.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MILLISECOND;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
+import static io.trino.spi.type.Timestamps.round;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.UuidType.UUID;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
@@ -622,6 +629,26 @@ public class TestingColumnReader
         };
     }
 
+    private static Assertion<DecodedTimestamp> assertInt96LongTimestampWithTimeZone(int precision)
+    {
+        TimestampWithTimeZoneType type = createTimestampWithTimeZoneType(precision);
+        return (values, block, offset, blockOffset) ->
+        {
+            long epochSeconds = values[offset].epochSeconds();
+            int nanos = values[offset].nanosOfSecond();
+            long epochNanos = epochSeconds * Timestamps.NANOSECONDS_PER_SECOND + nanos;
+            if (precision < 9) {
+                epochNanos = round(epochNanos, 9 - precision);
+            }
+
+            LongTimestampWithTimeZone packed = (LongTimestampWithTimeZone) type.getObject(block, blockOffset);
+            long picos = (packed.getEpochMillis() * PICOSECONDS_PER_MILLISECOND) + packed.getPicosOfMilli();
+            TimeZoneKey timeZoneKey = getTimeZoneKey(packed.getTimeZoneKey());
+            assertThat(timeZoneKey).isEqualTo(UTC_KEY);
+            assertThat(picos).isEqualTo(epochNanos * PICOSECONDS_PER_NANOSECOND);
+        };
+    }
+
     private TestingColumnReader() {}
 
     public enum DataPageVersion
@@ -754,6 +781,9 @@ public class TestingColumnReader
                 new ColumnReaderFormat<>(INT96, 12, null, TIMESTAMP_NANOS, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_INT96, assertTimestampNanos()),
                 new ColumnReaderFormat<>(INT96, 12, null, TIMESTAMP_PICOS, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_INT96, assertTimestampNanos()),
                 new ColumnReaderFormat<>(INT96, 12, null, TIMESTAMP_TZ_MILLIS, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_INT96, assertTimestampWithTimeZoneMillis()),
+                new ColumnReaderFormat<>(INT96, 12, null, TIMESTAMP_TZ_MICROS, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_INT96, assertInt96LongTimestampWithTimeZone(6)),
+                new ColumnReaderFormat<>(INT96, 12, null, TIMESTAMP_TZ_NANOS, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_INT96, assertInt96LongTimestampWithTimeZone(9)),
+                new ColumnReaderFormat<>(INT96, 12, null, TIMESTAMP_TZ_PICOS, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_INT96, assertInt96LongTimestampWithTimeZone(12)),
                 // timestamps read as bigint
                 new ColumnReaderFormat<>(INT64, timestampType(false, MILLIS), BIGINT, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, ASSERT_LONG),
                 new ColumnReaderFormat<>(INT64, timestampType(false, MICROS), BIGINT, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, ASSERT_LONG),

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
@@ -21,9 +21,14 @@ import io.trino.filesystem.FileEntry;
 import io.trino.filesystem.FileIterator;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.metastore.Column;
 import io.trino.metastore.HiveMetastore;
+import io.trino.metastore.HiveType;
+import io.trino.metastore.PrincipalPrivileges;
+import io.trino.metastore.Storage;
 import io.trino.plugin.base.util.Closables;
 import io.trino.plugin.blackhole.BlackHolePlugin;
+import io.trino.plugin.hive.HiveStorageFormat;
 import io.trino.plugin.hive.TestingHivePlugin;
 import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
 import io.trino.plugin.iceberg.fileio.ForwardingFileIo;
@@ -56,6 +61,7 @@ import org.apache.iceberg.data.parquet.GenericParquetWriter;
 import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.mapping.MappingUtil;
 import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
@@ -69,6 +75,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CyclicBarrier;
@@ -98,7 +105,9 @@ import static java.util.concurrent.Executors.newFixedThreadPool;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.iceberg.FileFormat.ORC;
 import static org.apache.iceberg.FileFormat.PARQUET;
+import static org.apache.iceberg.TableProperties.DEFAULT_NAME_MAPPING;
 import static org.apache.iceberg.TableProperties.SPLIT_SIZE;
+import static org.apache.iceberg.mapping.NameMappingParser.toJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
@@ -953,6 +962,69 @@ public class TestIcebergV2
                     fileSystemFactory.create(SESSION));
             assertThat(withUnenforcedFilter.getRowCount().getValue()).isEqualTo(2.0);
         }
+    }
+
+    @Test
+    public void testInt96TimestampWithTimeZone()
+    {
+        assertUpdate("CREATE TABLE hive.tpch.test_timestamptz_base (t timestamp) WITH (format = 'PARQUET')");
+        assertUpdate("INSERT INTO hive.tpch.test_timestamptz_base (t) VALUES (timestamp '2022-07-26 12:13')", 1);
+
+        // Writing TIMESTAMP WITH LOCAL TIME ZONE is not supported, so we first create Parquet object by writing unzoned
+        // timestamp (which is converted to UTC using default timezone) and then creating another table that reads from the same file.
+        String tableLocation = metastore.getTable("tpch", "test_timestamptz_base").orElseThrow().getStorage().getLocation();
+
+        // TIMESTAMP WITH LOCAL TIME ZONE is not mapped to any Trino type, so we need to create the metastore entry manually
+        metastore.createTable(
+                new io.trino.metastore.Table(
+                        "tpch",
+                        "test_timestamptz",
+                        Optional.of("hive"),
+                        "EXTERNAL_TABLE",
+                        new Storage(
+                                HiveStorageFormat.PARQUET.toStorageFormat(),
+                                Optional.of(tableLocation),
+                                Optional.empty(),
+                                false,
+                                ImmutableMap.of()),
+                        List.of(new Column("t", HiveType.HIVE_TIMESTAMPLOCALTZ, Optional.empty(), Map.of())),
+                        List.of(),
+                        ImmutableMap.of(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        OptionalLong.empty()),
+                PrincipalPrivileges.fromHivePrivilegeInfos(ImmutableSet.of()));
+
+        assertThat(query("SELECT * FROM hive.tpch.test_timestamptz"))
+                .matches("VALUES TIMESTAMP '2022-07-26 17:13:00.000 UTC'");
+
+        String path = (String) computeScalar("SELECT \"$path\" FROM hive.tpch.test_timestamptz_base");
+        long size = (long) computeScalar("SELECT \"$file_size\" FROM hive.tpch.test_timestamptz_base");
+
+        // Read a Parquet file from Iceberg connector
+        assertUpdate("CREATE TABLE iceberg.tpch.test_timestamptz_migrated(t TIMESTAMP(6) WITH TIME ZONE)");
+
+        BaseTable table = loadTable("test_timestamptz_migrated");
+
+        table.updateProperties()
+                .set(DEFAULT_NAME_MAPPING, toJson(MappingUtil.create(table.schema())))
+                .commit();
+
+        table.newAppend()
+                .appendFile(DataFiles.builder(table.spec())
+                        .withPath(path)
+                        .withFormat(PARQUET)
+                        .withFileSizeInBytes(size)
+                        .withRecordCount(1)
+                        .build())
+                .commit();
+
+        assertThat(query("SELECT * FROM iceberg.tpch.test_timestamptz_migrated"))
+                .matches("VALUES TIMESTAMP '2022-07-26 17:13:00.000000 UTC'");
+
+        assertUpdate("DROP TABLE hive.tpch.test_timestamptz_base");
+        assertUpdate("DROP TABLE hive.tpch.test_timestamptz");
+        assertUpdate("DROP TABLE iceberg.tpch.test_timestamptz_migrated");
     }
 
     @Test


### PR DESCRIPTION
Hive tables migrated to iceberg through Spark require the ability to read INT96 timestamps as LongTimestampWithTimeZoneType

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fixes https://github.com/trinodb/trino/issues/11338


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Fix failure to read hive tables migrated to iceberg through Apache Spark. ({issue}`11338`)
```
