### PR TITLE
Enhance documentation for `delta.checkpoint-filtering.enabled` setting

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.md
+++ b/docs/src/main/sphinx/connector/delta-lake.md
@@ -134,7 +134,10 @@ values. Typical usage does not require you to configure them.
 * - ``delta.checkpoint-filtering.enabled``
   - Enable pruning of data file entries as well as data file statistics
     columns which are irrelevant for the query when reading Delta Lake
-    checkpoint files.
+    checkpoint files. Reading only the relevant active file data from
+    the checkpoint, directly from the storage, instead of relying on
+    the active files caching, will likely result in decreased memory
+    pressure on the coordinator.
     The equivalent catalog session property is ``checkpoint_filtering_enabled``.
   - ``true``
 * - `delta.dynamic-filtering.wait-timeout`


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

It is rather unclear the fact that enabling `delta.checkpoint-filtering.enabled` implies probably also decreased memory pressure on the coordinator because there is no need anymore for storing the active files of the tables in the cache.

Related property `delta.metadata.live-files.cache-size` property 


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
