### PR TITLE
Add support for S3 conditional writes

### DIFF
--- a/docs/src/main/sphinx/object-storage/file-system-s3.md
+++ b/docs/src/main/sphinx/object-storage/file-system-s3.md
@@ -28,6 +28,8 @@ support:
   - Required region name for S3.
 * - `s3.path-style-access`
   - Use path-style access for all requests to S3
+* - `s3.exclusive-create`
+  - Whether conditional write is supported by the S3-compatible storage. Defaults to `true`.
 * - `s3.canned-acl`
   - [Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl)
     to use when uploading files to S3. Defaults to `NONE`, which has the same

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/AbstractTestAzureFileSystem.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/AbstractTestAzureFileSystem.java
@@ -194,12 +194,6 @@ public abstract class AbstractTestAzureFileSystem
         assertThat(blobContainerClient.listBlobs()).map(BlobItem::getName).isEmpty();
     }
 
-    @Override
-    protected boolean supportsCreateExclusive()
-    {
-        return true;
-    }
-
     @Test
     @Override
     public void testPaths()

--- a/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestAlluxioCacheFileSystem.java
+++ b/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestAlluxioCacheFileSystem.java
@@ -89,12 +89,6 @@ public class TestAlluxioCacheFileSystem
     }
 
     @Override
-    protected boolean supportsCreateExclusive()
-    {
-        return true;
-    }
-
-    @Override
     protected TrinoFileSystem getFileSystem()
     {
         return fileSystem;

--- a/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/AbstractTestGcsFileSystem.java
+++ b/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/AbstractTestGcsFileSystem.java
@@ -126,12 +126,6 @@ public abstract class AbstractTestGcsFileSystem
     }
 
     @Override
-    protected final boolean supportsCreateExclusive()
-    {
-        return true;
-    }
-
-    @Override
     protected final boolean supportsRenameFile()
     {
         return false;

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3Context.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3Context.java
@@ -30,7 +30,7 @@ import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_SEC
 import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY;
 import static java.util.Objects.requireNonNull;
 
-record S3Context(int partSize, boolean requesterPays, S3SseType sseType, String sseKmsKeyId, Optional<AwsCredentialsProvider> credentialsProviderOverride, ObjectCannedAcl cannedAcl)
+record S3Context(int partSize, boolean requesterPays, S3SseType sseType, String sseKmsKeyId, Optional<AwsCredentialsProvider> credentialsProviderOverride, ObjectCannedAcl cannedAcl, boolean exclusiveWriteSupported)
 {
     private static final int MIN_PART_SIZE = 5 * 1024 * 1024; // S3 requirement
 
@@ -49,7 +49,7 @@ record S3Context(int partSize, boolean requesterPays, S3SseType sseType, String 
 
     public S3Context withKmsKeyId(String kmsKeyId)
     {
-        return new S3Context(partSize, requesterPays, sseType, kmsKeyId, credentialsProviderOverride, cannedAcl);
+        return new S3Context(partSize, requesterPays, sseType, kmsKeyId, credentialsProviderOverride, cannedAcl, exclusiveWriteSupported);
     }
 
     public S3Context withCredentials(ConnectorIdentity identity)
@@ -72,7 +72,8 @@ record S3Context(int partSize, boolean requesterPays, S3SseType sseType, String 
                 sseType,
                 sseKmsKeyId,
                 Optional.of(credentialsProviderOverride),
-                cannedAcl);
+                cannedAcl,
+                exclusiveWriteSupported);
     }
 
     public void applyCredentialProviderOverride(AwsRequestOverrideConfiguration.Builder builder)

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
@@ -114,6 +114,7 @@ public class S3FileSystemConfig
     private ObjectCannedAcl objectCannedAcl = ObjectCannedAcl.NONE;
     private RetryMode retryMode = RetryMode.LEGACY;
     private int maxErrorRetries = 10;
+    private boolean supportsExclusiveCreate = true;
 
     public String getAwsAccessKey()
     {
@@ -495,6 +496,19 @@ public class S3FileSystemConfig
     public S3FileSystemConfig setNonProxyHosts(String nonProxyHosts)
     {
         this.nonProxyHosts = ImmutableSet.copyOf(Splitter.on(',').omitEmptyStrings().trimResults().split(nullToEmpty(nonProxyHosts)));
+        return this;
+    }
+
+    public boolean isSupportsExclusiveCreate()
+    {
+        return supportsExclusiveCreate;
+    }
+
+    @Config("s3.exclusive-create")
+    @ConfigDescription("Whether S3-compatible storage supports exclusive create (true for Minio and AWS S3)")
+    public S3FileSystemConfig setSupportsExclusiveCreate(boolean supportsExclusiveCreate)
+    {
+        this.supportsExclusiveCreate = supportsExclusiveCreate;
         return this;
     }
 }

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemLoader.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemLoader.java
@@ -79,7 +79,8 @@ final class S3FileSystemLoader
                 config.getSseType(),
                 config.getSseKmsKeyId(),
                 Optional.empty(),
-                config.getCannedAcl());
+                config.getCannedAcl(),
+                config.isSupportsExclusiveCreate());
     }
 
     @Override

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/AbstractTestS3FileSystem.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/AbstractTestS3FileSystem.java
@@ -84,12 +84,6 @@ public abstract class AbstractTestS3FileSystem
     }
 
     @Override
-    protected boolean isCreateExclusive()
-    {
-        return false;
-    }
-
-    @Override
     protected final boolean supportsRenameFile()
     {
         return false;

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemAwsS3.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemAwsS3.java
@@ -71,6 +71,7 @@ public class TestS3FileSystemAwsS3
                 .setAwsAccessKey(accessKey)
                 .setAwsSecretKey(secretKey)
                 .setRegion(region)
+                .setSupportsExclusiveCreate(true)
                 .setStreamingPartSize(DataSize.valueOf("5.5MB")));
     }
 

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemConfig.java
@@ -66,7 +66,8 @@ public class TestS3FileSystemConfig
                 .setNonProxyHosts(null)
                 .setHttpProxyUsername(null)
                 .setHttpProxyPassword(null)
-                .setHttpProxyPreemptiveBasicProxyAuth(false));
+                .setHttpProxyPreemptiveBasicProxyAuth(false)
+                .setSupportsExclusiveCreate(true));
     }
 
     @Test
@@ -103,6 +104,7 @@ public class TestS3FileSystemConfig
                 .put("s3.http-proxy.username", "test")
                 .put("s3.http-proxy.password", "test")
                 .put("s3.http-proxy.preemptive-basic-auth", "true")
+                .put("s3.exclusive-create", "false")
                 .buildOrThrow();
 
         S3FileSystemConfig expected = new S3FileSystemConfig()
@@ -135,7 +137,8 @@ public class TestS3FileSystemConfig
                 .setNonProxyHosts("test1, test2, test3")
                 .setHttpProxyUsername("test")
                 .setHttpProxyPassword("test")
-                .setHttpProxyPreemptiveBasicProxyAuth(true);
+                .setHttpProxyPreemptiveBasicProxyAuth(true)
+                .setSupportsExclusiveCreate(false);
 
         assertFullMapping(properties, expected);
     }

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemLocalStack.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemLocalStack.java
@@ -32,7 +32,7 @@ public class TestS3FileSystemLocalStack
     private static final String BUCKET = "test-bucket";
 
     @Container
-    private static final LocalStackContainer LOCALSTACK = new LocalStackContainer(DockerImageName.parse("localstack/localstack:3.3.0"))
+    private static final LocalStackContainer LOCALSTACK = new LocalStackContainer(DockerImageName.parse("localstack/localstack:3.7.0"))
             .withServices(Service.S3);
 
     @Override
@@ -41,18 +41,6 @@ public class TestS3FileSystemLocalStack
         try (S3Client s3Client = createS3Client()) {
             s3Client.createBucket(builder -> builder.bucket(BUCKET).build());
         }
-    }
-
-    @Override
-    protected boolean isCreateExclusive()
-    {
-        return false; // not supported by localstack
-    }
-
-    @Override
-    protected boolean supportsCreateExclusive()
-    {
-        return false; // not supported by localstack
     }
 
     @Override
@@ -80,7 +68,6 @@ public class TestS3FileSystemLocalStack
                 .setAwsSecretKey(LOCALSTACK.getSecretKey())
                 .setEndpoint(LOCALSTACK.getEndpointOverride(Service.S3).toString())
                 .setRegion(LOCALSTACK.getRegion())
-                .setStreamingPartSize(DataSize.valueOf("5.5MB"))
-                .setSupportsExclusiveCreate(false));
+                .setStreamingPartSize(DataSize.valueOf("5.5MB")));
     }
 }

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemLocalStack.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemLocalStack.java
@@ -44,6 +44,18 @@ public class TestS3FileSystemLocalStack
     }
 
     @Override
+    protected boolean isCreateExclusive()
+    {
+        return false; // not supported by localstack
+    }
+
+    @Override
+    protected boolean supportsCreateExclusive()
+    {
+        return false; // not supported by localstack
+    }
+
+    @Override
     protected String bucket()
     {
         return BUCKET;
@@ -68,6 +80,7 @@ public class TestS3FileSystemLocalStack
                 .setAwsSecretKey(LOCALSTACK.getSecretKey())
                 .setEndpoint(LOCALSTACK.getEndpointOverride(Service.S3).toString())
                 .setRegion(LOCALSTACK.getRegion())
-                .setStreamingPartSize(DataSize.valueOf("5.5MB")));
+                .setStreamingPartSize(DataSize.valueOf("5.5MB"))
+                .setSupportsExclusiveCreate(false));
     }
 }

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemMinIo.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemMinIo.java
@@ -79,6 +79,7 @@ public class TestS3FileSystemMinIo
                 .setPathStyleAccess(true)
                 .setAwsAccessKey(Minio.MINIO_ACCESS_KEY)
                 .setAwsSecretKey(Minio.MINIO_SECRET_KEY)
+                .setSupportsExclusiveCreate(true)
                 .setStreamingPartSize(DataSize.valueOf("5.5MB")));
     }
 

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemS3Mock.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemS3Mock.java
@@ -36,6 +36,18 @@ public class TestS3FileSystemS3Mock
             .withInitialBuckets(BUCKET);
 
     @Override
+    protected boolean isCreateExclusive()
+    {
+        return false; // not supported by s3-mock
+    }
+
+    @Override
+    protected boolean supportsCreateExclusive()
+    {
+        return false; // not supported by s3-mock
+    }
+
+    @Override
     protected String bucket()
     {
         return BUCKET;
@@ -62,6 +74,7 @@ public class TestS3FileSystemS3Mock
                 .setEndpoint(S3_MOCK.getHttpEndpoint())
                 .setRegion(Region.US_EAST_1.id())
                 .setPathStyleAccess(true)
-                .setStreamingPartSize(DataSize.valueOf("5.5MB")));
+                .setStreamingPartSize(DataSize.valueOf("5.5MB"))
+                .setSupportsExclusiveCreate(false));
     }
 }

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/AbstractTestTrinoFileSystem.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/AbstractTestTrinoFileSystem.java
@@ -85,7 +85,7 @@ public abstract class AbstractTestTrinoFileSystem
      */
     protected boolean supportsCreateExclusive()
     {
-        return false;
+        return true;
     }
 
     protected boolean supportsRenameFile()

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/local/TestLocalFileSystem.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/local/TestLocalFileSystem.java
@@ -47,6 +47,12 @@ public class TestLocalFileSystem
         fileSystem = new LocalFileSystem(tempDirectory);
     }
 
+    @Override
+    protected boolean supportsCreateExclusive()
+    {
+        return false;
+    }
+
     @AfterEach
     void afterEach()
             throws IOException

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/memory/TestMemoryFileSystem.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/memory/TestMemoryFileSystem.java
@@ -45,12 +45,6 @@ public class TestMemoryFileSystem
     }
 
     @Override
-    protected boolean supportsCreateExclusive()
-    {
-        return true;
-    }
-
-    @Override
     protected TrinoFileSystem getFileSystem()
     {
         return fileSystem;

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/memory/TestMemoryFileSystemCache.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/memory/TestMemoryFileSystemCache.java
@@ -64,12 +64,6 @@ public class TestMemoryFileSystemCache
     }
 
     @Override
-    protected boolean supportsCreateExclusive()
-    {
-        return true;
-    }
-
-    @Override
     protected TrinoFileSystem getFileSystem()
     {
         return fileSystem;

--- a/lib/trino-hdfs/src/test/java/io/trino/filesystem/hdfs/TestHdfsFileSystemHdfs.java
+++ b/lib/trino-hdfs/src/test/java/io/trino/filesystem/hdfs/TestHdfsFileSystemHdfs.java
@@ -86,6 +86,12 @@ public class TestHdfsFileSystemHdfs
     }
 
     @Override
+    protected boolean supportsCreateExclusive()
+    {
+        return false;
+    }
+
+    @Override
     protected boolean supportsIncompleteWriteNoClobber()
     {
         return false;

--- a/lib/trino-hdfs/src/test/java/io/trino/filesystem/hdfs/TestHdfsFileSystemLocal.java
+++ b/lib/trino-hdfs/src/test/java/io/trino/filesystem/hdfs/TestHdfsFileSystemLocal.java
@@ -82,6 +82,12 @@ public class TestHdfsFileSystemLocal
         Files.delete(tempDirectory);
     }
 
+    @Override
+    protected boolean supportsCreateExclusive()
+    {
+        return false;
+    }
+
     private void cleanupFiles()
             throws IOException
     {

--- a/lib/trino-hdfs/src/test/java/io/trino/filesystem/hdfs/TestHdfsFileSystemS3Mock.java
+++ b/lib/trino-hdfs/src/test/java/io/trino/filesystem/hdfs/TestHdfsFileSystemS3Mock.java
@@ -115,6 +115,12 @@ public class TestHdfsFileSystemS3Mock
     }
 
     @Override
+    protected boolean supportsCreateExclusive()
+    {
+        return false;
+    }
+
+    @Override
     protected boolean normalizesListFilesResult()
     {
         return true;


### PR DESCRIPTION
This allows implementing exclusive write that will ensure that the next putObject won't override existing file.

This makes all three major cloud storage filesystem implementations support `createExclusive`

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
