### PR TITLE
Fail when there are toLoad duplicates in getAll

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
@@ -334,7 +334,7 @@ public final class CachingHiveMetastore
     private static <K, V> Map<K, V> getAll(Cache<K, AtomicReference<V>> cache, Iterable<K> keys, Function<Set<K>, Map<K, V>> bulkLoader)
     {
         ImmutableMap.Builder<K, V> result = ImmutableMap.builder();
-        Map<K, AtomicReference<V>> toLoad = new HashMap<>();
+        ImmutableMap.Builder<K, AtomicReference<V>> toLoadBuilder = ImmutableMap.builder();
 
         for (K key : keys) {
             AtomicReference<V> valueHolder = uncheckedCacheGet(cache, key, AtomicReference::new);
@@ -343,10 +343,11 @@ public final class CachingHiveMetastore
                 result.put(key, value);
             }
             else {
-                toLoad.put(key, valueHolder);
+                toLoadBuilder.put(key, valueHolder);
             }
         }
 
+        Map<K, AtomicReference<V>> toLoad = toLoadBuilder.buildOrThrow();
         if (toLoad.isEmpty()) {
             return result.buildOrThrow();
         }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
@@ -109,7 +109,8 @@ public final class CachingHiveMetastore
         DISABLED
     }
 
-    public enum ObjectType {
+    public enum ObjectType
+    {
         PARTITION,
         STATS,
         OTHER,


### PR DESCRIPTION
getAll is used by CachingHiveMetastore#getPartitionsByNames, which is expected to return the same number of entries as input partitionNames (see HiveSplitManager#getPartitionMetadata).
