### PR TITLE
Increase hive.metastore-cache-maximum-size to 20000

### DIFF
--- a/docs/src/main/sphinx/object-storage/metastores.md
+++ b/docs/src/main/sphinx/object-storage/metastores.md
@@ -71,7 +71,7 @@ are also available. They are discussed later in this topic.
   - `5m`
 * - `hive.metastore-cache-maximum-size`
   - Maximum number of metastore data objects in the Hive metastore cache.
-  - `10000`
+  - `20000`
 * - `hive.metastore-refresh-interval`
   - Asynchronously refresh cached metastore data after access if it is older
     than this but is not yet expired, allowing subsequent accesses to see fresh

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastoreConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastoreConfig.java
@@ -37,7 +37,7 @@ public class CachingHiveMetastoreConfig
     private Duration metastoreCacheTtl = new Duration(0, SECONDS);
     private Optional<Duration> statsCacheTtl = Optional.empty();
     private Optional<Duration> metastoreRefreshInterval = Optional.empty();
-    private long metastoreCacheMaximumSize = 10000;
+    private long metastoreCacheMaximumSize = 20000;
     private int maxMetastoreRefreshThreads = 10;
     private boolean partitionCacheEnabled = true;
     private boolean cacheMissing = true;

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastoreConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastoreConfig.java
@@ -39,7 +39,7 @@ public class TestCachingHiveMetastoreConfig
                 .setMetastoreCacheTtl(new Duration(0, SECONDS))
                 .setStatsCacheTtl(new Duration(5, MINUTES))
                 .setMetastoreRefreshInterval(null)
-                .setMetastoreCacheMaximumSize(10000)
+                .setMetastoreCacheMaximumSize(20000)
                 .setMaxMetastoreRefreshThreads(10)
                 .setPartitionCacheEnabled(true)
                 .setCacheMissing(true)


### PR DESCRIPTION
## Description
Current default is not large enough to keep partitions metadata in cache for certain tpcds queries which access all the fact tables


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Improve performance of queries which scan a large number of partitions. ({issue}`23194`)
```
