### PR TITLE
Fix custom catalog store plugin loading

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/CatalogStoreConfig.java
+++ b/core/trino-main/src/main/java/io/trino/connector/CatalogStoreConfig.java
@@ -18,16 +18,21 @@ import jakarta.validation.constraints.NotNull;
 
 public class CatalogStoreConfig
 {
-    private String catalogStoreKind = "file";
+    public enum CatalogStoreKind
+    {
+        MEMORY, FILE, CUSTOM
+    }
+
+    private CatalogStoreKind catalogStoreKind = CatalogStoreKind.FILE;
 
     @NotNull
-    public String getCatalogStoreKind()
+    public CatalogStoreKind getCatalogStoreKind()
     {
         return catalogStoreKind;
     }
 
     @Config("catalog.store")
-    public CatalogStoreConfig setCatalogStoreKind(String catalogStoreKind)
+    public CatalogStoreConfig setCatalogStoreKind(CatalogStoreKind catalogStoreKind)
     {
         this.catalogStoreKind = catalogStoreKind;
         return this;

--- a/core/trino-main/src/main/java/io/trino/connector/DynamicCatalogManagerModule.java
+++ b/core/trino-main/src/main/java/io/trino/connector/DynamicCatalogManagerModule.java
@@ -24,7 +24,6 @@ import io.trino.spi.catalog.CatalogStore;
 
 import java.util.Locale;
 
-import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 
 public class DynamicCatalogManagerModule
@@ -44,7 +43,6 @@ public class DynamicCatalogManagerModule
                 }
                 default -> {
                     binder.bind(CatalogStoreManager.class).in(Scopes.SINGLETON);
-                    newOptionalBinder(binder, CatalogStoreManager.class).setBinding().to(CatalogStoreManager.class).in(Scopes.SINGLETON);
                     binder.bind(CatalogStore.class).to(CatalogStoreManager.class).in(Scopes.SINGLETON);
                 }
             }

--- a/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
+++ b/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
@@ -137,6 +137,7 @@ import java.util.function.Consumer;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
@@ -276,7 +277,8 @@ public class TestingTrinoServer
 
         if (coordinator) {
             if (catalogMangerKind == CatalogMangerKind.DYNAMIC) {
-                serverProperties.put("catalog.store", "memory");
+                Optional<String> catalogStore = Optional.ofNullable(properties.get("catalog.store"));
+                verify(catalogStore.isPresent(), "catalog.store must be set when dynamic catalogs are used");
             }
             serverProperties.put("failure-detector.enabled", "false");
 

--- a/core/trino-main/src/test/java/io/trino/connector/TestCatalogStoreConfig.java
+++ b/core/trino-main/src/test/java/io/trino/connector/TestCatalogStoreConfig.java
@@ -24,7 +24,7 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertFullMappin
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 
-public class TestingCatalogStoreConfig
+public class TestCatalogStoreConfig
 {
     @Test
     public void testDefaults()

--- a/core/trino-main/src/test/java/io/trino/connector/TestingCatalogStoreConfig.java
+++ b/core/trino-main/src/test/java/io/trino/connector/TestingCatalogStoreConfig.java
@@ -14,8 +14,10 @@
 package io.trino.connector;
 
 import com.google.common.collect.ImmutableMap;
+import io.trino.connector.CatalogStoreConfig.CatalogStoreKind;
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
 import java.util.Map;
 
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
@@ -28,16 +30,22 @@ public class TestingCatalogStoreConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(CatalogStoreConfig.class)
-                .setCatalogStoreKind("file"));
+                .setCatalogStoreKind(CatalogStoreKind.FILE));
     }
 
     @Test
     public void testExplicitPropertyMappings()
     {
-        Map<String, String> properties = ImmutableMap.of("catalog.store", "other");
+        testExplicitPropertyMappings("memory");
+        testExplicitPropertyMappings("custom");
+    }
+
+    private void testExplicitPropertyMappings(String catalogStore)
+    {
+        Map<String, String> properties = ImmutableMap.of("catalog.store", catalogStore);
 
         CatalogStoreConfig expected = new CatalogStoreConfig()
-                .setCatalogStoreKind("other");
+                .setCatalogStoreKind(CatalogStoreKind.valueOf(catalogStore.toUpperCase(Locale.ROOT)));
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Currently a custom catalog store plugin cannot be used because the Guice bindings are incorrect.

Fixes https://github.com/trinodb/trino/issues/22554

I couldn't think of any way to test this other than a product test - but that too would need me to add a custom plugin to the build just to test this - I manually tested this instead for now.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

See https://github.com/trinodb/trino/issues/22554 for details. And https://github.com/trinodb/trino/pull/20489 for earlier changes.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix loading of custom `CatalogStore` implementations. ({issue}`22554`)
```
