### PR TITLE
Fix memory tracking for varchar grouped aggregations

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/StateCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/StateCompiler.java
@@ -151,6 +151,41 @@ public final class StateCompiler
         return ObjectBigArray.class;
     }
 
+    private static Class<?> bigArrayElementType(Class<?> bigArrayType)
+    {
+        if (bigArrayType.equals(LongBigArray.class)) {
+            return long.class;
+        }
+        if (bigArrayType.equals(ByteBigArray.class)) {
+            return byte.class;
+        }
+        if (bigArrayType.equals(DoubleBigArray.class)) {
+            return double.class;
+        }
+        if (bigArrayType.equals(BooleanBigArray.class)) {
+            return boolean.class;
+        }
+        if (bigArrayType.equals(IntBigArray.class)) {
+            return int.class;
+        }
+        if (bigArrayType.equals(SliceBigArray.class)) {
+            return Slice.class;
+        }
+        if (bigArrayType.equals(BlockBigArray.class)) {
+            return Block.class;
+        }
+        if (bigArrayType.equals(SqlMapBigArray.class)) {
+            return SqlMap.class;
+        }
+        if (bigArrayType.equals(SqlRowBigArray.class)) {
+            return SqlRow.class;
+        }
+        if (bigArrayType.equals(ObjectBigArray.class)) {
+            return Object.class;
+        }
+        throw new IllegalArgumentException("Unsupported bigArrayType: " + bigArrayType.getName());
+    }
+
     public static <T extends AccumulatorState> AccumulatorStateSerializer<T> generateStateSerializer(Class<T> clazz)
     {
         return generateStateSerializer(clazz, ImmutableMap.of());
@@ -475,8 +510,9 @@ public final class StateCompiler
 
         ImmutableList.Builder<FieldDefinition> fieldDefinitions = ImmutableList.builder();
         FieldDefinition groupIdField = definition.declareField(a(PRIVATE), "groupId", int.class);
-        Class<?> valueElementType = inOutGetterReturnType(type);
-        FieldDefinition valueField = definition.declareField(a(PRIVATE, FINAL), "value", getBigArrayType(valueElementType));
+        Class<?> bigArrayType = getBigArrayType(type.getJavaType());
+        Class<?> valueElementType = bigArrayElementType(bigArrayType);
+        FieldDefinition valueField = definition.declareField(a(PRIVATE, FINAL), "value", bigArrayType);
         fieldDefinitions.add(valueField);
         constructor.getBody().append(constructor.getThis().setField(valueField, newInstance(valueField.getType())));
         Function<Scope, BytecodeExpression> valueGetter = scope -> scope.getThis().getField(valueField).invoke("get", valueElementType, scope.getThis().getField(groupIdField).cast(long.class));


### PR DESCRIPTION
## Description
Changes `StateCompiler` to use `SliceBigArray` instead of `ObjectBigArray` when generating `GroupedInOut` state values for slices. When `ObjectBigArray` is used, the size of the values themselves are not tracked which can lead to OOM's for aggregations over large strings.

## Additional context and related issues
Fixes https://github.com/trinodb/trino/issues/23105. This issue was partially fixed by https://github.com/trinodb/trino/pull/21425 in Trino 445, but only addressed the issue for fixed width primitive types and not variable width types that were previously backed backed by `ObjectBigArray`.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix memory tracking issue for aggregations that could cause worker crashes with out-of-memory errors ({issue}`23098`)
```
