### PR TITLE
Add support for creating Delta tables with deletion vectors

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.md
+++ b/docs/src/main/sphinx/connector/delta-lake.md
@@ -192,6 +192,9 @@ values. Typical usage does not require you to configure them.
     the [VACUUM](delta-lake-vacuum) procedure. The equivalent catalog session
     property is `vacuum_min_retention`.
   - `7 DAYS`
+* - `delta.deletion-vectors-enabled`
+  - Set to `true` for enabling deletion vectors by default when creating new tables.
+  - `false`
 :::
 
 ### Catalog session properties
@@ -687,6 +690,8 @@ The following table properties are available for use:
     * `NONE`
 
     Defaults to `NONE`.
+* - `deletion_vectors_enabled`
+  - Enables deletion vectors.
 :::
 
 The following example uses all available table properties:
@@ -698,7 +703,8 @@ WITH (
   partitioned_by = ARRAY['regionkey'],
   checkpoint_interval = 5,
   change_data_feed_enabled = false,
-  column_mapping_mode = 'name'
+  column_mapping_mode = 'name',
+  deletion_vectors_enabled = false
 )
 AS SELECT name, comment, regionkey FROM tpch.tiny.nation;
 ```

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConfig.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConfig.java
@@ -84,6 +84,7 @@ public class DeltaLakeConfig
     private boolean registerTableProcedureEnabled;
     private boolean projectionPushdownEnabled = true;
     private boolean queryPartitionFilterRequired;
+    private boolean deletionVectorsEnabled;
 
     public Duration getMetadataCacheTtl()
     {
@@ -516,6 +517,19 @@ public class DeltaLakeConfig
     public DeltaLakeConfig setQueryPartitionFilterRequired(boolean queryPartitionFilterRequired)
     {
         this.queryPartitionFilterRequired = queryPartitionFilterRequired;
+        return this;
+    }
+
+    public boolean isDeletionVectorsEnabled()
+    {
+        return deletionVectorsEnabled;
+    }
+
+    @Config("delta.deletion-vectors-enabled")
+    @ConfigDescription("Enable deletion vectors by default for new tables")
+    public DeltaLakeConfig setDeletionVectorsEnabled(boolean deletionVectorsEnabled)
+    {
+        this.deletionVectorsEnabled = deletionVectorsEnabled;
         return this;
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -237,6 +237,7 @@ import static io.trino.plugin.deltalake.DeltaLakeTableProperties.LOCATION_PROPER
 import static io.trino.plugin.deltalake.DeltaLakeTableProperties.PARTITIONED_BY_PROPERTY;
 import static io.trino.plugin.deltalake.DeltaLakeTableProperties.getChangeDataFeedEnabled;
 import static io.trino.plugin.deltalake.DeltaLakeTableProperties.getCheckpointInterval;
+import static io.trino.plugin.deltalake.DeltaLakeTableProperties.getColumnMappingMode;
 import static io.trino.plugin.deltalake.DeltaLakeTableProperties.getLocation;
 import static io.trino.plugin.deltalake.DeltaLakeTableProperties.getPartitionedBy;
 import static io.trino.plugin.deltalake.metastore.DeltaLakeTableMetadataScheduler.containsSchemaString;
@@ -1152,7 +1153,7 @@ public class DeltaLakeMetadata
         Location deltaLogDirectory = Location.of(getTransactionLogDir(location));
         Optional<Long> checkpointInterval = getCheckpointInterval(tableMetadata.getProperties());
         Optional<Boolean> changeDataFeedEnabled = getChangeDataFeedEnabled(tableMetadata.getProperties());
-        ColumnMappingMode columnMappingMode = DeltaLakeTableProperties.getColumnMappingMode(tableMetadata.getProperties());
+        ColumnMappingMode columnMappingMode = getColumnMappingMode(tableMetadata.getProperties());
         AtomicInteger fieldId = new AtomicInteger();
 
         validateTableColumns(tableMetadata);
@@ -1338,7 +1339,7 @@ public class DeltaLakeMetadata
             external = false;
         }
 
-        ColumnMappingMode columnMappingMode = DeltaLakeTableProperties.getColumnMappingMode(tableMetadata.getProperties());
+        ColumnMappingMode columnMappingMode = getColumnMappingMode(tableMetadata.getProperties());
         AtomicInteger fieldId = new AtomicInteger();
 
         Location finalLocation = Location.of(location);
@@ -2891,7 +2892,7 @@ public class DeltaLakeMetadata
             // Enabling cdf (change data feed) requires setting the writer version to 4
             writerVersion = CDF_SUPPORTED_WRITER_VERSION;
         }
-        ColumnMappingMode columnMappingMode = DeltaLakeTableProperties.getColumnMappingMode(properties);
+        ColumnMappingMode columnMappingMode = getColumnMappingMode(properties);
         if (columnMappingMode == ID || columnMappingMode == NAME) {
             readerVersion = max(readerVersion, COLUMN_MAPPING_MODE_SUPPORTED_READER_VERSION);
             writerVersion = max(writerVersion, COLUMN_MAPPING_MODE_SUPPORTED_WRITER_VERSION);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeOutputTableHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeOutputTableHandle.java
@@ -36,6 +36,7 @@ public record DeltaLakeOutputTableHandle(
         boolean external,
         Optional<String> comment,
         Optional<Boolean> changeDataFeedEnabled,
+        boolean deletionVectorsEnabled,
         String schemaString,
         ColumnMappingMode columnMappingMode,
         OptionalInt maxColumnId,

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTableProperties.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTableProperties.java
@@ -42,13 +42,13 @@ public class DeltaLakeTableProperties
     public static final String CHECKPOINT_INTERVAL_PROPERTY = "checkpoint_interval";
     public static final String CHANGE_DATA_FEED_ENABLED_PROPERTY = "change_data_feed_enabled";
     public static final String COLUMN_MAPPING_MODE_PROPERTY = "column_mapping_mode";
-    // TODO Add support for creating tables with deletion vectors
+    public static final String DELETION_VECTORS_ENABLED_PROPERTY = "deletion_vectors_enabled";
 
     private final List<PropertyMetadata<?>> tableProperties;
 
     @SuppressWarnings("unchecked")
     @Inject
-    public DeltaLakeTableProperties()
+    public DeltaLakeTableProperties(DeltaLakeConfig config)
     {
         tableProperties = ImmutableList.<PropertyMetadata<?>>builder()
                 .add(stringProperty(
@@ -89,6 +89,11 @@ public class DeltaLakeTableProperties
                             }
                         },
                         false))
+                .add(booleanProperty(
+                        DELETION_VECTORS_ENABLED_PROPERTY,
+                        "Enables deletion vectors",
+                        config.isDeletionVectorsEnabled(),
+                        false))
                 .build();
     }
 
@@ -128,5 +133,10 @@ public class DeltaLakeTableProperties
     public static ColumnMappingMode getColumnMappingMode(Map<String, Object> tableProperties)
     {
         return ColumnMappingMode.valueOf(tableProperties.get(COLUMN_MAPPING_MODE_PROPERTY).toString().toUpperCase(ENGLISH));
+    }
+
+    public static boolean getDeletionVectorsEnabled(Map<String, Object> tableProperties)
+    {
+        return (boolean) tableProperties.getOrDefault(DELETION_VECTORS_ENABLED_PROPERTY, false);
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeSchemaSupport.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeSchemaSupport.java
@@ -102,7 +102,7 @@ public final class DeltaLakeSchemaSupport
     public static final String COLUMN_MAPPING_PHYSICAL_NAME_CONFIGURATION_KEY = "delta.columnMapping.physicalName";
     public static final String MAX_COLUMN_ID_CONFIGURATION_KEY = "delta.columnMapping.maxColumnId";
     public static final String ISOLATION_LEVEL_CONFIGURATION_KEY = "delta.isolationLevel";
-    private static final String DELETION_VECTORS_CONFIGURATION_KEY = "delta.enableDeletionVectors";
+    public static final String DELETION_VECTORS_CONFIGURATION_KEY = "delta.enableDeletionVectors";
     // https://github.com/delta-io/delta/blob/master/docs/source/delta-uniform.md
     private static final String UNIVERSAL_FORMAT_CONFIGURATION_KEY = "delta.universalFormat.enabledFormats";
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/MetadataEntry.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/MetadataEntry.java
@@ -31,6 +31,7 @@ import java.util.UUID;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_INVALID_SCHEMA;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.COLUMN_MAPPING_MODE_CONFIGURATION_KEY;
+import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.DELETION_VECTORS_CONFIGURATION_KEY;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.MAX_COLUMN_ID_CONFIGURATION_KEY;
 import static java.lang.Long.parseLong;
 import static java.lang.String.format;
@@ -167,12 +168,14 @@ public class MetadataEntry
     public static Map<String, String> configurationForNewTable(
             Optional<Long> checkpointInterval,
             Optional<Boolean> changeDataFeedEnabled,
+            boolean deletionVectorsEnabled,
             ColumnMappingMode columnMappingMode,
             OptionalInt maxFieldId)
     {
         ImmutableMap.Builder<String, String> configurationMapBuilder = ImmutableMap.builder();
         checkpointInterval.ifPresent(interval -> configurationMapBuilder.put(DELTA_CHECKPOINT_INTERVAL_PROPERTY, String.valueOf(interval)));
         changeDataFeedEnabled.ifPresent(enabled -> configurationMapBuilder.put(DELTA_CHANGE_DATA_FEED_ENABLED_PROPERTY, String.valueOf(enabled)));
+        configurationMapBuilder.put(DELETION_VECTORS_CONFIGURATION_KEY, Boolean.toString(deletionVectorsEnabled));
         switch (columnMappingMode) {
             case NONE -> { /* do nothing */ }
             case ID, NAME -> {

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAlluxioCacheFileOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAlluxioCacheFileOperations.java
@@ -93,7 +93,7 @@ public class TestDeltaLakeAlluxioCacheFileOperations
         assertFileSystemAccesses(
                 "SELECT * FROM test_cache_file_operations",
                 ImmutableMultiset.<CacheOperation>builder()
-                        .add(new CacheOperation("Alluxio.readCached", "00000000000000000000.json", 0, 757))
+                        .add(new CacheOperation("Alluxio.readCached", "00000000000000000000.json", 0, 794))
                         .add(new CacheOperation("Alluxio.readCached", "00000000000000000001.json", 0, 636))
                         .add(new CacheOperation("Alluxio.readCached", "00000000000000000002.json", 0, 636))
                         .add(new CacheOperation("Alluxio.readExternal", "00000000000000000002.json", 0, 636))
@@ -108,7 +108,7 @@ public class TestDeltaLakeAlluxioCacheFileOperations
         assertFileSystemAccesses(
                 "SELECT * FROM test_cache_file_operations",
                 ImmutableMultiset.<CacheOperation>builder()
-                        .add(new CacheOperation("Alluxio.readCached", "00000000000000000000.json", 0, 757))
+                        .add(new CacheOperation("Alluxio.readCached", "00000000000000000000.json", 0, 794))
                         .add(new CacheOperation("Alluxio.readCached", "00000000000000000001.json", 0, 636))
                         .add(new CacheOperation("Alluxio.readCached", "00000000000000000002.json", 0, 636))
                         .add(new CacheOperation("Alluxio.readCached", "key=p1/", 0, 220))
@@ -120,7 +120,7 @@ public class TestDeltaLakeAlluxioCacheFileOperations
         assertFileSystemAccesses(
                 "SELECT * FROM test_cache_file_operations",
                 ImmutableMultiset.<CacheOperation>builder()
-                        .add(new CacheOperation("Alluxio.readCached", "00000000000000000000.json", 0, 757))
+                        .add(new CacheOperation("Alluxio.readCached", "00000000000000000000.json", 0, 794))
                         .add(new CacheOperation("Alluxio.readCached", "00000000000000000001.json", 0, 636))
                         .add(new CacheOperation("Alluxio.readCached", "00000000000000000002.json", 0, 636))
                         .add(new CacheOperation("Alluxio.readCached", "00000000000000000003.json", 0, 636))
@@ -143,7 +143,7 @@ public class TestDeltaLakeAlluxioCacheFileOperations
         assertFileSystemAccesses(
                 "SELECT * FROM test_cache_file_operations",
                 ImmutableMultiset.<CacheOperation>builder()
-                        .add(new CacheOperation("Alluxio.readCached", "00000000000000000000.json", 0, 757))
+                        .add(new CacheOperation("Alluxio.readCached", "00000000000000000000.json", 0, 794))
                         .add(new CacheOperation("Alluxio.readCached", "00000000000000000001.json", 0, 636))
                         .add(new CacheOperation("Alluxio.readCached", "00000000000000000002.json", 0, 636))
                         .add(new CacheOperation("Alluxio.readCached", "00000000000000000003.json", 0, 636))
@@ -435,9 +435,9 @@ public class TestDeltaLakeAlluxioCacheFileOperations
 
         assertFileSystemAccesses("CREATE OR REPLACE TABLE test_create_or_replace (id VARCHAR, age INT)",
                 ImmutableMultiset.<CacheOperation>builder()
-                        .add(new CacheOperation("Alluxio.readCached", "00000000000000000000.json", 0, 762))
-                        .add(new CacheOperation("Alluxio.readExternal", "00000000000000000000.json", 0, 762))
-                        .add(new CacheOperation("Alluxio.writeCache", "00000000000000000000.json", 0, 762))
+                        .add(new CacheOperation("Alluxio.readCached", "00000000000000000000.json", 0, 799))
+                        .add(new CacheOperation("Alluxio.readExternal", "00000000000000000000.json", 0, 799))
+                        .add(new CacheOperation("Alluxio.writeCache", "00000000000000000000.json", 0, 799))
                         .build());
         assertUpdate("DROP TABLE test_create_or_replace");
     }
@@ -451,9 +451,9 @@ public class TestDeltaLakeAlluxioCacheFileOperations
         assertFileSystemAccesses(
                 "CREATE OR REPLACE TABLE test_create_or_replace_as_select AS SELECT 1 col_name",
                 ImmutableMultiset.<CacheOperation>builder()
-                        .add(new CacheOperation("Alluxio.readCached", "00000000000000000000.json", 0, 1004))
-                        .add(new CacheOperation("Alluxio.readExternal", "00000000000000000000.json", 0, 1004))
-                        .add(new CacheOperation("Alluxio.writeCache", "00000000000000000000.json", 0, 1004))
+                        .add(new CacheOperation("Alluxio.readCached", "00000000000000000000.json", 0, 1041))
+                        .add(new CacheOperation("Alluxio.readExternal", "00000000000000000000.json", 0, 1041))
+                        .add(new CacheOperation("Alluxio.writeCache", "00000000000000000000.json", 0, 1041))
                         .build());
 
         assertUpdate("DROP TABLE test_create_or_replace_as_select");

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
@@ -42,6 +42,7 @@ import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.MaterializedRow;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingSession;
+import io.trino.testing.sql.TestTable;
 import org.apache.parquet.schema.PrimitiveType;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.BeforeAll;
@@ -59,6 +60,7 @@ import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -79,6 +81,7 @@ import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.util.Files.fileNamesIn;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
@@ -997,6 +1000,71 @@ public class TestDeltaLakeBasic
         assertQueryFails("INSERT INTO allow_column_defaults (a) VALUES (2)", "\\QUnsupported writer features: [allowColumnDefaults]");
     }
 
+    @Test
+    public void testDeletionVectorsEnabledCreateTable()
+            throws Exception
+    {
+        testDeletionVectorsEnabledCreateTable("(x int) WITH (deletion_vectors_enabled = true)");
+        testDeletionVectorsEnabledCreateTable("WITH (deletion_vectors_enabled = true) AS SELECT 1 x");
+    }
+
+    private void testDeletionVectorsEnabledCreateTable(String tableDefinition)
+            throws Exception
+    {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "deletion_vectors", tableDefinition)) {
+            assertThat((String) computeScalar("SHOW CREATE TABLE " + table.getName()))
+                    .contains("deletion_vectors_enabled = true");
+
+            String tableLocation = getTableLocation(table.getName());
+            List<DeltaLakeTransactionLogEntry> transactionLogs = getEntriesFromJson(0, tableLocation + "/_delta_log", FILE_SYSTEM).orElseThrow();
+            assertThat(transactionLogs.get(1).getProtocol())
+                    .isEqualTo(new ProtocolEntry(3, 7, Optional.of(Set.of("deletionVectors")), Optional.of(Set.of("deletionVectors"))));
+
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES 2, 3", 2);
+            assertUpdate("DELETE FROM " + table.getName() + " WHERE x = 2", 1);
+
+            assertThat(fileNamesIn(new URI(tableLocation).getPath(), false))
+                    .anyMatch(path -> path.matches(".*/deletion_vector_.*.bin"));
+
+            // TODO Allow disabling deletion_vectors_enabled table property. Delta Lake allows the operation.
+            assertQueryFails(
+                    "ALTER TABLE " + table.getName() + " SET PROPERTIES deletion_vectors_enabled = false",
+                    "The following properties cannot be updated: deletion_vectors_enabled");
+        }
+    }
+
+    @Test
+    public void testDeletionVectorsDisabledCreateTable()
+            throws Exception
+    {
+        testDeletionVectorsDisabledCreateTable("(x int) WITH (deletion_vectors_enabled = false)");
+        testDeletionVectorsDisabledCreateTable("WITH (deletion_vectors_enabled = false) AS SELECT 1 x");
+    }
+
+    private void testDeletionVectorsDisabledCreateTable(String tableDefinition)
+            throws Exception
+    {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "deletion_vectors", tableDefinition)) {
+            assertThat((String) computeScalar("SHOW CREATE TABLE " + table.getName()))
+                    .doesNotContain("deletion_vectors_enabled");
+
+            String tableLocation = getTableLocation(table.getName());
+            List<DeltaLakeTransactionLogEntry> transactionLogs = getEntriesFromJson(0, tableLocation + "/_delta_log", FILE_SYSTEM).orElseThrow();
+            assertThat(transactionLogs.get(1).getProtocol())
+                    .isEqualTo(new ProtocolEntry(1, 2, Optional.empty(), Optional.empty()));
+
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES 2, 3", 2);
+            assertUpdate("DELETE FROM " + table.getName() + " WHERE x = 2", 1);
+
+            assertThat(fileNamesIn(new URI(tableLocation).getPath(), false))
+                    .noneSatisfy(path -> assertThat(path).matches(".*/deletion_vector_.*.bin"));
+
+            // TODO Allow enabling deletion_vectors_enabled table property. Delta Lake allows the operation.
+            assertQueryFails(
+                    "ALTER TABLE " + table.getName() + " SET PROPERTIES deletion_vectors_enabled = true",
+                    "The following properties cannot be updated: deletion_vectors_enabled");
+        }
+    }
 
     /**
      * @see databricks122.deletion_vectors
@@ -1010,6 +1078,9 @@ public class TestDeltaLakeBasic
         Path tableLocation = catalogDir.resolve(tableName);
         copyDirectoryContents(new File(Resources.getResource("databricks122/deletion_vectors").toURI()).toPath(), tableLocation);
         assertUpdate("CALL system.register_table('%s', '%s', '%s')".formatted(getSession().getSchema().orElseThrow(), tableName, tableLocation.toUri()));
+
+        assertThat((String) computeScalar("SHOW CREATE TABLE " + tableName))
+                .contains("deletion_vectors_enabled = true");
 
         assertQuery("SELECT * FROM " + tableName, "VALUES (1, 11)");
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConfig.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConfig.java
@@ -71,7 +71,8 @@ public class TestDeltaLakeConfig
                 .setUniqueTableLocation(true)
                 .setRegisterTableProcedureEnabled(false)
                 .setProjectionPushdownEnabled(true)
-                .setQueryPartitionFilterRequired(false));
+                .setQueryPartitionFilterRequired(false)
+                .setDeletionVectorsEnabled(false));
     }
 
     @Test
@@ -110,6 +111,7 @@ public class TestDeltaLakeConfig
                 .put("delta.register-table-procedure.enabled", "true")
                 .put("delta.projection-pushdown-enabled", "false")
                 .put("delta.query-partition-filter-required", "true")
+                .put("delta.deletion-vectors-enabled", "true")
                 .buildOrThrow();
 
         DeltaLakeConfig expected = new DeltaLakeConfig()
@@ -144,7 +146,8 @@ public class TestDeltaLakeConfig
                 .setUniqueTableLocation(false)
                 .setRegisterTableProcedureEnabled(true)
                 .setProjectionPushdownEnabled(false)
-                .setQueryPartitionFilterRequired(true);
+                .setQueryPartitionFilterRequired(true)
+                .setDeletionVectorsEnabled(true);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
@@ -174,6 +174,7 @@ public class TestDeltaLakePageSink
                 true,
                 Optional.empty(),
                 Optional.of(false),
+                false,
                 schemaString,
                 NONE,
                 OptionalInt.empty(),

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSystemTables.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSystemTables.java
@@ -103,7 +103,12 @@ public class TestDeltaLakeSystemTables
         String tableName = "test_simple_properties_table";
         try {
             assertUpdate("CREATE TABLE " + tableName + " (_bigint BIGINT) WITH (change_data_feed_enabled = true, checkpoint_interval = 5)");
-            assertQuery("SELECT * FROM \"" + tableName + "$properties\"", "VALUES ('delta.enableChangeDataFeed', 'true'), ('delta.checkpointInterval', '5'), ('delta.minReaderVersion', '1'), ('delta.minWriterVersion', '4')");
+            assertQuery("SELECT * FROM \"" + tableName + "$properties\"", "VALUES " +
+                    "('delta.enableChangeDataFeed', 'true')," +
+                    "('delta.enableDeletionVectors', 'false')," +
+                    "('delta.checkpointInterval', '5')," +
+                    "('delta.minReaderVersion', '1')," +
+                    "('delta.minWriterVersion', '4')");
         }
         finally {
             assertUpdate("DROP TABLE IF EXISTS " + tableName);


### PR DESCRIPTION
## Description

Fixes #22104

## Release notes

```markdown
# Delta Lake
* Add support for creating tables with deletion vectors. ({issue}`22104`)
```
