### PR TITLE
Add character set field to JdbcTypeHandle

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcTypeHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcTypeHandle.java
@@ -27,9 +27,22 @@ public record JdbcTypeHandle(
         Optional<Integer> columnSize,
         Optional<Integer> decimalDigits,
         Optional<Integer> arrayDimensions,
-        Optional<CaseSensitivity> caseSensitivity)
+        Optional<CaseSensitivity> caseSensitivity,
+        Optional<String> characterSet)
 {
     private static final int INSTANCE_SIZE = instanceSize(JdbcTypeHandle.class);
+
+    @Deprecated
+    public JdbcTypeHandle(
+            int jdbcType,
+            Optional<String> jdbcTypeName,
+            Optional<Integer> columnSize,
+            Optional<Integer> decimalDigits,
+            Optional<Integer> arrayDimensions,
+            Optional<CaseSensitivity> caseSensitivity)
+    {
+        this(jdbcType, jdbcTypeName, columnSize, decimalDigits, arrayDimensions, caseSensitivity, Optional.empty());
+    }
 
     public JdbcTypeHandle
     {
@@ -38,6 +51,7 @@ public record JdbcTypeHandle(
         requireNonNull(decimalDigits, "decimalDigits is null");
         requireNonNull(arrayDimensions, "arrayDimensions is null");
         requireNonNull(caseSensitivity, "caseSensitivity is null");
+        requireNonNull(characterSet, "characterSet is null");
     }
 
     public int requiredColumnSize()

--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
@@ -238,7 +238,7 @@ public class ClickHouseClient
         super("\"", connectionFactory, queryBuilder, config.getJdbcTypesMappedToVarchar(), identifierMapping, queryModifier, false);
         this.uuidType = typeManager.getType(new TypeSignature(StandardTypes.UUID));
         this.ipAddressType = typeManager.getType(new TypeSignature(StandardTypes.IPADDRESS));
-        JdbcTypeHandle bigintTypeHandle = new JdbcTypeHandle(Types.BIGINT, Optional.of("bigint"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+        JdbcTypeHandle bigintTypeHandle = new JdbcTypeHandle(Types.BIGINT, Optional.of("bigint"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
         this.connectorExpressionRewriter = JdbcConnectorExpressionRewriterBuilder.newBuilder()
                 .addStandardRules(this::quoted)
                 .build();
@@ -328,7 +328,7 @@ public class ClickHouseClient
 
     private static Optional<JdbcTypeHandle> toTypeHandle(DecimalType decimalType)
     {
-        return Optional.of(new JdbcTypeHandle(Types.DECIMAL, Optional.of("Decimal"), Optional.of(decimalType.getPrecision()), Optional.of(decimalType.getScale()), Optional.empty(), Optional.empty()));
+        return Optional.of(new JdbcTypeHandle(Types.DECIMAL, Optional.of("Decimal"), Optional.of(decimalType.getPrecision()), Optional.of(decimalType.getScale()), Optional.empty(), Optional.empty(), Optional.empty()));
     }
 
     @Override

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
@@ -219,7 +219,7 @@ public class PhoenixClient
     public static final String ROWKEY = "ROWKEY";
     public static final JdbcColumnHandle ROWKEY_COLUMN_HANDLE = new JdbcColumnHandle(
             ROWKEY,
-            new JdbcTypeHandle(Types.BIGINT, Optional.of("BIGINT"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()),
+            new JdbcTypeHandle(Types.BIGINT, Optional.of("BIGINT"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()),
             BIGINT);
 
     private static final String DATE_FORMAT = "y-MM-dd G";
@@ -878,6 +878,7 @@ public class PhoenixClient
                 Optional.of(arrayTypeName),
                 arrayTypeHandle.columnSize(),
                 arrayTypeHandle.decimalDigits(),
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
     }

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
@@ -312,7 +312,7 @@ public class PhoenixMetadata
 
         return new JdbcColumnHandle(
                 MERGE_ROW_ID_COLUMN_NAME,
-                new JdbcTypeHandle(Types.ROWID, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()),
+                new JdbcTypeHandle(Types.ROWID, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()),
                 RowType.from(fields));
     }
 

--- a/plugin/trino-snowflake/src/main/java/io/trino/plugin/snowflake/SnowflakeClient.java
+++ b/plugin/trino-snowflake/src/main/java/io/trino/plugin/snowflake/SnowflakeClient.java
@@ -173,7 +173,7 @@ public class SnowflakeClient
     {
         super("\"", connectionFactory, queryBuilder, config.getJdbcTypesMappedToVarchar(), identifierMapping, remoteQueryModifier, false);
 
-        JdbcTypeHandle bigintTypeHandle = new JdbcTypeHandle(Types.BIGINT, Optional.of("bigint"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+        JdbcTypeHandle bigintTypeHandle = new JdbcTypeHandle(Types.BIGINT, Optional.of("bigint"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
         ConnectorExpressionRewriter<ParameterizedExpression> connectorExpressionRewriter = JdbcConnectorExpressionRewriterBuilder.newBuilder()
                 .addStandardRules(this::quoted)
                 .build();
@@ -347,6 +347,7 @@ public class SnowflakeClient
                 Optional.of("NUMBER"),
                 Optional.of(decimalType.getPrecision()),
                 Optional.of(decimalType.getScale()),
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty()));
     }

--- a/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestSnowflakeClient.java
+++ b/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestSnowflakeClient.java
@@ -45,14 +45,14 @@ public class TestSnowflakeClient
             JdbcColumnHandle.builder()
                     .setColumnName("c_bigint")
                     .setColumnType(BIGINT)
-                    .setJdbcTypeHandle(new JdbcTypeHandle(Types.BIGINT, Optional.of("int8"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()))
+                    .setJdbcTypeHandle(new JdbcTypeHandle(Types.BIGINT, Optional.of("int8"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()))
                     .build();
 
     private static final JdbcColumnHandle DOUBLE_COLUMN =
             JdbcColumnHandle.builder()
                     .setColumnName("c_double")
                     .setColumnType(DOUBLE)
-                    .setJdbcTypeHandle(new JdbcTypeHandle(Types.DOUBLE, Optional.of("double"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()))
+                    .setJdbcTypeHandle(new JdbcTypeHandle(Types.DOUBLE, Optional.of("double"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()))
                     .build();
 
     private static final JdbcClient JDBC_CLIENT = new SnowflakeClient(


### PR DESCRIPTION
## Description

SQL standard supports character set:
```
<character set specification> ::=
       <standard character set name>
    |  <implementation-defined character set name>
    |  <user-defined character set name>

<standard character set name> ::=
   <character set name>

<implementation-defined character set name> ::=
   <character set name>

<user-defined character set name> ::=
   <character set name>
```
The new field isn't yet used in this repository, but allows 3rd party developers to use it in their JDBC-based connectors. 
This extra info is required especially for rewrite rule on char/varchar columns. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
