### PR TITLE
Use ORDER BY tuple() by default in ClickHouse MergeTree

### DIFF
--- a/docs/src/main/sphinx/connector/clickhouse.md
+++ b/docs/src/main/sphinx/connector/clickhouse.md
@@ -154,13 +154,13 @@ WITH (
 
 The following are supported ClickHouse table properties from [https://clickhouse.tech/docs/en/engines/table-engines/mergetree-family/mergetree/](https://clickhouse.tech/docs/en/engines/table-engines/mergetree-family/mergetree/)
 
-| Property name  | Default value | Description                                                                                                             |
-| -------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `engine`       | `Log`         | Name and parameters of the engine.                                                                                      |
-| `order_by`     | (none)        | Array of columns or expressions to concatenate to create the sorting key. Required if `engine` is `MergeTree`.          |
-| `partition_by` | (none)        | Array of columns or expressions to use as nested partition keys. Optional.                                              |
-| `primary_key`  | (none)        | Array of columns or expressions to concatenate to create the primary key. Optional.                                     |
-| `sample_by`    | (none)        | An expression to use for [sampling](https://clickhouse.tech/docs/en/sql-reference/statements/select/sample/). Optional. |
+| Property name  | Default value | Description                                                                                                                            |
+| -------------- | ------------- |----------------------------------------------------------------------------------------------------------------------------------------|
+| `engine`       | `Log`         | Name and parameters of the engine.                                                                                                     |
+| `order_by`     | (none)        | Array of columns or expressions to concatenate to create the sorting key. `tuple()` is used by default if `order_by is` not specified. |
+| `partition_by` | (none)        | Array of columns or expressions to use as nested partition keys. Optional.                                                             |
+| `primary_key`  | (none)        | Array of columns or expressions to concatenate to create the primary key. Optional.                                                    |
+| `sample_by`    | (none)        | An expression to use for [sampling](https://clickhouse.tech/docs/en/sql-reference/statements/select/sample/). Optional.                |
 
 Currently the connector only supports `Log` and `MergeTree` table engines
 in create table statement. `ReplicatedMergeTree` engine is not yet supported.

--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
@@ -157,7 +157,6 @@ import static io.trino.plugin.jdbc.StandardColumnMappings.varcharWriteFunction;
 import static io.trino.plugin.jdbc.TypeHandlingJdbcSessionProperties.getUnsupportedTypeHandling;
 import static io.trino.plugin.jdbc.UnsupportedTypeHandling.CONVERT_TO_VARCHAR;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
-import static io.trino.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.SCHEMA_NOT_EMPTY;
 import static io.trino.spi.connector.ConnectorMetadata.MODIFYING_ROWS_MESSAGE;
@@ -401,9 +400,8 @@ public class ClickHouseClient
         ClickHouseEngineType engine = ClickHouseTableProperties.getEngine(tableProperties);
         tableOptions.add("ENGINE = " + engine.getEngineType());
         if (engine == ClickHouseEngineType.MERGETREE && formatProperty(ClickHouseTableProperties.getOrderBy(tableProperties)).isEmpty()) {
-            // order_by property is required
-            throw new TrinoException(INVALID_TABLE_PROPERTY,
-                    format("The property of %s is required for table engine %s", ClickHouseTableProperties.ORDER_BY_PROPERTY, engine.getEngineType()));
+            // https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/mergetree#order_by
+            tableOptions.add("ORDER BY tuple()");
         }
         formatProperty(ClickHouseTableProperties.getOrderBy(tableProperties)).ifPresent(value -> tableOptions.add("ORDER BY " + value));
         formatProperty(ClickHouseTableProperties.getPrimaryKey(tableProperties)).ifPresent(value -> tableOptions.add("PRIMARY KEY " + value));

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
@@ -355,7 +355,9 @@ public class TestClickHouseConnectorTest
         assertThat(getQueryRunner().tableExists(getSession(), tableName)).isTrue();
         assertUpdate("DROP TABLE " + tableName);
         // MergeTree without order by
-        assertQueryFails("CREATE TABLE " + tableName + " (id int NOT NULL, x VARCHAR) WITH (engine = 'MergeTree')", "The property of order_by is required for table engine MergeTree\\(\\)");
+        assertUpdate("CREATE TABLE " + tableName + " (id int NOT NULL, x VARCHAR) WITH (engine = 'MergeTree')");
+        assertThat(getQueryRunner().tableExists(getSession(), tableName)).isTrue();
+        assertUpdate("DROP TABLE " + tableName);
 
         // MergeTree with optional
         assertUpdate("CREATE TABLE " + tableName + " (id int NOT NULL, x VARCHAR, logdate DATE NOT NULL) WITH " +
@@ -373,7 +375,7 @@ public class TestClickHouseConnectorTest
 
         //NOT support engine
         assertQueryFails("CREATE TABLE " + tableName + " (id int NOT NULL, x VARCHAR) WITH (engine = 'bad_engine')",
-                "line 1:76: Unable to set catalog 'clickhouse' table property 'engine' to.*");
+                ".* Unable to set catalog 'clickhouse' table property 'engine' to.*");
     }
 
     @Test
@@ -509,15 +511,15 @@ public class TestClickHouseConnectorTest
 
         // Primary key must be a prefix of the sorting key,
         assertQueryFails("CREATE TABLE " + tableName + " (id int NOT NULL, x boolean NOT NULL, y boolean NOT NULL) WITH (engine = 'MergeTree', order_by = ARRAY['id'], sample_by = ARRAY['x', 'y'])",
-                "line 1:151: Invalid value for catalog 'clickhouse' table property 'sample_by': .*");
+                ".* Invalid value for catalog 'clickhouse' table property 'sample_by': .*");
 
         // wrong property type
         assertQueryFails("CREATE TABLE " + tableName + " (id int NOT NULL) WITH (engine = 'MergeTree', order_by = 'id')",
-                "line 1:87: Invalid value for catalog 'clickhouse' table property 'order_by': .*");
+                ".* Invalid value for catalog 'clickhouse' table property 'order_by': .*");
         assertQueryFails("CREATE TABLE " + tableName + " (id int NOT NULL) WITH (engine = 'MergeTree', order_by = ARRAY['id'], primary_key = 'id')",
-                "line 1:111: Invalid value for catalog 'clickhouse' table property 'primary_key': .*");
+                ".* Invalid value for catalog 'clickhouse' table property 'primary_key': .*");
         assertQueryFails("CREATE TABLE " + tableName + " (id int NOT NULL) WITH (engine = 'MergeTree', order_by = ARRAY['id'], primary_key = ARRAY['id'], partition_by = 'id')",
-                "line 1:138: Invalid value for catalog 'clickhouse' table property 'partition_by': .*");
+                ".* Invalid value for catalog 'clickhouse' table property 'partition_by': .*");
     }
 
     @Test

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
@@ -346,7 +346,7 @@ public class TestClickHouseConnectorTest
     @Test
     public void testDifferentEngine()
     {
-        String tableName = "test_add_column_" + randomNameSuffix();
+        String tableName = "test_different_engine_" + randomNameSuffix();
         // MergeTree
         assertUpdate("CREATE TABLE " + tableName + " (id int NOT NULL, x VARCHAR) WITH (engine = 'MergeTree', order_by = ARRAY['id'])");
         assertThat(getQueryRunner().tableExists(getSession(), tableName)).isTrue();
@@ -379,7 +379,7 @@ public class TestClickHouseConnectorTest
     @Test
     public void testTableProperty()
     {
-        String tableName = "test_add_column_" + randomNameSuffix();
+        String tableName = "test_table_property_" + randomNameSuffix();
         // no table property, it should create a table with default Log engine table
         assertUpdate("CREATE TABLE " + tableName + " (id int NOT NULL, x VARCHAR)");
         assertThat(getQueryRunner().tableExists(getSession(), tableName)).isTrue();


### PR DESCRIPTION
## Description

ClickHouse allows `ORDER BY tuple()` expression when no sorting is required with MergeTree engine.

Fixes #23048

## Release notes

```markdown
# ClickHouse
* TBD. ({issue}`23048`)
```
