### PR TITLE
Add missing check in PreAggregateCaseAggregations

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PreAggregateCaseAggregations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PreAggregateCaseAggregations.java
@@ -383,36 +383,39 @@ public class PreAggregateCaseAggregations
         }
 
         Expression defaultValue = optimizeExpression(caseExpression.defaultValue(), context);
-        if (defaultValue instanceof Constant(Type type, Object value) && value != null) {
-            if (!name.equals(SUM)) {
-                return Optional.empty();
-            }
+        if (defaultValue instanceof Constant(Type type, Object value)) {
+            if (value != null) {
+                if (!name.equals(SUM)) {
+                    return Optional.empty();
+                }
 
-            // sum aggregation is only supported if default value is null or 0, otherwise it wouldn't be cumulative
-            if (type instanceof BigintType
-                    || type == INTEGER
-                    || type == SMALLINT
-                    || type == TINYINT
-                    || type == DOUBLE
-                    || type == REAL
-                    || type instanceof DecimalType) {
+                // sum aggregation is only supported if default value is null or 0, otherwise it wouldn't be cumulative
                 if (!value.equals(0L) && !value.equals(0.0d) && !value.equals(Int128.ZERO)) {
                     return Optional.empty();
                 }
+
+                if (!(type instanceof BigintType)
+                        && type != INTEGER
+                        && type != SMALLINT
+                        && type != TINYINT
+                        && type != DOUBLE
+                        && type != REAL
+                        && !(type instanceof DecimalType)) {
+                    return Optional.empty();
+                }
             }
-            else {
-                return Optional.empty();
-            }
+
+            return Optional.of(new CaseAggregation(
+                    aggregationSymbol,
+                    resolvedFunction,
+                    cumulativeFunction,
+                    name,
+                    caseExpression.whenClauses().get(0).getOperand(),
+                    caseExpression.whenClauses().get(0).getResult(),
+                    new Cast(caseExpression.defaultValue(), aggregationType)));
         }
 
-        return Optional.of(new CaseAggregation(
-                aggregationSymbol,
-                resolvedFunction,
-                cumulativeFunction,
-                name,
-                caseExpression.whenClauses().get(0).getOperand(),
-                caseExpression.whenClauses().get(0).getResult(),
-                new Cast(caseExpression.defaultValue(), aggregationType)));
+        return Optional.empty();
     }
 
     private Type getType(Expression expression)

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestIssue22806.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestIssue22806.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestIssue22806
+{
+    @Test
+    public void test()
+    {
+        try (QueryAssertions assertions = new QueryAssertions()) {
+            assertThat(assertions.query(
+                    """
+                    SELECT
+                        a,
+                        SUM(CASE WHEN b = 1 THEN c ELSE 0 END),
+                        SUM(CASE WHEN b = 2 THEN 0 ELSE c END),
+                        SUM(CASE WHEN b = 3 THEN 0 ELSE d END),
+                        SUM(CASE WHEN b = 4 THEN d ELSE 0 END)
+                    FROM (
+                      VALUES
+                        (1, 1, 1, 1)
+                    ) t(a, b, c, d)
+                    GROUP BY a
+                    """))
+                    .matches("VALUES  (1, BIGINT '1' , BIGINT '1', BIGINT '1', BIGINT '0')");
+        }
+    }
+}


### PR DESCRIPTION
In 69ac97ac72a954471420f6c6c707d279691eb142, a check allowing for the result of the call to optimize an expression to be a non-constant expression was lost:

    Object defaultValue = optimizeExpression(caseExpression.defaultValue().get(), context);
    if (defaultValue != null) {
      ...
    }

As a result, the optimization produced plans with references to invalid columns.

This change restores the check and cleans up the nested if/else structure to make it more readable.

Fixes https://github.com/trinodb/trino/issues/22806

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix planning failure for queries involving multiple aggregations and `CASE` expressions. ({issue}`22806`)
```
