### PR TITLE
Remove line endings from prometheus bearer token

### DIFF
--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusClient.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusClient.java
@@ -180,7 +180,7 @@ public class PrometheusClient
     {
         return bearerTokenFile.map(tokenFileName -> {
             try {
-                return readString(tokenFileName.toPath(), UTF_8);
+                return readString(tokenFileName.toPath(), UTF_8).replace("\n", "").replace("\r", "");
             }
             catch (IOException e) {
                 throw new TrinoException(PROMETHEUS_UNKNOWN_ERROR, "Failed to read bearer token file: " + tokenFileName, e);


### PR DESCRIPTION
PrometheusClient

https://github.com/trinodb/trino/issues/22818

This resolves errors when the client attempts to authenticate but errors from an 0x0a (LR) at the end of the string that is not present in the source file.

 On branch prometheus_client_token_LR_fix
 Changes to be committed:
	modified:   plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusClient.java

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This resolves errors when the client attempts to authenticate but errors from an 0x0a (LR) at the end of the string that is not present in the source file.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
The readString adds an LR character at the end of the prometheus authentication token, causing Promethues auth to fail. This patch strips line ending characters `\r` and `\r` 


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( x) Release notes are required, with the following suggested text:
The readString adds an LR character at the end of the prometheus authentication token, causing Promethues auth to fail. This patch strips line ending characters `\r` and `\n` 
https://github.com/trinodb/trino/issues/22818

```markdown
# Section
* This resolves errors when the client attempts to authenticate but errors from an 0x0a (LR) at the end of the string that is not present in the source file. [https://github.com/trinodb/trino/issues/22818]
```
