### PR TITLE
Support varbinary json cast

### DIFF
--- a/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
+++ b/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
@@ -519,7 +519,9 @@ public final class JsonUtil
             }
             else {
                 Slice value = type.getSlice(block, position);
-                jsonGenerator.writeString(Base64.getEncoder().encodeToString(value.byteArray()));
+                byte[] currentValue = new byte[value.length()];
+                System.arraycopy(value.byteArray(), value.byteArrayOffset(), currentValue, 0, value.length());
+                jsonGenerator.writeString(Base64.getEncoder().encodeToString(currentValue));
             }
         }
     }

--- a/core/trino-main/src/test/java/io/trino/type/TestJsonOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestJsonOperators.java
@@ -438,6 +438,11 @@ public class TestJsonOperators
                 .isNull(JSON);
 
         assertThat(assertions.expression("cast(a as JSON)")
+                .binding("a", "cast(null as varbinary)"))
+                .isNull(JSON);
+
+
+        assertThat(assertions.expression("cast(a as JSON)")
                 .binding("a", "128"))
                 .hasType(JSON)
                 .isEqualTo("128");
@@ -456,6 +461,11 @@ public class TestJsonOperators
                 .binding("a", "TINYINT '127'"))
                 .hasType(JSON)
                 .isEqualTo("127");
+
+        assertThat(assertions.expression("cast(a as JSON)")
+                .binding("a", "VARBINARY X'4F'"))
+                .hasType(JSON)
+                .isEqualTo("Tw==");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestJsonOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestJsonOperators.java
@@ -441,7 +441,6 @@ public class TestJsonOperators
                 .binding("a", "cast(null as varbinary)"))
                 .isNull(JSON);
 
-
         assertThat(assertions.expression("cast(a as JSON)")
                 .binding("a", "128"))
                 .hasType(JSON)
@@ -463,7 +462,7 @@ public class TestJsonOperators
                 .isEqualTo("127");
 
         assertThat(assertions.expression("cast(a as JSON)")
-                .binding("a", "VARBINARY X'4F'"))
+                .binding("a", "VARBINARY '4F'"))
                 .hasType(JSON)
                 .isEqualTo("Tw==");
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
- Support the ROW, MAP, ARRAY field varbinary to json
- Support varbinary literal to json
- Use the Base64 to encode the varbinary to string

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Current Trino doesn't support varbinary to json cast, so when there is field in the complex record with varbinary, it will fail to convert it to json. 
How it's tested
```
trino> CREATE TABLE memory.default.example_table (
    ->     id INTEGER,
    ->     data ROW(
    ->         name VARCHAR,
    ->         value VARBINARY
    ->     )
    -> );

trino> INSERT INTO memory.default.example_table (id, data) VALUES
    -> (
    ->     1,
    ->     ROW('example_name', CAST('4F' AS VARBINARY))
    -> );
INSERT: 1 row

trino> select * from memory.default.example_table;
 id |               data
----+----------------------------------
  1 | {name=example_name, value=34 46}

trino> select cast(data as json)  from memory.default.example_table;
                 _col0
----------------------------------------
 {"name":"example_name","value":"NEY="}

```

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix varbinary json cast. ({issue}`10814`)
```
