### PR TITLE
Remove double slashes from S3 paths in native FS

### DIFF
--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3Location.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3Location.java
@@ -16,12 +16,15 @@ package io.trino.filesystem.s3;
 import io.trino.filesystem.Location;
 
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 record S3Location(Location location)
 {
+    private static final Pattern SLASHES = Pattern.compile("/+");
+
     S3Location
     {
         requireNonNull(location, "location is null");
@@ -44,7 +47,7 @@ record S3Location(Location location)
 
     public String key()
     {
-        return location.path();
+        return SLASHES.matcher(location.path()).replaceAll("/");
     }
 
     @Override

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3Location.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3Location.java
@@ -30,8 +30,8 @@ public class TestS3Location
         assertS3Uri("s3://abc/xyz/../foo", "abc", "xyz/../foo");
         assertS3Uri("s3://abc/..", "abc", "..");
         assertS3Uri("s3://abc/xyz/%41%xx", "abc", "xyz/%41%xx");
-        assertS3Uri("s3://abc///what", "abc", "//what");
-        assertS3Uri("s3://abc///what//", "abc", "//what//");
+        assertS3Uri("s3://abc///what", "abc", "/what");
+        assertS3Uri("s3://abc///what//", "abc", "/what/");
         assertS3Uri("s3a://hello/what/xxx", "hello", "what/xxx");
     }
 


### PR DESCRIPTION
Legacy FS S3 paths will not contain double-slashes. This causes issues when Iceberg table location countains double slashes. In such case different filename will be resolved in (Hadoop) legacy FS vs native FS. For compatibility purpouse it's better to remove double slashes in native FS too.

Fixes: https://github.com/trinodb/trino/issues/23043


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg, Hive
* Normalize `//` into `/` in native S3 filesystem paths. This prevents failures when matastore
  file locations contain double slashes but are accessed by both Hadoop and native S3 filesytems ({issue}`issuenumber`)
```
