### PR TITLE
Fix TDigestHistogram serialization across classloaders 

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/metrics/TDigestHistogram.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/metrics/TDigestHistogram.java
@@ -11,19 +11,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.trino.plugin.base.metrics;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.util.StdConverter;
-import io.airlift.slice.Slice;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.google.errorprone.annotations.DoNotCall;
 import io.airlift.stats.TDigest;
 import io.trino.spi.metrics.Distribution;
 
-import java.util.Base64;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -33,11 +29,10 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static java.lang.String.format;
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.NONE) // Do not add @class property
 public class TDigestHistogram
         implements Distribution<TDigestHistogram>
 {
-    @JsonSerialize(converter = TDigestToBase64Converter.class)
-    @JsonDeserialize(converter = Base64ToTDigestConverter.class)
     private final TDigest digest;
 
     public static TDigestHistogram fromValue(double value)
@@ -52,16 +47,27 @@ public class TDigestHistogram
         return new TDigestHistogram(digest);
     }
 
-    @JsonCreator
     public TDigestHistogram(TDigest digest)
     {
         this.digest = digest;
     }
 
-    @JsonProperty
     public synchronized TDigest getDigest()
     {
         return TDigest.copyOf(digest);
+    }
+
+    @JsonProperty("digest")
+    public synchronized byte[] serialize()
+    {
+        return digest.serialize().getBytes();
+    }
+
+    @JsonCreator
+    @DoNotCall
+    public static TDigestHistogram deserialize(@JsonProperty("digest") byte[] digest)
+    {
+        return new TDigestHistogram(TDigest.deserialize(wrappedBuffer(digest)));
     }
 
     @Override
@@ -203,35 +209,5 @@ public class TDigestHistogram
     private static String formatDouble(double value)
     {
         return format(Locale.US, "%.2f", value);
-    }
-
-    public static class TDigestToBase64Converter
-            extends StdConverter<TDigest, String>
-    {
-        public TDigestToBase64Converter()
-        {
-        }
-
-        @Override
-        public String convert(TDigest value)
-        {
-            Slice slice = value.serialize();
-            return Base64.getEncoder().encodeToString(slice.getBytes());
-        }
-    }
-
-    public static class Base64ToTDigestConverter
-            extends StdConverter<String, TDigest>
-    {
-        public Base64ToTDigestConverter()
-        {
-        }
-
-        @Override
-        public TDigest convert(String value)
-        {
-            Slice slice = wrappedBuffer(Base64.getDecoder().decode(value));
-            return TDigest.deserialize(slice);
-        }
     }
 }


### PR DESCRIPTION
`com.fasterxml.jackson.core:jackson-databind` dependency
`and com.fasterxml.jackson.databind.annotation` package
are not part of the SPI so they cannot work properly across
different classloaders.

Instead of using Json(De)Serialize annotations, use JsonCreator and JsonProperty
to serialize TDigest in a desired shape.