### PR TITLE
Improve messages for INTERVAL literal semantic errors

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -1259,6 +1259,9 @@ public class ExpressionAnalyzer
             try {
                 literalInterpreter.evaluate(node, type);
             }
+            catch (TrinoException e) {
+                throw new TrinoException(e::getErrorCode, extractLocation(node), e.getMessage(), e);
+            }
             catch (RuntimeException e) {
                 throw semanticException(INVALID_LITERAL, node, e, "'%s' is not a valid INTERVAL literal", node.getValue());
             }

--- a/core/trino-main/src/main/java/io/trino/util/DateTimeUtils.java
+++ b/core/trino-main/src/main/java/io/trino/util/DateTimeUtils.java
@@ -191,24 +191,24 @@ public final class DateTimeUtils
     private static final int SECOND_FIELD = 6;
     private static final int MILLIS_FIELD = 7;
 
-    private static final PeriodFormatter INTERVAL_DAY_SECOND_FORMATTER = cretePeriodFormatter(IntervalField.DAY, IntervalField.SECOND);
-    private static final PeriodFormatter INTERVAL_DAY_MINUTE_FORMATTER = cretePeriodFormatter(IntervalField.DAY, IntervalField.MINUTE);
-    private static final PeriodFormatter INTERVAL_DAY_HOUR_FORMATTER = cretePeriodFormatter(IntervalField.DAY, IntervalField.HOUR);
-    private static final PeriodFormatter INTERVAL_DAY_FORMATTER = cretePeriodFormatter(IntervalField.DAY, IntervalField.DAY);
+    private static final PeriodFormatter INTERVAL_DAY_SECOND_FORMATTER = createPeriodFormatter(IntervalField.DAY, IntervalField.SECOND);
+    private static final PeriodFormatter INTERVAL_DAY_MINUTE_FORMATTER = createPeriodFormatter(IntervalField.DAY, IntervalField.MINUTE);
+    private static final PeriodFormatter INTERVAL_DAY_HOUR_FORMATTER = createPeriodFormatter(IntervalField.DAY, IntervalField.HOUR);
+    private static final PeriodFormatter INTERVAL_DAY_FORMATTER = createPeriodFormatter(IntervalField.DAY, IntervalField.DAY);
 
-    private static final PeriodFormatter INTERVAL_HOUR_SECOND_FORMATTER = cretePeriodFormatter(IntervalField.HOUR, IntervalField.SECOND);
-    private static final PeriodFormatter INTERVAL_HOUR_MINUTE_FORMATTER = cretePeriodFormatter(IntervalField.HOUR, IntervalField.MINUTE);
-    private static final PeriodFormatter INTERVAL_HOUR_FORMATTER = cretePeriodFormatter(IntervalField.HOUR, IntervalField.HOUR);
+    private static final PeriodFormatter INTERVAL_HOUR_SECOND_FORMATTER = createPeriodFormatter(IntervalField.HOUR, IntervalField.SECOND);
+    private static final PeriodFormatter INTERVAL_HOUR_MINUTE_FORMATTER = createPeriodFormatter(IntervalField.HOUR, IntervalField.MINUTE);
+    private static final PeriodFormatter INTERVAL_HOUR_FORMATTER = createPeriodFormatter(IntervalField.HOUR, IntervalField.HOUR);
 
-    private static final PeriodFormatter INTERVAL_MINUTE_SECOND_FORMATTER = cretePeriodFormatter(IntervalField.MINUTE, IntervalField.SECOND);
-    private static final PeriodFormatter INTERVAL_MINUTE_FORMATTER = cretePeriodFormatter(IntervalField.MINUTE, IntervalField.MINUTE);
+    private static final PeriodFormatter INTERVAL_MINUTE_SECOND_FORMATTER = createPeriodFormatter(IntervalField.MINUTE, IntervalField.SECOND);
+    private static final PeriodFormatter INTERVAL_MINUTE_FORMATTER = createPeriodFormatter(IntervalField.MINUTE, IntervalField.MINUTE);
 
-    private static final PeriodFormatter INTERVAL_SECOND_FORMATTER = cretePeriodFormatter(IntervalField.SECOND, IntervalField.SECOND);
+    private static final PeriodFormatter INTERVAL_SECOND_FORMATTER = createPeriodFormatter(IntervalField.SECOND, IntervalField.SECOND);
 
-    private static final PeriodFormatter INTERVAL_YEAR_MONTH_FORMATTER = cretePeriodFormatter(IntervalField.YEAR, IntervalField.MONTH);
-    private static final PeriodFormatter INTERVAL_YEAR_FORMATTER = cretePeriodFormatter(IntervalField.YEAR, IntervalField.YEAR);
+    private static final PeriodFormatter INTERVAL_YEAR_MONTH_FORMATTER = createPeriodFormatter(IntervalField.YEAR, IntervalField.MONTH);
+    private static final PeriodFormatter INTERVAL_YEAR_FORMATTER = createPeriodFormatter(IntervalField.YEAR, IntervalField.YEAR);
 
-    private static final PeriodFormatter INTERVAL_MONTH_FORMATTER = cretePeriodFormatter(IntervalField.MONTH, IntervalField.MONTH);
+    private static final PeriodFormatter INTERVAL_MONTH_FORMATTER = createPeriodFormatter(IntervalField.MONTH, IntervalField.MONTH);
 
     public static long parseDayTimeInterval(String value, IntervalField startField, Optional<IntervalField> endField)
     {
@@ -329,7 +329,7 @@ public final class DateTimeUtils
         throw new TrinoException(INVALID_LITERAL, "Invalid interval qualifier: " + startField + " TO " + endField);
     }
 
-    private static PeriodFormatter cretePeriodFormatter(IntervalField startField, IntervalField endField)
+    private static PeriodFormatter createPeriodFormatter(IntervalField startField, IntervalField endField)
     {
         if (endField == null) {
             endField = startField;

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/interval/TestIntervalDayTime.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/interval/TestIntervalDayTime.java
@@ -138,20 +138,79 @@ public class TestIntervalDayTime
         assertThat(assertions.expression("INTERVAL '32' SECOND"))
                 .isEqualTo(interval(0, 0, 0, 32, 0));
 
+        // Invalid literals
         assertThatThrownBy(assertions.expression("INTERVAL '12X' DAY")::evaluate)
-                .hasMessage("line 1:12: '12X' is not a valid INTERVAL literal");
+                .hasMessage("line 1:12: Invalid INTERVAL DAY value: 12X");
 
         assertThatThrownBy(assertions.expression("INTERVAL '12 10' DAY")::evaluate)
-                .hasMessage("line 1:12: '12 10' is not a valid INTERVAL literal");
+                .hasMessage("line 1:12: Invalid INTERVAL DAY value: 12 10");
 
         assertThatThrownBy(assertions.expression("INTERVAL '12 X' DAY TO HOUR")::evaluate)
-                .hasMessage("line 1:12: '12 X' is not a valid INTERVAL literal");
+                .hasMessage("line 1:12: Invalid INTERVAL DAY TO HOUR value: 12 X");
 
         assertThatThrownBy(assertions.expression("INTERVAL '12 -10' DAY TO HOUR")::evaluate)
-                .hasMessage("line 1:12: '12 -10' is not a valid INTERVAL literal");
+                .hasMessage("line 1:12: Invalid INTERVAL DAY TO HOUR value: 12 -10");
 
         assertThatThrownBy(assertions.expression("INTERVAL '--12 -10' DAY TO HOUR")::evaluate)
-                .hasMessage("line 1:12: '--12 -10' is not a valid INTERVAL literal");
+                .hasMessage("line 1:12: Invalid INTERVAL DAY TO HOUR value: --12 -10");
+
+        // Invalid qualifiers (DAY TO xxx)
+        assertThatThrownBy(assertions.expression("INTERVAL '12' DAY TO DAY")::evaluate)
+                .hasMessage("line 1:12: Invalid interval qualifier: DAY TO DAY");
+
+        assertThatThrownBy(assertions.expression("INTERVAL '12-10' DAY TO YEAR")::evaluate)
+                .hasMessage("line 1:12: Invalid interval qualifier: DAY TO YEAR");
+
+        assertThatThrownBy(assertions.expression("INTERVAL '12-10' DAY TO MONTH")::evaluate)
+                .hasMessage("line 1:12: Invalid interval qualifier: DAY TO MONTH");
+
+        // Invalid qualifiers (HOUR TO xxx)
+        assertThatThrownBy(assertions.expression("INTERVAL '10' HOUR TO HOUR")::evaluate)
+                .hasMessage("line 1:12: Invalid interval qualifier: HOUR TO HOUR");
+
+        assertThatThrownBy(assertions.expression("INTERVAL '12-10' HOUR TO YEAR")::evaluate)
+                .hasMessage("line 1:12: Invalid interval qualifier: HOUR TO YEAR");
+
+        assertThatThrownBy(assertions.expression("INTERVAL '12-10' HOUR TO MONTH")::evaluate)
+                .hasMessage("line 1:12: Invalid interval qualifier: HOUR TO MONTH");
+
+        assertThatThrownBy(assertions.expression("INTERVAL '12-10' HOUR TO DAY")::evaluate)
+                .hasMessage("line 1:12: Invalid interval qualifier: HOUR TO DAY");
+
+        // Invalid qualifiers (MINUTE TO xxx)
+        assertThatThrownBy(assertions.expression("INTERVAL '45' MINUTE TO MINUTE")::evaluate)
+                .hasMessage("line 1:12: Invalid interval qualifier: MINUTE TO MINUTE");
+
+        assertThatThrownBy(assertions.expression("INTERVAL '12-10' MINUTE TO YEAR")::evaluate)
+                .hasMessage("line 1:12: Invalid interval qualifier: MINUTE TO YEAR");
+
+        assertThatThrownBy(assertions.expression("INTERVAL '12-10' MINUTE TO MONTH")::evaluate)
+                .hasMessage("line 1:12: Invalid interval qualifier: MINUTE TO MONTH");
+
+        assertThatThrownBy(assertions.expression("INTERVAL '12-10' MINUTE TO DAY")::evaluate)
+                .hasMessage("line 1:12: Invalid interval qualifier: MINUTE TO DAY");
+
+        assertThatThrownBy(assertions.expression("INTERVAL '12-10' MINUTE TO HOUR")::evaluate)
+                .hasMessage("line 1:12: Invalid interval qualifier: MINUTE TO HOUR");
+
+        // Invalid qualifiers (SECOND TO xxx)
+        assertThatThrownBy(assertions.expression("INTERVAL '32' SECOND TO SECOND")::evaluate)
+                .hasMessage("line 1:12: Invalid interval qualifier: SECOND TO SECOND");
+
+        assertThatThrownBy(assertions.expression("INTERVAL '12-10' SECOND TO YEAR")::evaluate)
+                .hasMessage("line 1:12: Invalid interval qualifier: SECOND TO YEAR");
+
+        assertThatThrownBy(assertions.expression("INTERVAL '12-10' SECOND TO MONTH")::evaluate)
+                .hasMessage("line 1:12: Invalid interval qualifier: SECOND TO MONTH");
+
+        assertThatThrownBy(assertions.expression("INTERVAL '12-10' SECOND TO DAY")::evaluate)
+                .hasMessage("line 1:12: Invalid interval qualifier: SECOND TO DAY");
+
+        assertThatThrownBy(assertions.expression("INTERVAL '12-10' SECOND TO HOUR")::evaluate)
+                .hasMessage("line 1:12: Invalid interval qualifier: SECOND TO HOUR");
+
+        assertThatThrownBy(assertions.expression("INTERVAL '12-10' SECOND TO MINUTE")::evaluate)
+                .hasMessage("line 1:12: Invalid interval qualifier: SECOND TO MINUTE");
     }
 
     private static SqlIntervalDayTime interval(int day, int hour, int minute, int second, int milliseconds)

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/interval/TestIntervalYearMonth.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/interval/TestIntervalYearMonth.java
@@ -66,20 +66,56 @@ public class TestIntervalYearMonth
         assertThat(assertions.expression("INTERVAL '32767-32767' YEAR TO MONTH"))
                 .isEqualTo(interval(32767, 32767));
 
+        // Invalid literals
         assertThatThrownBy(assertions.expression("INTERVAL '124X' YEAR")::evaluate)
-                .hasMessage("line 1:12: '124X' is not a valid INTERVAL literal");
+                .hasMessage("line 1:12: Invalid INTERVAL YEAR value: 124X");
 
         assertThatThrownBy(assertions.expression("INTERVAL '124-30' YEAR")::evaluate)
-                .hasMessage("line 1:12: '124-30' is not a valid INTERVAL literal");
+                .hasMessage("line 1:12: Invalid INTERVAL YEAR value: 124-30");
 
         assertThatThrownBy(assertions.expression("INTERVAL '124-X' YEAR TO MONTH")::evaluate)
-                .hasMessage("line 1:12: '124-X' is not a valid INTERVAL literal");
+                .hasMessage("line 1:12: Invalid INTERVAL YEAR TO MONTH value: 124-X");
 
         assertThatThrownBy(assertions.expression("INTERVAL '124--30' YEAR TO MONTH")::evaluate)
-                .hasMessage("line 1:12: '124--30' is not a valid INTERVAL literal");
+                .hasMessage("line 1:12: Invalid INTERVAL YEAR TO MONTH value: 124--30");
 
         assertThatThrownBy(assertions.expression("INTERVAL '--124--30' YEAR TO MONTH")::evaluate)
-                .hasMessage("line 1:12: '--124--30' is not a valid INTERVAL literal");
+                .hasMessage("line 1:12: Invalid INTERVAL YEAR TO MONTH value: --124--30");
+
+        // Invalid qualifiers (YEAR TO xxx)
+        assertThatThrownBy(assertions.expression("INTERVAL '32767' YEAR TO YEAR")::evaluate)
+                .hasMessage("line 1:12: Invalid interval qualifier: YEAR TO YEAR");
+
+        assertThatThrownBy(assertions.expression("INTERVAL '124-30' YEAR TO DAY")::evaluate)
+                .hasMessage("line 1:12: Invalid interval qualifier: YEAR TO DAY");
+
+        assertThatThrownBy(assertions.expression("INTERVAL '124-30' YEAR TO HOUR")::evaluate)
+                .hasMessage("line 1:12: Invalid interval qualifier: YEAR TO HOUR");
+
+        assertThatThrownBy(assertions.expression("INTERVAL '124-30' YEAR TO MINUTE")::evaluate)
+                .hasMessage("line 1:12: Invalid interval qualifier: YEAR TO MINUTE");
+
+        assertThatThrownBy(assertions.expression("INTERVAL '124-30' YEAR TO SECOND")::evaluate)
+                .hasMessage("line 1:12: Invalid interval qualifier: YEAR TO SECOND");
+
+        // Invalid qualifiers (MONTH TO xxx)
+        assertThatThrownBy(assertions.expression("INTERVAL '30' MONTH TO MONTH")::evaluate)
+                .hasMessage("line 1:12: Invalid interval qualifier: MONTH TO MONTH");
+
+        assertThatThrownBy(assertions.expression("INTERVAL '124-30' MONTH TO YEAR")::evaluate)
+                .hasMessage("line 1:12: Invalid interval qualifier: MONTH TO YEAR");
+
+        assertThatThrownBy(assertions.expression("INTERVAL '124-30' MONTH TO DAY")::evaluate)
+                .hasMessage("line 1:12: Invalid interval qualifier: MONTH TO DAY");
+
+        assertThatThrownBy(assertions.expression("INTERVAL '124-30' MONTH TO HOUR")::evaluate)
+                .hasMessage("line 1:12: Invalid interval qualifier: MONTH TO HOUR");
+
+        assertThatThrownBy(assertions.expression("INTERVAL '124-30' MONTH TO MINUTE")::evaluate)
+                .hasMessage("line 1:12: Invalid interval qualifier: MONTH TO MINUTE");
+
+        assertThatThrownBy(assertions.expression("INTERVAL '124-30' MONTH TO SECOND")::evaluate)
+                .hasMessage("line 1:12: Invalid interval qualifier: MONTH TO SECOND");
     }
 
     private static SqlIntervalYearMonth interval(int year, int month)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
When an INTERVAL literal is invalid, `ExpressionAnalyzer` ignores an original error and always report as `'xxxx' is not a valid INTERVAL literal` which is confusing in cases like below:

```sql
INTERVAL '12-10' YEAR TO DAY
```

In this case, `YEAR TO DAY` is invalid in the first place but still reported as `'12-10' is not a valid INTERVAL literal`.

It would be better to keep the original error message for better error reporting.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
