### PR TITLE
Fix binding of FileBasedNetworkTopology

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/TopologyAwareNodeSelectorModule.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/TopologyAwareNodeSelectorModule.java
@@ -50,6 +50,7 @@ public class TopologyAwareNodeSelectorModule
                 binder -> {
                     configBinder(binder).bindConfig(TopologyFileConfig.class);
                     binder.bind(NetworkTopology.class).to(FileBasedNetworkTopology.class).in(Scopes.SINGLETON);
+                    binder.bind(FileBasedNetworkTopology.class).in(Scopes.SINGLETON);
                     newExporter(binder).export(FileBasedNetworkTopology.class).withGeneratedName();
                 }));
 


### PR DESCRIPTION
## Description

Configuring
```
node-scheduler.policy=topology
node-scheduler.network-topology.type=file
```
currently fails with
```
1) [Guice/JitDisabled]: Explicit bindings are required and FileBasedNetworkTopology is not explicitly bound.
  while locating FileBasedNetworkTopology
  at GuiceMBeanExporter.<init>(GuiceMBeanExporter.java:40)
  at MBeanModule.configure(MBeanModule.java:39)
  while locating GuiceMBeanExporter

1 error

======================
Full classname legend:
======================
FileBasedNetworkTopology: "io.trino.execution.scheduler.FileBasedNetworkTopology"
GuiceMBeanExporter:       "org.weakref.jmx.guice.GuiceMBeanExporter"
MBeanModule:              "org.weakref.jmx.guice.MBeanModule"
========================
End of classname legend:
========================
```


The failure occurs because `FileBasedNetworkTopology` is not bound before `newExporter(binder).export(FileBasedNetworkTopology.class).withGeneratedName();` is called.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes #18793

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Node scheduler
* Fix binding of FileBasedNetworkTopology. ({issue}`18793`)
```
