### PR TITLE
Skip PreAggregateCaseAggregations it aggregations are not reduced

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PreAggregateCaseAggregations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PreAggregateCaseAggregations.java
@@ -161,6 +161,11 @@ public class PreAggregateCaseAggregations
         }
 
         Map<PreAggregationKey, PreAggregation> preAggregations = getPreAggregations(aggregations, context);
+        if (preAggregations.size() == aggregations.size()) {
+            // Prevent rule execution if number of pre-aggregations is equal to number of case aggregations.
+            // In such case there is no gain in performance, and it could lead to infinite rule execution loop.
+            return Result.empty();
+        }
 
         Assignments.Builder preGroupingExpressionsBuilder = Assignments.builder();
         preGroupingExpressionsBuilder.putIdentities(extraGroupingKeys);

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPreAggregateCaseAggregations.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPreAggregateCaseAggregations.java
@@ -288,6 +288,7 @@ public class TestPreAggregateCaseAggregations
                 "SELECT " +
                 "col_varchar, " +
                 "sum(CASE WHEN col_bigint = 1 THEN col_bigint ELSE BIGINT '0' END), " +
+                "sum(CASE WHEN col_bigint = 2 THEN col_bigint ELSE BIGINT '0' END), " +
                 "sum(CASE WHEN col_bigint = 2 THEN col_tinyint ELSE TINYINT '0' END), " +
                 "sum(CASE WHEN col_bigint = 3 THEN col_double ELSE DOUBLE '0' END), " +
                 "sum(CASE WHEN col_bigint = 4 THEN col_decimal ELSE DECIMAL '0.0' END), " +
@@ -422,6 +423,19 @@ public class TestPreAggregateCaseAggregations
                         "sum(col_decimal) " +
                         "FROM t " +
                         "GROUP BY col_varchar");
+    }
+
+    @Test
+    public void testDoesNotFireIfAggregationsAreNotReduced()
+    {
+        assertThatDoesNotFire("""
+                SELECT
+                    SUM(IF(col_varchar != 'V', col_bigint + col_decimal)),
+                    SUM(IF(col_varchar != 'V', col_decimal + col_tinyint)),
+                    SUM(IF(col_varchar != 'V', col_tinyint + col_double)),
+                    SUM(IF(col_varchar != 'V', col_double + col_bigint))
+                FROM t
+                """);
     }
 
     private void assertFires(@Language("SQL") String query)

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestAggregations.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestAggregations.java
@@ -70,23 +70,25 @@ public class TestAggregations
                 "SELECT " +
                         "key, " +
                         "sum(CASE WHEN sequence = 0 THEN value END), " +
+                        "sum(CASE WHEN sequence = 2 THEN value END), " +
                         "min(CASE WHEN sequence = 1 THEN value ELSE null END), " +
                         "max(CASE WHEN sequence = 0 THEN value END), " +
                         "sum(CASE WHEN sequence = 1 THEN cast(value * 2 as real) ELSE cast(0 as real) END) " +
                         "FROM test_table " +
                         "GROUP BY key",
-                "VALUES ('a', 1, 2, 1, 10), ('b', 21, 13, 11, 54)",
+                "VALUES ('a', 1, null, 2, 1, 10), ('b', 21, null, 13, 11, 54)",
                 plan -> assertAggregationNodeCount(plan, 4));
 
         assertQuery(
                 memorySession,
                 "SELECT " +
                         "sum(CASE WHEN sequence = 0 THEN value END), " +
+                        "sum(CASE WHEN sequence = 2 THEN value END), " +
                         "min(CASE WHEN sequence = 1 THEN value ELSE null END), " +
                         "max(CASE WHEN sequence = 0 THEN value END), " +
                         "sum(CASE WHEN sequence = 1 THEN value * 2 ELSE 0 END) " +
                         "FROM test_table",
-                "VALUES (22, 2, 11, 64)",
+                "VALUES (22, null, 2, 11, 64)",
                 plan -> assertAggregationNodeCount(plan, 4));
 
         assertQuery(
@@ -94,12 +96,13 @@ public class TestAggregations
                 "SELECT " +
                         "key, " +
                         "sum(CASE WHEN sequence = 0 THEN value END), " +
+                        "sum(CASE WHEN sequence = 2 THEN value END), " +
                         "min(CASE WHEN sequence = 1 THEN value ELSE null END), " +
                         "max(CASE WHEN sequence = 0 THEN value END), " +
                         "sum(CASE WHEN sequence = 1 THEN value * 2 ELSE 1 END) " +
                         "FROM test_table " +
                         "GROUP BY key",
-                "VALUES ('a', 1, 2, 1, 12), ('b', 21, 13, 11, 56)",
+                "VALUES ('a', 1, null, 2, 1, 12), ('b', 21, null, 13, 11, 56)",
                 plan -> assertAggregationNodeCount(plan, 2));
 
         // non null default value on max aggregation
@@ -108,12 +111,13 @@ public class TestAggregations
                 "SELECT " +
                         "key, " +
                         "sum(CASE WHEN sequence = 0 THEN value END), " +
+                        "sum(CASE WHEN sequence = 2 THEN value END), " +
                         "min(CASE WHEN sequence = 1 THEN value ELSE null END), " +
                         "max(CASE WHEN sequence = 0 THEN value END), " +
                         "max(CASE WHEN sequence = 1 THEN value * 2 ELSE 100 END) " +
                         "FROM test_table " +
                         "GROUP BY key",
-                "VALUES ('a', 1, 2, 1, 100), ('b', 21, 13, 11, 100)",
+                "VALUES ('a', 1, null, 2, 1, 100), ('b', 21, null, 13, 11, 100)",
                 plan -> assertAggregationNodeCount(plan, 2));
 
         // no rows matching sequence number
@@ -149,12 +153,13 @@ public class TestAggregations
                 memorySession,
                 "SELECT " +
                         "sum(CASE WHEN sequence = 0 THEN value END), " +
+                        "sum(CASE WHEN sequence = 2 THEN value END), " +
                         "min(CASE WHEN sequence = 1 THEN value ELSE null END), " +
                         "max(CASE WHEN sequence = 0 THEN value END), " +
                         "sum(CASE WHEN sequence = 1 THEN value * 2 ELSE 0 END) " +
                         "FROM test_table " +
                         "WHERE sequence = 42",
-                "VALUES (null, null, null, null)",
+                "VALUES (null, null, null, null, null)",
                 plan -> assertAggregationNodeCount(plan, 4));
     }
 


### PR DESCRIPTION
If the number of pre-aggregations is equal to number of case aggregations, then there is no performance gain in rule execution. Additionally, firing rule in such case could lead to infinite rule execution loop, since new pre-aggregations could be eligable for further optimization.

Alternative approach to: https://github.com/trinodb/trino/pull/22666

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix optimizer timeout for certain queries involving aggregations and `CASE` expressions. ({issue}`22813`)
```
