### PR TITLE
Replacing NaN on coordinator to value n/a

### DIFF
--- a/core/trino-main/src/main/resources/webapp/src/utils.js
+++ b/core/trino-main/src/main/resources/webapp/src/utils.js
@@ -340,6 +340,9 @@ export function computeRate(count: number, ms: number): number {
 }
 
 export function precisionRound(n: number): string {
+    if (n === undefined){
+        return "n/a";
+    }
     if (n < 10) {
         return n.toFixed(2);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Currently on loading coordinator UI initially it shows NaN for some values because those values are still undefined yet this change will check for NaN and would return empty string in it's place making it more understandable that no value is available for those statistics yet.

Cherry pick from https://github.com/prestodb/presto/pull/23285

Currently it shows 

![image](https://github.com/user-attachments/assets/b0421731-a3d7-4c5e-8cda-e3e22a5d3530)
 
After this change it would look like 

<img width="1075" alt="image" src="https://github.com/user-attachments/assets/f7d1a37e-894b-4926-8bbf-e89c5df7f5c0">



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
