### PR TITLE
Fix failure when rewriting distance functions in PostgreSQL

### DIFF
--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/rule/RewriteVectorDistanceFunction.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/rule/RewriteVectorDistanceFunction.java
@@ -124,12 +124,13 @@ public final class RewriteVectorDistanceFunction
         if (expression instanceof Call call && call.getFunctionName().equals(CAST_FUNCTION_NAME)) {
             ConnectorExpression argument = getOnlyElement(call.getArguments());
             if (argument instanceof Variable variable) {
-                JdbcTypeHandle typeHandle = ((JdbcColumnHandle) context.getAssignment(variable.getName())).getJdbcTypeHandle();
+                JdbcColumnHandle columnHandle = (JdbcColumnHandle) context.getAssignment(variable.getName());
+                JdbcTypeHandle typeHandle = columnHandle.getJdbcTypeHandle();
                 // TODO type.equals("vector") should be improved to support pushdown on vector type which is installed in other schemas
                 if (!typeHandle.jdbcTypeName().map(type -> type.equals("vector")).orElse(false)) {
                     return Optional.empty();
                 }
-                return Optional.of(new ParameterizedExpression(quoted(variable.getName()), ImmutableList.of()));
+                return Optional.of(new ParameterizedExpression(quoted(columnHandle.getColumnName()), ImmutableList.of()));
             }
             return Optional.empty();
         }


### PR DESCRIPTION
## Description

Fixes #23152

## Release notes

```markdown
# PostgreSQL
* Fix potential failure when pushdown `euclidean_distance`, `cosine_distance` and `dot_product` functions. ({issue}`23152`)
```
