### PR TITLE
Enable SSE with customer key for S3

### DIFF
--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3Context.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3Context.java
@@ -14,7 +14,6 @@
 package io.trino.filesystem.s3;
 
 import io.trino.filesystem.s3.S3FileSystemConfig.ObjectCannedAcl;
-import io.trino.filesystem.s3.S3FileSystemConfig.S3SseType;
 import io.trino.spi.security.ConnectorIdentity;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
@@ -25,20 +24,26 @@ import software.amazon.awssdk.services.s3.model.RequestPayer;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.filesystem.s3.S3FileSystemConfig.S3SseType.KMS;
 import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY;
 import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_SECRET_KEY_PROPERTY;
 import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY;
 import static java.util.Objects.requireNonNull;
 
-record S3Context(int partSize, boolean requesterPays, S3SseType sseType, String sseKmsKeyId, Optional<AwsCredentialsProvider> credentialsProviderOverride, ObjectCannedAcl cannedAcl, boolean exclusiveWriteSupported)
+record S3Context(
+        int partSize,
+        boolean requesterPays,
+        S3SseContext s3SseContext,
+        Optional<AwsCredentialsProvider> credentialsProviderOverride,
+        ObjectCannedAcl cannedAcl,
+        boolean exclusiveWriteSupported)
 {
     private static final int MIN_PART_SIZE = 5 * 1024 * 1024; // S3 requirement
 
     public S3Context
     {
         checkArgument(partSize >= MIN_PART_SIZE, "partSize must be at least %s bytes", MIN_PART_SIZE);
-        requireNonNull(sseType, "sseType is null");
-        checkArgument((sseType != S3SseType.KMS) || (sseKmsKeyId != null), "sseKmsKeyId is null for SSE-KMS");
+        requireNonNull(s3SseContext, "sseContext is null");
         requireNonNull(credentialsProviderOverride, "credentialsProviderOverride is null");
     }
 
@@ -49,7 +54,7 @@ record S3Context(int partSize, boolean requesterPays, S3SseType sseType, String 
 
     public S3Context withKmsKeyId(String kmsKeyId)
     {
-        return new S3Context(partSize, requesterPays, S3SseType.KMS, kmsKeyId, credentialsProviderOverride, cannedAcl, exclusiveWriteSupported);
+        return new S3Context(partSize, requesterPays, S3SseContext.withKmsKeyId(kmsKeyId), credentialsProviderOverride, cannedAcl, exclusiveWriteSupported);
     }
 
     public S3Context withCredentials(ConnectorIdentity identity)
@@ -69,8 +74,7 @@ record S3Context(int partSize, boolean requesterPays, S3SseType sseType, String 
         return new S3Context(
                 partSize,
                 requesterPays,
-                sseType,
-                sseKmsKeyId,
+                s3SseContext,
                 Optional.of(credentialsProviderOverride),
                 cannedAcl,
                 exclusiveWriteSupported);
@@ -79,5 +83,19 @@ record S3Context(int partSize, boolean requesterPays, S3SseType sseType, String 
     public void applyCredentialProviderOverride(AwsRequestOverrideConfiguration.Builder builder)
     {
         credentialsProviderOverride.ifPresent(builder::credentialsProvider);
+    }
+
+    record S3SseContext(S3FileSystemConfig.S3SseType sseType, Optional<String> sseKmsKeyId)
+    {
+        public S3SseContext
+        {
+            requireNonNull(sseType, "sseType is null");
+            checkArgument((sseType != KMS) || (sseKmsKeyId.isPresent()), "sseKmsKeyId is missing for SSE-KMS");
+        }
+
+        public static S3SseContext withKmsKeyId(String kmsKeyId)
+        {
+            return new S3SseContext(KMS, Optional.ofNullable(kmsKeyId));
+        }
     }
 }

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3Context.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3Context.java
@@ -90,6 +90,7 @@ record S3Context(
         public S3SseContext
         {
             requireNonNull(sseType, "sseType is null");
+            requireNonNull(sseKmsKeyId, "sseKmsKeyId is null");
             checkArgument((sseType != KMS) || (sseKmsKeyId.isPresent()), "sseKmsKeyId is missing for SSE-KMS");
         }
 

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
@@ -23,6 +23,7 @@ import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.airlift.units.MaxDataSize;
 import io.airlift.units.MinDataSize;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import software.amazon.awssdk.retries.api.RetryStrategy;
@@ -41,7 +42,7 @@ public class S3FileSystemConfig
 {
     public enum S3SseType
     {
-        NONE, S3, KMS
+        NONE, S3, KMS, CUSTOMER
     }
 
     public enum ObjectCannedAcl
@@ -96,6 +97,7 @@ public class S3FileSystemConfig
     private String stsRegion;
     private S3SseType sseType = S3SseType.NONE;
     private String sseKmsKeyId;
+    private String sseCustomerKey;
     private boolean useWebIdentityTokenCredentialsProvider;
     private DataSize streamingPartSize = DataSize.of(16, MEGABYTE);
     private boolean requesterPays;
@@ -318,6 +320,29 @@ public class S3FileSystemConfig
     {
         this.useWebIdentityTokenCredentialsProvider = useWebIdentityTokenCredentialsProvider;
         return this;
+    }
+
+    public String getSseCustomerKey()
+    {
+        return sseCustomerKey;
+    }
+
+    @Config("s3.sse.customer-key")
+    @ConfigDescription("Customer Key to use for S3 server-side encryption with Customer key (SSE-C)")
+    @ConfigSecuritySensitive
+    public S3FileSystemConfig setSseCustomerKey(String sseCustomerKey)
+    {
+        this.sseCustomerKey = sseCustomerKey;
+        return this;
+    }
+
+    @AssertTrue(message = "s3.sse.customer-key has to be set for server-side encryption with customer-provided key")
+    public boolean isSseWithCustomerKeyConfigValid()
+    {
+        if (sseType == S3SseType.CUSTOMER) {
+            return sseCustomerKey != null;
+        }
+        return true;
     }
 
     @NotNull

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemLoader.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemLoader.java
@@ -18,6 +18,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkTelemetry;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.filesystem.s3.S3Context.S3SseContext;
 import jakarta.annotation.PreDestroy;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -88,8 +89,9 @@ final class S3FileSystemLoader
         this.context = new S3Context(
                 toIntExact(config.getStreamingPartSize().toBytes()),
                 config.isRequesterPays(),
-                config.getSseType(),
-                config.getSseKmsKeyId(),
+                new S3SseContext(
+                        config.getSseType(),
+                        Optional.ofNullable(config.getSseKmsKeyId())),
                 Optional.empty(),
                 config.getCannedAcl(),
                 config.isSupportsExclusiveCreate());

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemLoader.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemLoader.java
@@ -89,9 +89,10 @@ final class S3FileSystemLoader
         this.context = new S3Context(
                 toIntExact(config.getStreamingPartSize().toBytes()),
                 config.isRequesterPays(),
-                new S3SseContext(
+                S3SseContext.of(
                         config.getSseType(),
-                        Optional.ofNullable(config.getSseKmsKeyId())),
+                        config.getSseKmsKeyId(),
+                        config.getSseCustomerKey()),
                 Optional.empty(),
                 config.getCannedAcl(),
                 config.isSupportsExclusiveCreate());

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3OutputStream.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3OutputStream.java
@@ -14,7 +14,6 @@
 package io.trino.filesystem.s3;
 
 import io.trino.filesystem.encryption.EncryptionKey;
-import io.trino.filesystem.s3.S3FileSystemConfig.S3SseType;
 import io.trino.memory.context.AggregatedMemoryContext;
 import io.trino.memory.context.LocalMemoryContext;
 import software.amazon.awssdk.core.exception.SdkException;
@@ -49,6 +48,7 @@ import static io.trino.filesystem.s3.S3FileSystemConfig.ObjectCannedAcl.getCanne
 import static io.trino.filesystem.s3.S3FileSystemConfig.S3SseType.NONE;
 import static io.trino.filesystem.s3.S3SseCUtils.encoded;
 import static io.trino.filesystem.s3.S3SseCUtils.md5Checksum;
+import static io.trino.filesystem.s3.S3SseRequestConfigurator.addEncryptionSettings;
 import static java.lang.Math.clamp;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
@@ -56,8 +56,6 @@ import static java.lang.System.arraycopy;
 import static java.net.HttpURLConnection.HTTP_PRECON_FAILED;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
-import static software.amazon.awssdk.services.s3.model.ServerSideEncryption.AES256;
-import static software.amazon.awssdk.services.s3.model.ServerSideEncryption.AWS_KMS;
 
 final class S3OutputStream
         extends OutputStream
@@ -70,8 +68,6 @@ final class S3OutputStream
     private final S3Context context;
     private final int partSize;
     private final RequestPayer requestPayer;
-    private final S3SseType sseType;
-    private final Optional<String> sseKmsKeyId;
     private final ObjectCannedACL cannedAcl;
     private final boolean exclusiveCreate;
     private final Optional<EncryptionKey> key;
@@ -101,12 +97,10 @@ final class S3OutputStream
         this.context = requireNonNull(context, "context is null");
         this.partSize = context.partSize();
         this.requestPayer = context.requestPayer();
-        this.sseType = context.s3SseContext().sseType();
-        this.sseKmsKeyId = context.s3SseContext().sseKmsKeyId();
         this.cannedAcl = getCannedAcl(context.cannedAcl());
         this.key = requireNonNull(key, "key is null");
 
-        verify(key.isEmpty() || sseType == NONE, "Encryption key cannot be used with SSE configuration");
+        verify(key.isEmpty() || context.s3SseContext().sseType() == NONE, "Encryption key cannot be used with SSE configuration");
     }
 
     @SuppressWarnings("NumericCastThatLosesPrecision")
@@ -230,11 +224,7 @@ final class S3OutputStream
                             builder.sseCustomerAlgorithm(encryption.algorithm());
                             builder.sseCustomerKeyMD5(md5Checksum(encryption));
                         });
-                        switch (sseType) {
-                            case NONE -> { /* ignored */ }
-                            case S3 -> builder.serverSideEncryption(AES256);
-                            case KMS -> sseKmsKeyId.ifPresent(builder.serverSideEncryption(AWS_KMS)::ssekmsKeyId);
-                        }
+                        addEncryptionSettings(builder, context.s3SseContext());
                     })
                     .build();
 
@@ -320,11 +310,7 @@ final class S3OutputStream
                             builder.sseCustomerAlgorithm(encryption.algorithm());
                             builder.sseCustomerKeyMD5(md5Checksum(encryption));
                         });
-                        switch (sseType) {
-                            case NONE -> { /* ignored */ }
-                            case S3 -> builder.serverSideEncryption(AES256);
-                            case KMS -> sseKmsKeyId.ifPresent(builder.serverSideEncryption(AWS_KMS)::ssekmsKeyId);
-                        }
+                        addEncryptionSettings(builder, context.s3SseContext());
                     })
                     .build();
 

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3SseCustomerKey.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3SseCustomerKey.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.s3;
+
+import static java.util.Objects.requireNonNull;
+import static software.amazon.awssdk.utils.BinaryUtils.fromBase64;
+import static software.amazon.awssdk.utils.Md5Utils.md5AsBase64;
+
+public record S3SseCustomerKey(String key, String md5, String algorithm)
+{
+    private static final String SSE_C_ALGORITHM = "AES256";
+
+    public S3SseCustomerKey
+    {
+        requireNonNull(key, "key is null");
+        requireNonNull(md5, "md5 is null");
+        requireNonNull(algorithm, "algorithm is null");
+    }
+
+    public static S3SseCustomerKey onAes256(String key)
+    {
+        return new S3SseCustomerKey(key, md5AsBase64(fromBase64(key)), SSE_C_ALGORITHM);
+    }
+}

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3SseRequestConfigurator.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3SseRequestConfigurator.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.s3;
+
+import io.trino.filesystem.s3.S3Context.S3SseContext;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import static software.amazon.awssdk.services.s3.model.ServerSideEncryption.AES256;
+import static software.amazon.awssdk.services.s3.model.ServerSideEncryption.AWS_KMS;
+
+public final class S3SseRequestConfigurator
+{
+    private S3SseRequestConfigurator() {}
+
+    public static void addEncryptionSettings(PutObjectRequest.Builder builder, S3SseContext context)
+    {
+        switch (context.sseType()) {
+            case NONE -> { /* ignored */ }
+            case S3 -> builder.serverSideEncryption(AES256);
+            case KMS -> context.sseKmsKeyId().ifPresent(builder.serverSideEncryption(AWS_KMS)::ssekmsKeyId);
+        }
+    }
+
+    public static void addEncryptionSettings(CreateMultipartUploadRequest.Builder builder, S3SseContext context)
+    {
+        switch (context.sseType()) {
+            case NONE -> { /* ignored */ }
+            case S3 -> builder.serverSideEncryption(AES256);
+            case KMS -> context.sseKmsKeyId().ifPresent(builder.serverSideEncryption(AWS_KMS)::ssekmsKeyId);
+        }
+    }
+}

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3SseRequestConfigurator.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3SseRequestConfigurator.java
@@ -14,9 +14,14 @@
 package io.trino.filesystem.s3;
 
 import io.trino.filesystem.s3.S3Context.S3SseContext;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 
+import static io.trino.filesystem.s3.S3FileSystemConfig.S3SseType.CUSTOMER;
 import static software.amazon.awssdk.services.s3.model.ServerSideEncryption.AES256;
 import static software.amazon.awssdk.services.s3.model.ServerSideEncryption.AWS_KMS;
 
@@ -24,21 +29,73 @@ public final class S3SseRequestConfigurator
 {
     private S3SseRequestConfigurator() {}
 
-    public static void addEncryptionSettings(PutObjectRequest.Builder builder, S3SseContext context)
+    public static void setEncryptionSettings(PutObjectRequest.Builder builder, S3SseContext context)
     {
         switch (context.sseType()) {
             case NONE -> { /* ignored */ }
             case S3 -> builder.serverSideEncryption(AES256);
             case KMS -> context.sseKmsKeyId().ifPresent(builder.serverSideEncryption(AWS_KMS)::ssekmsKeyId);
+            case CUSTOMER -> {
+                context.sseCustomerKey().ifPresent(s3SseCustomerKey ->
+                        builder.sseCustomerAlgorithm(s3SseCustomerKey.algorithm())
+                                .sseCustomerKey(s3SseCustomerKey.key())
+                                .sseCustomerKeyMD5(s3SseCustomerKey.md5()));
+            }
         }
     }
 
-    public static void addEncryptionSettings(CreateMultipartUploadRequest.Builder builder, S3SseContext context)
+    public static void setEncryptionSettings(CreateMultipartUploadRequest.Builder builder, S3SseContext context)
     {
         switch (context.sseType()) {
             case NONE -> { /* ignored */ }
             case S3 -> builder.serverSideEncryption(AES256);
             case KMS -> context.sseKmsKeyId().ifPresent(builder.serverSideEncryption(AWS_KMS)::ssekmsKeyId);
+            case CUSTOMER -> {
+                context.sseCustomerKey().ifPresent(s3SseCustomerKey ->
+                        builder.sseCustomerAlgorithm(s3SseCustomerKey.algorithm())
+                                .sseCustomerKey(s3SseCustomerKey.key())
+                                .sseCustomerKeyMD5(s3SseCustomerKey.md5()));
+            }
+        }
+    }
+
+    public static void setEncryptionSettings(CompleteMultipartUploadRequest.Builder builder, S3SseContext context)
+    {
+        if (context.sseType() == CUSTOMER) {
+            context.sseCustomerKey().ifPresent(s3SseCustomerKey ->
+                    builder.sseCustomerAlgorithm(s3SseCustomerKey.algorithm())
+                            .sseCustomerKey(s3SseCustomerKey.key())
+                            .sseCustomerKeyMD5(s3SseCustomerKey.md5()));
+        }
+    }
+
+    public static void setEncryptionSettings(GetObjectRequest.Builder builder, S3SseContext context)
+    {
+        if (context.sseType().equals(CUSTOMER)) {
+            context.sseCustomerKey().ifPresent(s3SseCustomerKey ->
+                    builder.sseCustomerAlgorithm(s3SseCustomerKey.algorithm())
+                            .sseCustomerKey(s3SseCustomerKey.key())
+                            .sseCustomerKeyMD5(s3SseCustomerKey.md5()));
+        }
+    }
+
+    public static void setEncryptionSettings(HeadObjectRequest.Builder builder, S3SseContext context)
+    {
+        if (context.sseType().equals(CUSTOMER)) {
+            context.sseCustomerKey().ifPresent(s3SseCustomerKey ->
+                    builder.sseCustomerAlgorithm(s3SseCustomerKey.algorithm())
+                            .sseCustomerKey(s3SseCustomerKey.key())
+                            .sseCustomerKeyMD5(s3SseCustomerKey.md5()));
+        }
+    }
+
+    public static void setEncryptionSettings(UploadPartRequest.Builder builder, S3SseContext context)
+    {
+        if (context.sseType() == CUSTOMER) {
+            context.sseCustomerKey().ifPresent(s3SseCustomerKey ->
+                    builder.sseCustomerAlgorithm(s3SseCustomerKey.algorithm())
+                            .sseCustomerKey(s3SseCustomerKey.key())
+                            .sseCustomerKeyMD5(s3SseCustomerKey.md5()));
         }
     }
 }

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemAwsS3WithSseCustomerKey.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemAwsS3WithSseCustomerKey.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.s3;
+
+import io.airlift.units.DataSize;
+import io.opentelemetry.api.OpenTelemetry;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.DelegatingS3Client;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Request;
+import software.amazon.awssdk.utils.BinaryUtils;
+
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.function.Function;
+
+import static io.trino.filesystem.s3.S3FileSystemConfig.S3SseType.CUSTOMER;
+import static java.util.Objects.requireNonNull;
+
+public class TestS3FileSystemAwsS3WithSseCustomerKey
+        extends AbstractTestS3FileSystem
+{
+    private static final String CUSTOMER_KEY = generateCustomerKey();
+
+    private String accessKey;
+    private String secretKey;
+    private String region;
+    private String bucket;
+    private S3SseCustomerKey s3SseCustomerKey;
+
+    @Override
+    protected void initEnvironment()
+    {
+        accessKey = environmentVariable("AWS_ACCESS_KEY_ID");
+        secretKey = environmentVariable("AWS_SECRET_ACCESS_KEY");
+        region = environmentVariable("AWS_REGION");
+        bucket = environmentVariable("EMPTY_S3_BUCKET");
+        s3SseCustomerKey = S3SseCustomerKey.onAes256(CUSTOMER_KEY);
+    }
+
+    @Override
+    protected String bucket()
+    {
+        return bucket;
+    }
+
+    @Override
+    protected S3Client createS3Client()
+    {
+        S3Client s3Client = S3Client.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
+                .region(Region.of(region))
+                .build();
+
+        return new DelegatingS3Client(s3Client)
+        {
+            @Override
+            protected <T extends S3Request, ReturnT> ReturnT invokeOperation(T request, Function<T, ReturnT> operation)
+            {
+                if (request instanceof PutObjectRequest putObjectRequest) {
+                    PutObjectRequest.Builder putObjectRequestBuilder = putObjectRequest.toBuilder();
+                    putObjectRequestBuilder.sseCustomerAlgorithm(s3SseCustomerKey.algorithm());
+                    putObjectRequestBuilder.sseCustomerKey(s3SseCustomerKey.key());
+                    putObjectRequestBuilder.sseCustomerKeyMD5(s3SseCustomerKey.md5());
+                    return operation.apply((T) putObjectRequestBuilder.build());
+                }
+                else if (request instanceof GetObjectRequest getObjectRequest) {
+                    GetObjectRequest.Builder getObjectRequestBuilder = getObjectRequest.toBuilder();
+                    getObjectRequestBuilder.sseCustomerAlgorithm(s3SseCustomerKey.algorithm());
+                    getObjectRequestBuilder.sseCustomerKey(s3SseCustomerKey.key());
+                    getObjectRequestBuilder.sseCustomerKeyMD5(s3SseCustomerKey.md5());
+                    return operation.apply((T) getObjectRequestBuilder.build());
+                }
+                return operation.apply(request);
+            }
+        };
+    }
+
+    @Override
+    protected S3FileSystemFactory createS3FileSystemFactory()
+    {
+        return new S3FileSystemFactory(
+                OpenTelemetry.noop(),
+                new S3FileSystemConfig()
+                        .setAwsAccessKey(accessKey)
+                        .setAwsSecretKey(secretKey)
+                        .setRegion(region)
+                        .setSseType(CUSTOMER)
+                        .setSseCustomerKey(s3SseCustomerKey.key())
+                        .setStreamingPartSize(DataSize.valueOf("5.5MB")),
+                new S3FileSystemStats());
+    }
+
+    private static String environmentVariable(String name)
+    {
+        return requireNonNull(System.getenv(name), "Environment variable not set: " + name);
+    }
+
+    private static String generateCustomerKey()
+    {
+        try {
+            KeyGenerator keyGenerator = KeyGenerator.getInstance("AES");
+            keyGenerator.init(256, new SecureRandom());
+            SecretKey secretKey = keyGenerator.generateKey();
+            return BinaryUtils.toBase64(secretKey.getEncoded());
+        }
+        catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
The PR enables Server Side Encryption with Customer Key mode (SSE-C) for data encryption on S3 storage.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
New value `CUSTOMER` for the property `s3.sse.type` - indicates that we want to use Customer Key for SSE (SSE-C mode)
New property: `s3.sse.customer-key` - Customer Key to use for S3 server-side encryption with Customer key (SSE-C)


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
```
