### PR TITLE
Introduce Loki connector.

### DIFF
--- a/core/trino-server/src/main/provisio/trino.xml
+++ b/core/trino-server/src/main/provisio/trino.xml
@@ -201,6 +201,12 @@
         </artifact>
     </artifactSet>
 
+    <artifactSet to="plugin/loki">
+        <artifact id="${project.groupId}:trino-loki:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
+
     <artifactSet to="plugin/mariadb">
         <artifact id="${project.groupId}:trino-mariadb:zip:${project.version}">
             <unpack />

--- a/plugin/trino-loki/README.md
+++ b/plugin/trino-loki/README.md
@@ -1,0 +1,16 @@
+# Trino Loki Connector
+
+## Testing
+
+The test query runner in `src/test/java/io.trino.loki` starts a Docker compose with Loki and Grafana. It can be used with `trino-cli  http://127.0.0.1:8080/loki/default` or through
+Grafana under http://localhost:3000.
+
+The are some example queries:
+
+```sql
+SELECT * FROM TABLE(default.loki(QUERY => 'sum by(level)(bytes_over_time({source="stdout"} | logfmt [5m]))'));
+```
+
+```sql
+SELECT labels['service_name'], COUNT(*) FROM TABLE(default.loki(QUERY => '{source="stdout"}')) group by labels['service_name'];
+```

--- a/plugin/trino-loki/pom.xml
+++ b/plugin/trino-loki/pom.xml
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.trino</groupId>
+        <artifactId>trino-root</artifactId>
+        <version>470-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>trino-loki</artifactId>
+    <packaging>trino-plugin</packaging>
+    <description>Trino - Loki connector</description>
+
+    <properties>
+        <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.jeschkies</groupId>
+            <artifactId>loki-client</artifactId>
+            <version>0.0.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-plugin-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jol</groupId>
+            <artifactId>jol-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log-manager</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>node</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>http-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>junit-extensions</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>4.4.16</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiColumnHandle.java
+++ b/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiColumnHandle.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.loki;
+
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.type.Type;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public record LokiColumnHandle(String name, Type type, int ordinalPosition)
+        implements ColumnHandle
+{
+    public LokiColumnHandle
+    {
+        requireNonNull(name, "name is null");
+        requireNonNull(type, "type is null");
+
+        checkArgument(ordinalPosition >= 0, "Ordinal position must be greater or equal to 0");
+    }
+
+    public ColumnMetadata columnMetadata()
+    {
+        return new ColumnMetadata(name, type);
+    }
+}

--- a/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiConnector.java
+++ b/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiConnector.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.loki;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
+import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorRecordSetProvider;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplitManager;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.function.table.ConnectorTableFunction;
+import io.trino.spi.transaction.IsolationLevel;
+
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public class LokiConnector
+        implements Connector
+{
+    private final ConnectorMetadata metadata;
+    private final ConnectorSplitManager splitManager;
+    private final ConnectorRecordSetProvider recordSetProvider;
+    private final Set<ConnectorTableFunction> connectorTableFunctions;
+
+    @Inject
+    public LokiConnector(
+            ConnectorMetadata metadata,
+            ConnectorSplitManager splitManager,
+            ConnectorRecordSetProvider recordSetProvider,
+            Set<ConnectorTableFunction> connectorTableFunctions)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.splitManager = requireNonNull(splitManager, "splitManager is null");
+        this.recordSetProvider = requireNonNull(recordSetProvider, "recordSetProvider is null");
+        this.connectorTableFunctions = ImmutableSet.copyOf(requireNonNull(connectorTableFunctions, "connectorTableFunctions is null"));
+    }
+
+    public enum LokiTransactionHandle
+            implements ConnectorTransactionHandle
+    {
+        INSTANCE
+    }
+
+    @Override
+    public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly, boolean autoCommit)
+    {
+        return LokiTransactionHandle.INSTANCE;
+    }
+
+    @Override
+    public ConnectorMetadata getMetadata(ConnectorSession session, ConnectorTransactionHandle transactionHandle)
+    {
+        return metadata;
+    }
+
+    @Override
+    public Set<ConnectorTableFunction> getTableFunctions()
+    {
+        return connectorTableFunctions;
+    }
+
+    @Override
+    public ConnectorSplitManager getSplitManager()
+    {
+        return splitManager;
+    }
+
+    @Override
+    public ConnectorRecordSetProvider getRecordSetProvider()
+    {
+        return recordSetProvider;
+    }
+}

--- a/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiConnectorConfig.java
+++ b/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiConnectorConfig.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.loki;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigSecuritySensitive;
+import io.airlift.units.Duration;
+import io.airlift.units.MinDuration;
+import jakarta.validation.constraints.AssertFalse;
+import jakarta.validation.constraints.NotNull;
+
+import java.net.URI;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+public class LokiConnectorConfig
+{
+    private URI lokiUri;
+    private String user;
+    private String password;
+    private Duration queryTimeout = new Duration(10, TimeUnit.SECONDS);
+
+    @NotNull
+    public URI getLokiUri()
+    {
+        return lokiUri;
+    }
+
+    @Config("loki.uri")
+    @ConfigDescription("Loki API endpoint base")
+    public LokiConnectorConfig setLokiUri(URI lokiUri)
+    {
+        this.lokiUri = lokiUri;
+        return this;
+    }
+
+    @NotNull
+    public Optional<String> getUser()
+    {
+        return Optional.ofNullable(user);
+    }
+
+    @Config("loki.auth.user")
+    public LokiConnectorConfig setUser(String user)
+    {
+        this.user = user;
+        return this;
+    }
+
+    @NotNull
+    public Optional<String> getPassword()
+    {
+        return Optional.ofNullable(password);
+    }
+
+    @Config("loki.auth.password")
+    @ConfigSecuritySensitive
+    public LokiConnectorConfig setPassword(String password)
+    {
+        this.password = password;
+        return this;
+    }
+
+    @MinDuration("1s")
+    public Duration getQueryTimeout()
+    {
+        return queryTimeout;
+    }
+
+    @Config("loki.query-timeout")
+    @ConfigDescription("How much time a query to Loki has before timing out")
+    public LokiConnectorConfig setQueryTimeout(Duration queryTimeout)
+    {
+        this.queryTimeout = queryTimeout;
+        return this;
+    }
+
+    @AssertFalse(message = "Either User and password must be specified or none.")
+    public boolean isConfigValid()
+    {
+        return getPassword().isPresent() ^ getUser().isPresent();
+    }
+}

--- a/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiConnectorFactory.java
+++ b/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiConnectorFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.loki;
+
+import com.google.inject.Injector;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.json.JsonModule;
+import io.trino.plugin.base.TypeDeserializerModule;
+import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorContext;
+import io.trino.spi.connector.ConnectorFactory;
+
+import java.util.Map;
+
+import static com.google.common.base.Throwables.throwIfUnchecked;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
+import static java.util.Objects.requireNonNull;
+
+public class LokiConnectorFactory
+        implements ConnectorFactory
+{
+    @Override
+    public String getName()
+    {
+        return "loki";
+    }
+
+    @Override
+    public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
+    {
+        requireNonNull(requiredConfig, "requiredConfig is null");
+        checkStrictSpiVersionMatch(context, this);
+
+        try {
+            // A plugin is not required to use Guice; it is just very convenient
+            Bootstrap app = new Bootstrap(
+                    new JsonModule(),
+                    new TypeDeserializerModule(context.getTypeManager()),
+                    new LokiModule());
+
+            Injector injector = app
+                    .doNotInitializeLogging()
+                    .setRequiredConfigurationProperties(requiredConfig)
+                    .initialize();
+
+            return injector.getInstance(LokiConnector.class);
+        }
+        catch (Exception e) {
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiErrorCode.java
+++ b/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiErrorCode.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.loki;
+
+import io.trino.spi.ErrorCode;
+import io.trino.spi.ErrorCodeSupplier;
+import io.trino.spi.ErrorType;
+
+import static io.trino.spi.ErrorType.EXTERNAL;
+
+public enum LokiErrorCode
+        implements ErrorCodeSupplier
+{
+    LOKI_CLIENT_ERROR(0, EXTERNAL),
+    LOKI_TABLE_ERROR(1, EXTERNAL);
+
+    private final ErrorCode errorCode;
+
+    LokiErrorCode(int code, ErrorType type)
+    {
+        errorCode = new ErrorCode(code + 0x0513_0000, name(), type);
+    }
+
+    @Override
+    public ErrorCode toErrorCode()
+    {
+        return errorCode;
+    }
+}

--- a/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiMatrixValuePairsIterator.java
+++ b/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiMatrixValuePairsIterator.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.loki;
+
+import io.github.jeschkies.loki.client.model.Matrix;
+import io.github.jeschkies.loki.client.model.MetricPoint;
+import io.trino.spi.type.TimeZoneKey;
+
+import java.time.Instant;
+import java.util.Iterator;
+import java.util.Map;
+
+import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
+
+public class LokiMatrixValuePairsIterator
+        implements LokiQueryResultIterator
+{
+    private final Iterator<LokiMatrixValuePairsIterator.Point> metrics;
+
+    record Point(MetricPoint timeAndValue, Map<String, String> labels) {}
+
+    private Point current;
+
+    public LokiMatrixValuePairsIterator(Matrix matrix)
+    {
+        this.metrics = matrix.getMetrics()
+                .stream()
+                .flatMap(metric -> metric.values().stream()
+                        .map(value -> new LokiMatrixValuePairsIterator.Point(value, metric.labels()))).iterator();
+    }
+
+    @Override
+    public boolean advanceNextPosition()
+    {
+        if (!metrics.hasNext()) {
+            return false;
+        }
+        current = metrics.next();
+        return true;
+    }
+
+    @Override
+    public Map<String, String> getLabels()
+    {
+        return current.labels;
+    }
+
+    @Override
+    public long getTimestamp()
+    {
+        return toTimeWithTimeZone(current.timeAndValue.getTs());
+    }
+
+    @Override
+    public Object getValue()
+    {
+        return current.timeAndValue.getValue();
+    }
+
+    /**
+     * Metric value pairs have a timestamp in seconds.
+     *
+     * @param seconds since epoch.
+     * @return time in Trino's packed format.
+     */
+    long toTimeWithTimeZone(Long seconds)
+    {
+        return packDateTimeWithZone(Instant.ofEpochSecond(seconds).toEpochMilli(), TimeZoneKey.UTC_KEY);
+    }
+}

--- a/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiMetadata.java
+++ b/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiMetadata.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.loki;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import io.github.jeschkies.loki.client.LokiClient;
+import io.github.jeschkies.loki.client.LokiClientException;
+import io.github.jeschkies.loki.client.model.Data;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.ConnectorTableVersion;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.TableFunctionApplicationResult;
+import io.trino.spi.function.table.ConnectorTableFunctionHandle;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeManager;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.loki.LokiTableFunction.SCHEMA_NAME;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static io.trino.spi.type.TypeSignature.mapType;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.util.Objects.requireNonNull;
+
+public class LokiMetadata
+        implements ConnectorMetadata
+{
+    private static final String TABLE_NAME = "default";
+
+    private final Type labelsMapType;
+
+    private final LokiClient lokiClient;
+
+    @Inject
+    public LokiMetadata(LokiClient lokiClient, TypeManager typeManager)
+    {
+        this.lokiClient = requireNonNull(lokiClient, "lokiClient is null");
+        labelsMapType = typeManager.getType(mapType(VARCHAR.getTypeSignature(), VARCHAR.getTypeSignature()));
+    }
+
+    @Override
+    public Optional<TableFunctionApplicationResult<ConnectorTableHandle>> applyTableFunction(ConnectorSession session, ConnectorTableFunctionHandle handle)
+    {
+        if (!(handle instanceof LokiTableFunction.QueryHandle queryHandle)) {
+            return Optional.empty();
+        }
+
+        LokiTableHandle tableHandle = queryHandle.getTableHandle();
+        return Optional.of(new TableFunctionApplicationResult<>(tableHandle, tableHandle.columnHandles()));
+    }
+
+    @Override
+    public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
+    {
+        LokiTableHandle lokiTableHandle = (LokiTableHandle) table;
+
+        List<ColumnMetadata> columns = lokiTableHandle.columnHandles()
+                .stream()
+                .map(LokiColumnHandle.class::cast)
+                .map(LokiColumnHandle::columnMetadata)
+                .collect(toImmutableList());
+
+        return new ConnectorTableMetadata(new SchemaTableName(SCHEMA_NAME, TABLE_NAME), columns);
+    }
+
+    @Override
+    public ConnectorTableHandle getTableHandle(
+            ConnectorSession session,
+            SchemaTableName tableName,
+            Optional<ConnectorTableVersion> startVersion,
+            Optional<ConnectorTableVersion> endVersion)
+    {
+        throw new TrinoException(LokiErrorCode.LOKI_TABLE_ERROR, "Loki connector does not support querying tables directly. Use the TABLE function instead.");
+    }
+
+    @Override
+    public ColumnMetadata getColumnMetadata(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
+    {
+        LokiColumnHandle lokiColumnHandler = (LokiColumnHandle) columnHandle;
+        return lokiColumnHandler.columnMetadata();
+    }
+
+    public List<ColumnHandle> getColumnHandles(String query)
+    {
+        ImmutableList.Builder<ColumnHandle> columnsBuilder = ImmutableList.builderWithExpectedSize(3);
+        columnsBuilder.add(new LokiColumnHandle("labels", this.labelsMapType, 0));
+        columnsBuilder.add(new LokiColumnHandle("timestamp", TIMESTAMP_TZ_MILLIS, 1));
+
+        try {
+            Type valueType = lokiClient.getExpectedResultType(query) == Data.ResultType.Matrix ? DOUBLE : VARCHAR;
+            columnsBuilder.add(new LokiColumnHandle("value", valueType, 2));
+        }
+        catch (LokiClientException e) {
+            throw new TrinoException(LokiErrorCode.LOKI_CLIENT_ERROR, e);
+        }
+
+        return columnsBuilder.build();
+    }
+}

--- a/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiModule.java
+++ b/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiModule.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.loki;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+import io.github.jeschkies.loki.client.LokiClient;
+import io.github.jeschkies.loki.client.LokiClientConfig;
+import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorRecordSetProvider;
+import io.trino.spi.connector.ConnectorSplitManager;
+import io.trino.spi.function.table.ConnectorTableFunction;
+
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class LokiModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(LokiConnector.class).in(Scopes.SINGLETON);
+        binder.bind(ConnectorMetadata.class).to(LokiMetadata.class).in(Scopes.SINGLETON);
+        binder.bind(LokiMetadata.class).in(Scopes.SINGLETON);
+        binder.bind(ConnectorSplitManager.class).to(LokiSplitManager.class).in(Scopes.SINGLETON);
+        binder.bind(ConnectorRecordSetProvider.class).to(LokiRecordSetProvider.class).in(Scopes.SINGLETON);
+        newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(LokiTableFunctionProvider.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfig(LokiConnectorConfig.class);
+    }
+
+    @Provides
+    @Singleton
+    public static LokiClient getLokiClient(LokiConnectorConfig config)
+    {
+        return new LokiClient(new LokiClientConfig(config.getLokiUri(), config.getQueryTimeout().toJavaTime()));
+    }
+}

--- a/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiPlugin.java
+++ b/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiPlugin.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.loki;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.Plugin;
+import io.trino.spi.connector.ConnectorFactory;
+
+public class LokiPlugin
+        implements Plugin
+{
+    @Override
+    public Iterable<ConnectorFactory> getConnectorFactories()
+    {
+        return ImmutableList.of(new LokiConnectorFactory());
+    }
+}

--- a/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiQueryResultIterator.java
+++ b/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiQueryResultIterator.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.loki;
+
+import java.util.Map;
+
+public interface LokiQueryResultIterator
+{
+    boolean advanceNextPosition();
+
+    Map<String, String> getLabels();
+
+    /**
+     * @return TimestampWithZone
+     */
+    long getTimestamp();
+
+    Object getValue();
+}

--- a/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiRecordCursor.java
+++ b/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiRecordCursor.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.loki;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.spi.block.SqlMap;
+import io.trino.spi.connector.RecordCursor;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeUtils;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.spi.block.MapValueBuilder.buildMapValue;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static java.util.Objects.requireNonNull;
+
+public class LokiRecordCursor
+        implements RecordCursor
+{
+    private final List<LokiColumnHandle> columnHandles;
+    private final LokiQueryResultIterator resultIterator;
+
+    private boolean advanced;
+
+    public LokiRecordCursor(List<LokiColumnHandle> columnHandles, LokiQueryResultIterator queryResult)
+    {
+        requireNonNull(columnHandles, "columnHandles is null");
+        requireNonNull(queryResult, "queryResult is null");
+
+        this.resultIterator = queryResult;
+        this.columnHandles = columnHandles.stream()
+                .sorted(Comparator.comparing(LokiColumnHandle::ordinalPosition))
+                .collect(toImmutableList());
+    }
+
+    @Override
+    public boolean advanceNextPosition()
+    {
+        this.advanced = true;
+        return this.resultIterator.advanceNextPosition();
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return 0;
+    }
+
+    @Override
+    public Type getType(int field)
+    {
+        checkArgument(field < columnHandles.size(), "Invalid field index");
+        return columnHandles.get(field).type();
+    }
+
+    @Override
+    public boolean getBoolean(int field)
+    {
+        throw new UnsupportedOperationException("Loki connector does not support boolean fields");
+    }
+
+    @Override
+    public long getLong(int field)
+    {
+        checkFieldType(field, TIMESTAMP_TZ_MILLIS);
+        return (long) requireNonNull(getFieldValue(field));
+    }
+
+    @Override
+    public double getDouble(int field)
+    {
+        checkFieldType(field, DOUBLE);
+        return (double) requireNonNull(getFieldValue(field));
+    }
+
+    @Override
+    public Slice getSlice(int field)
+    {
+        checkFieldType(field, createUnboundedVarcharType());
+        return Slices.utf8Slice((String) requireNonNull(getFieldValue(field)));
+    }
+
+    @Override
+    public Object getObject(int field)
+    {
+        return getFieldValue(field);
+    }
+
+    @Override
+    public boolean isNull(int field)
+    {
+        checkArgument(field < columnHandles.size(), "Invalid field index");
+        return getFieldValue(field) == null;
+    }
+
+    private Object getFieldValue(int field)
+    {
+        checkState(this.advanced, "Cursor has not been advanced yet");
+
+        if (field < 0 || field >= columnHandles.size()) {
+            throw new IllegalArgumentException("Invalid field index: " + field);
+        }
+
+        LokiColumnHandle column = this.columnHandles.get(field);
+        return switch (column.name()) {
+            case "labels" -> getSqlMapFromLabels((MapType) column.type(), this.resultIterator.getLabels());
+            case "timestamp" -> this.resultIterator.getTimestamp();
+            case "value" -> this.resultIterator.getValue();
+            default -> throw new IllegalArgumentException("Unknown column: " + column.name());
+        };
+    }
+
+    @Override
+    public void close()
+    {
+    }
+
+    private void checkFieldType(int field, Type expected)
+    {
+        Type actual = getType(field);
+        checkArgument(actual.equals(expected), "Expected field %s to be type %s but is %s", field, expected, actual);
+    }
+
+    // Copy from Loki to handle map<string,string>
+    static SqlMap getSqlMapFromLabels(MapType mapType, Map<String, String> labels)
+    {
+        Type keyType = mapType.getKeyType();
+        Type valueType = mapType.getValueType();
+
+        return buildMapValue(mapType, labels.size(), (keyBuilder, valueBuilder) -> {
+            labels.forEach((key, value) -> {
+                TypeUtils.writeNativeValue(keyType, keyBuilder, key);
+                TypeUtils.writeNativeValue(valueType, valueBuilder, value);
+            });
+        });
+    }
+}

--- a/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiRecordSet.java
+++ b/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiRecordSet.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.loki;
+
+import com.google.common.collect.ImmutableList;
+import io.github.jeschkies.loki.client.LokiClient;
+import io.github.jeschkies.loki.client.LokiClientException;
+import io.github.jeschkies.loki.client.model.Matrix;
+import io.github.jeschkies.loki.client.model.QueryResult;
+import io.github.jeschkies.loki.client.model.Streams;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.RecordCursor;
+import io.trino.spi.connector.RecordSet;
+import io.trino.spi.type.Type;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class LokiRecordSet
+        implements RecordSet
+{
+    private final List<LokiColumnHandle> columnHandles;
+    private final List<Type> columnTypes;
+
+    private final QueryResult result;
+
+    public LokiRecordSet(LokiClient lokiClient, LokiSplit split, List<LokiColumnHandle> columnHandles)
+    {
+        requireNonNull(lokiClient, "lokiClient is null");
+        requireNonNull(split, "split is null");
+        requireNonNull(columnHandles, "columnHandles is null");
+
+        this.columnHandles = ImmutableList.copyOf(columnHandles);
+        this.columnTypes = columnHandles.stream().map(LokiColumnHandle::type).collect(toImmutableList());
+
+        // Execute the query
+        try {
+            this.result = lokiClient.rangeQuery(split.query(), split.start(), split.end());
+        }
+        catch (LokiClientException e) {
+            throw new TrinoException(LokiErrorCode.LOKI_CLIENT_ERROR, e);
+        }
+    }
+
+    @Override
+    public List<Type> getColumnTypes()
+    {
+        return columnTypes;
+    }
+
+    @Override
+    public RecordCursor cursor()
+    {
+        return switch (result.getData().getResult()) {
+            case Streams streams -> new LokiRecordCursor(columnHandles, new LokiStreamEntriesIterator(streams));
+            case Matrix matrix -> new LokiRecordCursor(columnHandles, new LokiMatrixValuePairsIterator(matrix));
+        };
+    }
+}

--- a/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiRecordSetProvider.java
+++ b/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiRecordSetProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.loki;
+
+import com.google.inject.Inject;
+import io.github.jeschkies.loki.client.LokiClient;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorRecordSetProvider;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.RecordSet;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+// TODO: replace with LokiPageSourceProvider eventually.
+public class LokiRecordSetProvider
+        implements ConnectorRecordSetProvider
+{
+    private final LokiClient lokiClient;
+
+    @Inject
+    public LokiRecordSetProvider(LokiClient lokiClient)
+    {
+        this.lokiClient = requireNonNull(lokiClient, "lokiClient is null");
+    }
+
+    @Override
+    public RecordSet getRecordSet(ConnectorTransactionHandle transaction, ConnectorSession session, ConnectorSplit split, ConnectorTableHandle table, List<? extends ColumnHandle> columns)
+    {
+        LokiSplit lokiSplit = (LokiSplit) split;
+
+        List<LokiColumnHandle> handles = columns.stream().map(LokiColumnHandle.class::cast).collect(toImmutableList());
+        return new LokiRecordSet(lokiClient, lokiSplit, handles);
+    }
+}

--- a/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiSplit.java
+++ b/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiSplit.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.loki;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.connector.ConnectorSplit;
+
+import java.time.Instant;
+
+import static java.util.Objects.requireNonNull;
+
+public record LokiSplit(
+        @JsonProperty("query") String query,
+        @JsonProperty("start") Instant start,
+        @JsonProperty("end") Instant end)
+        implements ConnectorSplit
+{
+    @JsonCreator
+    public LokiSplit
+    {
+        requireNonNull(query);
+        requireNonNull(start);
+        requireNonNull(end);
+    }
+}

--- a/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiSplitManager.java
+++ b/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiSplitManager.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.loki;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.log.Logger;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.connector.ConnectorSplitManager;
+import io.trino.spi.connector.ConnectorSplitSource;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.Constraint;
+import io.trino.spi.connector.DynamicFilter;
+import io.trino.spi.connector.FixedSplitSource;
+
+import java.util.List;
+
+public class LokiSplitManager
+        implements ConnectorSplitManager
+{
+    private static final Logger log = Logger.get(LokiSplitManager.class);
+
+    @Override
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transaction,
+            ConnectorSession session,
+            ConnectorTableHandle connectorTableHandle,
+            DynamicFilter dynamicFilter,
+            Constraint constraint)
+    {
+        final LokiTableHandle table = (LokiTableHandle) connectorTableHandle;
+
+        List<ConnectorSplit> splits = ImmutableList.of(new LokiSplit(table.query(), table.start(), table.end()));
+
+        log.debug("created %d splits", splits.size());
+        return new FixedSplitSource(splits);
+    }
+}

--- a/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiStreamEntriesIterator.java
+++ b/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiStreamEntriesIterator.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.loki;
+
+import io.github.jeschkies.loki.client.model.LogEntry;
+import io.github.jeschkies.loki.client.model.Streams;
+import io.trino.spi.type.TimeZoneKey;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
+import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MILLISECOND;
+
+public class LokiStreamEntriesIterator
+        implements LokiQueryResultIterator
+{
+    private final Iterator<LabelledEntry> entries;
+
+    record LabelledEntry(LogEntry entry, Map<String, String> labels) {}
+
+    private LabelledEntry current;
+
+    public LokiStreamEntriesIterator(Streams streamsResult)
+    {
+        this.entries = streamsResult.getStreams()
+                .stream()
+                .flatMap(stream -> stream.values().stream()
+                        .map(value -> new LabelledEntry(value, stream.labels()))).iterator();
+    }
+
+    @Override
+    public boolean advanceNextPosition()
+    {
+        if (!entries.hasNext()) {
+            return false;
+        }
+        current = entries.next();
+        return true;
+    }
+
+    @Override
+    public Map<String, String> getLabels()
+    {
+        return current.labels;
+    }
+
+    @Override
+    public long getTimestamp()
+    {
+        return toTimeWithTimeZone(current.entry.getTs());
+    }
+
+    @Override
+    public Object getValue()
+    {
+        return current.entry.getLine();
+    }
+
+    /**
+     * Stream entries have a timestamp in nanos. It's converted to a millisecond precision because we use a ShortTimeWithTimeZoneType.
+     *
+     * @param nanos nanoseconds since epoch.
+     * @return time in Trino's packed format.
+     */
+    long toTimeWithTimeZone(Long nanos)
+    {
+        return packDateTimeWithZone(nanos / NANOSECONDS_PER_MILLISECOND, TimeZoneKey.UTC_KEY);
+    }
+}

--- a/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiTableFunction.java
+++ b/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiTableFunction.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.loki;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
+import io.airlift.slice.Slice;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorAccessControl;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.function.table.AbstractConnectorTableFunction;
+import io.trino.spi.function.table.Argument;
+import io.trino.spi.function.table.ConnectorTableFunctionHandle;
+import io.trino.spi.function.table.Descriptor;
+import io.trino.spi.function.table.ScalarArgument;
+import io.trino.spi.function.table.ScalarArgumentSpecification;
+import io.trino.spi.function.table.TableFunctionAnalysis;
+import io.trino.spi.type.LongTimestampWithTimeZone;
+import io.trino.spi.type.VarcharType;
+
+import java.lang.reflect.UndeclaredThrowableException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.function.table.ReturnTypeSpecification.GenericTable.GENERIC_TABLE;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_NANOS;
+import static io.trino.spi.type.Timestamps.MILLISECONDS_PER_SECOND;
+import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MILLISECOND;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
+import static java.lang.Math.floorDiv;
+import static java.lang.Math.floorMod;
+import static java.util.Objects.requireNonNull;
+
+public class LokiTableFunction
+        extends AbstractConnectorTableFunction
+{
+    public static final String SCHEMA_NAME = "system";
+    public static final String NAME = "query_range";
+
+    private final LokiMetadata metadata;
+
+    public LokiTableFunction(LokiMetadata metadata)
+    {
+        super(
+                SCHEMA_NAME,
+                NAME,
+                List.of(
+                        ScalarArgumentSpecification.builder()
+                                .name("QUERY")
+                                .type(VarcharType.VARCHAR)
+                                .build(),
+                        ScalarArgumentSpecification.builder()
+                                .name("START")
+                                .type(TIMESTAMP_TZ_NANOS)
+                                .build(),
+                        ScalarArgumentSpecification.builder()
+                                .name("END")
+                                .type(TIMESTAMP_TZ_NANOS)
+                                .build()),
+                GENERIC_TABLE);
+
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
+    @Override
+    public TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments, ConnectorAccessControl accessControl)
+    {
+        ScalarArgument argument = (ScalarArgument) arguments.get("QUERY");
+        String query = ((Slice) argument.getValue()).toStringUtf8();
+
+        LongTimestampWithTimeZone startArgument = (LongTimestampWithTimeZone) ((ScalarArgument) arguments.get("START")).getValue();
+        LongTimestampWithTimeZone endArgument = (LongTimestampWithTimeZone) ((ScalarArgument) arguments.get("END")).getValue();
+
+        if (Strings.isNullOrEmpty(query)) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, query);
+        }
+        requireNonNull(startArgument);
+        requireNonNull(endArgument);
+        requireNonNull(metadata);
+
+        // determine the returned row type
+        List<ColumnHandle> columnHandles;
+        try {
+            columnHandles = metadata.getColumnHandles(query);
+        }
+        catch (UndeclaredThrowableException e) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "Cannot get column definition", Throwables.getRootCause(e));
+        }
+
+        checkArgument(!columnHandles.isEmpty(), "Cannot get column definition");
+
+        Descriptor returnedType = new Descriptor(columnHandles.stream()
+                .map(LokiColumnHandle.class::cast)
+                .map(column -> new Descriptor.Field(column.name(), Optional.of(column.type())))
+                .collect(toImmutableList()));
+
+        Instant end = toInstant(endArgument);
+        Instant start = toInstant(startArgument);
+
+        final LokiTableHandle tableHandle = new LokiTableHandle(
+                query,
+                start,
+                end,
+                columnHandles);
+
+        return TableFunctionAnalysis.builder()
+                .returnedType(returnedType)
+                .handle(new QueryHandle(tableHandle))
+                .build();
+    }
+
+    /**
+     * Convert LongTimestampWithTimeZone to Instant. See BigQuery code for an example
+     */
+    private Instant toInstant(LongTimestampWithTimeZone timestamp)
+    {
+        long epochSeconds = floorDiv(timestamp.getEpochMillis(), MILLISECONDS_PER_SECOND);
+        long nanosOfSecond = (long) floorMod(timestamp.getEpochMillis(), MILLISECONDS_PER_SECOND) * NANOSECONDS_PER_MILLISECOND + timestamp.getPicosOfMilli() / PICOSECONDS_PER_NANOSECOND;
+        return Instant.ofEpochSecond(epochSeconds, nanosOfSecond);
+    }
+
+    public static class QueryHandle
+            implements ConnectorTableFunctionHandle
+    {
+        private final LokiTableHandle tableHandle;
+
+        @JsonCreator
+        public QueryHandle(@JsonProperty("tableHandle") LokiTableHandle tableHandle)
+        {
+            this.tableHandle = requireNonNull(tableHandle, "tableHandle is null");
+        }
+
+        @JsonProperty
+        public LokiTableHandle getTableHandle()
+        {
+            return tableHandle;
+        }
+    }
+}

--- a/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiTableFunctionProvider.java
+++ b/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiTableFunctionProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.loki;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorTableFunction;
+import io.trino.spi.function.table.ConnectorTableFunction;
+
+import static java.util.Objects.requireNonNull;
+
+public class LokiTableFunctionProvider
+        implements Provider<ConnectorTableFunction>
+{
+    private final LokiMetadata lokiMetadata;
+
+    @Inject
+    public LokiTableFunctionProvider(LokiMetadata lokiMetadata)
+    {
+        this.lokiMetadata = requireNonNull(lokiMetadata, "lokiMetadata is null");
+    }
+
+    @Override
+    public ConnectorTableFunction get()
+    {
+        return new ClassLoaderSafeConnectorTableFunction(new LokiTableFunction(this.lokiMetadata), getClass().getClassLoader());
+    }
+}

--- a/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiTableHandle.java
+++ b/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiTableHandle.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.loki;
+
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorTableHandle;
+
+import java.time.Instant;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public record LokiTableHandle(String query, Instant start, Instant end, List<ColumnHandle> columnHandles)
+        implements ConnectorTableHandle
+{
+    public LokiTableHandle
+    {
+        requireNonNull(query);
+        requireNonNull(start);
+        requireNonNull(end);
+        requireNonNull(columnHandles);
+    }
+}

--- a/plugin/trino-loki/src/test/java/io/trino/plugin/loki/LokiQueryRunner.java
+++ b/plugin/trino-loki/src/test/java/io/trino/plugin/loki/LokiQueryRunner.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.loki;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.airlift.log.Level;
+import io.airlift.log.Logger;
+import io.airlift.log.Logging;
+import io.trino.plugin.base.util.Closables;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.trino.testing.TestingSession.testSessionBuilder;
+
+public final class LokiQueryRunner
+{
+    private LokiQueryRunner() {}
+
+    public static Builder builder(TestingLokiServer lokiServer)
+    {
+        return new Builder()
+                .addConnectorProperty("loki.uri", lokiServer.getUri().toString());
+    }
+
+    public static class Builder
+            extends DistributedQueryRunner.Builder<Builder>
+    {
+        private final Map<String, String> connectorProperties = new HashMap<>();
+
+        protected Builder()
+        {
+            super(testSessionBuilder()
+                    .setCatalog("loki")
+                    .setSchema("default")
+                    .build());
+        }
+
+        @CanIgnoreReturnValue
+        public Builder addConnectorProperty(String key, String value)
+        {
+            this.connectorProperties.put(key, value);
+            return this;
+        }
+
+        @Override
+        public DistributedQueryRunner build()
+                throws Exception
+        {
+            DistributedQueryRunner queryRunner = super.build();
+            try {
+                queryRunner.installPlugin(new LokiPlugin());
+                queryRunner.createCatalog("loki", "loki", connectorProperties);
+            }
+            catch (Throwable e) {
+                Closables.closeAllSuppress(e, queryRunner);
+                throw e;
+            }
+            return queryRunner;
+        }
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        Logging logger = Logging.initialize();
+        logger.setLevel("io.trino.loki", Level.DEBUG);
+        logger.setLevel("io.trino", Level.INFO);
+
+        QueryRunner queryRunner = builder(new TestingLokiServer())
+                .addCoordinatorProperty("http-server.http.port", "8080")
+                .build();
+        Logger log = Logger.get(LokiQueryRunner.class);
+        log.info("======== SERVER STARTED ========");
+        log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());
+    }
+}

--- a/plugin/trino-loki/src/test/java/io/trino/plugin/loki/TestLokiIntegration.java
+++ b/plugin/trino-loki/src/test/java/io/trino/plugin/loki/TestLokiIntegration.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.loki;
+
+import io.github.jeschkies.loki.client.LokiClient;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+
+public class TestLokiIntegration
+        extends AbstractTestQueryFramework
+{
+    private LokiClient client;
+
+    private static final DateTimeFormatter timestampFormatter = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC);
+    private static final DateTimeFormatter timestampFormatterAtEasternTime = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss'-05:00'").withZone(ZoneId.of("US/Eastern"));
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        final TestingLokiServer server = closeAfterClass(new TestingLokiServer());
+        this.client = server.createLokiClient();
+        return LokiQueryRunner.builder(server).build();
+    }
+
+    @Test
+    public void testLogsQuery()
+            throws Exception
+    {
+        Instant start = Instant.now().minus(Duration.ofHours(3));
+        Instant end = start.plus(Duration.ofHours(2));
+
+        this.client.pushLogLine("line 1", end.minus(Duration.ofMinutes(10)), ImmutableMap.of("test", "logs_query"));
+        this.client.pushLogLine("line 2", end.minus(Duration.ofMinutes(5)), ImmutableMap.of("test", "logs_query"));
+        this.client.pushLogLine("line 3", end.minus(Duration.ofMinutes(1)), ImmutableMap.of("test", "logs_query"));
+        this.client.flush();
+
+        assertQuery(String.format("""
+                        SELECT value FROM
+                        TABLE(system.query_range(
+                         '{test="logs_query"}',
+                         TIMESTAMP '%s',
+                         TIMESTAMP '%s'
+                        ))
+                        LIMIT 1
+                        """, timestampFormatter.format(start), timestampFormatter.format(end)),
+                "VALUES ('line 1')");
+
+        assertQuery(String.format("""
+                        SELECT value FROM
+                        TABLE(system.query_range(
+                         '{test="logs_query"}',
+                         TIMESTAMP '%s',
+                         TIMESTAMP '%s'
+                        ))
+                        LIMIT 1
+                        """, timestampFormatterAtEasternTime.format(start), timestampFormatterAtEasternTime.format(end)),
+                "VALUES ('line 1')");
+    }
+
+    @Test
+    public void testMetricsQuery()
+            throws Exception
+    {
+        Instant start = Instant.now().minus(Duration.ofHours(3));
+        Instant end = start.plus(Duration.ofHours(2));
+
+        this.client.pushLogLine("line 1", end.minus(Duration.ofMinutes(3)), ImmutableMap.of("test", "metrics_query"));
+        this.client.pushLogLine("line 2", end.minus(Duration.ofMinutes(2)), ImmutableMap.of("test", "metrics_query"));
+        this.client.pushLogLine("line 3", end.minus(Duration.ofMinutes(1)), ImmutableMap.of("test", "metrics_query"));
+        this.client.flush();
+        assertQuery(String.format("""
+                        SELECT value FROM
+                        TABLE(system.query_range(
+                         'count_over_time({test="metrics_query"}[5m])',
+                         TIMESTAMP '%s',
+                         TIMESTAMP '%s'
+                        ))
+                        LIMIT 1
+                        """, timestampFormatter.format(start), timestampFormatter.format(end)),
+                "VALUES (1.0)");
+    }
+
+    @Test
+    public void testLabels()
+            throws Exception
+    {
+        Instant start = Instant.now().minus(Duration.ofHours(3));
+        Instant end = start.plus(Duration.ofHours(2));
+
+        this.client.pushLogLine("line 1", end.minus(Duration.ofMinutes(3)), ImmutableMap.of("test", "labels"));
+        this.client.pushLogLine("line 2", end.minus(Duration.ofMinutes(2)), ImmutableMap.of("test", "labels"));
+        this.client.pushLogLine("line 3", end.minus(Duration.ofMinutes(1)), ImmutableMap.of("test", "labels"));
+        this.client.flush();
+        assertQuery(String.format("""
+                        SELECT labels['test'] FROM
+                        TABLE(system.query_range(
+                         'count_over_time({test="labels"}[5m])',
+                         TIMESTAMP '%s',
+                         TIMESTAMP '%s'
+                        ))
+                        LIMIT 1
+                        """, timestampFormatter.format(start), timestampFormatter.format(end)),
+                "VALUES ('labels')");
+    }
+
+    @Test
+    public void testLabelsComplex()
+            throws Exception
+    {
+        Instant start = Instant.now().minus(Duration.ofHours(3));
+        Instant end = start.plus(Duration.ofHours(2));
+
+        this.client.pushLogLine("line 1", end.minus(Duration.ofMinutes(3)), ImmutableMap.of("test", "labels_complex", "service", "one"));
+        this.client.pushLogLine("line 2", end.minus(Duration.ofMinutes(2)), ImmutableMap.of("test", "labels_complex", "service", "two"));
+        this.client.pushLogLine("line 3", end.minus(Duration.ofMinutes(1)), ImmutableMap.of("test", "labels_complex", "service", "one"));
+        this.client.flush();
+        assertQuery(String.format("""
+                        SELECT labels['service'], COUNT(*) FROM
+                        TABLE(system.query_range(
+                          '{test="labels_complex"}',
+                          TIMESTAMP '%s',
+                          TIMESTAMP '%s'
+                        ))
+                        GROUP BY labels['service']
+                        """, timestampFormatter.format(start), timestampFormatter.format(end)),
+                "VALUES ('one', 2.0), ('two', 1.0)");
+    }
+
+    @Test
+    public void testSelectTimestamp()
+            throws Exception
+    {
+        DateTimeFormatter isoTimestampFormatter = DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC);
+        Instant start = Instant.now().truncatedTo(ChronoUnit.DAYS).minus(Duration.ofHours(12));
+        Instant end = start.plus(Duration.ofHours(4));
+        Instant firstLineTimestamp = start.truncatedTo(ChronoUnit.MILLIS);
+
+        this.client.pushLogLine("line 1", firstLineTimestamp, ImmutableMap.of("test", "select_timestamp_query"));
+        this.client.pushLogLine("line 2", firstLineTimestamp.plus(Duration.ofHours(1)), ImmutableMap.of("test", "select_timestamp_query"));
+        this.client.pushLogLine("line 3", firstLineTimestamp.plus(Duration.ofHours(2)), ImmutableMap.of("test", "select_timestamp_query"));
+        this.client.flush();
+        assertQuery(String.format("""
+                        SELECT
+                          -- H2 does not support TIMESTAMP WITH TIME ZONE so cast to VARCHAR
+                          to_iso8601(timestamp), value
+                        FROM
+                        TABLE(system.query_range(
+                         '{test="select_timestamp_query"}',
+                         TIMESTAMP '%s',
+                         TIMESTAMP '%s'
+                        ))
+                        ORDER BY timestamp
+                        LIMIT 1
+                        """, timestampFormatter.format(start), timestampFormatter.format(end)),
+                String.format("VALUES ('%s', 'line 1')", isoTimestampFormatter.format(firstLineTimestamp)));
+
+        assertQuery(String.format("""
+                        SELECT
+                          -- H2 does not support TIMESTAMP WITH TIME ZONE so cast to VARCHAR
+                          to_iso8601(timestamp), value
+                        FROM
+                        TABLE(system.query_range(
+                         'count_over_time({test="select_timestamp_query"}[5m])',
+                         TIMESTAMP '%s',
+                         TIMESTAMP '%s'
+                        ))
+                        ORDER BY timestamp ASC
+                        LIMIT 1
+                        """, timestampFormatter.format(start), timestampFormatter.format(end)),
+                // Since the start is always noon the previous day we know how the steps align.
+                String.format("VALUES ('%s', 1.0)", isoTimestampFormatter.format(start.plus(Duration.ofSeconds(48)))));
+    }
+
+    @Test
+    public void testSelectFromTableFails()
+    {
+        assertQueryFails("SELECT * FROM default", "Loki connector does not support querying tables directly. Use the TABLE function instead.");
+    }
+}

--- a/plugin/trino-loki/src/test/java/io/trino/plugin/loki/TestingLokiServer.java
+++ b/plugin/trino-loki/src/test/java/io/trino/plugin/loki/TestingLokiServer.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.loki;
+
+import io.github.jeschkies.loki.client.LokiClient;
+import io.github.jeschkies.loki.client.LokiClientConfig;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import java.io.Closeable;
+import java.net.URI;
+import java.time.Duration;
+
+public class TestingLokiServer
+        implements Closeable
+{
+    private static final int LOKI_PORT = 3100;
+    private static final String DEFAULT_VERSION = "3.1.0";
+
+    private final GenericContainer<?> loki;
+
+    public TestingLokiServer()
+    {
+        this(DEFAULT_VERSION, false);
+    }
+
+    public TestingLokiServer(String version, boolean enableBasicAuth)
+    {
+        this.loki = new GenericContainer<>("grafana/loki:%s".formatted(version))
+                .withExposedPorts(LOKI_PORT)
+                .waitingFor(Wait.forHttp("/ready").forResponsePredicate(response -> response.contains("ready")))
+                .withStartupTimeout(Duration.ofMinutes(6));
+        this.loki.start();
+    }
+
+    public LokiClient createLokiClient()
+    {
+        LokiClientConfig config = new LokiClientConfig(this.getUri(), Duration.ofSeconds(10));
+        return new LokiClient(config);
+    }
+
+    public URI getUri()
+    {
+        return URI.create("http://localhost:" + loki.getMappedPort(LOKI_PORT));
+    }
+
+    @Override
+    public void close()
+    {
+        loki.close();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
         <module>plugin/trino-kafka</module>
         <module>plugin/trino-kafka-event-listener</module>
         <module>plugin/trino-kudu</module>
+        <module>plugin/trino-loki</module>
         <module>plugin/trino-mariadb</module>
         <module>plugin/trino-memory</module>
         <module>plugin/trino-ml</module>


### PR DESCRIPTION
## Description
This change introduce a [Loki](https://grafana.com/loki) connector. It supports log and metric queries.

## Additional context and related issues
Currently the connector uses the older `ResultSetProvider`. A `PageSourceProvider` is planned as is predicate push down.

This is a side project. There is no official support from Grafana Labs.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
```
## Loki
- Add Loki connector to connect with Grafana Loki (https://grafana.com/oss/loki/)
```
Co-authored-by: Janos <janos.gub@grafana.com>