### PR TITLE
Update OrderingCompiler.java

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/gen/OrderingCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/OrderingCompiler.java
@@ -271,7 +271,7 @@ public class OrderingCompiler
             comparator = pageWithPositionsComparatorClass.getConstructor().newInstance();
         }
         catch (Throwable t) {
-            log.error(t, "Error compiling comparator for channels %s with order %s", sortChannels, sortChannels);
+            log.error(t, "Error compiling comparator for channels %s with order %s", sortChannels, sortOrders);
             comparator = new SimplePageWithPositionComparator(types, sortChannels, sortOrders, typeOperators);
         }
         return comparator;


### PR DESCRIPTION
The original logging statement incorrectly used `sortChannels` for both the channels and orders in the message. This update corrects the inconsistency by using '`sortOrders`' for the order parameter, aligning the static logging text with the dynamic variables it references, thus adhering to the principle of consistency.
