### PR TITLE
Remove unnecessary reassignment in ComparisonStatsCalculator

### DIFF
--- a/core/trino-main/src/main/java/io/trino/cost/ComparisonStatsCalculator.java
+++ b/core/trino-main/src/main/java/io/trino/cost/ComparisonStatsCalculator.java
@@ -97,7 +97,7 @@ public final class ComparisonStatsCalculator
                     .setNullsFraction(0.0)
                     .setDistinctValuesCount(max(expressionStatistics.getDistinctValuesCount() - 1, 0))
                     .build();
-            estimate = estimate.addSymbolStatistics(expressionSymbol.get(), symbolNewEstimate);
+            estimate.addSymbolStatistics(expressionSymbol.get(), symbolNewEstimate);
         }
         return estimate.build();
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
`PlanNodeStatsEstimate.addSymbolStatistics()` is a destructive method. It doesn't seem to need to reassign the result.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
