### PR TITLE
Fix regression on disabled HTTP/2 negotiation

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/uri/HttpClientFactory.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/HttpClientFactory.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 
 import static io.trino.client.KerberosUtil.defaultCredentialCachePath;
 import static io.trino.client.OkHttpUtil.basicAuth;
+import static io.trino.client.OkHttpUtil.disableHttp2;
 import static io.trino.client.OkHttpUtil.setupAlternateHostnameVerification;
 import static io.trino.client.OkHttpUtil.setupCookieJar;
 import static io.trino.client.OkHttpUtil.setupHttpLogging;
@@ -52,6 +53,7 @@ public class HttpClientFactory
     public static OkHttpClient.Builder toHttpClientBuilder(TrinoUri uri, String userAgent)
     {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
+        disableHttp2(builder);
         setupUserAgent(builder, userAgent);
         setupCookieJar(builder);
         setupSocksProxy(builder, uri.getSocksProxy());


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
~Remove dead code in OkHttpUtil.~
~I assume this isn't needed since we now support http2 (#21793).~

Fix regression on disabled HTTP/2 negotiation.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Added by:
https://github.com/trinodb/trino/commit/0de723656bce74d1c64050413a4e467fa43fab9e

Usage was gone in (unintentionally?):
https://github.com/trinodb/trino/commit/05bcba69b8651b7536ae1c1a4d99d8b5b309fbce#diff-2514cab429f6ab30764fd3c34e7318b2085145a670a206283497208b9547de40L617


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

- [x] This is not user-visible or is docs only, and no release notes are required.


(looks like the `- [x]` syntax triggers a task list)
