### PR TITLE
Add docs for Preview Web UI

### DIFF
--- a/docs/src/main/sphinx/admin.md
+++ b/docs/src/main/sphinx/admin.md
@@ -4,6 +4,7 @@
 :maxdepth: 1
 
 admin/web-interface
+admin/preview-web-interface
 admin/tuning
 admin/jmx
 admin/opentelemetry

--- a/docs/src/main/sphinx/admin/preview-web-interface.md
+++ b/docs/src/main/sphinx/admin/preview-web-interface.md
@@ -1,0 +1,32 @@
+# Preview Web UI
+
+In addition to the [](/admin/web-interface), Trino includes a preview version of
+a new web interface. It changes look and feel, available features, and many
+other aspects. In the future this new user interface will replace the existing
+user interface.
+
+:::{warning}
+
+The Preview Web UI is not suitable for production usage, and only available for
+testing and evaluation purposes. Feedback and assistance with development is
+encouraged. Find collaborators and discussions in ongoing pull requests and the
+[#web-ui channel](https://trinodb.slack.com/messages/CKCEWGYT0).
+
+:::
+
+## Activation
+
+The Preview Web UI is not available by default, and must be enabled in
+[](config-properties) with the following configuration:
+
+
+```properties
+web-ui.preview.enabled=true
+```
+
+## Access
+
+Once activated, users can access the interface in the URL context `/ui/preview`
+after successful login to the [](/admin/web-interface). For example, the full
+URL on a locally running Trino installation or Trino docker container without
+TLS configuration is [http://localhost:8080/ui/preview](http://localhost:8080/ui/preview).

--- a/docs/src/main/sphinx/admin/properties-web-interface.md
+++ b/docs/src/main/sphinx/admin/properties-web-interface.md
@@ -16,7 +16,14 @@ The authentication mechanism to allow user access to the Web UI. See
 - **Type:** {ref}`prop-type-boolean`
 - **Default value:** `true`
 
-This property controls whether or not the Web UI is available.
+This property controls whether or not the [](/admin/web-interface) is available.
+
+## `web-ui.preview.enabled`
+
+- **Type:** {ref}`prop-type-boolean`
+- **Default value:** `false`
+
+This property controls whether or not the [](/admin/preview-web-interface) is available.
 
 ## `web-ui.shared-secret`
 


### PR DESCRIPTION
## Description

Provide minimal guidance about the new user interface to enable users to test and provide feedback and potentially help out. I am not sure about the timing for when to merge this. At a minimum we have to wait for the linked PR to be merged. Then I think we can merge this even though there will be nearly nothing to see.

## Additional context and related issues

#22869


## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
