### PR TITLE
Using streams to collect the response' bytes

### DIFF
--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusClient.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusClient.java
@@ -179,7 +179,6 @@ public class PrometheusClient
                     return buffer.toByteArray();
                 }
             }
-
             throw new TrinoException(PROMETHEUS_UNKNOWN_ERROR, "Bad response " + response.code() + " " + response.message());
         }
         catch (IOException e) {

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusClient.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusClient.java
@@ -168,7 +168,7 @@ public class PrometheusClient
     {
         Request.Builder requestBuilder = new Request.Builder().url(uri.toString());
         try (Response response = httpClient.newCall(requestBuilder.build()).execute()) {
-            
+
             if (response.isSuccessful() && response.body() != null) {
                 try (InputStream inputStream = response.body().byteStream()) {
                     ByteArrayOutputStream buffer = new ByteArrayOutputStream();

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusClient.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusClient.java
@@ -168,7 +168,6 @@ public class PrometheusClient
     {
         Request.Builder requestBuilder = new Request.Builder().url(uri.toString());
         try (Response response = httpClient.newCall(requestBuilder.build()).execute()) {
-
             if (response.isSuccessful() && response.body() != null) {
                 try (InputStream inputStream = response.body().byteStream()) {
                     ByteArrayOutputStream buffer = new ByteArrayOutputStream();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
Prometheus client was attempting to get the whole response in one invocation of response.body().bytes()


Fixes https://github.com/trinodb/trino/issues/23013

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Using Stream to collect the response. ({issue}`23013`)
```
