### PR TITLE
Update airlift to 258

### DIFF
--- a/core/trino-main/src/main/java/io/trino/dispatcher/QueuedStatementResource.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/QueuedStatementResource.java
@@ -33,6 +33,7 @@ import io.trino.execution.QueryManagerConfig;
 import io.trino.execution.QueryState;
 import io.trino.server.DisconnectionAwareAsyncResponse;
 import io.trino.server.ExternalUriInfo;
+import io.trino.server.GoneException;
 import io.trino.server.HttpRequestSessionContextFactory;
 import io.trino.server.ServerConfig;
 import io.trino.server.SessionContext;
@@ -48,21 +49,22 @@ import jakarta.annotation.Nullable;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.Response.Status;
 
 import java.net.URI;
 import java.util.Optional;
@@ -93,10 +95,6 @@ import static io.trino.server.security.ResourceSecurity.AccessType.AUTHENTICATED
 import static io.trino.server.security.ResourceSecurity.AccessType.PUBLIC;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
-import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
-import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
-import static jakarta.ws.rs.core.Response.Status.FORBIDDEN;
-import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -164,7 +162,7 @@ public class QueuedStatementResource
             @BeanParam ExternalUriInfo externalUriInfo)
     {
         if (isNullOrEmpty(statement)) {
-            throw badRequest(BAD_REQUEST, "SQL statement is empty");
+            throw new BadRequestException("SQL statement is empty");
         }
 
         Query query = registerQuery(statement, servletRequest, httpHeaders);
@@ -177,7 +175,7 @@ public class QueuedStatementResource
         Optional<String> remoteAddress = Optional.ofNullable(servletRequest.getRemoteAddr());
         Optional<Identity> identity = authenticatedIdentity(servletRequest);
         if (identity.flatMap(Identity::getPrincipal).map(InternalPrincipal.class::isInstance).orElse(false)) {
-            throw badRequest(FORBIDDEN, "Internal communication can not be used to start a query");
+            throw new ForbiddenException("Internal communication can not be used to start a query");
         }
 
         MultivaluedMap<String, String> headers = httpHeaders.getRequestHeaders();
@@ -241,7 +239,7 @@ public class QueuedStatementResource
     {
         Query query = queryManager.getQuery(queryId);
         if (query == null || !query.getSlug().isValid(QUEUED_QUERY, slug, token)) {
-            throw badRequest(NOT_FOUND, "Query not found");
+            throw new NotFoundException("Query not found");
         }
         return query;
     }
@@ -294,15 +292,6 @@ public class QueuedStatementResource
                 ImmutableList.of(),
                 null,
                 null);
-    }
-
-    private static WebApplicationException badRequest(Status status, String message)
-    {
-        throw new WebApplicationException(
-                Response.status(status)
-                        .type(TEXT_PLAIN_TYPE)
-                        .entity(message)
-                        .build());
     }
 
     private static final class Query
@@ -387,7 +376,7 @@ public class QueuedStatementResource
             long lastToken = this.lastToken.get();
             // token should be the last token or the next token
             if (token != lastToken && token != lastToken + 1) {
-                throw new WebApplicationException(Response.Status.GONE);
+                throw new GoneException("Invalid token");
             }
             // advance (or stay at) the token
             this.lastToken.compareAndSet(lastToken, token);
@@ -402,9 +391,7 @@ public class QueuedStatementResource
 
             DispatchInfo dispatchInfo = dispatchManager.getDispatchInfo(queryId)
                     // query should always be found, but it may have just been determined to be abandoned
-                    .orElseThrow(() -> new WebApplicationException(Response
-                            .status(NOT_FOUND)
-                            .build()));
+                    .orElseThrow(NotFoundException::new);
 
             return createQueryResults(token + 1, externalUriInfo, dispatchInfo);
         }

--- a/core/trino-main/src/main/java/io/trino/server/GoneException.java
+++ b/core/trino-main/src/main/java/io/trino/server/GoneException.java
@@ -11,17 +11,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.server.ui;
+package io.trino.server;
 
-import jakarta.ws.rs.NotFoundException;
-import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 
-public class NoWebUiAuthenticationFilter
-        implements WebUiAuthenticationFilter
+public class GoneException
+        extends WebApplicationException
 {
-    @Override
-    public void filter(ContainerRequestContext request)
+    public GoneException(String message)
     {
-        throw new NotFoundException();
+        super(message, Response.Status.GONE);
+    }
+
+    public GoneException()
+    {
+        super(Response.Status.GONE);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/QueryResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/QueryResource.java
@@ -97,7 +97,7 @@ public class QueryResource
         Optional<QueryInfo> queryInfo = dispatchManager.getFullQueryInfo(queryId)
                 .map(info -> pruned ? pruneQueryInfo(info, info.getVersion()) : info);
         if (queryInfo.isEmpty()) {
-            return Response.status(Status.GONE).build();
+            throw new GoneException();
         }
         try {
             checkCanViewQueryOwnedBy(sessionContextFactory.extractAuthorizedIdentity(servletRequest, httpHeaders), queryInfo.get().getSession().toIdentity(), accessControl);
@@ -165,7 +165,7 @@ public class QueryResource
             throw new ForbiddenException();
         }
         catch (NoSuchElementException e) {
-            return Response.status(Status.GONE).build();
+            throw new GoneException();
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/QueryStateInfoResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/QueryStateInfoResource.java
@@ -24,11 +24,11 @@ import io.trino.spi.security.AccessDeniedException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
@@ -46,7 +46,6 @@ import static io.trino.security.AccessControlUtil.filterQueries;
 import static io.trino.server.QueryStateInfo.createQueryStateInfo;
 import static io.trino.server.QueryStateInfo.createQueuedQueryStateInfo;
 import static io.trino.server.security.ResourceSecurity.AccessType.AUTHENTICATED_USER;
-import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 import static java.util.Objects.requireNonNull;
 
 @Path("/v1/queryState")
@@ -108,7 +107,6 @@ public class QueryStateInfoResource
     @Path("{queryId}")
     @Produces(MediaType.APPLICATION_JSON)
     public QueryStateInfo getQueryStateInfo(@PathParam("queryId") String queryId, @Context HttpServletRequest servletRequest, @Context HttpHeaders httpHeaders)
-            throws WebApplicationException
     {
         try {
             BasicQueryInfo queryInfo = dispatchManager.getQueryInfo(new QueryId(queryId));
@@ -119,7 +117,7 @@ public class QueryStateInfoResource
             throw new ForbiddenException();
         }
         catch (NoSuchElementException e) {
-            throw new WebApplicationException(NOT_FOUND);
+            throw new NotFoundException();
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/ResourceGroupStateInfoResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/ResourceGroupStateInfoResource.java
@@ -19,10 +19,10 @@ import io.trino.server.security.ResourceSecurity;
 import io.trino.spi.resourcegroups.ResourceGroupId;
 import jakarta.ws.rs.Encoded;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 
 import java.net.URLDecoder;
@@ -31,7 +31,6 @@ import java.util.Arrays;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.server.security.ResourceSecurity.AccessType.MANAGEMENT_READ;
-import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
@@ -59,9 +58,9 @@ public class ResourceGroupStateInfoResource
                             Arrays.stream(resourceGroupIdString.split("/"))
                                     .map(ResourceGroupStateInfoResource::urlDecode)
                                     .collect(toImmutableList())))
-                    .orElseThrow(() -> new WebApplicationException(NOT_FOUND));
+                    .orElseThrow(NotFoundException::new);
         }
-        throw new WebApplicationException(NOT_FOUND);
+        throw new NotFoundException();
     }
 
     private static String urlDecode(String value)

--- a/core/trino-main/src/main/java/io/trino/server/ThrowableMapper.java
+++ b/core/trino-main/src/main/java/io/trino/server/ThrowableMapper.java
@@ -17,6 +17,12 @@ import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.ServerErrorException;
+import jakarta.ws.rs.ServiceUnavailableException;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
@@ -45,20 +51,59 @@ public class ThrowableMapper
     @Override
     public Response toResponse(Throwable throwable)
     {
-        if (throwable instanceof WebApplicationException) {
-            return ((WebApplicationException) throwable).getResponse();
-        }
+        // In HTTP/2 status consists of the code alone, without the reason phrase which exists only in the HTTP/1.
+        // Airlift enabled RESPONSE_SET_STATUS_OVER_SEND_ERROR which means that for 4xx and 5xx status codes,
+        // HttpServletResponse.setStatus will be called instead of HttpServletResponse.sendError.
+        //
+        // HttpServletResponse.sendError is problematic, as usually it resets entity, response headers and provide error page
+        // which is then rendered by the container implementation (e.g. Jetty). The generated errors depend on the implementation
+        // of the container and may not be consistent across different versions.
+        //
+        // Another problem with HttpServletResponse.sendError is that if the ServletFilter is used, it can't access
+        // ServletRequest/ServletResponse objects as they can be recycled by Jetty after sendError was called.
+        //
+        // With RESPONSE_SET_STATUS_OVER_SEND_ERROR enabled, the jax-rs application controls the process of returning errors
+        // and ServletFilters can access the request/response objects.
+        return switch (throwable) {
+            case ForbiddenException forbiddenException -> plainTextError(Response.Status.FORBIDDEN)
+                    .entity("Error 403 Forbidden: " + forbiddenException.getMessage())
+                    .build();
+            case ServiceUnavailableException serviceUnavailableException -> plainTextError(Response.Status.SERVICE_UNAVAILABLE)
+                    .entity("Error 503 Service Unavailable: " + serviceUnavailableException.getMessage())
+                    .build();
+            case NotFoundException notFoundException -> plainTextError(Response.Status.NOT_FOUND)
+                    .entity("Error 404 Not Found: " + notFoundException.getMessage())
+                    .build();
+            case BadRequestException badRequestException -> plainTextError(Response.Status.BAD_REQUEST)
+                    .entity("Error 400 Bad Request: " + badRequestException.getMessage())
+                    .build();
+            case InternalServerErrorException internalServerErrorException -> plainTextError(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity("Error 500 Internal Server Error: " + internalServerErrorException.getMessage())
+                    .build();
+            case ServerErrorException serverErrorException -> plainTextError(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity("Error 500 Internal Server Error: " + serverErrorException.getMessage())
+                    .build();
+            case GoneException goneException -> plainTextError(Response.Status.GONE)
+                    .entity("Error 410 Gone: " + goneException.getMessage())
+                    .build();
+            case WebApplicationException webApplicationException -> webApplicationException.getResponse();
+            default -> {
+                log.warn(throwable, "Request failed for %s", request.getRequestURI());
 
-        log.warn(throwable, "Request failed for %s", request.getRequestURI());
+                ResponseBuilder responseBuilder = plainTextError(Response.Status.INTERNAL_SERVER_ERROR);
+                if (includeExceptionInResponse) {
+                    responseBuilder.entity(Throwables.getStackTraceAsString(throwable));
+                }
+                else {
+                    responseBuilder.entity("Exception processing request");
+                }
+                yield responseBuilder.build();
+            }
+        };
+    }
 
-        ResponseBuilder responseBuilder = Response.serverError()
-                .header(CONTENT_TYPE, TEXT_PLAIN);
-        if (includeExceptionInResponse) {
-            responseBuilder.entity(Throwables.getStackTraceAsString(throwable));
-        }
-        else {
-            responseBuilder.entity("Exception processing request");
-        }
-        return responseBuilder.build();
+    private static ResponseBuilder plainTextError(Response.Status status)
+    {
+        return Response.status(status).header(CONTENT_TYPE, TEXT_PLAIN);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResource.java
@@ -37,11 +37,11 @@ import jakarta.annotation.PreDestroy;
 import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -60,8 +60,6 @@ import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.server.DisconnectionAwareAsyncResponse.bindDisconnectionAwareAsyncResponse;
 import static io.trino.server.protocol.Slug.Context.EXECUTING_QUERY;
 import static io.trino.server.security.ResourceSecurity.AccessType.PUBLIC;
-import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
-import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
@@ -172,7 +170,7 @@ public class ExecutingStatementResource
         Query query = queries.get(queryId);
         if (query != null) {
             if (!query.isSlugValid(slug, token)) {
-                throw queryNotFound();
+                throw new NotFoundException("Query not found");
             }
             return query;
         }
@@ -184,11 +182,11 @@ public class ExecutingStatementResource
             session = queryManager.getQuerySession(queryId);
             querySlug = queryManager.getQuerySlug(queryId);
             if (!querySlug.isValid(EXECUTING_QUERY, slug, token)) {
-                throw queryNotFound();
+                throw new NotFoundException("Query not found");
             }
         }
         catch (NoSuchElementException e) {
-            throw queryNotFound();
+            throw new NotFoundException("Query not found");
         }
 
         query = queries.computeIfAbsent(queryId, id -> Query.create(
@@ -291,7 +289,7 @@ public class ExecutingStatementResource
         Query query = queries.get(queryId);
         if (query != null) {
             if (!query.isSlugValid(slug, token)) {
-                throw queryNotFound();
+                throw new NotFoundException("Query not found");
             }
             query.cancel();
             return Response.noContent().build();
@@ -300,13 +298,13 @@ public class ExecutingStatementResource
         // cancel the query execution directly instead of creating the statement client
         try {
             if (!queryManager.getQuerySlug(queryId).isValid(EXECUTING_QUERY, slug, token)) {
-                throw queryNotFound();
+                throw new NotFoundException("Query not found");
             }
             queryManager.cancelQuery(queryId);
             return Response.noContent().build();
         }
         catch (NoSuchElementException e) {
-            throw queryNotFound();
+            throw new NotFoundException("Query not found");
         }
     }
 
@@ -321,15 +319,6 @@ public class ExecutingStatementResource
     {
         Query query = getQuery(queryId, slug, token);
         query.partialCancel(stage);
-    }
-
-    private static WebApplicationException queryNotFound()
-    {
-        throw new WebApplicationException(
-                Response.status(NOT_FOUND)
-                        .type(TEXT_PLAIN_TYPE)
-                        .entity("Query not found")
-                        .build());
     }
 
     private static String urlEncode(String value)

--- a/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
@@ -45,6 +45,7 @@ import io.trino.execution.buffer.PagesSerdeFactory;
 import io.trino.memory.context.SimpleLocalMemoryContext;
 import io.trino.operator.DirectExchangeClientSupplier;
 import io.trino.server.ExternalUriInfo;
+import io.trino.server.GoneException;
 import io.trino.server.ResultQueryInfo;
 import io.trino.spi.ErrorCode;
 import io.trino.spi.Page;
@@ -55,8 +56,7 @@ import io.trino.spi.security.SelectedRole;
 import io.trino.spi.type.Type;
 import io.trino.transaction.TransactionId;
 import io.trino.util.Ciphers;
-import jakarta.ws.rs.WebApplicationException;
-import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.NotFoundException;
 
 import java.net.URI;
 import java.util.List;
@@ -382,18 +382,18 @@ class Query
 
         // if this is a result before the lastResult, the data is gone
         if (token < lastToken) {
-            throw new WebApplicationException(Response.Status.GONE);
+            throw new GoneException();
         }
 
         // if this is a request for a result after the end of the stream, return not found
         if (nextToken.isEmpty()) {
-            throw new WebApplicationException(Response.Status.NOT_FOUND);
+            throw new NotFoundException();
         }
 
         // if this is not a request for the next results, return not found
         if (token != nextToken.getAsLong()) {
             // unknown token
-            throw new WebApplicationException(Response.Status.NOT_FOUND);
+            throw new NotFoundException();
         }
 
         return Optional.empty();

--- a/core/trino-main/src/main/java/io/trino/server/ui/UiQueryResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/UiQueryResource.java
@@ -21,6 +21,7 @@ import io.trino.execution.QueryState;
 import io.trino.security.AccessControl;
 import io.trino.server.BasicQueryInfo;
 import io.trino.server.DisableHttpCache;
+import io.trino.server.GoneException;
 import io.trino.server.HttpRequestSessionContextFactory;
 import io.trino.server.security.ResourceSecurity;
 import io.trino.spi.QueryId;
@@ -102,7 +103,7 @@ public class UiQueryResource
                 throw new ForbiddenException();
             }
         }
-        return Response.status(Status.GONE).build();
+        throw new GoneException();
     }
 
     @ResourceSecurity(WEB_UI)
@@ -143,7 +144,7 @@ public class UiQueryResource
             throw new ForbiddenException();
         }
         catch (NoSuchElementException e) {
-            return Response.status(Status.GONE).build();
+            throw new GoneException();
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/ui/WebUiStaticResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/WebUiStaticResource.java
@@ -17,6 +17,7 @@ import io.trino.server.ExternalUriInfo;
 import io.trino.server.security.ResourceSecurity;
 import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
@@ -27,7 +28,6 @@ import java.io.IOException;
 import static io.trino.server.security.ResourceSecurity.AccessType.PUBLIC;
 import static io.trino.server.security.ResourceSecurity.AccessType.WEB_UI;
 import static io.trino.web.ui.WebUiResources.webUiResource;
-import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 
 @Path("")
 public class WebUiStaticResource
@@ -55,7 +55,7 @@ public class WebUiStaticResource
         // The "getFile" resource method matches all GET requests, and without a
         // resource for POST requests, a METHOD_NOT_ALLOWED error will be returned
         // instead of a NOT_FOUND error
-        return Response.status(NOT_FOUND).build();
+        throw new NotFoundException();
     }
 
     // asset files are always visible

--- a/core/trino-web-ui/src/main/java/io/trino/web/ui/WebUiResources.java
+++ b/core/trino-web-ui/src/main/java/io/trino/web/ui/WebUiResources.java
@@ -15,6 +15,7 @@ package io.trino.web.ui;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.Resources;
+import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
 
 import java.io.IOException;
@@ -23,7 +24,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
-import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 import static java.util.Locale.ENGLISH;
 
 public class WebUiResources
@@ -37,7 +37,7 @@ public class WebUiResources
     {
         if (!isCanonical(path)) {
             // consider redirecting to the absolute path
-            return Response.status(NOT_FOUND).build();
+            throw new NotFoundException();
         }
 
         try {
@@ -45,7 +45,7 @@ public class WebUiResources
             return Response.ok(resource.openStream(), mediaType(resource.toString())).build();
         }
         catch (IllegalArgumentException e) {
-            return Response.status(NOT_FOUND).build();
+            throw new NotFoundException();
         }
     }
 

--- a/core/trino-web-ui/src/test/java/io/trino/web/ui/TestWebUiResources.java
+++ b/core/trino-web-ui/src/test/java/io/trino/web/ui/TestWebUiResources.java
@@ -13,6 +13,7 @@
  */
 package io.trino.web.ui;
 
+import jakarta.ws.rs.NotFoundException;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -20,6 +21,7 @@ import java.io.IOException;
 import static io.trino.web.ui.WebUiResources.mediaType;
 import static io.trino.web.ui.WebUiResources.webUiResource;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class TestWebUiResources
 {
@@ -27,8 +29,10 @@ class TestWebUiResources
     public void testUiResources()
             throws IOException
     {
-        assertThat(webUiResource("notExistingPath").getStatus()).isEqualTo(404);
-        assertThat(webUiResource("/webapp/index.html/../index.html").getStatus()).isEqualTo(404); // not canonical
+        assertThatThrownBy(() -> webUiResource("notExistingPath").getStatus())
+                .isInstanceOf(NotFoundException.class);
+        assertThatThrownBy(() -> webUiResource("/webapp/index.html/../index.html").getStatus())
+                .isInstanceOf(NotFoundException.class); // not canonical
 
         assertThat(webUiResource("/webapp/index.html").getStatus()).isEqualTo(200);
         assertThat(webUiResource("/webapp-preview/dist/index.html").getStatus()).isEqualTo(200);

--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
         <!-- keep dependency properties sorted -->
         <dep.accumulo-hadoop.version>2.7.7-1</dep.accumulo-hadoop.version>
         <dep.accumulo.version>3.0.0</dep.accumulo.version>
-        <dep.airlift.version>256</dep.airlift.version>
+        <dep.airlift.version>258</dep.airlift.version>
         <dep.alluxio.version>2.9.6</dep.alluxio.version>
         <dep.antlr.version>4.13.1</dep.antlr.version>
         <dep.avro.version>1.11.3</dep.avro.version>


### PR DESCRIPTION
Changes requires as now, errors are rendered using jax-rs, rather than by the servlet container (Jetty).

See: https://eclipse-ee4j.github.io/jersey.github.io/apidocs/3.1.1/jersey/org/glassfish/jersey/server/ServerProperties.html#RESPONSE_SET_STATUS_OVER_SEND_ERROR