### PR TITLE
Simplify testJoinDynamicFilteringBlockProbeSide tests

### DIFF
--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduIntegrationDynamicFilter.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduIntegrationDynamicFilter.java
@@ -159,15 +159,14 @@ public class TestKuduIntegrationDynamicFilter
     @Test
     public void testJoinDynamicFilteringBlockProbeSide()
     {
-        // Wait for both build sides to finish before starting the scan of 'lineitem' table (should be very selective given the dynamic filters).
+        // Wait for both build side to finish before starting the scan of 'lineitem' table (should be very selective given the dynamic filters).
         assertDynamicFiltering(
                 "SELECT l.comment" +
-                        " FROM  lineitem l, part p, orders o" +
-                        " WHERE l.orderkey = o.orderkey AND o.comment = 'nstructions sleep furiously among '" +
-                        " AND p.partkey = l.partkey AND p.comment = 'onic deposits'",
+                        " FROM  lineitem l, orders o" +
+                        " WHERE l.orderkey = o.orderkey AND o.comment = 'nstructions sleep furiously among '",
                 withBroadcastJoinNonReordering(),
-                1,
-                1);
+                6,
+                6);
     }
 
     private void assertDynamicFiltering(@Language("SQL") String selectQuery, Session session, int expectedRowCount, int expectedProbeInputRowsRead)

--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
@@ -282,15 +282,14 @@ public class TestMemoryConnectorTest
     public void testJoinDynamicFilteringBlockProbeSide()
     {
         for (JoinDistributionType joinDistributionType : JoinDistributionType.values()) {
-            // Wait for both build sides to finish before starting the scan of 'lineitem' table (should be very selective given the dynamic filters).
+            // Wait for both build side to finish before starting the scan of 'lineitem' table (should be very selective given the dynamic filters).
             assertDynamicFiltering(
                     "SELECT l.comment" +
-                            " FROM  lineitem l, part p, orders o" +
-                            " WHERE l.orderkey = o.orderkey AND o.comment = 'nstructions sleep furiously among '" +
-                            " AND p.partkey = l.partkey AND p.comment = 'onic deposits'",
+                            " FROM  lineitem l, orders o" +
+                            " WHERE l.orderkey = o.orderkey AND o.comment = 'nstructions sleep furiously among '",
                     noJoinReordering(joinDistributionType),
-                    1,
-                    1, PART_COUNT, ORDERS_COUNT);
+                    6,
+                    6, ORDERS_COUNT);
         }
     }
 

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoDynamicFiltering.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoDynamicFiltering.java
@@ -156,15 +156,14 @@ public class TestMongoDynamicFiltering
     @Test
     public void testJoinDynamicFilteringBlockProbeSide()
     {
-        // Wait for both build sides to finish before starting the scan of 'lineitem' table (should be very selective given the dynamic filters).
+        // Wait for both build side to finish before starting the scan of 'lineitem' table (should be very selective given the dynamic filters).
         assertDynamicFiltering(
                 "SELECT l.comment" +
-                        " FROM  lineitem l, part p, orders o" +
-                        " WHERE l.orderkey = o.orderkey AND o.comment = 'nstructions sleep furiously among '" +
-                        " AND p.partkey = l.partkey AND p.comment = 'onic deposits'",
+                        " FROM  lineitem l, orders o" +
+                        " WHERE l.orderkey = o.orderkey AND o.comment = 'nstructions sleep furiously among '",
                 withBroadcastJoinNonReordering(),
-                1,
-                1);
+                6,
+                6);
     }
 
     private void assertDynamicFiltering(@Language("SQL") String selectQuery, Session session, int expectedRowCount, int... expectedOperatorRowsRead)


### PR DESCRIPTION
The assumption for waiting for build side only works for first join due to how Driver#processInternal works.

Fixes: https://github.com/trinodb/trino/issues/21724
