### PR TITLE
Fix BigQuery configuration with parent-project-id

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -639,11 +639,15 @@ jobs:
         env:
           BIGQUERY_CREDENTIALS_KEY: ${{ secrets.BIGQUERY_CREDENTIALS_KEY }}
           GCP_STORAGE_BUCKET: ${{ vars.GCP_STORAGE_BUCKET }}
+          BIGQUERY_TESTING_PROJECT_ID: ${{ vars.BIGQUERY_TESTING_PROJECT_ID }}
+          BIGQUERY_TESTING_PARENT_PROJECT_ID: ${{ vars.BIGQUERY_TESTING_PARENT_PROJECT_ID }}
         if: matrix.modules == 'plugin/trino-bigquery' && !contains(matrix.profile, 'cloud-tests-2') && (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || env.BIGQUERY_CREDENTIALS_KEY != '')
         run: |
           $MAVEN test ${MAVEN_TEST} -pl :trino-bigquery -Pcloud-tests-1 \
             -Dbigquery.credentials-key="${BIGQUERY_CREDENTIALS_KEY}" \
-            -Dtesting.gcp-storage-bucket="${GCP_STORAGE_BUCKET}"
+            -Dtesting.gcp-storage-bucket="${GCP_STORAGE_BUCKET}" \
+            -Dtesting.bigquery-project-id="${BIGQUERY_TESTING_PROJECT_ID}" \
+            -Dtesting.bigquery-parent-project-id="${BIGQUERY_TESTING_PARENT_PROJECT_ID}"
       - name: Cloud BigQuery Smoke Tests
         id: tests-bq-smoke
         env:

--- a/plugin/trino-bigquery/pom.xml
+++ b/plugin/trino-bigquery/pom.xml
@@ -537,6 +537,7 @@
                                 <exclude>**/TestBigQueryCaseInsensitiveMapping.java</exclude>
                                 <exclude>**/TestBigQuery*FailureRecoveryTest.java</exclude>
                                 <exclude>**/TestBigQueryWithProxyTest.java</exclude>
+                                <exclude>**/TestBigQueryParentProjectId.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>
@@ -557,6 +558,7 @@
                         <configuration>
                             <includes>
                                 <include>**/TestBigQueryAvroConnectorTest.java</include>
+                                <include>**/TestBigQueryParentProjectId.java</include>
                             </includes>
                         </configuration>
                     </plugin>

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
@@ -259,7 +259,7 @@ public class BigQueryClient
      */
     public String getParentProjectId()
     {
-        return bigQuery.getOptions().getProjectId();
+        return Optional.ofNullable(bigQuery.getOptions().getQuotaProjectId()).orElse(bigQuery.getOptions().getProjectId());
     }
 
     /**

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/CredentialsOptionsConfigurer.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/CredentialsOptionsConfigurer.java
@@ -36,7 +36,7 @@ public class CredentialsOptionsConfigurer
     @Inject
     public CredentialsOptionsConfigurer(BigQueryConfig bigQueryConfig, BigQueryCredentialsSupplier credentialsSupplier)
     {
-        this.parentProjectId = requireNonNull(bigQueryConfig, "bigQueryConfig is null").getParentProjectId();
+        this.parentProjectId = bigQueryConfig.getParentProjectId();
         this.credentialsSupplier = requireNonNull(credentialsSupplier, "credentialsSupplier is null");
     }
 

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/CredentialsOptionsConfigurer.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/CredentialsOptionsConfigurer.java
@@ -31,12 +31,12 @@ public class CredentialsOptionsConfigurer
         implements BigQueryOptionsConfigurer
 {
     private final BigQueryCredentialsSupplier credentialsSupplier;
-    private final Optional<String> parentProjectId;
+    private final Optional<String> configParentProjectId;
 
     @Inject
     public CredentialsOptionsConfigurer(BigQueryConfig bigQueryConfig, BigQueryCredentialsSupplier credentialsSupplier)
     {
-        this.parentProjectId = bigQueryConfig.getParentProjectId();
+        this.configParentProjectId = bigQueryConfig.getParentProjectId();
         this.credentialsSupplier = requireNonNull(credentialsSupplier, "credentialsSupplier is null");
     }
 
@@ -44,9 +44,9 @@ public class CredentialsOptionsConfigurer
     public BigQueryOptions.Builder configure(BigQueryOptions.Builder builder, ConnectorSession session)
     {
         Optional<Credentials> credentials = credentialsSupplier.getCredentials(session);
-        String billingProjectId = calculateBillingProjectId(parentProjectId, credentials);
+        String parentProjectId = resolveProjectId(configParentProjectId, credentials);
         credentials.ifPresent(builder::setCredentials);
-        builder.setProjectId(billingProjectId);
+        builder.setProjectId(parentProjectId);
         return builder;
     }
 
@@ -69,10 +69,10 @@ public class CredentialsOptionsConfigurer
 
     // Note that at this point the config has been validated, which means that option 2 or option 3 will always be valid
     @VisibleForTesting
-    static String calculateBillingProjectId(Optional<String> configParentProjectId, Optional<Credentials> credentials)
+    static String resolveProjectId(Optional<String> configProjectId, Optional<Credentials> credentials)
     {
         // 1. Get from configuration
-        return configParentProjectId
+        return configProjectId
                 // 2. Get from the provided credentials, but only ServiceAccountCredentials contains the project id.
                 // All other credentials types (User, AppEngine, GCE, CloudShell, etc.) take it from the environment
                 .orElseGet(() -> credentials

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/CredentialsOptionsConfigurer.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/CredentialsOptionsConfigurer.java
@@ -31,11 +31,13 @@ public class CredentialsOptionsConfigurer
         implements BigQueryOptionsConfigurer
 {
     private final BigQueryCredentialsSupplier credentialsSupplier;
+    private final Optional<String> configProjectId;
     private final Optional<String> configParentProjectId;
 
     @Inject
     public CredentialsOptionsConfigurer(BigQueryConfig bigQueryConfig, BigQueryCredentialsSupplier credentialsSupplier)
     {
+        this.configProjectId = bigQueryConfig.getProjectId();
         this.configParentProjectId = bigQueryConfig.getParentProjectId();
         this.credentialsSupplier = requireNonNull(credentialsSupplier, "credentialsSupplier is null");
     }
@@ -44,9 +46,11 @@ public class CredentialsOptionsConfigurer
     public BigQueryOptions.Builder configure(BigQueryOptions.Builder builder, ConnectorSession session)
     {
         Optional<Credentials> credentials = credentialsSupplier.getCredentials(session);
-        String parentProjectId = resolveProjectId(configParentProjectId, credentials);
+        String projectId = resolveProjectId(configProjectId, credentials);
         credentials.ifPresent(builder::setCredentials);
-        builder.setProjectId(parentProjectId);
+        builder.setProjectId(projectId);
+        // Quota project id is different name for parent project id, both indicates project used for quota and billing purposes.
+        configParentProjectId.ifPresent(builder::setQuotaProjectId);
         return builder;
     }
 

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryParentProjectId.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryParentProjectId.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
+import static io.trino.tpch.TpchTable.NATION;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestBigQueryParentProjectId
+        extends AbstractTestQueryFramework
+{
+    private final String testingProjectId;
+    private final String testingParentProjectId;
+
+    TestBigQueryParentProjectId()
+    {
+        testingProjectId = requiredNonEmptySystemProperty("testing.bigquery-project-id");
+        testingParentProjectId = requiredNonEmptySystemProperty("testing.bigquery-parent-project-id");
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return BigQueryQueryRunner.builder()
+                .setConnectorProperties(ImmutableMap.<String, String>builder()
+                        .put("bigquery.project-id", testingProjectId)
+                        .put("bigquery.parent-project-id", testingParentProjectId)
+                        .buildOrThrow())
+                .setInitialTables(ImmutableList.of(NATION))
+                .build();
+    }
+
+    @Test
+    void testQueriesWithParentProjectId()
+    {
+        assertThat(computeScalar("SELECT name FROM bigquery.tpch.nation WHERE nationkey = 0")).isEqualTo("ALGERIA");
+        assertThat(computeScalar("SELECT * FROM TABLE(bigquery.system.query(query => 'SELECT name FROM tpch.nation WHERE nationkey = 0'))")).isEqualTo("ALGERIA");
+        assertThat(computeScalar(format("SELECT * FROM TABLE(bigquery.system.query(query => 'SELECT name FROM %s.tpch.nation WHERE nationkey = 0'))", testingProjectId)))
+                .isEqualTo("ALGERIA");
+    }
+}

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestCredentialsOptionsConfigurer.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestCredentialsOptionsConfigurer.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.Optional;
 
-import static io.trino.plugin.bigquery.CredentialsOptionsConfigurer.calculateBillingProjectId;
+import static io.trino.plugin.bigquery.CredentialsOptionsConfigurer.resolveProjectId;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestCredentialsOptionsConfigurer
@@ -28,7 +28,7 @@ public class TestCredentialsOptionsConfigurer
     @Test
     public void testConfigurationOnly()
     {
-        String projectId = calculateBillingProjectId(Optional.of("pid"), Optional.empty());
+        String projectId = resolveProjectId(Optional.of("pid"), Optional.empty());
         assertThat(projectId).isEqualTo("pid");
     }
 
@@ -36,7 +36,7 @@ public class TestCredentialsOptionsConfigurer
     public void testCredentialsOnly()
             throws Exception
     {
-        String projectId = calculateBillingProjectId(Optional.empty(), credentials());
+        String projectId = resolveProjectId(Optional.empty(), credentials());
         assertThat(projectId).isEqualTo("presto-bq-credentials-test");
     }
 
@@ -44,7 +44,7 @@ public class TestCredentialsOptionsConfigurer
     public void testBothConfigurationAndCredentials()
             throws Exception
     {
-        String projectId = calculateBillingProjectId(Optional.of("pid"), credentials());
+        String projectId = resolveProjectId(Optional.of("pid"), credentials());
         assertThat(projectId).isEqualTo("pid");
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

If `bigquery.parent-project-id` was specified in configuration it was set as `projectId` in `BigQueryOptions`. 
For queries without `TableId` or `DatasetId` specified `BigQueryOptions` was used resulting in using wrong projectId.

This problem is visible when using PTF with parent-proejct-id set, resulting in permission problem like:
```
Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 403 Forbidden
POST https://bigquery.googleapis.com/bigquery/v2/projects/parent-project-id/jobs?prettyPrint=false
{
  "code": 403,
  "errors": [
    {
      "domain": "global",
      "message": "Access Denied: Table parent-project-id:tpch.nation: User does not have permission to query table parent-project-id:tpch.nation, or perhaps it does not exist.",
      "reason": "accessDenied"
    }
  ],
  "message": "Access Denied: Table parent-project-id:tpch.nation: User does not have permission to query table parent-project-id:tpch.nation, or perhaps it does not exist.",
  "status": "PERMISSION_DENIED"
}
```

Billing project id should be set using `setQuotaProjectId'  according to https://cloud.google.com/java/docs/reference/google-cloud-core/latest/com.google.cloud.ServiceOptions#com_google_cloud_ServiceOptions_getQuotaProjectId__

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# BigQuery
* Fix configuration with parent-project-id. ({issue}`23041`)
```
