### PR TITLE
Allow DevelopmentServer testing with internal and external plugins together

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ product-test-reports
 .github/bin/redshift/.cluster-identifier
 **/dependency-reduced-pom.xml
 core/trino-web-ui/src/main/resources/webapp/dist/
+
+# Local plugins added for testing should be excluded
+testing/trino-server-dev/etc/plugin/*
+!testing/trino-server-dev/etc/plugin/README.md

--- a/testing/trino-server-dev/etc/config.properties
+++ b/testing/trino-server-dev/etc/config.properties
@@ -57,4 +57,5 @@ plugin.bundles=\
   ../../plugin/trino-exchange-hdfs/pom.xml, \
   ../../plugin/trino-mysql-event-listener/pom.xml
 
+plugin.dir=etc/plugin
 node-scheduler.include-coordinator=true

--- a/testing/trino-server-dev/etc/plugin/README.md
+++ b/testing/trino-server-dev/etc/plugin/README.md
@@ -1,0 +1,4 @@
+### External Plugins Directory
+
+External plugins can be added to this directory to test with `DevelopmentServer`. Each 
+plugin should be added as its own subdirectory.

--- a/testing/trino-server-dev/src/main/java/io/trino/server/DevelopmentServer.java
+++ b/testing/trino-server-dev/src/main/java/io/trino/server/DevelopmentServer.java
@@ -31,7 +31,9 @@ public final class DevelopmentServer
     {
         return ImmutableList.of(binder -> {
             newOptionalBinder(binder, PluginsProvider.class).setBinding()
-                    .to(DevelopmentPluginsProvider.class).in(Scopes.SINGLETON);
+                    .to(HybridDevelopmentPluginsProvider.class).in(Scopes.SINGLETON);
+            binder.bind(DevelopmentPluginsProvider.class).in(Scopes.SINGLETON);
+            binder.bind(ServerPluginsProvider.class).in(Scopes.SINGLETON);
             configBinder(binder).bindConfig(DevelopmentLoaderConfig.class);
         });
     }

--- a/testing/trino-server-dev/src/main/java/io/trino/server/HybridDevelopmentPluginsProvider.java
+++ b/testing/trino-server-dev/src/main/java/io/trino/server/HybridDevelopmentPluginsProvider.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server;
+
+import com.google.inject.Inject;
+import io.trino.server.PluginManager.PluginsProvider;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Supports loading internal and external plugins simultaneously during development.
+ * The `plugin.dir` value in `config.properties` is relative to `trino-server-dev` module.
+ */
+public class HybridDevelopmentPluginsProvider
+        implements PluginsProvider
+{
+    private final DevelopmentPluginsProvider developmentPluginsProvider;
+    private final ServerPluginsProvider serverPluginsProvider;
+
+    @Inject
+    public HybridDevelopmentPluginsProvider(DevelopmentPluginsProvider developmentPluginsProvider, ServerPluginsProvider serverPluginsProvider)
+    {
+        this.developmentPluginsProvider = requireNonNull(developmentPluginsProvider, "developmentPluginsProvider is null");
+        this.serverPluginsProvider = requireNonNull(serverPluginsProvider, "serverPluginsProvider is null");
+    }
+
+    @Override
+    public void loadPlugins(Loader loader, ClassLoaderFactory createClassLoader)
+    {
+        developmentPluginsProvider.loadPlugins(loader, createClassLoader);
+        serverPluginsProvider.loadPlugins(loader, createClassLoader);
+    }
+}


### PR DESCRIPTION
## Description
This PR makes it possible to use the local `DevelopmentServer` with both "internal" plugins (those within the `trino` repo) as well as "external" plugins that originate from outside of the repository. A new `HybridDevelopmentPluginsProvider` is added which loads plugins _both_ from `plugin.dir` and from `plugin.bundles`, and this is now used by default in `DevelopmentServer`. No additional plugins are loaded by default, but any plugin directories dropped into `testing/trino-server-dev/etc/plugin` will be picked up automatically.

For now this is added as an entirely new `PluginsProvider` which combines the behavior of the development and server plugins providers, but I would also be happy to structure it such that `DevelopmentPluginsProvider` just does this internally (by delegating to `ServerPluginsProvider`). Feedback is welcomed.

## Additional context and related issues

In #6834, the whole dev server was refactored. Previously, it was possible to use `plugin.dir` as well as `plugin.bundles` simultaneously, but after the refactor, these were moved to two separate plugin loaders (`ServerPluginsProvider` and `DevelopmentPluginsProviders`, respectively). `DevelopmentServer` only uses `DevelopmentPluginsProvider`, so it can load plugins from POM, but cannot load plugins from a directory, making it challenging to leverage the `DevelopmentServer` to test other plugins. This can be really useful while working on third party plugins that live outside of the Trino repo, and in particular, to test interactions _between_ plugins, such as redirection, or inspecting the events received by a third-party event listener when working with an internal catalog.

## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: