### PR TITLE
Add support for CombineTextInputFormat from Hive

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveStorageFormat.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveStorageFormat.java
@@ -192,6 +192,8 @@ public enum HiveStorageFormat
             .put(new SerdeAndInputFormat(PARQUET_HIVE_SERDE_CLASS, "parquet.hive.DeprecatedParquetInputFormat"), PARQUET)
             .put(new SerdeAndInputFormat(PARQUET_HIVE_SERDE_CLASS, "org.apache.hadoop.mapred.TextInputFormat"), PARQUET)
             .put(new SerdeAndInputFormat(PARQUET_HIVE_SERDE_CLASS, "parquet.hive.MapredParquetInputFormat"), PARQUET)
+            .put(new SerdeAndInputFormat(LAZY_SIMPLE_SERDE_CLASS, "org.apache.hadoop.mapred.lib.CombineTextInputFormat"), TEXTFILE)
+            .put(new SerdeAndInputFormat(LAZY_SIMPLE_SERDE_CLASS, "org.apache.hadoop.mapreduce.lib.input.CombineTextInputFormat"), TEXTFILE)
             .buildOrThrow();
 
     public static Optional<HiveStorageFormat> getHiveStorageFormat(StorageFormat storageFormat)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
As brought up in https://github.com/trinodb/trino/issues/21842, I am unable to query text based hive tables that use `org.apache.hadoop.mapred.lib.CombineTextInputFormat`. I get this error:
```
io.trino.spi.TrinoException: Unsupported storage format: mydatabase.mytable:<UNPARTITIONED> StorageFormat{serde=org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe, inputFormat=org.apache.hadoop.mapred.lib.CombineTextInputFormat, outputFormat=org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat}
```
This change was the suggestion from the linked issue. To test this out I tried to query with Trino 453 without the code change, and I get this error on the CLI:
```
$ ./trino https://localhost:8443 --catalog hive
trino> select count(*) from <my hive table>;
Query 20240819_203410_00002_cg577 failed: Unsupported storage format: <my hive table>:dateint=20240810/state=open StorageFormat{serde=org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe, inputFormat=org.apache.hadoop.mapred.lib.CombineTextInputFormat, outputFormat=org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat}
```
Then I built the hive plugin jar with the code change and copied it onto the Trino docker image I was using, and re-ran my query with success:
```
$ ./trino https://localhost:8443 --catalog hive
trino> select count(*) from <my hive table>;
 _col0
--------
 242185
(1 row)

Query 20240819_203152_00000_r8kgb, FINISHED, 1 node
Splits: 5,616 total, 5,616 done (100.00%)
30.30 [242K rows, 131MB] [7.99K rows/s, 4.31MB/s]
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

c.c. @electrum 