### PR TITLE
Allow default parallelism for table functions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddLocalExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddLocalExchanges.java
@@ -507,8 +507,11 @@ public class AddLocalExchanges
             else {
                 childRequirements = parentPreferences
                         .constrainTo(node.getSource().orElseThrow().getOutputSymbols())
-                        .withDefaultParallelism(session)
-                        .withPartitioning(partitionBy);
+                        .withDefaultParallelism(session);
+
+                if (!partitionBy.isEmpty()) {
+                    childRequirements = childRequirements.withPartitioning(partitionBy);
+                }
             }
 
             PlanWithProperties child = planAndEnforce(node.getSource().orElseThrow(), childRequirements, childRequirements);


### PR DESCRIPTION
## Description

Table function parallelism is effectively 1 when a `PARTITION BY` clause was not specified.

## Additional context and related issues

Of note, we have been leveraging commits from https://github.com/trinodb/trino/pull/21558 in our fork and have seen our workloads reduce overall memory pressure substantially. I believe it is worthwhile to see what needs to be done to get it merged in.

CC @findepi 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
