### PR TITLE
Fix OpenX JSON decoding of top level JSON array

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/openxjson/OpenXJsonDeserializer.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/openxjson/OpenXJsonDeserializer.java
@@ -55,6 +55,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.IntFunction;
+import java.util.function.IntUnaryOperator;
 import java.util.regex.Pattern;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -113,6 +114,12 @@ public final class OpenXJsonDeserializer
                 .map(formatter -> formatter.withZone(ZoneOffset.UTC))
                 .collect(toImmutableList());
 
+        ImmutableMap.Builder<Integer, Integer> ordinals = ImmutableMap.builderWithExpectedSize(columns.size());
+        for (int i = 0; i < columns.size(); i++) {
+            ordinals.put(columns.get(i).ordinal(), i);
+        }
+        Map<Integer, Integer> topLevelOrdinalMap = ordinals.buildOrThrow();
+
         rowDecoder = new RowDecoder(
                 RowType.from(columns.stream()
                         .map(column -> field(column.name().toLowerCase(Locale.ROOT), column.type()))
@@ -121,7 +128,8 @@ public final class OpenXJsonDeserializer
                 columns.stream()
                         .map(Column::type)
                         .map(fieldType -> createDecoder(fieldType, options, timestampFormatters))
-                        .collect(toImmutableList()));
+                        .collect(toImmutableList()),
+                ordinal -> topLevelOrdinalMap.getOrDefault(ordinal, -1));
     }
 
     @Override
@@ -219,7 +227,8 @@ public final class OpenXJsonDeserializer
                     rowType.getFields().stream()
                             .map(Field::getType)
                             .map(fieldType -> createDecoder(fieldType, options, timestampFormatters))
-                            .collect(toImmutableList()));
+                            .collect(toImmutableList()),
+                    ordinal -> ordinal < rowType.getFields().size() ? ordinal : -1);
         }
         throw new UnsupportedOperationException("Unsupported column type: " + type);
     }
@@ -747,8 +756,9 @@ public final class OpenXJsonDeserializer
         private final List<FieldName> fieldNames;
         private final List<Decoder> fieldDecoders;
         private final boolean dotsInKeyNames;
+        private final IntUnaryOperator ordinalToFieldPosition;
 
-        public RowDecoder(RowType rowType, OpenXJsonOptions options, List<Decoder> fieldDecoders)
+        public RowDecoder(RowType rowType, OpenXJsonOptions options, List<Decoder> fieldDecoders, IntUnaryOperator ordinalToFieldPosition)
         {
             this.fieldNames = rowType.getFields().stream()
                     .map(field -> field.getName().orElseThrow())
@@ -757,6 +767,7 @@ public final class OpenXJsonDeserializer
                     .collect(toImmutableList());
             this.fieldDecoders = fieldDecoders;
             this.dotsInKeyNames = options.isDotsInFieldNames();
+            this.ordinalToFieldPosition = requireNonNull(ordinalToFieldPosition, "ordinalToFieldPosition is null");
         }
 
         public void decode(Object jsonValue, PageBuilder builder)
@@ -830,14 +841,28 @@ public final class OpenXJsonDeserializer
 
         private void decodeValueFromList(List<?> jsonArray, IntFunction<BlockBuilder> fieldBuilders)
         {
-            for (int i = 0; i < fieldDecoders.size(); i++) {
-                Object fieldValue = jsonArray.size() > i ? jsonArray.get(i) : null;
-                BlockBuilder blockBuilder = fieldBuilders.apply(i);
+            boolean[] fieldWritten = new boolean[fieldDecoders.size()];
+            for (int ordinal = 0; ordinal < jsonArray.size(); ordinal++) {
+                int fieldPosition = ordinalToFieldPosition.applyAsInt(ordinal);
+                if (fieldPosition < 0) {
+                    continue;
+                }
+
+                Object fieldValue = jsonArray.get(ordinal);
+                BlockBuilder blockBuilder = fieldBuilders.apply(fieldPosition);
                 if (fieldValue == null) {
                     blockBuilder.appendNull();
                 }
                 else {
-                    fieldDecoders.get(i).decode(fieldValue, blockBuilder);
+                    fieldDecoders.get(fieldPosition).decode(fieldValue, blockBuilder);
+                }
+                fieldWritten[fieldPosition] = true;
+            }
+
+            // write null to unset fields
+            for (int i = 0; i < fieldWritten.length; i++) {
+                if (!fieldWritten[i]) {
+                    fieldBuilders.apply(i).appendNull();
                 }
             }
         }

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/openxjson/TestOpenxJsonFormat.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/openxjson/TestOpenxJsonFormat.java
@@ -1236,9 +1236,9 @@ public class TestOpenxJsonFormat
 
     private static void internalAssertValueTrino(Type type, String jsonValue, Object expectedValue, OpenXJsonOptions options)
     {
-        List<Column> columns = ImmutableList.of(new Column("test", type, 33));
+        List<Column> columns = ImmutableList.of(new Column("test", type, 2));
         internalAssertLineTrino(columns, "{\"test\" : " + jsonValue + "}", singletonList(expectedValue), options);
-        internalAssertLineTrino(columns, "[" + jsonValue + "]", singletonList(expectedValue), options);
+        internalAssertLineTrino(columns, "[ , 42, " + jsonValue + ", 99]", singletonList(expectedValue), options);
     }
 
     private static void internalAssertLineTrino(List<Column> columns, String line, List<Object> expectedValues, OpenXJsonOptions options)


### PR DESCRIPTION
## Description

OpenX JSON supports decoding JSON lines containing a JSON array, as opposed to a JSON object. In this case the values are mapped to columns using the ordinal position instead of mapping by field name. The decoder was not using the Column ordinal and instead was just using the position in the output list, which resulted in data appearing in the wrong output column.

This bug has been present since the first version of the native OpenX JSON decoder.

Fixes #23120 

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# Hive
* Fix OpenX JSON decoding a JSON array line that resulted in data being written to wrong output column. ({issue}`23120`)
```
