### PR TITLE
[FTE] Adaptive reorder partitioned join

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -199,6 +199,9 @@ public final class SystemSessionProperties
     private static final String FAULT_TOLERANT_EXECUTION_SMALL_STAGE_REQUIRE_NO_MORE_PARTITIONS = "fault_tolerant_execution_small_stage_require_no_more_partitions";
     private static final String FAULT_TOLERANT_EXECUTION_STAGE_ESTIMATION_FOR_EAGER_PARENT_ENABLED = "fault_tolerant_execution_stage_estimation_for_eager_parent_enabled";
     public static final String FAULT_TOLERANT_EXECUTION_ADAPTIVE_QUERY_PLANNING_ENABLED = "fault_tolerant_execution_adaptive_query_planning_enabled";
+    public static final String FAULT_TOLERANT_EXECUTION_ADAPTIVE_JOIN_REORDERING_ENABLED = "fault_tolerant_execution_adaptive_join_reordering_enabled";
+    public static final String FAULT_TOLERANT_EXECUTION_ADAPTIVE_JOIN_REORDERING_SIZE_DIFFERENCE_RATIO = "fault_tolerant_execution_adaptive_join_reordering_size_difference_ratio";
+    public static final String FAULT_TOLERANT_EXECUTION_ADAPTIVE_JOIN_REORDERING_MIN_SIZE_THRESHOLD = "fault_tolerant_execution_adaptive_join_reordering_min_size_threshold";
     public static final String ADAPTIVE_PARTIAL_AGGREGATION_ENABLED = "adaptive_partial_aggregation_enabled";
     public static final String ADAPTIVE_PARTIAL_AGGREGATION_UNIQUE_ROWS_RATIO_THRESHOLD = "adaptive_partial_aggregation_unique_rows_ratio_threshold";
     public static final String REMOTE_TASK_ADAPTIVE_UPDATE_REQUEST_SIZE_ENABLED = "remote_task_adaptive_update_request_size_enabled";
@@ -1015,6 +1018,28 @@ public final class SystemSessionProperties
                         "Enable adaptive query planning for the fault tolerant execution",
                         queryManagerConfig.isFaultTolerantExecutionAdaptiveQueryPlanningEnabled(),
                         false),
+                booleanProperty(
+                        FAULT_TOLERANT_EXECUTION_ADAPTIVE_JOIN_REORDERING_ENABLED,
+                        "Reorder partitioned join based on run time stats in fault tolerant execution",
+                        queryManagerConfig.isFaultTolerantExecutionAdaptiveJoinReorderingEnabled(),
+                        false),
+                doubleProperty(
+                        FAULT_TOLERANT_EXECUTION_ADAPTIVE_JOIN_REORDERING_SIZE_DIFFERENCE_RATIO,
+                        "The ratio of difference in estimated size of right and left side of join to consider reordering",
+                        queryManagerConfig.getFaultTolerantExecutionAdaptiveJoinReorderingSizeDifferenceRatio(),
+                        value -> {
+                            if (value < 1.0) {
+                                throw new TrinoException(
+                                        INVALID_SESSION_PROPERTY,
+                                        format("%s must be greater than or equal to 1.0: %s", FAULT_TOLERANT_EXECUTION_SMALL_STAGE_SOURCE_SIZE_MULTIPLIER, value));
+                            }
+                        },
+                        true),
+                dataSizeProperty(
+                        FAULT_TOLERANT_EXECUTION_ADAPTIVE_JOIN_REORDERING_MIN_SIZE_THRESHOLD,
+                        "The minimum size of the right side of join to consider reordering",
+                        queryManagerConfig.getFaultTolerantExecutionAdaptiveJoinReorderingMinSizeThreshold(),
+                        true),
                 booleanProperty(
                         ADAPTIVE_PARTIAL_AGGREGATION_ENABLED,
                         "When enabled, partial aggregation might be adaptively turned off when it does not provide any performance gain",
@@ -1891,6 +1916,21 @@ public final class SystemSessionProperties
     public static boolean isFaultTolerantExecutionAdaptiveQueryPlanningEnabled(Session session)
     {
         return session.getSystemProperty(FAULT_TOLERANT_EXECUTION_ADAPTIVE_QUERY_PLANNING_ENABLED, Boolean.class);
+    }
+
+    public static boolean isFaultTolerantExecutionAdaptiveJoinReorderingEnabled(Session session)
+    {
+        return session.getSystemProperty(FAULT_TOLERANT_EXECUTION_ADAPTIVE_JOIN_REORDERING_ENABLED, Boolean.class);
+    }
+
+    public static double getFaultTolerantExecutionAdaptiveJoinReorderingSizeDifferenceRatio(Session session)
+    {
+        return session.getSystemProperty(FAULT_TOLERANT_EXECUTION_ADAPTIVE_JOIN_REORDERING_SIZE_DIFFERENCE_RATIO, Double.class);
+    }
+
+    public static DataSize getFaultTolerantExecutionAdaptiveJoinReorderingMinSizeThreshold(Session session)
+    {
+        return session.getSystemProperty(FAULT_TOLERANT_EXECUTION_ADAPTIVE_JOIN_REORDERING_MIN_SIZE_THRESHOLD, DataSize.class);
     }
 
     public static boolean isAdaptivePartialAggregationEnabled(Session session)

--- a/core/trino-main/src/main/java/io/trino/cost/PlanNodeStatsEstimateMath.java
+++ b/core/trino-main/src/main/java/io/trino/cost/PlanNodeStatsEstimateMath.java
@@ -13,11 +13,21 @@
  */
 package io.trino.cost;
 
+import com.google.common.collect.ImmutableList;
 import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.Lookup;
+import io.trino.sql.planner.optimizations.PlanNodeSearcher;
+import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.RemoteSourceNode;
+import io.trino.sql.planner.plan.TableScanNode;
+import io.trino.sql.planner.plan.UnnestNode;
+import io.trino.sql.planner.plan.ValuesNode;
 import io.trino.util.MoreMath;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -31,12 +41,14 @@ import static java.util.stream.Stream.concat;
 
 public final class PlanNodeStatsEstimateMath
 {
-    private PlanNodeStatsEstimateMath() {}
+    private static final List<Class<? extends PlanNode>> EXPANDING_NODE_CLASSES = ImmutableList.of(JoinNode.class, UnnestNode.class);
 
+    private PlanNodeStatsEstimateMath() {}
     /**
      * Subtracts subset stats from supersets stats.
      * It is assumed that each NDV from subset has a matching NDV in superset.
      */
+
     public static PlanNodeStatsEstimate subtractSubsetStats(PlanNodeStatsEstimate superset, PlanNodeStatsEstimate subset)
     {
         if (superset.isOutputRowCountUnknown() || subset.isOutputRowCountUnknown()) {
@@ -227,6 +239,66 @@ public final class PlanNodeStatsEstimateMath
         result.setOutputRowCount(0);
         stats.getSymbolsWithKnownStatistics().forEach(symbol -> result.addSymbolStatistics(symbol, SymbolStatsEstimate.zero()));
         return result.build();
+    }
+
+    /**
+     * Recursively looks for the first source node with a known estimate and uses that to return an approximate output size.
+     * Returns NaN if an un-estimated expanding node (Join or Unnest) is encountered.
+     * The amount of reduction in size from un-estimated non-expanding nodes (e.g. an un-estimated filter or aggregation)
+     * is not accounted here. We make use of the first available estimate and make decision about flipping join sides only if
+     * we find a large difference in output size of both sides.
+     */
+    public static double getFirstKnownOutputSizeInBytes(PlanNode node, Lookup lookup, StatsProvider statsProvider)
+    {
+        return Stream.of(node)
+                .map(lookup::resolve)
+                .mapToDouble(resolvedNode -> {
+                    double outputSizeInBytes = statsProvider.getStats(resolvedNode).getOutputSizeInBytes(
+                            resolvedNode.getOutputSymbols());
+                    if (!isNaN(outputSizeInBytes)) {
+                        return outputSizeInBytes;
+                    }
+
+                    if (EXPANDING_NODE_CLASSES.stream().anyMatch(clazz -> clazz.isInstance(resolvedNode))) {
+                        return NaN;
+                    }
+
+                    List<PlanNode> sourceNodes = resolvedNode.getSources();
+                    if (sourceNodes.isEmpty()) {
+                        return NaN;
+                    }
+
+                    double sourcesOutputSizeInBytes = 0;
+                    for (PlanNode sourceNode : sourceNodes) {
+                        double firstKnownOutputSizeInBytes = getFirstKnownOutputSizeInBytes(sourceNode, lookup, statsProvider);
+                        if (isNaN(firstKnownOutputSizeInBytes)) {
+                            return NaN;
+                        }
+                        sourcesOutputSizeInBytes += firstKnownOutputSizeInBytes;
+                    }
+                    return sourcesOutputSizeInBytes;
+                })
+                .sum();
+    }
+
+    public static double getSourceTablesSizeInBytes(PlanNode node, Lookup lookup, StatsProvider statsProvider)
+    {
+        boolean hasExpandingNodes = PlanNodeSearcher.searchFrom(node, lookup)
+                .whereIsInstanceOfAny(EXPANDING_NODE_CLASSES)
+                .matches();
+        if (hasExpandingNodes) {
+            return NaN;
+        }
+
+        List<PlanNode> sourceNodes = PlanNodeSearcher.searchFrom(node, lookup)
+                // Include RemoteSourceNode to account for adaptive planning where a finished subplan is
+                // replaced with a RemoteSourceNode.
+                .whereIsInstanceOfAny(TableScanNode.class, ValuesNode.class, RemoteSourceNode.class)
+                .findAll();
+
+        return sourceNodes.stream()
+                .mapToDouble(sourceNode -> statsProvider.getStats(sourceNode).getOutputSizeInBytes(sourceNode.getOutputSymbols()))
+                .sum();
     }
 
     @FunctionalInterface

--- a/core/trino-main/src/main/java/io/trino/execution/QueryManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryManagerConfig.java
@@ -149,7 +149,17 @@ public class QueryManagerConfig
     private double faultTolerantExecutionSmallStageSourceSizeMultiplier = 1.2;
     private boolean faultTolerantExecutionSmallStageRequireNoMorePartitions;
     private boolean faultTolerantExecutionStageEstimationForEagerParentEnabled = true;
-    private boolean faultTolerantExecutionAdaptiveQueryPlanningEnabled;
+    private boolean faultTolerantExecutionAdaptiveQueryPlanningEnabled = true;
+    private boolean faultTolerantExecutionAdaptiveJoinReorderingEnabled = true;
+    // Use a smaller threshold to change the order since the cost of changing the order is lower here. Additionally,
+    // the data size stats are more accurate compared to static planning since they are collected at run time from the
+    // stage execution.
+    private double faultTolerantExecutionAdaptiveJoinReorderingSizeDifferenceRatio = 1.5;
+    // With speculative execution, reordering small joins might cause unnecessary restarts of the
+    // join stage and lead to performance degradation. Hence, we only reorder if the size of the right side is
+    // above this threshold.
+    // TODO: Consider the cost of restarting the stage as part of adaptive planning.
+    private DataSize faultTolerantExecutionAdaptiveJoinReorderingMinSizeThreshold = DataSize.of(5, GIGABYTE);
 
     @Min(1)
     public int getScheduleSplitBatchSize()
@@ -1130,6 +1140,47 @@ public class QueryManagerConfig
     public QueryManagerConfig setFaultTolerantExecutionAdaptiveQueryPlanningEnabled(boolean faultTolerantExecutionSmallStageEstimationEnabled)
     {
         this.faultTolerantExecutionAdaptiveQueryPlanningEnabled = faultTolerantExecutionSmallStageEstimationEnabled;
+        return this;
+    }
+
+    public boolean isFaultTolerantExecutionAdaptiveJoinReorderingEnabled()
+    {
+        return faultTolerantExecutionAdaptiveJoinReorderingEnabled;
+    }
+
+    @Config("fault-tolerant-execution-adaptive-join-reordering-enabled")
+    @ConfigDescription("Reorder partitioned join based on run time stats in fault tolerant execution")
+    public QueryManagerConfig setFaultTolerantExecutionAdaptiveJoinReorderingEnabled(boolean faultTolerantExecutionAdaptiveJoinReorderingEnabled)
+    {
+        this.faultTolerantExecutionAdaptiveJoinReorderingEnabled = faultTolerantExecutionAdaptiveJoinReorderingEnabled;
+        return this;
+    }
+
+    @DecimalMin("1.0")
+    public double getFaultTolerantExecutionAdaptiveJoinReorderingSizeDifferenceRatio()
+    {
+        return faultTolerantExecutionAdaptiveJoinReorderingSizeDifferenceRatio;
+    }
+
+    @Config("fault-tolerant-execution-adaptive-join-reordering-size-difference-ratio")
+    @ConfigDescription("The ratio of difference in estimated size of right and left side of join to consider reordering")
+    public QueryManagerConfig setFaultTolerantExecutionAdaptiveJoinReorderingSizeDifferenceRatio(double faultTolerantExecutionAdaptiveJoinReorderingSizeDifferenceRatio)
+    {
+        this.faultTolerantExecutionAdaptiveJoinReorderingSizeDifferenceRatio = faultTolerantExecutionAdaptiveJoinReorderingSizeDifferenceRatio;
+        return this;
+    }
+
+    @NotNull
+    public DataSize getFaultTolerantExecutionAdaptiveJoinReorderingMinSizeThreshold()
+    {
+        return faultTolerantExecutionAdaptiveJoinReorderingMinSizeThreshold;
+    }
+
+    @Config("fault-tolerant-execution-adaptive-join-reordering-min-size-threshold")
+    @ConfigDescription("The minimum size of the right side of join to consider reordering")
+    public QueryManagerConfig setFaultTolerantExecutionAdaptiveJoinReorderingMinSizeThreshold(DataSize faultTolerantExecutionAdaptiveJoinReorderingMinSizeThreshold)
+    {
+        this.faultTolerantExecutionAdaptiveJoinReorderingMinSizeThreshold = faultTolerantExecutionAdaptiveJoinReorderingMinSizeThreshold;
         return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/AdaptivePlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/AdaptivePlanner.java
@@ -359,7 +359,9 @@ public class AdaptivePlanner
                     node.getId(),
                     node.getExchangeType(),
                     REMOTE,
-                    partitioningScheme,
+                    // We need to translate the output layout of the partitioning scheme to the output layout
+                    // of the RemoteSourceNode.
+                    partitioningScheme.translateOutputLayout(node.getOutputSymbols()),
                     sourceNodes,
                     inputs,
                     node.getOrderingScheme());

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/AdaptiveReorderPartitionedJoin.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/AdaptiveReorderPartitionedJoin.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import io.airlift.units.DataSize;
+import io.trino.Session;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.metadata.Metadata;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.Lookup;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.optimizations.PlanNodeSearcher;
+import io.trino.sql.planner.optimizations.StreamPreferredProperties;
+import io.trino.sql.planner.plan.ExchangeNode;
+import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.PlanNode;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.SystemSessionProperties.getFaultTolerantExecutionAdaptiveJoinReorderingMinSizeThreshold;
+import static io.trino.SystemSessionProperties.getFaultTolerantExecutionAdaptiveJoinReorderingSizeDifferenceRatio;
+import static io.trino.SystemSessionProperties.getRetryPolicy;
+import static io.trino.SystemSessionProperties.isFaultTolerantExecutionAdaptiveJoinReorderingEnabled;
+import static io.trino.cost.PlanNodeStatsEstimateMath.getFirstKnownOutputSizeInBytes;
+import static io.trino.operator.RetryPolicy.TASK;
+import static io.trino.sql.planner.optimizations.StreamPreferredProperties.partitionedOn;
+import static io.trino.sql.planner.optimizations.StreamPropertyDerivations.StreamProperties;
+import static io.trino.sql.planner.optimizations.StreamPropertyDerivations.deriveStreamPropertiesWithoutActualProperties;
+import static io.trino.sql.planner.plan.AggregationNode.Step.PARTIAL;
+import static io.trino.sql.planner.plan.ExchangeNode.Scope.LOCAL;
+import static io.trino.sql.planner.plan.ExchangeNode.Type.GATHER;
+import static io.trino.sql.planner.plan.ExchangeNode.partitionedExchange;
+import static io.trino.sql.planner.plan.JoinNode.DistributionType.PARTITIONED;
+import static io.trino.sql.planner.plan.Patterns.Join.right;
+import static io.trino.sql.planner.plan.Patterns.aggregation;
+import static io.trino.sql.planner.plan.Patterns.exchange;
+import static io.trino.sql.planner.plan.Patterns.join;
+import static io.trino.sql.planner.plan.Patterns.source;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Flip sides for partitioned join based on data size stats. This rule is only used during Adaptive Planning in FTE.
+ * From:
+ * <pre>
+ *    Join (PARTITIONED)
+ *      - left side (partitioned)
+ *      - Partial Aggregation (optional)
+ *          - Exchange (LOCAL)
+ *              - right side (partitioned)
+ * </pre>
+ * TO:
+ * <pre>
+ *    Join (PARTITIONED)
+ *      - Partial Aggregation (optional)
+ *          - right side (partitioned)
+ *      - Exchange (LOCAL) (if needed, derived using source stream properties)
+ *          - left side (partitioned)
+ * </pre>
+ */
+public class AdaptiveReorderPartitionedJoin
+        implements Rule<JoinNode>
+{
+    private static final Capture<ExchangeNode> LOCAL_EXCHANGE_NODE = Capture.newCapture();
+    private static final Pattern<JoinNode> PATTERN = join()
+            .matching(AdaptiveReorderPartitionedJoin::isPartitionedJoinWithNoHashSymbols)
+            .or(
+                    // In case partial aggregation is missing
+                    prev -> prev.with(right().matching(
+                            exchange().matching(exchangeNode -> exchangeNode.getScope().equals(LOCAL)
+                                            // Skip when exchange is gather
+                                            && !exchangeNode.getType().equals(GATHER))
+                                    .capturedAs(LOCAL_EXCHANGE_NODE))),
+                    // In case partial aggregation is present
+                    prev -> prev.with(right().matching(
+                            aggregation().matching(node -> node.getStep() == PARTIAL)
+                                    .with(source().matching(
+                                            exchange().matching(exchangeNode -> exchangeNode.getScope().equals(LOCAL)
+                                                            // Skip when exchange is gather
+                                                            && !exchangeNode.getType().equals(GATHER))
+                                                    .capturedAs(LOCAL_EXCHANGE_NODE))))));
+
+    private final Metadata metadata;
+
+    public AdaptiveReorderPartitionedJoin(Metadata metadata)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
+    private static boolean isPartitionedJoinWithNoHashSymbols(JoinNode joinNode)
+    {
+        // Check if the join is partitioned and does not have hash symbols
+        return joinNode.getDistributionType().equals(Optional.of(PARTITIONED))
+                // TODO: Add support for hash symbols. For now, it's not important since hash optimization
+                //  is disabled by default
+                && joinNode.getRightHashSymbol().isEmpty()
+                && joinNode.getLeftHashSymbol().isEmpty();
+    }
+
+    @Override
+    public Pattern<JoinNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        // This rule is only enabled in case of FTE
+        return getRetryPolicy(session) == TASK && isFaultTolerantExecutionAdaptiveJoinReorderingEnabled(session);
+    }
+
+    @Override
+    public Result apply(JoinNode joinNode, Captures captures, Context context)
+    {
+        ExchangeNode localExchangeNode = captures.get(LOCAL_EXCHANGE_NODE);
+        // Check if the captured exchange node is the build side local exchange node, otherwise bail out
+        List<Symbol> buildSymbols = Lists.transform(joinNode.getCriteria(), JoinNode.EquiJoinClause::getRight);
+        if (!isBuildSideLocalExchangeNode(localExchangeNode, ImmutableSet.copyOf(buildSymbols))) {
+            return Result.empty();
+        }
+
+        // Remove local exchange from build side
+        JoinNode joinNodeWithoutExchanges = removeLocalExchangeFromBuildSide(joinNode, localExchangeNode, context);
+        JoinNode flippedJoin = flipJoinBasedOnStats(joinNodeWithoutExchanges, context);
+        if (flippedJoin != joinNodeWithoutExchanges) {
+            // Add local exchange back to build side after flipping
+            return Result.ofPlanNode(addLocalExchangeToBuildSideIfNeeded(flippedJoin, metadata, context));
+        }
+        return Result.empty();
+    }
+
+    private static boolean isBuildSideLocalExchangeNode(ExchangeNode exchangeNode, Set<Symbol> rightSymbols)
+    {
+        return exchangeNode.getScope() == LOCAL
+                && exchangeNode.getPartitioningScheme().getPartitioning().getColumns().equals(rightSymbols)
+                // TODO: Add support for local exchange with hash symbols. For now, it's not important since hash
+                //  optimization is disabled by default
+                && exchangeNode.getPartitioningScheme().getHashColumn().isEmpty();
+    }
+
+    private static JoinNode removeLocalExchangeFromBuildSide(JoinNode joinNode, ExchangeNode localExchangeNode, Context context)
+    {
+        PlanNode rightNodeWithoutLocalExchange = PlanNodeSearcher
+                .searchFrom(joinNode.getRight(), context.getLookup())
+                .where(node -> node.getId().equals(localExchangeNode.getId()))
+                .removeFirst();
+
+        return new JoinNode(
+                joinNode.getId(),
+                joinNode.getType(),
+                joinNode.getLeft(),
+                rightNodeWithoutLocalExchange,
+                joinNode.getCriteria(),
+                joinNode.getLeftOutputSymbols(),
+                joinNode.getRightOutputSymbols(),
+                joinNode.isMaySkipOutputDuplicates(),
+                joinNode.getFilter(),
+                joinNode.getLeftHashSymbol(),
+                joinNode.getRightHashSymbol(),
+                joinNode.getDistributionType(),
+                joinNode.isSpillable(),
+                joinNode.getDynamicFilters(),
+                joinNode.getReorderJoinStatsAndCost());
+    }
+
+    private static JoinNode addLocalExchangeToBuildSideIfNeeded(JoinNode joinNode, Metadata metadata, Context context)
+    {
+        StreamProperties rightProperties = deriveStreamPropertiesRecursively(
+                joinNode.getRight(),
+                metadata,
+                context.getLookup(),
+                context.getSession());
+        List<Symbol> buildSymbols = Lists.transform(joinNode.getCriteria(), JoinNode.EquiJoinClause::getRight);
+        StreamPreferredProperties expectedRightProperties = partitionedOn(buildSymbols);
+        if (expectedRightProperties.isSatisfiedBy(rightProperties)) {
+            return joinNode;
+        }
+
+        // Add local exchange to build side
+        ExchangeNode exchangeNode = partitionedExchange(
+                context.getIdAllocator().getNextId(),
+                LOCAL,
+                joinNode.getRight(),
+                buildSymbols,
+                joinNode.getRightHashSymbol());
+        return new JoinNode(
+                joinNode.getId(),
+                joinNode.getType(),
+                joinNode.getLeft(),
+                exchangeNode,
+                joinNode.getCriteria(),
+                joinNode.getLeftOutputSymbols(),
+                joinNode.getRightOutputSymbols(),
+                joinNode.isMaySkipOutputDuplicates(),
+                joinNode.getFilter(),
+                joinNode.getLeftHashSymbol(),
+                joinNode.getRightHashSymbol(),
+                joinNode.getDistributionType(),
+                joinNode.isSpillable(),
+                joinNode.getDynamicFilters(),
+                joinNode.getReorderJoinStatsAndCost());
+    }
+
+    private static JoinNode flipJoinBasedOnStats(JoinNode joinNode, Context context)
+    {
+        double leftOutputSizeInBytes = getFirstKnownOutputSizeInBytes(
+                joinNode.getLeft(),
+                context.getLookup(),
+                context.getStatsProvider());
+        double rightOutputSizeInBytes = getFirstKnownOutputSizeInBytes(
+                joinNode.getRight(),
+                context.getLookup(),
+                context.getStatsProvider());
+        DataSize minSizeThreshold = getFaultTolerantExecutionAdaptiveJoinReorderingMinSizeThreshold(context.getSession());
+        double sizeDifferenceRatio = getFaultTolerantExecutionAdaptiveJoinReorderingSizeDifferenceRatio(context.getSession());
+        if (rightOutputSizeInBytes > minSizeThreshold.toBytes()
+                && rightOutputSizeInBytes > sizeDifferenceRatio * leftOutputSizeInBytes) {
+            return joinNode.flipChildren();
+        }
+        return joinNode;
+    }
+
+    private static StreamProperties deriveStreamPropertiesRecursively(PlanNode node, Metadata metadata, Lookup lookup, Session session)
+    {
+        PlanNode resolvedNode = lookup.resolve(node);
+        List<StreamProperties> inputProperties = resolvedNode.getSources().stream()
+                .map(source -> deriveStreamPropertiesRecursively(source, metadata, lookup, session))
+                .collect(toImmutableList());
+        return deriveStreamPropertiesWithoutActualProperties(resolvedNode, inputProperties, metadata, session);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/execution/TestQueryManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestQueryManagerConfig.java
@@ -112,7 +112,10 @@ public class TestQueryManagerConfig
                 .setFaultTolerantExecutionSmallStageSourceSizeMultiplier(1.2)
                 .setFaultTolerantExecutionSmallStageRequireNoMorePartitions(false)
                 .setFaultTolerantExecutionStageEstimationForEagerParentEnabled(true)
-                .setFaultTolerantExecutionAdaptiveQueryPlanningEnabled(false)
+                .setFaultTolerantExecutionAdaptiveQueryPlanningEnabled(true)
+                .setFaultTolerantExecutionAdaptiveJoinReorderingEnabled(true)
+                .setFaultTolerantExecutionAdaptiveJoinReorderingMinSizeThreshold(DataSize.of(5, GIGABYTE))
+                .setFaultTolerantExecutionAdaptiveJoinReorderingSizeDifferenceRatio(1.5)
                 .setMaxWriterTaskCount(100));
     }
 
@@ -191,7 +194,10 @@ public class TestQueryManagerConfig
                 .put("fault-tolerant-execution-small-stage-source-size-multiplier", "1.6")
                 .put("fault-tolerant-execution-small-stage-require-no-more-partitions", "true")
                 .put("fault-tolerant-execution-stage-estimation-for-eager-parent-enabled", "false")
-                .put("fault-tolerant-execution-adaptive-query-planning-enabled", "true")
+                .put("fault-tolerant-execution-adaptive-query-planning-enabled", "false")
+                .put("fault-tolerant-execution-adaptive-join-reordering-enabled", "false")
+                .put("fault-tolerant-execution-adaptive-join-reordering-min-size-threshold", "1GB")
+                .put("fault-tolerant-execution-adaptive-join-reordering-size-difference-ratio", "2")
                 .buildOrThrow();
 
         QueryManagerConfig expected = new QueryManagerConfig()
@@ -265,7 +271,10 @@ public class TestQueryManagerConfig
                 .setFaultTolerantExecutionSmallStageSourceSizeMultiplier(1.6)
                 .setFaultTolerantExecutionSmallStageRequireNoMorePartitions(true)
                 .setFaultTolerantExecutionStageEstimationForEagerParentEnabled(false)
-                .setFaultTolerantExecutionAdaptiveQueryPlanningEnabled(true)
+                .setFaultTolerantExecutionAdaptiveQueryPlanningEnabled(false)
+                .setFaultTolerantExecutionAdaptiveJoinReorderingEnabled(false)
+                .setFaultTolerantExecutionAdaptiveJoinReorderingMinSizeThreshold(DataSize.of(1, GIGABYTE))
+                .setFaultTolerantExecutionAdaptiveJoinReorderingSizeDifferenceRatio(2.0)
                 .setMaxWriterTaskCount(101);
 
         assertFullMapping(properties, expected);

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
@@ -150,6 +150,21 @@ public final class PlanMatchPattern
                         sourceFragmentIds,
                         Optional.empty(),
                         Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()));
+    }
+
+    public static PlanMatchPattern remoteSource(
+            List<PlanFragmentId> sourceFragmentIds,
+            List<String> outputSymbols,
+            ExchangeNode.Type exchangeType)
+    {
+        return node(RemoteSourceNode.class)
+                .with(new RemoteSourceMatcher(
+                        sourceFragmentIds,
+                        Optional.of(outputSymbols),
+                        Optional.empty(),
+                        Optional.of(exchangeType),
                         Optional.empty()));
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestAdaptiveReorderPartitionedJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestAdaptiveReorderPartitionedJoin.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.trino.cost.PlanNodeStatsEstimate;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.trino.sql.planner.iterative.rule.test.RuleAssert;
+import io.trino.sql.planner.iterative.rule.test.RuleTester;
+import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.PlanFragmentId;
+import io.trino.sql.planner.plan.PlanNodeId;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.trino.SystemSessionProperties.RETRY_POLICY;
+import static io.trino.operator.RetryPolicy.TASK;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.exchange;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.remoteSource;
+import static io.trino.sql.planner.plan.AggregationNode.Step.PARTIAL;
+import static io.trino.sql.planner.plan.ExchangeNode.Scope.LOCAL;
+import static io.trino.sql.planner.plan.ExchangeNode.Type.REPARTITION;
+import static io.trino.sql.planner.plan.JoinNode.DistributionType.PARTITIONED;
+import static io.trino.sql.planner.plan.JoinType.INNER;
+
+public class TestAdaptiveReorderPartitionedJoin
+        extends BaseRuleTest
+{
+    @Test
+    public void testReorderPartitionedJoin()
+    {
+        assertWithoutPartialAgg(20_000_000_000L, 10_000_000_000L)
+                .matches(
+                        join(INNER, builder -> builder
+                                .equiCriteria("buildSymbol", "probeSymbol")
+                                .distributionType(PARTITIONED)
+                                .left(remoteSource(
+                                        ImmutableList.of(new PlanFragmentId("2")),
+                                        ImmutableList.of("buildSymbol", "symbol1"),
+                                        REPARTITION))
+                                .right(exchange(
+                                        LOCAL,
+                                        REPARTITION,
+                                        ImmutableList.of(),
+                                        ImmutableSet.of("probeSymbol"),
+                                        Optional.of(ImmutableList.of(ImmutableList.of("probeSymbol", "symbol2"))),
+                                        remoteSource(
+                                                ImmutableList.of(new PlanFragmentId("1")),
+                                                ImmutableList.of("probeSymbol", "symbol2"),
+                                                REPARTITION)))));
+
+        assertWithPartialAgg(20_000_000_000L, 10_000_000_000L)
+                .matches(
+                        join(INNER, builder -> builder
+                                .equiCriteria("buildSymbol", "probeSymbol")
+                                .distributionType(PARTITIONED)
+                                .left(aggregation(
+                                        ImmutableMap.of(),
+                                        PARTIAL,
+                                        remoteSource(
+                                                ImmutableList.of(new PlanFragmentId("2")),
+                                                ImmutableList.of("buildSymbol", "symbol1"),
+                                                REPARTITION)))
+                                .right(exchange(
+                                        LOCAL,
+                                        REPARTITION,
+                                        ImmutableList.of(),
+                                        ImmutableSet.of("probeSymbol"),
+                                        Optional.of(ImmutableList.of(ImmutableList.of("probeSymbol", "symbol2"))),
+                                        remoteSource(
+                                                ImmutableList.of(new PlanFragmentId("1")),
+                                                ImmutableList.of("probeSymbol", "symbol2"),
+                                                REPARTITION)))));
+    }
+
+    @Test
+    public void testNoChangesWhenBuildSourceIsSmaller()
+    {
+        assertWithPartialAgg(10_000_000_000L, 20_000_000_000L)
+                .doesNotFire();
+        assertWithoutPartialAgg(10_000_000_000L, 20_000_000_000L)
+                .doesNotFire();
+    }
+
+    @Test
+    public void testNoChangesWhenBuildSideIsBelowMinSizeLimit()
+    {
+        // Right size is below the default min size limit of 5 GB data size
+        assertWithPartialAgg(1_00_000_000L, 1_000_000L)
+                .doesNotFire();
+        assertWithoutPartialAgg(1_00_000_000L, 1_000_000L)
+                .doesNotFire();
+    }
+
+    @Test
+    public void testNoChangesWhenEitherBuildOrProbeSideIsNan()
+    {
+        assertWithoutPartialAgg(Double.NaN, 10_000_000_000L)
+                .doesNotFire();
+        assertWithoutPartialAgg(20_000_000_000L, Double.NaN)
+                .doesNotFire();
+        assertWithoutPartialAgg(Double.NaN, Double.NaN)
+                .doesNotFire();
+    }
+
+    private RuleAssert assertWithPartialAgg(double buildRowCount, double probeRowCount)
+    {
+        RuleTester ruleTester = tester();
+        String buildRemoteSourceId = "buildRemoteSourceId";
+        String probeRemoteSourceId = "probeRemoteSourceId";
+        return ruleTester.assertThat(new AdaptiveReorderPartitionedJoin(ruleTester.getMetadata()))
+                .setSystemProperty(RETRY_POLICY, TASK.name())
+                .overrideStats("buildRemoteSourceId", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(buildRowCount)
+                        .build())
+                .overrideStats("probeRemoteSourceId", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(probeRowCount)
+                        .build())
+                .on(p -> {
+                    Symbol buildSymbol = p.symbol("buildSymbol", BIGINT);
+                    Symbol symbol1 = p.symbol("symbol1", BIGINT);
+                    Symbol probeSymbol = p.symbol("probeSymbol", BIGINT);
+                    Symbol symbol2 = p.symbol("symbol2", BIGINT);
+                    return p.join(
+                            INNER,
+                            PARTITIONED,
+                            p.remoteSource(
+                                    new PlanNodeId(probeRemoteSourceId),
+                                    ImmutableList.of(new PlanFragmentId("1")),
+                                    ImmutableList.of(probeSymbol, symbol2),
+                                    Optional.empty(),
+                                    REPARTITION,
+                                    TASK),
+                            p.aggregation(ab -> ab
+                                    .step(PARTIAL)
+                                    .singleGroupingSet(buildSymbol, symbol1)
+                                    .source(p.exchange(builder -> builder
+                                            .addInputsSet(buildSymbol, symbol1)
+                                            .addSource(p.remoteSource(
+                                                    new PlanNodeId(buildRemoteSourceId),
+                                                    ImmutableList.of(new PlanFragmentId("2")),
+                                                    ImmutableList.of(buildSymbol, symbol1),
+                                                    Optional.empty(),
+                                                    REPARTITION,
+                                                    TASK))
+                                            .fixedHashDistributionPartitioningScheme(
+                                                    ImmutableList.of(buildSymbol, symbol1),
+                                                    ImmutableList.of(buildSymbol))
+                                            .type(REPARTITION)
+                                            .scope(LOCAL)))),
+                            new JoinNode.EquiJoinClause(probeSymbol, buildSymbol));
+                });
+    }
+
+    private RuleAssert assertWithoutPartialAgg(double buildRowCount, double probeRowCount)
+    {
+        RuleTester ruleTester = tester();
+        String buildRemoteSourceId = "buildRemoteSourceId";
+        String probeRemoteSourceId = "probeRemoteSourceId";
+        return ruleTester.assertThat(new AdaptiveReorderPartitionedJoin(ruleTester.getMetadata()))
+                .setSystemProperty(RETRY_POLICY, TASK.name())
+                .overrideStats("buildRemoteSourceId", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(buildRowCount)
+                        .build())
+                .overrideStats("probeRemoteSourceId", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(probeRowCount)
+                        .build())
+                .on(p -> {
+                    Symbol buildSymbol = p.symbol("buildSymbol", BIGINT);
+                    Symbol symbol1 = p.symbol("symbol1", BIGINT);
+                    Symbol probeSymbol = p.symbol("probeSymbol", BIGINT);
+                    Symbol symbol2 = p.symbol("symbol2", BIGINT);
+                    return p.join(
+                            INNER,
+                            PARTITIONED,
+                            p.remoteSource(
+                                    new PlanNodeId(probeRemoteSourceId),
+                                    ImmutableList.of(new PlanFragmentId("1")),
+                                    ImmutableList.of(probeSymbol, symbol2),
+                                    Optional.empty(),
+                                    REPARTITION,
+                                    TASK),
+                            p.exchange(builder -> builder
+                                    .addInputsSet(buildSymbol, symbol1)
+                                    .addSource(p.remoteSource(
+                                            new PlanNodeId(buildRemoteSourceId),
+                                            ImmutableList.of(new PlanFragmentId("2")),
+                                            ImmutableList.of(buildSymbol, symbol1),
+                                            Optional.empty(),
+                                            REPARTITION,
+                                            TASK))
+                                    .fixedHashDistributionPartitioningScheme(
+                                            ImmutableList.of(buildSymbol, symbol1),
+                                            ImmutableList.of(buildSymbol))
+                                    .type(REPARTITION)
+                                    .scope(LOCAL)),
+                            new JoinNode.EquiJoinClause(probeSymbol, buildSymbol));
+                });
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestDetermineJoinDistributionType.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestDetermineJoinDistributionType.java
@@ -54,6 +54,8 @@ import java.util.Optional;
 
 import static io.trino.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static io.trino.SystemSessionProperties.JOIN_MAX_BROADCAST_TABLE_SIZE;
+import static io.trino.cost.PlanNodeStatsEstimateMath.getFirstKnownOutputSizeInBytes;
+import static io.trino.cost.PlanNodeStatsEstimateMath.getSourceTablesSizeInBytes;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
@@ -64,8 +66,6 @@ import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
 import static io.trino.sql.planner.iterative.Lookup.noLookup;
-import static io.trino.sql.planner.iterative.rule.DetermineJoinDistributionType.getFirstKnownOutputSizeInBytes;
-import static io.trino.sql.planner.iterative.rule.DetermineJoinDistributionType.getSourceTablesSizeInBytes;
 import static io.trino.sql.planner.plan.JoinNode.DistributionType.PARTITIONED;
 import static io.trino.sql.planner.plan.JoinNode.DistributionType.REPLICATED;
 import static io.trino.sql.planner.plan.JoinType.FULL;

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -1421,6 +1421,17 @@ public class PlanBuilder
         return new RemoteSourceNode(idAllocator.getNextId(), sourceFragmentIds, outputs, orderingScheme, exchangeType, retryPolicy);
     }
 
+    public RemoteSourceNode remoteSource(
+            PlanNodeId id,
+            List<PlanFragmentId> sourceFragmentIds,
+            List<Symbol> outputs,
+            Optional<OrderingScheme> orderingScheme,
+            ExchangeNode.Type exchangeType,
+            RetryPolicy retryPolicy)
+    {
+        return new RemoteSourceNode(id, sourceFragmentIds, outputs, orderingScheme, exchangeType, retryPolicy);
+    }
+
     public static AggregationFunction aggregation(String name, List<Expression> arguments)
     {
         return new AggregationFunction(name, Optional.empty(), Optional.empty(), false, arguments);

--- a/lib/trino-matching/src/main/java/io/trino/matching/DefaultPrinter.java
+++ b/lib/trino-matching/src/main/java/io/trino/matching/DefaultPrinter.java
@@ -16,8 +16,11 @@ package io.trino.matching;
 import io.trino.matching.pattern.CapturePattern;
 import io.trino.matching.pattern.EqualsPattern;
 import io.trino.matching.pattern.FilterPattern;
+import io.trino.matching.pattern.OrPattern;
 import io.trino.matching.pattern.TypeOfPattern;
 import io.trino.matching.pattern.WithPattern;
+
+import java.util.Iterator;
 
 import static java.lang.String.format;
 
@@ -68,6 +71,22 @@ public class DefaultPrinter
     {
         visitPrevious(pattern);
         appendLine("filter(%s)", pattern.predicate());
+    }
+
+    @Override
+    public void visitOr(OrPattern<?> pattern)
+    {
+        visitPrevious(pattern);
+        level += 1;
+        Iterator<?> iterator = pattern.getPatterns().iterator();
+        while (iterator.hasNext()) {
+            Pattern<?> subPattern = (Pattern<?>) iterator.next();
+            subPattern.accept(this);
+            if (iterator.hasNext()) {
+                appendLine("or");
+            }
+        }
+        level -= 1;
     }
 
     private void appendLine(String template, Object... arguments)

--- a/lib/trino-matching/src/main/java/io/trino/matching/Pattern.java
+++ b/lib/trino-matching/src/main/java/io/trino/matching/Pattern.java
@@ -16,15 +16,20 @@ package io.trino.matching;
 import com.google.common.collect.Iterables;
 import io.trino.matching.pattern.CapturePattern;
 import io.trino.matching.pattern.FilterPattern;
+import io.trino.matching.pattern.OrPattern;
 import io.trino.matching.pattern.TypeOfPattern;
 import io.trino.matching.pattern.WithPattern;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.BiPredicate;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import static com.google.common.base.Predicates.not;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 public abstract class Pattern<T>
@@ -82,6 +87,15 @@ public abstract class Pattern<T>
     public Pattern<T> with(PropertyPattern<? super T, ?, ?> pattern)
     {
         return new WithPattern<>(pattern, this);
+    }
+
+    @SafeVarargs
+    public final Pattern<T> or(Function<Pattern<T>, Pattern<T>>... patternsSupplier)
+    {
+        List<Pattern<T>> patterns = Arrays.stream(patternsSupplier)
+                .map(supplier -> supplier.apply(this))
+                .collect(toImmutableList());
+        return new OrPattern<>(patterns, this);
     }
 
     public Optional<Pattern<?>> previous()

--- a/lib/trino-matching/src/main/java/io/trino/matching/PatternVisitor.java
+++ b/lib/trino-matching/src/main/java/io/trino/matching/PatternVisitor.java
@@ -16,6 +16,7 @@ package io.trino.matching;
 import io.trino.matching.pattern.CapturePattern;
 import io.trino.matching.pattern.EqualsPattern;
 import io.trino.matching.pattern.FilterPattern;
+import io.trino.matching.pattern.OrPattern;
 import io.trino.matching.pattern.TypeOfPattern;
 import io.trino.matching.pattern.WithPattern;
 
@@ -32,6 +33,8 @@ public interface PatternVisitor
     void visitEquals(EqualsPattern<?> equalsPattern);
 
     void visitFilter(FilterPattern<?> pattern);
+
+    void visitOr(OrPattern<?> pattern);
 
     default void visitPrevious(Pattern<?> pattern)
     {

--- a/lib/trino-matching/src/main/java/io/trino/matching/pattern/OrPattern.java
+++ b/lib/trino-matching/src/main/java/io/trino/matching/pattern/OrPattern.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.matching.pattern;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Match;
+import io.trino.matching.Pattern;
+import io.trino.matching.PatternVisitor;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+public class OrPattern<T>
+        extends Pattern<T>
+{
+    private final List<Pattern<T>> patterns;
+
+    public OrPattern(List<Pattern<T>> patterns, Pattern<T> previous)
+    {
+        super(previous);
+        this.patterns = patterns;
+    }
+
+    public List<Pattern<T>> getPatterns()
+    {
+        return patterns;
+    }
+
+    @Override
+    public <C> Stream<Match> accept(Object object, Captures captures, C context)
+    {
+        return patterns.stream()
+                .flatMap(pattern -> pattern.accept(object, captures, context));
+    }
+
+    @Override
+    public void accept(PatternVisitor patternVisitor)
+    {
+        patternVisitor.visitOr(this);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Flip sides for partitioned join based on data size stats. This rule is only used during Adaptive Planning in FTE.

It helps fix the join order due to either missing or incorrect stats, or maybe wrong estimations caused by skewed distribution of filters, etc.

### Benchmarks
Example query using the TPCDS dataset. Here the last join has an incorrect order.
```
SELECT sum(c.c_current_cdemo_sk), max(c.c_birth_country),
sum(ss.ss_quantity), sum(ss.ss_list_price), sum(ss.ss_coupon_amt),
max(i.i_current_price), sum(cs.cs_wholesale_cost), sum(cs.cs_list_price),
sum(cs.cs_sales_price), sum(cs.cs_ext_sales_price),
sum(cs.cs_net_paid_inc_tax), sum(cs.cs_net_paid_inc_ship),
sum(cs.cs_net_profit), sum(cs.cs_ext_tax), sum(cs.cs_coupon_amt),
sum(cs.cs_ext_ship_cost), sum(cs.cs_net_paid), sum(cs.cs_net_paid_inc_tax),
sum(cs.cs_net_paid_inc_ship), sum(cs.cs_call_center_sk),
sum(cs.cs_net_paid_inc_ship_tax), sum(cs.cs_net_profit),
sum(cs.cs_call_center_sk), sum(cs.cs_warehouse_sk), sum(cs.cs_bill_hdemo_sk)
FROM store_sales AS ss
LEFT JOIN item AS i
ON ss.ss_item_sk = i.i_item_sk
LEFT JOIN customer AS c ON (ss.ss_customer_sk = c.c_customer_sk)
LEFT JOIN catalog_sales AS cs  ON (ss.ss_item_sk=cs.cs_item_sk AND ss.ss_sold_date_sk = cs.cs_sold_date_sk)
WHERE c.c_birth_year > 1968;
```
Before:
```
Query 20240805_175839_00010_wvcdc, FINISHED, 8 nodes
Splits: 13,798 total, 13,798 done (100.00%)
2:05 [4.33B rows, 68.7GB] [34.7M rows/s, 564MB/s]
```
After:
```
Query 20240805_175654_00008_wvcdc, FINISHED, 8 nodes
Splits: 9,394 total, 9,394 done (100.00%)
1:12 [4.33B rows, 68.7GB] [60.5M rows/s, 982MB/s]
```

There’s also a significant improvement in CPU and memory usage.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# General
* Add optimisation which can reorder joins at runtime if retry_policy is set to `TASK`, even if table statistics are not available.
  Note: In case of unexpected issues feature can be disabled with  `fault_tolerant_execution_adaptive_join_reordering_enabled` session property
  or fault-tolerant-execution-adaptive-join-reordering-enabled config property. ({issue}`23182`)
```
