### PR TITLE
Fix past table versions listing in vacuum procedure

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogAccess.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogAccess.java
@@ -596,7 +596,7 @@ public class TransactionLogAccess
             }
             catch (FileNotFoundException e) {
                 // no longer exists, break iteration
-                return null;
+                break;
             }
             catch (IOException e) {
                 throw new UncheckedIOException(e);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
When listing past table versions, correctly break iteration once we get to a file which no longer exists, e.g. removed by an external system.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Motivation: vacuum procedure call would otherwise fail with `NullPointerException` when setting the retention to a value which overlaps with externally deleted log file.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
