### PR TITLE
Disable testTableSampleBernoulli in BigQuery

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
@@ -68,6 +68,8 @@ import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.connector.RecordCursor;
 import io.trino.spi.connector.RelationCommentMetadata;
 import io.trino.spi.connector.RetryMode;
+import io.trino.spi.connector.SampleApplicationResult;
+import io.trino.spi.connector.SampleType;
 import io.trino.spi.connector.SaveMode;
 import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
@@ -825,6 +827,13 @@ public class BigQueryMetadata
     {
         // TODO Fix BaseBigQueryFailureRecoveryTest when implementing this method
         return ConnectorMetadata.super.getStatisticsCollectionMetadata(session, tableHandle, analyzeProperties);
+    }
+
+    @Override
+    public Optional<SampleApplicationResult<ConnectorTableHandle>> applySample(ConnectorSession session, ConnectorTableHandle handle, SampleType sampleType, double sampleRatio)
+    {
+        // TODO Enable BaseBigQueryConnectorTest.testTableSampleBernoulli when supporting this pushdown
+        return ConnectorMetadata.super.applySample(session, handle, sampleType, sampleRatio);
     }
 
     @Override

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
@@ -96,6 +96,11 @@ public abstract class BaseBigQueryConnectorTest
         };
     }
 
+    @Test
+    @Disabled // Disable this test because this test is slow and BigQuery connector doesn't support sample pushdown
+    @Override
+    public void testTableSampleBernoulli() {}
+
     @Override
     @Test
     public void testShowColumns()


### PR DESCRIPTION
## Description

The test is slow and increases the possibility of CI failures due to BigQuery SLA because it contains 100 executions. 
Disabling this test should be safe since the connector doesn't support SAMPLE pushdown. 
I think we can make this test conditional with `TestingConnectorBehavior` in a follow-up. 

https://github.com/trinodb/trino/blob/90c48bba606135bb03f482bce2f616ce6a78025f/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueries.java#L456-L476

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
