### PR TITLE
Delta lake S3 exclusive write reconciliation 

### DIFF
--- a/plugin/trino-delta-lake/pom.xml
+++ b/plugin/trino-delta-lake/pom.xml
@@ -113,6 +113,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-filesystem-s3</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-hive</artifactId>
         </dependency>
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/writer/S3ConditionalWriteLogSynchronizer.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/writer/S3ConditionalWriteLogSynchronizer.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake.transactionlog.writer;
+
+import com.google.inject.Inject;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.spi.connector.ConnectorSession;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.FileAlreadyExistsException;
+
+import static java.util.Objects.requireNonNull;
+
+public class S3ConditionalWriteLogSynchronizer
+        implements TransactionLogSynchronizer
+{
+    private final TrinoFileSystemFactory fileSystemFactory;
+
+    @Inject
+    S3ConditionalWriteLogSynchronizer(TrinoFileSystemFactory fileSystemFactory)
+    {
+        this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
+    }
+
+    @Override
+    public void write(ConnectorSession session, String clusterId, Location newLogEntryPath, byte[] entryContents)
+    {
+        TrinoFileSystem fileSystem = fileSystemFactory.create(session);
+        try {
+            fileSystem.newOutputFile(newLogEntryPath).createExclusive(entryContents);
+        }
+        catch (FileAlreadyExistsException e) {
+            throw new TransactionConflictException("Conflict detected while writing Transaction Log entry " + newLogEntryPath + " to S3", e);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public boolean isUnsafe()
+    {
+        return false;
+    }
+}

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/writer/S3LockBasedTransactionLogSynchronizer.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/writer/S3LockBasedTransactionLogSynchronizer.java
@@ -63,10 +63,10 @@ public class S3LockBasedTransactionLogSynchronizer
     private final JsonCodec<LockFileContents> lockFileContentsJsonCodec;
 
     @Inject
-    S3LockBasedTransactionLogSynchronizer(TrinoFileSystemFactory fileSystemFactory, JsonCodec<LockFileContents> lockFileContentesCodec)
+    S3LockBasedTransactionLogSynchronizer(TrinoFileSystemFactory fileSystemFactory, JsonCodec<LockFileContents> lockFileContentsJsonCodec)
     {
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
-        this.lockFileContentsJsonCodec = requireNonNull(lockFileContentesCodec, "lockFileContentesCodec is null");
+        this.lockFileContentsJsonCodec = requireNonNull(lockFileContentsJsonCodec, "lockFileContentsJsonCodec is null");
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/writer/S3LockBasedTransactionLogSynchronizer.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/writer/S3LockBasedTransactionLogSynchronizer.java
@@ -46,12 +46,12 @@ import static java.time.temporal.ChronoUnit.MINUTES;
 import static java.util.Objects.requireNonNull;
 
 /**
- * The S3 Native synchronizer is a {@link TransactionLogSynchronizer} for S3 that requires no other dependencies.
+ * The S3 lock-based synchronizer is a {@link TransactionLogSynchronizer} for S3-compatible storage that doesn't support conditional writes
  */
-public class S3NativeTransactionLogSynchronizer
+public class S3LockBasedTransactionLogSynchronizer
         implements TransactionLogSynchronizer
 {
-    public static final Logger LOG = Logger.get(S3NativeTransactionLogSynchronizer.class);
+    public static final Logger LOG = Logger.get(S3LockBasedTransactionLogSynchronizer.class);
 
     // TODO: add refreshing of log expiration time (https://github.com/trinodb/trino/issues/12008)
     private static final Duration EXPIRATION_DURATION = Duration.of(5, MINUTES);
@@ -63,7 +63,7 @@ public class S3NativeTransactionLogSynchronizer
     private final JsonCodec<LockFileContents> lockFileContentsJsonCodec;
 
     @Inject
-    public S3NativeTransactionLogSynchronizer(TrinoFileSystemFactory fileSystemFactory, JsonCodec<LockFileContents> lockFileContentesCodec)
+    S3LockBasedTransactionLogSynchronizer(TrinoFileSystemFactory fileSystemFactory, JsonCodec<LockFileContents> lockFileContentesCodec)
     {
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.lockFileContentsJsonCodec = requireNonNull(lockFileContentesCodec, "lockFileContentesCodec is null");

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/writer/S3LockBasedTransactionLogSynchronizer.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/writer/S3LockBasedTransactionLogSynchronizer.java
@@ -50,8 +50,6 @@ public class S3LockBasedTransactionLogSynchronizer
         implements TransactionLogSynchronizer
 {
     public static final Logger LOG = Logger.get(S3LockBasedTransactionLogSynchronizer.class);
-
-    // TODO: add refreshing of log expiration time (https://github.com/trinodb/trino/issues/12008)
     private static final Duration EXPIRATION_DURATION = Duration.of(5, MINUTES);
     private static final String LOCK_DIRECTORY = "_sb_lock";
     private static final String LOCK_INFIX = "sb-lock_";

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/writer/S3LockBasedTransactionLogSynchronizer.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/writer/S3LockBasedTransactionLogSynchronizer.java
@@ -13,8 +13,6 @@
  */
 package io.trino.plugin.deltalake.transactionlog.writer;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import io.airlift.json.JsonCodec;
@@ -254,53 +252,26 @@ public class S3LockBasedTransactionLogSynchronizer
 
         public String getClusterId()
         {
-            return contents.getClusterId();
+            return contents.clusterId();
         }
 
         public String getOwningQuery()
         {
-            return contents.getOwningQuery();
+            return contents.owningQuery();
         }
 
         public Instant getExpirationTime()
         {
-            return Instant.ofEpochMilli(contents.getExpirationEpochMillis());
+            return Instant.ofEpochMilli(contents.expirationEpochMillis());
         }
     }
 
-    public static class LockFileContents
+    public record LockFileContents(String clusterId, String owningQuery, long expirationEpochMillis)
     {
-        private final String clusterId;
-        private final String owningQuery;
-        private final long expirationEpochMillis;
-
-        @JsonCreator
-        public LockFileContents(
-                @JsonProperty("clusterId") String clusterId,
-                @JsonProperty("owningQuery") String owningQuery,
-                @JsonProperty("expirationEpochMillis") long expirationEpochMillis)
+        public LockFileContents
         {
-            this.clusterId = requireNonNull(clusterId, "clusterId is null");
-            this.owningQuery = requireNonNull(owningQuery, "owningQuery is null");
-            this.expirationEpochMillis = expirationEpochMillis;
-        }
-
-        @JsonProperty
-        public String getClusterId()
-        {
-            return clusterId;
-        }
-
-        @JsonProperty
-        public String getOwningQuery()
-        {
-            return owningQuery;
-        }
-
-        @JsonProperty
-        public long getExpirationEpochMillis()
-        {
-            return expirationEpochMillis;
+            requireNonNull(clusterId, "clusterId is null");
+            requireNonNull(owningQuery, "owningQuery is null");
         }
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/writer/S3NativeTransactionLogSynchronizer.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/writer/S3NativeTransactionLogSynchronizer.java
@@ -46,7 +46,7 @@ import static java.time.temporal.ChronoUnit.MINUTES;
 import static java.util.Objects.requireNonNull;
 
 /**
- * The S3 Native synhcornizer is a {@link TransactionLogSynchronizer} for S3 that requires no other dependencies.
+ * The S3 Native synchronizer is a {@link TransactionLogSynchronizer} for S3 that requires no other dependencies.
  */
 public class S3NativeTransactionLogSynchronizer
         implements TransactionLogSynchronizer

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -223,7 +223,8 @@ public class TestDeltaLakeConnectorTest
                 "|Target file already exists: .*/_delta_log/\\d+.json" +
                 "|Conflicting concurrent writes found\\..*" +
                 "|Multiple live locks found for:.*" +
-                "|Target file was created during locking: .*";
+                "|Target file was created during locking: .*" +
+                "|Conflict detected while writing Transaction Log .* to S3";
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMinioAndLockBasedSynchronizerSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMinioAndLockBasedSynchronizerSmokeTest.java
@@ -1,0 +1,261 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.json.ObjectMapperProvider;
+import io.airlift.units.Duration;
+import io.trino.metastore.HiveMetastore;
+import io.trino.plugin.deltalake.transactionlog.writer.S3LockBasedTransactionLogSynchronizer;
+import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
+import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.containers.Minio;
+import io.trino.testing.minio.MinioClient;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.base.util.Closables.closeAllSuppress;
+import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.DELTA_CATALOG;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.testing.assertions.Assert.assertEventually;
+import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
+import static io.trino.testing.containers.Minio.MINIO_REGION;
+import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Delta Lake connector smoke test exercising Hive metastore and MinIO storage with exclusive create support disabled.
+ */
+public class TestDeltaLakeMinioAndLockBasedSynchronizerSmokeTest
+        extends AbstractTestQueryFramework
+{
+    protected static final String SCHEMA = "test_schema";
+
+    protected final String bucketName = "test-bucket-" + randomNameSuffix();
+    protected MinioClient minioClient;
+    protected Minio minio;
+    protected HiveMetastore metastore;
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapperProvider().get();
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        minio = closeAfterClass(Minio.builder().build());
+        minio.start();
+        minio.createBucket(bucketName);
+        minioClient = closeAfterClass(minio.createMinioClient());
+
+        QueryRunner queryRunner = DistributedQueryRunner.builder(testSessionBuilder()
+                        .setCatalog(DELTA_CATALOG)
+                        .setSchema(SCHEMA)
+                        .build())
+                .build();
+        try {
+            queryRunner.installPlugin(new TpchPlugin());
+            queryRunner.createCatalog("tpch", "tpch");
+
+            queryRunner.installPlugin(new DeltaLakePlugin());
+            queryRunner.createCatalog(DELTA_CATALOG, DeltaLakeConnectorFactory.CONNECTOR_NAME, ImmutableMap.<String, String>builder()
+                    .put("hive.metastore", "file")
+                    .put("hive.metastore.catalog.dir", queryRunner.getCoordinator().getBaseDataDir().resolve("file-metastore").toString())
+                    .put("hive.metastore.disable-location-checks", "true")
+                    // required by the file metastore
+                    .put("fs.hadoop.enabled", "true")
+                    .put("fs.native-s3.enabled", "true")
+                    .put("s3.aws-access-key", MINIO_ACCESS_KEY)
+                    .put("s3.aws-secret-key", MINIO_SECRET_KEY)
+                    .put("s3.region", MINIO_REGION)
+                    .put("s3.endpoint", minio.getMinioAddress())
+                    .put("s3.path-style-access", "true")
+                    .put("s3.streaming.part-size", "5MB") // minimize memory usage
+                    .put("s3.exclusive-create", "false") // disable so we can test our own locking scheme
+                    .put("delta.metastore.store-table-metadata", "true")
+                    .put("delta.enable-non-concurrent-writes", "true")
+                    .put("delta.register-table-procedure.enabled", "true")
+                    .buildOrThrow());
+            metastore = TestingDeltaLakeUtils.getConnectorService(queryRunner, HiveMetastoreFactory.class)
+                    .createMetastore(Optional.empty());
+
+            queryRunner.execute("CREATE SCHEMA " + SCHEMA + " WITH (location = 's3://" + bucketName + "/" + SCHEMA + "')");
+            metastore = TestingDeltaLakeUtils.getConnectorService(queryRunner, HiveMetastoreFactory.class)
+                    .createMetastore(Optional.empty());
+        }
+        catch (Throwable e) {
+            closeAllSuppress(e, queryRunner);
+            throw e;
+        }
+
+        return queryRunner;
+    }
+
+    @Test
+    public void testWritesLocked()
+            throws Exception
+    {
+        testWritesLocked("INSERT INTO %s VALUES (3, 'kota'), (4, 'psa')");
+        testWritesLocked("UPDATE %s SET a_string = 'kota' WHERE a_number = 2");
+        testWritesLocked("DELETE FROM %s WHERE a_number = 1");
+    }
+
+    private void testWritesLocked(String writeStatement)
+            throws Exception
+    {
+        String tableName = "test_writes_locked" + randomNameSuffix();
+        try {
+            assertUpdate(
+                    format("CREATE TABLE %s (a_number, a_string) WITH (location = 's3://%s/%s') AS " +
+                                    "VALUES (1, 'ala'), (2, 'ma')",
+                            tableName,
+                            bucketName,
+                            tableName),
+                    2);
+
+            Set<String> originalFiles = ImmutableSet.copyOf(getTableFiles(tableName));
+            assertThat(originalFiles).isNotEmpty(); // sanity check
+
+            String lockFilePath = lockTable(tableName, java.time.Duration.ofMinutes(5));
+            assertThatThrownBy(() -> computeActual(format(writeStatement, tableName)))
+                    .hasStackTraceContaining("Transaction log locked(1); lockingCluster=some_cluster; lockingQuery=some_query");
+            assertThat(listLocks(tableName)).containsExactly(lockFilePath); // we should not delete exising, not-expired lock
+
+            // files from failed write should be cleaned up
+            Set<String> expectedFiles = ImmutableSet.<String>builder()
+                    .addAll(originalFiles)
+                    .add(lockFilePath)
+                    .build();
+            assertEventually(
+                    new Duration(5, TimeUnit.SECONDS),
+                    () -> assertThat(getTableFiles(tableName)).containsExactlyInAnyOrderElementsOf(expectedFiles));
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableName);
+        }
+    }
+
+    @Test
+    public void testWritesLockExpired()
+            throws Exception
+    {
+        testWritesLockExpired("INSERT INTO %s VALUES (3, 'kota')", "VALUES (1,'ala'), (2,'ma'), (3,'kota')");
+        testWritesLockExpired("UPDATE %s SET a_string = 'kota' WHERE a_number = 2", "VALUES (1,'ala'), (2,'kota')");
+        testWritesLockExpired("DELETE FROM %s WHERE a_number = 2", "VALUES (1,'ala')");
+    }
+
+    private void testWritesLockExpired(String writeStatement, String expectedValues)
+            throws Exception
+    {
+        String tableName = "test_writes_locked" + randomNameSuffix();
+        assertUpdate(
+                format("CREATE TABLE %s (a_number, a_string) WITH (location = 's3://%s/%s') AS " +
+                                "VALUES (1, 'ala'), (2, 'ma')",
+                        tableName,
+                        bucketName,
+                        tableName),
+                2);
+
+        lockTable(tableName, java.time.Duration.ofSeconds(-5));
+        assertUpdate(format(writeStatement, tableName), 1);
+        assertQuery("SELECT * FROM " + tableName, expectedValues);
+        assertThat(listLocks(tableName)).isEmpty(); // expired lock should be cleaned up
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testWritesLockInvalidContents()
+    {
+        testWritesLockInvalidContents("INSERT INTO %s VALUES (3, 'kota')", "VALUES (1,'ala'), (2,'ma'), (3,'kota')");
+        testWritesLockInvalidContents("UPDATE %s SET a_string = 'kota' WHERE a_number = 2", "VALUES (1,'ala'), (2,'kota')");
+        testWritesLockInvalidContents("DELETE FROM %s WHERE a_number = 2", "VALUES (1,'ala')");
+    }
+
+    private void testWritesLockInvalidContents(String writeStatement, String expectedValues)
+    {
+        String tableName = "test_writes_locked" + randomNameSuffix();
+        assertUpdate(
+                format("CREATE TABLE %s (a_number, a_string) WITH (location = 's3://%s/%s') AS " +
+                                "VALUES (1, 'ala'), (2, 'ma')",
+                        tableName,
+                        bucketName,
+                        tableName),
+                2);
+
+        String lockFilePath = invalidLockTable(tableName);
+        assertUpdate(format(writeStatement, tableName), 1);
+        assertQuery("SELECT * FROM " + tableName, expectedValues);
+        assertThat(listLocks(tableName)).containsExactly(lockFilePath); // we should not delete unparsable lock file
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    private String lockTable(String tableName, java.time.Duration lockDuration)
+            throws Exception
+    {
+        String lockFilePath = format("%s/00000000000000000001.json.sb-lock_blah", getLockFileDirectory(tableName));
+        String lockFileContents = OBJECT_MAPPER.writeValueAsString(
+                new S3LockBasedTransactionLogSynchronizer.LockFileContents("some_cluster", "some_query", Instant.now().plus(lockDuration).toEpochMilli()));
+        minioClient.putObject(bucketName, lockFileContents.getBytes(UTF_8), lockFilePath);
+        String lockUri = format("s3://%s/%s", bucketName, lockFilePath);
+        assertThat(listLocks(tableName)).containsExactly(lockUri); // sanity check
+        return lockUri;
+    }
+
+    private String invalidLockTable(String tableName)
+    {
+        String lockFilePath = format("%s/00000000000000000001.json.sb-lock_blah", getLockFileDirectory(tableName));
+        String invalidLockFileContents = "some very wrong json contents";
+        minioClient.putObject(bucketName, invalidLockFileContents.getBytes(UTF_8), lockFilePath);
+        String lockUri = format("s3://%s/%s", bucketName, lockFilePath);
+        assertThat(listLocks(tableName)).containsExactly(lockUri); // sanity check
+        return lockUri;
+    }
+
+    private List<String> listLocks(String tableName)
+    {
+        List<String> paths = minioClient.listObjects(bucketName, getLockFileDirectory(tableName));
+        return paths.stream()
+                .filter(path -> path.contains(".sb-lock_"))
+                .map(path -> format("s3://%s/%s", bucketName, path))
+                .collect(toImmutableList());
+    }
+
+    private String getLockFileDirectory(String tableName)
+    {
+        return format("%s/_delta_log/_sb_lock", tableName);
+    }
+
+    protected List<String> getTableFiles(String tableName)
+    {
+        return minioClient.listObjects(bucketName, tableName).stream()
+                .map(path -> format("s3://%s/%s", bucketName, path))
+                .collect(toImmutableList());
+    }
+}


### PR DESCRIPTION
https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-requests.html#conditional-writes

This allows for the faster, concurrent write reconciliation without the custom locking mechanism
that was implemented for S3 when it lacked exclusive write support. Since this is now supported,
we should use faster path if possible.

Enabled in tests for S3 and Minio tests. Doesn't work in s3mock and ~local-stack~ (support added 29/08/2024).

Release notes: Add support for lock-less Delta Lake write reconciliation on S3