### PR TITLE
Add legacy note for spill to disk

### DIFF
--- a/docs/src/main/sphinx/admin/spill.md
+++ b/docs/src/main/sphinx/admin/spill.md
@@ -12,6 +12,12 @@ implemented on the application level to address specific needs of Trino.
 
 Properties related to spilling are described in {doc}`properties-spilling`.
 
+:::{warning} 
+The spill to disk feature and implementation are a legacy functionality of
+Trino. Consider using [](/admin/fault-tolerant-execution) with the `task` retry
+policy and a configured [](fte-exchange-manager).
+:::
+
 ## Memory management and spill
 
 By default, Trino kills queries, if the memory requested by the query execution


### PR DESCRIPTION
## Description

This keeps coming up... might as well make it official. 

## Additional context and related issues

https://trinodb.slack.com/archives/CLEDR9V7G/p1722011311628259

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
