### PR TITLE
Use ICEBERG_MISSING_METADATA error code in IcebergSplitSource

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergExceptions.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergExceptions.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import java.io.FileNotFoundException;
+
+public final class IcebergExceptions
+{
+    private IcebergExceptions() {}
+
+    public static boolean isNotFoundException(Throwable failure)
+    {
+        // qualified name, as this is NOT the io.trino.spi.connector.NotFoundException
+        return failure instanceof org.apache.iceberg.exceptions.NotFoundException ||
+                // This is used in context where the code cannot throw a checked exception, so FileNotFoundException would need to be wrapped
+                failure.getCause() instanceof FileNotFoundException;
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergExceptions.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergExceptions.java
@@ -15,15 +15,16 @@ package io.trino.plugin.iceberg;
 
 import java.io.FileNotFoundException;
 
+import static com.google.common.base.Throwables.getCausalChain;
+
 public final class IcebergExceptions
 {
     private IcebergExceptions() {}
 
     public static boolean isNotFoundException(Throwable failure)
     {
-        // qualified name, as this is NOT the io.trino.spi.connector.NotFoundException
-        return failure instanceof org.apache.iceberg.exceptions.NotFoundException ||
-                // This is used in context where the code cannot throw a checked exception, so FileNotFoundException would need to be wrapped
-                failure.getCause() instanceof FileNotFoundException;
+        return getCausalChain(failure).stream().anyMatch(e ->
+                e instanceof org.apache.iceberg.exceptions.NotFoundException
+                        || e instanceof FileNotFoundException);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractIcebergTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractIcebergTableOperations.java
@@ -35,7 +35,6 @@ import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.types.Types.NestedField;
 
-import java.io.FileNotFoundException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -51,6 +50,7 @@ import static io.trino.hive.formats.HiveClassNames.FILE_OUTPUT_FORMAT_CLASS;
 import static io.trino.hive.formats.HiveClassNames.LAZY_SIMPLE_SERDE_CLASS;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_MISSING_METADATA;
+import static io.trino.plugin.iceberg.IcebergExceptions.isNotFoundException;
 import static io.trino.plugin.iceberg.IcebergTableName.isMaterializedViewStorage;
 import static io.trino.plugin.iceberg.IcebergUtil.METADATA_FOLDER_NAME;
 import static io.trino.plugin.iceberg.IcebergUtil.fixBrokenMetadataLocation;
@@ -286,14 +286,6 @@ public abstract class AbstractIcebergTableOperations
         currentMetadataLocation = newLocation;
         version = OptionalInt.of(parseVersion(Location.of(newLocation).fileName()));
         shouldRefresh = false;
-    }
-
-    private static boolean isNotFoundException(Throwable failure)
-    {
-        // qualified name, as this is NOT the io.trino.spi.connector.NotFoundException
-        return failure instanceof org.apache.iceberg.exceptions.NotFoundException ||
-               // This is used in context where the code cannot throw a checked exception, so FileNotFoundException would need to be wrapped
-               failure.getCause() instanceof FileNotFoundException;
     }
 
     protected static String newTableMetadataFilePath(TableMetadata meta, int newVersion)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
@@ -481,10 +481,11 @@ public final class IcebergQueryRunner
         {
             Logger log = Logger.get(IcebergQueryRunnerWithTaskRetries.class);
 
-            Path exchangeManagerDirectory = createTempDirectory("exchange_manager");
+            File exchangeManagerDirectory = createTempDirectory("exchange_manager").toFile();
             Map<String, String> exchangeManagerProperties = ImmutableMap.<String, String>builder()
-                    .put("exchange.base-directories", exchangeManagerDirectory.toAbsolutePath().toString())
+                    .put("exchange.base-directories", exchangeManagerDirectory.getAbsolutePath())
                     .buildOrThrow();
+            exchangeManagerDirectory.deleteOnExit();
 
             File metastoreDir = createTempDirectory("iceberg_query_runner").toFile();
             metastoreDir.deleteOnExit();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

    Previously if we got exception pointing out to missing metadata files
    during split enumeration query was failing with GENERIC_INTERNAL_ERROR
    instead of more appropriate, Iceberg specific error code.



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
