### PR TITLE
Do not remove double-slashes for s3a and s3n paths

### DIFF
--- a/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HadoopPaths.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HadoopPaths.java
@@ -29,7 +29,8 @@ public final class HadoopPaths
         // hack to preserve the original path for S3 if necessary
         String path = location.toString();
         Path hadoopPath = new Path(path);
-        if ("s3".equals(hadoopPath.toUri().getScheme()) && !path.equals(hadoopPath.toString())) {
+        String scheme = hadoopPath.toUri().getScheme();
+        if (("s3".equals(scheme) || "s3a".equals(scheme) || "s3n".equals(scheme)) && !path.equals(hadoopPath.toString())) {
             return new Path(toPathEncodedUri(location));
         }
         return hadoopPath;

--- a/lib/trino-hdfs/src/test/java/io/trino/hdfs/s3/TestS3HadoopPaths.java
+++ b/lib/trino-hdfs/src/test/java/io/trino/hdfs/s3/TestS3HadoopPaths.java
@@ -57,6 +57,12 @@ public class TestS3HadoopPaths
                 .hasToString("s3://test/abc/xyz.csv#abc//xyz.csv")
                 .extracting(TrinoS3FileSystem::keyFromPath)
                 .isEqualTo("abc//xyz.csv");
+        assertThat(hadoopPath(Location.of("s3a://test/abc//xyz.csv")))
+                .isEqualTo(new Path(URI.create("s3a://test/abc/xyz.csv#abc//xyz.csv")))
+                .hasToString("s3a://test/abc/xyz.csv#abc//xyz.csv");
+        assertThat(hadoopPath(Location.of("s3n://test/abc//xyz.csv")))
+                .isEqualTo(new Path(URI.create("s3n://test/abc/xyz.csv#abc//xyz.csv")))
+                .hasToString("s3n://test/abc/xyz.csv#abc//xyz.csv");
     }
 
     @Test


### PR DESCRIPTION
s3a and s3n are valid S3 paths hence double slashes should be preserved.

```markdown
# Hive, Iceberg, Delta
* Preserve double slashes in s3a and s3n paths when legacy FS is used. ({issue}`issuenumber`)
```
