### PR TITLE
Unify constructField between Iceberg and Hive

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
@@ -189,19 +189,6 @@ public final class ParquetTypeUtils
         return Optional.of(DecimalType.createDecimalType(decimalLogicalType.getPrecision(), decimalLogicalType.getScale()));
     }
 
-    /**
-     * For optional fields:
-     * <ul>
-     * <li>definitionLevel == maxDefinitionLevel     =&gt; Value is defined</li>
-     * <li>definitionLevel == maxDefinitionLevel - 1 =&gt; Value is null</li>
-     * <li>definitionLevel &lt; maxDefinitionLevel - 1  =&gt; Value does not exist, because one of its optional parent fields is null</li>
-     * </ul>
-     */
-    public static boolean isValueNull(boolean required, int definitionLevel, int maxDefinitionLevel)
-    {
-        return !required && (definitionLevel == maxDefinitionLevel - 1);
-    }
-
     public static boolean isOptionalFieldValueNull(int definitionLevel, int maxDefinitionLevel)
     {
         return definitionLevel == maxDefinitionLevel - 1;

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
@@ -529,20 +529,12 @@ public class ParquetReader
     private ColumnChunk readColumnChunk(Field field)
             throws IOException
     {
-        ColumnChunk columnChunk;
-        if (field.getType() instanceof RowType) {
-            columnChunk = readStruct((GroupField) field);
-        }
-        else if (field.getType() instanceof MapType) {
-            columnChunk = readMap((GroupField) field);
-        }
-        else if (field.getType() instanceof ArrayType) {
-            columnChunk = readArray((GroupField) field);
-        }
-        else {
-            columnChunk = readPrimitive((PrimitiveField) field);
-        }
-        return columnChunk;
+        return switch (field.getType()) {
+            case RowType _ -> readStruct((GroupField) field);
+            case MapType _ -> readMap((GroupField) field);
+            case ArrayType _ -> readArray((GroupField) field);
+            default -> readPrimitive((PrimitiveField) field);
+        };
     }
 
     public ParquetDataSource getDataSource()

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -410,13 +410,13 @@ public class IcebergPageSourceProvider
 
         Types.StructType structType = partitionSpec.partitionType();
         PartitionKey partitionKey = partitionKeyFactories.computeIfAbsent(
-                partitionSpec.specId(),
-                key -> {
-                    // creating the template wrapper is expensive, reuse it for all partitions of the same spec
-                    // reuse is only safe because we only use the copyFor method which is thread safe
-                    StructLikeWrapper templateWrapper = StructLikeWrapper.forType(structType);
-                    return data -> new PartitionKey(key, templateWrapper.copyFor(data));
-                })
+                        partitionSpec.specId(),
+                        key -> {
+                            // creating the template wrapper is expensive, reuse it for all partitions of the same spec
+                            // reuse is only safe because we only use the copyFor method which is thread safe
+                            StructLikeWrapper templateWrapper = StructLikeWrapper.forType(structType);
+                            return data -> new PartitionKey(key, templateWrapper.copyFor(data));
+                        })
                 .apply(partitionData);
 
         return partitionedDeleteManagers.computeIfAbsent(partitionKey, ignored -> new DeleteManager(typeManager));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -52,7 +52,6 @@ import io.trino.plugin.hive.ReaderProjectionsAdapter;
 import io.trino.plugin.hive.orc.OrcPageSource;
 import io.trino.plugin.hive.orc.OrcPageSource.ColumnAdaptation;
 import io.trino.plugin.hive.parquet.ParquetPageSource;
-import io.trino.plugin.iceberg.IcebergParquetColumnIOConverter.FieldContext;
 import io.trino.plugin.iceberg.delete.DeleteFile;
 import io.trino.plugin.iceberg.delete.DeleteManager;
 import io.trino.plugin.iceberg.delete.RowPredicate;
@@ -1001,7 +1000,7 @@ public class IcebergPageSourceProvider
                     }
                     // The top level columns are already mapped by name/id appropriately.
                     ColumnIO columnIO = messageColumnIO.getChild(parquetField.getName());
-                    Optional<Field> field = IcebergParquetColumnIOConverter.constructField(new FieldContext(trinoType, column.getColumnIdentity()), columnIO);
+                    Optional<Field> field = IcebergParquetColumnIOConverter.constructField(trinoType, columnIO, column.getColumnIdentity());
                     if (field.isEmpty()) {
                         pageSourceBuilder.addNullColumn(trinoType);
                         continue;

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergParquetColumnIOConverter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergParquetColumnIOConverter.java
@@ -13,99 +13,103 @@
  */
 package io.trino.plugin.iceberg;
 
-import com.google.common.collect.ImmutableList;
 import io.trino.parquet.Field;
-import io.trino.parquet.GroupField;
-import io.trino.parquet.PrimitiveField;
-import io.trino.spi.type.ArrayType;
-import io.trino.spi.type.MapType;
+import io.trino.parquet.ParquetTypeUtils;
+import io.trino.parquet.ParquetTypeUtils.FieldContext;
+import io.trino.parquet.ParquetTypeUtils.TrinoFieldContext;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import org.apache.parquet.io.ColumnIO;
 import org.apache.parquet.io.GroupColumnIO;
-import org.apache.parquet.io.PrimitiveColumnIO;
+import org.apache.parquet.schema.Type.ID;
 
-import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static io.trino.parquet.ParquetTypeUtils.getArrayElementColumn;
-import static io.trino.parquet.ParquetTypeUtils.getMapKeyValueColumn;
 import static io.trino.parquet.ParquetTypeUtils.lookupColumnById;
 import static java.util.Objects.requireNonNull;
-import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
 
 public final class IcebergParquetColumnIOConverter
 {
     private IcebergParquetColumnIOConverter() {}
 
-    public static Optional<Field> constructField(FieldContext context, ColumnIO columnIO)
+    public static Optional<Field> constructField(Type type, ColumnIO columnIO, ColumnIdentity columnIdentity)
     {
-        requireNonNull(context, "context is null");
-        if (columnIO == null) {
-            return Optional.empty();
-        }
-        boolean required = columnIO.getType().getRepetition() != OPTIONAL;
-        int repetitionLevel = columnIO.getRepetitionLevel();
-        int definitionLevel = columnIO.getDefinitionLevel();
-        Type type = context.type();
-        if (type instanceof RowType rowType) {
-            List<ColumnIdentity> subColumns = context.columnIdentity().getChildren();
-            GroupColumnIO groupColumnIO = (GroupColumnIO) columnIO;
-            ImmutableList.Builder<Optional<Field>> fieldsBuilder = ImmutableList.builder();
-            List<RowType.Field> fields = rowType.getFields();
-            boolean structHasParameters = false;
-            for (int i = 0; i < fields.size(); i++) {
-                RowType.Field rowField = fields.get(i);
-                ColumnIdentity fieldIdentity = subColumns.get(i);
-                Optional<Field> field = constructField(new FieldContext(rowField.getType(), fieldIdentity), lookupColumnById(groupColumnIO, fieldIdentity.getId()));
-                structHasParameters |= field.isPresent();
-                fieldsBuilder.add(field);
-            }
-            if (structHasParameters) {
-                return Optional.of(new GroupField(type, repetitionLevel, definitionLevel, required, fieldsBuilder.build()));
-            }
-            return Optional.empty();
-        }
-        if (type instanceof MapType mapType) {
-            GroupColumnIO groupColumnIO = (GroupColumnIO) columnIO;
-            GroupColumnIO keyValueColumnIO = getMapKeyValueColumn(groupColumnIO);
-            if (keyValueColumnIO.getChildrenCount() != 2) {
-                return Optional.empty();
-            }
-            List<ColumnIdentity> subColumns = context.columnIdentity().getChildren();
-            checkArgument(subColumns.size() == 2, "Not a map: %s", context);
-            ColumnIdentity keyIdentity = subColumns.get(0);
-            ColumnIdentity valueIdentity = subColumns.get(1);
-            // TODO validate column ID
-            Optional<Field> keyField = constructField(new FieldContext(mapType.getKeyType(), keyIdentity), keyValueColumnIO.getChild(0));
-            // TODO validate column ID
-            Optional<Field> valueField = constructField(new FieldContext(mapType.getValueType(), valueIdentity), keyValueColumnIO.getChild(1));
-            return Optional.of(new GroupField(type, repetitionLevel, definitionLevel, required, ImmutableList.of(keyField, valueField)));
-        }
-        if (type instanceof ArrayType arrayType) {
-            GroupColumnIO groupColumnIO = (GroupColumnIO) columnIO;
-            if (groupColumnIO.getChildrenCount() != 1) {
-                return Optional.empty();
-            }
-            List<ColumnIdentity> subColumns = context.columnIdentity().getChildren();
-            checkArgument(subColumns.size() == 1, "Not an array: %s", context);
-            ColumnIdentity elementIdentity = getOnlyElement(subColumns);
-            // TODO validate column ID
-            Optional<Field> field = constructField(new FieldContext(arrayType.getElementType(), elementIdentity), getArrayElementColumn(groupColumnIO.getChild(0)));
-            return Optional.of(new GroupField(type, repetitionLevel, definitionLevel, required, ImmutableList.of(field)));
-        }
-        PrimitiveColumnIO primitiveColumnIO = (PrimitiveColumnIO) columnIO;
-        return Optional.of(new PrimitiveField(type, required, primitiveColumnIO.getColumnDescriptor(), primitiveColumnIO.getId()));
+        requireNonNull(columnIdentity, "columnIdentity is null");
+        return ParquetTypeUtils.constructField(columnIO, new IcebergFieldContext(type, columnIdentity));
     }
 
-    public record FieldContext(Type type, ColumnIdentity columnIdentity)
+    private static class IcebergFieldContext
+            implements FieldContext
     {
-        public FieldContext
+        private final TrinoFieldContext context;
+        private final ColumnIdentity identity;
+
+        public IcebergFieldContext(Type type, ColumnIdentity identity)
         {
-            requireNonNull(type, "type is null");
-            requireNonNull(columnIdentity, "columnIdentity is null");
+            this(new TrinoFieldContext(type), identity);
+        }
+
+        private IcebergFieldContext(TrinoFieldContext context, ColumnIdentity identity)
+        {
+            this.context = requireNonNull(context, "context is null");
+            this.identity = requireNonNull(identity, "identity is null");
+        }
+
+        @Override
+        public Type type()
+        {
+            return context.type();
+        }
+
+        @Override
+        public IcebergFieldContext getArrayElement(ColumnIO elementColumnIO)
+        {
+            checkArgument(identity.getChildren().size() == 1, "Not an array: %s", identity);
+            return new IcebergFieldContext(
+                    context.getArrayElement(elementColumnIO),
+                    validateColumn(getOnlyElement(identity.getChildren()), elementColumnIO));
+        }
+
+        @Override
+        public IcebergFieldContext getMapKey(ColumnIO keyColumnIO)
+        {
+            checkArgument(identity.getChildren().size() == 2, "Not a map: %s", identity);
+            return new IcebergFieldContext(
+                    context.getMapKey(keyColumnIO),
+                    validateColumn(identity.getChildren().get(0), keyColumnIO));
+        }
+
+        @Override
+        public FieldContext getMapValue(ColumnIO valueColumnIO)
+        {
+            checkArgument(identity.getChildren().size() == 2, "Not a map: %s", identity);
+            return new IcebergFieldContext(
+                    context.getMapValue(valueColumnIO),
+                    validateColumn(identity.getChildren().get(1), valueColumnIO));
+        }
+
+        @Override
+        public FieldContext getRowField(int index)
+        {
+            checkArgument(index < identity.getChildren().size(), "Invalid field index: %s for: %s", index, identity);
+            return new IcebergFieldContext(
+                    context.getRowField(index),
+                    identity.getChildren().get(index));
+        }
+
+        @Override
+        public Optional<ColumnIO> lookupRowColumn(RowType.Field field, GroupColumnIO groupColumnIO)
+        {
+            return Optional.ofNullable(lookupColumnById(groupColumnIO, identity.getId()));
+        }
+
+        private ColumnIdentity validateColumn(ColumnIdentity identity, ColumnIO columnIO)
+        {
+            ID columnId = columnIO.getType().getId();
+            checkArgument(columnId == null || identity.getId() == columnId.intValue(), "Iceberg column ID (%s) does not match Parquet field ID (%s)", identity.getId(), columnId);
+            return identity;
         }
     }
 }


### PR DESCRIPTION
    This is needed so that changes in constructField
    implementation are shared by both Iceberg and Hive
    (e.g. https://github.com/trinodb/trino/pull/20943)

