### PR TITLE
Use RemoteTableName in JdbcOutputTableHandle

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -388,7 +388,7 @@ public class CachingJdbcClient
     public void commitCreateTable(ConnectorSession session, JdbcOutputTableHandle handle, Set<Long> pageSinkIds)
     {
         delegate.commitCreateTable(session, handle, pageSinkIds);
-        invalidateTableCaches(new SchemaTableName(handle.getSchemaName(), handle.getTableName()));
+        invalidateTableCaches(handle.getRemoteTableName().getSchemaTableName());
     }
 
     @Override
@@ -401,7 +401,7 @@ public class CachingJdbcClient
     public void finishInsertTable(ConnectorSession session, JdbcOutputTableHandle handle, Set<Long> pageSinkIds)
     {
         delegate.finishInsertTable(session, handle, pageSinkIds);
-        onDataChanged(new SchemaTableName(handle.getSchemaName(), handle.getTableName()));
+        onDataChanged(handle.getRemoteTableName().getSchemaTableName());
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcOutputTableHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcOutputTableHandle.java
@@ -19,22 +19,18 @@ import com.google.common.collect.ImmutableList;
 import io.trino.spi.connector.ConnectorInsertTableHandle;
 import io.trino.spi.connector.ConnectorOutputTableHandle;
 import io.trino.spi.type.Type;
-import jakarta.annotation.Nullable;
 
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class JdbcOutputTableHandle
         implements ConnectorOutputTableHandle, ConnectorInsertTableHandle
 {
-    private final String catalogName;
-    private final String schemaName;
-    private final String tableName;
+    private final RemoteTableName remoteTableName;
     private final List<String> columnNames;
     private final List<Type> columnTypes;
     private final Optional<List<JdbcTypeHandle>> jdbcColumnTypes;
@@ -43,18 +39,14 @@ public class JdbcOutputTableHandle
 
     @JsonCreator
     public JdbcOutputTableHandle(
-            @JsonProperty("catalogName") @Nullable String catalogName,
-            @JsonProperty("schemaName") @Nullable String schemaName,
-            @JsonProperty("tableName") String tableName,
+            @JsonProperty("remoteTableName") RemoteTableName remoteTableName,
             @JsonProperty("columnNames") List<String> columnNames,
             @JsonProperty("columnTypes") List<Type> columnTypes,
             @JsonProperty("jdbcColumnTypes") Optional<List<JdbcTypeHandle>> jdbcColumnTypes,
             @JsonProperty("temporaryTableName") Optional<String> temporaryTableName,
             @JsonProperty("pageSinkIdColumnName") Optional<String> pageSinkIdColumnName)
     {
-        this.catalogName = catalogName;
-        this.schemaName = schemaName;
-        this.tableName = requireNonNull(tableName, "tableName is null");
+        this.remoteTableName = requireNonNull(remoteTableName, "remoteTableName is null");
         this.temporaryTableName = requireNonNull(temporaryTableName, "temporaryTableName is null");
 
         requireNonNull(columnNames, "columnNames is null");
@@ -68,23 +60,9 @@ public class JdbcOutputTableHandle
     }
 
     @JsonProperty
-    @Nullable
-    public String getCatalogName()
+    public RemoteTableName getRemoteTableName()
     {
-        return catalogName;
-    }
-
-    @JsonProperty
-    @Nullable
-    public String getSchemaName()
-    {
-        return schemaName;
-    }
-
-    @JsonProperty
-    public String getTableName()
-    {
-        return tableName;
+        return remoteTableName;
     }
 
     @JsonProperty
@@ -120,16 +98,14 @@ public class JdbcOutputTableHandle
     @Override
     public String toString()
     {
-        return format("jdbc:%s.%s.%s", catalogName, schemaName, tableName);
+        return "jdbc:%s".formatted(remoteTableName);
     }
 
     @Override
     public int hashCode()
     {
         return Objects.hash(
-                catalogName,
-                schemaName,
-                tableName,
+                remoteTableName,
                 columnNames,
                 columnTypes,
                 jdbcColumnTypes,
@@ -147,9 +123,7 @@ public class JdbcOutputTableHandle
             return false;
         }
         JdbcOutputTableHandle other = (JdbcOutputTableHandle) obj;
-        return Objects.equals(this.catalogName, other.catalogName) &&
-                Objects.equals(this.schemaName, other.schemaName) &&
-                Objects.equals(this.tableName, other.tableName) &&
+        return Objects.equals(this.remoteTableName, other.remoteTableName) &&
                 Objects.equals(this.columnNames, other.columnNames) &&
                 Objects.equals(this.columnTypes, other.columnTypes) &&
                 Objects.equals(this.jdbcColumnTypes, other.jdbcColumnTypes) &&

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/RemoteTableName.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/RemoteTableName.java
@@ -17,6 +17,7 @@ package io.trino.plugin.jdbc;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Joiner;
+import io.trino.spi.connector.SchemaTableName;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -56,6 +57,11 @@ public final class RemoteTableName
     public String getTableName()
     {
         return tableName;
+    }
+
+    public SchemaTableName getSchemaTableName()
+    {
+        return new SchemaTableName(schemaName.orElseThrow(), tableName);
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcOutputTableHandle.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcOutputTableHandle.java
@@ -29,9 +29,7 @@ public class TestJdbcOutputTableHandle
     public void testJsonRoundTrip()
     {
         JdbcOutputTableHandle handleForCreate = new JdbcOutputTableHandle(
-                "catalog",
-                "schema",
-                "table",
+                new RemoteTableName(Optional.of("catalog"), Optional.of("schema"), "table"),
                 ImmutableList.of("abc", "xyz"),
                 ImmutableList.of(VARCHAR, VARCHAR),
                 Optional.empty(),
@@ -41,9 +39,7 @@ public class TestJdbcOutputTableHandle
         assertJsonRoundTrip(OUTPUT_TABLE_CODEC, handleForCreate);
 
         JdbcOutputTableHandle handleForInsert = new JdbcOutputTableHandle(
-                "catalog",
-                "schema",
-                "table",
+                new RemoteTableName(Optional.of("catalog"), Optional.of("schema"), "table"),
                 ImmutableList.of("abc", "xyz"),
                 ImmutableList.of(VARCHAR, VARCHAR),
                 Optional.of(ImmutableList.of(JDBC_VARCHAR, JDBC_VARCHAR)),

--- a/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteClient.java
+++ b/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteClient.java
@@ -37,6 +37,7 @@ import io.trino.plugin.jdbc.LongReadFunction;
 import io.trino.plugin.jdbc.LongWriteFunction;
 import io.trino.plugin.jdbc.PreparedQuery;
 import io.trino.plugin.jdbc.QueryBuilder;
+import io.trino.plugin.jdbc.RemoteTableName;
 import io.trino.plugin.jdbc.WriteFunction;
 import io.trino.plugin.jdbc.WriteMapping;
 import io.trino.plugin.jdbc.aggregation.ImplementAvgFloatingPoint;
@@ -415,8 +416,7 @@ public class IgniteClient
             execute(session, connection, sql);
 
             return new IgniteOutputTableHandle(
-                    schemaTableName.getSchemaName(),
-                    schemaTableName.getTableName(),
+                    new RemoteTableName(Optional.empty(), Optional.of(schemaTableName.getSchemaName()), schemaTableName.getTableName()),
                     columnNames,
                     columnTypes.build(),
                     Optional.empty(),
@@ -568,7 +568,7 @@ public class IgniteClient
         }
         return format(
                 "INSERT INTO %s (%s) VALUES (%s)",
-                quoted(null, handle.getSchemaName(), handle.getTableName()),
+                quoted(handle.getRemoteTableName()),
                 columns,
                 params);
     }

--- a/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteMetadata.java
+++ b/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteMetadata.java
@@ -104,8 +104,7 @@ public class IgniteMetadata
 
         RemoteTableName remoteTableName = handle.asPlainTable().getRemoteTableName();
         return new IgniteOutputTableHandle(
-                remoteTableName.getSchemaName().orElse(null),
-                remoteTableName.getTableName(),
+                remoteTableName,
                 columnNames.build(),
                 columnTypes.build(),
                 Optional.of(columnJdbcTypeHandles.build()),

--- a/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteOutputTableHandle.java
+++ b/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteOutputTableHandle.java
@@ -17,8 +17,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.plugin.jdbc.JdbcOutputTableHandle;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
+import io.trino.plugin.jdbc.RemoteTableName;
 import io.trino.spi.type.Type;
-import jakarta.annotation.Nullable;
 
 import java.util.List;
 import java.util.Optional;
@@ -32,14 +32,13 @@ public class IgniteOutputTableHandle
 
     @JsonCreator
     public IgniteOutputTableHandle(
-            @Nullable @JsonProperty("schemaName") String schemaName,
-            @JsonProperty("tableName") String tableName,
+            @JsonProperty("remoteTableName") RemoteTableName remoteTableName,
             @JsonProperty("columnNames") List<String> columnNames,
             @JsonProperty("columnTypes") List<Type> columnTypes,
             @JsonProperty("jdbcColumnTypes") Optional<List<JdbcTypeHandle>> jdbcColumnTypes,
             @JsonProperty("dummyIdColumn") Optional<String> dummyIdColumn)
     {
-        super("", schemaName, tableName, columnNames, columnTypes, jdbcColumnTypes, Optional.empty(), Optional.empty());
+        super(remoteTableName, columnNames, columnTypes, jdbcColumnTypes, Optional.empty(), Optional.empty());
         this.dummyIdColumn = requireNonNull(dummyIdColumn, "dummyIdColumn is null");
     }
 

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
@@ -410,13 +410,13 @@ public class PhoenixClient
         if (outputHandle.rowkeyColumn().isPresent()) {
             String nextId = format(
                     "NEXT VALUE FOR %s, ",
-                    quoted(null, handle.getSchemaName(), handle.getTableName() + "_sequence"));
+                    quoted(null, handle.getRemoteTableName().getSchemaName().orElse(null), handle.getRemoteTableName().getTableName() + "_sequence"));
             params = nextId + params;
             columns = outputHandle.rowkeyColumn().get() + ", " + columns;
         }
         return format(
                 "UPSERT INTO %s (%s) VALUES (%s)",
-                quoted(null, handle.getSchemaName(), handle.getTableName()),
+                quoted(handle.getRemoteTableName()),
                 columns,
                 params);
     }
@@ -696,8 +696,7 @@ public class PhoenixClient
             execute(session, sql);
 
             return new PhoenixOutputTableHandle(
-                    schema,
-                    table,
+                    new RemoteTableName(Optional.empty(), Optional.ofNullable(schema), table),
                     columnNames.build(),
                     columnTypes.build(),
                     Optional.empty(),

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
@@ -238,8 +238,7 @@ public class PhoenixMetadata
 
         RemoteTableName remoteTableName = handle.asPlainTable().getRemoteTableName();
         return new PhoenixOutputTableHandle(
-                remoteTableName.getSchemaName().orElse(null),
-                remoteTableName.getTableName(),
+                remoteTableName,
                 columnHandles.stream().map(JdbcColumnHandle::getColumnName).collect(toImmutableList()),
                 columnHandles.stream().map(JdbcColumnHandle::getColumnType).collect(toImmutableList()),
                 Optional.of(columnHandles.stream().map(JdbcColumnHandle::getJdbcTypeHandle).collect(toImmutableList())),

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixOutputTableHandle.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixOutputTableHandle.java
@@ -17,8 +17,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.plugin.jdbc.JdbcOutputTableHandle;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
+import io.trino.plugin.jdbc.RemoteTableName;
 import io.trino.spi.type.Type;
-import jakarta.annotation.Nullable;
 
 import java.util.List;
 import java.util.Optional;
@@ -32,14 +32,13 @@ public class PhoenixOutputTableHandle
 
     @JsonCreator
     public PhoenixOutputTableHandle(
-            @Nullable @JsonProperty("schemaName") String schemaName,
-            @JsonProperty("tableName") String tableName,
+            @JsonProperty("remoteTableName") RemoteTableName remoteTableName,
             @JsonProperty("columnNames") List<String> columnNames,
             @JsonProperty("columnTypes") List<Type> columnTypes,
             @JsonProperty("jdbcColumnTypes") Optional<List<JdbcTypeHandle>> jdbcColumnTypes,
             @JsonProperty("rowkeyColumn") Optional<String> rowkeyColumn)
     {
-        super("", schemaName, tableName, columnNames, columnTypes, jdbcColumnTypes, Optional.empty(), Optional.empty());
+        super(remoteTableName, columnNames, columnTypes, jdbcColumnTypes, Optional.empty(), Optional.empty());
         this.rowkeyColumn = requireNonNull(rowkeyColumn, "rowkeyColumn is null");
     }
 

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
@@ -379,7 +379,10 @@ public class SqlServerClient
             // 'table lock on bulk load' table option causes the bulk load processes on user-defined tables to obtain a bulk update lock
             // note: this is not a request to lock a table immediately
             String sql = format("EXEC sp_tableoption '%s', 'table lock on bulk load', '1'",
-                    quoted(table.getCatalogName(), table.getSchemaName(), table.getTemporaryTableName().orElseGet(table::getTableName)));
+                    quoted(
+                            table.getRemoteTableName().getCatalogName().orElse(null),
+                            table.getRemoteTableName().getSchemaName().orElse(null),
+                            table.getTemporaryTableName().orElseGet(() -> table.getRemoteTableName().getTableName())));
             execute(session, connection, sql);
         }
         catch (SQLException e) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The `catalogName` and `schemaName` members are annotated with nullable, but it's easy to miss the info when use getter. Instead, use `RemoteTableName`, which encapsulates the `catalogName` and `schemaName` within `Optional` wrapper.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
