### PR TITLE
Reduce allocations in matching patterns

### DIFF
--- a/lib/trino-matching/src/main/java/io/trino/matching/Pattern.java
+++ b/lib/trino-matching/src/main/java/io/trino/matching/Pattern.java
@@ -29,6 +29,8 @@ import static java.util.Objects.requireNonNull;
 
 public abstract class Pattern<T>
 {
+    protected static final Stream<Match> NO_MATCHES = Stream.of();
+
     private final Optional<Pattern<?>> previous;
 
     public static Pattern<Object> any()

--- a/lib/trino-matching/src/main/java/io/trino/matching/pattern/EqualsPattern.java
+++ b/lib/trino-matching/src/main/java/io/trino/matching/pattern/EqualsPattern.java
@@ -42,8 +42,10 @@ public class EqualsPattern<T>
     @Override
     public <C> Stream<Match> accept(Object object, Captures captures, C context)
     {
-        return Stream.of(Match.of(captures))
-                .filter(match -> expectedValue.equals(object));
+        if (expectedValue.equals(object)) {
+            return Stream.of(Match.of(captures));
+        }
+        return NO_MATCHES;
     }
 
     @Override

--- a/lib/trino-matching/src/main/java/io/trino/matching/pattern/FilterPattern.java
+++ b/lib/trino-matching/src/main/java/io/trino/matching/pattern/FilterPattern.java
@@ -45,8 +45,10 @@ public class FilterPattern<T>
     {
         //TODO remove cast
         BiPredicate<? super T, C> predicate = (BiPredicate<? super T, C>) this.predicate;
-        return Stream.of(Match.of(captures))
-                .filter(match -> predicate.test((T) object, context));
+        if (predicate.test((T) object, context)) {
+            return Stream.of(Match.of(captures));
+        }
+        return NO_MATCHES;
     }
 
     @Override

--- a/lib/trino-matching/src/main/java/io/trino/matching/pattern/TypeOfPattern.java
+++ b/lib/trino-matching/src/main/java/io/trino/matching/pattern/TypeOfPattern.java
@@ -50,7 +50,7 @@ public class TypeOfPattern<T>
         if (expectedClass.isInstance(object)) {
             return Stream.of(Match.of(captures));
         }
-        return Stream.of();
+        return NO_MATCHES;
     }
 
     @Override

--- a/lib/trino-matching/src/main/java/io/trino/matching/pattern/WithPattern.java
+++ b/lib/trino-matching/src/main/java/io/trino/matching/pattern/WithPattern.java
@@ -53,8 +53,10 @@ public class WithPattern<T>
         //TODO remove cast
         BiFunction<? super T, C, Optional<?>> property = (BiFunction<? super T, C, Optional<?>>) propertyPattern.getProperty().getFunction();
         Optional<?> propertyValue = property.apply((T) object, context);
-        return propertyValue.map(value -> propertyPattern.getPattern().match(value, captures, context))
-                .orElseGet(Stream::of);
+        if (propertyValue.isEmpty()) {
+            return NO_MATCHES;
+        }
+        return propertyPattern.getPattern().match(propertyValue.get(), captures, context);
     }
 
     @Override

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/aggregation/AggregateFunctionPatterns.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/aggregation/AggregateFunctionPatterns.java
@@ -88,12 +88,12 @@ public final class AggregateFunctionPatterns
             public <C> Stream<Match> accept(Object object, Captures captures, C context)
             {
                 if (!(object instanceof List)) {
-                    return Stream.of();
+                    return NO_MATCHES;
                 }
                 @SuppressWarnings("unchecked")
                 List<ConnectorExpression> arguments = (List<ConnectorExpression>) object;
                 if (!arguments.stream().allMatch(Variable.class::isInstance)) {
-                    return Stream.of();
+                    return NO_MATCHES;
                 }
                 return Stream.of(Match.of(captures));
             }


### PR DESCRIPTION
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Avoids allocating fresh empty stream objects when pattern implementations do not match by returning a reference to a static empty stream instance.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
