### PR TITLE
Proof of concept - add hybrid security mode for views

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -104,7 +104,7 @@ statement
         (WITH properties)? AS rootQuery                                #createMaterializedView
     | CREATE (OR REPLACE)? VIEW qualifiedName
         (COMMENT string)?
-        (SECURITY (DEFINER | INVOKER))?
+        (SECURITY (DEFINER | INVOKER | HYBRID))?
         (WITH properties)? AS rootQuery                                #createView
     | REFRESH MATERIALIZED VIEW qualifiedName                          #refreshMaterializedView
     | DROP MATERIALIZED VIEW (IF EXISTS)? qualifiedName                #dropMaterializedView
@@ -881,7 +881,7 @@ routineCharacteristic
     | NOT? DETERMINISTIC                #deterministicCharacteristic
     | RETURNS NULL ON NULL INPUT        #returnsNullOnNullInputCharacteristic
     | CALLED ON NULL INPUT              #calledOnNullInputCharacteristic
-    | SECURITY (DEFINER | INVOKER)      #securityCharacteristic
+    | SECURITY (DEFINER | INVOKER | HYBRID)      #securityCharacteristic
     | COMMENT string                    #commentCharacteristic
     ;
 
@@ -992,7 +992,7 @@ nonReserved
     | ELSEIF | EMPTY | ENCODING | ERROR | EXCLUDING | EXECUTE | EXPLAIN
     | FETCH | FILTER | FINAL | FIRST | FOLLOWING | FORMAT | FUNCTION | FUNCTIONS
     | GRACE | GRANT | GRANTED | GRANTS | GRAPHVIZ | GROUPS
-    | HOUR
+    | HOUR | HYBRID
     | IF | IGNORE | IMMEDIATE | INCLUDING | INITIAL | INPUT | INTERVAL | INVOKER | IO | ITERATE | ISOLATION
     | JSON
     | KEEP | KEY | KEYS
@@ -1114,6 +1114,7 @@ GROUPING: 'GROUPING';
 GROUPS: 'GROUPS';
 HAVING: 'HAVING';
 HOUR: 'HOUR';
+HYBRID: 'HYBRID';
 IF: 'IF';
 IGNORE: 'IGNORE';
 IMMEDIATE: 'IMMEDIATE';

--- a/core/trino-main/src/main/java/io/trino/execution/CreateViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateViewTask.java
@@ -31,6 +31,7 @@ import io.trino.sql.analyzer.Analysis;
 import io.trino.sql.analyzer.AnalyzerFactory;
 import io.trino.sql.parser.SqlParser;
 import io.trino.sql.tree.CreateView;
+import io.trino.sql.tree.CreateView.Security;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.NodeRef;
 import io.trino.sql.tree.Parameter;
@@ -143,6 +144,7 @@ public class CreateViewTask
                 columns,
                 statement.getComment(),
                 owner,
+                statement.getSecurity().orElse(null) == Security.HYBRID,
                 session.getPath().getPath().stream()
                         // system path elements currently are not stored
                         .filter(element -> !element.getCatalogName().equals(GlobalSystemConnector.NAME))

--- a/core/trino-main/src/main/java/io/trino/metadata/LanguageFunctionManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/LanguageFunctionManager.java
@@ -495,7 +495,7 @@ public class LanguageFunctionManager
                 Session functionSession = createFunctionSession(newIdentity);
 
                 if (!identity.getUser().equals(session.getUser())) {
-                    accessControl = new ViewAccessControl(accessControl);
+                    accessControl = new ViewAccessControl(accessControl, functionSession.toSecurityContext());
                 }
 
                 return new FunctionContext(functionSession, accessControl);

--- a/core/trino-main/src/main/java/io/trino/metadata/MaterializedViewDefinition.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MaterializedViewDefinition.java
@@ -44,7 +44,7 @@ public class MaterializedViewDefinition
             List<CatalogSchemaName> path,
             Optional<CatalogSchemaTableName> storageTable)
     {
-        super(originalSql, catalog, schema, columns, comment, Optional.of(owner), path);
+        super(originalSql, catalog, schema, columns, comment, Optional.of(owner), false, path);
         this.gracePeriod = requireNonNull(gracePeriod, "gracePeriod is null");
         checkArgument(gracePeriod.isEmpty() || !gracePeriod.get().isNegative(), "gracePeriod cannot be negative: %s", gracePeriod);
         this.storageTable = requireNonNull(storageTable, "storageTable is null");

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -1543,6 +1543,7 @@ public final class MetadataManager
                         .collect(toImmutableList()),
                 view.getComment(),
                 runAsIdentity,
+                view.isHybrid(),
                 view.getPath());
     }
 

--- a/core/trino-main/src/main/java/io/trino/metadata/ViewDefinition.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/ViewDefinition.java
@@ -33,6 +33,7 @@ public class ViewDefinition
     private final List<ViewColumn> columns;
     private final Optional<String> comment;
     private final Optional<Identity> runAsIdentity;
+    private final boolean hybrid;
     private final List<CatalogSchemaName> path;
 
     public ViewDefinition(
@@ -42,6 +43,7 @@ public class ViewDefinition
             List<ViewColumn> columns,
             Optional<String> comment,
             Optional<Identity> runAsIdentity,
+            boolean hybrid,
             List<CatalogSchemaName> path)
     {
         this.originalSql = requireNonNull(originalSql, "originalSql is null");
@@ -50,6 +52,7 @@ public class ViewDefinition
         this.columns = List.copyOf(requireNonNull(columns, "columns is null"));
         this.comment = requireNonNull(comment, "comment is null");
         this.runAsIdentity = requireNonNull(runAsIdentity, "runAsIdentity is null");
+        this.hybrid = hybrid;
         this.path = requireNonNull(path, "path is null");
         checkArgument(schema.isEmpty() || catalog.isPresent(), "catalog must be present if schema is present");
         checkArgument(!columns.isEmpty(), "columns list is empty");
@@ -90,6 +93,10 @@ public class ViewDefinition
         return runAsIdentity;
     }
 
+    public boolean isHybrid() {
+		return hybrid;
+	}
+
     public List<CatalogSchemaName> getPath()
     {
         return path;
@@ -107,6 +114,7 @@ public class ViewDefinition
                 comment,
                 runAsIdentity.map(Identity::getUser),
                 runAsIdentity.isEmpty(),
+                hybrid,
                 path);
     }
 
@@ -120,6 +128,7 @@ public class ViewDefinition
                 .add("columns", columns)
                 .add("comment", comment.orElse(null))
                 .add("runAsIdentity", runAsIdentity.orElse(null))
+                .add("hybrid", hybrid)
                 .add("path", path)
                 .toString();
     }

--- a/core/trino-main/src/main/java/io/trino/security/ViewAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/ViewAccessControl.java
@@ -30,10 +30,12 @@ public class ViewAccessControl
         extends ForwardingAccessControl
 {
     private final AccessControl delegate;
+	private final SecurityContext viewContext;
 
-    public ViewAccessControl(AccessControl delegate)
+    public ViewAccessControl(AccessControl delegate, SecurityContext viewContext)
     {
         this.delegate = requireNonNull(delegate, "delegate is null");
+        this.viewContext = requireNonNull(viewContext, "viewContext is null");
     }
 
     @Override
@@ -49,43 +51,43 @@ public class ViewAccessControl
         // In SQL, views are special in that they execute with permissions of the owner.
         // This means that the owner of the view is effectively granting permissions to the user running the query,
         // and thus must have the equivalent of the SQL standard "GRANT ... WITH GRANT OPTION".
-        wrapAccessDeniedException(() -> delegate.checkCanCreateViewWithSelectFromColumns(context, tableName, columnNames));
+        wrapAccessDeniedException(() -> delegate.checkCanCreateViewWithSelectFromColumns(viewContext, tableName, columnNames));
     }
 
     @Override
     public Map<SchemaTableName, Set<String>> filterColumns(SecurityContext context, String catalogName, Map<SchemaTableName, Set<String>> tableColumns)
     {
-        return delegate.filterColumns(context, catalogName, tableColumns);
+        return delegate.filterColumns(viewContext, catalogName, tableColumns);
     }
 
     @Override
     public void checkCanCreateViewWithSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> columnNames)
     {
-        wrapAccessDeniedException(() -> delegate.checkCanCreateViewWithSelectFromColumns(context, tableName, columnNames));
+        wrapAccessDeniedException(() -> delegate.checkCanCreateViewWithSelectFromColumns(viewContext, tableName, columnNames));
     }
 
     @Override
     public boolean canExecuteFunction(SecurityContext context, QualifiedObjectName functionName)
     {
-        return delegate.canCreateViewWithExecuteFunction(context, functionName);
+        return delegate.canCreateViewWithExecuteFunction(viewContext, functionName);
     }
 
     @Override
     public boolean canCreateViewWithExecuteFunction(SecurityContext context, QualifiedObjectName functionName)
     {
-        return delegate.canCreateViewWithExecuteFunction(context, functionName);
+        return delegate.canCreateViewWithExecuteFunction(viewContext, functionName);
     }
 
     @Override
     public List<ViewExpression> getRowFilters(SecurityContext context, QualifiedObjectName tableName)
     {
-        return delegate.getRowFilters(context, tableName);
+        return delegate.getRowFilters(viewContext, tableName);
     }
 
     @Override
     public Map<ColumnSchema, ViewExpression> getColumnMasks(SecurityContext context, QualifiedObjectName tableName, List<ColumnSchema> columns)
     {
-        return delegate.getColumnMasks(context, tableName, columns);
+        return delegate.getColumnMasks(viewContext, tableName, columns);
     }
 
     private static void wrapAccessDeniedException(Runnable runnable)

--- a/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
+++ b/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
@@ -222,6 +222,7 @@ public abstract class BaseDataDefinitionTaskTest
                 columns,
                 Optional.empty(),
                 Optional.empty(),
+                false,
                 ImmutableList.of());
     }
 
@@ -599,6 +600,7 @@ public abstract class BaseDataDefinitionTaskTest
                             view.getColumns(),
                             comment,
                             view.getRunAsIdentity(),
+                            false,
                             view.getPath()));
         }
 
@@ -632,6 +634,7 @@ public abstract class BaseDataDefinitionTaskTest
                                     .collect(toImmutableList()),
                             view.getComment(),
                             view.getRunAsIdentity(),
+                            false,
                             view.getPath()));
         }
 

--- a/core/trino-main/src/test/java/io/trino/metadata/TestInformationSchemaMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestInformationSchemaMetadata.java
@@ -87,6 +87,7 @@ public class TestInformationSchemaMetadata
                             Optional.of("comment"),
                             Optional.empty(),
                             true,
+                            false,
                             ImmutableList.of());
                     SchemaTableName viewName = new SchemaTableName("test_schema", "test_view");
                     return ImmutableMap.of(viewName, definition);

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -200,8 +200,8 @@ import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.spi.type.VarcharType.createVarcharType;
-import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.SELECT_COLUMN;
 import static io.trino.testing.TestingAccessControlManager.privilege;
+import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.SELECT_COLUMN;
 import static io.trino.testing.TestingEventListenerManager.emptyEventListenerManager;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static io.trino.testing.TransactionBuilder.transaction;
@@ -7420,6 +7420,7 @@ public class TestAnalyzer
                 ImmutableList.of(new ViewColumn("a", BIGINT.getTypeId(), Optional.empty())),
                 Optional.of("comment"),
                 Optional.of(Identity.ofUser("user")),
+                false,
                 ImmutableList.of());
         inSetupTransaction(session -> metadata.createView(session, new QualifiedObjectName(TPCH_CATALOG, "s1", "v1"), viewData1, ImmutableMap.of(), false));
 
@@ -7431,6 +7432,7 @@ public class TestAnalyzer
                 ImmutableList.of(new ViewColumn("a", VARCHAR.getTypeId(), Optional.empty())),
                 Optional.of("comment"),
                 Optional.of(Identity.ofUser("user")),
+                false,
                 ImmutableList.of());
         inSetupTransaction(session -> metadata.createView(session, new QualifiedObjectName(TPCH_CATALOG, "s1", "v2"), viewData2, ImmutableMap.of(), false));
 
@@ -7442,6 +7444,7 @@ public class TestAnalyzer
                 ImmutableList.of(new ViewColumn("a", BIGINT.getTypeId(), Optional.empty())),
                 Optional.of("comment"),
                 Optional.of(Identity.ofUser("user")),
+                false,
                 ImmutableList.of());
         inSetupTransaction(session -> metadata.createView(session, new QualifiedObjectName("tpch", "s1", "v4"), viewData4,ImmutableMap.of(), false));
 
@@ -7453,6 +7456,7 @@ public class TestAnalyzer
                 ImmutableList.of(new ViewColumn("a", BIGINT.getTypeId(), Optional.empty())),
                 Optional.of("comment"),
                 Optional.of(Identity.ofUser("user")),
+                false,
                 ImmutableList.of());
         inSetupTransaction(session -> metadata.createView(session, new QualifiedObjectName(TPCH_CATALOG, "s1", "v5"), viewData5, ImmutableMap.of(), false));
 
@@ -7543,6 +7547,7 @@ public class TestAnalyzer
                 ImmutableList.of(new ViewColumn("a", BIGINT.getTypeId(), Optional.empty())),
                 Optional.empty(),
                 Optional.empty(),
+                false,
                 ImmutableList.of());
         inSetupTransaction(session -> metadata.createView(
                 session,

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestRemoveEmptyUnionBranches.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestRemoveEmptyUnionBranches.java
@@ -88,6 +88,7 @@ public class TestRemoveEmptyUnionBranches
                             Optional.empty(),
                             Optional.empty(),
                             true,
+                            false,
                             ImmutableList.of()));
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestColumnMask.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestColumnMask.java
@@ -46,8 +46,8 @@ import static io.trino.connector.MockConnectorEntities.TPCH_WITH_HIDDEN_COLUMN_D
 import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_SPLITS_PER_NODE;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.spi.type.IntegerType.INTEGER;
-import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.SELECT_COLUMN;
 import static io.trino.testing.TestingAccessControlManager.privilege;
+import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.SELECT_COLUMN;
 import static io.trino.testing.TestingHandles.TEST_CATALOG_NAME;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -88,6 +88,7 @@ public class TestColumnMask
                 Optional.empty(),
                 Optional.of(VIEW_OWNER),
                 false,
+                false,
                 ImmutableList.of());
 
         ConnectorViewDefinition viewWithNested = new ConnectorViewDefinition(
@@ -108,6 +109,7 @@ public class TestColumnMask
                         new ConnectorViewDefinition.ViewColumn("id", INTEGER.getTypeId(), Optional.empty())),
                 Optional.empty(),
                 Optional.of(VIEW_OWNER),
+                false,
                 false,
                 ImmutableList.of());
 

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestRowFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestRowFilter.java
@@ -90,6 +90,7 @@ public class TestRowFilter
                 Optional.empty(),
                 Optional.of(VIEW_OWNER),
                 false,
+                false,
                 ImmutableList.of());
 
         runner.installPlugin(new MockConnectorPlugin(MockConnectorFactory.builder()

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestShowQueries.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestShowQueries.java
@@ -80,6 +80,7 @@ public class TestShowQueries
                                 Optional.empty(),
                                 Optional.empty(),
                                 true,
+                                false,
                                 ImmutableList.of())))
                 .withGetViewProperties(() -> ImmutableList.of(PropertyMetadata.booleanProperty("boolean_property", "sample_property", true, false)))
                 .build()));

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -895,6 +895,9 @@ class AstBuilder
         else if (context.INVOKER() != null) {
             security = Optional.of(CreateView.Security.INVOKER);
         }
+        else if (context.HYBRID() != null) {
+        	security = Optional.of(CreateView.Security.HYBRID);
+        }
 
         List<Property> properties = ImmutableList.of();
         if (context.properties() != null) {
@@ -3764,9 +3767,16 @@ class AstBuilder
     @Override
     public Node visitSecurityCharacteristic(SqlBaseParser.SecurityCharacteristicContext context)
     {
-        return new SecurityCharacteristic(getLocation(context), (context.INVOKER() != null)
-                ? SecurityCharacteristic.Security.INVOKER
-                : SecurityCharacteristic.Security.DEFINER);
+    	SecurityCharacteristic.Security security = null;
+
+    	if (context.INVOKER() != null) {
+    		security = SecurityCharacteristic.Security.INVOKER;
+    	} else if (context.DEFINER() != null) {
+    		security = SecurityCharacteristic.Security.DEFINER;
+    	} else if (context.HYBRID() != null) {
+    		security = SecurityCharacteristic.Security.HYBRID;
+    	}
+        return new SecurityCharacteristic(getLocation(context), security);
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/CreateView.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/CreateView.java
@@ -27,7 +27,7 @@ public class CreateView
 {
     public enum Security
     {
-        INVOKER, DEFINER
+        INVOKER, DEFINER, HYBRID
     }
 
     private final QualifiedName name;

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/SecurityCharacteristic.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/SecurityCharacteristic.java
@@ -26,7 +26,7 @@ public final class SecurityCharacteristic
 {
     public enum Security
     {
-        INVOKER, DEFINER
+        INVOKER, DEFINER, HYBRID
     }
 
     private final Security security;

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorViewDefinition.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorViewDefinition.java
@@ -33,6 +33,7 @@ public class ConnectorViewDefinition
     private final Optional<String> comment;
     private final Optional<String> owner;
     private final boolean runAsInvoker;
+    private final boolean hybrid;
     private final List<CatalogSchemaName> path;
 
     @JsonCreator
@@ -44,6 +45,7 @@ public class ConnectorViewDefinition
             @JsonProperty("comment") Optional<String> comment,
             @JsonProperty("owner") Optional<String> owner,
             @JsonProperty("runAsInvoker") boolean runAsInvoker,
+            @JsonProperty("hybrid") boolean hybrid,
             @JsonProperty("path") List<CatalogSchemaName> path)
     {
         this.originalSql = requireNonNull(originalSql, "originalSql is null");
@@ -53,6 +55,7 @@ public class ConnectorViewDefinition
         this.comment = requireNonNull(comment, "comment is null");
         this.owner = requireNonNull(owner, "owner is null");
         this.runAsInvoker = runAsInvoker;
+        this.hybrid = hybrid;
         this.path = path == null ? List.of() : List.copyOf(path);
         if (catalog.isEmpty() && schema.isPresent()) {
             throw new IllegalArgumentException("catalog must be present if schema is present");
@@ -63,6 +66,19 @@ public class ConnectorViewDefinition
         if (columns.isEmpty()) {
             throw new IllegalArgumentException("columns list is empty");
         }
+    }
+
+    public ConnectorViewDefinition(
+            @JsonProperty("originalSql") String originalSql,
+            @JsonProperty("catalog") Optional<String> catalog,
+            @JsonProperty("schema") Optional<String> schema,
+            @JsonProperty("columns") List<ViewColumn> columns,
+            @JsonProperty("comment") Optional<String> comment,
+            @JsonProperty("owner") Optional<String> owner,
+            @JsonProperty("runAsInvoker") boolean runAsInvoker,
+            @JsonProperty("path") List<CatalogSchemaName> path)
+    {
+    	this(originalSql, catalog, schema, columns, comment, owner, runAsInvoker, false, path);
     }
 
     @JsonProperty
@@ -107,6 +123,10 @@ public class ConnectorViewDefinition
         return runAsInvoker;
     }
 
+    public boolean isHybrid() {
+		return hybrid;
+	}
+
     @JsonProperty
     public List<CatalogSchemaName> getPath()
     {
@@ -123,6 +143,7 @@ public class ConnectorViewDefinition
                 comment,
                 Optional.empty(),
                 runAsInvoker,
+                hybrid,
                 path);
     }
 
@@ -131,6 +152,7 @@ public class ConnectorViewDefinition
     {
         StringJoiner joiner = new StringJoiner(", ", "[", "]");
         owner.ifPresent(value -> joiner.add("owner=" + value));
+        joiner.add("hybrid=" + hybrid);
         comment.ifPresent(value -> joiner.add("comment=" + value));
         joiner.add("runAsInvoker=" + runAsInvoker);
         joiner.add("columns=" + columns);

--- a/core/trino-spi/src/test/java/io/trino/spi/connector/TestConnectorViewDefinition.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/connector/TestConnectorViewDefinition.java
@@ -106,6 +106,7 @@ public class TestConnectorViewDefinition
                 Optional.of("comment"),
                 Optional.of("test_owner"),
                 false,
+                false,
                 ImmutableList.of()));
     }
 

--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryMetadata.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryMetadata.java
@@ -455,6 +455,7 @@ public class MemoryMetadata
                 comment,
                 view.getOwner(),
                 view.isRunAsInvoker(),
+                view.isHybrid(),
                 view.getPath()));
     }
 
@@ -472,6 +473,7 @@ public class MemoryMetadata
                 view.getComment(),
                 view.getOwner(),
                 view.isRunAsInvoker(),
+                view.isHybrid(),
                 view.getPath()));
     }
 

--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryMetadata.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryMetadata.java
@@ -356,6 +356,7 @@ public class TestMemoryMetadata
                 Optional.empty(),
                 Optional.empty(),
                 true,
+                false,
                 ImmutableList.of());
     }
 

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
@@ -56,6 +56,7 @@ import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.TypeSignature;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.SymbolKeyDeserializer;
+import io.trino.sql.planner.planprinter.JsonRenderer.JsonRenderedNode;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
@@ -92,7 +93,6 @@ import static io.trino.spi.metrics.Metrics.EMPTY;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.VarcharType.createVarcharType;
-import static io.trino.sql.planner.planprinter.JsonRenderer.JsonRenderedNode;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.lang.Double.NaN;
 import static java.lang.String.format;
@@ -180,6 +180,7 @@ public class TestEventListenerBasic
                                             Optional.empty(),
                                             Optional.empty(),
                                             true,
+                                            false,
                                             ImmutableList.of()),
                                     new SchemaTableName("default", "test_view_nesting"), new ConnectorViewDefinition(
                                             "SELECT test_column FROM mock.default.test_view",
@@ -189,6 +190,7 @@ public class TestEventListenerBasic
                                             Optional.empty(),
                                             Optional.empty(),
                                             true,
+                                            false,
                                             ImmutableList.of()),
                                     new SchemaTableName("default", "test_view_with_row_filter"), new ConnectorViewDefinition(
                                             "SELECT test_varchar AS test_column FROM mock.default.test_table_with_row_filter",
@@ -198,6 +200,7 @@ public class TestEventListenerBasic
                                             Optional.empty(),
                                             Optional.empty(),
                                             true,
+                                            false,
                                             ImmutableList.of()),
                                     new SchemaTableName("default", "test_view_with_redirect"), new ConnectorViewDefinition(
                                             "SELECT nationkey AS test_column FROM mock.default.nation_redirect",
@@ -207,6 +210,7 @@ public class TestEventListenerBasic
                                             Optional.empty(),
                                             Optional.empty(),
                                             true,
+                                            false,
                                             ImmutableList.of())))
                         .withGetMaterializedViews((connectorSession, prefix) -> {
                             ConnectorMaterializedViewDefinition definitionStale = new ConnectorMaterializedViewDefinition(

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestGrantOnTable.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestGrantOnTable.java
@@ -88,6 +88,7 @@ public class TestGrantOnTable
                                         Optional.empty(),
                                         Optional.empty(),
                                         true,
+                                        false,
                                         ImmutableList.of())))
                 .withGetMaterializedViews((connectorSession, prefix) ->
                         ImmutableMap.of(

--- a/testing/trino-tests/src/test/java/io/trino/security/TestAccessControl.java
+++ b/testing/trino-tests/src/test/java/io/trino/security/TestAccessControl.java
@@ -86,6 +86,7 @@ import static io.trino.spi.session.PropertyMetadata.doubleProperty;
 import static io.trino.spi.session.PropertyMetadata.integerProperty;
 import static io.trino.spi.session.PropertyMetadata.stringProperty;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.testing.TestingAccessControlManager.privilege;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.ADD_COLUMN;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.ALTER_COLUMN;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.COMMENT_COLUMN;
@@ -111,7 +112,6 @@ import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.SHOW_CREATE_TABLE;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.TRUNCATE_TABLE;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.UPDATE_TABLE;
-import static io.trino.testing.TestingAccessControlManager.privilege;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.lang.String.format;
@@ -189,6 +189,7 @@ public class TestAccessControl
                             Optional.of("comment"),
                             Optional.of("admin"),
                             false,
+                            false,
                             ImmutableList.of());
                     ConnectorViewDefinition definitionRunAsInvoker = new ConnectorViewDefinition(
                             "SELECT 1 AS test",
@@ -198,6 +199,7 @@ public class TestAccessControl
                             Optional.of("comment"),
                             Optional.empty(),
                             true,
+                            false,
                             ImmutableList.of());
                     return ImmutableMap.of(
                             new SchemaTableName("default", "test_view_definer"), definitionRunAsDefiner,

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestMetadataManager.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestMetadataManager.java
@@ -222,6 +222,7 @@ public class TestMetadataManager
                 Optional.of("comment"),
                 Optional.of("test_owner"),
                 false,
+                false,
                 ImmutableList.of());
     }
 }

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestMockConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestMockConnector.java
@@ -88,6 +88,7 @@ public class TestMockConnector
                                                 Optional.empty(),
                                                 Optional.of("alice"),
                                                 false,
+                                                false,
                                                 ImmutableList.of())))
                                 .withGetMaterializedViewProperties(() -> ImmutableList.of(
                                         durationProperty(


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

See #22832 for context. This adds a new security mode that uses the Trino access control of the definer, but connections are made as the invoker.

This is very much a proof of concept.

* Is this a sensible approach?

If so...
* How should this be named? _Hybrid doesn't seem like the best name._
* This works with the memory connector. What should happen when this security mode is used elsewhere?
* Tests aren't present yet.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Key changes are in the grammar/parser, view model and `StatementAnalyzer`.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Support hybrid security mode for views that use the access control of the definer but connect as the invoker. ({issue}`issuenumber`)
```
