### PR TITLE
Split / Parallel Read in Oracle Connector

### DIFF
--- a/plugin/trino-oracle/pom.xml
+++ b/plugin/trino-oracle/pom.xml
@@ -41,6 +41,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
         </dependency>
 
@@ -120,12 +125,6 @@
         <dependency>
             <groupId>dev.failsafe</groupId>
             <artifactId>failsafe</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>log</artifactId>
             <scope>runtime</scope>
         </dependency>
 

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/GatherStatsProvider.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/GatherStatsProvider.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.oracle;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import io.airlift.log.Logger;
+import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.JdbcProcedureHandle;
+import io.trino.spi.TrinoException;
+import io.trino.spi.classloader.ThreadContextClassLoader;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.procedure.Procedure;
+
+import java.lang.invoke.MethodHandle;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.lang.invoke.MethodHandles.lookup;
+
+public class GatherStatsProvider
+        implements Provider<Procedure>
+{
+    private static final Logger log = Logger.get(GatherStatsProvider.class);
+    private static final MethodHandle methodHandle;
+    private final JdbcClient oracleClient;
+
+    @Inject
+    public GatherStatsProvider(JdbcClient client)
+    {
+        this.oracleClient = client;
+    }
+
+    static {
+        try {
+            methodHandle = lookup().unreflect(GatherStatsProvider.class.getMethod("gatherTableStats", ConnectorSession.class, String.class, String.class, Double.class));
+        }
+        catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    public void gatherTableStats(ConnectorSession session, String schemaName, String tableName, Double estimate)
+    {
+        // this line guarantees that classLoader that we stored in the field will be used inside try/catch
+        // as we captured reference to PluginClassLoader during initialization of this class
+        // we can use it now to correctly execute the procedure
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
+            doGatherTableStats(session, schemaName, tableName, estimate);
+        }
+    }
+
+    public void doGatherTableStats(ConnectorSession session, String schemaName, String tableName, Double estimate)
+    {
+        //SchemaTableName sourceTableName = new SchemaTableName(schemaName, tableName);
+        log.debug("Gather table stats called with " + schemaName + " ; " + tableName + " ( " + estimate + " ) ");
+        String sql = "BEGIN DBMS_STATS.GATHER_TABLE_STATS('" + schemaName + "', '" + tableName + "'); END;";
+        JdbcProcedureHandle.ProcedureQuery procQuery = new JdbcProcedureHandle.ProcedureQuery(sql);
+        JdbcProcedureHandle handle = new JdbcProcedureHandle(procQuery,
+                java.util.List.of());
+        try {
+            Connection connection = oracleClient.getConnection(session, null, handle);
+            CallableStatement callableStatement = oracleClient.buildProcedure(session, connection, null, handle);
+            callableStatement.execute();
+            callableStatement.close();
+            connection.close();
+            log.info("GatherStatsProvider: " + sql);
+        }
+        catch (SQLException e) {
+            throw new TrinoException(JDBC_ERROR, e);
+        }
+        //oracleClient.gatherTableStats(session, schemaName, tableName);
+    }
+
+    @Override
+    public Procedure get()
+    {
+        return new Procedure("rdbms", "gather_table_stats",
+                ImmutableList.of(
+                        new Procedure.Argument("SCHEMA_NAME", VARCHAR),
+                        new Procedure.Argument("TABLE_NAME", VARCHAR),
+                        new Procedure.Argument("ESTIMATE_PERCENT", DOUBLE, false, 0.0)),
+                        GatherStatsProvider.methodHandle.bindTo(this));
+    }
+}

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/GrantProvider.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/GrantProvider.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.oracle;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import io.airlift.log.Logger;
+import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.JdbcProcedureHandle;
+import io.trino.spi.TrinoException;
+import io.trino.spi.classloader.ThreadContextClassLoader;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.procedure.Procedure;
+
+import java.lang.invoke.MethodHandle;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.lang.invoke.MethodHandles.lookup;
+
+public class GrantProvider
+        implements Provider<Procedure>
+{
+    private static final Logger log = Logger.get(GatherStatsProvider.class);
+    private static final MethodHandle methodHandle;
+    private final JdbcClient oracleClient;
+
+    @Inject
+    public GrantProvider(JdbcClient client)
+    {
+        this.oracleClient = client;
+    }
+
+    static {
+        try {
+            methodHandle = lookup().unreflect(GrantProvider.class.getMethod("grant", ConnectorSession.class, String.class, String.class, String.class, String.class));
+        }
+        catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    public void grant(ConnectorSession session, String schemaName, String tableName, String access, String grantee)
+    {
+        // this line guarantees that classLoader that we stored in the field will be used inside try/catch
+        // as we captured reference to PluginClassLoader during initialization of this class
+        // we can use it now to correctly execute the procedure
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
+            doGrant(session, schemaName, tableName, access, grantee);
+        }
+    }
+
+    public void doGrant(ConnectorSession session, String schemaName, String tableName, String access, String grantee)
+    {
+        //SchemaTableName sourceTableName = new SchemaTableName(schemaName, tableName);
+        log.debug("Grant called with " + schemaName + " ; " + tableName + " ; " + access + " grantee=> " + grantee);
+        String sql = "GRANT " + access + " ON " + schemaName + "." + tableName + " TO " + grantee + "";
+        log.info("doGrant : " + sql);
+        JdbcProcedureHandle.ProcedureQuery procQuery = new JdbcProcedureHandle.ProcedureQuery(sql);
+        JdbcProcedureHandle handle = new JdbcProcedureHandle(procQuery,
+                java.util.List.of());
+        try {
+            Connection connection = oracleClient.getConnection(session, null, handle);
+            CallableStatement callableStatement = oracleClient.buildProcedure(session, connection, null, handle);
+            callableStatement.execute();
+            callableStatement.close();
+            connection.close();
+            log.info("GatherStatsProvider: " + sql);
+        }
+        catch (SQLException e) {
+            throw new TrinoException(JDBC_ERROR, e);
+        }
+        //oracleClient.gatherTableStats(session, schemaName, tableName);
+    }
+
+    @Override
+    public Procedure get()
+    {
+        return new Procedure("rdbms", "grant",
+                ImmutableList.of(
+                        new Procedure.Argument("SCHEMA_NAME", VARCHAR),
+                        new Procedure.Argument("TABLE_NAME", VARCHAR),
+                        new Procedure.Argument("ACCESS", VARCHAR),
+                        new Procedure.Argument("GRANTEE", VARCHAR)),
+                GrantProvider.methodHandle.bindTo(this));
+    }
+}

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClientModule.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClientModule.java
@@ -42,7 +42,9 @@ import java.util.Properties;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.trino.plugin.jdbc.JdbcModule.bindProcedure;
 import static io.trino.plugin.jdbc.JdbcModule.bindSessionPropertiesProvider;
+import static io.trino.plugin.jdbc.JdbcModule.bindTablePropertiesProvider;
 import static io.trino.plugin.oracle.OracleClient.ORACLE_MAX_LIST_EXPRESSIONS;
 
 public class OracleClientModule
@@ -54,10 +56,15 @@ public class OracleClientModule
         binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class).to(OracleClient.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, TimestampTimeZoneDomain.class).setBinding().toInstance(TimestampTimeZoneDomain.ANY);
         bindSessionPropertiesProvider(binder, OracleSessionProperties.class);
+        bindTablePropertiesProvider(binder, OracleTableProperties.class);
         configBinder(binder).bindConfig(OracleConfig.class);
         newOptionalBinder(binder, Key.get(int.class, MaxDomainCompactionThreshold.class)).setBinding().toInstance(ORACLE_MAX_LIST_EXPRESSIONS);
         newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(Query.class).in(Scopes.SINGLETON);
         newSetBinder(binder, RetryStrategy.class).addBinding().to(OracleRetryStrategy.class).in(Scopes.SINGLETON);
+        bindProcedure(binder, GatherStatsProvider.class);
+        bindProcedure(binder, GrantProvider.class);
+//        binder.bind(ConnectorMetadata.class).annotatedWith(ForClassLoaderSafe.class).to(EnhancedMetadata.class).in(Scopes.SINGLETON);
+//        newOptionalBinder(binder, QueryBuilder.class).setBinding().to(EnhancedQueryBuilder.class).in(Scopes.SINGLETON);
     }
 
     @Provides

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleConfig.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleConfig.java
@@ -36,13 +36,39 @@ public class OracleConfig
     private RoundingMode numberRoundingMode = RoundingMode.UNNECESSARY;
     private boolean connectionPoolEnabled = true;
     private int connectionPoolMinSize = 1;
-    private int connectionPoolMaxSize = 30;
+    private int connectionPoolMaxSize = 50;
     private Duration inactiveConnectionTimeout = new Duration(20, MINUTES);
     private Integer fetchSize;
+    private boolean experimentalSplit = true;
+    private String splitRule = "";
 
     public boolean isSynonymsEnabled()
     {
         return synonymsEnabled;
+    }
+
+    public boolean getExperimentalSplit()
+    {
+        return experimentalSplit;
+    }
+
+    @Config("oracle.split_rule")
+    public OracleConfig setSplitRule(String s)
+    {
+        this.splitRule = s;
+        return this;
+    }
+
+    public String getSplitRule()
+    {
+        return splitRule;
+    }
+
+    @Config("oracle.experimental.split")
+    public OracleConfig setExperimentalSplit(boolean split)
+    {
+        this.experimentalSplit = split;
+        return this;
     }
 
     @Config("oracle.synonyms.enabled")

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleSessionProperties.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleSessionProperties.java
@@ -23,8 +23,10 @@ import java.math.RoundingMode;
 import java.util.List;
 import java.util.Optional;
 
+import static io.trino.spi.session.PropertyMetadata.booleanProperty;
 import static io.trino.spi.session.PropertyMetadata.enumProperty;
 import static io.trino.spi.session.PropertyMetadata.integerProperty;
+import static io.trino.spi.session.PropertyMetadata.stringProperty;
 
 public final class OracleSessionProperties
         implements SessionPropertiesProvider
@@ -49,6 +51,15 @@ public final class OracleSessionProperties
                         "Default scale for Oracle Number data type",
                         config.getDefaultNumberScale().orElse(null),
                         false))
+                .add(booleanProperty(
+                        "experimental_split",
+                        "Experimental split",
+                        config.getExperimentalSplit(), false))
+                .add(stringProperty(
+                        "split_rule",
+                        "Splitting rule",
+                        config.getSplitRule(),
+                        false))
                 .build();
     }
 
@@ -56,6 +67,21 @@ public final class OracleSessionProperties
     public List<PropertyMetadata<?>> getSessionProperties()
     {
         return sessionProperties;
+    }
+
+    public static Boolean getExperimentalSplit(ConnectorSession session)
+    {
+        return session.getProperty("experimental_split", Boolean.class);
+    }
+
+    public static String getSplitRule(ConnectorSession session)
+    {
+        return session.getProperty("split_rule", String.class);
+    }
+
+    public static Integer getSplitStride(ConnectorSession session)
+    {
+        return session.getProperty("split_stride", Integer.class);
     }
 
     public static RoundingMode getNumberRoundingMode(ConnectorSession session)

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleTableProperties.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleTableProperties.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.oracle;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.plugin.jdbc.TablePropertiesProvider;
+import io.trino.spi.session.PropertyMetadata;
+import io.trino.spi.type.ArrayType;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static io.trino.spi.type.VarcharType.VARCHAR;
+
+public class OracleTableProperties
+        implements TablePropertiesProvider
+{
+    private final List<PropertyMetadata<?>> props;
+
+    OracleTableProperties()
+    {
+        props = Collections.unmodifiableList(Arrays.asList(
+                new PropertyMetadata<>(
+                        "index",
+                        "Indexes",
+                        new ArrayType(VARCHAR),
+                        List.class,
+                        ImmutableList.of(),
+                        false,
+                        value -> (List<?>) value,
+                        value -> value)));
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getTableProperties()
+    {
+        return props;
+    }
+}

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/QueryEnhancedInfo.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/QueryEnhancedInfo.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.oracle;
+
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcNamedRelationHandle;
+
+import java.util.Map;
+
+public class QueryEnhancedInfo
+{
+    public boolean isNamedRelation;
+    public JdbcNamedRelationHandle namedRelation;
+    public boolean isJoin;
+    public QueryEnhancedInfo leftInfo;
+    public QueryEnhancedInfo rightInfo;
+    Map<JdbcColumnHandle, String> leftProjections;
+    Map<JdbcColumnHandle, String> rightProjections;
+
+    public QueryEnhancedInfo(JdbcNamedRelationHandle namedRelation1)
+    {
+        namedRelation = namedRelation1;
+        isNamedRelation = true;
+    }
+
+    public QueryEnhancedInfo(QueryEnhancedInfo leftInfo, QueryEnhancedInfo rightInfo)
+    {
+        this.isJoin = true;
+        this.leftInfo = leftInfo;
+        this.rightInfo = rightInfo;
+    }
+
+    public QueryEnhancedInfo(QueryEnhancedInfo leftInfo, QueryEnhancedInfo rightInfo,
+                             Map<JdbcColumnHandle, String> leftProjections, Map<JdbcColumnHandle, String> rightProjections)
+    {
+        this.isJoin = true;
+        this.leftInfo = leftInfo;
+        this.rightInfo = rightInfo;
+        this.leftProjections = leftProjections;
+        this.rightProjections = rightProjections;
+    }
+}

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/SplittingRule.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/SplittingRule.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.oracle;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SplittingRule
+{
+    List<Rule> rules = new ArrayList<>();
+    int stride;
+
+    public enum RuleType {
+        ROWID,
+        INDEX,
+        NTILE
+    }
+
+    public static class Rule
+    {
+        String tableName;
+        RuleType ruleType;
+        int partitions;
+        int stride;
+        boolean anyTable;
+        String colOrIdx;
+
+        Rule(String table, RuleType rule)
+        {
+            this.ruleType = rule;
+            this.tableName = table;
+            if ("*".equals(tableName)) {
+                this.anyTable = true;
+            }
+        }
+
+        public Rule withPartitions(int i)
+        {
+            this.partitions = i;
+            return this;
+        }
+
+        public Rule withColOrIdx(String s)
+        {
+            this.colOrIdx = s;
+            return this;
+        }
+
+        public Rule withStride(int i)
+        {
+            this.stride = i;
+            return this;
+        }
+
+        public boolean isAnyTable()
+        {
+            return this.anyTable;
+        }
+    }
+
+    public Rule newRule(String tableName, RuleType ruleName)
+    {
+        Rule r = new Rule(tableName, ruleName);
+        rules.add(r);
+        return r;
+    }
+}

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleConfig.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleConfig.java
@@ -41,9 +41,11 @@ public class TestOracleConfig
                 .setNumberRoundingMode(RoundingMode.UNNECESSARY)
                 .setConnectionPoolEnabled(true)
                 .setConnectionPoolMinSize(1)
-                .setConnectionPoolMaxSize(30)
+                .setConnectionPoolMaxSize(50)
                 .setInactiveConnectionTimeout(new Duration(20, MINUTES))
-                .setFetchSize(null));
+                .setFetchSize(null)
+                .setExperimentalSplit(true)
+                .setSplitRule(""));
     }
 
     @Test
@@ -59,6 +61,8 @@ public class TestOracleConfig
                 .put("oracle.connection-pool.max-size", "20")
                 .put("oracle.connection-pool.inactive-timeout", "30s")
                 .put("oracle.fetch-size", "2000")
+                .put("oracle.experimental.split", "false")
+                .put("oracle.split_rule", "ROWID:*(100)")
                 .buildOrThrow();
 
         OracleConfig expected = new OracleConfig()
@@ -70,7 +74,9 @@ public class TestOracleConfig
                 .setConnectionPoolMinSize(10)
                 .setConnectionPoolMaxSize(20)
                 .setInactiveConnectionTimeout(new Duration(30, SECONDS))
-                .setFetchSize(2000);
+                .setFetchSize(2000)
+                .setSplitRule("ROWID:*(100)")
+                .setExperimentalSplit(false);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This PR enables Trino parallel read capability when using the Oracle Connector. 

In order to be able to do parallel read, the session variable split_rule must be set. For example, to enable parallel read by splitting  the table A into 100 splits using  oracle's rowid :
`set session oraclecatalog.split_rule= 'ROWID:A(100)';`

And to enable parallel read by index on ROWNO column on A table, splitting into 100 splits of ROWNO intervals  :
`set session oraclecatalog.split_rule= 'NTILE:A(ROWNO,100)';`

Enable parallel read on any oracle table using ROWID, into 800 splits  :
`set session oraclecatalog.split_rule= 'INDEX:*(800)';`

Enable parallel read by index on ROWNO column on A table, splitting into 1000 integer increments wide intervals  :
`set session oraclecatalog.split_rule= 'INDEX:A(ROWNO,1000)';`


## Additional context and related issues
Rule parsing were done in OracleClient.parseRules method. Splits identification in getSplits for join queries are based on cached metadata obtained when the join were executed in implementJoin and legacyImplementJoin. 


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:
Enables oracle parallel read with table splitting rule set in session property value.
```markdown
Related to #389 
```
