### PR TITLE
UseTask - check access before database metadata

### DIFF
--- a/core/trino-main/src/test/java/io/trino/execution/TestQueryStateMachine.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestQueryStateMachine.java
@@ -128,7 +128,8 @@ public class TestQueryStateMachine
     private static final List<String> RESET_SESSION_PROPERTIES = ImmutableList.of("candy");
     private static final Optional<QueryType> QUERY_TYPE = Optional.of(QueryType.SELECT);
 
-    private ExecutorService executor = newCachedThreadPool(daemonThreadsNamed(getClass().getSimpleName() + "=%s"));
+    private static ExecutorService executor = newCachedThreadPool(daemonThreadsNamed(
+            TestQueryStateMachine.class.getSimpleName() + "=%s"));
 
     @AfterAll
     public void tearDown()
@@ -742,17 +743,17 @@ public class TestQueryStateMachine
         }
     }
 
-    private QueryStateMachine createQueryStateMachine()
+    protected static QueryStateMachine createQueryStateMachine()
     {
         return queryStateMachine().build();
     }
 
-    private QueryStateMachineBuilder queryStateMachine()
+    private static QueryStateMachineBuilder queryStateMachine()
     {
         return new QueryStateMachineBuilder();
     }
 
-    private class QueryStateMachineBuilder
+    private static class QueryStateMachineBuilder
     {
         private Ticker ticker = Ticker.systemTicker();
         private Metadata metadata;

--- a/core/trino-main/src/test/java/io/trino/execution/TestUseTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestUseTask.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution;
+
+import io.trino.metadata.AbstractMockMetadata;
+import io.trino.metadata.Metadata;
+import io.trino.security.DenyAllAccessControl;
+import io.trino.security.SecurityContext;
+import io.trino.spi.security.AccessDeniedException;
+import io.trino.sql.tree.Identifier;
+import io.trino.sql.tree.Use;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestUseTask
+{
+    private static final Metadata METADATA = AbstractMockMetadata.dummyMetadata();
+
+    private static final Use STATEMENT =
+            new Use(Optional.of(new Identifier("identifier")), new Identifier("identifier"));
+
+    private static final QueryStateMachine STATE_MACHINE = TestQueryStateMachine.createQueryStateMachine();
+
+    @Test
+    public void checkCatalogAccessBeforeMetadata()
+    {
+        UseTask task = new UseTask(METADATA, new DenyAllAccessControl());
+
+        assertThatThrownBy(() -> task.execute(STATEMENT, STATE_MACHINE, null, null))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("Cannot access catalog");
+    }
+
+    @Test
+    public void checkSchemaAccessBeforeMetadata()
+    {
+        class AllowCatalogAccessControl
+                extends DenyAllAccessControl
+        {
+            @Override
+            public Set<String> filterCatalogs(SecurityContext context, Set<String> catalogs)
+            {
+                return catalogs;
+            }
+        }
+
+        UseTask task = new UseTask(METADATA, new AllowCatalogAccessControl());
+
+        assertThatThrownBy(() -> task.execute(STATEMENT, STATE_MACHINE, null, null))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("Cannot access schema");
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Fixes access control ordering for UseTask. This is one part of #22804 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
