### PR TITLE
Allow specifying bigint type in repeat function

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/RepeatFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/RepeatFunction.java
@@ -40,7 +40,7 @@ public final class RepeatFunction
     @SqlType("array(unknown)")
     public static Block repeat(
             @SqlNullable @SqlType("unknown") Boolean element,
-            @SqlType(StandardTypes.INTEGER) long count)
+            @SqlType(StandardTypes.BIGINT) long count)
     {
         checkCondition(element == null, INVALID_FUNCTION_ARGUMENT, "expect null values");
         BlockBuilder blockBuilder = createBlockBuilder(UNKNOWN, count);
@@ -52,7 +52,7 @@ public final class RepeatFunction
     public static Block repeat(
             @TypeParameter("T") Type type,
             @SqlNullable @SqlType("T") Object element,
-            @SqlType(StandardTypes.INTEGER) long count)
+            @SqlType(StandardTypes.BIGINT) long count)
     {
         BlockBuilder blockBuilder = createBlockBuilder(type, count);
         if (element == null) {
@@ -73,7 +73,7 @@ public final class RepeatFunction
     public static Block repeat(
             @TypeParameter("T") Type type,
             @SqlNullable @SqlType("T") Long element,
-            @SqlType(StandardTypes.INTEGER) long count)
+            @SqlType(StandardTypes.BIGINT) long count)
     {
         BlockBuilder blockBuilder = createBlockBuilder(type, count);
         if (element == null) {
@@ -90,7 +90,7 @@ public final class RepeatFunction
     public static Block repeat(
             @TypeParameter("T") Type type,
             @SqlNullable @SqlType("T") Boolean element,
-            @SqlType(StandardTypes.INTEGER) long count)
+            @SqlType(StandardTypes.BIGINT) long count)
     {
         BlockBuilder blockBuilder = createBlockBuilder(type, count);
         if (element == null) {
@@ -107,7 +107,7 @@ public final class RepeatFunction
     public static Block repeat(
             @TypeParameter("T") Type type,
             @SqlNullable @SqlType("T") Double element,
-            @SqlType(StandardTypes.INTEGER) long count)
+            @SqlType(StandardTypes.BIGINT) long count)
     {
         BlockBuilder blockBuilder = createBlockBuilder(type, count);
         if (element == null) {

--- a/core/trino-main/src/test/java/io/trino/type/TestArrayOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestArrayOperators.java
@@ -4115,7 +4115,15 @@ public class TestArrayOperators
                 .hasType(new ArrayType(INTEGER))
                 .isEqualTo(ImmutableList.of(1, 1, 1, 1, 1));
 
+        assertThat(assertions.function("repeat", "1", "BIGINT '5'"))
+                .hasType(new ArrayType(INTEGER))
+                .isEqualTo(ImmutableList.of(1, 1, 1, 1, 1));
+
         assertThat(assertions.function("repeat", "'varchar'", "3"))
+                .hasType(new ArrayType(createVarcharType(7)))
+                .isEqualTo(ImmutableList.of("varchar", "varchar", "varchar"));
+
+        assertThat(assertions.function("repeat", "'varchar'", "BIGINT '3'"))
                 .hasType(new ArrayType(createVarcharType(7)))
                 .isEqualTo(ImmutableList.of("varchar", "varchar", "varchar"));
 
@@ -4123,13 +4131,29 @@ public class TestArrayOperators
                 .hasType(new ArrayType(BOOLEAN))
                 .isEqualTo(ImmutableList.of(true));
 
+        assertThat(assertions.function("repeat", "true", "BIGINT '1'"))
+                .hasType(new ArrayType(BOOLEAN))
+                .isEqualTo(ImmutableList.of(true));
+
         assertThat(assertions.function("repeat", "0.5E0", "4"))
+                .hasType(new ArrayType(DOUBLE))
+                .isEqualTo(ImmutableList.of(0.5, 0.5, 0.5, 0.5));
+
+        assertThat(assertions.function("repeat", "0.5E0", "BIGINT '4'"))
                 .hasType(new ArrayType(DOUBLE))
                 .isEqualTo(ImmutableList.of(0.5, 0.5, 0.5, 0.5));
 
         assertThat(assertions.function("repeat", "array[1]", "4"))
                 .hasType(new ArrayType(new ArrayType(INTEGER)))
                 .isEqualTo(ImmutableList.of(ImmutableList.of(1), ImmutableList.of(1), ImmutableList.of(1), ImmutableList.of(1)));
+
+        assertThat(assertions.function("repeat", "array[1]", "BIGINT '4'"))
+                .hasType(new ArrayType(new ArrayType(INTEGER)))
+                .isEqualTo(ImmutableList.of(ImmutableList.of(1), ImmutableList.of(1), ImmutableList.of(1), ImmutableList.of(1)));
+
+        assertThat(assertions.function("repeat", "array[NULL]", "BIGINT '4'"))
+                .hasType(new ArrayType(new ArrayType(UNKNOWN)))
+                .isEqualTo(ImmutableList.of(singletonList(null), singletonList(null), singletonList(null), singletonList(null)));
 
         // null values
         assertThat(assertions.function("repeat", "null", "4"))


### PR DESCRIPTION
## Description

Fixes #22867

## Release notes

```markdown
# General
* Add support for specifying `bigint` type in `repeat` function. ({issue}`22867`)
```
