### PR TITLE
ensure strict json parsing in JSON functions

### DIFF
--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestJsonFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestJsonFunctions.java
@@ -689,6 +689,9 @@ public class TestJsonFunctions
 
         assertTrinoExceptionThrownBy(assertions.function("json_parse", "''")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
+
+        assertTrinoExceptionThrownBy(assertions.function("json_parse", "'{\"key\": \"v1\", \"key\": \"v2\"}'")::evaluate)
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
     }
 
     @Test

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/util/JsonTypeUtil.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/util/JsonTypeUtil.java
@@ -49,6 +49,7 @@ public final class JsonTypeUtil
         // If you make changes to this function (e.g. use parse JSON string into some internal representation),
         // make sure `$internal$json_string_to_array/map/row_cast` is changed accordingly.
         try (JsonParser parser = createJsonParser(JSON_FACTORY, slice)) {
+            parser.enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);
             SliceOutput output = new DynamicSliceOutput(slice.length());
             SORTED_MAPPER.writeValue((OutputStream) output, SORTED_MAPPER.readValue(parser, Object.class));
             // At this point, the end of input should be reached. nextToken() has three possible results:


### PR DESCRIPTION
## Description

ensure string json parsing, so that errors such as duplicate key issues will not occur.

## Additional context and related issues

address #22329

## Release notes

(x) Release notes are required. Please propose a release note for me.

