### PR TITLE
Fix wrong Delta Lake change in 449 release note

### DIFF
--- a/docs/src/main/sphinx/release/release-449.md
+++ b/docs/src/main/sphinx/release/release-449.md
@@ -26,8 +26,8 @@
 * Add support for configuring the request retry policy on the native S3
   filesystem with the `s3.retry-mode` and `s3.max-error-retries` configuration
   properties. ({issue}`21900`)
-* Automatically use `varchar` in struct types as a type during table creation
-  when `char` is specified. ({issue}`21511`)
+* Automatically use `timestamp(6)` in struct types as a type during table creation
+  when `timestamp` is specified. ({issue}`21511`)
 * Improve performance of writing data files. ({issue}`22089`)
 * Fix query failure when the `hive.metastore.glue.catalogid` configuration
   property is set. ({issue}`22048`)


### PR DESCRIPTION
## Description

The expected type is `timestamp` type:
https://github.com/trinodb/trino/pull/21721/files#diff-79f367e47040dda32ac81ecec46b27cfd7cc822858bc8c31fe435a15a47446dcR670

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
