### PR TITLE
Allow configuring endpoint for Azure FS

### DIFF
--- a/docs/src/main/sphinx/object-storage/file-system-azure.md
+++ b/docs/src/main/sphinx/object-storage/file-system-azure.md
@@ -27,6 +27,12 @@ system support:
     authentication used with `NONE`. Use `ACCESS_KEY` for
     [](azure-access-key-authentication) or and `OAUTH` for
     [](azure-oauth-authentication).
+* - `azure.endpoint`
+  - Hostname suffix of the Azure storage endpoint.
+    Defaults to `core.windows.net` for the global Azure cloud.
+    Use `core.usgovcloudapi.net` for the Azure US Government cloud,
+    `core.cloudapi.de` for the Azure Germany cloud,
+    or `core.chinacloudapi.cn` for the Azure China cloud.
 * - `azure.read-block-size`
   - [Data size](prop-type-data-size) for blocks during read operations. Defaults
     to `4MB`.

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemConfig.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemConfig.java
@@ -16,6 +16,7 @@ package io.trino.filesystem.azure;
 import io.airlift.configuration.Config;
 import io.airlift.units.DataSize;
 import io.airlift.units.DataSize.Unit;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 public class AzureFileSystemConfig
@@ -28,7 +29,7 @@ public class AzureFileSystemConfig
     }
 
     private AuthType authType = AuthType.DEFAULT;
-
+    private String endpoint = "core.windows.net";
     private DataSize readBlockSize = DataSize.of(4, Unit.MEGABYTE);
     private DataSize writeBlockSize = DataSize.of(4, Unit.MEGABYTE);
     private int maxWriteConcurrency = 8;
@@ -44,6 +45,19 @@ public class AzureFileSystemConfig
     public AzureFileSystemConfig setAuthType(AuthType authType)
     {
         this.authType = authType;
+        return this;
+    }
+
+    @NotEmpty
+    public String getEndpoint()
+    {
+        return endpoint;
+    }
+
+    @Config("azure.endpoint")
+    public AzureFileSystemConfig setEndpoint(String endpoint)
+    {
+        this.endpoint = endpoint;
         return this;
     }
 

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemFactory.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemFactory.java
@@ -38,6 +38,7 @@ public class AzureFileSystemFactory
         implements TrinoFileSystemFactory
 {
     private final AzureAuth auth;
+    private final String endpoint;
     private final DataSize readBlockSize;
     private final DataSize writeBlockSize;
     private final int maxWriteConcurrency;
@@ -51,6 +52,7 @@ public class AzureFileSystemFactory
     {
         this(openTelemetry,
                 azureAuth,
+                config.getEndpoint(),
                 config.getReadBlockSize(),
                 config.getWriteBlockSize(),
                 config.getMaxWriteConcurrency(),
@@ -60,12 +62,14 @@ public class AzureFileSystemFactory
     public AzureFileSystemFactory(
             OpenTelemetry openTelemetry,
             AzureAuth azureAuth,
+            String endpoint,
             DataSize readBlockSize,
             DataSize writeBlockSize,
             int maxWriteConcurrency,
             DataSize maxSingleUploadSize)
     {
         this.auth = requireNonNull(azureAuth, "azureAuth is null");
+        this.endpoint = requireNonNull(endpoint, "endpoint is null");
         this.readBlockSize = requireNonNull(readBlockSize, "readBlockSize is null");
         this.writeBlockSize = requireNonNull(writeBlockSize, "writeBlockSize is null");
         checkArgument(maxWriteConcurrency >= 0, "maxWriteConcurrency is negative");
@@ -89,7 +93,7 @@ public class AzureFileSystemFactory
     @Override
     public TrinoFileSystem create(ConnectorIdentity identity)
     {
-        return new AzureFileSystem(httpClient, tracingOptions, auth, readBlockSize, writeBlockSize, maxWriteConcurrency, maxSingleUploadSize);
+        return new AzureFileSystem(httpClient, tracingOptions, auth, endpoint, readBlockSize, writeBlockSize, maxWriteConcurrency, maxSingleUploadSize);
     }
 
     public static HttpClient createAzureHttpClient(OkHttpClient okHttpClient, HttpClientOptions clientOptions)

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemConfig.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemConfig.java
@@ -32,6 +32,7 @@ class TestAzureFileSystemConfig
     {
         assertRecordedDefaults(recordDefaults(AzureFileSystemConfig.class)
                 .setAuthType(AuthType.DEFAULT)
+                .setEndpoint("core.windows.net")
                 .setReadBlockSize(DataSize.of(4, Unit.MEGABYTE))
                 .setWriteBlockSize(DataSize.of(4, Unit.MEGABYTE))
                 .setMaxWriteConcurrency(8)
@@ -43,6 +44,7 @@ class TestAzureFileSystemConfig
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("azure.auth-type", "oauth")
+                .put("azure.endpoint", "core.usgovcloudapi.net")
                 .put("azure.read-block-size", "3MB")
                 .put("azure.write-block-size", "5MB")
                 .put("azure.max-write-concurrency", "7")
@@ -51,6 +53,7 @@ class TestAzureFileSystemConfig
 
         AzureFileSystemConfig expected = new AzureFileSystemConfig()
                 .setAuthType(AuthType.OAUTH)
+                .setEndpoint("core.usgovcloudapi.net")
                 .setReadBlockSize(DataSize.of(3, Unit.MEGABYTE))
                 .setWriteBlockSize(DataSize.of(5, Unit.MEGABYTE))
                 .setMaxWriteConcurrency(7)


### PR DESCRIPTION
## Additional context and related issues

Fixes #21307

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Delta Lake
* Allow configuring endpoint for the native Azure filesystem. ({issue}`23071`)

# Hive
* Allow configuring endpoint for the native Azure filesystem. ({issue}`23071`)

# Hudi
* Allow configuring endpoint for the native Azure filesystem. ({issue}`23071`)

# Iceberg
* Allow configuring endpoint for the native Azure filesystem. ({issue}`23071`)
```
