### PR TITLE
Remove deprecated ConnectorMetadata.createView from SPI

### DIFF
--- a/core/trino-main/src/main/java/io/trino/testing/TestingMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingMetadata.java
@@ -198,8 +198,9 @@ public class TestingMetadata
     }
 
     @Override
-    public void createView(ConnectorSession session, SchemaTableName viewName, ConnectorViewDefinition definition, boolean replace)
+    public void createView(ConnectorSession session, SchemaTableName viewName, ConnectorViewDefinition definition, Map<String, Object> viewProperties, boolean replace)
     {
+        checkArgument(viewProperties.isEmpty(), "This connector does not support creating views with properties");
         if (replace) {
             views.put(viewName, definition);
         }

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
@@ -818,15 +818,6 @@ public class TracingConnectorMetadata
     }
 
     @Override
-    public void createView(ConnectorSession session, SchemaTableName viewName, ConnectorViewDefinition definition, boolean replace)
-    {
-        Span span = startSpan("createView", viewName);
-        try (var _ = scopedSpan(span)) {
-            delegate.createView(session, viewName, definition, replace);
-        }
-    }
-
-    @Override
     public void renameView(ConnectorSession session, SchemaTableName source, SchemaTableName target)
     {
         Span span = startSpan("renameView", source);

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
@@ -696,7 +696,7 @@ public class MockConnector
         public void dropColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle column) {}
 
         @Override
-        public void createView(ConnectorSession session, SchemaTableName viewName, ConnectorViewDefinition definition, boolean replace) {}
+        public void createView(ConnectorSession session, SchemaTableName viewName, ConnectorViewDefinition definition, Map<String, Object> viewProperties, boolean replace) {}
 
         @Override
         public void renameView(ConnectorSession session, SchemaTableName source, SchemaTableName target) {}

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -969,22 +969,6 @@ public interface ConnectorMetadata
      */
     default void createView(ConnectorSession session, SchemaTableName viewName, ConnectorViewDefinition definition, Map<String, Object> viewProperties, boolean replace)
     {
-        if (viewProperties.isEmpty()) {
-            createView(session, viewName, definition, replace);
-            return;
-        }
-        throw new TrinoException(NOT_SUPPORTED, "This connector does not support creating views");
-    }
-
-    /**
-     * Create the specified view. The view definition is intended to
-     * be serialized by the connector for permanent storage.
-     *
-     * @deprecated use {@link #createView(ConnectorSession, SchemaTableName, ConnectorViewDefinition, Map, boolean)}
-     */
-    @Deprecated
-    default void createView(ConnectorSession session, SchemaTableName viewName, ConnectorViewDefinition definition, boolean replace)
-    {
         throw new TrinoException(NOT_SUPPORTED, "This connector does not support creating views");
     }
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -690,14 +690,6 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
-    public void createView(ConnectorSession session, SchemaTableName viewName, ConnectorViewDefinition definition, boolean replace)
-    {
-        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
-            delegate.createView(session, viewName, definition, replace);
-        }
-    }
-
-    @Override
     public void renameView(ConnectorSession session, SchemaTableName source, SchemaTableName target)
     {
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {

--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloMetadata.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloMetadata.java
@@ -170,8 +170,9 @@ public class AccumuloMetadata
     }
 
     @Override
-    public void createView(ConnectorSession session, SchemaTableName viewName, ConnectorViewDefinition definition, boolean replace)
+    public void createView(ConnectorSession session, SchemaTableName viewName, ConnectorViewDefinition definition, Map<String, Object> viewProperties, boolean replace)
     {
+        checkArgument(viewProperties.isEmpty(), "This connector does not support creating views with properties");
         String viewData = VIEW_CODEC.toJson(definition);
         if (replace) {
             metadataManager.createOrReplaceView(viewName, viewData);

--- a/plugin/trino-blackhole/src/main/java/io/trino/plugin/blackhole/BlackHoleMetadata.java
+++ b/plugin/trino-blackhole/src/main/java/io/trino/plugin/blackhole/BlackHoleMetadata.java
@@ -62,6 +62,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.plugin.blackhole.BlackHoleConnector.DISTRIBUTED_ON;
@@ -409,8 +410,9 @@ public class BlackHoleMetadata
     public void truncateTable(ConnectorSession session, ConnectorTableHandle tableHandle) {}
 
     @Override
-    public void createView(ConnectorSession session, SchemaTableName viewName, ConnectorViewDefinition definition, boolean replace)
+    public void createView(ConnectorSession session, SchemaTableName viewName, ConnectorViewDefinition definition, Map<String, Object> viewProperties, boolean replace)
     {
+        checkArgument(viewProperties.isEmpty(), "This connector does not support creating views with properties");
         views.put(viewName, definition);
     }
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -3128,8 +3128,9 @@ public class DeltaLakeMetadata
     }
 
     @Override
-    public void createView(ConnectorSession session, SchemaTableName viewName, ConnectorViewDefinition definition, boolean replace)
+    public void createView(ConnectorSession session, SchemaTableName viewName, ConnectorViewDefinition definition, Map<String, Object> viewProperties, boolean replace)
     {
+        checkArgument(viewProperties.isEmpty(), "This connector does not support creating views with properties");
         trinoViewHiveMetastore.createView(session, viewName, definition, replace);
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -2548,8 +2548,9 @@ public class IcebergMetadata
     }
 
     @Override
-    public void createView(ConnectorSession session, SchemaTableName viewName, ConnectorViewDefinition definition, boolean replace)
+    public void createView(ConnectorSession session, SchemaTableName viewName, ConnectorViewDefinition definition, Map<String, Object> viewProperties, boolean replace)
     {
+        checkArgument(viewProperties.isEmpty(), "This connector does not support creating views with properties");
         catalog.createView(session, viewName, definition, replace);
     }
 

--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryMetadata.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryMetadata.java
@@ -468,8 +468,9 @@ public class MemoryMetadata
     }
 
     @Override
-    public synchronized void createView(ConnectorSession session, SchemaTableName viewName, ConnectorViewDefinition definition, boolean replace)
+    public synchronized void createView(ConnectorSession session, SchemaTableName viewName, ConnectorViewDefinition definition, Map<String, Object> viewProperties, boolean replace)
     {
+        checkArgument(viewProperties.isEmpty(), "This connector does not support creating views with properties");
         checkSchemaExists(viewName.getSchemaName());
         if (tableIds.containsKey(viewName) && !replace) {
             throw new TrinoException(ALREADY_EXISTS, "View already exists: " + viewName);

--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryMetadata.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryMetadata.java
@@ -171,12 +171,12 @@ public class TestMemoryMetadata
         MemoryMetadata metadata = createMetadata();
         metadata.createSchema(SESSION, "test", ImmutableMap.of(), new TrinoPrincipal(USER, SESSION.getUser()));
         try {
-            metadata.createView(SESSION, test, testingViewDefinition("test"), false);
+            metadata.createView(SESSION, test, testingViewDefinition("test"), ImmutableMap.of(), false);
         }
         catch (Exception e) {
             fail("should have succeeded");
         }
-        assertThatThrownBy(() -> metadata.createView(SESSION, test, testingViewDefinition("test"), false))
+        assertThatThrownBy(() -> metadata.createView(SESSION, test, testingViewDefinition("test"), ImmutableMap.of(), false))
                 .isInstanceOf(TrinoException.class)
                 .hasMessageMatching("View already exists: test\\.test_view");
     }
@@ -188,8 +188,8 @@ public class TestMemoryMetadata
 
         MemoryMetadata metadata = createMetadata();
         metadata.createSchema(SESSION, "test", ImmutableMap.of(), new TrinoPrincipal(USER, SESSION.getUser()));
-        metadata.createView(SESSION, test, testingViewDefinition("aaa"), true);
-        metadata.createView(SESSION, test, testingViewDefinition("bbb"), true);
+        metadata.createView(SESSION, test, testingViewDefinition("aaa"), ImmutableMap.of(), true);
+        metadata.createView(SESSION, test, testingViewDefinition("bbb"), ImmutableMap.of(), true);
 
         assertThat(metadata.getView(SESSION, test))
                 .map(ConnectorViewDefinition::getOriginalSql)
@@ -204,7 +204,7 @@ public class TestMemoryMetadata
 
         MemoryMetadata metadata = createMetadata();
         metadata.createSchema(SESSION, schemaName, ImmutableMap.of(), new TrinoPrincipal(USER, SESSION.getUser()));
-        metadata.createView(SESSION, viewName, testingViewDefinition("aaa"), true);
+        metadata.createView(SESSION, viewName, testingViewDefinition("aaa"), ImmutableMap.of(), true);
 
         assertThat(metadata.listTables(SESSION, Optional.of(schemaName)))
                 .contains(viewName);
@@ -222,8 +222,8 @@ public class TestMemoryMetadata
         metadata.createSchema(SESSION, "test", ImmutableMap.of(), new TrinoPrincipal(USER, SESSION.getUser()));
 
         // create views
-        metadata.createView(SESSION, test1, testingViewDefinition("test1"), false);
-        metadata.createView(SESSION, test2, testingViewDefinition("test2"), false);
+        metadata.createView(SESSION, test1, testingViewDefinition("test1"), ImmutableMap.of(), false);
+        metadata.createView(SESSION, test2, testingViewDefinition("test2"), ImmutableMap.of(), false);
 
         // verify listing
         List<SchemaTableName> list = metadata.listViews(SESSION, Optional.of("test"));
@@ -292,13 +292,13 @@ public class TestMemoryMetadata
         assertThat(metadata.getTableHandle(SESSION, table1, Optional.empty(), Optional.empty())).isNull();
 
         SchemaTableName view2 = new SchemaTableName("test2", "test_schema_view2");
-        assertTrinoExceptionThrownBy(() -> metadata.createView(SESSION, view2, testingViewDefinition("aaa"), false))
+        assertTrinoExceptionThrownBy(() -> metadata.createView(SESSION, view2, testingViewDefinition("aaa"), ImmutableMap.of(), false))
                 .hasErrorCode(NOT_FOUND)
                 .hasMessage("Schema test2 not found");
         assertThat(metadata.getTableHandle(SESSION, view2, Optional.empty(), Optional.empty())).isNull();
 
         SchemaTableName view3 = new SchemaTableName("test3", "test_schema_view3");
-        assertTrinoExceptionThrownBy(() -> metadata.createView(SESSION, view3, testingViewDefinition("bbb"), true))
+        assertTrinoExceptionThrownBy(() -> metadata.createView(SESSION, view3, testingViewDefinition("bbb"), ImmutableMap.of(), true))
                 .hasErrorCode(NOT_FOUND)
                 .hasMessage("Schema test3 not found");
         assertThat(metadata.getTableHandle(SESSION, view3, Optional.empty(), Optional.empty())).isNull();

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorMetadata.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorMetadata.java
@@ -886,8 +886,9 @@ public class RaptorMetadata
     }
 
     @Override
-    public void createView(ConnectorSession session, SchemaTableName viewName, ConnectorViewDefinition definition, boolean replace)
+    public void createView(ConnectorSession session, SchemaTableName viewName, ConnectorViewDefinition definition, Map<String, Object> viewProperties, boolean replace)
     {
+        checkArgument(viewProperties.isEmpty(), "This connector does not support creating views with properties");
         String schemaName = viewName.getSchemaName();
         String tableName = viewName.getTableName();
         String viewData = VIEW_CODEC.toJson(definition);

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/metadata/TestRaptorMetadata.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/metadata/TestRaptorMetadata.java
@@ -597,8 +597,8 @@ public class TestRaptorMetadata
         SchemaTableName test2 = new SchemaTableName("test", "test_view2");
 
         // create views
-        metadata.createView(SESSION, test1, testingViewDefinition("test1"), false);
-        metadata.createView(SESSION, test2, testingViewDefinition("test2"), false);
+        metadata.createView(SESSION, test1, testingViewDefinition("test1"), ImmutableMap.of(), false);
+        metadata.createView(SESSION, test2, testingViewDefinition("test2"), ImmutableMap.of(), false);
 
         // verify listing
         List<SchemaTableName> list = metadata.listViews(SESSION, Optional.of("test"));
@@ -631,8 +631,8 @@ public class TestRaptorMetadata
     public void testCreateViewWithoutReplace()
     {
         SchemaTableName test = new SchemaTableName("test", "test_view");
-        metadata.createView(SESSION, test, testingViewDefinition("test"), false);
-        assertThatThrownBy(() -> metadata.createView(SESSION, test, testingViewDefinition("test"), false))
+        metadata.createView(SESSION, test, testingViewDefinition("test"), ImmutableMap.of(), false);
+        assertThatThrownBy(() -> metadata.createView(SESSION, test, testingViewDefinition("test"), ImmutableMap.of(), false))
                 .isInstanceOf(TrinoException.class)
                 .hasMessage("View already exists: test.test_view");
     }
@@ -642,8 +642,8 @@ public class TestRaptorMetadata
     {
         SchemaTableName test = new SchemaTableName("test", "test_view");
 
-        metadata.createView(SESSION, test, testingViewDefinition("aaa"), true);
-        metadata.createView(SESSION, test, testingViewDefinition("bbb"), true);
+        metadata.createView(SESSION, test, testingViewDefinition("aaa"), ImmutableMap.of(), true);
+        metadata.createView(SESSION, test, testingViewDefinition("bbb"), ImmutableMap.of(), true);
 
         assertThat(metadata.getView(SESSION, test))
                 .map(ConnectorViewDefinition::getOriginalSql)


### PR DESCRIPTION
## Description

Using `checkArgument` method instead of TrinoException because 
unsupported view properties should be blocked in the engine. 

## Release notes

```markdown
# SPI
* Remove deprecated `ConnectorMetadata.createView` method. ({issue}`23208`)
```
