### PR TITLE
Adds default value info for property hive.s3.streaming.enable in doc

### DIFF
--- a/docs/src/main/sphinx/object-storage/legacy-s3.md
+++ b/docs/src/main/sphinx/object-storage/legacy-s3.md
@@ -86,7 +86,7 @@ Trino uses its own S3 filesystem for the URI prefixes
     may be expected to be part of the table or partition. Defaults to `false`.
 * - `hive.s3.streaming.enabled`
   - Use S3 multipart upload API to upload file in streaming way, without staging
-    file to be created in the local file system.
+    file to be created in the local file system. Defaults to `true`.
 * - `hive.s3.streaming.part-size`
   - The part size for S3 streaming upload. Defaults to `16MB`.
 * - `hive.s3.proxy.host`


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Adds the info about the default value for property hive.s3.streaming.enable  in the documentation
https://github.com/trinodb/trino/blob/2119eddcc89591795d5082589bc65f9d30a54a17/lib/trino-hdfs/src/main/java/io/trino/hdfs/s3/HiveS3Config.java#L74

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

