### PR TITLE
Enable errorprone StringCaseLocaleUsage

### DIFF
--- a/.mvn/modernizer/violations.xml
+++ b/.mvn/modernizer/violations.xml
@@ -19,18 +19,6 @@
     </violation>
 
     <violation>
-        <name>java/lang/String.toLowerCase:()Ljava/lang/String;</name>
-        <version>1.1</version>
-        <comment>Prefer String.toLowerCase(java.util.Locale)</comment>
-    </violation>
-
-    <violation>
-        <name>java/lang/String.toUpperCase:()Ljava/lang/String;</name>
-        <version>1.1</version>
-        <comment>Prefer String.toUpperCase(java.util.Locale)</comment>
-    </violation>
-
-    <violation>
         <name>java/lang/String.toString:()Ljava/lang/String;</name>
         <version>1.1</version>
         <comment>Call to toString() is redundant</comment>

--- a/pom.xml
+++ b/pom.xml
@@ -2777,6 +2777,7 @@
                                     -Xep:StaticAssignmentOfThrowable:ERROR \
                                     -Xep:StaticGuardedByInstance:ERROR \
                                     -Xep:StreamResourceLeak:ERROR \
+                                    -Xep:StringCaseLocaleUsage:ERROR \
                                     -Xep:SuppressWarningsDeprecated:ERROR \
                                     -Xep:ThreeLetterTimeZoneID:ERROR \
                                     -Xep:UnicodeEscape:ERROR \


### PR DESCRIPTION
## Description

Enable https://errorprone.info/bugpattern/StringCaseLocaleUsage
I prefer compilation failure (earlier phase) to modernizer report. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
