### PR TITLE
TEST: Throw a better exception in Azure FS createOrOverwrite

### DIFF
--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureOutputFile.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureOutputFile.java
@@ -15,10 +15,13 @@ package io.trino.filesystem.azure;
 
 import com.azure.core.util.BinaryData;
 import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.models.BlobErrorCode;
+import com.azure.storage.blob.models.BlobStorageException;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoOutputFile;
 import io.trino.memory.context.AggregatedMemoryContext;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.FileAlreadyExistsException;
@@ -69,7 +72,15 @@ class AzureOutputFile
     public void createOrOverwrite(byte[] data)
             throws IOException
     {
-        blobClient.getBlockBlobClient().upload(BinaryData.fromBytes(data), true);
+        try {
+            blobClient.getBlockBlobClient().upload(BinaryData.fromBytes(data), true);
+        }
+        catch (BlobStorageException e) {
+            if (BlobErrorCode.CONTAINER_NOT_FOUND.equals(e.getErrorCode())) {
+                throw new FileNotFoundException(location.toString());
+            }
+            throw e;
+        }
     }
 
     @Override


### PR DESCRIPTION
Throw FileNotFoundException instead of a BlobStorageException, since the latter doesn't extend IOException. This addresses a test failure missed in 1073b0836bf1fb560a3a4a664f67171f5047d086.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
