### PR TITLE
Add temporary escape hatch to allow unsafe pushdowns

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -112,6 +112,7 @@ public final class SystemSessionProperties
     public static final String ENABLE_INTERMEDIATE_AGGREGATIONS = "enable_intermediate_aggregations";
     public static final String PUSH_AGGREGATION_THROUGH_OUTER_JOIN = "push_aggregation_through_outer_join";
     public static final String PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN = "push_partial_aggregation_through_join";
+    public static final String ALLOW_UNSAFE_PUSHDOWN = "allow_unsafe_pushdown";
     public static final String PRE_AGGREGATE_CASE_AGGREGATIONS_ENABLED = "pre_aggregate_case_aggregations_enabled";
     public static final String FORCE_SINGLE_NODE_OUTPUT = "force_single_node_output";
     public static final String FILTER_AND_PROJECT_MIN_OUTPUT_PAGE_SIZE = "filter_and_project_min_output_page_size";
@@ -1097,6 +1098,11 @@ public final class SystemSessionProperties
                 durationProperty(CLOSE_IDLE_WRITERS_TRIGGER_DURATION,
                         "The duration after which the writer operator tries to close the idle writers",
                         new Duration(5, SECONDS),
+                        true),
+                booleanProperty(
+                        ALLOW_UNSAFE_PUSHDOWN,
+                        "Allow pushing down expressions that may fail for some inputs",
+                        optimizerConfig.isUnsafePushdownAllowed(),
                         true));
     }
 
@@ -1970,5 +1976,10 @@ public final class SystemSessionProperties
     public static boolean isColumnarFilterEvaluationEnabled(Session session)
     {
         return session.getSystemProperty(COLUMNAR_FILTER_EVALUATION_ENABLED, Boolean.class);
+    }
+
+    public static boolean isUnsafePushdownAllowed(Session session)
+    {
+        return session.getSystemProperty(ALLOW_UNSAFE_PUSHDOWN, Boolean.class);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/OptimizerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/OptimizerConfig.java
@@ -100,6 +100,8 @@ public class OptimizerConfig
     private DataSize minInputSizePerTask = DataSize.of(5, GIGABYTE);
     private long minInputRowsPerTask = 10_000_000L;
 
+    private boolean allowUnsafePushdown; // TODO: remove once https://github.com/trinodb/trino/issues/22268 is fixed
+
     public enum JoinReorderingStrategy
     {
         NONE,
@@ -818,6 +820,19 @@ public class OptimizerConfig
     public OptimizerConfig setPushFilterIntoValuesMaxRowCount(int pushFilterIntoValuesMaxRowCount)
     {
         this.pushFilterIntoValuesMaxRowCount = pushFilterIntoValuesMaxRowCount;
+        return this;
+    }
+
+    public boolean isUnsafePushdownAllowed()
+    {
+        return allowUnsafePushdown;
+    }
+
+    @Config("optimizer.allow-unsafe-pushdown")
+    @ConfigDescription("Allow pushing down expressions that mail fail for some inputs")
+    public OptimizerConfig setUnsafePushdownAllowed(boolean value)
+    {
+        this.allowUnsafePushdown = value;
         return this;
     }
 }

--- a/core/trino-main/src/test/java/io/trino/cost/TestOptimizerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/cost/TestOptimizerConfig.java
@@ -91,7 +91,8 @@ public class TestOptimizerConfig
                 .setMinInputRowsPerTask(10_000_000L)
                 .setUseExactPartitioning(false)
                 .setUseCostBasedPartitioning(true)
-                .setPushFilterIntoValuesMaxRowCount(100));
+                .setPushFilterIntoValuesMaxRowCount(100)
+                .setUnsafePushdownAllowed(false));
     }
 
     @Test
@@ -150,6 +151,7 @@ public class TestOptimizerConfig
                 .put("optimizer.use-exact-partitioning", "true")
                 .put("optimizer.use-cost-based-partitioning", "false")
                 .put("optimizer.push-filter-into-values-max-row-count", "5")
+                .put("optimizer.allow-unsafe-pushdown", "true")
                 .buildOrThrow();
 
         OptimizerConfig expected = new OptimizerConfig()
@@ -204,7 +206,8 @@ public class TestOptimizerConfig
                 .setMinInputRowsPerTask(1_000_000L)
                 .setUseExactPartitioning(true)
                 .setUseCostBasedPartitioning(false)
-                .setPushFilterIntoValuesMaxRowCount(5);
+                .setPushFilterIntoValuesMaxRowCount(5)
+                .setUnsafePushdownAllowed(true);
         assertFullMapping(properties, expected);
     }
 }


### PR DESCRIPTION
PR #21429 fixed an issue that might cause query failures due to aggressive pushdown of expressions that could fail on certain inputs.

Unfortunately, it resulted in a regression in use cases that were relying on this behavior (e.g., issue #22268). A proper fix is not trivial, so we introduce a temporary escape hatch to allow users to restore the old behavior until the final fix is in place.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# General
* TBD. ({issue}`...`)
```
