### PR TITLE
Add Kafka Transport support in Trino Open Lineage Plugin

### DIFF
--- a/plugin/trino-openlineage/pom.xml
+++ b/plugin/trino-openlineage/pom.xml
@@ -80,6 +80,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <scope>provided</scope>
@@ -193,4 +198,20 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <failOnWarning>false</failOnWarning>
+                    <ignoredUnusedDeclaredDependencies>
+                        <!-- kafka-clients is needed on class path for KafkaTransport to work in openlineage-java lib -->
+                        <ignoredUnusedDeclaredDependency>kafka-clients:::</ignoredUnusedDeclaredDependency>
+                    </ignoredUnusedDeclaredDependencies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/OpenLineageListenerModule.java
+++ b/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/OpenLineageListenerModule.java
@@ -21,14 +21,17 @@ import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.openlineage.client.OpenLineageClient;
 import io.trino.plugin.openlineage.config.OpenLineageListenerConfig;
 import io.trino.plugin.openlineage.config.http.OpenLineageClientHttpTransportConfig;
+import io.trino.plugin.openlineage.config.kafka.OpenLineageClientKafkaTransportConfig;
 import io.trino.plugin.openlineage.transport.OpenLineageConsoleTransport;
 import io.trino.plugin.openlineage.transport.OpenLineageTransport;
 import io.trino.plugin.openlineage.transport.http.OpenLineageHttpTransport;
+import io.trino.plugin.openlineage.transport.kafka.OpenLineageKafkaTransport;
 
 import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.trino.plugin.openlineage.OpenLineageTransport.CONSOLE;
 import static io.trino.plugin.openlineage.OpenLineageTransport.HTTP;
+import static io.trino.plugin.openlineage.OpenLineageTransport.KAFKA;
 
 public class OpenLineageListenerModule
         extends AbstractConfigurationAwareModule
@@ -51,6 +54,14 @@ public class OpenLineageListenerModule
                 internalBinder -> {
                     configBinder(internalBinder).bindConfig(OpenLineageClientHttpTransportConfig.class);
                     internalBinder.bind(OpenLineageTransport.class).to(OpenLineageHttpTransport.class);
+                }));
+
+        install(conditionalModule(
+                OpenLineageListenerConfig.class,
+                config -> config.getTransport().equals(KAFKA),
+                internalBinder -> {
+                    configBinder(internalBinder).bindConfig(OpenLineageClientKafkaTransportConfig.class);
+                    internalBinder.bind(OpenLineageTransport.class).to(OpenLineageKafkaTransport.class);
                 }));
     }
 

--- a/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/OpenLineageTransport.java
+++ b/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/OpenLineageTransport.java
@@ -17,5 +17,5 @@ public enum OpenLineageTransport
 {
     CONSOLE,
     HTTP,
-    /**/
+    KAFKA
 }

--- a/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/config/kafka/OpenLineageClientKafkaTransportConfig.java
+++ b/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/config/kafka/OpenLineageClientKafkaTransportConfig.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.openlineage.config.kafka;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import jakarta.validation.constraints.NotNull;
+
+public class OpenLineageClientKafkaTransportConfig
+{
+    private String topicName;
+    private String messageKey;
+    private String brokerEndpoints;
+
+    @NotNull
+    public String getTopicName()
+    {
+        return topicName;
+    }
+
+    @Config("openlineage-event-listener.transport.kafka.topic")
+    @ConfigDescription("String specifying the topic to which events will be sent")
+    public OpenLineageClientKafkaTransportConfig setTopicName(String topicName)
+    {
+        this.topicName = topicName;
+        return this;
+    }
+
+    @NotNull
+    public String getBrokerEndpoints()
+    {
+        return brokerEndpoints;
+    }
+
+    @Config("openlineage-event-listener.transport.kafka.broker-endpoints")
+    @ConfigDescription("List of kafka brokers provided as: \"broker_host1:broker_port1,broker_host2:broker_port2, ...\"")
+    public OpenLineageClientKafkaTransportConfig setBrokerEndpoints(String brokerEndpoints)
+    {
+        this.brokerEndpoints = brokerEndpoints;
+        return this;
+    }
+
+    public String getMessageKey()
+    {
+        return messageKey;
+    }
+
+    @Config("openlineage-event-listener.transport.kafka.message-key")
+    @ConfigDescription("String key for all kafka messages produced")
+    public OpenLineageClientKafkaTransportConfig setMessageKey(String messageKey)
+    {
+        this.messageKey = messageKey;
+        return this;
+    }
+}

--- a/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/transport/kafka/OpenLineageKafkaTransport.java
+++ b/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/transport/kafka/OpenLineageKafkaTransport.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.openlineage.transport.kafka;
+
+import com.google.inject.Inject;
+import io.openlineage.client.transports.KafkaConfig;
+import io.openlineage.client.transports.KafkaTransport;
+import io.openlineage.client.transports.Transport;
+import io.trino.plugin.openlineage.config.kafka.OpenLineageClientKafkaTransportConfig;
+import io.trino.plugin.openlineage.transport.OpenLineageTransport;
+
+import java.util.Properties;
+
+public class OpenLineageKafkaTransport
+        implements OpenLineageTransport
+{
+    private final String topicName;
+    private final String messageKey;
+    private final String brokerEndpoints;
+    private final String bootstrapServers = "bootstrap.servers";
+    private final String acks = "acks";
+    private final String acksDefault = "all";
+    private final String keySerializer = "key.serializer";
+    private final String keySerializerDefault = "org.apache.kafka.common.serialization.StringSerializer";
+    private final String valueSerializer = "value.serializer";
+    private final String valueSerializerDefault = "org.apache.kafka.common.serialization.StringSerializer";
+
+    @Inject
+    public OpenLineageKafkaTransport(OpenLineageClientKafkaTransportConfig config)
+    {
+        this.topicName = config.getTopicName();
+        this.messageKey = config.getMessageKey();
+        this.brokerEndpoints = config.getBrokerEndpoints();
+    }
+
+    @Override
+    public Transport buildTransport()
+    {
+        Properties kafkaProperties = new Properties();
+        kafkaProperties.put(bootstrapServers, brokerEndpoints);
+        kafkaProperties.put(acks, acksDefault);
+        kafkaProperties.put(keySerializer, keySerializerDefault);
+        kafkaProperties.put(valueSerializer, valueSerializerDefault);
+        return new KafkaTransport(new KafkaConfig(topicName, messageKey, kafkaProperties));
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Currently Trino open lineage plugin supports Console and Http transport. This change is adding a Kafka transport support. 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Fixes https://github.com/trinodb/trino/issues/21599

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# General
* Add support for Kafka transport in Trino Open lineage Plugin (https://github.com/trinodb/trino/issues/21599)

```
