### PR TITLE
Adaptive broadcast to partitioned

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -202,6 +202,7 @@ public final class SystemSessionProperties
     public static final String FAULT_TOLERANT_EXECUTION_ADAPTIVE_JOIN_REORDERING_ENABLED = "fault_tolerant_execution_adaptive_join_reordering_enabled";
     public static final String FAULT_TOLERANT_EXECUTION_ADAPTIVE_JOIN_REORDERING_SIZE_DIFFERENCE_RATIO = "fault_tolerant_execution_adaptive_join_reordering_size_difference_ratio";
     public static final String FAULT_TOLERANT_EXECUTION_ADAPTIVE_JOIN_REORDERING_MIN_SIZE_THRESHOLD = "fault_tolerant_execution_adaptive_join_reordering_min_size_threshold";
+    public static final String FAULT_TOLERANT_EXECUTION_ADAPTIVE_BROADCAST_TO_PARTITIONED_JOIN_ENABLED = "fault_tolerant_execution_adaptive_broadcast_to_partitioned_join_enabled";
     public static final String ADAPTIVE_PARTIAL_AGGREGATION_ENABLED = "adaptive_partial_aggregation_enabled";
     public static final String ADAPTIVE_PARTIAL_AGGREGATION_UNIQUE_ROWS_RATIO_THRESHOLD = "adaptive_partial_aggregation_unique_rows_ratio_threshold";
     public static final String REMOTE_TASK_ADAPTIVE_UPDATE_REQUEST_SIZE_ENABLED = "remote_task_adaptive_update_request_size_enabled";
@@ -1040,6 +1041,11 @@ public final class SystemSessionProperties
                         "The minimum size of the right side of join to consider reordering",
                         queryManagerConfig.getFaultTolerantExecutionAdaptiveJoinReorderingMinSizeThreshold(),
                         true),
+                booleanProperty(
+                        FAULT_TOLERANT_EXECUTION_ADAPTIVE_BROADCAST_TO_PARTITIONED_JOIN_ENABLED,
+                        "Adapt broadcast join to partitioned join based on runtime stats in fault tolerant execution",
+                        queryManagerConfig.isFaultTolerantExecutionAdaptiveBroadcastToPartitionedJoinEnabled(),
+                        false),
                 booleanProperty(
                         ADAPTIVE_PARTIAL_AGGREGATION_ENABLED,
                         "When enabled, partial aggregation might be adaptively turned off when it does not provide any performance gain",
@@ -1931,6 +1937,11 @@ public final class SystemSessionProperties
     public static DataSize getFaultTolerantExecutionAdaptiveJoinReorderingMinSizeThreshold(Session session)
     {
         return session.getSystemProperty(FAULT_TOLERANT_EXECUTION_ADAPTIVE_JOIN_REORDERING_MIN_SIZE_THRESHOLD, DataSize.class);
+    }
+
+    public static boolean isFaultTolerantExecutionAdaptiveBroadcastToPartitionedJoinEnabled(Session session)
+    {
+        return session.getSystemProperty(FAULT_TOLERANT_EXECUTION_ADAPTIVE_BROADCAST_TO_PARTITIONED_JOIN_ENABLED, Boolean.class);
     }
 
     public static boolean isAdaptivePartialAggregationEnabled(Session session)

--- a/core/trino-main/src/main/java/io/trino/execution/QueryManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryManagerConfig.java
@@ -160,6 +160,7 @@ public class QueryManagerConfig
     // above this threshold.
     // TODO: Consider the cost of restarting the stage as part of adaptive planning.
     private DataSize faultTolerantExecutionAdaptiveJoinReorderingMinSizeThreshold = DataSize.of(5, GIGABYTE);
+    private boolean faultTolerantExecutionAdaptiveBroadcastToPartitionedJoinEnabled = true;
 
     @Min(1)
     public int getScheduleSplitBatchSize()
@@ -1181,6 +1182,19 @@ public class QueryManagerConfig
     public QueryManagerConfig setFaultTolerantExecutionAdaptiveJoinReorderingMinSizeThreshold(DataSize faultTolerantExecutionAdaptiveJoinReorderingMinSizeThreshold)
     {
         this.faultTolerantExecutionAdaptiveJoinReorderingMinSizeThreshold = faultTolerantExecutionAdaptiveJoinReorderingMinSizeThreshold;
+        return this;
+    }
+
+    public boolean isFaultTolerantExecutionAdaptiveBroadcastToPartitionedJoinEnabled()
+    {
+        return faultTolerantExecutionAdaptiveBroadcastToPartitionedJoinEnabled;
+    }
+
+    @Config("fault-tolerant-execution-adaptive-broadcast-to-partitioned-join-enabled")
+    @ConfigDescription("Adapt broadcast join to partitioned join based on runtime stats in fault tolerant execution")
+    public QueryManagerConfig setFaultTolerantExecutionAdaptiveBroadcastToPartitionedJoinEnabled(boolean faultTolerantExecutionAdaptiveBroadcastToPartitionedJoinEnabled)
+    {
+        this.faultTolerantExecutionAdaptiveBroadcastToPartitionedJoinEnabled = faultTolerantExecutionAdaptiveBroadcastToPartitionedJoinEnabled;
         return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanFragmenter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanFragmenter.java
@@ -79,6 +79,8 @@ import static io.trino.spi.connector.StandardWarningCode.TOO_MANY_STAGES;
 import static io.trino.sql.planner.AdaptivePlanner.ExchangeSourceId;
 import static io.trino.sql.planner.SchedulingOrderVisitor.scheduleOrder;
 import static io.trino.sql.planner.SystemPartitioningHandle.COORDINATOR_DISTRIBUTION;
+import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_ARBITRARY_DISTRIBUTION;
+import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_BROADCAST_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.SCALED_WRITER_HASH_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
@@ -484,8 +486,12 @@ public class PlanFragmenter
             else if (node.getExchangeType() == ExchangeNode.Type.REPARTITION) {
                 for (SubPlan child : completedChildren) {
                     PartitioningScheme partitioningScheme = child.getFragment().getOutputPartitioningScheme();
+                    PartitioningHandle handle = partitioningScheme.getPartitioning().getHandle();
+                    if (handle.equals(FIXED_BROADCAST_DISTRIBUTION)) {
+                        handle = FIXED_ARBITRARY_DISTRIBUTION;
+                    }
                     context.get().setDistribution(
-                            partitioningScheme.getPartitioning().getHandle(),
+                            handle,
                             partitioningScheme.getPartitionCount(),
                             metadata,
                             session);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -32,6 +32,7 @@ import io.trino.sql.PlannerContext;
 import io.trino.sql.planner.iterative.IterativeOptimizer;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.iterative.RuleStats;
+import io.trino.sql.planner.iterative.rule.AdaptiveBroadcastToPartitionedJoin;
 import io.trino.sql.planner.iterative.rule.AdaptiveReorderPartitionedJoin;
 import io.trino.sql.planner.iterative.rule.AddDynamicFilterSource;
 import io.trino.sql.planner.iterative.rule.AddExchangesBelowPartialAggregationOverGroupIdRuleSet;
@@ -1044,7 +1045,9 @@ public class PlanOptimizers
                 ruleStats,
                 statsCalculator,
                 costCalculator,
-                ImmutableSet.of(new AdaptiveReorderPartitionedJoin(metadata))));
+                ImmutableSet.of(
+                        new AdaptiveReorderPartitionedJoin(metadata),
+                        new AdaptiveBroadcastToPartitionedJoin(costComparator, taskCountEstimator))));
         this.adaptivePlanOptimizers = adaptivePlanOptimizers.build();
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/AdaptiveBroadcastToPartitionedJoin.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/AdaptiveBroadcastToPartitionedJoin.java
@@ -1,0 +1,464 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import io.airlift.units.DataSize;
+import io.trino.Session;
+import io.trino.cost.CostComparator;
+import io.trino.cost.LocalCostEstimate;
+import io.trino.cost.StatsProvider;
+import io.trino.cost.TaskCountEstimator;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.plan.AggregationNode;
+import io.trino.sql.planner.plan.ExchangeNode;
+import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.JoinType;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.RemoteSourceNode;
+import io.trino.sql.planner.plan.SimplePlanRewriter;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.Verify.verify;
+import static io.trino.SystemSessionProperties.getJoinMaxBroadcastTableSize;
+import static io.trino.SystemSessionProperties.getRetryPolicy;
+import static io.trino.SystemSessionProperties.isFaultTolerantExecutionAdaptiveBroadcastToPartitionedJoinEnabled;
+import static io.trino.cost.CostCalculatorWithEstimatedExchanges.calculateJoinCostWithoutOutput;
+import static io.trino.cost.CostCalculatorWithEstimatedExchanges.calculateRemoteRepartitionCost;
+import static io.trino.cost.LocalCostEstimate.addPartialComponents;
+import static io.trino.cost.PlanNodeStatsEstimateMath.getSourceTablesSizeInBytes;
+import static io.trino.matching.Pattern.any;
+import static io.trino.operator.RetryPolicy.TASK;
+import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_ARBITRARY_DISTRIBUTION;
+import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_BROADCAST_DISTRIBUTION;
+import static io.trino.sql.planner.optimizations.QueryCardinalityUtil.isAtMostScalar;
+import static io.trino.sql.planner.plan.AggregationNode.Step.PARTIAL;
+import static io.trino.sql.planner.plan.ChildReplacer.replaceChildren;
+import static io.trino.sql.planner.plan.ExchangeNode.Scope.LOCAL;
+import static io.trino.sql.planner.plan.ExchangeNode.Scope.REMOTE;
+import static io.trino.sql.planner.plan.ExchangeNode.Type.REPARTITION;
+import static io.trino.sql.planner.plan.ExchangeNode.Type.REPLICATE;
+import static io.trino.sql.planner.plan.ExchangeNode.partitionedExchange;
+import static io.trino.sql.planner.plan.JoinNode.DistributionType.PARTITIONED;
+import static io.trino.sql.planner.plan.JoinNode.DistributionType.REPLICATED;
+import static io.trino.sql.planner.plan.JoinType.INNER;
+import static io.trino.sql.planner.plan.JoinType.LEFT;
+import static io.trino.sql.planner.plan.Patterns.Join.left;
+import static io.trino.sql.planner.plan.Patterns.Join.right;
+import static io.trino.sql.planner.plan.Patterns.aggregation;
+import static io.trino.sql.planner.plan.Patterns.exchange;
+import static io.trino.sql.planner.plan.Patterns.join;
+import static io.trino.sql.planner.plan.Patterns.source;
+import static io.trino.sql.planner.plan.SimplePlanRewriter.rewriteWith;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Change the join type from broadcast to partitioned join based on runtime data size stats. This rule is only used
+ * during Adaptive Planning in FTE.
+ * <p>
+ * <pre>
+ * From:
+ *  - Join (distribution: REPLICATED)
+ *      - Partial Aggregation (optional)
+ *          - Remote Exchange (distribution: RoundRobin, absent if source is RemoteSource)
+ *              - left side or RemoteSource (distribution: REPARTITIONED)
+ *      - Partial Aggregation (optional)
+ *          - Local Exchange (optional)
+ *              - Remote Exchange (distribution: REPLICATED, absent if source is RemoteSource)
+ *                  - right side or RemoteSource (distribution: REPLICATED)
+ * To:
+ * - Join (distribution: PARTITIONED)
+ *      - Partial Aggregation (optional)
+ *          - Exchange (distribution: PARTITIONED, either change the existing one or add new if needed)
+ *              - left side or RemoteSource (distribution: REPARTITIONED)
+ *      - Partial Aggregation (optional)
+ *          - Local Exchange (optional)
+ *              - Remote Exchange (distribution: PARTITIONED, either change the existing one or add new if needed)
+ *                  - right side or RemoteSource (distribution: REPARTITION)
+ *</pre>
+ *
+ * <b>Note:</b>
+ * We will try to not add extra Exchange nodes when possible. For example, if the left side is not
+ * considered completed, and still has Exchange node with RoundRobin distribution, we will simply change the distribution
+ * type of that exchange node to PARTITIONED instead of adding a new Exchange node. Same applies to the right side.
+ * <p>
+ * However, if the node is considered completed (i.e. RemoteSourceNode), we will need to add a new Exchange node
+ * with partitioned distribution. We will try to consider the cost of adding an extra Exchange node while
+ * making this decision.
+ * <p>
+ * TODO: We can make this rule more efficient by using the StreamPropertyDerivation mechanism to determine the
+ *       RemoteExchangeNodes that can be reused instead of adding a new one. For instance, this will be helpful in
+ *       cases where either side of the join has union nodes.
+ *       https://github.com/trinodb/trino/issues/23372
+ */
+public class AdaptiveBroadcastToPartitionedJoin
+        implements Rule<JoinNode>
+{
+    private static final Capture<ExchangeNode> LEFT_EXCHANGE_NODE = Capture.newCapture();
+    private static final Capture<ExchangeNode> RIGHT_EXCHANGE_NODE = Capture.newCapture();
+
+    private static final Pattern<JoinNode> PATTERN = join()
+            .matching(joinNode -> joinNode.getDistributionType().equals(Optional.of(REPLICATED)))
+            // Left side pattern
+            .or(
+                    // Partial aggregation + remote exchange pattern
+                    prev -> prev.with(left()
+                            .matching(aggregation().matching(node -> node.getStep() == PARTIAL)
+                                    .with(source()
+                                            .matching(exchange()
+                                                    .matching(AdaptiveBroadcastToPartitionedJoin::isRoundRobinRemoteExchange)
+                                                    .capturedAs(LEFT_EXCHANGE_NODE))))),
+                    // remote exchange pattern
+                    prev -> prev.with(left()
+                            .matching(exchange().matching(AdaptiveBroadcastToPartitionedJoin::isRoundRobinRemoteExchange)
+                                    .capturedAs(LEFT_EXCHANGE_NODE))),
+                    // remote source node or any arbitrary node
+                    prev -> prev.with(left().matching(any())))
+            // Right side pattern
+            .or(
+                    // Partial aggregation + local exchange + remote exchange pattern
+                    prev -> prev.with(right().matching(aggregation().matching(node -> node.getStep() == PARTIAL)
+                            .with(source().matching(exchange().matching(node -> node.getScope() == LOCAL)
+                                    .with(source().matching(exchange()
+                                            .matching(AdaptiveBroadcastToPartitionedJoin::isBroadcastRemoteExchange)
+                                            .capturedAs(RIGHT_EXCHANGE_NODE))))))),
+                    // local exchange + remote exchange pattern
+                    prev -> prev.with(right().matching(exchange().matching(node -> node.getScope() == LOCAL)
+                            .with(source().matching(exchange()
+                                    .matching(AdaptiveBroadcastToPartitionedJoin::isBroadcastRemoteExchange)
+                                    .capturedAs(RIGHT_EXCHANGE_NODE))))),
+                    // remote exchange pattern
+                    prev -> prev.with(right().matching(exchange()
+                            .matching(AdaptiveBroadcastToPartitionedJoin::isBroadcastRemoteExchange)
+                            .capturedAs(RIGHT_EXCHANGE_NODE))),
+                    // remote source node or any arbitrary node
+                    prev -> prev.with(right().matching(any())));
+
+    private final CostComparator costComparator;
+    private final TaskCountEstimator taskCountEstimator;
+
+    private static boolean isRoundRobinRemoteExchange(ExchangeNode node)
+    {
+        return node.getScope() == REMOTE
+                && node.getType() == REPARTITION
+                && node.getPartitioningScheme().getPartitioning().getHandle().equals(FIXED_ARBITRARY_DISTRIBUTION)
+                && node.getSources().size() == 1;
+    }
+
+    private static boolean isBroadcastRemoteExchange(ExchangeNode node)
+    {
+        return node.getScope() == REMOTE
+                && node.getType() == REPLICATE
+                && node.getPartitioningScheme().getPartitioning().getHandle().equals(FIXED_BROADCAST_DISTRIBUTION)
+                && node.getSources().size() == 1;
+    }
+
+    public AdaptiveBroadcastToPartitionedJoin(CostComparator costComparator, TaskCountEstimator taskCountEstimator)
+    {
+        this.costComparator = requireNonNull(costComparator, "costComparator is null");
+        this.taskCountEstimator = requireNonNull(taskCountEstimator, "taskCountEstimator is null");
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        // This rule is only enabled in case of FTE
+        return getRetryPolicy(session) == TASK
+                && isFaultTolerantExecutionAdaptiveBroadcastToPartitionedJoinEnabled(session);
+    }
+
+    @Override
+    public Pattern<JoinNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(JoinNode node, Captures captures, Context context)
+    {
+        if (mustReplicate(node, context)) {
+            return Result.empty();
+        }
+        // Check if we need to add extra remote exchange nodes to partition the data
+        boolean isExtraRemoteExchangeNeededAtProbeSide = captures.getOptional(LEFT_EXCHANGE_NODE).isEmpty();
+        boolean isExtraRemoteExchangeNeededAtBuildSide = captures.getOptional(RIGHT_EXCHANGE_NODE).isEmpty();
+        boolean shouldChangeDistributionToPartitioned = changeDistributionToPartitioned(
+                node,
+                context,
+                isExtraRemoteExchangeNeededAtProbeSide,
+                isExtraRemoteExchangeNeededAtBuildSide);
+
+        if (!shouldChangeDistributionToPartitioned) {
+            return Result.empty();
+        }
+
+        return Result.ofPlanNode(convertToPartitionedJoin(node, context));
+    }
+
+    private static boolean mustReplicate(JoinNode joinNode, Context context)
+    {
+        JoinType type = joinNode.getType();
+        if (joinNode.getCriteria().isEmpty() && (type == INNER || type == LEFT)) {
+            // There is nothing to partition on
+            return true;
+        }
+        return isAtMostScalar(joinNode.getRight(), context.getLookup());
+    }
+
+    private boolean changeDistributionToPartitioned(
+            JoinNode joinNode,
+            Context context,
+            boolean isExtraRemoteExchangeNeededAtProbeSide,
+            boolean isExtraRemoteExchangeNeededAtBuildSide)
+    {
+        DataSize joinMaxBroadcastTableSize = getJoinMaxBroadcastTableSize(context.getSession());
+
+        PlanNodeWithCost replicatedJoinCost = getJoinNodeWithCost(
+                context,
+                joinNode,
+                false,
+                false);
+
+        PlanNodeWithCost partitionedJoinCost = getJoinNodeWithCost(
+                context,
+                joinNode.withDistributionType(PARTITIONED),
+                isExtraRemoteExchangeNeededAtProbeSide,
+                isExtraRemoteExchangeNeededAtBuildSide);
+
+        if (replicatedJoinCost.getCost().hasUnknownComponents() || partitionedJoinCost.getCost().hasUnknownComponents()) {
+            // Take decision simply based on the stats
+            return getSourceTablesSizeInBytes(joinNode.getRight(), context.getLookup(), context.getStatsProvider())
+                    > joinMaxBroadcastTableSize.toBytes();
+        }
+
+        return costComparator.compare(
+                context.getSession(),
+                replicatedJoinCost.getCost(),
+                partitionedJoinCost.getCost()) >= 0;
+    }
+
+    private JoinNode convertToPartitionedJoin(
+            JoinNode joinNode,
+            Context context)
+    {
+        // Left partitioned exchange node
+        List<Symbol> probeSymbols = Lists.transform(joinNode.getCriteria(), JoinNode.EquiJoinClause::getLeft);
+        ProbeSideRewriter probeSideRewriter = new ProbeSideRewriter(probeSymbols, context);
+        PlanNode probeNode = rewriteWith(probeSideRewriter, context.getLookup().resolve(joinNode.getLeft()));
+
+        // Change the join type to partitioned
+        List<Symbol> buildSymbols = Lists.transform(joinNode.getCriteria(), JoinNode.EquiJoinClause::getRight);
+        BuildSideRewriter buildSideRewriter = new BuildSideRewriter(buildSymbols, context);
+        PlanNode buildNode = rewriteWith(buildSideRewriter, context.getLookup().resolve(joinNode.getRight()));
+
+        return new JoinNode(
+                joinNode.getId(),
+                joinNode.getType(),
+                probeNode,
+                buildNode,
+                joinNode.getCriteria(),
+                joinNode.getLeftOutputSymbols(),
+                joinNode.getRightOutputSymbols(),
+                joinNode.isMaySkipOutputDuplicates(),
+                joinNode.getFilter(),
+                joinNode.getLeftHashSymbol(),
+                joinNode.getRightHashSymbol(),
+                Optional.of(PARTITIONED),
+                joinNode.isSpillable(),
+                joinNode.getDynamicFilters(),
+                joinNode.getReorderJoinStatsAndCost());
+    }
+
+    private PlanNodeWithCost getJoinNodeWithCost(
+            Context context,
+            JoinNode joinNode,
+            boolean isExtraRemoteExchangeNeededAtProbeSide,
+            boolean isExtraRemoteExchangeNeededAtBuildSide)
+    {
+        StatsProvider stats = context.getStatsProvider();
+        boolean replicated = joinNode.getDistributionType().get() == REPLICATED;
+        /*
+         *   HACK!
+         *
+         *   Currently cost model always has to compute the total cost of an operation.
+         *   For JOIN the total cost consist of 4 parts:
+         *     - Cost of exchanges that have to be introduced to execute a JOIN
+         *     - Cost of building a hash table
+         *     - Cost of probing a hash table
+         *     - Cost of building an output for matched rows
+         *
+         *   When output size for a JOIN cannot be estimated the cost model returns
+         *   UNKNOWN cost for the join.
+         *
+         *   However assuming the cost of JOIN output is always the same, we can still make
+         *   cost based decisions for choosing between REPLICATED and PARTITIONED join.
+         *
+         *   TODO Decision about the distribution should be based on LocalCostEstimate only when PlanCostEstimate cannot be calculated. Otherwise cost comparator cannot take query.max-memory into account.
+         */
+        int estimatedSourceDistributedTaskCount = taskCountEstimator.estimateSourceDistributedTaskCount(context.getSession());
+        LocalCostEstimate cost = calculateJoinCostWithoutOutput(
+                joinNode.getLeft(),
+                joinNode.getRight(),
+                stats,
+                replicated,
+                estimatedSourceDistributedTaskCount);
+
+        // In case we need to add extra remote exchange node to partition the data, we need
+        // to consider the cost of adding them.
+        if (isExtraRemoteExchangeNeededAtProbeSide) {
+            double probeSizeInBytes = stats.getStats(joinNode.getLeft()).getOutputSizeInBytes(joinNode.getLeft().getOutputSymbols());
+            LocalCostEstimate probeCost = calculateRemoteRepartitionCost(probeSizeInBytes);
+            cost = addPartialComponents(cost, probeCost);
+        }
+
+        // In case we need to add extra remote exchange node to partition the data, we need
+        // to consider the cost of adding them.
+        if (isExtraRemoteExchangeNeededAtBuildSide) {
+            double buildSizeInBytes = stats.getStats(joinNode.getRight()).getOutputSizeInBytes(joinNode.getRight().getOutputSymbols());
+            LocalCostEstimate buildCost = calculateRemoteRepartitionCost(buildSizeInBytes);
+            cost = addPartialComponents(cost, buildCost);
+        }
+
+        return new PlanNodeWithCost(cost.toPlanCost(), joinNode);
+    }
+
+    private static class ProbeSideRewriter
+            extends SimplePlanRewriter<Void>
+    {
+        private final List<Symbol> probeSymbols;
+        private final Context globalContext;
+
+        private ProbeSideRewriter(List<Symbol> probeSymbols, Context globalContext)
+        {
+            this.probeSymbols = requireNonNull(probeSymbols, "probeSymbols is null");
+            this.globalContext = requireNonNull(globalContext, "globalContext is null");
+        }
+
+        @Override
+        protected PlanNode visitPlan(PlanNode node, RewriteContext<Void> context)
+        {
+            return partitionedExchange(
+                    globalContext.getIdAllocator().getNextId(),
+                    REMOTE,
+                    node,
+                    probeSymbols,
+                    Optional.empty());
+        }
+
+        @Override
+        public PlanNode visitAggregation(AggregationNode node, RewriteContext<Void> context)
+        {
+            if (node.getStep() == PARTIAL) {
+                return rewriteSources(this, node, globalContext);
+            }
+            return visitPlan(node, context);
+        }
+
+        @Override
+        public PlanNode visitExchange(ExchangeNode node, RewriteContext<Void> context)
+        {
+            verify(node.getScope() == REMOTE && node.getType() == REPARTITION);
+            return partitionedExchange(
+                    globalContext.getIdAllocator().getNextId(),
+                    REMOTE,
+                    node.getSources().get(0),
+                    probeSymbols,
+                    Optional.empty());
+        }
+
+        @Override
+        public PlanNode visitRemoteSource(RemoteSourceNode node, RewriteContext<Void> context)
+        {
+            verify(node.getExchangeType() == REPARTITION);
+            return visitPlan(node, context);
+        }
+    }
+
+    private static class BuildSideRewriter
+            extends SimplePlanRewriter<Void>
+    {
+        private final List<Symbol> buildSymbols;
+        private final Context globalContext;
+
+        private BuildSideRewriter(List<Symbol> buildSymbols, Context globalContext)
+        {
+            this.buildSymbols = requireNonNull(buildSymbols, "buildSymbols is null");
+            this.globalContext = requireNonNull(globalContext, "globalContext is null");
+        }
+
+        @Override
+        protected PlanNode visitPlan(PlanNode node, RewriteContext<Void> context)
+        {
+            return partitionedExchange(
+                    globalContext.getIdAllocator().getNextId(),
+                    REMOTE,
+                    node,
+                    buildSymbols,
+                    Optional.empty());
+        }
+
+        @Override
+        public PlanNode visitAggregation(AggregationNode node, RewriteContext<Void> context)
+        {
+            if (node.getStep() == PARTIAL) {
+                return rewriteSources(this, node, globalContext);
+            }
+            return visitPlan(node, context);
+        }
+
+        @Override
+        public PlanNode visitExchange(ExchangeNode node, RewriteContext<Void> context)
+        {
+            if (node.getScope() == LOCAL) {
+                return rewriteSources(this, node, globalContext);
+            }
+            verify(node.getScope() == REMOTE && node.getType() == REPLICATE);
+            return partitionedExchange(
+                    globalContext.getIdAllocator().getNextId(),
+                    REMOTE,
+                    node.getSources().get(0),
+                    buildSymbols,
+                    Optional.empty());
+        }
+
+        @Override
+        public PlanNode visitRemoteSource(RemoteSourceNode node, RewriteContext<Void> context)
+        {
+            verify(node.getExchangeType() == REPLICATE);
+            RemoteSourceNode sourceNode = new RemoteSourceNode(
+                    node.getId(),
+                    node.getSourceFragmentIds(),
+                    node.getOutputSymbols(),
+                    node.getOrderingScheme(),
+                    REPARTITION,
+                    node.getRetryPolicy());
+            return visitPlan(sourceNode, context);
+        }
+    }
+
+    private static PlanNode rewriteSources(SimplePlanRewriter<Void> rewriter, PlanNode node, Context context)
+    {
+        ImmutableList.Builder<PlanNode> children = ImmutableList.builderWithExpectedSize(node.getSources().size());
+        node.getSources().forEach(source -> children.add(rewriteWith(rewriter, context.getLookup().resolve(source))));
+        return replaceChildren(node, children.build());
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/execution/TestQueryManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestQueryManagerConfig.java
@@ -116,6 +116,7 @@ public class TestQueryManagerConfig
                 .setFaultTolerantExecutionAdaptiveJoinReorderingEnabled(true)
                 .setFaultTolerantExecutionAdaptiveJoinReorderingMinSizeThreshold(DataSize.of(5, GIGABYTE))
                 .setFaultTolerantExecutionAdaptiveJoinReorderingSizeDifferenceRatio(1.5)
+                .setFaultTolerantExecutionAdaptiveBroadcastToPartitionedJoinEnabled(true)
                 .setMaxWriterTaskCount(100));
     }
 
@@ -198,6 +199,7 @@ public class TestQueryManagerConfig
                 .put("fault-tolerant-execution-adaptive-join-reordering-enabled", "false")
                 .put("fault-tolerant-execution-adaptive-join-reordering-min-size-threshold", "1GB")
                 .put("fault-tolerant-execution-adaptive-join-reordering-size-difference-ratio", "2")
+                .put("fault-tolerant-execution-adaptive-broadcast-to-partitioned-join-enabled", "false")
                 .buildOrThrow();
 
         QueryManagerConfig expected = new QueryManagerConfig()
@@ -275,6 +277,7 @@ public class TestQueryManagerConfig
                 .setFaultTolerantExecutionAdaptiveJoinReorderingEnabled(false)
                 .setFaultTolerantExecutionAdaptiveJoinReorderingMinSizeThreshold(DataSize.of(1, GIGABYTE))
                 .setFaultTolerantExecutionAdaptiveJoinReorderingSizeDifferenceRatio(2.0)
+                .setFaultTolerantExecutionAdaptiveBroadcastToPartitionedJoinEnabled(false)
                 .setMaxWriterTaskCount(101);
 
         assertFullMapping(properties, expected);

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestAdaptiveBroadcastToPartitionedJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestAdaptiveBroadcastToPartitionedJoin.java
@@ -1,0 +1,458 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.trino.cost.CostComparator;
+import io.trino.cost.PlanNodeStatsEstimate;
+import io.trino.cost.TaskCountEstimator;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.trino.sql.planner.iterative.rule.test.RuleAssert;
+import io.trino.sql.planner.iterative.rule.test.RuleTester;
+import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.PlanFragmentId;
+import io.trino.sql.planner.plan.PlanNodeId;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.trino.SystemSessionProperties.RETRY_POLICY;
+import static io.trino.operator.RetryPolicy.TASK;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.exchange;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.remoteSource;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.sql.planner.plan.AggregationNode.Step.PARTIAL;
+import static io.trino.sql.planner.plan.ExchangeNode.Scope.LOCAL;
+import static io.trino.sql.planner.plan.ExchangeNode.Scope.REMOTE;
+import static io.trino.sql.planner.plan.ExchangeNode.Type.REPARTITION;
+import static io.trino.sql.planner.plan.ExchangeNode.Type.REPLICATE;
+import static io.trino.sql.planner.plan.JoinNode.DistributionType.PARTITIONED;
+import static io.trino.sql.planner.plan.JoinNode.DistributionType.REPLICATED;
+import static io.trino.sql.planner.plan.JoinType.INNER;
+
+public class TestAdaptiveBroadcastToPartitionedJoin
+        extends BaseRuleTest
+{
+    private static final CostComparator COST_COMPARATOR = new CostComparator(75, 10, 15);
+    private static final TaskCountEstimator TASK_COUNT_ESTIMATOR = new TaskCountEstimator(() -> 10);
+
+    @Test
+    public void testBroadcastToPartitionedJoinWithArbitrarySource()
+    {
+        testBroadcastToPartitionedWithArbitrarySource(100_000_000, 200_000_000);
+    }
+
+    @Test
+    public void testBroadcastToPartitionedJoinWithExistingExchange()
+    {
+        testBroadcastToPartitionedWithExistingExchange(100_000_000, 200_000_000);
+    }
+
+    @Test
+    void testBroadcastToPartitionedWhenProbeSideIsNaN()
+    {
+        // In this scenario cost based comparison is not possible, so the rule simply change
+        // the distribution type based on stats from build side
+        // (buildRowCount > joinMaxBroadcastTableSize)
+        testBroadcastToPartitionedWithArbitrarySource(200_000_000, Double.NaN);
+        testBroadcastToPartitionedWithExistingExchange(200_000_000, Double.NaN);
+    }
+
+    @Test
+    void testWhenCostOfExtraRemoteExchangeIsHigh()
+    {
+        // No change in distribution type as the cost of extra remote exchange is high
+        assertArbitrarySourceWithoutPartialAgg(100_000_000, 1000_000_000)
+                .doesNotFire();
+        assertArbitrarySourceWithPartialAgg(100_000_000, 1000_000_000)
+                .doesNotFire();
+
+        // In this case, we don't have to add an extra exchange, so the rule should fire
+        testBroadcastToPartitionedWithExistingExchange(100_000_000, 1000_000_000);
+    }
+
+    @Test
+    public void testNoChangeWhenBuildSideIsSmaller()
+    {
+        assertArbitrarySourceWithoutPartialAgg(20_000, 200_000_000)
+                .doesNotFire();
+        assertArbitrarySourceWithPartialAgg(20_000, 200_000_000)
+                .doesNotFire();
+        assertRemoteExchangeWithoutPartialAgg(20_000, 200_000_000)
+                .doesNotFire();
+        assertRemoteExchangeWithPartialAgg(20_000, 200_000_000)
+                .doesNotFire();
+    }
+
+    @Test
+    public void testNoChangeWhenBuildSideIsNaN()
+    {
+        assertArbitrarySourceWithoutPartialAgg(Double.NaN, 20_000)
+                .doesNotFire();
+        assertArbitrarySourceWithPartialAgg(Double.NaN, 20_000)
+                .doesNotFire();
+        assertRemoteExchangeWithoutPartialAgg(Double.NaN, 20_000)
+                .doesNotFire();
+        assertRemoteExchangeWithPartialAgg(Double.NaN, 20_000)
+                .doesNotFire();
+    }
+
+    private void testBroadcastToPartitionedWithArbitrarySource(double buildRowCount, double probeRowCount)
+    {
+        assertArbitrarySourceWithoutPartialAgg(buildRowCount, probeRowCount)
+                .matches(join(INNER, builder -> builder
+                        .equiCriteria("probeSymbol", "buildSymbol")
+                        .distributionType(PARTITIONED)
+                        .left(exchange(
+                                REMOTE,
+                                REPARTITION,
+                                ImmutableList.of(),
+                                ImmutableSet.of("probeSymbol"),
+                                Optional.of(ImmutableList.of(ImmutableList.of("probeSymbol", "symbol2"))),
+                                remoteSource(
+                                        ImmutableList.of(new PlanFragmentId("1")),
+                                        ImmutableList.of("probeSymbol", "symbol2"),
+                                        REPARTITION)))
+                        .right(exchange(
+                                LOCAL,
+                                REPARTITION,
+                                ImmutableList.of(),
+                                ImmutableSet.of("buildSymbol"),
+                                Optional.of(ImmutableList.of(ImmutableList.of("buildSymbol", "symbol1"))),
+                                exchange(
+                                        REMOTE,
+                                        REPARTITION,
+                                        ImmutableList.of(),
+                                        ImmutableSet.of("buildSymbol"),
+                                        Optional.of(ImmutableList.of(ImmutableList.of("buildSymbol", "symbol1"))),
+                                        remoteSource(
+                                                ImmutableList.of(new PlanFragmentId("2")),
+                                                ImmutableList.of("buildSymbol", "symbol1"),
+                                                REPARTITION))))));
+        assertArbitrarySourceWithPartialAgg(buildRowCount, probeRowCount)
+                .matches(join(INNER, builder -> builder
+                        .equiCriteria("probeSymbol", "buildSymbol")
+                        .distributionType(PARTITIONED)
+                        .left(aggregation(
+                                ImmutableMap.of(),
+                                PARTIAL,
+                                exchange(
+                                        REMOTE,
+                                        REPARTITION,
+                                        ImmutableList.of(),
+                                        ImmutableSet.of("probeSymbol"),
+                                        Optional.of(ImmutableList.of(ImmutableList.of("probeSymbol", "symbol2"))),
+                                        remoteSource(
+                                                ImmutableList.of(new PlanFragmentId("1")),
+                                                ImmutableList.of("probeSymbol", "symbol2"),
+                                                REPARTITION))))
+                        .right(aggregation(
+                                ImmutableMap.of(),
+                                PARTIAL,
+                                exchange(
+                                        LOCAL,
+                                        REPARTITION,
+                                        ImmutableList.of(),
+                                        ImmutableSet.of("buildSymbol"),
+                                        Optional.of(ImmutableList.of(ImmutableList.of("buildSymbol", "symbol1"))),
+                                        exchange(
+                                                REMOTE,
+                                                REPARTITION,
+                                                ImmutableList.of(),
+                                                ImmutableSet.of("buildSymbol"),
+                                                Optional.of(ImmutableList.of(ImmutableList.of("buildSymbol", "symbol1"))),
+                                                remoteSource(
+                                                        ImmutableList.of(new PlanFragmentId("2")),
+                                                        ImmutableList.of("buildSymbol", "symbol1"),
+                                                        REPARTITION)))))));
+    }
+
+    private void testBroadcastToPartitionedWithExistingExchange(double buildRowCount, double probeRowCount)
+    {
+        assertRemoteExchangeWithoutPartialAgg(buildRowCount, probeRowCount)
+                .matches(join(INNER, builder -> builder
+                        .equiCriteria("probeSymbol", "buildSymbol")
+                        .distributionType(PARTITIONED)
+                        .left(exchange(
+                                REMOTE,
+                                REPARTITION,
+                                ImmutableList.of(),
+                                ImmutableSet.of("probeSymbol"),
+                                Optional.of(ImmutableList.of(ImmutableList.of("probeSymbol", "symbol2"))),
+                                values(ImmutableList.of("probeSymbol", "symbol2"))))
+                        .right(exchange(
+                                LOCAL,
+                                REPARTITION,
+                                ImmutableList.of(),
+                                ImmutableSet.of("buildSymbol"),
+                                Optional.of(ImmutableList.of(ImmutableList.of("buildSymbol", "symbol1"))),
+                                exchange(
+                                        REMOTE,
+                                        REPARTITION,
+                                        ImmutableList.of(),
+                                        ImmutableSet.of("buildSymbol"),
+                                        Optional.of(ImmutableList.of(ImmutableList.of("buildSymbol", "symbol1"))),
+                                        values(ImmutableList.of("buildSymbol", "symbol1")))))));
+
+        assertRemoteExchangeWithPartialAgg(buildRowCount, probeRowCount)
+                .matches(join(INNER, builder -> builder
+                        .equiCriteria("probeSymbol", "buildSymbol")
+                        .distributionType(PARTITIONED)
+                        .left(aggregation(
+                                ImmutableMap.of(),
+                                PARTIAL,
+                                exchange(
+                                        REMOTE,
+                                        REPARTITION,
+                                        ImmutableList.of(),
+                                        ImmutableSet.of("probeSymbol"),
+                                        Optional.of(ImmutableList.of(ImmutableList.of("probeSymbol", "symbol2"))),
+                                        values(ImmutableList.of("probeSymbol", "symbol2")))))
+                        .right(aggregation(
+                                ImmutableMap.of(),
+                                PARTIAL,
+                                exchange(
+                                        LOCAL,
+                                        REPARTITION,
+                                        ImmutableList.of(),
+                                        ImmutableSet.of("buildSymbol"),
+                                        Optional.of(ImmutableList.of(ImmutableList.of("buildSymbol", "symbol1"))),
+                                        exchange(
+                                                REMOTE,
+                                                REPARTITION,
+                                                ImmutableList.of(),
+                                                ImmutableSet.of("buildSymbol"),
+                                                Optional.of(ImmutableList.of(ImmutableList.of("buildSymbol", "symbol1"))),
+                                                values(ImmutableList.of("buildSymbol", "symbol1"))))))));
+    }
+
+    private RuleAssert assertArbitrarySourceWithoutPartialAgg(double buildRowCount, double probeRowCount)
+    {
+        RuleTester ruleTester = tester();
+        String buildRemoteSourceId = "buildRemoteSourceId";
+        String probeRemoteSourceId = "probeRemoteSourceId";
+        return ruleTester.assertThat(new AdaptiveBroadcastToPartitionedJoin(COST_COMPARATOR, TASK_COUNT_ESTIMATOR))
+                .setSystemProperty(RETRY_POLICY, TASK.name())
+                .overrideStats("buildRemoteSourceId", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(buildRowCount)
+                        .build())
+                .overrideStats("probeRemoteSourceId", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(probeRowCount)
+                        .build())
+                .on(p -> {
+                    Symbol buildSymbol = p.symbol("buildSymbol", BIGINT);
+                    Symbol symbol1 = p.symbol("symbol1", BIGINT);
+                    Symbol probeSymbol = p.symbol("probeSymbol", BIGINT);
+                    Symbol symbol2 = p.symbol("symbol2", BIGINT);
+                    return p.join(
+                            INNER,
+                            REPLICATED,
+                            p.remoteSource(
+                                    new PlanNodeId(probeRemoteSourceId),
+                                    ImmutableList.of(new PlanFragmentId("1")),
+                                    ImmutableList.of(probeSymbol, symbol2),
+                                    Optional.empty(),
+                                    REPARTITION,
+                                    TASK),
+                            p.exchange(builder -> builder
+                                    .addInputsSet(buildSymbol, symbol1)
+                                    .addSource(p.remoteSource(
+                                            new PlanNodeId(buildRemoteSourceId),
+                                            ImmutableList.of(new PlanFragmentId("2")),
+                                            ImmutableList.of(buildSymbol, symbol1),
+                                            Optional.empty(),
+                                            REPLICATE,
+                                            TASK))
+                                    .fixedHashDistributionPartitioningScheme(
+                                            ImmutableList.of(buildSymbol, symbol1),
+                                            ImmutableList.of(buildSymbol))
+                                    .type(REPARTITION)
+                                    .scope(LOCAL)),
+                            new JoinNode.EquiJoinClause(probeSymbol, buildSymbol));
+                });
+    }
+
+    private RuleAssert assertArbitrarySourceWithPartialAgg(double buildRowCount, double probeRowCount)
+    {
+        RuleTester ruleTester = tester();
+        String buildRemoteSourceId = "buildRemoteSourceId";
+        String probeRemoteSourceId = "probeRemoteSourceId";
+        return ruleTester.assertThat(new AdaptiveBroadcastToPartitionedJoin(COST_COMPARATOR, TASK_COUNT_ESTIMATOR))
+                .setSystemProperty(RETRY_POLICY, TASK.name())
+                .overrideStats("buildRemoteSourceId", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(buildRowCount)
+                        .build())
+                .overrideStats("probeRemoteSourceId", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(probeRowCount)
+                        .build())
+                .on(p -> {
+                    Symbol buildSymbol = p.symbol("buildSymbol", BIGINT);
+                    Symbol symbol1 = p.symbol("symbol1", BIGINT);
+                    Symbol probeSymbol = p.symbol("probeSymbol", BIGINT);
+                    Symbol symbol2 = p.symbol("symbol2", BIGINT);
+                    return p.join(
+                            INNER,
+                            REPLICATED,
+                            p.aggregation(ab -> ab
+                                    .step(PARTIAL)
+                                    .singleGroupingSet(probeSymbol, symbol2)
+                                    .source(p.remoteSource(
+                                            new PlanNodeId(probeRemoteSourceId),
+                                            ImmutableList.of(new PlanFragmentId("1")),
+                                            ImmutableList.of(probeSymbol, symbol2),
+                                            Optional.empty(),
+                                            REPARTITION,
+                                            TASK))),
+                            p.aggregation(ab -> ab
+                                    .step(PARTIAL)
+                                    .singleGroupingSet(buildSymbol, symbol1)
+                                    .source(p.exchange(builder -> builder
+                                            .addInputsSet(buildSymbol, symbol1)
+                                            .addSource(p.remoteSource(
+                                                    new PlanNodeId(buildRemoteSourceId),
+                                                    ImmutableList.of(new PlanFragmentId("2")),
+                                                    ImmutableList.of(buildSymbol, symbol1),
+                                                    Optional.empty(),
+                                                    REPLICATE,
+                                                    TASK))
+                                            .fixedHashDistributionPartitioningScheme(
+                                                    ImmutableList.of(buildSymbol, symbol1),
+                                                    ImmutableList.of(buildSymbol))
+                                            .type(REPARTITION)
+                                            .scope(LOCAL)))),
+                            new JoinNode.EquiJoinClause(probeSymbol, buildSymbol));
+                });
+    }
+
+    private RuleAssert assertRemoteExchangeWithoutPartialAgg(double buildRowCount, double probeRowCount)
+    {
+        RuleTester ruleTester = tester();
+        String buildRemoteSourceId = "buildRemoteSourceId";
+        String probeRemoteSourceId = "probeRemoteSourceId";
+        return ruleTester.assertThat(new AdaptiveBroadcastToPartitionedJoin(COST_COMPARATOR, TASK_COUNT_ESTIMATOR))
+                .setSystemProperty(RETRY_POLICY, TASK.name())
+                .overrideStats("buildRemoteSourceId", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(buildRowCount)
+                        .build())
+                .overrideStats("probeRemoteSourceId", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(probeRowCount)
+                        .build())
+                .on(p -> {
+                    Symbol buildSymbol = p.symbol("buildSymbol", BIGINT);
+                    Symbol symbol1 = p.symbol("symbol1", BIGINT);
+                    Symbol probeSymbol = p.symbol("probeSymbol", BIGINT);
+                    Symbol symbol2 = p.symbol("symbol2", BIGINT);
+                    return p.join(
+                            INNER,
+                            REPLICATED,
+                            p.exchange(builder -> builder
+                                    .addInputsSet(probeSymbol, symbol2)
+                                    .addSource(p.values(
+                                            new PlanNodeId(probeRemoteSourceId),
+                                            5,
+                                            probeSymbol,
+                                            symbol2))
+                                    .fixedArbitraryDistributionPartitioningScheme(
+                                            ImmutableList.of(probeSymbol, symbol2),
+                                            3)
+                                    .type(REPARTITION)
+                                    .scope(REMOTE)),
+                            p.exchange(builder -> builder
+                                    .addInputsSet(buildSymbol, symbol1)
+                                    .addSource(p.exchange(reBuilder -> reBuilder
+                                            .addInputsSet(buildSymbol, symbol1)
+                                            .addSource(p.values(
+                                                    new PlanNodeId(buildRemoteSourceId),
+                                                    5,
+                                                    buildSymbol,
+                                                    symbol1))
+                                            .broadcastPartitioningScheme(ImmutableList.of(buildSymbol, symbol1))
+                                            .type(REPLICATE)
+                                            .scope(REMOTE)))
+                                    .fixedHashDistributionPartitioningScheme(
+                                            ImmutableList.of(buildSymbol, symbol1),
+                                            ImmutableList.of(buildSymbol))
+                                    .type(REPARTITION)
+                                    .scope(LOCAL)),
+                            new JoinNode.EquiJoinClause(probeSymbol, buildSymbol));
+                });
+    }
+
+    private RuleAssert assertRemoteExchangeWithPartialAgg(double buildRowCount, double probeRowCount)
+    {
+        RuleTester ruleTester = tester();
+        String buildRemoteSourceId = "buildRemoteSourceId";
+        String probeRemoteSourceId = "probeRemoteSourceId";
+        return ruleTester.assertThat(new AdaptiveBroadcastToPartitionedJoin(COST_COMPARATOR, TASK_COUNT_ESTIMATOR))
+                .setSystemProperty(RETRY_POLICY, TASK.name())
+                .overrideStats("buildRemoteSourceId", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(buildRowCount)
+                        .build())
+                .overrideStats("probeRemoteSourceId", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(probeRowCount)
+                        .build())
+                .on(p -> {
+                    Symbol buildSymbol = p.symbol("buildSymbol", BIGINT);
+                    Symbol symbol1 = p.symbol("symbol1", BIGINT);
+                    Symbol probeSymbol = p.symbol("probeSymbol", BIGINT);
+                    Symbol symbol2 = p.symbol("symbol2", BIGINT);
+                    return p.join(
+                            INNER,
+                            REPLICATED,
+                            p.aggregation(ab -> ab
+                                    .step(PARTIAL)
+                                    .singleGroupingSet(probeSymbol, symbol2)
+                                    .source(p.exchange(builder -> builder
+                                            .addInputsSet(probeSymbol, symbol2)
+                                            .addSource(p.values(
+                                                    new PlanNodeId(probeRemoteSourceId),
+                                                    5,
+                                                    probeSymbol,
+                                                    symbol2))
+                                            .fixedArbitraryDistributionPartitioningScheme(
+                                                    ImmutableList.of(probeSymbol, symbol2),
+                                                    3)
+                                            .type(REPARTITION)
+                                            .scope(REMOTE)))),
+                            p.aggregation(ab -> ab
+                                    .step(PARTIAL)
+                                    .singleGroupingSet(buildSymbol, symbol1)
+                                    .source(p.exchange(builder -> builder
+                                            .addInputsSet(buildSymbol, symbol1)
+                                            .addSource(p.exchange(reBuilder -> reBuilder
+                                                    .addInputsSet(buildSymbol, symbol1)
+                                                    .addSource(p.values(
+                                                            new PlanNodeId(buildRemoteSourceId),
+                                                            5,
+                                                            buildSymbol,
+                                                            symbol1))
+                                                    .broadcastPartitioningScheme(ImmutableList.of(buildSymbol, symbol1))
+                                                    .type(REPLICATE)
+                                                    .scope(REMOTE)))
+                                            .fixedHashDistributionPartitioningScheme(
+                                                    ImmutableList.of(buildSymbol, symbol1),
+                                                    ImmutableList.of(buildSymbol))
+                                            .type(REPARTITION)
+                                            .scope(LOCAL)))),
+                            new JoinNode.EquiJoinClause(probeSymbol, buildSymbol));
+                });
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -139,6 +139,7 @@ import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.sql.ir.Booleans.TRUE;
 import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_ARBITRARY_DISTRIBUTION;
+import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_BROADCAST_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static io.trino.sql.planner.plan.JoinType.INNER;
@@ -920,6 +921,11 @@ public class PlanBuilder
         public ExchangeBuilder singleDistributionPartitioningScheme(List<Symbol> outputSymbols)
         {
             return partitioningScheme(new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), outputSymbols));
+        }
+
+        public ExchangeBuilder broadcastPartitioningScheme(List<Symbol> outputSymbols)
+        {
+            return partitioningScheme(new PartitioningScheme(Partitioning.create(FIXED_BROADCAST_DISTRIBUTION, ImmutableList.of()), outputSymbols));
         }
 
         public ExchangeBuilder fixedHashDistributionPartitioningScheme(List<Symbol> outputSymbols, List<Symbol> partitioningSymbols)

--- a/lib/trino-matching/src/main/java/io/trino/matching/Captures.java
+++ b/lib/trino-matching/src/main/java/io/trino/matching/Captures.java
@@ -15,6 +15,7 @@ package io.trino.matching;
 
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Optional;
 
 public class Captures
 {
@@ -47,6 +48,18 @@ public class Captures
             return other;
         }
         return new Captures(capture, value, tail.addAll(other));
+    }
+
+    @SuppressWarnings("unchecked cast")
+    public <T> Optional<T> getOptional(Capture<T> capture)
+    {
+        if (this.equals(NIL)) {
+            return Optional.empty();
+        }
+        if (this.capture.equals(capture)) {
+            return Optional.ofNullable((T) value);
+        }
+        return tail.getOptional(capture);
     }
 
     @SuppressWarnings("unchecked cast")

--- a/lib/trino-matching/src/main/java/io/trino/matching/pattern/OrPattern.java
+++ b/lib/trino-matching/src/main/java/io/trino/matching/pattern/OrPattern.java
@@ -21,6 +21,8 @@ import io.trino.matching.PatternVisitor;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
 public class OrPattern<T>
         extends Pattern<T>
 {
@@ -40,8 +42,15 @@ public class OrPattern<T>
     @Override
     public <C> Stream<Match> accept(Object object, Captures captures, C context)
     {
-        return patterns.stream()
-                .flatMap(pattern -> pattern.accept(object, captures, context));
+        // Check patterns in order, and return the first match
+        for (Pattern<T> pattern : patterns) {
+            List<Match> matches = pattern.accept(object, captures, context)
+                    .collect(toImmutableList());
+            if (!matches.isEmpty()) {
+                return matches.stream();
+            }
+        }
+        return Stream.of();
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Issue: https://github.com/trinodb/trino/issues/23182

This rule converts a broadcast join to a partitioned join at runtime which can significantly reduce memory usage and, in some cases, improve performance.

We can fix this kind of query at runtime using this rule.

Example (TPCDS):
```
set session join_distribution_type='BROADCAST';

SELECT
sum(ss.ss_quantity), sum(ss.ss_list_price), sum(ss.ss_coupon_amt), sum(cs.cs_wholesale_cost), sum(cs.cs_list_price),
sum(cs.cs_sales_price), sum(cs.cs_ext_sales_price),
sum(cs.cs_net_paid_inc_tax), sum(cs.cs_net_paid_inc_ship),
sum(cs.cs_net_profit), sum(cs.cs_ext_tax), sum(cs.cs_coupon_amt),
sum(cs.cs_ext_ship_cost), sum(cs.cs_net_paid), sum(cs.cs_net_paid_inc_tax),
sum(cs.cs_net_paid_inc_ship), sum(cs.cs_call_center_sk),
sum(cs.cs_net_paid_inc_ship_tax), sum(cs.cs_net_profit),
sum(cs.cs_call_center_sk), sum(cs.cs_warehouse_sk), sum(cs.cs_bill_hdemo_sk)
FROM store_sales AS ss
LEFT JOIN catalog_sales AS cs ON (ss.ss_customer_sk=cs.cs_bill_customer_sk AND ss.ss_sold_date_sk = cs.cs_sold_date_sk);
```
Before: 

It will fail due to high memory usage

```
Query 20240808_203757_00002_ivgw3, FAILED, 8 nodes
Splits: 4,410 total, 4,333 done (98.25%)
1:55 [13.8B rows, 694GB] [120M rows/s, 6.03GB/s]

Query 20240808_203757_00002_ivgw3 failed: Cannot allocate enough memory for task 
20240808_203757_00002_ivgw3.1.44.0. Reported peak memory reservation: 77323190690B. Maximum possible reservation: 77309411328B.
```

After:

```
Query 20240808_204327_00005_ivgw3, FINISHED, 8 nodes
Splits: 9,818 total, 9,818 done (100.00%)
41.83 [4.32B rows, 59.7GB] [103M rows/s, 1.43GB/s]
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
