### PR TITLE
Add missing TaskExecutorResource to jmx

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -303,7 +303,6 @@ public class ServerMainModule
         newOptionalBinder(binder, VersionEmbedder.class).setDefault().to(EmbedVersion.class).in(Scopes.SINGLETON);
         newExporter(binder).export(SqlTaskManager.class).withGeneratedName();
 
-        newExporter(binder).export(TaskExecutor.class).withGeneratedName();
         binder.bind(MultilevelSplitQueue.class).in(Scopes.SINGLETON);
         newExporter(binder).export(MultilevelSplitQueue.class).withGeneratedName();
         binder.bind(LocalExecutionPlanner.class).in(Scopes.SINGLETON);

--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -326,6 +326,7 @@ public class ServerMainModule
         else {
             jaxrsBinder(binder).bind(TaskExecutorResource.class);
             newExporter(binder).export(TaskExecutorResource.class).withGeneratedName();
+            newExporter(binder).export(TimeSharingTaskExecutor.class).withGeneratedName();
 
             binder.bind(TaskExecutor.class)
                     .to(TimeSharingTaskExecutor.class)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This is an attempt to fix #22905 which after #18118 the `TaskExecutor` class is moved to an abstract implementation with the detail used is now in the `TimeSharingTaskExecutor` class.  The intention of this PR is to add this class into the exposed jmx mbean.

Also, the `TaskExecutor` is exposed in the mbean with empty metrics so I've removed that as well. I'm unclear if `ThreadPerDriverTaskExecutor` should have any jmx metrics as an alternative TaskExecutor, but since JMX wasn't referenced, I didn't include that in the if block.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
I did notice that beans are now also prefixed with `jmx.trino...` in the domains. Is that intended? Previous model was just `trino...`.  I may be mistaken but this is how they're surfaced in Datadog if I include the additional timesharing metrics from `MultilevelSplitQueue` which are exposed in mbean.
EDIT: I've confused myself.  That alias is done via the [Datadog Trino integration](https://github.com/DataDog/integrations-extras/blob/master/trino/datadog_checks/trino/data/metrics.yaml). I'll also look into updating that as well.

Nothing additional to add here except that I don't know if this does everything I'm intending to. Just trying to push it along!


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
() Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

Add

```markdown
# Section
* Add JMX metrics for the bean, `trino.execution.executor.timesharing:name=TimeSharingTaskExecutor`.  This replaces metrics previously found in `trino.execution.executor:name=TaskExecutor`
```
