### PR TITLE
Update docker images to 99

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
         <dep.aws-sdk.version>1.12.761</dep.aws-sdk.version>
         <dep.cassandra.version>4.17.0</dep.cassandra.version>
         <dep.confluent.version>7.5.1</dep.confluent.version>
-        <dep.docker.images.version>98</dep.docker.images.version>
+        <dep.docker.images.version>99</dep.docker.images.version>
         <dep.drift.version>1.22</dep.drift.version>
         <dep.errorprone.version>2.29.2</dep.errorprone.version>
         <dep.flyway.version>10.16.0</dep.flyway.version>


### PR DESCRIPTION
## Description

* https://github.com/trinodb/docker-images/pull/204
* https://github.com/trinodb/docker-images/pull/203

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
