### PR TITLE
Add docs for client port optionality

### DIFF
--- a/docs/src/main/sphinx/client/cli.md
+++ b/docs/src/main/sphinx/client/cli.md
@@ -183,9 +183,10 @@ mode:
     with [](/sql/use).
 * - `--server`
   - The HTTP/HTTPS address and port of the Trino coordinator. The port must be
-    set to the port the Trino coordinator is listening for connections on. Trino
-    server location defaults to `http://localhost:8080`. Can only be set if URL
-    is not specified.
+    set to the port the Trino coordinator is listening for connections on. Port
+    80 for HTTP and Port 443 for HTTPS can be omitted. Trino server location
+    defaults to `http://localhost:8080`. Can only be set if URL is not
+    specified.
 * - `--session`
   - Sets one or more [session properties](session-properties-definition).
     Property can be used multiple times with the format

--- a/docs/src/main/sphinx/client/jdbc.md
+++ b/docs/src/main/sphinx/client/jdbc.md
@@ -70,6 +70,9 @@ jdbc:trino://host:port/catalog
 jdbc:trino://host:port/catalog/schema
 ```
 
+The value for `port` is optional if Trino is available at the default HTTP port
+`80` or with `SSL=true` and the default HTTPS port `443`.
+
 The following is an example of a JDBC URL used to create a connection:
 
 ```text


### PR DESCRIPTION
## Description

Follow up to #22724

## Additional context and related issues



## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
