### PR TITLE
Make max requests configurable in Azure native FS

### DIFF
--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemConfig.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemConfig.java
@@ -14,8 +14,10 @@
 package io.trino.filesystem.azure;
 
 import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
 import io.airlift.units.DataSize;
 import io.airlift.units.DataSize.Unit;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
@@ -34,6 +36,7 @@ public class AzureFileSystemConfig
     private DataSize writeBlockSize = DataSize.of(4, Unit.MEGABYTE);
     private int maxWriteConcurrency = 8;
     private DataSize maxSingleUploadSize = DataSize.of(4, Unit.MEGABYTE);
+    private Integer maxHttpRequests = 2 * Runtime.getRuntime().availableProcessors();
 
     @NotNull
     public AuthType getAuthType()
@@ -109,6 +112,20 @@ public class AzureFileSystemConfig
     public AzureFileSystemConfig setMaxSingleUploadSize(DataSize maxSingleUploadSize)
     {
         this.maxSingleUploadSize = maxSingleUploadSize;
+        return this;
+    }
+
+    @Min(1)
+    public int getMaxHttpRequests()
+    {
+        return maxHttpRequests;
+    }
+
+    @Config("azure.max-http-requests")
+    @ConfigDescription("Maximum number of concurrent HTTP requests to Azure on every node")
+    public AzureFileSystemConfig setMaxHttpRequests(int maxHttpRequests)
+    {
+        this.maxHttpRequests = maxHttpRequests;
         return this;
     }
 }

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemConfig.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemConfig.java
@@ -36,7 +36,8 @@ class TestAzureFileSystemConfig
                 .setReadBlockSize(DataSize.of(4, Unit.MEGABYTE))
                 .setWriteBlockSize(DataSize.of(4, Unit.MEGABYTE))
                 .setMaxWriteConcurrency(8)
-                .setMaxSingleUploadSize(DataSize.of(4, Unit.MEGABYTE)));
+                .setMaxSingleUploadSize(DataSize.of(4, Unit.MEGABYTE))
+                .setMaxHttpRequests(2 * Runtime.getRuntime().availableProcessors()));
     }
 
     @Test
@@ -49,6 +50,7 @@ class TestAzureFileSystemConfig
                 .put("azure.write-block-size", "5MB")
                 .put("azure.max-write-concurrency", "7")
                 .put("azure.max-single-upload-size", "7MB")
+                .put("azure.max-http-requests", "128")
                 .buildOrThrow();
 
         AzureFileSystemConfig expected = new AzureFileSystemConfig()
@@ -57,7 +59,8 @@ class TestAzureFileSystemConfig
                 .setReadBlockSize(DataSize.of(3, Unit.MEGABYTE))
                 .setWriteBlockSize(DataSize.of(5, Unit.MEGABYTE))
                 .setMaxWriteConcurrency(7)
-                .setMaxSingleUploadSize(DataSize.of(7, Unit.MEGABYTE));
+                .setMaxSingleUploadSize(DataSize.of(7, Unit.MEGABYTE))
+                .setMaxHttpRequests(128);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Max requests were increased from 5 to 2 * number of CPUs in
bd289dc4773baca88c94670f625538a4b98f8398 (#22561). With a very large number of
nodes in a cluster, this can cause throttling and result in failed
queries. Make it configurable allows to tune the value, if the default
one is too big.
    
This change also sets the max requests and max requests per host to the
same value, to limit the number of new configuration options.

Fixes #22915 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Allow configuring max requests in native FS for Azure. ({issue}`issuenumber`)
```
