### PR TITLE
Use exponential backoff retry strategy for glue client

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueMetastoreModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueMetastoreModule.java
@@ -36,6 +36,7 @@ import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.http.apache.ProxyConfiguration;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
+import software.amazon.awssdk.retries.api.BackoffStrategy;
 import software.amazon.awssdk.services.glue.GlueClient;
 import software.amazon.awssdk.services.glue.GlueClientBuilder;
 import software.amazon.awssdk.services.glue.model.ConcurrentModificationException;
@@ -131,6 +132,9 @@ public class GlueMetastoreModule
                         .build().newExecutionInterceptor())
                 .retryStrategy(retryBuilder -> retryBuilder
                         .retryOnException(throwable -> throwable instanceof ConcurrentModificationException)
+                        .backoffStrategy(BackoffStrategy.exponentialDelay(
+                                java.time.Duration.ofMillis(20),
+                                java.time.Duration.ofMillis(1500)))
                         .maxAttempts(config.getMaxGlueErrorRetries())));
 
         Optional<StaticCredentialsProvider> staticCredentialsProvider = getStaticCredentialsProvider(config);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/v1/GlueClientUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/v1/GlueClientUtil.java
@@ -18,8 +18,10 @@ import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.handlers.RequestHandler2;
 import com.amazonaws.metrics.RequestMetricCollector;
+import com.amazonaws.retry.PredefinedBackoffStrategies.ExponentialBackoffStrategy;
 import com.amazonaws.retry.PredefinedRetryPolicies;
 import com.amazonaws.retry.RetryPolicy;
+import com.amazonaws.retry.RetryPolicy.BackoffStrategy;
 import com.amazonaws.retry.RetryPolicy.RetryCondition;
 import com.amazonaws.services.glue.AWSGlueAsync;
 import com.amazonaws.services.glue.AWSGlueAsyncClientBuilder;
@@ -45,11 +47,12 @@ public final class GlueClientUtil
         RetryCondition customRetryCondition = (requestContext, exception, retriesAttempted) ->
                 defaultRetryPolicy.getRetryCondition().shouldRetry(requestContext, exception, retriesAttempted)
                 || exception instanceof ConcurrentModificationException;
+        BackoffStrategy customBackoffStrategy = new ExponentialBackoffStrategy(20, 1500);
 
         RetryPolicy glueRetryPolicy = RetryPolicy.builder()
                 .withRetryMode(defaultRetryPolicy.getRetryMode())
                 .withRetryCondition(customRetryCondition)
-                .withBackoffStrategy(defaultRetryPolicy.getBackoffStrategy())
+                .withBackoffStrategy(customBackoffStrategy)
                 .withFastFailRateLimiting(defaultRetryPolicy.isFastFailRateLimiting())
                 .withMaxErrorRetry(config.getMaxGlueErrorRetries())
                 .build();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
After merging https://github.com/trinodb/trino/pull/22814, @ebyhr reporter that `TestIcebergGlueCatalogConnectorSmokeTest#testDeleteRowsConcurrently` became flaky

After running it several times locally, I found that commit https://github.com/trinodb/trino/commit/4b28d9b5c009b061aa7043c6d41768fd83fae0ac seems to be problematic

Default retry strategy, which brings default backoff strategy, wasn't good enough when dealing with such concurrent use cases. After changing to exponential backoff strategy it feels much more stable now.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
https://github.com/trinodb/trino/pull/22814


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# Section
* Use exponential backoff in glue client retries
```
