### PR TITLE
Fix handling of duplicate column names in parquet reader

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
@@ -113,7 +113,9 @@ public final class ParquetTypeUtils
                 .stream()
                 .collect(toImmutableMap(
                         columnIO -> Arrays.asList(columnIO.getFieldPath()),
-                        PrimitiveColumnIO::getColumnDescriptor));
+                        PrimitiveColumnIO::getColumnDescriptor,
+                        // Same column name may occur more than once when the file is written by case-sensitive tools
+                        (oldValue, _) -> oldValue));
     }
 
     @SuppressWarnings("deprecation")

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/metadata/PrunedBlockMetadata.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/metadata/PrunedBlockMetadata.java
@@ -38,7 +38,11 @@ public final class PrunedBlockMetadata
     {
         Set<List<String>> requiredPaths = descriptorsByPath.keySet();
         Map<List<String>, ColumnChunkMetadata> columnMetadataByPath = blockMetadata.columns().stream()
-                .collect(toImmutableMap(column -> asList(column.getPath().toArray()), identity()));
+                .collect(toImmutableMap(
+                        column -> asList(column.getPath().toArray()),
+                        identity(),
+                        // Same column name may occur more than once when the file is written by case-sensitive tools
+                        (oldValue, _) -> oldValue));
         ImmutableMap.Builder<List<String>, ColumnChunkMetadata> columnMetadataByPathBuilder = ImmutableMap.builderWithExpectedSize(requiredPaths.size());
         for (Map.Entry<List<String>, ColumnDescriptor> entry : descriptorsByPath.entrySet()) {
             List<String> requiredPath = entry.getKey();

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
@@ -616,10 +616,11 @@ public final class TestHiveFileFormats
     public void testParquetCaseSensitivity(int rowCount)
             throws Exception
     {
-        TestColumn writeColumn = new TestColumn("UPPER_CASE_COLUMN", createVarcharType(4), new HiveVarchar("test", 4), utf8Slice("test"));
-        TestColumn readColumn = new TestColumn("uppeR_casE_columN", createVarcharType(4), new HiveVarchar("test", 4), utf8Slice("test"));
+        TestColumn writeColumnA = new TestColumn("UPPER_CASE_COLUMN", createVarcharType(5), new HiveVarchar("testA", 5), utf8Slice("testA"));
+        TestColumn writeColumnB = new TestColumn("Upper_Case_Column", createVarcharType(5), new HiveVarchar("testB", 5), utf8Slice("testB"));
+        TestColumn readColumn = new TestColumn("uppeR_casE_columN", createVarcharType(5), new HiveVarchar("testA", 5), utf8Slice("testA"));
         assertThatFileFormat(PARQUET)
-                .withWriteColumns(ImmutableList.of(writeColumn))
+                .withWriteColumns(ImmutableList.of(writeColumnA, writeColumnB))
                 .withReadColumns(ImmutableList.of(readColumn))
                 .withSession(PARQUET_SESSION_USE_NAME)
                 .withRowsCount(rowCount)


### PR DESCRIPTION
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Parquet files may contain duplicate column names when written by case sensitive tools. 
We read the first case insensitive match from the file in this scenario.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes query failures caused by https://github.com/trinodb/trino/pull/22538


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Hudi, Iceberg, Delta
* Fixes query failures due to "Multiple entries with same key" when reading parquet files. ({issue}`23050`)
```
