### PR TITLE
Treat Hive schema errors as EXTERNAL

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/HiveFormatsErrorCode.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/HiveFormatsErrorCode.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hive.formats;
+
+import io.trino.spi.ErrorCode;
+import io.trino.spi.ErrorCodeSupplier;
+import io.trino.spi.ErrorType;
+
+import static io.trino.spi.ErrorType.EXTERNAL;
+
+// these error codes must match the error codes in HiveErrorCode
+public enum HiveFormatsErrorCode
+        implements ErrorCodeSupplier
+{
+    HIVE_INVALID_METADATA(12, EXTERNAL),
+    /**/;
+
+    private final ErrorCode errorCode;
+
+    HiveFormatsErrorCode(int code, ErrorType type)
+    {
+        errorCode = new ErrorCode(code + 0x0100_0000, name(), type);
+    }
+
+    @Override
+    public ErrorCode toErrorCode()
+    {
+        return errorCode;
+    }
+}

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/TestHiveFormatUtils.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/TestHiveFormatUtils.java
@@ -22,8 +22,9 @@ import java.time.LocalDate;
 import static io.trino.hive.formats.HiveFormatUtils.TIMESTAMP_FORMATS_KEY;
 import static io.trino.hive.formats.HiveFormatUtils.getTimestampFormatsSchemaProperty;
 import static io.trino.hive.formats.HiveFormatUtils.parseHiveDate;
+import static io.trino.hive.formats.HiveFormatsErrorCode.HIVE_INVALID_METADATA;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class TestHiveFormatUtils
 {
@@ -39,12 +40,12 @@ public class TestHiveFormatUtils
     @Test
     public void testTimestampFormatEscaping()
     {
-        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() ->
-                        getTimestampFormatsSchemaProperty(ImmutableMap.of(TIMESTAMP_FORMATS_KEY, "\\")))
-                .withMessageContaining("unterminated escape");
-        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() ->
-                        getTimestampFormatsSchemaProperty(ImmutableMap.of(TIMESTAMP_FORMATS_KEY, "\\neither backslash nor comma")))
-                .withMessageContaining("Illegal escaped character");
+        assertTrinoExceptionThrownBy(() -> getTimestampFormatsSchemaProperty(ImmutableMap.of(TIMESTAMP_FORMATS_KEY, "\\")))
+                .hasErrorCode(HIVE_INVALID_METADATA)
+                .hasMessageContaining("unterminated escape");
+        assertTrinoExceptionThrownBy(() -> getTimestampFormatsSchemaProperty(ImmutableMap.of(TIMESTAMP_FORMATS_KEY, "\\neither backslash nor comma")))
+                .hasErrorCode(HIVE_INVALID_METADATA)
+                .hasMessageContaining("Illegal escaped character");
         assertThat(getTimestampFormatsSchemaProperty(ImmutableMap.of(TIMESTAMP_FORMATS_KEY, "\\\\"))).isEqualTo(ImmutableList.of("\\"));
         assertThat(getTimestampFormatsSchemaProperty(ImmutableMap.of(TIMESTAMP_FORMATS_KEY, "xx\\\\"))).isEqualTo(ImmutableList.of("xx\\"));
         assertThat(getTimestampFormatsSchemaProperty(ImmutableMap.of(TIMESTAMP_FORMATS_KEY, "\\\\yy"))).isEqualTo(ImmutableList.of("\\yy"));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

HiveFormatUtils sometimes throw exceptions upon encountering schema errors.  These are not TrinoExceptions, so they get automatically converted to GENERIC_INTERNAL_ERROR code by QueryStateMachine.  This is not correct, as the error is external, coming from the Hive table schema.

Fix it by throwing TrinoException in those cases, with a new error code for Hive schema problems.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

The new error code was added in the Hive plugin, where the HiveErrorCode enum lives.  This is, unfortunately, not visible from `io.trino.hive.formats`, so I added a new exception type there and tried to catch it along all call-chains in the Hive plugin to convert it to the new error code.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Report Hive schema problems as an EXTERNAL ErrorType, not INTERNAL_ERROR.
```
