### PR TITLE
Remove redundant copy in JsonUtil

### DIFF
--- a/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
+++ b/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
@@ -131,7 +131,7 @@ public final class JsonUtil
         // so we pass StringReader or an InputStreamReader instead.
         if (json.length() < STRING_READER_LENGTH_LIMIT) {
             // StringReader is more performant than InputStreamReader for small inputs
-            return factory.createParser(new StringReader(new String(json.getBytes(), UTF_8)));
+            return factory.createParser(new StringReader(json.toStringUtf8()));
         }
 
         return factory.createParser(new InputStreamReader(json.getInput(), UTF_8));


### PR DESCRIPTION
## Description
Avoids an extra byte array copy when creating `StringReader` inside of `JsonUtil.createJsonParser`

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
