### PR TITLE
Expose a more complete set of information from the JMX export of InternalResourceGroup

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroup.java
+++ b/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroup.java
@@ -312,6 +312,19 @@ public class InternalResourceGroup
         }
     }
 
+    @Managed
+    public long getCpuUsageMillis()
+    {
+        return getResourceUsageSnapshot().getCpuUsageMillis();
+    }
+
+    @Managed
+    public long getMemoryUsageBytes()
+    {
+        return getResourceUsageSnapshot().getMemoryUsageBytes();
+    }
+
+    @Managed
     @Override
     public long getSoftMemoryLimitBytes()
     {
@@ -329,6 +342,14 @@ public class InternalResourceGroup
             if (canRunMore() != oldCanRun) {
                 updateEligibility();
             }
+        }
+    }
+
+    @Managed
+    public long getSoftCpuLimitMillis()
+    {
+        synchronized (root) {
+            return softCpuLimitMillis;
         }
     }
 
@@ -355,6 +376,14 @@ public class InternalResourceGroup
         }
     }
 
+    @Managed
+    public long getHardCpuLimitMillis()
+    {
+        synchronized (root) {
+            return hardCpuLimitMillis;
+        }
+    }
+
     @Override
     public Duration getHardCpuLimit()
     {
@@ -378,6 +407,7 @@ public class InternalResourceGroup
         }
     }
 
+    @Managed
     @Override
     public long getCpuQuotaGenerationMillisPerSecond()
     {
@@ -395,6 +425,7 @@ public class InternalResourceGroup
         }
     }
 
+    @Managed
     @Override
     public int getSoftConcurrencyLimit()
     {
@@ -465,6 +496,7 @@ public class InternalResourceGroup
         return timeBetweenStartsSec;
     }
 
+    @Managed
     @Override
     public int getSchedulingWeight()
     {
@@ -485,6 +517,7 @@ public class InternalResourceGroup
         }
     }
 
+    @Managed
     @Override
     public SchedulingPolicy getSchedulingPolicy()
     {

--- a/core/trino-main/src/test/java/io/trino/execution/resourcegroups/TestResourceGroups.java
+++ b/core/trino-main/src/test/java/io/trino/execution/resourcegroups/TestResourceGroups.java
@@ -1276,6 +1276,7 @@ public class TestResourceGroups
         long actualMillis = group.getResourceUsageSnapshot().getCpuUsageMillis();
         assertThat(actualMillis).isEqualTo(expectedMillis);
         assertThat(actualMillis >= group.getHardCpuLimit().toMillis()).isTrue();
+        assertThat(group.getCpuUsageMillis()).isEqualTo(expectedMillis);
     }
 
     private static void assertWithinCpuLimit(InternalResourceGroup group, long expectedMillis)
@@ -1283,6 +1284,7 @@ public class TestResourceGroups
         long actualMillis = group.getResourceUsageSnapshot().getCpuUsageMillis();
         assertThat(actualMillis).isEqualTo(expectedMillis);
         assertThat(actualMillis < group.getHardCpuLimit().toMillis()).isTrue();
+        assertThat(group.getCpuUsageMillis()).isEqualTo(expectedMillis);
     }
 
     private static void assertExceedsMemoryLimit(InternalResourceGroup group, long expectedBytes)
@@ -1290,6 +1292,7 @@ public class TestResourceGroups
         long actualBytes = group.getResourceUsageSnapshot().getMemoryUsageBytes();
         assertThat(actualBytes).isEqualTo(expectedBytes);
         assertThat(actualBytes).isGreaterThan(group.getSoftMemoryLimitBytes());
+        assertThat(group.getMemoryUsageBytes()).isEqualTo(expectedBytes);
     }
 
     private static void assertWithinMemoryLimit(InternalResourceGroup group, long expectedBytes)
@@ -1297,5 +1300,6 @@ public class TestResourceGroups
         long actualBytes = group.getResourceUsageSnapshot().getMemoryUsageBytes();
         assertThat(actualBytes).isEqualTo(expectedBytes);
         assertThat(actualBytes).isLessThanOrEqualTo(group.getSoftMemoryLimitBytes());
+        assertThat(group.getMemoryUsageBytes()).isEqualTo(expectedBytes);
     }
 }


### PR DESCRIPTION
## Description

Add missing information from `InternalResourceGroup` to the set of metrics exposed when `jmxExport = true` to provide a more complete picture of the state of each resource group.

## Additional context and related issues

[Resource groups](https://trino.io/docs/current/admin/resource-groups.html) allow us to enable monitoring by using `jmxExport = true` (recently enabled by default in #20810, though subsequent reverted in #22185). However currently the set of information exposed by the resource group is restricted to a set of fields that seems fairly arbitrary to me, limiting the value. I would break the information into two categories: config information (e.g. what are the configured limits) and runtime information (e.g. how many queries are currently running). For this to be really useful, you need both things, so you can compare the current behavior against the limits, and you need a complete view of the picture. Below I list all of the fields from both categories, and the current status:

| Type    | Field                             | Currently Exposed? |
|---------|-----------------------------------|--------------------|
| Config  | SoftConcurrencyLimit              | NO                 |
| Config  | HardConcurrencyLimit              | YES                |
| Config  | SoftMemoryLimitBytes              | NO                 |
| Config  | SoftCpuLimitMillis                | NO                 |
| Config  | HardCpuLimitMillis                | NO                 |
| Config  | CpuQuotaGenerationMillisPerSecond | NO                 |
| Config  | MaxQueuedQueries                  | YES                |
| Config  | SchedulingWeight                  | NO                 |
| Config  | SchedulingPolicy                  | NO                 |
| Runtime | RunningQueries                    | YES                |
| Runtime | QueuedQueries                     | YES                |
| Runtime | WaitingQueuedQueries              | YES                |
| Runtime | CpuUsageMillis                    | NO                 |
| Runtime | MemoryUsageBytes                  | NO                 |
| Runtime | TimeBetweenStartsSec              | YES                |

This PR exposes all of the fields that are marked with NO above, to consistently expose everything.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# General
* Enhance information exposed to JMX about resource groups to be more complete. ({issue}`22957`)
```