### PR TITLE
Keep last parameters when updating Glue in Delta

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/glue/v1/DeltaLakeGlueV1MetastoreTableOperations.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/glue/v1/DeltaLakeGlueV1MetastoreTableOperations.java
@@ -63,7 +63,7 @@ public class DeltaLakeGlueV1MetastoreTableOperations
         ImmutableMap.Builder<String, String> parameters = ImmutableMap.builder();
         parameters.putAll(getTableParameters(currentTable));
         parameters.putAll(tableMetadataParameters(version, schemaString, tableComment));
-        tableInput.withParameters(parameters.buildOrThrow());
+        tableInput.withParameters(parameters.buildKeepingLast());
 
         UpdateTableRequest updateTableRequest = new UpdateTableRequest()
                 .withDatabaseName(schemaTableName.getSchemaName())


### PR DESCRIPTION
## Description

Otherwise, DeltaLakeTableMetadataScheduler fails internally. 
I manually tested and didn't add a test because this issue is specific to V1 (legacy). 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
