### PR TITLE
Normalize name when dropping catalogs

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/DropCatalogTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropCatalogTask.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
 public class DropCatalogTask
@@ -59,8 +60,9 @@ public class DropCatalogTask
             throw new TrinoException(NOT_SUPPORTED, "CASCADE is not yet supported for DROP SCHEMA");
         }
 
-        accessControl.checkCanDropCatalog(stateMachine.getSession().toSecurityContext(), statement.getCatalogName().toString());
-        catalogManager.dropCatalog(new CatalogName(statement.getCatalogName().toString()), statement.isExists());
+        String catalogName = statement.getCatalogName().getValue().toLowerCase(ENGLISH);
+        accessControl.checkCanDropCatalog(stateMachine.getSession().toSecurityContext(), catalogName);
+        catalogManager.dropCatalog(new CatalogName(catalogName), statement.isExists());
         return immediateVoidFuture();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/TestDropCatalogTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestDropCatalogTask.java
@@ -40,6 +40,7 @@ import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.execution.querystats.PlanOptimizersStatsCollector.createPlanOptimizersStatsCollector;
 import static io.trino.testing.TestingSession.testSession;
 import static java.util.Collections.emptyList;
+import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
@@ -94,6 +95,17 @@ public class TestDropCatalogTask
         DropCatalog statement = new DropCatalog(new Identifier(TEST_CATALOG), true, false);
         getFutureValue(task.execute(statement, createNewQuery(), emptyList(), WarningCollector.NOOP));
         assertThat(queryRunner.getPlannerContext().getMetadata().catalogExists(createNewQuery().getSession(), TEST_CATALOG)).isFalse();
+        getFutureValue(task.execute(statement, createNewQuery(), emptyList(), WarningCollector.NOOP));
+        assertThat(queryRunner.getPlannerContext().getMetadata().catalogExists(createNewQuery().getSession(), TEST_CATALOG)).isFalse();
+    }
+
+    @Test
+    void testCaseInsensitiveDropCatalog()
+    {
+        queryRunner.createCatalog(TEST_CATALOG, "tpch", ImmutableMap.of());
+        assertThat(queryRunner.getPlannerContext().getMetadata().catalogExists(createNewQuery().getSession(), TEST_CATALOG)).isTrue();
+
+        DropCatalog statement = new DropCatalog(new Identifier(TEST_CATALOG.toUpperCase(ENGLISH)), false, false);
         getFutureValue(task.execute(statement, createNewQuery(), emptyList(), WarningCollector.NOOP));
         assertThat(queryRunner.getPlannerContext().getMetadata().catalogExists(createNewQuery().getSession(), TEST_CATALOG)).isFalse();
     }


### PR DESCRIPTION
## Description

The example failure:
```sql
trino> CREATE CATALOG "t" USING tpch;
CREATE CATALOG
trino> DROP CATALOG "t";
Query 20240726_123547_00686_j342b failed: Catalog '"t"' not found
io.trino.spi.TrinoException: Catalog '"t"' not found
	at io.trino.connector.CoordinatorDynamicCatalogManager.dropCatalog(CoordinatorDynamicCatalogManager.java:328)
	at io.trino.execution.DropCatalogTask.execute(DropCatalogTask.java:63)
	at io.trino.execution.DropCatalogTask.execute(DropCatalogTask.java:32)
	at io.trino.execution.DataDefinitionExecution.start(DataDefinitionExecution.java:146)
	at io.trino.execution.SqlQueryManager.createQuery(SqlQueryManager.java:272)
	at io.trino.dispatcher.LocalDispatchQuery.startExecution(LocalDispatchQuery.java:145)
	at io.trino.dispatcher.LocalDispatchQuery.lambda$waitForMinimumWorkers$2(LocalDispatchQuery.java:129)
	at io.airlift.concurrent.MoreFutures.lambda$addSuccessCallback$12(MoreFutures.java:570)
	at io.airlift.concurrent.MoreFutures$3.onSuccess(MoreFutures.java:545)
	at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1137)
	at io.trino.$gen.Trino_446____20240726_120529_2.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1570)
```

## Release notes

```markdown
# General
* Fix some things. ({issue}`issuenumber`)
```
