### PR TITLE
Fix custom catalog store plugin loading (v2)

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/DynamicCatalogManagerModule.java
+++ b/core/trino-main/src/main/java/io/trino/connector/DynamicCatalogManagerModule.java
@@ -24,7 +24,6 @@ import io.trino.spi.catalog.CatalogStore;
 
 import java.util.Locale;
 
-import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 
 public class DynamicCatalogManagerModule
@@ -44,7 +43,6 @@ public class DynamicCatalogManagerModule
                 }
                 default -> {
                     binder.bind(CatalogStoreManager.class).in(Scopes.SINGLETON);
-                    newOptionalBinder(binder, CatalogStoreManager.class).setBinding().to(CatalogStoreManager.class).in(Scopes.SINGLETON);
                     binder.bind(CatalogStore.class).to(CatalogStoreManager.class).in(Scopes.SINGLETON);
                 }
             }

--- a/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
+++ b/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
@@ -276,7 +276,10 @@ public class TestingTrinoServer
 
         if (coordinator) {
             if (catalogMangerKind == CatalogMangerKind.DYNAMIC) {
-                serverProperties.put("catalog.store", "memory");
+                Optional<String> catalogStore = Optional.ofNullable(properties.get("catalog.store"));
+                if (catalogStore.isEmpty()) {
+                    serverProperties.put("catalog.store", "memory");
+                }
             }
             serverProperties.put("failure-detector.enabled", "false");
 

--- a/core/trino-main/src/test/java/io/trino/connector/TestCatalogStoreConfig.java
+++ b/core/trino-main/src/test/java/io/trino/connector/TestCatalogStoreConfig.java
@@ -22,7 +22,7 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertFullMappin
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 
-public class TestingCatalogStoreConfig
+public class TestCatalogStoreConfig
 {
     @Test
     public void testDefaults()

--- a/core/trino-main/src/test/java/io/trino/connector/TestCatalogStoreManager.java
+++ b/core/trino-main/src/test/java/io/trino/connector/TestCatalogStoreManager.java
@@ -38,12 +38,23 @@ class TestCatalogStoreManager
             throws IOException
     {
         try (TempFile tempFile = new TempFile()) {
-            Files.writeString(tempFile.path(), "catalog-store.name=test");
-            CatalogStoreManager catalogStoreManager = new CatalogStoreManager(new SecretsResolver(ImmutableMap.of()));
+            Files.writeString(tempFile.path(), "some-property=some-value");
+            CatalogStoreConfig catalogStoreConfig = new CatalogStoreConfig().setCatalogStoreKind("test");
+            CatalogStoreManager catalogStoreManager = new CatalogStoreManager(new SecretsResolver(ImmutableMap.of()), catalogStoreConfig);
             catalogStoreManager.addCatalogStoreFactory(new TestingCatalogStoreFactory());
-            catalogStoreManager.loadConfiguredCatalogStore(tempFile.file());
+            catalogStoreManager.loadConfiguredCatalogStore(catalogStoreConfig.getCatalogStoreKind(), tempFile.file());
             assertThat(catalogStoreManager.getCatalogs()).containsExactly(TestingCatalogStore.STORED_CATALOG);
         }
+    }
+
+    @Test
+    void testCatalogStoreIsLoadedWithoutConfiguration()
+            throws IOException
+    {
+        CatalogStoreManager catalogStoreManager = new CatalogStoreManager(new SecretsResolver(ImmutableMap.of()), new CatalogStoreConfig().setCatalogStoreKind("test"));
+        catalogStoreManager.addCatalogStoreFactory(new TestingCatalogStoreFactory());
+        catalogStoreManager.loadConfiguredCatalogStore();
+        assertThat(catalogStoreManager.getCatalogs()).containsExactly(TestingCatalogStore.STORED_CATALOG);
     }
 
     private static class TestingCatalogStoreFactory

--- a/core/trino-main/src/test/java/io/trino/server/testing/TestTestingTrinoServer.java
+++ b/core/trino-main/src/test/java/io/trino/server/testing/TestTestingTrinoServer.java
@@ -16,6 +16,7 @@ package io.trino.server.testing;
 import com.google.inject.Key;
 import io.trino.connector.ConnectorServicesProvider;
 import io.trino.connector.CoordinatorDynamicCatalogManager;
+import io.trino.connector.FileCatalogStore;
 import io.trino.connector.InMemoryCatalogStore;
 import io.trino.connector.StaticCatalogManager;
 import io.trino.connector.WorkerDynamicCatalogManager;
@@ -61,6 +62,28 @@ final class TestTestingTrinoServer
                 .build()) {
             assertThat(server.getInstance(Key.get(CatalogManager.class)))
                     .isInstanceOf(StaticCatalogManager.class);
+        }
+    }
+
+    @Test
+    void testDefaultCatalogStore()
+            throws IOException
+    {
+        try (TestingTrinoServer server = TestingTrinoServer.builder().build()) {
+            assertThat(server.getInstance(Key.get(CatalogStore.class)))
+                    .isInstanceOf(InMemoryCatalogStore.class);
+        }
+    }
+
+    @Test
+    void testExplicitCatalogStore()
+            throws IOException
+    {
+        try (TestingTrinoServer server = TestingTrinoServer.builder()
+                .addProperty("catalog.store", "file")
+                .build()) {
+            assertThat(server.getInstance(Key.get(CatalogStore.class)))
+                    .isInstanceOf(FileCatalogStore.class);
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Currently a custom catalog store plugin cannot be used because the Guice bindings are incorrect.

Fixes https://github.com/trinodb/trino/issues/22554
Supercedes https://github.com/trinodb/trino/pull/22784

I couldn't think of any way to test this other than a product test - but that too would need me to add a custom plugin to the build just to test this - I manually tested this instead for now.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

See https://github.com/trinodb/trino/issues/22554 for details. And https://github.com/trinodb/trino/pull/20489 for earlier changes.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix loading of custom `CatalogStore` implementations. Set `catalog.store` to the name of the custom `CatalogStoreFactory`. `catalog-store.name` in `etc/catalog-store.properties` is no longer required. ({issue}`22554`)
```
