### PR TITLE
Parquet writer cleanups

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/BigintValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/BigintValueWriter.java
@@ -15,6 +15,7 @@ package io.trino.parquet.writer.valuewriter;
 
 import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
+import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.schema.PrimitiveType;
 
@@ -34,12 +35,14 @@ public class BigintValueWriter
     @Override
     public void write(Block block)
     {
+        ValuesWriter valuesWriter = requireNonNull(getValuesWriter(), "valuesWriter is null");
+        Statistics<?> statistics = requireNonNull(getStatistics(), "statistics is null");
         boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); i++) {
             if (!mayHaveNull || !block.isNull(i)) {
                 long value = type.getLong(block, i);
-                getValueWriter().writeLong(value);
-                getStatistics().updateStats(value);
+                valuesWriter.writeLong(value);
+                statistics.updateStats(value);
             }
         }
     }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/BigintValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/BigintValueWriter.java
@@ -34,8 +34,9 @@ public class BigintValueWriter
     @Override
     public void write(Block block)
     {
+        boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); i++) {
-            if (!block.isNull(i)) {
+            if (!mayHaveNull || !block.isNull(i)) {
                 long value = type.getLong(block, i);
                 getValueWriter().writeLong(value);
                 getStatistics().updateStats(value);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/BinaryValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/BinaryValueWriter.java
@@ -38,8 +38,9 @@ public class BinaryValueWriter
     @Override
     public void write(Block block)
     {
+        boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); i++) {
-            if (!block.isNull(i)) {
+            if (!mayHaveNull || !block.isNull(i)) {
                 Slice slice = type.getSlice(block, i);
                 // fromReusedByteBuffer must be used instead of fromConstantByteBuffer to avoid retaining entire
                 // base byte array of the Slice in DictionaryValuesWriter.PlainBinaryDictionaryValuesWriter

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/BinaryValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/BinaryValueWriter.java
@@ -43,9 +43,9 @@ public class BinaryValueWriter
         for (int i = 0; i < block.getPositionCount(); i++) {
             if (!mayHaveNull || !block.isNull(i)) {
                 Slice slice = type.getSlice(block, i);
-                // fromReusedByteBuffer must be used instead of fromConstantByteBuffer to avoid retaining entire
+                // fromReusedByteArray must be used instead of fromConstantByteArray to avoid retaining entire
                 // base byte array of the Slice in DictionaryValuesWriter.PlainBinaryDictionaryValuesWriter
-                Binary binary = Binary.fromReusedByteBuffer(slice.toByteBuffer());
+                Binary binary = Binary.fromReusedByteArray(slice.byteArray(), slice.byteArrayOffset(), slice.length());
                 valuesWriter.writeBytes(binary);
                 statistics.updateStats(binary);
             }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/BooleanValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/BooleanValueWriter.java
@@ -34,8 +34,9 @@ public class BooleanValueWriter
     @Override
     public void write(Block block)
     {
+        boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); i++) {
-            if (!block.isNull(i)) {
+            if (!mayHaveNull || !block.isNull(i)) {
                 boolean value = BOOLEAN.getBoolean(block, i);
                 valuesWriter.writeBoolean(value);
                 getStatistics().updateStats(value);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/BooleanValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/BooleanValueWriter.java
@@ -14,6 +14,7 @@
 package io.trino.parquet.writer.valuewriter;
 
 import io.trino.spi.block.Block;
+import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.schema.PrimitiveType;
 
@@ -23,23 +24,22 @@ import static java.util.Objects.requireNonNull;
 public class BooleanValueWriter
         extends PrimitiveValueWriter
 {
-    private final ValuesWriter valuesWriter;
-
     public BooleanValueWriter(ValuesWriter valuesWriter, PrimitiveType parquetType)
     {
         super(parquetType, valuesWriter);
-        this.valuesWriter = requireNonNull(valuesWriter, "valuesWriter is null");
     }
 
     @Override
     public void write(Block block)
     {
+        ValuesWriter valuesWriter = requireNonNull(getValuesWriter(), "valuesWriter is null");
+        Statistics<?> statistics = requireNonNull(getStatistics(), "statistics is null");
         boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); i++) {
             if (!mayHaveNull || !block.isNull(i)) {
                 boolean value = BOOLEAN.getBoolean(block, i);
                 valuesWriter.writeBoolean(value);
-                getStatistics().updateStats(value);
+                statistics.updateStats(value);
             }
         }
     }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/DateValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/DateValueWriter.java
@@ -34,8 +34,9 @@ public class DateValueWriter
     @Override
     public void write(Block block)
     {
+        boolean mayHaveNull = block.mayHaveNull();
         for (int position = 0; position < block.getPositionCount(); position++) {
-            if (!block.isNull(position)) {
+            if (!mayHaveNull || !block.isNull(position)) {
                 int value = DATE.getInt(block, position);
                 valuesWriter.writeInteger(value);
                 getStatistics().updateStats(value);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/DateValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/DateValueWriter.java
@@ -14,6 +14,7 @@
 package io.trino.parquet.writer.valuewriter;
 
 import io.trino.spi.block.Block;
+import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.schema.PrimitiveType;
 
@@ -23,23 +24,22 @@ import static java.util.Objects.requireNonNull;
 public class DateValueWriter
         extends PrimitiveValueWriter
 {
-    private final ValuesWriter valuesWriter;
-
     public DateValueWriter(ValuesWriter valuesWriter, PrimitiveType parquetType)
     {
         super(parquetType, valuesWriter);
-        this.valuesWriter = requireNonNull(valuesWriter, "valuesWriter is null");
     }
 
     @Override
     public void write(Block block)
     {
+        ValuesWriter valuesWriter = requireNonNull(getValuesWriter(), "valuesWriter is null");
+        Statistics<?> statistics = requireNonNull(getStatistics(), "statistics is null");
         boolean mayHaveNull = block.mayHaveNull();
         for (int position = 0; position < block.getPositionCount(); position++) {
             if (!mayHaveNull || !block.isNull(position)) {
                 int value = DATE.getInt(block, position);
                 valuesWriter.writeInteger(value);
-                getStatistics().updateStats(value);
+                statistics.updateStats(value);
             }
         }
     }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/DoubleValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/DoubleValueWriter.java
@@ -34,8 +34,9 @@ public class DoubleValueWriter
     @Override
     public void write(Block block)
     {
+        boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); ++i) {
-            if (!block.isNull(i)) {
+            if (!mayHaveNull || !block.isNull(i)) {
                 double value = DOUBLE.getDouble(block, i);
                 valuesWriter.writeDouble(value);
                 getStatistics().updateStats(value);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/DoubleValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/DoubleValueWriter.java
@@ -14,6 +14,7 @@
 package io.trino.parquet.writer.valuewriter;
 
 import io.trino.spi.block.Block;
+import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.schema.PrimitiveType;
 
@@ -23,23 +24,22 @@ import static java.util.Objects.requireNonNull;
 public class DoubleValueWriter
         extends PrimitiveValueWriter
 {
-    private final ValuesWriter valuesWriter;
-
     public DoubleValueWriter(ValuesWriter valuesWriter, PrimitiveType parquetType)
     {
         super(parquetType, valuesWriter);
-        this.valuesWriter = requireNonNull(valuesWriter, "valuesWriter is null");
     }
 
     @Override
     public void write(Block block)
     {
+        ValuesWriter valuesWriter = requireNonNull(getValuesWriter(), "valuesWriter is null");
+        Statistics<?> statistics = requireNonNull(getStatistics(), "statistics is null");
         boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); ++i) {
             if (!mayHaveNull || !block.isNull(i)) {
                 double value = DOUBLE.getDouble(block, i);
                 valuesWriter.writeDouble(value);
-                getStatistics().updateStats(value);
+                statistics.updateStats(value);
             }
         }
     }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/FixedLenByteArrayLongDecimalValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/FixedLenByteArrayLongDecimalValueWriter.java
@@ -17,6 +17,7 @@ import io.trino.spi.block.Block;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Int128;
 import io.trino.spi.type.Type;
+import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.PrimitiveType;
@@ -47,14 +48,16 @@ public class FixedLenByteArrayLongDecimalValueWriter
     @Override
     public void write(Block block)
     {
+        ValuesWriter valuesWriter = requireNonNull(getValuesWriter(), "valuesWriter is null");
+        Statistics<?> statistics = requireNonNull(getStatistics(), "statistics is null");
         boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); ++i) {
             if (!mayHaveNull || !block.isNull(i)) {
                 Int128 decimal = (Int128) decimalType.getObject(block, i);
                 BigInteger bigInteger = decimal.toBigInteger();
                 Binary binary = Binary.fromConstantByteArray(paddingBigInteger(bigInteger, getTypeLength()));
-                getValueWriter().writeBytes(binary);
-                getStatistics().updateStats(binary);
+                valuesWriter.writeBytes(binary);
+                statistics.updateStats(binary);
             }
         }
     }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/FixedLenByteArrayLongDecimalValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/FixedLenByteArrayLongDecimalValueWriter.java
@@ -47,8 +47,9 @@ public class FixedLenByteArrayLongDecimalValueWriter
     @Override
     public void write(Block block)
     {
+        boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); ++i) {
-            if (!block.isNull(i)) {
+            if (!mayHaveNull || !block.isNull(i)) {
                 Int128 decimal = (Int128) decimalType.getObject(block, i);
                 BigInteger bigInteger = decimal.toBigInteger();
                 Binary binary = Binary.fromConstantByteArray(paddingBigInteger(bigInteger, getTypeLength()));

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/FixedLenByteArrayShortDecimalValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/FixedLenByteArrayShortDecimalValueWriter.java
@@ -16,6 +16,7 @@ package io.trino.parquet.writer.valuewriter;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Type;
+import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.PrimitiveType;
@@ -43,13 +44,15 @@ public class FixedLenByteArrayShortDecimalValueWriter
     @Override
     public void write(Block block)
     {
+        ValuesWriter valuesWriter = requireNonNull(getValuesWriter(), "valuesWriter is null");
+        Statistics<?> statistics = requireNonNull(getStatistics(), "statistics is null");
         boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); i++) {
             if (!mayHaveNull || !block.isNull(i)) {
                 long value = decimalType.getLong(block, i);
                 Binary binary = Binary.fromConstantByteArray(paddingLong(value));
-                getValueWriter().writeBytes(binary);
-                getStatistics().updateStats(binary);
+                valuesWriter.writeBytes(binary);
+                statistics.updateStats(binary);
             }
         }
     }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/FixedLenByteArrayShortDecimalValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/FixedLenByteArrayShortDecimalValueWriter.java
@@ -43,8 +43,9 @@ public class FixedLenByteArrayShortDecimalValueWriter
     @Override
     public void write(Block block)
     {
+        boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); i++) {
-            if (!block.isNull(i)) {
+            if (!mayHaveNull || !block.isNull(i)) {
                 long value = decimalType.getLong(block, i);
                 Binary binary = Binary.fromConstantByteArray(paddingLong(value));
                 getValueWriter().writeBytes(binary);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/FixedLenByteArrayShortDecimalValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/FixedLenByteArrayShortDecimalValueWriter.java
@@ -47,76 +47,75 @@ public class FixedLenByteArrayShortDecimalValueWriter
         ValuesWriter valuesWriter = requireNonNull(getValuesWriter(), "valuesWriter is null");
         Statistics<?> statistics = requireNonNull(getStatistics(), "statistics is null");
         boolean mayHaveNull = block.mayHaveNull();
+        byte[] buffer = new byte[getTypeLength()];
+        Binary reusedBinary = Binary.fromReusedByteArray(buffer);
         for (int i = 0; i < block.getPositionCount(); i++) {
             if (!mayHaveNull || !block.isNull(i)) {
                 long value = decimalType.getLong(block, i);
-                Binary binary = Binary.fromConstantByteArray(paddingLong(value));
-                valuesWriter.writeBytes(binary);
-                statistics.updateStats(binary);
+                storeLongIntoBuffer(value, buffer);
+                valuesWriter.writeBytes(reusedBinary);
+                statistics.updateStats(reusedBinary);
             }
         }
     }
 
-    private byte[] paddingLong(long unscaledValue)
+    private static void storeLongIntoBuffer(long unscaledValue, byte[] buffer)
     {
-        int numBytes = getTypeLength();
-        byte[] result = new byte[numBytes];
-        switch (numBytes) {
+        switch (buffer.length) {
             case 1:
-                result[0] = (byte) unscaledValue;
+                buffer[0] = (byte) unscaledValue;
                 break;
             case 2:
-                result[0] = (byte) (unscaledValue >> 8);
-                result[1] = (byte) unscaledValue;
+                buffer[0] = (byte) (unscaledValue >> 8);
+                buffer[1] = (byte) unscaledValue;
                 break;
             case 3:
-                result[0] = (byte) (unscaledValue >> 16);
-                result[1] = (byte) (unscaledValue >> 8);
-                result[2] = (byte) unscaledValue;
+                buffer[0] = (byte) (unscaledValue >> 16);
+                buffer[1] = (byte) (unscaledValue >> 8);
+                buffer[2] = (byte) unscaledValue;
                 break;
             case 4:
-                result[0] = (byte) (unscaledValue >> 24);
-                result[1] = (byte) (unscaledValue >> 16);
-                result[2] = (byte) (unscaledValue >> 8);
-                result[3] = (byte) unscaledValue;
+                buffer[0] = (byte) (unscaledValue >> 24);
+                buffer[1] = (byte) (unscaledValue >> 16);
+                buffer[2] = (byte) (unscaledValue >> 8);
+                buffer[3] = (byte) unscaledValue;
                 break;
             case 5:
-                result[0] = (byte) (unscaledValue >> 32);
-                result[1] = (byte) (unscaledValue >> 24);
-                result[2] = (byte) (unscaledValue >> 16);
-                result[3] = (byte) (unscaledValue >> 8);
-                result[4] = (byte) unscaledValue;
+                buffer[0] = (byte) (unscaledValue >> 32);
+                buffer[1] = (byte) (unscaledValue >> 24);
+                buffer[2] = (byte) (unscaledValue >> 16);
+                buffer[3] = (byte) (unscaledValue >> 8);
+                buffer[4] = (byte) unscaledValue;
                 break;
             case 6:
-                result[0] = (byte) (unscaledValue >> 40);
-                result[1] = (byte) (unscaledValue >> 32);
-                result[2] = (byte) (unscaledValue >> 24);
-                result[3] = (byte) (unscaledValue >> 16);
-                result[4] = (byte) (unscaledValue >> 8);
-                result[5] = (byte) unscaledValue;
+                buffer[0] = (byte) (unscaledValue >> 40);
+                buffer[1] = (byte) (unscaledValue >> 32);
+                buffer[2] = (byte) (unscaledValue >> 24);
+                buffer[3] = (byte) (unscaledValue >> 16);
+                buffer[4] = (byte) (unscaledValue >> 8);
+                buffer[5] = (byte) unscaledValue;
                 break;
             case 7:
-                result[0] = (byte) (unscaledValue >> 48);
-                result[1] = (byte) (unscaledValue >> 40);
-                result[2] = (byte) (unscaledValue >> 32);
-                result[3] = (byte) (unscaledValue >> 24);
-                result[4] = (byte) (unscaledValue >> 16);
-                result[5] = (byte) (unscaledValue >> 8);
-                result[6] = (byte) unscaledValue;
+                buffer[0] = (byte) (unscaledValue >> 48);
+                buffer[1] = (byte) (unscaledValue >> 40);
+                buffer[2] = (byte) (unscaledValue >> 32);
+                buffer[3] = (byte) (unscaledValue >> 24);
+                buffer[4] = (byte) (unscaledValue >> 16);
+                buffer[5] = (byte) (unscaledValue >> 8);
+                buffer[6] = (byte) unscaledValue;
                 break;
             case 8:
-                result[0] = (byte) (unscaledValue >> 56);
-                result[1] = (byte) (unscaledValue >> 48);
-                result[2] = (byte) (unscaledValue >> 40);
-                result[3] = (byte) (unscaledValue >> 32);
-                result[4] = (byte) (unscaledValue >> 24);
-                result[5] = (byte) (unscaledValue >> 16);
-                result[6] = (byte) (unscaledValue >> 8);
-                result[7] = (byte) unscaledValue;
+                buffer[0] = (byte) (unscaledValue >> 56);
+                buffer[1] = (byte) (unscaledValue >> 48);
+                buffer[2] = (byte) (unscaledValue >> 40);
+                buffer[3] = (byte) (unscaledValue >> 32);
+                buffer[4] = (byte) (unscaledValue >> 24);
+                buffer[5] = (byte) (unscaledValue >> 16);
+                buffer[6] = (byte) (unscaledValue >> 8);
+                buffer[7] = (byte) unscaledValue;
                 break;
             default:
-                throw new IllegalArgumentException("Invalid number of bytes: " + numBytes);
+                throw new IllegalArgumentException("Invalid number of bytes: " + buffer.length);
         }
-        return result;
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/Int32ShortDecimalValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/Int32ShortDecimalValueWriter.java
@@ -38,8 +38,9 @@ public class Int32ShortDecimalValueWriter
     @Override
     public void write(Block block)
     {
+        boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); i++) {
-            if (!block.isNull(i)) {
+            if (!mayHaveNull || !block.isNull(i)) {
                 int value = toIntExact(decimalType.getLong(block, i));
                 getValueWriter().writeInteger(value);
                 getStatistics().updateStats(value);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/Int32ShortDecimalValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/Int32ShortDecimalValueWriter.java
@@ -16,6 +16,7 @@ package io.trino.parquet.writer.valuewriter;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Type;
+import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.schema.PrimitiveType;
 
@@ -38,12 +39,14 @@ public class Int32ShortDecimalValueWriter
     @Override
     public void write(Block block)
     {
+        ValuesWriter valuesWriter = requireNonNull(getValuesWriter(), "valuesWriter is null");
+        Statistics<?> statistics = requireNonNull(getStatistics(), "statistics is null");
         boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); i++) {
             if (!mayHaveNull || !block.isNull(i)) {
                 int value = toIntExact(decimalType.getLong(block, i));
-                getValueWriter().writeInteger(value);
-                getStatistics().updateStats(value);
+                valuesWriter.writeInteger(value);
+                statistics.updateStats(value);
             }
         }
     }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/Int64ShortDecimalValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/Int64ShortDecimalValueWriter.java
@@ -37,8 +37,9 @@ public class Int64ShortDecimalValueWriter
     @Override
     public void write(Block block)
     {
+        boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); i++) {
-            if (!block.isNull(i)) {
+            if (!mayHaveNull || !block.isNull(i)) {
                 long value = decimalType.getLong(block, i);
                 getValueWriter().writeLong(value);
                 getStatistics().updateStats(value);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/Int64ShortDecimalValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/Int64ShortDecimalValueWriter.java
@@ -16,6 +16,7 @@ package io.trino.parquet.writer.valuewriter;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Type;
+import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.schema.PrimitiveType;
 
@@ -37,12 +38,14 @@ public class Int64ShortDecimalValueWriter
     @Override
     public void write(Block block)
     {
+        ValuesWriter valuesWriter = requireNonNull(getValuesWriter(), "valuesWriter is null");
+        Statistics<?> statistics = requireNonNull(getStatistics(), "statistics is null");
         boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); i++) {
             if (!mayHaveNull || !block.isNull(i)) {
                 long value = decimalType.getLong(block, i);
-                getValueWriter().writeLong(value);
-                getStatistics().updateStats(value);
+                valuesWriter.writeLong(value);
+                statistics.updateStats(value);
             }
         }
     }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/Int96TimestampValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/Int96TimestampValueWriter.java
@@ -17,6 +17,7 @@ import io.trino.spi.block.Block;
 import io.trino.spi.type.LongTimestamp;
 import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.Type;
+import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.PrimitiveType;
@@ -87,6 +88,8 @@ public class Int96TimestampValueWriter
             }
         }
 
+        ValuesWriter valuesWriter = getValuesWriter();
+        Statistics<?> statistics = getStatistics();
         for (int i = 0; i < nonNullsCount; i++) {
             long epochMillis = parquetTimeZone.convertLocalToUTC(localEpochMillis[i], false);
             long epochDay = floorDiv(epochMillis, MILLISECONDS_PER_DAY);
@@ -94,8 +97,8 @@ public class Int96TimestampValueWriter
 
             long nanosOfEpochDay = nanosOfMillis[i] + ((long) floorMod(epochMillis, MILLISECONDS_PER_DAY) * NANOSECONDS_PER_MILLISECOND);
             Binary binary = toBinary(julianDay, nanosOfEpochDay);
-            getValueWriter().writeBytes(binary);
-            getStatistics().updateStats(binary);
+            valuesWriter.writeBytes(binary);
+            statistics.updateStats(binary);
         }
     }
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/Int96TimestampValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/Int96TimestampValueWriter.java
@@ -23,6 +23,9 @@ import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.PrimitiveType;
 import org.joda.time.DateTimeZone;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.parquet.ParquetTimestampUtils.JULIAN_EPOCH_OFFSET_DAYS;
 import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
@@ -60,73 +63,69 @@ public class Int96TimestampValueWriter
     @Override
     public void write(Block block)
     {
-        int positionCount = block.getPositionCount();
-        long[] localEpochMillis = new long[positionCount];
-        int[] nanosOfMillis = new int[positionCount];
-        int nonNullsCount = 0;
         if (timestampType.isShort()) {
-            for (int position = 0; position < positionCount; position++) {
-                if (!block.isNull(position)) {
-                    long epochMicros = timestampType.getLong(block, position);
-                    localEpochMillis[nonNullsCount] = floorDiv(epochMicros, MICROSECONDS_PER_MILLISECOND);
-                    nanosOfMillis[nonNullsCount] = floorMod(epochMicros, MICROSECONDS_PER_MILLISECOND) * NANOSECONDS_PER_MICROSECOND;
-                    nonNullsCount++;
-                }
-            }
+            writeShortTimestamps(block);
         }
         else {
-            for (int position = 0; position < positionCount; position++) {
-                if (!block.isNull(position)) {
-                    LongTimestamp timestamp = (LongTimestamp) timestampType.getObject(block, position);
-                    long epochMicros = timestamp.getEpochMicros();
-                    // This should divide exactly because timestamp precision is <= 9
-                    int nanosOfMicro = timestamp.getPicosOfMicro() / PICOSECONDS_PER_NANOSECOND;
-                    localEpochMillis[nonNullsCount] = floorDiv(epochMicros, MICROSECONDS_PER_MILLISECOND);
-                    nanosOfMillis[nonNullsCount] = floorMod(epochMicros, MICROSECONDS_PER_MILLISECOND) * NANOSECONDS_PER_MICROSECOND + nanosOfMicro;
-                    nonNullsCount++;
-                }
+            writeLongTimestamps(block);
+        }
+    }
+
+    private void writeShortTimestamps(Block block)
+    {
+        ValuesWriter valuesWriter = requireNonNull(getValuesWriter(), "valuesWriter is null");
+        Statistics<?> statistics = requireNonNull(getStatistics(), "statistics is null");
+        boolean mayHaveNull = block.mayHaveNull();
+        byte[] buffer = new byte[Long.BYTES + Integer.BYTES];
+        Binary reusedBinary = Binary.fromReusedByteArray(buffer);
+
+        for (int position = 0; position < block.getPositionCount(); position++) {
+            if (!mayHaveNull || !block.isNull(position)) {
+                long epochMicros = timestampType.getLong(block, position);
+                long localEpochMillis = floorDiv(epochMicros, MICROSECONDS_PER_MILLISECOND);
+                int nanosOfMillis = floorMod(epochMicros, MICROSECONDS_PER_MILLISECOND) * NANOSECONDS_PER_MICROSECOND;
+
+                convertAndWriteToBuffer(localEpochMillis, nanosOfMillis, buffer);
+                valuesWriter.writeBytes(reusedBinary);
+                statistics.updateStats(reusedBinary);
             }
         }
+    }
 
-        ValuesWriter valuesWriter = getValuesWriter();
-        Statistics<?> statistics = getStatistics();
-        for (int i = 0; i < nonNullsCount; i++) {
-            long epochMillis = parquetTimeZone.convertLocalToUTC(localEpochMillis[i], false);
-            long epochDay = floorDiv(epochMillis, MILLISECONDS_PER_DAY);
-            int julianDay = JULIAN_EPOCH_OFFSET_DAYS + toIntExact(epochDay);
+    private void writeLongTimestamps(Block block)
+    {
+        ValuesWriter valuesWriter = requireNonNull(getValuesWriter(), "valuesWriter is null");
+        Statistics<?> statistics = requireNonNull(getStatistics(), "statistics is null");
+        boolean mayHaveNull = block.mayHaveNull();
+        byte[] buffer = new byte[Long.BYTES + Integer.BYTES];
+        Binary reusedBinary = Binary.fromReusedByteArray(buffer);
 
-            long nanosOfEpochDay = nanosOfMillis[i] + ((long) floorMod(epochMillis, MILLISECONDS_PER_DAY) * NANOSECONDS_PER_MILLISECOND);
-            Binary binary = toBinary(julianDay, nanosOfEpochDay);
-            valuesWriter.writeBytes(binary);
-            statistics.updateStats(binary);
+        for (int position = 0; position < block.getPositionCount(); position++) {
+            if (!mayHaveNull || !block.isNull(position)) {
+                LongTimestamp timestamp = (LongTimestamp) timestampType.getObject(block, position);
+                long epochMicros = timestamp.getEpochMicros();
+                // This should divide exactly because timestamp precision is <= 9
+                int nanosOfMicro = timestamp.getPicosOfMicro() / PICOSECONDS_PER_NANOSECOND;
+                long localEpochMillis = floorDiv(epochMicros, MICROSECONDS_PER_MILLISECOND);
+                int nanosOfMillis = floorMod(epochMicros, MICROSECONDS_PER_MILLISECOND) * NANOSECONDS_PER_MICROSECOND + nanosOfMicro;
+
+                convertAndWriteToBuffer(localEpochMillis, nanosOfMillis, buffer);
+                valuesWriter.writeBytes(reusedBinary);
+                statistics.updateStats(reusedBinary);
+            }
         }
     }
 
-    private Binary toBinary(int julianDay, long nanosOfEpochDay)
+    private void convertAndWriteToBuffer(long localEpochMillis, int nanosOfMillis, byte[] buffer)
     {
-        byte[] buffer = new byte[Long.BYTES + Integer.BYTES];
-        longToBytes(buffer, nanosOfEpochDay);
-        intToBytes(buffer, julianDay);
-        return Binary.fromConstantByteArray(buffer);
-    }
+        long epochMillis = parquetTimeZone.convertLocalToUTC(localEpochMillis, false);
+        long epochDay = floorDiv(epochMillis, MILLISECONDS_PER_DAY);
+        int julianDay = JULIAN_EPOCH_OFFSET_DAYS + toIntExact(epochDay);
 
-    private static void intToBytes(byte[] outBuffer, int value)
-    {
-        outBuffer[Long.BYTES + 3] = (byte) (value >>> 24);
-        outBuffer[Long.BYTES + 2] = (byte) (value >>> 16);
-        outBuffer[Long.BYTES + 1] = (byte) (value >>> 8);
-        outBuffer[Long.BYTES] = (byte) value;
-    }
-
-    private static void longToBytes(byte[] outBuffer, long value)
-    {
-        outBuffer[7] = (byte) (value >>> 56);
-        outBuffer[6] = (byte) (value >>> 48);
-        outBuffer[5] = (byte) (value >>> 40);
-        outBuffer[4] = (byte) (value >>> 32);
-        outBuffer[3] = (byte) (value >>> 24);
-        outBuffer[2] = (byte) (value >>> 16);
-        outBuffer[1] = (byte) (value >>> 8);
-        outBuffer[0] = (byte) value;
+        long nanosOfEpochDay = nanosOfMillis + ((long) floorMod(epochMillis, MILLISECONDS_PER_DAY) * NANOSECONDS_PER_MILLISECOND);
+        ByteBuffer.wrap(buffer)
+                .order(ByteOrder.LITTLE_ENDIAN)
+                .putLong(0, nanosOfEpochDay)
+                .putInt(Long.BYTES, julianDay);
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/IntegerValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/IntegerValueWriter.java
@@ -15,6 +15,7 @@ package io.trino.parquet.writer.valuewriter;
 
 import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
+import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.schema.PrimitiveType;
 
@@ -34,12 +35,14 @@ public class IntegerValueWriter
     @Override
     public void write(Block block)
     {
+        ValuesWriter valuesWriter = requireNonNull(getValuesWriter(), "valuesWriter is null");
+        Statistics<?> statistics = requireNonNull(getStatistics(), "statistics is null");
         boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); ++i) {
             if (!mayHaveNull || !block.isNull(i)) {
                 int value = (int) type.getLong(block, i);
-                getValueWriter().writeInteger(value);
-                getStatistics().updateStats(value);
+                valuesWriter.writeInteger(value);
+                statistics.updateStats(value);
             }
         }
     }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/IntegerValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/IntegerValueWriter.java
@@ -34,8 +34,9 @@ public class IntegerValueWriter
     @Override
     public void write(Block block)
     {
+        boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); ++i) {
-            if (!block.isNull(i)) {
+            if (!mayHaveNull || !block.isNull(i)) {
                 int value = (int) type.getLong(block, i);
                 getValueWriter().writeInteger(value);
                 getStatistics().updateStats(value);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/PrimitiveValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/PrimitiveValueWriter.java
@@ -37,7 +37,7 @@ public abstract class PrimitiveValueWriter
         this.statistics = Statistics.createStats(parquetType);
     }
 
-    ValuesWriter getValueWriter()
+    ValuesWriter getValuesWriter()
     {
         return valuesWriter;
     }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/RealValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/RealValueWriter.java
@@ -34,8 +34,9 @@ public class RealValueWriter
     @Override
     public void write(Block block)
     {
+        boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); i++) {
-            if (!block.isNull(i)) {
+            if (!mayHaveNull || !block.isNull(i)) {
                 float value = REAL.getFloat(block, i);
                 valuesWriter.writeFloat(value);
                 getStatistics().updateStats(value);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/RealValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/RealValueWriter.java
@@ -14,6 +14,7 @@
 package io.trino.parquet.writer.valuewriter;
 
 import io.trino.spi.block.Block;
+import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.schema.PrimitiveType;
 
@@ -23,23 +24,22 @@ import static java.util.Objects.requireNonNull;
 public class RealValueWriter
         extends PrimitiveValueWriter
 {
-    private final ValuesWriter valuesWriter;
-
     public RealValueWriter(ValuesWriter valuesWriter, PrimitiveType parquetType)
     {
         super(parquetType, valuesWriter);
-        this.valuesWriter = requireNonNull(valuesWriter, "valuesWriter is null");
     }
 
     @Override
     public void write(Block block)
     {
+        ValuesWriter valuesWriter = requireNonNull(getValuesWriter(), "valuesWriter is null");
+        Statistics<?> statistics = requireNonNull(getStatistics(), "statistics is null");
         boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); i++) {
             if (!mayHaveNull || !block.isNull(i)) {
                 float value = REAL.getFloat(block, i);
                 valuesWriter.writeFloat(value);
-                getStatistics().updateStats(value);
+                statistics.updateStats(value);
             }
         }
     }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/TimeMicrosValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/TimeMicrosValueWriter.java
@@ -14,11 +14,13 @@
 package io.trino.parquet.writer.valuewriter;
 
 import io.trino.spi.block.Block;
+import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.schema.PrimitiveType;
 
 import static io.trino.spi.type.TimeType.TIME_MICROS;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
+import static java.util.Objects.requireNonNull;
 
 public class TimeMicrosValueWriter
         extends PrimitiveValueWriter
@@ -31,12 +33,14 @@ public class TimeMicrosValueWriter
     @Override
     public void write(Block block)
     {
+        ValuesWriter valuesWriter = requireNonNull(getValuesWriter(), "valuesWriter is null");
+        Statistics<?> statistics = requireNonNull(getStatistics(), "statistics is null");
         boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); i++) {
             if (!mayHaveNull || !block.isNull(i)) {
                 long scaledValue = TIME_MICROS.getLong(block, i) / PICOSECONDS_PER_MICROSECOND;
-                getValueWriter().writeLong(scaledValue);
-                getStatistics().updateStats(scaledValue);
+                valuesWriter.writeLong(scaledValue);
+                statistics.updateStats(scaledValue);
             }
         }
     }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/TimeMicrosValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/TimeMicrosValueWriter.java
@@ -31,8 +31,9 @@ public class TimeMicrosValueWriter
     @Override
     public void write(Block block)
     {
+        boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); i++) {
-            if (!block.isNull(i)) {
+            if (!mayHaveNull || !block.isNull(i)) {
                 long scaledValue = TIME_MICROS.getLong(block, i) / PICOSECONDS_PER_MICROSECOND;
                 getValueWriter().writeLong(scaledValue);
                 getStatistics().updateStats(scaledValue);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/TimestampMillisValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/TimestampMillisValueWriter.java
@@ -36,8 +36,9 @@ public class TimestampMillisValueWriter
     @Override
     public void write(Block block)
     {
+        boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); i++) {
-            if (!block.isNull(i)) {
+            if (!mayHaveNull || !block.isNull(i)) {
                 long scaledValue = floorDiv(type.getLong(block, i), MICROSECONDS_PER_MILLISECOND);
                 getValueWriter().writeLong(scaledValue);
                 getStatistics().updateStats(scaledValue);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/TimestampMillisValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/TimestampMillisValueWriter.java
@@ -15,6 +15,7 @@ package io.trino.parquet.writer.valuewriter;
 
 import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
+import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.schema.PrimitiveType;
 
@@ -36,12 +37,14 @@ public class TimestampMillisValueWriter
     @Override
     public void write(Block block)
     {
+        ValuesWriter valuesWriter = requireNonNull(getValuesWriter(), "valuesWriter is null");
+        Statistics<?> statistics = requireNonNull(getStatistics(), "statistics is null");
         boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); i++) {
             if (!mayHaveNull || !block.isNull(i)) {
                 long scaledValue = floorDiv(type.getLong(block, i), MICROSECONDS_PER_MILLISECOND);
-                getValueWriter().writeLong(scaledValue);
-                getStatistics().updateStats(scaledValue);
+                valuesWriter.writeLong(scaledValue);
+                statistics.updateStats(scaledValue);
             }
         }
     }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/TimestampNanosValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/TimestampNanosValueWriter.java
@@ -40,8 +40,9 @@ public class TimestampNanosValueWriter
     @Override
     public void write(Block block)
     {
+        boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); i++) {
-            if (!block.isNull(i)) {
+            if (!mayHaveNull || !block.isNull(i)) {
                 LongTimestamp value = (LongTimestamp) type.getObject(block, i);
                 long epochNanos = multiplyExact(value.getEpochMicros(), NANOSECONDS_PER_MICROSECOND) +
                         LongMath.divide(value.getPicosOfMicro(), PICOSECONDS_PER_NANOSECOND, UNNECESSARY);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/TimestampNanosValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/TimestampNanosValueWriter.java
@@ -17,6 +17,7 @@ import com.google.common.math.LongMath;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.LongTimestamp;
 import io.trino.spi.type.Type;
+import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.schema.PrimitiveType;
 
@@ -40,14 +41,16 @@ public class TimestampNanosValueWriter
     @Override
     public void write(Block block)
     {
+        ValuesWriter valuesWriter = requireNonNull(getValuesWriter(), "valuesWriter is null");
+        Statistics<?> statistics = requireNonNull(getStatistics(), "statistics is null");
         boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); i++) {
             if (!mayHaveNull || !block.isNull(i)) {
                 LongTimestamp value = (LongTimestamp) type.getObject(block, i);
                 long epochNanos = multiplyExact(value.getEpochMicros(), NANOSECONDS_PER_MICROSECOND) +
                         LongMath.divide(value.getPicosOfMicro(), PICOSECONDS_PER_NANOSECOND, UNNECESSARY);
-                getValueWriter().writeLong(epochNanos);
-                getStatistics().updateStats(epochNanos);
+                valuesWriter.writeLong(epochNanos);
+                statistics.updateStats(epochNanos);
             }
         }
     }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/TimestampTzMicrosValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/TimestampTzMicrosValueWriter.java
@@ -15,6 +15,7 @@ package io.trino.parquet.writer.valuewriter;
 
 import io.trino.spi.block.Block;
 import io.trino.spi.type.LongTimestampWithTimeZone;
+import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.schema.PrimitiveType;
 
@@ -22,6 +23,7 @@ import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MICROS;
 import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
 import static io.trino.spi.type.Timestamps.roundDiv;
+import static java.util.Objects.requireNonNull;
 
 public class TimestampTzMicrosValueWriter
         extends PrimitiveValueWriter
@@ -34,12 +36,14 @@ public class TimestampTzMicrosValueWriter
     @Override
     public void write(Block block)
     {
+        ValuesWriter valuesWriter = requireNonNull(getValuesWriter(), "valuesWriter is null");
+        Statistics<?> statistics = requireNonNull(getStatistics(), "statistics is null");
         boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); i++) {
             if (!mayHaveNull || !block.isNull(i)) {
                 long micros = toMicros((LongTimestampWithTimeZone) TIMESTAMP_TZ_MICROS.getObject(block, i));
-                getValueWriter().writeLong(micros);
-                getStatistics().updateStats(micros);
+                valuesWriter.writeLong(micros);
+                statistics.updateStats(micros);
             }
         }
     }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/TimestampTzMicrosValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/TimestampTzMicrosValueWriter.java
@@ -34,8 +34,9 @@ public class TimestampTzMicrosValueWriter
     @Override
     public void write(Block block)
     {
+        boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); i++) {
-            if (!block.isNull(i)) {
+            if (!mayHaveNull || !block.isNull(i)) {
                 long micros = toMicros((LongTimestampWithTimeZone) TIMESTAMP_TZ_MICROS.getObject(block, i));
                 getValueWriter().writeLong(micros);
                 getStatistics().updateStats(micros);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/TimestampTzMillisValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/TimestampTzMillisValueWriter.java
@@ -31,8 +31,9 @@ public class TimestampTzMillisValueWriter
     @Override
     public void write(Block block)
     {
+        boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); i++) {
-            if (!block.isNull(i)) {
+            if (!mayHaveNull || !block.isNull(i)) {
                 long millis = unpackMillisUtc(TIMESTAMP_TZ_MILLIS.getLong(block, i));
                 getValueWriter().writeLong(millis);
                 getStatistics().updateStats(millis);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/TimestampTzMillisValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/TimestampTzMillisValueWriter.java
@@ -14,11 +14,13 @@
 package io.trino.parquet.writer.valuewriter;
 
 import io.trino.spi.block.Block;
+import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.schema.PrimitiveType;
 
 import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static java.util.Objects.requireNonNull;
 
 public class TimestampTzMillisValueWriter
         extends PrimitiveValueWriter
@@ -31,12 +33,14 @@ public class TimestampTzMillisValueWriter
     @Override
     public void write(Block block)
     {
+        ValuesWriter valuesWriter = requireNonNull(getValuesWriter(), "valuesWriter is null");
+        Statistics<?> statistics = requireNonNull(getStatistics(), "statistics is null");
         boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); i++) {
             if (!mayHaveNull || !block.isNull(i)) {
                 long millis = unpackMillisUtc(TIMESTAMP_TZ_MILLIS.getLong(block, i));
-                getValueWriter().writeLong(millis);
-                getStatistics().updateStats(millis);
+                valuesWriter.writeLong(millis);
+                statistics.updateStats(millis);
             }
         }
     }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/UuidValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/UuidValueWriter.java
@@ -36,8 +36,9 @@ public class UuidValueWriter
     @Override
     public void write(Block block)
     {
+        boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); i++) {
-            if (!block.isNull(i)) {
+            if (!mayHaveNull || !block.isNull(i)) {
                 Slice slice = UUID.getSlice(block, i);
                 Binary binary = Binary.fromConstantByteArray(slice.getBytes());
                 valuesWriter.writeBytes(binary);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/UuidValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/UuidValueWriter.java
@@ -40,7 +40,9 @@ public class UuidValueWriter
         for (int i = 0; i < block.getPositionCount(); i++) {
             if (!mayHaveNull || !block.isNull(i)) {
                 Slice slice = UUID.getSlice(block, i);
-                Binary binary = Binary.fromConstantByteArray(slice.getBytes());
+                // fromReusedByteArray must be used instead of fromConstantByteArray to avoid retaining entire
+                // base byte array of the Slice in DictionaryValuesWriter.PlainBinaryDictionaryValuesWriter
+                Binary binary = Binary.fromReusedByteArray(slice.byteArray(), slice.byteArrayOffset(), slice.length());
                 valuesWriter.writeBytes(binary);
                 statistics.updateStats(binary);
             }


### PR DESCRIPTION
## Description
Refactors parquet `PrimitiveValueWriter` implementations to:
- use `Block#mayHaveNull()` to skip null checks when possible
- Remove redundant sub-class fields
- Reuse `Binary` instances where possible 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
