### PR TITLE
Remove query.low-memory-killer.delay

### DIFF
--- a/core/trino-main/src/main/java/io/trino/memory/MemoryManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/memory/MemoryManagerConfig.java
@@ -17,7 +17,6 @@ import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.DefunctConfig;
 import io.airlift.units.DataSize;
-import io.airlift.units.Duration;
 import jakarta.validation.constraints.NotNull;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -25,13 +24,12 @@ import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.succinctBytes;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
-import static java.util.concurrent.TimeUnit.MINUTES;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 @DefunctConfig({
         "experimental.cluster-memory-manager-enabled",
         "query.low-memory-killer.enabled",
-        "resources.reserved-system-memory"})
+        "resources.reserved-system-memory",
+        "query.low-memory-killer.delay"})
 public class MemoryManagerConfig
 {
     // enforced against user memory allocations
@@ -47,8 +45,6 @@ public class MemoryManagerConfig
     private DataSize faultTolerantExecutionEagerSpeculativeTasksNodeMemoryOvercommit = DataSize.of(20, GIGABYTE);
     private LowMemoryQueryKillerPolicy lowMemoryQueryKillerPolicy = LowMemoryQueryKillerPolicy.TOTAL_RESERVATION_ON_BLOCKED_NODES;
     private LowMemoryTaskKillerPolicy lowMemoryTaskKillerPolicy = LowMemoryTaskKillerPolicy.TOTAL_RESERVATION_ON_BLOCKED_NODES;
-    // default value is overwritten for fault tolerant execution in {@link #applyFaultTolerantExecutionDefaults()}}
-    private Duration killOnOutOfMemoryDelay = new Duration(30, SECONDS);
 
     @NotNull
     public DataSize getMaxQueryMemory()
@@ -197,25 +193,6 @@ public class MemoryManagerConfig
     {
         this.lowMemoryTaskKillerPolicy = lowMemoryTaskKillerPolicy;
         return this;
-    }
-
-    @NotNull
-    public Duration getKillOnOutOfMemoryDelay()
-    {
-        return killOnOutOfMemoryDelay;
-    }
-
-    @Config("query.low-memory-killer.delay")
-    @ConfigDescription("Delay between cluster running low on memory and invoking killer")
-    public MemoryManagerConfig setKillOnOutOfMemoryDelay(Duration killOnOutOfMemoryDelay)
-    {
-        this.killOnOutOfMemoryDelay = killOnOutOfMemoryDelay;
-        return this;
-    }
-
-    public void applyFaultTolerantExecutionDefaults()
-    {
-        killOnOutOfMemoryDelay = new Duration(0, MINUTES);
     }
 
     public enum LowMemoryQueryKillerPolicy

--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -293,10 +293,6 @@ public class ServerMainModule
         newExporter(binder).export(PauseMeter.class).withGeneratedName();
 
         configBinder(binder).bindConfig(MemoryManagerConfig.class);
-        if (retryPolicy == TASK) {
-            configBinder(binder).bindConfigDefaults(MemoryManagerConfig.class, MemoryManagerConfig::applyFaultTolerantExecutionDefaults);
-        }
-
         configBinder(binder).bindConfig(NodeMemoryConfig.class);
         binder.bind(LocalMemoryManager.class).in(Scopes.SINGLETON);
         binder.bind(LocalMemoryManagerExporter.class).in(Scopes.SINGLETON);

--- a/core/trino-main/src/test/java/io/trino/memory/TestMemoryManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/memory/TestMemoryManagerConfig.java
@@ -15,7 +15,6 @@ package io.trino.memory;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
-import io.airlift.units.Duration;
 import io.trino.memory.MemoryManagerConfig.LowMemoryQueryKillerPolicy;
 import io.trino.memory.MemoryManagerConfig.LowMemoryTaskKillerPolicy;
 import org.junit.jupiter.api.Test;
@@ -27,7 +26,6 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDe
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class TestMemoryManagerConfig
 {
@@ -45,8 +43,7 @@ public class TestMemoryManagerConfig
                 .setFaultTolerantExecutionMemoryRequirementIncreaseOnWorkerCrashEnabled(true)
                 .setFaultTolerantExecutionEagerSpeculativeTasksNodeMemoryOvercommit(DataSize.of(20, GIGABYTE))
                 .setLowMemoryQueryKillerPolicy(LowMemoryQueryKillerPolicy.TOTAL_RESERVATION_ON_BLOCKED_NODES)
-                .setLowMemoryTaskKillerPolicy(LowMemoryTaskKillerPolicy.TOTAL_RESERVATION_ON_BLOCKED_NODES)
-                .setKillOnOutOfMemoryDelay(new Duration(30, SECONDS)));
+                .setLowMemoryTaskKillerPolicy(LowMemoryTaskKillerPolicy.TOTAL_RESERVATION_ON_BLOCKED_NODES));
     }
 
     @Test
@@ -64,7 +61,6 @@ public class TestMemoryManagerConfig
                 .put("fault-tolerant-execution-eager-speculative-tasks-node_memory-overcommit", "21GB")
                 .put("query.low-memory-killer.policy", "none")
                 .put("task.low-memory-killer.policy", "none")
-                .put("query.low-memory-killer.delay", "20s")
                 .buildOrThrow();
 
         MemoryManagerConfig expected = new MemoryManagerConfig()
@@ -78,8 +74,7 @@ public class TestMemoryManagerConfig
                 .setFaultTolerantExecutionMemoryRequirementIncreaseOnWorkerCrashEnabled(false)
                 .setFaultTolerantExecutionEagerSpeculativeTasksNodeMemoryOvercommit(DataSize.of(21, GIGABYTE))
                 .setLowMemoryQueryKillerPolicy(LowMemoryQueryKillerPolicy.NONE)
-                .setLowMemoryTaskKillerPolicy(LowMemoryTaskKillerPolicy.NONE)
-                .setKillOnOutOfMemoryDelay(new Duration(20, SECONDS));
+                .setLowMemoryTaskKillerPolicy(LowMemoryTaskKillerPolicy.NONE);
 
         assertFullMapping(properties, expected);
     }

--- a/testing/trino-tests/src/test/java/io/trino/memory/TestMemoryManager.java
+++ b/testing/trino-tests/src/test/java/io/trino/memory/TestMemoryManager.java
@@ -118,7 +118,6 @@ public class TestMemoryManager
             throws Exception
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
-                .put("query.low-memory-killer.delay", "5s")
                 .put("query.low-memory-killer.policy", "total-reservation")
                 .buildOrThrow();
 


### PR DESCRIPTION
query.low-memory-killer.delay is not needed:
* It does not prevent cascades of query kills. That is achieved by isLastKillTargetGone check in ClusterMemoryManager
* OOM blocked worker cannot be unblocked by other means other than killing the query. Revocable memory (and spill to disk) also won't cause node to be considered out-of-memory. Hence low-memory-killer does not interfere with spill-to-disk.

    Having query.low-memory-killer.delay causes reduced concurrency
    on a cluster with higher concurrency and under low-memory situations.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Remove `query.low-memory-killer.delay` config property which should improve query concurrency
  in low-memory situations. ({issue}`issuenumber`)
```
