### PR TITLE
Add Kafka event listener plugin

### DIFF
--- a/core/trino-server/src/main/provisio/trino.xml
+++ b/core/trino-server/src/main/provisio/trino.xml
@@ -176,6 +176,12 @@
         </artifact>
     </artifactSet>
 
+    <artifactSet to="plugin/kafka-event-listener">
+        <artifact id="${project.groupId}:trino-kafka-event-listener:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
+
     <artifactSet to="plugin/kinesis">
         <artifact id="${project.groupId}:trino-kinesis:zip:${project.version}">
             <unpack />

--- a/plugin/trino-kafka-event-listener/pom.xml
+++ b/plugin/trino-kafka-event-listener/pom.xml
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.trino</groupId>
+        <artifactId>trino-root</artifactId>
+        <version>454-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>trino-kafka-event-listener</artifactId>
+    <packaging>trino-plugin</packaging>
+    <description>Trino - Kafka Event Listener</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>stats</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-kafka</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.confluent</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-plugin-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.weakref</groupId>
+            <artifactId>jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jol</groupId>
+            <artifactId>jol-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>junit-extensions</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing-kafka</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/KafkaEventListener.java
+++ b/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/KafkaEventListener.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.eventlistener.kafka;
+
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+import io.trino.plugin.eventlistener.kafka.metrics.KafkaEventListenerJmxStats;
+import io.trino.plugin.eventlistener.kafka.producer.KafkaProducerFactory;
+import io.trino.spi.eventlistener.EventListener;
+import io.trino.spi.eventlistener.QueryCompletedEvent;
+import io.trino.spi.eventlistener.QueryCreatedEvent;
+import io.trino.spi.eventlistener.SplitCompletedEvent;
+import org.weakref.jmx.Flatten;
+import org.weakref.jmx.Managed;
+
+import javax.annotation.Nullable;
+
+public class KafkaEventListener
+        implements EventListener
+{
+    private static final Logger LOG = Logger.get(KafkaEventListener.class);
+
+    private final KafkaEventListenerJmxStats stats = new KafkaEventListenerJmxStats();
+    private final boolean publishCreatedEvent;
+    private final boolean publishCompletedEvent;
+    private final boolean isAnonymizationEnabled;
+    @Nullable
+    private KafkaEventPublisher kafkaPublisher;
+
+    @Inject
+    public KafkaEventListener(KafkaEventListenerConfig config, KafkaProducerFactory producerFactory)
+            throws Exception
+    {
+        publishCreatedEvent = config.getPublishCreatedEvent();
+        publishCompletedEvent = config.getPublishCompletedEvent();
+        isAnonymizationEnabled = config.isAnonymizationEnabled();
+
+        try {
+            if (publishCreatedEvent || publishCompletedEvent) {
+                kafkaPublisher = new KafkaEventPublisher(config, producerFactory, stats);
+            }
+            else {
+                LOG.warn("Event listener will be no-op, as neither created events nor completed events are published.");
+            }
+        }
+        catch (Exception e) {
+            if (config.getTerminateOnInitializationFailure()) {
+                throw e;
+            }
+            else {
+                LOG.error(e, "Failed to initialize Kafka publisher.");
+                stats.kafkaPublisherFailedToInitialize();
+            }
+        }
+    }
+
+    @Managed
+    @Flatten
+    public KafkaEventListenerJmxStats getStats()
+    {
+        return stats;
+    }
+
+    @Override
+    public void queryCreated(QueryCreatedEvent event)
+    {
+        if (kafkaPublisher != null && publishCreatedEvent) {
+            kafkaPublisher.publishCreatedEvent(event);
+        }
+    }
+
+    @Override
+    public void queryCompleted(QueryCompletedEvent event)
+    {
+        if (kafkaPublisher != null && publishCompletedEvent) {
+            kafkaPublisher.publishCompletedEvent(event);
+        }
+    }
+
+    @Override
+    public void splitCompleted(SplitCompletedEvent event)
+    {
+        // not implemented
+    }
+
+    @Override
+    public boolean requiresAnonymizedPlan()
+    {
+        return isAnonymizationEnabled;
+    }
+
+    @Override
+    public void shutdown()
+    {
+        if (kafkaPublisher != null) {
+            kafkaPublisher.shutdown();
+        }
+    }
+}

--- a/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/KafkaEventListenerConfig.java
+++ b/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/KafkaEventListenerConfig.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.eventlistener.kafka;
+
+import com.google.common.base.Splitter;
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.units.Duration;
+import io.airlift.units.MinDuration;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class KafkaEventListenerConfig
+{
+    private static final Splitter.MapSplitter MAP_SPLITTER = Splitter.on(",").trimResults().omitEmptyStrings().withKeyValueSeparator("=");
+
+    private boolean anonymizationEnabled;
+    private boolean publishCreatedEvent = true;
+    private boolean publishCompletedEvent = true;
+    private Optional<String> completedTopicName = Optional.empty();
+    private Optional<String> createdTopicName = Optional.empty();
+    private String brokerEndpoints;
+    private Optional<String> clientId = Optional.empty();
+    private Set<String> excludedFields = Collections.emptySet();
+    private Map<String, String> kafkaClientOverrides = Collections.emptyMap();
+    private Duration requestTimeout = new Duration(10, SECONDS);
+    private boolean terminateOnInitializationFailure = true;
+    private Optional<String> environmentVariablePrefix = Optional.empty();
+
+    public boolean isAnonymizationEnabled()
+    {
+        return anonymizationEnabled;
+    }
+
+    @Config("kafka-event-listener.anonymization.enabled")
+    public KafkaEventListenerConfig setAnonymizationEnabled(boolean anonymizationEnabled)
+    {
+        this.anonymizationEnabled = anonymizationEnabled;
+        return this;
+    }
+
+    @NotEmpty
+    public String getBrokerEndpoints()
+    {
+        return brokerEndpoints;
+    }
+
+    @Config("kafka-event-listener.broker-endpoints")
+    public KafkaEventListenerConfig setBrokerEndpoints(String brokerEndpoints)
+    {
+        this.brokerEndpoints = brokerEndpoints;
+        return this;
+    }
+
+    public Optional<String> getClientId()
+    {
+        return clientId;
+    }
+
+    @Config("kafka-event-listener.client-id")
+    public KafkaEventListenerConfig setClientId(String clientId)
+    {
+        this.clientId = Optional.ofNullable(clientId);
+        return this;
+    }
+
+    public Optional<String> getCompletedTopicName()
+    {
+        return completedTopicName;
+    }
+
+    @Config("kafka-event-listener.completed-event.topic")
+    public KafkaEventListenerConfig setCompletedTopicName(String completedTopicName)
+    {
+        this.completedTopicName = Optional.ofNullable(completedTopicName);
+        return this;
+    }
+
+    public Optional<String> getCreatedTopicName()
+    {
+        return createdTopicName;
+    }
+
+    @Config("kafka-event-listener.created-event.topic")
+    public KafkaEventListenerConfig setCreatedTopicName(String createdTopicName)
+    {
+        this.createdTopicName = Optional.ofNullable(createdTopicName);
+        return this;
+    }
+
+    public boolean getPublishCreatedEvent()
+    {
+        return publishCreatedEvent;
+    }
+
+    @ConfigDescription("Whether to publish io.trino.spi.eventlistener.QueryCreatedEvent")
+    @Config("kafka-event-listener.publish-created-event")
+    public KafkaEventListenerConfig setPublishCreatedEvent(boolean publishCreatedEvent)
+    {
+        this.publishCreatedEvent = publishCreatedEvent;
+        return this;
+    }
+
+    public boolean getPublishCompletedEvent()
+    {
+        return publishCompletedEvent;
+    }
+
+    @ConfigDescription("Whether to publish io.trino.spi.eventlistener.QueryCompletedEvent")
+    @Config("kafka-event-listener.publish-completed-event")
+    public KafkaEventListenerConfig setPublishCompletedEvent(boolean publishCompletedEvent)
+    {
+        this.publishCompletedEvent = publishCompletedEvent;
+        return this;
+    }
+
+    public Set<String> getExcludedFields()
+    {
+        return this.excludedFields;
+    }
+
+    @ConfigDescription("Comma-separated list of field names to be excluded from the Kafka event (their value will be replaced with null). E.g.: 'payload,user'")
+    @Config("kafka-event-listener.excluded-fields")
+    public KafkaEventListenerConfig setExcludedFields(Set<String> excludedFields)
+    {
+        this.excludedFields = requireNonNull(excludedFields, "excludedFields is null").stream()
+                .filter(field -> !field.isBlank())
+                .collect(toImmutableSet());
+        return this;
+    }
+
+    public Map<String, String> getKafkaClientOverrides()
+    {
+        return this.kafkaClientOverrides;
+    }
+
+    @ConfigDescription("Comma-separated list of key-value pairs to specify kafka client config overrides. E.g.: 'buffer.memory=67108864,compression.type=zstd'")
+    @Config("kafka-event-listener.client-config-overrides")
+    public KafkaEventListenerConfig setKafkaClientOverrides(String kafkaClientOverrides)
+    {
+        this.kafkaClientOverrides = MAP_SPLITTER.split(requireNonNull(kafkaClientOverrides, "kafkaClientOverrides is null"));
+        return this;
+    }
+
+    @MinDuration("1ms")
+    public Duration getRequestTimeout()
+    {
+        return requestTimeout;
+    }
+
+    @ConfigDescription("Timeout value to complete a kafka request.")
+    @Config("kafka-event-listener.request-timeout")
+    public KafkaEventListenerConfig setRequestTimeout(Duration requestTimeout)
+    {
+        this.requestTimeout = requestTimeout;
+        return this;
+    }
+
+    public boolean getTerminateOnInitializationFailure()
+    {
+        return terminateOnInitializationFailure;
+    }
+
+    @ConfigDescription("Kafka publisher initialization might fail due to network issues reaching the Kafka brokers. This flag controls whether to throw an exception in such cases.")
+    @Config("kafka-event-listener.terminate-on-initialization-failure")
+    public KafkaEventListenerConfig setTerminateOnInitializationFailure(boolean terminateOnInitializationFailure)
+    {
+        this.terminateOnInitializationFailure = terminateOnInitializationFailure;
+        return this;
+    }
+
+    public Optional<String> getEnvironmentVariablePrefix()
+    {
+        return environmentVariablePrefix;
+    }
+
+    @ConfigDescription("When set, Kafka events will be sent with additional metadata populated from environment variables. " +
+            "E.g. if env-var-prefix is set to 'TRINO_INSIGHTS_' and there is an env var TRINO_INSIGHTS_CLUSTER_ID=foo, then Kafka payload metadata will contain CLUSTER_ID=foo.")
+    @Config("kafka-event-listener.env-var-prefix")
+    public KafkaEventListenerConfig setEnvironmentVariablePrefix(String environmentVariablePrefix)
+    {
+        this.environmentVariablePrefix = Optional.ofNullable(environmentVariablePrefix);
+        return this;
+    }
+
+    @AssertTrue(message = "Created topic name must be configured when publishing created events is enabled.")
+    public boolean isCreatedTopicNamePresent()
+    {
+        return !publishCreatedEvent || !createdTopicName.orElse("").isBlank();
+    }
+
+    @AssertTrue(message = "Completed topic name must be configured when publishing completed events is enabled.")
+    public boolean isCompletedTopicNamePresent()
+    {
+        return !publishCompletedEvent || !completedTopicName.orElse("").isBlank();
+    }
+}

--- a/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/KafkaEventListenerFactory.java
+++ b/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/KafkaEventListenerFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.eventlistener.kafka;
+
+import com.google.inject.Injector;
+import com.google.inject.Scopes;
+import io.airlift.bootstrap.Bootstrap;
+import io.trino.plugin.base.jmx.MBeanServerModule;
+import io.trino.spi.eventlistener.EventListener;
+import io.trino.spi.eventlistener.EventListenerFactory;
+import org.weakref.jmx.guice.MBeanModule;
+
+import java.util.Map;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
+
+public class KafkaEventListenerFactory
+        implements EventListenerFactory
+{
+    @Override
+    public String getName()
+    {
+        return "kafka-event-listener";
+    }
+
+    @Override
+    public EventListener create(Map<String, String> config)
+    {
+        Bootstrap app = new Bootstrap(
+                new MBeanModule(),
+                new MBeanServerModule(),
+                new KafkaProducerModule(),
+                binder -> {
+                    configBinder(binder).bindConfig(KafkaEventListenerConfig.class);
+                    binder.bind(KafkaEventListener.class).in(Scopes.SINGLETON);
+                    newExporter(binder).export(KafkaEventListener.class).withGeneratedName();
+                });
+
+        Injector injector = app
+                .doNotInitializeLogging()
+                .setRequiredConfigurationProperties(config)
+                .initialize();
+
+        return injector.getInstance(KafkaEventListener.class);
+    }
+}

--- a/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/KafkaEventListenerPlugin.java
+++ b/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/KafkaEventListenerPlugin.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.eventlistener.kafka;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.Plugin;
+import io.trino.spi.eventlistener.EventListenerFactory;
+
+public class KafkaEventListenerPlugin
+        implements Plugin
+{
+    @Override
+    public Iterable<EventListenerFactory> getEventListenerFactories()
+    {
+        return ImmutableList.of(new KafkaEventListenerFactory());
+    }
+}

--- a/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/KafkaEventPublisher.java
+++ b/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/KafkaEventPublisher.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.eventlistener.kafka;
+
+import io.airlift.log.Logger;
+import io.trino.plugin.eventlistener.kafka.metadata.EnvMetadataProvider;
+import io.trino.plugin.eventlistener.kafka.metadata.MetadataProvider;
+import io.trino.plugin.eventlistener.kafka.metadata.NoOpMetadataProvider;
+import io.trino.plugin.eventlistener.kafka.metrics.KafkaEventListenerJmxStats;
+import io.trino.plugin.eventlistener.kafka.producer.KafkaProducerFactory;
+import io.trino.plugin.eventlistener.kafka.producer.SSLKafkaProducerFactory;
+import io.trino.spi.eventlistener.QueryCompletedEvent;
+import io.trino.spi.eventlistener.QueryCreatedEvent;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.InvalidRecordException;
+import org.apache.kafka.common.errors.RecordTooLargeException;
+import org.apache.kafka.common.errors.TimeoutException;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class KafkaEventPublisher
+{
+    private static final Logger LOG = Logger.get(KafkaEventPublisher.class);
+
+    private final KafkaProducer<String, String> kafkaProducer;
+    private final KafkaRecordBuilder kafkaRecordBuilder;
+    private final KafkaEventListenerJmxStats stats;
+
+    public KafkaEventPublisher(KafkaEventListenerConfig config, KafkaProducerFactory producerFactory, KafkaEventListenerJmxStats stats)
+            throws Exception
+    {
+        this.stats = requireNonNull(stats, "stats cannot be null");
+        requireNonNull(config, "config cannot be null");
+        requireNonNull(producerFactory, "producerFactory cannot be null");
+        checkArgument(config.getCreatedTopicName().isPresent() || config.getCompletedTopicName().isPresent(), "Either created or completed topic must be present");
+
+        String createdTopic = config.getCreatedTopicName().orElse("");
+        String completedTopic = config.getCompletedTopicName().orElse("");
+
+        Map<String, String> configOverrides = config.getKafkaClientOverrides();
+        LOG.info("Creating Kafka publisher (SSL=%s) for topics: %s/%s with excluded fields: %s and kafka config overrides: %s",
+                producerFactory instanceof SSLKafkaProducerFactory, createdTopic, completedTopic, config.getExcludedFields(), configOverrides);
+        kafkaProducer = producerFactory.producer(configOverrides);
+        checkConnectivityToBrokers(config.getPublishCreatedEvent() ? createdTopic : completedTopic, config.getRequestTimeout().toMillis());
+        kafkaRecordBuilder = new KafkaRecordBuilder(createdTopic, completedTopic, config.getExcludedFields(), metadataProvider(config));
+        LOG.info("Successfully created Kafka publisher.");
+    }
+
+    private void checkConnectivityToBrokers(String topic, long requestTimeout)
+            throws Exception
+    {
+        LOG.info("checking connectivity to brokers (fetching partitions for topic=%s).", topic);
+        CompletableFuture<Void> future = CompletableFuture.runAsync(() -> kafkaProducer.partitionsFor(topic));
+        future.get(requestTimeout, TimeUnit.MILLISECONDS);
+        LOG.info("connectivity check succeeded.");
+    }
+
+    private MetadataProvider metadataProvider(KafkaEventListenerConfig config)
+    {
+        if (config.getEnvironmentVariablePrefix().isPresent()) {
+            return new EnvMetadataProvider(config.getEnvironmentVariablePrefix().get());
+        }
+        else {
+            return new NoOpMetadataProvider();
+        }
+    }
+
+    public void publishCompletedEvent(QueryCompletedEvent queryCompletedEvent)
+    {
+        stats.completedEventReceived();
+        String queryId = queryCompletedEvent.getMetadata().getQueryId();
+        LOG.debug("preparing to send QueryCompletedEvent for query id: %s", queryId);
+        ProducerRecord<String, String> record = null;
+        try {
+            record = kafkaRecordBuilder.buildCompletedRecord(queryCompletedEvent);
+        }
+        catch (Exception e) {
+            stats.completedEventBuildFailure();
+            LOG.warn(e, "unable to build QueryCompletedEvent for query id: %s", queryId);
+        }
+        if (record != null) {
+            kafkaProducer.send(record, (metadata, exception) -> {
+                if (exception != null) {
+                    switch (exception) {
+                        case TimeoutException e -> stats.completedEventSendFailureTimeout();
+                        case RecordTooLargeException e -> stats.completedEventSendFailureTooLarge();
+                        case InvalidRecordException e -> stats.completedEventSendFailureInvalidRecord();
+                        default -> stats.completedEventSendFailureOther();
+                    }
+                    LOG.warn(exception, "failed to send QueryCompletedEvent for query id: %s. Uncompressed message size: %s. Partition: %s",
+                            queryId, metadata.serializedValueSize(), metadata.partition());
+                }
+                else {
+                    stats.completedEventSuccessfulDispatch();
+                    LOG.debug("successfully sent QueryCompletedEvent for query id: %s", queryId);
+                }
+            });
+        }
+    }
+
+    public void publishCreatedEvent(QueryCreatedEvent queryCreatedEvent)
+    {
+        stats.createdEventReceived();
+        String queryId = queryCreatedEvent.getMetadata().getQueryId();
+        LOG.debug("preparing to send QueryCreatedEvent for query id: %s", queryId);
+        ProducerRecord<String, String> record = null;
+        try {
+            record = kafkaRecordBuilder.buildStartedRecord(queryCreatedEvent);
+        }
+        catch (Exception e) {
+            stats.createdEventBuildFailure();
+            LOG.warn(e, "unable to build QueryCreatedEvent for query id: %s", queryId);
+        }
+        if (record != null) {
+            kafkaProducer.send(record, (metadata, exception) -> {
+                if (exception != null) {
+                    switch (exception) {
+                        case TimeoutException e -> stats.createdEventSendFailureTimeout();
+                        case RecordTooLargeException e -> stats.createdEventSendFailureTooLarge();
+                        case InvalidRecordException e -> stats.createdEventSendFailureInvalidRecord();
+                        default -> stats.createdEventSendFailureOther();
+                    }
+                    LOG.warn(exception, "failed to send QueryCreatedEvent for query id: %s. Uncompressed message size: %s. Partition: %s",
+                            queryId, metadata.serializedValueSize(), metadata.partition());
+                }
+                else {
+                    stats.createdEventSuccessfulDispatch();
+                    LOG.debug("successfully sent QueryCreatedEvent for query id: %s", queryId);
+                }
+            });
+        }
+    }
+
+    public void shutdown()
+    {
+        kafkaProducer.close();
+    }
+}

--- a/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/KafkaProducerModule.java
+++ b/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/KafkaProducerModule.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.eventlistener.kafka;
+
+import com.google.inject.Binder;
+import com.google.inject.Scopes;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.plugin.eventlistener.kafka.producer.KafkaProducerFactory;
+import io.trino.plugin.eventlistener.kafka.producer.PlaintextKafkaProducerFactory;
+import io.trino.plugin.eventlistener.kafka.producer.SSLKafkaProducerFactory;
+import io.trino.plugin.kafka.KafkaSecurityConfig;
+import io.trino.plugin.kafka.security.KafkaSslConfig;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class KafkaProducerModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        install(conditionalModule(
+                KafkaSecurityConfig.class,
+                config -> config.getSecurityProtocol().orElse(SecurityProtocol.PLAINTEXT) == SecurityProtocol.PLAINTEXT,
+                // KafkaSecurityConfig only allows PLAINTEXT or SSL for security protocol types
+                plainTextBinder -> plainTextBinder.bind(KafkaProducerFactory.class).to(PlaintextKafkaProducerFactory.class).in(Scopes.SINGLETON),
+                sslBinder -> {
+                    sslBinder.bind(KafkaProducerFactory.class).to(SSLKafkaProducerFactory.class).in(Scopes.SINGLETON);
+                    configBinder(sslBinder).bindConfig(KafkaSslConfig.class);
+                }));
+    }
+}

--- a/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/KafkaRecordBuilder.java
+++ b/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/KafkaRecordBuilder.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.eventlistener.kafka;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.ser.FilterProvider;
+import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+import io.airlift.json.ObjectMapperProvider;
+import io.trino.plugin.eventlistener.kafka.metadata.MetadataProvider;
+import io.trino.plugin.eventlistener.kafka.model.QueryCompletedEventWrapper;
+import io.trino.plugin.eventlistener.kafka.model.QueryCreatedEventWrapper;
+import io.trino.spi.eventlistener.QueryCompletedEvent;
+import io.trino.spi.eventlistener.QueryCreatedEvent;
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+import java.util.Set;
+
+import static com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter.serializeAllExcept;
+
+public class KafkaRecordBuilder
+{
+    private final ObjectWriter writer;
+    private final String startedTopic;
+    private final String completedTopic;
+    private final MetadataProvider metadataProvider;
+
+    @JsonFilter("property-name-filter")
+    static class PropertyFilterMixIn {}
+
+    public KafkaRecordBuilder(String startedTopic, String completedTopic, Set<String> excludedFields, MetadataProvider metadataProvider)
+    {
+        this.startedTopic = startedTopic;
+        this.completedTopic = completedTopic;
+        FilterProvider filter = new SimpleFilterProvider().addFilter("property-name-filter", serializeAllExcept(excludedFields));
+        this.writer = new ObjectMapperProvider().get()
+                .addMixIn(Object.class, PropertyFilterMixIn.class)
+                .writer(filter);
+        this.metadataProvider = metadataProvider;
+    }
+
+    public ProducerRecord<String, String> buildStartedRecord(QueryCreatedEvent event)
+    {
+        QueryCreatedEventWrapper queryCreatedEvent = new QueryCreatedEventWrapper(event, metadataProvider.getMetadata());
+        return new ProducerRecord<>(startedTopic, writeJson(queryCreatedEvent));
+    }
+
+    public ProducerRecord<String, String> buildCompletedRecord(QueryCompletedEvent event)
+    {
+        QueryCompletedEventWrapper queryCompletedEvent = new QueryCompletedEventWrapper(event, metadataProvider.getMetadata());
+        return new ProducerRecord<>(completedTopic, writeJson(queryCompletedEvent));
+    }
+
+    private String writeJson(Object payload)
+    {
+        try {
+            return writer.writeValueAsString(payload);
+        }
+        catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/metadata/EnvMetadataProvider.java
+++ b/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/metadata/EnvMetadataProvider.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.eventlistener.kafka.metadata;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+
+public class EnvMetadataProvider
+        implements MetadataProvider
+{
+    protected final String prefix;
+
+    public EnvMetadataProvider(String prefix)
+    {
+        this.prefix = requireNonNull(prefix, "Prefix must be populated");
+    }
+
+    @Override
+    public Map<String, String> getMetadata()
+    {
+        return filter(System.getenv());
+    }
+
+    protected Map<String, String> filter(Map<String, String> metadata)
+    {
+        return metadata.entrySet().stream()
+                .filter(e -> e.getKey().startsWith(prefix))
+                .collect(Collectors.toMap(e -> e.getKey().substring(prefix.length()), Map.Entry::getValue));
+    }
+}

--- a/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/metadata/MetadataProvider.java
+++ b/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/metadata/MetadataProvider.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.eventlistener.kafka.metadata;
+
+import java.util.Map;
+
+public interface MetadataProvider
+{
+    Map<String, String> getMetadata();
+}

--- a/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/metadata/NoOpMetadataProvider.java
+++ b/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/metadata/NoOpMetadataProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.eventlistener.kafka.metadata;
+
+import java.util.Map;
+
+public class NoOpMetadataProvider
+        implements MetadataProvider
+{
+    @Override
+    public Map<String, String> getMetadata()
+    {
+        return Map.of();
+    }
+}

--- a/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/metrics/KafkaEventListenerJmxStats.java
+++ b/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/metrics/KafkaEventListenerJmxStats.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.eventlistener.kafka.metrics;
+
+import io.airlift.stats.CounterStat;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+@ThreadSafe
+public class KafkaEventListenerJmxStats
+{
+    private final CounterStat initializationFailure = new CounterStat();
+
+    // Query Completed Event stats
+    private final CounterStat completedEventReceived = new CounterStat();
+    private final CounterStat completedEventBuildFailure = new CounterStat();
+    private final CounterStat completedEventSuccessfulDispatch = new CounterStat();
+    private final CounterStat completedEventSendFailureTimeout = new CounterStat();
+    private final CounterStat completedEventSendFailureTooLarge = new CounterStat();
+    private final CounterStat completedEventSendFailureInvalidRecord = new CounterStat();
+    private final CounterStat completedEventSendFailureOther = new CounterStat();
+
+    // Query Created Event stats
+    private final CounterStat createdEventReceived = new CounterStat();
+    private final CounterStat createdEventBuildFailure = new CounterStat();
+    private final CounterStat createdEventSuccessfulDispatch = new CounterStat();
+    private final CounterStat createdEventSendFailureTimeout = new CounterStat();
+    private final CounterStat createdEventSendFailureTooLarge = new CounterStat();
+    private final CounterStat createdEventSendFailureInvalidRecord = new CounterStat();
+    private final CounterStat createdEventSendFailureOther = new CounterStat();
+
+    @Managed
+    @Nested
+    public CounterStat getInitializationFailure()
+    {
+        return initializationFailure;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getCompletedEventReceived()
+    {
+        return completedEventReceived;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getCompletedEventBuildFailure()
+    {
+        return completedEventBuildFailure;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getCompletedEventSendFailureTimeout()
+    {
+        return completedEventSendFailureTimeout;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getCompletedEventSendFailureTooLarge()
+    {
+        return completedEventSendFailureTooLarge;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getCompletedEventSendFailureInvalidRecord()
+    {
+        return completedEventSendFailureInvalidRecord;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getCompletedEventSendFailureOther()
+    {
+        return completedEventSendFailureOther;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getCreatedEventReceived()
+    {
+        return createdEventReceived;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getCreatedEventBuildFailure()
+    {
+        return createdEventBuildFailure;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getCreatedEventSendFailureTimeout()
+    {
+        return createdEventSendFailureTimeout;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getCreatedEventSendFailureTooLarge()
+    {
+        return createdEventSendFailureTooLarge;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getCreatedEventSendFailureInvalidRecord()
+    {
+        return createdEventSendFailureInvalidRecord;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getCreatedEventSendFailureOther()
+    {
+        return createdEventSendFailureOther;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getCreatedEventSuccessfulDispatch()
+    {
+        return createdEventSuccessfulDispatch;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getCompletedEventSuccessfulDispatch()
+    {
+        return completedEventSuccessfulDispatch;
+    }
+
+    public void kafkaPublisherFailedToInitialize()
+    {
+        initializationFailure.update(1);
+    }
+
+    public void completedEventReceived()
+    {
+        completedEventReceived.update(1);
+    }
+
+    public void completedEventBuildFailure()
+    {
+        completedEventBuildFailure.update(1);
+    }
+
+    public void completedEventSendFailureTimeout()
+    {
+        completedEventSendFailureTimeout.update(1);
+    }
+
+    public void completedEventSendFailureTooLarge()
+    {
+        completedEventSendFailureTooLarge.update(1);
+    }
+
+    public void completedEventSendFailureInvalidRecord()
+    {
+        completedEventSendFailureInvalidRecord.update(1);
+    }
+
+    public void completedEventSendFailureOther()
+    {
+        completedEventSendFailureOther.update(1);
+    }
+
+    public void completedEventSuccessfulDispatch()
+    {
+        completedEventSuccessfulDispatch.update(1);
+    }
+
+    public void createdEventReceived()
+    {
+        createdEventReceived.update(1);
+    }
+
+    public void createdEventBuildFailure()
+    {
+        createdEventBuildFailure.update(1);
+    }
+
+    public void createdEventSendFailureTimeout()
+    {
+        createdEventSendFailureTimeout.update(1);
+    }
+
+    public void createdEventSendFailureTooLarge()
+    {
+        createdEventSendFailureTooLarge.update(1);
+    }
+
+    public void createdEventSendFailureInvalidRecord()
+    {
+        createdEventSendFailureInvalidRecord.update(1);
+    }
+
+    public void createdEventSendFailureOther()
+    {
+        createdEventSendFailureOther.update(1);
+    }
+
+    public void createdEventSuccessfulDispatch()
+    {
+        createdEventSuccessfulDispatch.update(1);
+    }
+}

--- a/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/model/QueryCompletedEventWrapper.java
+++ b/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/model/QueryCompletedEventWrapper.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.eventlistener.kafka.model;
+
+import io.trino.spi.eventlistener.QueryCompletedEvent;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public record QueryCompletedEventWrapper(QueryCompletedEvent eventPayload, Map<String, String> eventMetadata)
+{
+    public QueryCompletedEventWrapper
+    {
+        requireNonNull(eventPayload, "eventPayload is null");
+        requireNonNull(eventMetadata, "eventMetadata is null");
+    }
+}

--- a/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/model/QueryCreatedEventWrapper.java
+++ b/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/model/QueryCreatedEventWrapper.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.eventlistener.kafka.model;
+
+import io.trino.spi.eventlistener.QueryCreatedEvent;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public record QueryCreatedEventWrapper(QueryCreatedEvent eventPayload, Map<String, String> eventMetadata)
+{
+    public QueryCreatedEventWrapper
+    {
+        requireNonNull(eventPayload, "eventPayload is null");
+        requireNonNull(eventMetadata, "eventMetadata is null");
+    }
+}

--- a/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/producer/BaseKafkaProducerFactory.java
+++ b/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/producer/BaseKafkaProducerFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.eventlistener.kafka.producer;
+
+import io.trino.plugin.eventlistener.kafka.KafkaEventListenerConfig;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+abstract class BaseKafkaProducerFactory
+        implements KafkaProducerFactory
+{
+    @Override
+    public KafkaProducer<String, String> producer(Map<String, String> overrides)
+    {
+        throw new UnsupportedOperationException("Cannot call producer() on abstract class");
+    }
+
+    protected Map<String, Object> baseConfig(KafkaEventListenerConfig config)
+    {
+        Map<String, Object> kafkaClientConfig = new HashMap<>();
+        kafkaClientConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, config.getBrokerEndpoints());
+        config.getClientId().ifPresent(clientId -> kafkaClientConfig.put(ProducerConfig.CLIENT_ID_CONFIG, clientId));
+        kafkaClientConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        kafkaClientConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        kafkaClientConfig.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "zstd");
+        kafkaClientConfig.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, "5242880");
+        kafkaClientConfig.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, Long.toString(config.getRequestTimeout().toMillis()));
+        return kafkaClientConfig;
+    }
+}

--- a/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/producer/KafkaProducerFactory.java
+++ b/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/producer/KafkaProducerFactory.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.eventlistener.kafka.producer;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+
+import java.util.Map;
+
+public interface KafkaProducerFactory
+{
+    KafkaProducer<String, String> producer(Map<String, String> overrides);
+}

--- a/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/producer/PlaintextKafkaProducerFactory.java
+++ b/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/producer/PlaintextKafkaProducerFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.eventlistener.kafka.producer;
+
+import com.google.inject.Inject;
+import io.trino.plugin.eventlistener.kafka.KafkaEventListenerConfig;
+import org.apache.kafka.clients.producer.KafkaProducer;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class PlaintextKafkaProducerFactory
+        extends BaseKafkaProducerFactory
+{
+    private final KafkaEventListenerConfig config;
+
+    @Inject
+    public PlaintextKafkaProducerFactory(KafkaEventListenerConfig config)
+    {
+        this.config = requireNonNull(config, "config is null");
+    }
+
+    @Override
+    public KafkaProducer<String, String> producer(Map<String, String> overrides)
+    {
+        return new KafkaProducer<>(createKafkaClientConfig(config, overrides));
+    }
+
+    private Map<String, Object> createKafkaClientConfig(KafkaEventListenerConfig config, Map<String, String> kafkaClientOverrides)
+    {
+        Map<String, Object> kafkaClientConfig = baseConfig(config);
+        kafkaClientConfig.putAll(kafkaClientOverrides);
+        return kafkaClientConfig;
+    }
+}

--- a/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/producer/SSLKafkaProducerFactory.java
+++ b/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/producer/SSLKafkaProducerFactory.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.eventlistener.kafka.producer;
+
+import com.google.inject.Inject;
+import io.trino.plugin.eventlistener.kafka.KafkaEventListenerConfig;
+import io.trino.plugin.kafka.security.KafkaSslConfig;
+import org.apache.kafka.clients.producer.KafkaProducer;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.kafka.clients.CommonClientConfigs.SECURITY_PROTOCOL_CONFIG;
+import static org.apache.kafka.common.config.SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG;
+import static org.apache.kafka.common.config.SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG;
+import static org.apache.kafka.common.config.SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG;
+import static org.apache.kafka.common.config.SslConfigs.SSL_KEYSTORE_TYPE_CONFIG;
+import static org.apache.kafka.common.config.SslConfigs.SSL_KEY_PASSWORD_CONFIG;
+import static org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG;
+import static org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG;
+import static org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG;
+import static org.apache.kafka.common.security.auth.SecurityProtocol.SSL;
+
+public class SSLKafkaProducerFactory
+        extends BaseKafkaProducerFactory
+{
+    private final KafkaEventListenerConfig config;
+    private final KafkaSslConfig sslConfig;
+
+    @Inject
+    public SSLKafkaProducerFactory(KafkaEventListenerConfig config, KafkaSslConfig sslConfig)
+    {
+        this.config = requireNonNull(config, "config is null");
+        this.sslConfig = sslConfig;
+    }
+
+    @Override
+    public KafkaProducer<String, String> producer(Map<String, String> overrides)
+    {
+        return new KafkaProducer<>(createKafkaClientConfig(config, sslConfig, overrides));
+    }
+
+    private Map<String, Object> createKafkaClientConfig(KafkaEventListenerConfig config, KafkaSslConfig sslConfig, Map<String, String> kafkaClientOverrides)
+    {
+        Map<String, Object> kafkaClientConfig = baseConfig(config);
+
+        sslConfig.getKeystoreLocation().ifPresent(value -> kafkaClientConfig.put(SSL_KEYSTORE_LOCATION_CONFIG, value));
+        sslConfig.getKeystorePassword().ifPresent(value -> kafkaClientConfig.put(SSL_KEYSTORE_PASSWORD_CONFIG, value));
+        sslConfig.getKeystoreType().ifPresent(value -> kafkaClientConfig.put(SSL_KEYSTORE_TYPE_CONFIG, value.name()));
+        sslConfig.getTruststoreLocation().ifPresent(value -> kafkaClientConfig.put(SSL_TRUSTSTORE_LOCATION_CONFIG, value));
+        sslConfig.getTruststorePassword().ifPresent(value -> kafkaClientConfig.put(SSL_TRUSTSTORE_PASSWORD_CONFIG, value));
+        sslConfig.getTruststoreType().ifPresent(value -> kafkaClientConfig.put(SSL_TRUSTSTORE_TYPE_CONFIG, value.name()));
+        sslConfig.getKeyPassword().ifPresent(value -> kafkaClientConfig.put(SSL_KEY_PASSWORD_CONFIG, value));
+        sslConfig.getEndpointIdentificationAlgorithm().ifPresent(value -> kafkaClientConfig.put(SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, value.getValue()));
+        kafkaClientConfig.put(SECURITY_PROTOCOL_CONFIG, SSL.name());
+
+        kafkaClientConfig.putAll(kafkaClientOverrides);
+        return kafkaClientConfig;
+    }
+}

--- a/plugin/trino-kafka-event-listener/src/test/java/io/trino/plugin/eventlistener/kafka/TestKafkaEventListenerConfig.java
+++ b/plugin/trino-kafka-event-listener/src/test/java/io/trino/plugin/eventlistener/kafka/TestKafkaEventListenerConfig.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.eventlistener.kafka;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestKafkaEventListenerConfig
+{
+    @Test
+    void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(KafkaEventListenerConfig.class)
+                .setAnonymizationEnabled(false)
+                .setPublishCreatedEvent(true)
+                .setPublishCompletedEvent(true)
+                .setCompletedTopicName(null)
+                .setCreatedTopicName(null)
+                .setBrokerEndpoints(null)
+                .setClientId(null)
+                .setExcludedFields(Set.of())
+                .setKafkaClientOverrides("")
+                .setRequestTimeout(new Duration(10, TimeUnit.SECONDS))
+                .setTerminateOnInitializationFailure(true)
+                .setEnvironmentVariablePrefix(null));
+    }
+
+    @Test
+    void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("kafka-event-listener.publish-created-event", "false")
+                .put("kafka-event-listener.publish-completed-event", "false")
+                .put("kafka-event-listener.broker-endpoints", "kafka-host-1:9093,kafka-host-2:9093")
+                .put("kafka-event-listener.created-event.topic", "query_created")
+                .put("kafka-event-listener.completed-event.topic", "query_completed")
+                .put("kafka-event-listener.client-id", "dashboard-cluster")
+                .put("kafka-event-listener.excluded-fields", "payload,ioMetadata,groups,cpuTimeDistribution")
+                .put("kafka-event-listener.client-config-overrides", "foo=bar,baz=yoo")
+                .put("kafka-event-listener.request-timeout", "3s")
+                .put("kafka-event-listener.env-var-prefix", "INSIGHTS_")
+                .put("kafka-event-listener.anonymization.enabled", "true")
+                .put("kafka-event-listener.terminate-on-initialization-failure", "false")
+                .buildOrThrow();
+
+        KafkaEventListenerConfig expected = new KafkaEventListenerConfig()
+                .setAnonymizationEnabled(true)
+                .setPublishCreatedEvent(false)
+                .setPublishCompletedEvent(false)
+                .setBrokerEndpoints("kafka-host-1:9093,kafka-host-2:9093")
+                .setCreatedTopicName("query_created")
+                .setCompletedTopicName("query_completed")
+                .setClientId("dashboard-cluster")
+                .setExcludedFields(Set.of("payload", "ioMetadata", "groups", "cpuTimeDistribution"))
+                .setKafkaClientOverrides("foo=bar,baz=yoo")
+                .setRequestTimeout(new Duration(3, TimeUnit.SECONDS))
+                .setEnvironmentVariablePrefix("INSIGHTS_")
+                .setTerminateOnInitializationFailure(false);
+
+        assertFullMapping(properties, expected);
+    }
+
+    @Test
+    public void testExcludedFields()
+    {
+        KafkaEventListenerConfig conf = new KafkaEventListenerConfig();
+        // check default
+        Set<String> excludedFields = conf.getExcludedFields();
+        assertThat(excludedFields.size()).isEqualTo(0);
+
+        // check setting multiple
+        conf.setExcludedFields(Set.of("payload", "plan", "user", "groups"));
+        excludedFields = conf.getExcludedFields();
+        assertThat(excludedFields.size()).isEqualTo(4);
+        assertThat(excludedFields.contains("payload")).isTrue();
+        assertThat(excludedFields.contains("plan")).isTrue();
+        assertThat(excludedFields.contains("user")).isTrue();
+        assertThat(excludedFields.contains("groups")).isTrue();
+
+        // setting to empty
+        conf.setExcludedFields(Set.of(""));
+        excludedFields = conf.getExcludedFields();
+        assertThat(excludedFields.size()).isEqualTo(0);
+
+        // setting to empty with commas
+        conf.setExcludedFields(Set.of(" ", ""));
+        excludedFields = conf.getExcludedFields();
+        assertThat(excludedFields.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void testKafkaClientOverrides()
+    {
+        KafkaEventListenerConfig conf = new KafkaEventListenerConfig();
+        // check default
+        Map<String, String> overrides = conf.getKafkaClientOverrides();
+        assertThat(overrides.size()).isEqualTo(0);
+
+        // check setting just one
+        conf.setKafkaClientOverrides("buffer.memory=444555");
+        overrides = conf.getKafkaClientOverrides();
+        assertThat(overrides.size()).isEqualTo(1);
+        assertThat(overrides.get("buffer.memory")).isEqualTo("444555");
+
+        // check setting multiple
+        conf.setKafkaClientOverrides("buffer.memory=444555, compression.type=zstd");
+        overrides = conf.getKafkaClientOverrides();
+        assertThat(overrides.size()).isEqualTo(2);
+        assertThat(overrides.get("buffer.memory")).isEqualTo("444555");
+        assertThat(overrides.get("compression.type")).isEqualTo("zstd");
+
+        // check empty trailing param
+        conf.setKafkaClientOverrides("buffer.memory=555777,");
+        overrides = conf.getKafkaClientOverrides();
+        assertThat(overrides.size()).isEqualTo(1);
+        assertThat(overrides.get("buffer.memory")).isEqualTo("555777");
+
+        conf.setKafkaClientOverrides(",, ,");
+        overrides = conf.getKafkaClientOverrides();
+        assertThat(overrides.size()).isEqualTo(0);
+
+        // check missing = throws
+        assertThatThrownBy(() -> conf.setKafkaClientOverrides("invalid,buffer.memory=555777"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/plugin/trino-kafka-event-listener/src/test/java/io/trino/plugin/eventlistener/kafka/TestKafkaEventListenerPlugin.java
+++ b/plugin/trino-kafka-event-listener/src/test/java/io/trino/plugin/eventlistener/kafka/TestKafkaEventListenerPlugin.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.eventlistener.kafka;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.spi.eventlistener.EventListener;
+import io.trino.spi.eventlistener.EventListenerFactory;
+import io.trino.testing.kafka.TestingKafka;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Properties;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestKafkaEventListenerPlugin
+{
+    private static final String CREATED_TOPIC = "query_created";
+    private static final String COMPLETED_TOPIC = "query_completed";
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static TestingKafka testingKafka;
+
+    @BeforeAll
+    public static void setUp()
+    {
+        testingKafka = TestingKafka.create();
+        testingKafka.start();
+        testingKafka.createTopic(CREATED_TOPIC);
+        testingKafka.createTopic(COMPLETED_TOPIC);
+    }
+
+    @AfterAll
+    public static void teardown()
+            throws IOException
+    {
+        testingKafka.close();
+    }
+
+    @Test
+    void testEventListenerEndToEnd()
+            throws JsonProcessingException
+    {
+        KafkaEventListenerPlugin plugin = new KafkaEventListenerPlugin();
+
+        EventListenerFactory factory = getOnlyElement(plugin.getEventListenerFactories());
+        EventListener eventListener = factory.create(
+                ImmutableMap.<String, String>builder()
+                        .put("kafka-event-listener.publish-created-event", "true")
+                        .put("kafka-event-listener.publish-completed-event", "true")
+                        .put("kafka-event-listener.broker-endpoints", testingKafka.getConnectString())
+                        .put("kafka-event-listener.created-event.topic", CREATED_TOPIC)
+                        .put("kafka-event-listener.completed-event.topic", COMPLETED_TOPIC)
+                        .put("kafka-event-listener.env-var-prefix", "INSIGHTS_")
+                        .put("kafka-event-listener.request-timeout", "30s")
+                        .put("kafka-event-listener.excluded-fields", "ioMetadata")
+                        .put("kafka.security-protocol", "plaintext")
+                        .buildOrThrow());
+
+        try {
+            // produce and consume a test created event
+            eventListener.queryCreated(TestUtils.queryCreatedEvent);
+            ConsumerRecord<String, String> record = getOnlyElement(pollJsonRecords(CREATED_TOPIC));
+            JsonNode jsonNode = MAPPER.readTree(record.value());
+            assertThat(jsonNode.get("eventMetadata")).isNotNull();
+            JsonNode jsonEvent = jsonNode.get("eventPayload");
+            assertThat(jsonEvent).isNotNull();
+            assertThat(jsonEvent.get("context")).isNotNull();
+            assertThat(jsonEvent.get("metadata")).isNotNull();
+            assertThat(jsonEvent.get("metadata").get("queryId").textValue()).isEqualTo(TestUtils.queryCreatedEvent.getMetadata().getQueryId());
+
+            // produce and consume a test completed event
+            eventListener.queryCompleted(TestUtils.queryCompletedEvent);
+            record = getOnlyElement(pollJsonRecords(COMPLETED_TOPIC));
+            jsonNode = MAPPER.readTree(record.value());
+            assertThat(jsonNode.get("eventMetadata")).isNotNull();
+            jsonEvent = jsonNode.get("eventPayload");
+            assertThat(jsonEvent).isNotNull();
+            assertThat(jsonEvent.get("context")).isNotNull();
+            assertThat(jsonEvent.get("metadata")).isNotNull();
+            assertThat(jsonEvent.get("statistics")).isNotNull();
+            assertThat(jsonEvent.get("warnings")).isNotNull();
+            // ioMetadata is excluded via config
+            assertThat(jsonEvent.get("ioMetadata")).isNull();
+            assertThat(jsonEvent.get("metadata").get("queryId").textValue()).isEqualTo(TestUtils.queryCompletedEvent.getMetadata().getQueryId());
+        }
+        finally {
+            eventListener.shutdown();
+        }
+    }
+
+    private ConsumerRecords<String, String> pollJsonRecords(String topic)
+    {
+        try (KafkaConsumer<String, String> jsonConsumer = createConsumer()) {
+            jsonConsumer.subscribe(ImmutableList.of(topic));
+            return jsonConsumer.poll(Duration.of(5, ChronoUnit.SECONDS));
+        }
+    }
+
+    private KafkaConsumer<String, String> createConsumer()
+    {
+        Properties properties = new Properties();
+        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, testingKafka.getConnectString());
+        properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        properties.put(ConsumerConfig.GROUP_ID_CONFIG, "test-consumer");
+        properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        return new KafkaConsumer<>(properties);
+    }
+}

--- a/plugin/trino-kafka-event-listener/src/test/java/io/trino/plugin/eventlistener/kafka/TestKafkaRecordBuilder.java
+++ b/plugin/trino-kafka-event-listener/src/test/java/io/trino/plugin/eventlistener/kafka/TestKafkaRecordBuilder.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.eventlistener.kafka;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import io.trino.plugin.eventlistener.kafka.metadata.EnvMetadataProvider;
+import io.trino.plugin.eventlistener.kafka.metadata.MetadataProvider;
+import io.trino.spi.eventlistener.QueryCompletedEvent;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestKafkaRecordBuilder
+{
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final Set<String> EXCLUDED_FIELDS = ImmutableSet.of(
+            "ioMetadata",
+            "payload",
+            "groups",
+            "cpuTimeDistribution",
+            "operatorSummaries",
+            "planNodeStatsAndCosts",
+            "stageGcStatistics");
+    private static final MetadataProvider TEST_PROVIDER = new TestMetadataProvider("TRINO_INSIGHTS");
+
+    @Test
+    public void testBuildKafkaRecord()
+            throws IOException
+    {
+        KafkaRecordBuilder builder = new KafkaRecordBuilder("TestQueryStartedEvent", "TestQueryCompletedEvent", EXCLUDED_FIELDS, TEST_PROVIDER);
+        QueryCompletedEvent queryCompletedEvent = TestUtils.queryCompletedEvent;
+
+        ProducerRecord<String, String> record = builder.buildCompletedRecord(queryCompletedEvent);
+
+        assertThat(record.topic()).isEqualTo("TestQueryCompletedEvent");
+        assertThat(record.key()).isNull();
+
+        JsonNode jsonNode = MAPPER.readTree(record.value()).get("eventPayload");
+        checkFieldsExcluded(jsonNode);
+    }
+
+    @Test
+    public void testBuildKafkaRecordWithExclusions()
+            throws IOException
+    {
+        Set<String> exclude = Sets.union(EXCLUDED_FIELDS, Set.of("query", "principal", "analysisTime", "writtenBytes"));
+        KafkaRecordBuilder builder = new KafkaRecordBuilder("TestQueryStartedEvent", "TestQueryCompletedEvent", exclude, TEST_PROVIDER);
+        QueryCompletedEvent queryCompletedEvent = TestUtils.queryCompletedEvent;
+
+        ProducerRecord<String, String> record = builder.buildCompletedRecord(queryCompletedEvent);
+
+        assertThat(record.topic()).isEqualTo("TestQueryCompletedEvent");
+        assertThat(record.key()).isNull();
+
+        JsonNode jsonNode = MAPPER.readTree(record.value()).get("eventPayload");
+        checkFieldsExcluded(jsonNode);
+        assertThat(jsonNode.get("metadata").get("query")).isNull();
+        assertThat(jsonNode.get("context").get("principal")).isNull();
+        assertThat(jsonNode.get("statistics").get("analysisTime")).isNull();
+        assertThat(jsonNode.get("statistics").get("writtenBytes")).isNull();
+    }
+
+    @Test
+    public void testBuildKafkaRecordWithMetadata()
+            throws IOException
+    {
+        Set<String> exclude = Sets.union(EXCLUDED_FIELDS, Set.of("context", "payload", "analysisTime"));
+        KafkaRecordBuilder builder = new KafkaRecordBuilder("TestQueryStartedEvent", "TestQueryCompletedEvent", exclude, TEST_PROVIDER);
+        QueryCompletedEvent queryCompletedEvent = TestUtils.queryCompletedEvent;
+
+        ProducerRecord<String, String> record = builder.buildCompletedRecord(queryCompletedEvent);
+
+        assertThat(record.topic()).isEqualTo("TestQueryCompletedEvent");
+        assertThat(record.key()).isNull();
+        Map<String, String> metadata = MAPPER.readValue(MAPPER.readTree(record.value()).get("eventMetadata").toString(), Map.class);
+
+        assertThat(metadata.size()).isEqualTo(1);
+        assertThat(metadata.get("baz")).isEqualTo("yoo");
+    }
+
+    static class TestMetadataProvider
+            extends EnvMetadataProvider
+    {
+        public TestMetadataProvider(String prefix)
+        {
+            super(prefix);
+        }
+
+        @Override
+        public Map<String, String> getMetadata()
+        {
+            return filter(Map.of("foo", "bar", prefix + "baz", "yoo"));
+        }
+    }
+
+    private static void checkFieldsExcluded(JsonNode jsonNode)
+    {
+        assertThat(jsonNode.get("ioMetadata")).isNull();
+        assertThat(jsonNode.get("context").isNull()).isFalse();
+        assertThat(jsonNode.get("context").get("user").isNull()).isFalse();
+        assertThat(jsonNode.get("context").get("groups")).isNull();
+        assertThat(jsonNode.get("metadata").isNull()).isFalse();
+        assertThat(jsonNode.get("metadata").get("queryId").isNull()).isFalse();
+        assertThat(jsonNode.get("metadata").get("payload")).isNull();
+        assertThat(jsonNode.get("statistics").isNull()).isFalse();
+        assertThat(jsonNode.get("statistics").get("totalBytes").isNull()).isFalse();
+        assertThat(jsonNode.get("statistics").get("stageGcStatistics")).isNull();
+        assertThat(jsonNode.get("statistics").get("planNodeStatsAndCosts")).isNull();
+        assertThat(jsonNode.get("statistics").get("operatorSummaries")).isNull();
+        assertThat(jsonNode.get("statistics").get("cpuTimeDistribution")).isNull();
+    }
+}

--- a/plugin/trino-kafka-event-listener/src/test/java/io/trino/plugin/eventlistener/kafka/TestUtils.java
+++ b/plugin/trino-kafka-event-listener/src/test/java/io/trino/plugin/eventlistener/kafka/TestUtils.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.eventlistener.kafka;
+
+import io.trino.operator.RetryPolicy;
+import io.trino.spi.ErrorCode;
+import io.trino.spi.ErrorType;
+import io.trino.spi.TrinoWarning;
+import io.trino.spi.WarningCode;
+import io.trino.spi.eventlistener.QueryCompletedEvent;
+import io.trino.spi.eventlistener.QueryContext;
+import io.trino.spi.eventlistener.QueryCreatedEvent;
+import io.trino.spi.eventlistener.QueryFailureInfo;
+import io.trino.spi.eventlistener.QueryIOMetadata;
+import io.trino.spi.eventlistener.QueryMetadata;
+import io.trino.spi.eventlistener.QueryStatistics;
+import io.trino.spi.eventlistener.SplitCompletedEvent;
+import io.trino.spi.eventlistener.SplitStatistics;
+import io.trino.spi.eventlistener.StageOutputBufferUtilization;
+import io.trino.spi.resourcegroups.QueryType;
+import io.trino.spi.resourcegroups.ResourceGroupId;
+import io.trino.spi.session.ResourceEstimates;
+
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
+import static java.time.Duration.ofMillis;
+
+public class TestUtils
+{
+    private static final QueryIOMetadata queryIOMetadata;
+    private static final QueryContext queryContext;
+    private static final QueryMetadata queryMetadata;
+    private static final SplitStatistics splitStatistics;
+    private static final QueryStatistics queryStatistics;
+
+    private static final Optional<QueryFailureInfo> queryFailureInfo;
+
+    static final SplitCompletedEvent splitCompletedEvent;
+    static final QueryCreatedEvent queryCreatedEvent;
+    static final QueryCompletedEvent queryCompletedEvent;
+
+    private TestUtils()
+    {
+    }
+
+    static {
+        queryIOMetadata = new QueryIOMetadata(Collections.emptyList(), Optional.empty());
+
+        queryContext = new QueryContext(
+                "user",
+                "originalUser",
+                Optional.of("principal"),
+                Set.of(),
+                Set.of(), // groups
+                Optional.empty(), // traceToken
+                Optional.empty(), // remoteClientAddress
+                Optional.empty(), // userAgent
+                Optional.empty(), // clientInfo
+                new HashSet<>(), // clientTags
+                new HashSet<>(), // clientCapabilities
+                Optional.of("source"),
+                UTC_KEY.getId(),
+                Optional.of("catalog"),
+                Optional.of("schema"),
+                Optional.of(new ResourceGroupId("name")),
+                new HashMap<>(), // sessionProperties
+                new ResourceEstimates(Optional.empty(), Optional.empty(), Optional.of(1000L)),
+                "serverAddress", "serverVersion", "environment",
+                Optional.of(QueryType.SELECT),
+                RetryPolicy.QUERY.toString());
+
+        queryMetadata = new QueryMetadata(
+                "queryId",
+                Optional.empty(),
+                "query",
+                Optional.of("updateType"),
+                Optional.of("preparedQuery"),
+                "queryState",
+                List.of(),
+                List.of(),
+                URI.create("http://localhost"),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+
+        splitStatistics = new SplitStatistics(
+                ofMillis(1000),
+                ofMillis(2000),
+                ofMillis(3000),
+                ofMillis(4000),
+                1,
+                2,
+                Optional.of(Duration.ofMillis(100)),
+                Optional.of(Duration.ofMillis(200)));
+
+        queryStatistics = new QueryStatistics(
+                ofMillis(1000),
+                ofMillis(1000),
+                ofMillis(1000),
+                ofMillis(1000),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0.0f,
+                Collections.emptyList(),
+                0,
+                true,
+                Collections.emptyList(),
+                List.of(new StageOutputBufferUtilization(0, 10, 0.1, 0.5, 0.10, 0.25, 0.50, 0.75, 0.90, 0.95, 0.99, 0.0, 1.0, Duration.ofSeconds(1234))),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Optional.empty());
+
+        queryFailureInfo = Optional.of(
+                new QueryFailureInfo(
+                        new ErrorCode(404, "Access Denied", ErrorType.EXTERNAL),
+                        Optional.of("EXTERNAL_ERROR"),
+                        Optional.of("Access Denied"),
+                        Optional.of("task"),
+                        Optional.of("host"),
+                        "testJson"));
+
+        splitCompletedEvent = new SplitCompletedEvent(
+                "queryId",
+                "stageId",
+                "taskId",
+                Optional.of("catalogName"),
+                Instant.now(),
+                Optional.of(Instant.now()),
+                Optional.of(Instant.now()),
+                splitStatistics,
+                Optional.empty(),
+                "payload");
+
+        queryCreatedEvent = new QueryCreatedEvent(
+                Instant.now(),
+                queryContext,
+                queryMetadata);
+
+        queryCompletedEvent = new QueryCompletedEvent(
+                queryMetadata,
+                queryStatistics,
+                queryContext,
+                queryIOMetadata,
+                queryFailureInfo,
+                List.of(new TrinoWarning(new WarningCode(101, "TestCode"), "Test error message")),
+                Instant.now(),
+                Instant.now(),
+                Instant.now());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
         <module>plugin/trino-ignite</module>
         <module>plugin/trino-jmx</module>
         <module>plugin/trino-kafka</module>
+        <module>plugin/trino-kafka-event-listener</module>
         <module>plugin/trino-kinesis</module>
         <module>plugin/trino-kudu</module>
         <module>plugin/trino-local-file</module>
@@ -1186,6 +1187,12 @@
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-jmx</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.trino</groupId>
+                <artifactId>trino-kafka</artifactId>
                 <version>${project.version}</version>
             </dependency>
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Issue: https://github.com/trinodb/trino/issues/22426

This PR adds a new `trino-kafka-event-listener` plugin to send `QueryCreatedEvent`s and `QueryCompletedEvent`s to Kafka, similarly to the existing `trino-mysql-event-listener` plugin.

It reuses the SSL configuration options from the `trino-kafka` module (`kafka.ssl.keystore.location`, etc.).

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Example plugin configuration:
```
event-listener.name=kafka-event-listener
kafka-event-listener.publish-created-event=false
kafka-event-listener.publish-completed-event=true
kafka-event-listener.completed-event.topic=query_completed
kafka-event-listener.client-id=marton.bod.test
kafka-event-listener.broker-endpoints=kafka-host-1:9093,kafka-host-2:9093
kafka-event-listener.excluded-fields=ioMetadata,payload,groups,cpuTimeDistribution
kafka.security-protocol=plaintext
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# General
* Add Kafka event listener plugin (https://github.com/trinodb/trino/issues/22426)
```
