### PR TITLE
Add support for execute procedure in BigQuery connector

### DIFF
--- a/docs/src/main/sphinx/connector/bigquery.md
+++ b/docs/src/main/sphinx/connector/bigquery.md
@@ -386,6 +386,11 @@ the following features:
 ```{include} sql-delete-limitation.fragment
 ```
 
+### Procedures
+
+```{include} procedures-execute.fragment
+```
+
 ### Table functions
 
 The connector provides specific {doc}`table functions </functions/table>` to

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnector.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnector.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.bigquery;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import io.airlift.bootstrap.LifeCycleManager;
 import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata;
@@ -25,6 +26,7 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.function.table.ConnectorTableFunction;
+import io.trino.spi.procedure.Procedure;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.transaction.IsolationLevel;
 
@@ -43,6 +45,7 @@ public class BigQueryConnector
     private final BigQueryPageSourceProvider pageSourceProvider;
     private final BigQueryPageSinkProvider pageSinkProvider;
     private final Set<ConnectorTableFunction> connectorTableFunctions;
+    private final Set<Procedure> procedures;
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
@@ -53,6 +56,7 @@ public class BigQueryConnector
             BigQueryPageSourceProvider pageSourceProvider,
             BigQueryPageSinkProvider pageSinkProvider,
             Set<ConnectorTableFunction> connectorTableFunctions,
+            Set<Procedure> procedures,
             Set<SessionPropertiesProvider> sessionPropertiesProviders)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
@@ -61,6 +65,7 @@ public class BigQueryConnector
         this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
         this.pageSinkProvider = requireNonNull(pageSinkProvider, "pageSinkProvider is null");
         this.connectorTableFunctions = requireNonNull(connectorTableFunctions, "connectorTableFunctions is null");
+        this.procedures = ImmutableSet.copyOf(requireNonNull(procedures, "procedures is null"));
         this.sessionProperties = sessionPropertiesProviders.stream()
                 .flatMap(sessionPropertiesProvider -> sessionPropertiesProvider.getSessionProperties().stream())
                 .collect(toImmutableList());
@@ -112,6 +117,12 @@ public class BigQueryConnector
     public Set<ConnectorTableFunction> getTableFunctions()
     {
         return connectorTableFunctions;
+    }
+
+    @Override
+    public Set<Procedure> getProcedures()
+    {
+        return procedures;
     }
 
     @Override

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorModule.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorModule.java
@@ -26,9 +26,11 @@ import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.trino.plugin.base.logging.FormatInterpolator;
 import io.trino.plugin.base.logging.SessionInterpolatedValues;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
+import io.trino.plugin.bigquery.procedure.ExecuteProcedure;
 import io.trino.plugin.bigquery.ptf.Query;
 import io.trino.spi.NodeManager;
 import io.trino.spi.function.table.ConnectorTableFunction;
+import io.trino.spi.procedure.Procedure;
 
 import java.lang.management.ManagementFactory;
 import java.util.Set;
@@ -83,6 +85,7 @@ public class BigQueryConnectorModule
                     BigQueryConfig::isArrowSerializationEnabled,
                     ClientModule::verifyPackageAccessAllowed));
             newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(Query.class).in(Scopes.SINGLETON);
+            newSetBinder(binder, Procedure.class).addBinding().toProvider(ExecuteProcedure.class).in(Scopes.SINGLETON);
             newSetBinder(binder, SessionPropertiesProvider.class).addBinding().to(BigQuerySessionProperties.class).in(Scopes.SINGLETON);
 
             Multibinder<BigQueryOptionsConfigurer> optionsConfigurers = newSetBinder(binder, BigQueryOptionsConfigurer.class);

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/procedure/ExecuteProcedure.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/procedure/ExecuteProcedure.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery.procedure;
+
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import io.trino.plugin.bigquery.BigQueryClient;
+import io.trino.plugin.bigquery.BigQueryClientFactory;
+import io.trino.spi.classloader.ThreadContextClassLoader;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.procedure.Procedure;
+import io.trino.spi.procedure.Procedure.Argument;
+
+import java.lang.invoke.MethodHandle;
+
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.lang.invoke.MethodHandles.lookup;
+import static java.util.Objects.requireNonNull;
+
+public final class ExecuteProcedure
+        implements Provider<Procedure>
+{
+    private static final MethodHandle EXECUTE;
+
+    static {
+        try {
+            EXECUTE = lookup().unreflect(ExecuteProcedure.class.getMethod("execute", ConnectorSession.class, String.class));
+        }
+        catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private final BigQueryClientFactory clientFactory;
+
+    @Inject
+    public ExecuteProcedure(BigQueryClientFactory clientFactory)
+    {
+        this.clientFactory = requireNonNull(clientFactory, "clientFactory is null");
+    }
+
+    @Override
+    public Procedure get()
+    {
+        return new Procedure(
+                "system",
+                "execute",
+                ImmutableList.of(new Argument("QUERY", VARCHAR)),
+                EXECUTE.bindTo(this));
+    }
+
+    public void execute(ConnectorSession session, String query)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
+            BigQueryClient client = clientFactory.create(session);
+            client.executeUpdate(session, QueryJobConfiguration.of(query));
+        }
+    }
+}


### PR DESCRIPTION
## Description

Add support for `execute` procedure in BigQuery connector
Fixes #22692

## Release notes

```markdown
# BigQuery
* Add support for `execute` procedure. ({issue}`22692`)
```
