### PR TITLE
Disable `testRegisterTableWithDroppedTable` in Polaris

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergPolarisCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergPolarisCatalogConnectorSmokeTest.java
@@ -25,6 +25,7 @@ import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
 import org.apache.iceberg.BaseTable;
 import org.assertj.core.util.Files;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Isolated;
@@ -180,6 +181,7 @@ final class TestIcebergPolarisCatalogConnectorSmokeTest
 
     @Test
     @Override
+    @Disabled("Disable as register table is broken with S3 in Polaris. More info at https://github.com/trinodb/trino/pull/23099")
     public void testRegisterTableWithTrailingSpaceInLocation()
     {
         assertThatThrownBy(super::testRegisterTableWithTrailingSpaceInLocation)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Related to https://github.com/trinodb/trino/issues/23082

Issue appears due to the fact that drop table collects only latest metatdata file but older metadata files remains untouched. Ideally `testRegisterTableWithDroppedTable` should not have to be overridden as all the functionalities are supported by the Polaris catalog.

---
Below shows that create and drop table leaves behind no metadata files.
```
trino:tpch> CREATE TABLE sample (a int, b varchar, c boolean);
CREATE TABLE
trino:tpch> show create table sample;
                                                                       Create Table                                                                        
-----------------------------------------------------------------------------------------------------------------------------------------------------------
 CREATE TABLE iceberg.tpch.sample (                                                                                                                        
    a integer,                                                                                                                                             
    b varchar,                                                                                                                                             
    c boolean                                                                                                                                              
 )                                                                                                                                                         
 WITH (                                                                                                                                                    
    format = 'PARQUET',                                                                                                                                    
    format_version = 2,                                                                                                                                    
    location = 'file:///var/folders/7_/5nvc34mn7gz7njzzgc4gx4cc0000gq/T/f0b846c9-83a2-4e29-bce8-ea430b6960f2/tpch/sample-4c4aabf62e2e42f7a7b6a6b31fbe5e82' 
 )                                                                                                                                                         


- /var/folders/7_/5nvc34mn7gz7njzzgc4gx4cc0000gq/T/f0b846c9-83a2-4e29-bce8-ea430b6960f2/tpch/sample-4c4aabf62e2e42f7a7b6a6b31fbe5e82/metadata $ ls -lrt
total 24
-rw-r--r--  1 xxx  staff  4313 21 Aug 16:40 snap-7359453686538607615-1-6d0f9c27-d039-4117-82c4-c0186191d20b.avro
-rw-r--r--  1 xxx  staff  2296 21 Aug 16:40 00000-143af204-6ad7-4dc4-b152-13b963913689.metadata.json


trino:tpch> DROP TABLE sample;
DROP TABLE

- /var/folders/7_/5nvc34mn7gz7njzzgc4gx4cc0000gq/T/f0b846c9-83a2-4e29-bce8-ea430b6960f2/tpch/sample-4c4aabf62e2e42f7a7b6a6b31fbe5e82/metadata $ ls -lrt
total 16
-rw-r--r--  1 xxx  staff  4313 21 Aug 16:40 snap-7359453686538607615-1-6d0f9c27-d039-4117-82c4-c0186191d20b.avro

```
---

Below shows that create, insert and delete when execute subsequently leaving behind multiple metadata files. Hence, register table doesn't fail with `No versioned metadata file exists at location` but rather tries to register table.
```
trino:tpch> CREATE TABLE sample (a int, b varchar, c boolean);
CREATE TABLE
trino:tpch> INSERT INTO sample values(1, 'value', true);
INSERT: 1 row


trino:tpch> show create table sample;
                                                                       Create Table                                                                        
-----------------------------------------------------------------------------------------------------------------------------------------------------------
 CREATE TABLE iceberg.tpch.sample (                                                                                                                        
    a integer,                                                                                                                                             
    b varchar,                                                                                                                                             
    c boolean                                                                                                                                              
 )                                                                                                                                                         
 WITH (                                                                                                                                                    
    format = 'PARQUET',                                                                                                                                    
    format_version = 2,                                                                                                                                    
    location = 'file:///var/folders/7_/5nvc34mn7gz7njzzgc4gx4cc0000gq/T/f0b846c9-83a2-4e29-bce8-ea430b6960f2/tpch/sample-22b14321ed364b3fb86785d14c737820' 
 )                                                                                                                                                         


- /var/folders/7_/5nvc34mn7gz7njzzgc4gx4cc0000gq/T/f0b846c9-83a2-4e29-bce8-ea430b6960f2/tpch/sample-22b14321ed364b3fb86785d14c737820/metadata $ ls -lrt
total 88
-rw-r--r--  1 xxx  staff  4313 21 Aug 16:43 snap-8848760311187813596-1-3e082893-c7b9-4545-b066-9183a05b07af.avro
-rw-r--r--  1 xxx  staff  2296 21 Aug 16:43 00000-610c4d46-81d9-494f-96e4-5e5e6cac7eae.metadata.json
-rw-r--r--  1 xxx  staff  6820 21 Aug 16:43 f0a8d60a-1dbf-4861-82f3-71cdcfb7e7db-m0.avro
-rw-r--r--  1 xxx  staff  4538 21 Aug 16:43 snap-8332981462980940770-1-f0a8d60a-1dbf-4861-82f3-71cdcfb7e7db.avro
-rw-r--r--  1 xxx  staff  3616 21 Aug 16:43 00001-8c762f66-ffd4-46d9-a2ea-3f605273d592.metadata.json
-rw-r--r--  1 xxx  staff   722 21 Aug 16:43 20240821_204326_00030_p33mp-8394d2a2-c1a0-497e-9bce-391585b5a636.stats
-rw-r--r--  1 xxx  staff  4882 21 Aug 16:43 00002-a5564894-6054-4ef5-b948-fbdca58c5fbc.metadata.json
- /var/folders/7_/5nvc34mn7gz7njzzgc4gx4cc0000gq/T/f0b846c9-83a2-4e29-bce8-ea430b6960f2/tpch/sample-22b14321ed364b3fb86785d14c737820/metadata $ 

trino:tpch> DROP TABLE sample;
DROP TABLE

- /var/folders/7_/5nvc34mn7gz7njzzgc4gx4cc0000gq/T/f0b846c9-83a2-4e29-bce8-ea430b6960f2/tpch/sample-22b14321ed364b3fb86785d14c737820/metadata $ ls -lrt
total 56
-rw-r--r--  1 xxx  staff  4313 21 Aug 16:43 snap-8848760311187813596-1-3e082893-c7b9-4545-b066-9183a05b07af.avro
-rw-r--r--  1 xxx  staff  2296 21 Aug 16:43 00000-610c4d46-81d9-494f-96e4-5e5e6cac7eae.metadata.json
-rw-r--r--  1 xxx  staff  4538 21 Aug 16:43 snap-8332981462980940770-1-f0a8d60a-1dbf-4861-82f3-71cdcfb7e7db.avro
-rw-r--r--  1 xxx  staff  3616 21 Aug 16:43 00001-8c762f66-ffd4-46d9-a2ea-3f605273d592.metadata.json
-rw-r--r--  1 xxx  staff   722 21 Aug 16:43 20240821_204326_00030_p33mp-8394d2a2-c1a0-497e-9bce-391585b5a636.stats

```

Im not sure if its catalog's responsibility or engine's. If its engine responsibility then we need to modify `TrinoRestCatalog#dropTable` to cleanup storage like other catalog implementations, if its catalog's responsibility then something could be broken in `BasePolarisCatalog#dropTable` in Polaris. We can reenable this test once we conclude on this point, given my analysis is correct.

However, worth noting that register table is already broken atleast when using S3 as storage https://github.com/apache/polaris/issues/156

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
