### PR TITLE
Improve visibilty for Breaking change warning

### DIFF
--- a/docs/src/main/sphinx/conf.py
+++ b/docs/src/main/sphinx/conf.py
@@ -117,7 +117,7 @@ myst_enable_extensions = [
 ]
 
 myst_substitutions = {
-    "breaking": "<a href='../release.html#breaking-changes' title='Breaking change'>⚠️</a>"
+    "breaking": "<a href='../release.html#breaking-changes' title='Breaking change'>⚠️ Breaking change:</a>"
 }
 
 # -- Options for HTML output ---------------------------------------------------


### PR DESCRIPTION
## Description

- Found out that users did not realize the meaning
- Also found out that users did not realize its a link to more explanation
- New approach is the same as in Trino Gateway 10 and onwards

## Additional context and related issues

<img width="831" alt="image" src="https://github.com/user-attachments/assets/4d3e7068-c32c-447f-a05f-324be151afe0">



## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
