### PR TITLE
don't pass serialization lib to coral

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/CoralSemiTransactionalHiveMSCAdapter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/CoralSemiTransactionalHiveMSCAdapter.java
@@ -134,7 +134,6 @@ public class CoralSemiTransactionalHiveMSCAdapter
         var result = new com.linkedin.coral.hive.metastore.api.SerDeInfo();
         result.setName(info.getName());
         result.setDescription(info.getDescription());
-        result.setSerializationLib(info.getSerializationLib());
         result.setSerializerClass(info.getSerializerClass());
         result.setDeserializerClass(info.getDeserializerClass());
         result.setParameters(info.getParameters());


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Closes #22801 

Fix the spammed coral log by _not_ passing the serialization lib to coral.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

We noticed a spammed log from the Coral library every time we queried a Hive view:

`com.linkedin.coral.common.HiveTable`
`Failed to get columns using deserializer: java.lang.NoClassDefFoundError: com/linkedin/coral/$internal/org/apache/hadoop/fs/FileSystem`

 We realized it happens due to a missing dependency which was removed as part of a project to [decouple Trino from Hadoop and Hive](https://github.com/trinodb/trino/issues/15921).

Since we don’t want Coral to use the Hadoop FileSystem code, we decided the best way to solve this is to make the code change.

[Link](https://trinodb.slack.com/archives/CGB0QHWSW/p1718975042473409) to Slack thread

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
