### PR TITLE
Add EXTERNAL_TABLE_PURGE to hive table properties

### DIFF
--- a/docs/src/main/sphinx/connector/hive.md
+++ b/docs/src/main/sphinx/connector/hive.md
@@ -800,6 +800,9 @@ WITH (format='CSV',
   - Indicates to the configured metastore to perform a purge when a table or
     partition is deleted instead of a soft deletion using the trash.
   -
+* - `external_table_purge`
+  - Indicates to the configured metastore to delete data when external table is dropped.
+  - false
 * - `avro_schema_url`
   - The URI pointing to [](hive-avro-schema) for the table.
   -

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableProperties.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableProperties.java
@@ -72,6 +72,7 @@ public class HiveTableProperties
     public static final String REGEX_CASE_INSENSITIVE = "regex_case_insensitive";
     public static final String TRANSACTIONAL = "transactional";
     public static final String AUTO_PURGE = "auto_purge";
+    public static final String EXTERNAL_TABLE_PURGE = "external_table_purge";
     public static final String EXTRA_PROPERTIES = "extra_properties";
 
     private final List<PropertyMetadata<?>> tableProperties;
@@ -176,6 +177,11 @@ public class HiveTableProperties
                 booleanProperty(REGEX_CASE_INSENSITIVE, "REGEX pattern is case insensitive", null, false),
                 booleanProperty(TRANSACTIONAL, "Table is transactional", null, false),
                 booleanProperty(AUTO_PURGE, "Skip trash when table or partition is deleted", config.isAutoPurge(), false),
+                booleanProperty(
+                        EXTERNAL_TABLE_PURGE,
+                        "External table data deleted when the table is dropped",
+                        null,
+                        false),
                 booleanProperty(
                         PARTITION_PROJECTION_IGNORE,
                         "Disable AWS Athena partition projection in Trino only",
@@ -351,6 +357,11 @@ public class HiveTableProperties
     public static Optional<Boolean> isAutoPurge(Map<String, Object> tableProperties)
     {
         return Optional.ofNullable((Boolean) tableProperties.get(AUTO_PURGE));
+    }
+
+    public static Optional<Boolean> isExternalTablePurge(Map<String, Object> tableProperties)
+    {
+        return Optional.ofNullable((Boolean) tableProperties.get(EXTERNAL_TABLE_PURGE));
     }
 
     public static Optional<Map<String, String>> getExtraProperties(Map<String, Object> tableProperties)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestExternalHiveTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestExternalHiveTable.java
@@ -151,6 +151,17 @@ public class TestExternalHiveTable
         onTrino().executeQuery(format("CREATE TABLE %s.%s.%s WITH (external_location = '%s') AS SELECT * FROM tpch.tiny.nation", HIVE_CATALOG_WITH_EXTERNAL_WRITES, schema, table, tableLocation));
     }
 
+    @Test
+    public void testExternalTablePurgeProperty()
+    {
+        String schema = "schema_without_location";
+        String extTable = "test_external_purge_table";
+        String tableLocation = "/tmp/" + extTable;
+        onTrino().executeQuery(format("CREATE TABLE %s.%s.%s WITH (external_location = '%s', external_table_purge = true) AS SELECT * FROM tpch.tiny.nation", HIVE_CATALOG_WITH_EXTERNAL_WRITES, schema, extTable, tableLocation));
+        onTrino().executeQuery(format("DROP TABLE IF EXISTS %s.%s.%s", HIVE_CATALOG_WITH_EXTERNAL_WRITES, schema, extTable));
+        assertThat(hdfsClient.exist(tableLocation)).isFalse();
+    }
+
     private void insertNationPartition(TableInstance<?> nation, int partition)
     {
         onHive().executeQuery(


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Hive has a boolean table property external.table.purge which we should expose as a Trino table property in the Hive connector.
external_table_purge[Trino tbl property] will map to external.table.purge[Hive tbl property]
See https://issues.apache.org/jira/browse/HIVE-19981

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
