### PR TITLE
Expose FileSystemExchangeSource metrics

### DIFF
--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeStorage.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeStorage.java
@@ -25,7 +25,7 @@ public interface FileSystemExchangeStorage
     void createDirectories(URI dir)
             throws IOException;
 
-    ExchangeStorageReader createExchangeStorageReader(List<ExchangeSourceFile> sourceFiles, int maxPageStorageSize);
+    ExchangeStorageReader createExchangeStorageReader(List<ExchangeSourceFile> sourceFiles, int maxPageStorageSize, MetricsBuilder metricsBuilder);
 
     ExchangeStorageWriter createExchangeStorageWriter(URI file);
 

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/MetricsBuilder.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/MetricsBuilder.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.exchange.filesystem;
+
+import io.airlift.stats.TDigest;
+import io.trino.plugin.base.metrics.LongCount;
+import io.trino.plugin.base.metrics.TDigestHistogram;
+import io.trino.spi.metrics.Metric;
+import io.trino.spi.metrics.Metrics;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+
+public class MetricsBuilder
+{
+    public static final String SOURCE_FILES_TOTAL = "FileSystemExchangeSource.filesTotal";
+    public static final String SOURCE_FILES_PROCESSED = "FileSystemExchangeSource.filesProcessed";
+
+    private final ConcurrentMap<String, MetricBuilder> metricBuilders = new ConcurrentHashMap<>();
+
+    public Metrics buildMetrics()
+    {
+        return new Metrics(
+                metricBuilders.entrySet().stream()
+                        .collect(toImmutableMap(
+                                Map.Entry::getKey,
+                                entry -> entry.getValue().build())));
+    }
+
+    private interface MetricBuilder
+    {
+        Metric<?> build();
+    }
+
+    public CounterMetricBuilder getCounterMetric(String key)
+    {
+        return (CounterMetricBuilder) metricBuilders.computeIfAbsent(key, _ -> new CounterMetricBuilder());
+    }
+
+    public DistributionMetricBuilder getDistributionMetric(String key)
+    {
+        return (DistributionMetricBuilder) metricBuilders.computeIfAbsent(key, _ -> new DistributionMetricBuilder());
+    }
+
+    public static class CounterMetricBuilder
+            implements MetricBuilder
+    {
+        private final AtomicLong counter = new AtomicLong();
+
+        public void increment()
+        {
+            counter.incrementAndGet();
+        }
+
+        public void add(long delta)
+        {
+            counter.addAndGet(delta);
+        }
+
+        @Override
+        public Metric<?> build()
+        {
+            return new LongCount(counter.get());
+        }
+    }
+
+    public static class DistributionMetricBuilder
+            implements MetricBuilder
+    {
+        private final TDigest digest = new TDigest();
+
+        public synchronized void add(double value)
+        {
+            digest.add(value);
+        }
+
+        @Override
+        public synchronized Metric<?> build()
+        {
+            return new TDigestHistogram(TDigest.copyOf(digest));
+        }
+    }
+}

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/local/LocalFileSystemExchangeStorage.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/local/LocalFileSystemExchangeStorage.java
@@ -27,6 +27,8 @@ import io.trino.plugin.exchange.filesystem.ExchangeStorageReader;
 import io.trino.plugin.exchange.filesystem.ExchangeStorageWriter;
 import io.trino.plugin.exchange.filesystem.FileStatus;
 import io.trino.plugin.exchange.filesystem.FileSystemExchangeStorage;
+import io.trino.plugin.exchange.filesystem.MetricsBuilder;
+import io.trino.plugin.exchange.filesystem.MetricsBuilder.CounterMetricBuilder;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -50,6 +52,7 @@ import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
+import static io.trino.plugin.exchange.filesystem.MetricsBuilder.SOURCE_FILES_PROCESSED;
 import static java.lang.Math.toIntExact;
 import static java.nio.file.Files.createFile;
 import static java.util.Objects.requireNonNull;
@@ -67,9 +70,9 @@ public class LocalFileSystemExchangeStorage
     }
 
     @Override
-    public ExchangeStorageReader createExchangeStorageReader(List<ExchangeSourceFile> sourceFiles, int maxPageStorageSize)
+    public ExchangeStorageReader createExchangeStorageReader(List<ExchangeSourceFile> sourceFiles, int maxPageStorageSize, MetricsBuilder metricsBuilder)
     {
-        return new LocalExchangeStorageReader(sourceFiles);
+        return new LocalExchangeStorageReader(sourceFiles, metricsBuilder);
     }
 
     @Override
@@ -140,15 +143,18 @@ public class LocalFileSystemExchangeStorage
 
         @GuardedBy("this")
         private final Queue<ExchangeSourceFile> sourceFiles;
+        CounterMetricBuilder sourceFilesProcessedMetric;
 
         @GuardedBy("this")
         private InputStreamSliceInput sliceInput;
         @GuardedBy("this")
         private boolean closed;
 
-        public LocalExchangeStorageReader(List<ExchangeSourceFile> sourceFiles)
+        public LocalExchangeStorageReader(List<ExchangeSourceFile> sourceFiles, MetricsBuilder metricsBuilder)
         {
             this.sourceFiles = new ArrayDeque<>(requireNonNull(sourceFiles, "sourceFiles is null"));
+            requireNonNull(metricsBuilder, "metricsBuilder is null");
+            sourceFilesProcessedMetric = metricsBuilder.getCounterMetric(SOURCE_FILES_PROCESSED);
         }
 
         @Override
@@ -165,6 +171,7 @@ public class LocalFileSystemExchangeStorage
                 }
                 else {
                     sliceInput.close();
+                    sourceFilesProcessedMetric.increment();
                 }
             }
 

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/s3/S3FileSystemExchangeStorage.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/s3/S3FileSystemExchangeStorage.java
@@ -20,6 +20,7 @@ import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageBatch;
 import com.google.cloud.storage.StorageOptions;
+import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Lists;
@@ -43,6 +44,9 @@ import io.trino.plugin.exchange.filesystem.ExchangeStorageReader;
 import io.trino.plugin.exchange.filesystem.ExchangeStorageWriter;
 import io.trino.plugin.exchange.filesystem.FileStatus;
 import io.trino.plugin.exchange.filesystem.FileSystemExchangeStorage;
+import io.trino.plugin.exchange.filesystem.MetricsBuilder;
+import io.trino.plugin.exchange.filesystem.MetricsBuilder.CounterMetricBuilder;
+import io.trino.plugin.exchange.filesystem.MetricsBuilder.DistributionMetricBuilder;
 import jakarta.annotation.PreDestroy;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -113,11 +117,13 @@ import static io.airlift.concurrent.Threads.threadsNamed;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.plugin.exchange.filesystem.FileSystemExchangeFutures.translateFailures;
 import static io.trino.plugin.exchange.filesystem.FileSystemExchangeManager.PATH_SEPARATOR;
+import static io.trino.plugin.exchange.filesystem.MetricsBuilder.SOURCE_FILES_PROCESSED;
 import static io.trino.plugin.exchange.filesystem.s3.S3FileSystemExchangeStorage.CompatibilityMode.GCP;
 import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElseGet;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static software.amazon.awssdk.core.async.AsyncRequestBody.fromByteBufferUnsafe;
 import static software.amazon.awssdk.core.client.config.SdkAdvancedClientOption.USER_AGENT_PREFIX;
@@ -226,9 +232,9 @@ public class S3FileSystemExchangeStorage
     }
 
     @Override
-    public ExchangeStorageReader createExchangeStorageReader(List<ExchangeSourceFile> sourceFiles, int maxPageStorageSize)
+    public ExchangeStorageReader createExchangeStorageReader(List<ExchangeSourceFile> sourceFiles, int maxPageStorageSize, MetricsBuilder metricsBuilder)
     {
-        return new S3ExchangeStorageReader(stats, s3AsyncClient, multiUploadPartSize, sourceFiles, maxPageStorageSize);
+        return new S3ExchangeStorageReader(stats, s3AsyncClient, multiUploadPartSize, sourceFiles, metricsBuilder, maxPageStorageSize);
     }
 
     @Override
@@ -489,6 +495,9 @@ public class S3FileSystemExchangeStorage
 
         private final S3FileSystemExchangeStorageStats stats;
         private final S3AsyncClient s3AsyncClient;
+        CounterMetricBuilder sourceFilesProcessedMetric;
+        DistributionMetricBuilder s3GetObjectRequestsSuccessMetric;
+        DistributionMetricBuilder s3GetObjectRequestsFailedMetric;
         private final int partSize;
         private final int bufferSize;
 
@@ -511,12 +520,17 @@ public class S3FileSystemExchangeStorage
                 S3AsyncClient s3AsyncClient,
                 int partSize,
                 List<ExchangeSourceFile> sourceFiles,
+                MetricsBuilder metricsBuilder,
                 int maxPageStorageSize)
         {
             this.stats = requireNonNull(stats, "stats is null");
             this.s3AsyncClient = requireNonNull(s3AsyncClient, "s3AsyncClient is null");
             this.partSize = partSize;
             this.sourceFiles = new ArrayDeque<>(requireNonNull(sourceFiles, "sourceFiles is null"));
+            requireNonNull(metricsBuilder, "metricsBuilder is null");
+            sourceFilesProcessedMetric = metricsBuilder.getCounterMetric(SOURCE_FILES_PROCESSED);
+            s3GetObjectRequestsSuccessMetric = metricsBuilder.getDistributionMetric("FileSystemExchangeSource.s3GetObjectRequestsSuccess");
+            s3GetObjectRequestsFailedMetric = metricsBuilder.getDistributionMetric("FileSystemExchangeSource.s3GetObjectRequestsFailed");
             // Make sure buffer can accommodate at least one complete Slice, and keep reads aligned to part boundaries
             this.bufferSize = maxPageStorageSize + partSize;
 
@@ -640,12 +654,14 @@ public class S3FileSystemExchangeStorage
                             BufferWriteAsyncResponseTransformer.toBufferWrite(buffer, bufferFill)));
                     stats.getGetObject().record(getObjectFuture);
                     stats.getGetObjectDataSizeInBytes().add(length);
+                    recordDistributionMetric(getObjectFuture, s3GetObjectRequestsSuccessMetric, s3GetObjectRequestsFailedMetric);
                     getObjectFutures.add(getObjectFuture);
                     bufferFill += length;
                     fileOffset += length;
                 }
 
                 if (fileOffset == fileSize) {
+                    sourceFilesProcessedMetric.increment();
                     currentFile = sourceFiles.poll();
                     if (currentFile == null) {
                         break;
@@ -658,6 +674,25 @@ public class S3FileSystemExchangeStorage
             sliceInput = Slices.wrappedBuffer(buffer, 0, bufferFill).getInput();
             bufferRetainedSize = sliceInput.getRetainedSize();
         }
+    }
+
+    private static <T> void recordDistributionMetric(ListenableFuture<T> future, DistributionMetricBuilder successMetric, DistributionMetricBuilder failureMetric)
+    {
+        Stopwatch stopwatch = Stopwatch.createStarted();
+        Futures.addCallback(future, new FutureCallback<T>()
+        {
+            @Override
+            public void onSuccess(T result)
+            {
+                successMetric.add(stopwatch.elapsed(MILLISECONDS));
+            }
+
+            @Override
+            public void onFailure(Throwable t)
+            {
+                failureMetric.add(stopwatch.elapsed(MILLISECONDS));
+            }
+        }, directExecutor());
     }
 
     @NotThreadSafe

--- a/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/HadoopFileSystemExchangeStorage.java
+++ b/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/HadoopFileSystemExchangeStorage.java
@@ -26,6 +26,7 @@ import io.trino.plugin.exchange.filesystem.ExchangeStorageReader;
 import io.trino.plugin.exchange.filesystem.ExchangeStorageWriter;
 import io.trino.plugin.exchange.filesystem.FileStatus;
 import io.trino.plugin.exchange.filesystem.FileSystemExchangeStorage;
+import io.trino.plugin.exchange.filesystem.MetricsBuilder;
 import io.trino.spi.classloader.ThreadContextClassLoader;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -47,6 +48,7 @@ import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.airlift.slice.SizeOf.instanceSize;
+import static io.trino.plugin.exchange.filesystem.MetricsBuilder.SOURCE_FILES_PROCESSED;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
@@ -77,9 +79,9 @@ public class HadoopFileSystemExchangeStorage
     }
 
     @Override
-    public ExchangeStorageReader createExchangeStorageReader(List<ExchangeSourceFile> sourceFiles, int maxPageStorageSize)
+    public ExchangeStorageReader createExchangeStorageReader(List<ExchangeSourceFile> sourceFiles, int maxPageStorageSize, MetricsBuilder metricsBuilder)
     {
-        return new HadoopExchangeStorageReader(fileSystem, sourceFiles, blockSize);
+        return new HadoopExchangeStorageReader(fileSystem, sourceFiles, metricsBuilder, blockSize);
     }
 
     @Override
@@ -159,6 +161,7 @@ public class HadoopFileSystemExchangeStorage
         private final FileSystem fileSystem;
         @GuardedBy("this")
         private final Queue<ExchangeSourceFile> sourceFiles;
+        private final MetricsBuilder.CounterMetricBuilder sourceFilesProcessedMetric;
         private final int blockSize;
 
         @GuardedBy("this")
@@ -166,10 +169,12 @@ public class HadoopFileSystemExchangeStorage
         @GuardedBy("this")
         private boolean closed;
 
-        public HadoopExchangeStorageReader(FileSystem fileSystem, List<ExchangeSourceFile> sourceFiles, int blockSize)
+        public HadoopExchangeStorageReader(FileSystem fileSystem, List<ExchangeSourceFile> sourceFiles, MetricsBuilder metricsBuilder, int blockSize)
         {
             this.fileSystem = requireNonNull(fileSystem, "fileSystem is null");
             this.sourceFiles = new ArrayDeque<>(requireNonNull(sourceFiles, "sourceFiles is null"));
+            requireNonNull(metricsBuilder, "metricsBuilder is null");
+            sourceFilesProcessedMetric = metricsBuilder.getCounterMetric(SOURCE_FILES_PROCESSED);
             this.blockSize = blockSize;
         }
 
@@ -187,6 +192,7 @@ public class HadoopFileSystemExchangeStorage
                 }
                 else {
                     sliceInput.close();
+                    sourceFilesProcessedMetric.increment();
                 }
             }
 


### PR DESCRIPTION
Reitroduce https://github.com/trinodb/trino/pull/22775.
Now safe after https://github.com/trinodb/trino/pull/22797