### PR TITLE
Add support for TopN and aggregation pushdown in Elasticsearch

### DIFF
--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/AggregateQueryPageSource.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/AggregateQueryPageSource.java
@@ -1,0 +1,322 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.elasticsearch;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.plugin.elasticsearch.client.ElasticsearchClient;
+import io.trino.plugin.elasticsearch.decoders.Decoder;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeManager;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
+import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
+import org.elasticsearch.search.aggregations.metrics.Stats;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.elasticsearch.ElasticsearchQueryBuilder.buildAggregationQuery;
+import static io.trino.plugin.elasticsearch.ElasticsearchQueryBuilder.buildSearchQuery;
+import static java.util.Objects.requireNonNull;
+
+public class AggregateQueryPageSource
+        implements ConnectorPageSource
+{
+    private static final SearchHit NO_HIT = new SearchHit(0);
+    private final List<Decoder> decoders;
+
+    private final ElasticsearchClient client;
+    private final ElasticsearchTableHandle table;
+    private final ElasticsearchSplit split;
+    private QueryBuilder queryBuilder;
+
+    private final BlockBuilder[] columnBuilders;
+    private final List<ElasticsearchColumnHandle> columns;
+    private long totalBytes;
+    private long readTimeNanos;
+    private Optional<Map<String, Object>> after = Optional.empty();
+    private boolean fetched;
+    private long fetchedSize;
+
+    public AggregateQueryPageSource(
+            ElasticsearchClient client,
+            TypeManager typeManager,
+            ElasticsearchTableHandle table,
+            ElasticsearchSplit split,
+            List<ElasticsearchColumnHandle> columns)
+    {
+        requireNonNull(client, "client is null");
+        requireNonNull(table, "table is null");
+        requireNonNull(split, "split is null");
+        requireNonNull(typeManager, "typeManager is null");
+        requireNonNull(columns, "columns is null");
+
+        this.client = client;
+        this.table = table;
+        this.split = split;
+
+        this.columns = ImmutableList.copyOf(columns);
+
+        decoders = createDecoders(columns);
+
+        columnBuilders = columns.stream()
+                .map(ElasticsearchColumnHandle::type)
+                .map(type -> type.createBlockBuilder(null, 1))
+                .toArray(BlockBuilder[]::new);
+        this.queryBuilder = buildSearchQuery(table.constraint().transformKeys(ElasticsearchColumnHandle.class::cast), table.query(), table.regexes());
+
+        long start = System.nanoTime();
+        readTimeNanos += System.nanoTime() - start;
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return totalBytes;
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return readTimeNanos;
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        // One of the following situation may stop the fetching
+        // 1. afterKey is empty, that means no more result can be fetched
+        // 2. fetchedSize >= the potential limit constraint
+        return (fetched && after.isEmpty()) || (table.topN().isPresent() && fetchedSize >= table.topN().get().getLimit());
+    }
+
+    @Override
+    public long getMemoryUsage()
+    {
+        return 0;
+    }
+
+    @Override
+    public void close()
+    {
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        long start = System.nanoTime();
+        OptionalInt pageSize = table.topN().isEmpty() ? OptionalInt.empty() : OptionalInt.of((int) table.topN().get().getLimit());
+        SearchResponse searchResponse = client.beginSearch(
+                split.index(),
+                split.shard(),
+                this.queryBuilder,
+                Optional.ofNullable(
+                        buildAggregationQuery(table.termAggregations(), table.metricAggregations(), pageSize, after)),
+                Optional.empty(),
+                Collections.emptyList(),
+                table.topN());
+        readTimeNanos += System.nanoTime() - start;
+        fetched = true;
+        List<Map<String, Object>> flatResult = getResult(searchResponse);
+        fetchedSize += flatResult.size();
+        after = extractAfter(searchResponse);
+        for (Map<String, Object> result : flatResult) {
+            for (int i = 0; i < columns.size(); i++) {
+                String key = columns.get(i).name();
+                decoders.get(i).decode(NO_HIT, () -> result.get(key), columnBuilders[i]);
+            }
+        }
+        Block[] blocks = new Block[columnBuilders.length];
+        for (int i = 0; i < columnBuilders.length; i++) {
+            blocks[i] = columnBuilders[i].build();
+            columnBuilders[i] = columnBuilders[i].newBlockBuilderLike(null);
+        }
+        return new Page(blocks);
+    }
+
+    private Optional<Map<String, Object>> extractAfter(SearchResponse searchResponse)
+    {
+        Aggregations aggregations = searchResponse.getAggregations();
+        if (aggregations == null) {
+            return Optional.empty();
+        }
+        for (Aggregation agg : aggregations) {
+            if (agg instanceof CompositeAggregation) {
+                CompositeAggregation compositeAggregation = (CompositeAggregation) agg;
+                return Optional.ofNullable(compositeAggregation.afterKey());
+            }
+        }
+        return Optional.empty();
+    }
+
+    public static Object getField(Map<String, Object> document, String field)
+    {
+        Object value = document.get(field);
+        if (value == null) {
+            Map<String, Object> result = new HashMap<>();
+            String prefix = field + ".";
+            for (Map.Entry<String, Object> entry : document.entrySet()) {
+                String key = entry.getKey();
+                if (key.startsWith(prefix)) {
+                    result.put(key.substring(prefix.length()), entry.getValue());
+                }
+            }
+
+            if (!result.isEmpty()) {
+                return result;
+            }
+        }
+
+        return value;
+    }
+
+    private Map<String, Type> flattenFields(List<ElasticsearchColumnHandle> columns)
+    {
+        Map<String, Type> result = new HashMap<>();
+
+        for (ElasticsearchColumnHandle column : columns) {
+            flattenFields(result, column.name(), column.type());
+        }
+
+        return result;
+    }
+
+    private void flattenFields(Map<String, Type> result, String fieldName, Type type)
+    {
+        if (type instanceof RowType) {
+            for (RowType.Field field : ((RowType) type).getFields()) {
+                flattenFields(result, appendPath(fieldName, field.getName().get()), field.getType());
+            }
+        }
+        else {
+            result.put(fieldName, type);
+        }
+    }
+
+    private List<Decoder> createDecoders(List<ElasticsearchColumnHandle> columns)
+    {
+        return columns.stream()
+                .map(ElasticsearchColumnHandle::decoderDescriptor)
+                .map(DecoderDescriptor::createDecoder)
+                .collect(toImmutableList());
+    }
+
+    private static String appendPath(String base, String element)
+    {
+        if (base.isEmpty()) {
+            return element;
+        }
+
+        return base + "." + element;
+    }
+
+    private List<Map<String, Object>> getResult(SearchResponse searchResponse)
+    {
+        Aggregations aggregations = searchResponse.getAggregations();
+        if (aggregations == null) {
+            return Collections.emptyList();
+        }
+        Map<String, Object> singleValueMap = new LinkedHashMap<>();
+        ImmutableList.Builder<Map<String, Object>> result = ImmutableList.builder();
+        boolean hasBucketsAggregation = false;
+        boolean hasMetricAggregation = false;
+        for (Aggregation agg : aggregations) {
+            if (agg instanceof CompositeAggregation) {
+                hasBucketsAggregation = true;
+                if (hasMetricAggregation) {
+                    throw new IllegalStateException("Bucket and metric aggregations should not be both present.");
+                }
+                CompositeAggregation compositeAggregation = (CompositeAggregation) agg;
+                for (CompositeAggregation.Bucket bucket : compositeAggregation.getBuckets()) {
+                    Map<String, Object> line = new HashMap<>();
+                    line.putAll(bucket.getKey());
+                    for (Aggregation metricAgg : bucket.getAggregations()) {
+                        if (metricAgg instanceof NumericMetricsAggregation.SingleValue) {
+                            NumericMetricsAggregation.SingleValue sv = (NumericMetricsAggregation.SingleValue) metricAgg;
+                            line.put(metricAgg.getName(), extractSingleValue(sv));
+                        }
+                        else if (metricAgg instanceof Stats) {
+                            line.put(metricAgg.getName(), extractSumFromStatsValue((Stats) metricAgg));
+                        }
+                    }
+                    result.add(line);
+                }
+            }
+            else if (agg instanceof NumericMetricsAggregation.SingleValue) {
+                hasMetricAggregation = true;
+                if (hasBucketsAggregation) {
+                    throw new IllegalStateException("Bucket and metric aggregations should not be both present.");
+                }
+                NumericMetricsAggregation.SingleValue sv = (NumericMetricsAggregation.SingleValue) agg;
+                singleValueMap.put(agg.getName(), extractSingleValue(sv));
+            }
+            // We use stats aggregation instead of sum aggregation
+            else if (agg instanceof Stats) {
+                hasMetricAggregation = true;
+                if (hasBucketsAggregation) {
+                    throw new IllegalStateException("Bucket and metric aggregations should not be both present.");
+                }
+                singleValueMap.put(agg.getName(), extractSumFromStatsValue((Stats) agg));
+            }
+            else {
+                throw new IllegalStateException("Unrecognized aggregation type: " + agg.getType());
+            }
+        }
+        if (hasBucketsAggregation) {
+            return result.build();
+        }
+        else {
+            return ImmutableList.of(singleValueMap);
+        }
+    }
+
+    private Double extractSumFromStatsValue(Stats statsValue)
+    {
+        double sumValue = statsValue.getSum();
+        // Check min(not avg) result to see if the sum result is valid.
+        // Es server return null for avg/min/max, but the es client return 0 as the result of avg even server return null.
+        // See org.elasticsearch.search.aggregations.metrics.stats.ParsedStats for more
+        double minValue = statsValue.getMin();
+        if (Double.isInfinite(minValue)) {
+            return null;
+        }
+        return sumValue;
+    }
+
+    private Double extractSingleValue(NumericMetricsAggregation.SingleValue singleValue)
+    {
+        // null will be decoded as Double.POSITIVE_INFINITY or Double.NEGATIVE_INFINITY
+        if (Double.isInfinite(singleValue.value())) {
+            return null;
+        }
+        else {
+            return singleValue.value();
+        }
+    }
+}

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/AggregateQueryPageSource.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/AggregateQueryPageSource.java
@@ -113,7 +113,7 @@ public class AggregateQueryPageSource
         // One of the following situation may stop the fetching
         // 1. afterKey is empty, that means no more result can be fetched
         // 2. fetchedSize >= the potential limit constraint
-        return (fetched && after.isEmpty()) || (table.topN().isPresent() && fetchedSize >= table.topN().get().getLimit());
+        return (fetched && after.isEmpty()) || (table.topN().isPresent() && fetchedSize >= table.topN().get().limit());
     }
 
     @Override
@@ -131,7 +131,7 @@ public class AggregateQueryPageSource
     public Page getNextPage()
     {
         long start = System.nanoTime();
-        OptionalInt pageSize = table.topN().isEmpty() ? OptionalInt.empty() : OptionalInt.of((int) table.topN().get().getLimit());
+        OptionalInt pageSize = table.topN().isEmpty() ? OptionalInt.empty() : OptionalInt.of((int) table.topN().get().limit());
         SearchResponse searchResponse = client.beginSearch(
                 split.index(),
                 split.shard(),

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/CountQueryPageSource.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/CountQueryPageSource.java
@@ -47,7 +47,7 @@ class CountQueryPageSource
         readTimeNanos = System.nanoTime() - start;
 
         if (table.topN().isPresent()) {
-            count = Math.min(table.topN().get().getLimit(), count);
+            count = Math.min(table.topN().get().limit(), count);
         }
 
         remaining = count;

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/CountQueryPageSource.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/CountQueryPageSource.java
@@ -46,8 +46,8 @@ class CountQueryPageSource
                 buildSearchQuery(table.constraint().transformKeys(ElasticsearchColumnHandle.class::cast), table.query(), table.regexes()));
         readTimeNanos = System.nanoTime() - start;
 
-        if (table.limit().isPresent()) {
-            count = Math.min(table.limit().getAsLong(), count);
+        if (table.topN().isPresent()) {
+            count = Math.min(table.topN().get().getLimit(), count);
         }
 
         remaining = count;

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
@@ -19,6 +19,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import io.airlift.slice.Slice;
 import io.trino.plugin.base.expression.ConnectorExpressions;
+import io.trino.plugin.elasticsearch.aggregation.MetricAggregation;
+import io.trino.plugin.elasticsearch.aggregation.TermAggregation;
 import io.trino.plugin.elasticsearch.client.ElasticsearchClient;
 import io.trino.plugin.elasticsearch.client.IndexMetadata;
 import io.trino.plugin.elasticsearch.client.IndexMetadata.DateTimeType;
@@ -39,8 +41,12 @@ import io.trino.plugin.elasticsearch.decoders.TimestampDecoder;
 import io.trino.plugin.elasticsearch.decoders.TinyintDecoder;
 import io.trino.plugin.elasticsearch.decoders.VarbinaryDecoder;
 import io.trino.plugin.elasticsearch.decoders.VarcharDecoder;
+import io.trino.plugin.elasticsearch.expression.TopN;
 import io.trino.plugin.elasticsearch.ptf.RawQuery.RawQueryFunctionHandle;
 import io.trino.spi.TrinoException;
+import io.trino.spi.connector.AggregateFunction;
+import io.trino.spi.connector.AggregationApplicationResult;
+import io.trino.spi.connector.Assignment;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorMetadata;
@@ -54,8 +60,10 @@ import io.trino.spi.connector.ConstraintApplicationResult;
 import io.trino.spi.connector.LimitApplicationResult;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
+import io.trino.spi.connector.SortItem;
 import io.trino.spi.connector.TableColumnsMetadata;
 import io.trino.spi.connector.TableFunctionApplicationResult;
+import io.trino.spi.connector.TopNApplicationResult;
 import io.trino.spi.expression.Call;
 import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.expression.Constant;
@@ -77,19 +85,20 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.OptionalLong;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
 import static com.google.common.base.Verify.verifyNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterators.singletonIterator;
 import static io.airlift.slice.SliceUtf8.getCodePointAt;
 import static io.airlift.slice.SliceUtf8.lengthOfCodePoint;
+import static io.trino.plugin.elasticsearch.ElasticsearchTableHandle.Type.AGGREGATION;
 import static io.trino.plugin.elasticsearch.ElasticsearchTableHandle.Type.QUERY;
 import static io.trino.plugin.elasticsearch.ElasticsearchTableHandle.Type.SCAN;
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
@@ -113,6 +122,7 @@ import static java.util.Objects.requireNonNull;
 public class ElasticsearchMetadata
         implements ConnectorMetadata
 {
+    private static final String SYNTHETIC_COLUMN_NAME_PREFIX = "_efgnrtd_";
     private static final String PASSTHROUGH_QUERY_RESULT_COLUMN_NAME = "result";
     private static final ColumnMetadata PASSTHROUGH_QUERY_RESULT_COLUMN_METADATA = ColumnMetadata.builder()
             .setName(PASSTHROUGH_QUERY_RESULT_COLUMN_NAME)
@@ -490,9 +500,11 @@ public class ElasticsearchMetadata
             return Optional.empty();
         }
 
-        if (handle.limit().isPresent() && handle.limit().getAsLong() <= limit) {
+        if (handle.topN().isPresent() && handle.topN().get().getLimit() <= limit) {
             return Optional.empty();
         }
+
+        TopN topN = TopN.fromLimit(limit);
 
         handle = new ElasticsearchTableHandle(
                 handle.type(),
@@ -501,7 +513,9 @@ public class ElasticsearchMetadata
                 handle.constraint(),
                 handle.regexes(),
                 handle.query(),
-                OptionalLong.of(limit));
+                handle.termAggregations(),
+                handle.metricAggregations(),
+                Optional.of(topN));
 
         return Optional.of(new LimitApplicationResult<>(handle, false, false));
     }
@@ -577,7 +591,9 @@ public class ElasticsearchMetadata
                 newDomain,
                 newRegexes,
                 handle.query(),
-                handle.limit());
+                handle.termAggregations(),
+                handle.metricAggregations(),
+                handle.topN());
 
         return Optional.of(new ConstraintApplicationResult<>(handle, TupleDomain.withColumnDomains(unsupported), newExpression, false));
     }
@@ -682,4 +698,146 @@ public class ElasticsearchMetadata
     private record InternalTableMetadata(SchemaTableName tableName, List<ColumnMetadata> columnMetadata, Map<String, ColumnHandle> columnHandles) {}
 
     private record TypeAndDecoder(Type type, DecoderDescriptor decoderDescriptor) {}
+
+    @Override
+    public Optional<TopNApplicationResult<ConnectorTableHandle>> applyTopN(
+            ConnectorSession session,
+            ConnectorTableHandle table,
+            long topNCount,
+            List<SortItem> sortItems,
+            Map<String, ColumnHandle> assignments)
+    {
+        ElasticsearchTableHandle handle = (ElasticsearchTableHandle) table;
+
+        if (isPassthroughQuery(handle)) {
+            // topN pushdown currently not supported passthrough query
+            return Optional.empty();
+        }
+        if (handle.topN().isPresent()) {
+            return Optional.empty();
+        }
+
+        TopN topN = TopN.fromLimit(topNCount);
+        for (SortItem sortItem : sortItems) {
+            ElasticsearchColumnHandle ch = (ElasticsearchColumnHandle) assignments.get(sortItem.getName());
+            if (!ch.supportsPredicates()) {
+                return Optional.empty();
+            }
+            topN.addSortItem(TopN.TopNSortItem.sortBy(ch.name(), sortItem.getSortOrder()));
+        }
+
+        ElasticsearchTableHandle newHandle = new ElasticsearchTableHandle(
+                handle.type(),
+                handle.schema(),
+                handle.index(),
+                handle.constraint(),
+                handle.regexes(),
+                handle.query(),
+                handle.termAggregations(),
+                handle.metricAggregations(),
+                Optional.of(topN));
+
+        return Optional.of(new TopNApplicationResult<>(newHandle, false, false));
+    }
+
+    @Override
+    public Optional<AggregationApplicationResult<ConnectorTableHandle>> applyAggregation(
+            ConnectorSession session,
+            ConnectorTableHandle table,
+            List<AggregateFunction> aggregates,
+            Map<String, ColumnHandle> assignments,
+            List<List<ColumnHandle>> groupingSets)
+    {
+        ElasticsearchTableHandle handle = (ElasticsearchTableHandle) table;
+        if (isPassthroughQuery(handle)) {
+            // aggregation pushdown currently not supported passthrough query
+            return Optional.empty();
+        }
+        // Global aggregation is represented by [[]]
+        verify(!groupingSets.isEmpty(), "No grouping sets provided");
+        if (!handle.termAggregations().isEmpty()) {
+            /*
+             applyAggregation may be called multiple times if an aggregation is done over the results of another aggregation
+             for example
+              SELECT sum(DISTINCT regionkey) FROM nation
+              SELECT max(x)
+                FROM (
+                  SELECT k, sum(v) AS x
+                    FROM t
+                  GROUP BY k)
+             We skip the second one, but the first group by will be still applied
+             */
+            return Optional.empty();
+        }
+
+        ImmutableList.Builder<ConnectorExpression> projections = ImmutableList.builder();
+        ImmutableList.Builder<Assignment> resultAssignments = ImmutableList.builder();
+        ImmutableList.Builder<MetricAggregation> metricAggregations = ImmutableList.builder();
+        ImmutableList.Builder<TermAggregation> termAggregations = ImmutableList.builder();
+        for (int i = 0; i < aggregates.size(); i++) {
+            AggregateFunction aggregationFunction = aggregates.get(i);
+            String colName = SYNTHETIC_COLUMN_NAME_PREFIX + i;
+            Optional<MetricAggregation> metricAggregation =
+                    MetricAggregation.handleAggregation(aggregationFunction, assignments, colName);
+            if (metricAggregation.isEmpty()) {
+                return Optional.empty();
+            }
+            DecoderDescriptor descriptor = getAggregateOutputDecoderDescriptor(colName, aggregationFunction.getOutputType());
+            if (descriptor == null) {
+                return Optional.empty();
+            }
+            ElasticsearchColumnHandle newColumn = new ElasticsearchColumnHandle(
+                    colName,
+                    aggregationFunction.getOutputType(),
+                    descriptor,
+                    // new column never support predicates
+                    false);
+            projections.add(new Variable(colName, aggregationFunction.getOutputType()));
+            resultAssignments.add(new Assignment(colName, newColumn, aggregationFunction.getOutputType()));
+            metricAggregations.add(metricAggregation.get());
+        }
+        for (ColumnHandle columnHandle : groupingSets.get(0)) {
+            Optional<TermAggregation> termAggregation = TermAggregation.fromColumnHandle(columnHandle);
+            if (termAggregation.isEmpty()) {
+                return Optional.empty();
+            }
+            termAggregations.add(termAggregation.get());
+        }
+        List<MetricAggregation> aggregationList = metricAggregations.build();
+        List<TermAggregation> termAggregationList = termAggregations.build();
+        ElasticsearchTableHandle tableHandle = new ElasticsearchTableHandle(
+                AGGREGATION,
+                handle.schema(),
+                handle.index(),
+                handle.constraint(),
+                handle.regexes(),
+                handle.query(),
+                termAggregationList,
+                aggregationList,
+                handle.topN());
+        return Optional.of(new AggregationApplicationResult<>(tableHandle, projections.build(), resultAssignments.build(), ImmutableMap.of(), false));
+    }
+
+    private DecoderDescriptor getAggregateOutputDecoderDescriptor(String name, Type type)
+    {
+        switch (type.getBaseName()) {
+            case StandardTypes.REAL:
+                return new RealDecoder.Descriptor(name);
+            case StandardTypes.DOUBLE:
+                return new DoubleDecoder.Descriptor(name);
+            case StandardTypes.TINYINT:
+                return new TinyintDecoder.Descriptor(name);
+            case StandardTypes.SMALLINT:
+                return new SmallintDecoder.Descriptor(name);
+            case StandardTypes.INTEGER:
+                return new IntegerDecoder.Descriptor(name);
+            case StandardTypes.BIGINT:
+                return new BigintDecoder.Descriptor(name);
+            case StandardTypes.VARCHAR:
+                return new VarcharDecoder.Descriptor(name);
+            case StandardTypes.BOOLEAN:
+                return new BooleanDecoder.Descriptor(name);
+        }
+        return null;
+    }
 }

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
@@ -717,14 +717,15 @@ public class ElasticsearchMetadata
             return Optional.empty();
         }
 
-        TopN topN = TopN.fromLimit(topNCount);
+        ImmutableList.Builder<TopN.TopNSortItem> topNSortItems = ImmutableList.builder();
         for (SortItem sortItem : sortItems) {
             ElasticsearchColumnHandle ch = (ElasticsearchColumnHandle) assignments.get(sortItem.getName());
             if (!ch.supportsPredicates()) {
                 return Optional.empty();
             }
-            topN.addSortItem(TopN.TopNSortItem.sortBy(ch.name(), sortItem.getSortOrder()));
+            topNSortItems.add(TopN.TopNSortItem.sortBy(ch.name(), sortItem.getSortOrder()));
         }
+        TopN topN = new TopN(topNCount, topNSortItems.build());
 
         ElasticsearchTableHandle newHandle = new ElasticsearchTableHandle(
                 handle.type(),

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
@@ -500,7 +500,7 @@ public class ElasticsearchMetadata
             return Optional.empty();
         }
 
-        if (handle.topN().isPresent() && handle.topN().get().getLimit() <= limit) {
+        if (handle.topN().isPresent() && handle.topN().get().limit() <= limit) {
             return Optional.empty();
         }
 

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchPageSourceProvider.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchPageSourceProvider.java
@@ -28,6 +28,7 @@ import io.trino.spi.type.TypeManager;
 import java.util.List;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.elasticsearch.ElasticsearchTableHandle.Type.AGGREGATION;
 import static io.trino.plugin.elasticsearch.ElasticsearchTableHandle.Type.QUERY;
 import static java.util.Objects.requireNonNull;
 
@@ -61,6 +62,17 @@ public class ElasticsearchPageSourceProvider
 
         if (elasticsearchTable.type().equals(QUERY)) {
             return new PassthroughQueryPageSource(client, elasticsearchTable);
+        }
+
+        if (elasticsearchTable.type().equals(AGGREGATION)) {
+            return new AggregateQueryPageSource(
+                    client,
+                    typeManager,
+                    elasticsearchTable,
+                    elasticsearchSplit,
+                    columns.stream()
+                            .map(ElasticsearchColumnHandle.class::cast)
+                            .collect(toImmutableList()));
         }
 
         if (columns.isEmpty()) {

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchQueryBuilder.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchQueryBuilder.java
@@ -14,7 +14,10 @@
 package io.trino.plugin.elasticsearch;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
+import io.trino.plugin.elasticsearch.aggregation.MetricAggregation;
+import io.trino.plugin.elasticsearch.aggregation.TermAggregation;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.Range;
 import io.trino.spi.predicate.TupleDomain;
@@ -27,12 +30,23 @@ import org.elasticsearch.index.query.QueryStringQueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.query.RegexpQueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.composite.CompositeValuesSourceBuilder;
+import org.elasticsearch.search.aggregations.bucket.composite.TermsValuesSourceBuilder;
+import org.elasticsearch.search.aggregations.metrics.AvgAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.MaxAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.MinAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.SumAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.ValueCountAggregationBuilder;
 
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.function.BiFunction;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -54,6 +68,62 @@ import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
 public final class ElasticsearchQueryBuilder
 {
     private ElasticsearchQueryBuilder() {}
+
+    private static final Map<String, BiFunction<String, String, AggregationBuilder>> CONVERTERS =
+            ImmutableMap.of(MetricAggregation.MAX, (alias, field) -> new MaxAggregationBuilder(alias).field(field),
+                    MetricAggregation.MIN, (alias, field) -> new MinAggregationBuilder(alias).field(field),
+                    MetricAggregation.SUM, (alias, field) -> new SumAggregationBuilder(alias).field(field),
+                    MetricAggregation.AVG, (alias, field) -> new AvgAggregationBuilder(alias).field(field),
+                    MetricAggregation.COUNT, (alias, field) -> new ValueCountAggregationBuilder(alias).field(field));
+
+    public static List<AggregationBuilder> buildAggregationQuery(
+            List<TermAggregation> termAggregations,
+            List<MetricAggregation> aggregates,
+            OptionalInt pageSize,
+            Optional<Map<String, Object>> after)
+    {
+        ImmutableList.Builder<AggregationBuilder> aggregationsBuilder = ImmutableList.builder();
+        CompositeAggregationBuilder compositeAggregationBuilder = null;
+        if (termAggregations != null && !termAggregations.isEmpty()) {
+            ImmutableList.Builder<CompositeValuesSourceBuilder<?>> compositeValuesSourceListBuilder = ImmutableList.builder();
+            for (TermAggregation termAggregation : termAggregations) {
+                compositeValuesSourceListBuilder.add(new TermsValuesSourceBuilder(termAggregation.getTerm())
+                        .field(termAggregation.getTerm()).missingBucket(true));
+            }
+            compositeAggregationBuilder = new CompositeAggregationBuilder("groupBy", compositeValuesSourceListBuilder.build());
+            // pagination
+            pageSize.ifPresent(compositeAggregationBuilder::size);
+            after.ifPresent(compositeAggregationBuilder::aggregateAfter);
+            aggregationsBuilder.add(compositeAggregationBuilder);
+        }
+        if (aggregates != null && !aggregates.isEmpty()) {
+            for (MetricAggregation aggregation : aggregates) {
+                AggregationBuilder subAggregation = buildMetricAggregation(aggregation);
+                if (subAggregation != null) {
+                    if (compositeAggregationBuilder != null) {
+                        compositeAggregationBuilder.subAggregation(subAggregation);
+                    }
+                    else {
+                        aggregationsBuilder.add(subAggregation);
+                    }
+                }
+            }
+        }
+        return aggregationsBuilder.build();
+    }
+
+    private static AggregationBuilder buildMetricAggregation(MetricAggregation aggregation)
+    {
+        Optional<ElasticsearchColumnHandle> column = aggregation.getColumnHandle();
+        String field;
+        if (column.isEmpty()) {
+            field = "_id"; // use value_count("_id") aggregation to resolve count(*)
+        }
+        else {
+            field = column.get().name();
+        }
+        return CONVERTERS.get(aggregation.getFunctionName()).apply(aggregation.getAlias(), field);
+    }
 
     public static QueryBuilder buildSearchQuery(TupleDomain<ElasticsearchColumnHandle> constraint, Optional<String> query, Map<String, String> regexes)
     {

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchSplitManager.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchSplitManager.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.elasticsearch.ElasticsearchTableHandle.Type.AGGREGATION;
 import static io.trino.plugin.elasticsearch.ElasticsearchTableHandle.Type.QUERY;
 import static java.util.Objects.requireNonNull;
 
@@ -52,7 +53,7 @@ public class ElasticsearchSplitManager
     {
         ElasticsearchTableHandle tableHandle = (ElasticsearchTableHandle) table;
 
-        if (tableHandle.type().equals(QUERY)) {
+        if (tableHandle.type().equals(QUERY) || tableHandle.type().equals(AGGREGATION)) {
             return new FixedSplitSource(new ElasticsearchSplit(tableHandle.index(), 0, Optional.empty()));
         }
         List<ElasticsearchSplit> splits = client.getSearchShards(tableHandle.index()).stream()

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ScanQueryPageSource.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ScanQueryPageSource.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import io.airlift.log.Logger;
 import io.trino.plugin.elasticsearch.client.ElasticsearchClient;
 import io.trino.plugin.elasticsearch.decoders.Decoder;
+import io.trino.plugin.elasticsearch.expression.TopN;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
@@ -42,6 +43,8 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.elasticsearch.BuiltinColumns.SOURCE;
 import static io.trino.plugin.elasticsearch.BuiltinColumns.isBuiltinColumn;
 import static io.trino.plugin.elasticsearch.ElasticsearchQueryBuilder.buildSearchQuery;
+import static io.trino.plugin.elasticsearch.expression.TopN.NO_LIMIT;
+import static io.trino.plugin.elasticsearch.expression.TopN.TopNSortItem.DEFAULT_SORT_BY_DOC;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Predicate.isEqual;
@@ -98,13 +101,13 @@ public class ScanQueryPageSource
                 .filter(name -> !isBuiltinColumn(name))
                 .collect(toList());
 
-        // sorting by _doc (index order) get special treatment in Elasticsearch and is more efficient
-        Optional<String> sort = Optional.of("_doc");
-
-        if (table.query().isPresent()) {
-            // However, if we're using a custom Elasticsearch query, use default sorting.
-            // Documents will be scored and returned based on relevance
-            sort = Optional.empty();
+        Optional<TopN> topN = table.topN();
+        if (topN.isEmpty()) {
+            topN = Optional.of(TopN.fromLimit(NO_LIMIT));
+            if (table.query().isEmpty()) {
+                // sorting by _doc (index order) get special treatment in Elasticsearch and is more efficient
+                topN.get().addSortItem(DEFAULT_SORT_BY_DOC);
+            }
         }
 
         long start = System.nanoTime();
@@ -112,12 +115,12 @@ public class ScanQueryPageSource
                 split.index(),
                 split.shard(),
                 buildSearchQuery(table.constraint().transformKeys(ElasticsearchColumnHandle.class::cast), table.query(), table.regexes()),
+                Optional.empty(),
                 needAllFields ? Optional.empty() : Optional.of(requiredFields),
                 documentFields,
-                sort,
-                table.limit());
+                topN);
         readTimeNanos += System.nanoTime() - start;
-        this.iterator = new SearchHitIterator(client, () -> searchResponse, table.limit());
+        this.iterator = new SearchHitIterator(client, () -> searchResponse, OptionalLong.of(topN.get().getLimit()));
     }
 
     @Override

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ScanQueryPageSource.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ScanQueryPageSource.java
@@ -103,10 +103,11 @@ public class ScanQueryPageSource
 
         Optional<TopN> topN = table.topN();
         if (topN.isEmpty()) {
-            topN = Optional.of(TopN.fromLimit(NO_LIMIT));
             if (table.query().isEmpty()) {
-                // sorting by _doc (index order) get special treatment in Elasticsearch and is more efficient
-                topN.get().addSortItem(DEFAULT_SORT_BY_DOC);
+                topN = Optional.of(new TopN(NO_LIMIT, ImmutableList.of(DEFAULT_SORT_BY_DOC)));
+            }
+            else {
+                topN = Optional.of(TopN.fromLimit(NO_LIMIT));
             }
         }
 

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ScanQueryPageSource.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ScanQueryPageSource.java
@@ -120,7 +120,7 @@ public class ScanQueryPageSource
                 documentFields,
                 topN);
         readTimeNanos += System.nanoTime() - start;
-        this.iterator = new SearchHitIterator(client, () -> searchResponse, OptionalLong.of(topN.get().getLimit()));
+        this.iterator = new SearchHitIterator(client, () -> searchResponse, OptionalLong.of(topN.get().limit()));
     }
 
     @Override

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/aggregation/MetricAggregation.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/aggregation/MetricAggregation.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.elasticsearch.aggregation;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.plugin.elasticsearch.ElasticsearchColumnHandle;
+import io.trino.spi.connector.AggregateFunction;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.expression.Variable;
+import io.trino.spi.type.Type;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TinyintType.TINYINT;
+
+public class MetricAggregation
+{
+    public static final String MAX = "max";
+    public static final String MIN = "min";
+    public static final String AVG = "avg";
+    public static final String SUM = "sum";
+    public static final String COUNT = "count";
+    private static final List<String> SUPPORTED_AGGREGATION_FUNCTIONS = Arrays.asList(MAX, MIN, AVG, SUM, COUNT);
+    private static final List<Type> NUMERIC_TYPES = Arrays.asList(REAL, DOUBLE, TINYINT, SMALLINT, INTEGER, BIGINT);
+    private final String functionName;
+    private final Type outputType;
+    private final Optional<ElasticsearchColumnHandle> columnHandle;
+    private final String alias;
+
+    @JsonCreator
+    public MetricAggregation(
+            @JsonProperty("functionName") String functionName,
+            @JsonProperty("outputType") Type outputType,
+            @JsonProperty("columnHandle") Optional<ElasticsearchColumnHandle> columnHandle,
+            @JsonProperty("alias") String alias)
+    {
+        this.functionName = functionName;
+        this.outputType = outputType;
+        this.columnHandle = columnHandle;
+        this.alias = alias;
+    }
+
+    @JsonProperty
+    public String getFunctionName()
+    {
+        return functionName;
+    }
+
+    @JsonProperty
+    public Type getOutputType()
+    {
+        return outputType;
+    }
+
+    @JsonProperty
+    public Optional<ElasticsearchColumnHandle> getColumnHandle()
+    {
+        return columnHandle;
+    }
+
+    @JsonProperty
+    public String getAlias()
+    {
+        return alias;
+    }
+
+    public static boolean isNumericType(Type type)
+    {
+        return NUMERIC_TYPES.contains(type);
+    }
+
+    public static Optional<MetricAggregation> handleAggregation(
+            AggregateFunction function,
+            Map<String, ColumnHandle> assignments,
+            String alias)
+    {
+        if (!SUPPORTED_AGGREGATION_FUNCTIONS.contains(function.getFunctionName())) {
+            return Optional.empty();
+        }
+        // check
+        // 1. Function input can be found in assignments
+        // 2. Target type of column being aggregate must be numeric type
+        // 3. ColumnHandle support predicates(since text treats as VARCHAR, but text can not be treats as term in es by default
+        Optional<ElasticsearchColumnHandle> parameterColumnHandle = function.getArguments().stream()
+                .filter(input -> input instanceof Variable)
+                .map(Variable.class::cast)
+                .map(Variable::getName)
+                .filter(assignments::containsKey)
+                .findFirst()
+                .map(assignments::get)
+                .map(ElasticsearchColumnHandle.class::cast)
+                .filter(column -> MetricAggregation.isNumericType(column.type()))
+                .filter(ElasticsearchColumnHandle::supportsPredicates);
+        if (parameterColumnHandle.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(new MetricAggregation(function.getFunctionName(), function.getOutputType(), parameterColumnHandle, alias));
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MetricAggregation that = (MetricAggregation) o;
+        return Objects.equals(functionName, that.functionName) &&
+                Objects.equals(outputType, that.outputType) &&
+                Objects.equals(columnHandle, that.columnHandle) &&
+                Objects.equals(alias, that.alias);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(functionName, outputType, columnHandle, alias);
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("%s(%s)", functionName, columnHandle.map(ElasticsearchColumnHandle::name).orElse(""));
+    }
+}

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/aggregation/TermAggregation.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/aggregation/TermAggregation.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.elasticsearch.aggregation;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.plugin.elasticsearch.ElasticsearchColumnHandle;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.type.Type;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class TermAggregation
+{
+    private final String term;
+    private final Type type;
+
+    @JsonCreator
+    public TermAggregation(
+            @JsonProperty("term") String term,
+            @JsonProperty("type") Type type)
+    {
+        this.term = term;
+        this.type = type;
+    }
+
+    @JsonProperty
+    public String getTerm()
+    {
+        return term;
+    }
+
+    @JsonProperty
+    public Type getType()
+    {
+        return type;
+    }
+
+    public static Optional<TermAggregation> fromColumnHandle(ColumnHandle columnHandle)
+    {
+        ElasticsearchColumnHandle column = (ElasticsearchColumnHandle) columnHandle;
+        if (column.supportsPredicates()) {
+            return Optional.of(new TermAggregation(column.name(), column.type()));
+        }
+        else {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TermAggregation that = (TermAggregation) o;
+        return Objects.equals(term, that.term) &&
+                Objects.equals(type, that.type);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(term, type);
+    }
+
+    @Override
+    public String toString()
+    {
+        return term;
+    }
+}

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/ElasticsearchClient.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/ElasticsearchClient.java
@@ -36,6 +36,7 @@ import io.airlift.units.Duration;
 import io.trino.plugin.elasticsearch.AwsSecurityConfig;
 import io.trino.plugin.elasticsearch.ElasticsearchConfig;
 import io.trino.plugin.elasticsearch.PasswordConfig;
+import io.trino.plugin.elasticsearch.expression.TopN;
 import io.trino.spi.TrinoException;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
@@ -64,6 +65,7 @@ import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
@@ -78,7 +80,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -97,6 +98,7 @@ import static io.trino.plugin.elasticsearch.ElasticsearchErrorCode.ELASTICSEARCH
 import static io.trino.plugin.elasticsearch.ElasticsearchErrorCode.ELASTICSEARCH_INVALID_RESPONSE;
 import static io.trino.plugin.elasticsearch.ElasticsearchErrorCode.ELASTICSEARCH_QUERY_FAILURE;
 import static io.trino.plugin.elasticsearch.ElasticsearchErrorCode.ELASTICSEARCH_SSL_INITIALIZATION_FAILURE;
+import static io.trino.plugin.elasticsearch.expression.TopN.NO_LIMIT;
 import static java.lang.StrictMath.toIntExact;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -575,20 +577,28 @@ public class ElasticsearchClient
         return body;
     }
 
-    public SearchResponse beginSearch(String index, int shard, QueryBuilder query, Optional<List<String>> fields, List<String> documentFields, Optional<String> sort, OptionalLong limit)
+    public SearchResponse beginSearch(String index, int shard, QueryBuilder query, Optional<List<AggregationBuilder>> aggregations, Optional<List<String>> fields, List<String> documentFields, Optional<TopN> topN)
     {
         SearchSourceBuilder sourceBuilder = SearchSourceBuilder.searchSource()
                 .query(query);
 
-        if (limit.isPresent() && limit.getAsLong() < scrollSize) {
-            // Safe to cast it to int because scrollSize is int.
-            sourceBuilder.size(toIntExact(limit.getAsLong()));
+        if (aggregations.isPresent()) {
+            aggregations.get().forEach(sourceBuilder::aggregation);
+            sourceBuilder.size(0);
         }
         else {
-            sourceBuilder.size(scrollSize);
+            if (topN.isPresent() &&
+                    topN.get().getLimit() != NO_LIMIT &&
+                    topN.get().getLimit() < scrollSize) {
+                // Safe to cast it to int because scrollSize is int.
+                sourceBuilder.size(toIntExact(topN.get().getLimit()));
+            }
+            else {
+                sourceBuilder.size(scrollSize);
+            }
         }
 
-        sort.ifPresent(sourceBuilder::sort);
+        topN.ifPresent(n -> n.getTopNSortItems().forEach(it -> sourceBuilder.sort(it.toSortBuilder())));
 
         fields.ifPresent(values -> {
             if (values.isEmpty()) {
@@ -604,9 +614,12 @@ public class ElasticsearchClient
 
         SearchRequest request = new SearchRequest(index)
                 .searchType(QUERY_THEN_FETCH)
-                .preference("_shards:" + shard)
-                .scroll(new TimeValue(scrollTimeout.toMillis()))
                 .source(sourceBuilder);
+
+        if (aggregations.isEmpty()) {
+            request.preference("_shards:" + shard)
+                    .scroll(new TimeValue(scrollTimeout.toMillis()));
+        }
 
         long start = System.nanoTime();
         try {

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/ElasticsearchClient.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/ElasticsearchClient.java
@@ -588,17 +588,17 @@ public class ElasticsearchClient
         }
         else {
             if (topN.isPresent() &&
-                    topN.get().getLimit() != NO_LIMIT &&
-                    topN.get().getLimit() < scrollSize) {
+                    topN.get().limit() != NO_LIMIT &&
+                    topN.get().limit() < scrollSize) {
                 // Safe to cast it to int because scrollSize is int.
-                sourceBuilder.size(toIntExact(topN.get().getLimit()));
+                sourceBuilder.size(toIntExact(topN.get().limit()));
             }
             else {
                 sourceBuilder.size(scrollSize);
             }
         }
 
-        topN.ifPresent(n -> n.getTopNSortItems().forEach(it -> sourceBuilder.sort(it.toSortBuilder())));
+        topN.ifPresent(n -> n.topNSortItems().forEach(it -> sourceBuilder.sort(it.toSortBuilder())));
 
         fields.ifPresent(values -> {
             if (values.isEmpty()) {

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/expression/TopN.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/expression/TopN.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.elasticsearch.expression;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.connector.SortOrder;
+import org.elasticsearch.search.sort.SortBuilder;
+import org.elasticsearch.search.sort.SortBuilders;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class TopN
+{
+    public static final long NO_LIMIT = -1;
+    public static final TopN EMPTY = new TopN(NO_LIMIT, new ArrayList<>());
+
+    private final long limit;
+    private final List<TopNSortItem> topNSortItems;
+
+    public static TopN fromLimit(long limit)
+    {
+        return new TopN(limit, new ArrayList<>());
+    }
+
+    @JsonCreator
+    public TopN(@JsonProperty("limit") long limit,
+            @JsonProperty("topNSortItems") List<TopNSortItem> topNSortItems)
+    {
+        this.limit = limit;
+        this.topNSortItems = requireNonNull(topNSortItems, "topNSortItems is null");
+    }
+
+    @JsonProperty("limit")
+    public long getLimit()
+    {
+        return limit;
+    }
+
+    @JsonProperty("topNSortItems")
+    public List<TopNSortItem> getTopNSortItems()
+    {
+        return topNSortItems;
+    }
+
+    public TopN addSortItem(TopNSortItem sortItem)
+    {
+        topNSortItems.add(sortItem);
+        return this;
+    }
+
+    public boolean isOnlyLimit()
+    {
+        return limit != NO_LIMIT && topNSortItems.isEmpty();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TopN that = (TopN) o;
+        return limit == that.limit &&
+                topNSortItems.equals(that.topNSortItems);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(limit, topNSortItems);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("limit", limit)
+                .add("items", topNSortItems)
+                .toString();
+    }
+
+    public static class TopNSortItem
+    {
+        // sorting by _doc (index order) get special treatment in Elasticsearch and is more efficient
+        public static final TopNSortItem DEFAULT_SORT_BY_DOC = sortBy("_doc");
+        private final String field;
+        private final SortOrder order;
+
+        public static TopNSortItem sortBy(String field)
+        {
+            return new TopNSortItem(field, SortOrder.ASC_NULLS_LAST);
+        }
+
+        public static TopNSortItem sortBy(String field, SortOrder order)
+        {
+            return new TopNSortItem(field, order);
+        }
+
+        @JsonCreator
+        public TopNSortItem(@JsonProperty("field") String field, @JsonProperty("order") SortOrder order)
+        {
+            this.field = field;
+            this.order = order;
+        }
+
+        @JsonProperty("field")
+        public String getField()
+        {
+            return field;
+        }
+
+        @JsonProperty("order")
+        public SortOrder getOrder()
+        {
+            return order;
+        }
+
+        public SortBuilder<? extends SortBuilder<?>> toSortBuilder()
+        {
+            if (order.isNullsFirst()) {
+                return SortBuilders
+                        .fieldSort(field)
+                        .order(toEsSortOrder(order))
+                        .missing("_first");
+            }
+            // The missing parameter's default value is _last.
+            return SortBuilders
+                    .fieldSort(field)
+                    .order(toEsSortOrder(order));
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            TopNSortItem that = (TopNSortItem) o;
+            return field.equals(that.field) && order == that.order;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(field, order);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("field", field)
+                    .add("order", order)
+                    .toString();
+        }
+
+        private static org.elasticsearch.search.sort.SortOrder toEsSortOrder(SortOrder sortOrder)
+        {
+            if (sortOrder.isAscending()) {
+                return org.elasticsearch.search.sort.SortOrder.ASC;
+            }
+            return org.elasticsearch.search.sort.SortOrder.DESC;
+        }
+    }
+}

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/expression/TopN.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/expression/TopN.java
@@ -25,7 +25,6 @@ import static java.util.Objects.requireNonNull;
 public record TopN(long limit, List<TopNSortItem> topNSortItems)
 {
     public static final long NO_LIMIT = -1;
-    public static final TopN EMPTY = fromLimit(NO_LIMIT);
 
     public static TopN fromLimit(long limit)
     {
@@ -35,12 +34,6 @@ public record TopN(long limit, List<TopNSortItem> topNSortItems)
     public TopN
     {
         requireNonNull(topNSortItems, "topNSortItems is null");
-    }
-
-    public TopN addSortItem(TopNSortItem sortItem)
-    {
-        topNSortItems.add(sortItem);
-        return this;
     }
 
     public boolean isOnlyLimit()

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
@@ -85,23 +85,23 @@ public abstract class BaseElasticsearchConnectorTest
     {
         return switch (connectorBehavior) {
             case SUPPORTS_ADD_COLUMN,
-                    SUPPORTS_COMMENT_ON_COLUMN,
-                    SUPPORTS_COMMENT_ON_TABLE,
-                    SUPPORTS_CREATE_MATERIALIZED_VIEW,
-                    SUPPORTS_CREATE_SCHEMA,
-                    SUPPORTS_CREATE_TABLE,
-                    SUPPORTS_CREATE_VIEW,
-                    SUPPORTS_DELETE,
-                    SUPPORTS_INSERT,
-                    SUPPORTS_MERGE,
-                    SUPPORTS_RENAME_COLUMN,
-                    SUPPORTS_RENAME_TABLE,
-                    SUPPORTS_ROW_TYPE,
-                    SUPPORTS_SET_COLUMN_TYPE,
-                    SUPPORTS_UPDATE -> false;
+                 SUPPORTS_COMMENT_ON_COLUMN,
+                 SUPPORTS_COMMENT_ON_TABLE,
+                 SUPPORTS_CREATE_MATERIALIZED_VIEW,
+                 SUPPORTS_CREATE_SCHEMA,
+                 SUPPORTS_CREATE_TABLE,
+                 SUPPORTS_CREATE_VIEW,
+                 SUPPORTS_DELETE,
+                 SUPPORTS_INSERT,
+                 SUPPORTS_MERGE,
+                 SUPPORTS_RENAME_COLUMN,
+                 SUPPORTS_RENAME_TABLE,
+                 SUPPORTS_ROW_TYPE,
+                 SUPPORTS_SET_COLUMN_TYPE,
+                 SUPPORTS_UPDATE -> false;
             case SUPPORTS_LIMIT_PUSHDOWN,
-                    SUPPORTS_TOPN_PUSHDOWN,
-                    SUPPORTS_AGGREGATION_PUSHDOWN -> true;
+                 SUPPORTS_TOPN_PUSHDOWN,
+                 SUPPORTS_AGGREGATION_PUSHDOWN -> true;
             default -> super.hasBehavior(connectorBehavior);
         };
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This pull request adds support for pushing down TopN and Aggregation to Elasticsearch.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Opening a new merge request because the previous one was automatically closed for being stale, and we couldn't reopen the stale pull request.
 
https://github.com/trinodb/trino/pull/16919

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Fixes
* Support for order by pushdown in elasticsearch connector #12381 
* Elasticsearch connector aggregation push down support #7026 
* Elasticsearch connector TopN pushdown #4803 
```
