### PR TITLE
Keep most recent task failure in failures history

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
@@ -2433,6 +2433,8 @@ public class EventDrivenFaultTolerantQueryScheduler
             }
 
             RuntimeException failure = failureInfo.toException();
+            recordTaskFailureInLog(taskId, failure);
+
             ErrorCode errorCode = failureInfo.getErrorCode();
             partitionMemoryEstimator.registerPartitionFinished(
                     partition.getMemoryRequirements(),
@@ -2470,8 +2472,6 @@ public class EventDrivenFaultTolerantQueryScheduler
                 // stage failed, don't reschedule
                 return ImmutableList.of();
             }
-
-            recordTaskFailureInLog(taskId, failure);
 
             if (!partition.isSealed()) {
                 // don't reschedule speculative tasks


### PR DESCRIPTION
We are keeping history of task failures which is appended to final failure of query if we run out of retries. The last task failure which caused the query to fail was not part of the history. It was root exception but task Id was missing. With this PR we will keep it both as root exception and as part of history.
