### PR TITLE
Remove redundant constructors from some classes in `io.trino.sql.tree` package

### DIFF
--- a/core/trino-main/src/test/java/io/trino/execution/TestCallTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCallTask.java
@@ -35,6 +35,7 @@ import io.trino.spi.resourcegroups.ResourceGroupId;
 import io.trino.spi.security.AccessDeniedException;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.tree.Call;
+import io.trino.sql.tree.NodeLocation;
 import io.trino.sql.tree.QualifiedName;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.StandaloneQueryRunner;
@@ -143,7 +144,7 @@ public class TestCallTask
                     .build();
             new CallTask(transactionManager, plannerContext, accessControl, procedureRegistry)
                     .execute(
-                            new Call(QualifiedName.of("testing_procedure"), ImmutableList.of()),
+                            new Call(new NodeLocation(1, 1), QualifiedName.of("testing_procedure"), ImmutableList.of()),
                             stateMachine(transactionManager, plannerContext.getMetadata(), accessControl),
                             ImmutableList.of(),
                             WarningCollector.NOOP);

--- a/core/trino-main/src/test/java/io/trino/execution/TestCommentTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCommentTask.java
@@ -22,6 +22,7 @@ import io.trino.metadata.TableHandle;
 import io.trino.security.AllowAllAccessControl;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.sql.tree.Comment;
+import io.trino.sql.tree.NodeLocation;
 import io.trino.sql.tree.QualifiedName;
 import org.junit.jupiter.api.Test;
 
@@ -63,7 +64,7 @@ public class TestCommentTask
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(setComment(TABLE, asQualifiedName(viewName), Optional.of("new comment"))))
                 .hasErrorCode(TABLE_NOT_FOUND)
-                .hasMessage("Table '%1$s' does not exist, but a view with that name exists. Did you mean COMMENT ON VIEW %1$s IS ...?", viewName);
+                .hasMessageContaining("Table '%1$s' does not exist, but a view with that name exists. Did you mean COMMENT ON VIEW %1$s IS ...?", viewName);
     }
 
     @Test
@@ -74,7 +75,7 @@ public class TestCommentTask
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(setComment(TABLE, asQualifiedName(materializedViewName), Optional.of("new comment"))))
                 .hasErrorCode(TABLE_NOT_FOUND)
-                .hasMessage("Table '%s' does not exist, but a materialized view with that name exists. Setting comments on materialized views is unsupported.", materializedViewName);
+                .hasMessageContaining("Table '%s' does not exist, but a materialized view with that name exists. Setting comments on materialized views is unsupported.", materializedViewName);
     }
 
     @Test
@@ -96,7 +97,7 @@ public class TestCommentTask
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(setComment(VIEW, asQualifiedName(tableName), Optional.of("new comment"))))
                 .hasErrorCode(TABLE_NOT_FOUND)
-                .hasMessage("View '%1$s' does not exist, but a table with that name exists. Did you mean COMMENT ON TABLE %1$s IS ...?", tableName);
+                .hasMessageContaining("View '%1$s' does not exist, but a table with that name exists. Did you mean COMMENT ON TABLE %1$s IS ...?", tableName);
     }
 
     @Test
@@ -107,7 +108,7 @@ public class TestCommentTask
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(setComment(VIEW, asQualifiedName(materializedViewName), Optional.of("new comment"))))
                 .hasErrorCode(TABLE_NOT_FOUND)
-                .hasMessage("View '%s' does not exist, but a materialized view with that name exists. Setting comments on materialized views is unsupported.", materializedViewName);
+                .hasMessageContaining("View '%s' does not exist, but a materialized view with that name exists. Setting comments on materialized views is unsupported.", materializedViewName);
     }
 
     @Test
@@ -139,7 +140,7 @@ public class TestCommentTask
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(setComment(COLUMN, missingColumnName, Optional.of("comment for missing column"))))
                 .hasErrorCode(COLUMN_NOT_FOUND)
-                .hasMessage("Column does not exist: %s", missingColumnName.getSuffix());
+                .hasMessageContaining("Column does not exist: %s", missingColumnName.getSuffix());
     }
 
     @Test
@@ -158,11 +159,11 @@ public class TestCommentTask
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(setComment(COLUMN, missingColumnName, Optional.of("comment for missing column"))))
                 .hasErrorCode(COLUMN_NOT_FOUND)
-                .hasMessage("Column does not exist: %s", missingColumnName.getSuffix());
+                .hasMessageContaining("Column does not exist: %s", missingColumnName.getSuffix());
     }
 
     private ListenableFuture<Void> setComment(Comment.Type type, QualifiedName viewName, Optional<String> comment)
     {
-        return new CommentTask(metadata, new AllowAllAccessControl()).execute(new Comment(type, viewName, comment), queryStateMachine, ImmutableList.of(), WarningCollector.NOOP);
+        return new CommentTask(metadata, new AllowAllAccessControl()).execute(new Comment(new NodeLocation(1, 1), type, viewName, comment), queryStateMachine, ImmutableList.of(), WarningCollector.NOOP);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/TestDropMaterializedViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestDropMaterializedViewTask.java
@@ -20,6 +20,7 @@ import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.security.AllowAllAccessControl;
 import io.trino.sql.tree.DropMaterializedView;
+import io.trino.sql.tree.NodeLocation;
 import io.trino.sql.tree.QualifiedName;
 import org.junit.jupiter.api.Test;
 
@@ -51,7 +52,7 @@ public class TestDropMaterializedViewTask
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeDropMaterializedView(viewName, false)))
                 .hasErrorCode(GENERIC_USER_ERROR)
-                .hasMessage("Materialized view '%s' does not exist", viewName);
+                .hasMessageContaining("Materialized view '%s' does not exist", viewName);
     }
 
     @Test
@@ -71,7 +72,7 @@ public class TestDropMaterializedViewTask
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeDropMaterializedView(asQualifiedName(tableName), true)))
                 .hasErrorCode(GENERIC_USER_ERROR)
-                .hasMessage("Materialized view '%s' does not exist, but a table with that name exists. Did you mean DROP TABLE %s?", tableName, tableName);
+                .hasMessageContaining("Materialized view '%s' does not exist, but a table with that name exists. Did you mean DROP TABLE %s?", tableName, tableName);
     }
 
     @Test
@@ -82,7 +83,7 @@ public class TestDropMaterializedViewTask
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeDropMaterializedView(asQualifiedName(tableName), true)))
                 .hasErrorCode(GENERIC_USER_ERROR)
-                .hasMessage("Materialized view '%s' does not exist, but a table with that name exists. Did you mean DROP TABLE %s?", tableName, tableName);
+                .hasMessageContaining("Materialized view '%s' does not exist, but a table with that name exists. Did you mean DROP TABLE %s?", tableName, tableName);
     }
 
     @Test
@@ -93,7 +94,7 @@ public class TestDropMaterializedViewTask
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeDropMaterializedView(viewName, false)))
                 .hasErrorCode(GENERIC_USER_ERROR)
-                .hasMessage("Materialized view '%s' does not exist, but a view with that name exists. Did you mean DROP VIEW %s?", viewName, viewName);
+                .hasMessageContaining("Materialized view '%s' does not exist, but a view with that name exists. Did you mean DROP VIEW %s?", viewName, viewName);
     }
 
     @Test
@@ -104,12 +105,12 @@ public class TestDropMaterializedViewTask
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeDropMaterializedView(viewName, false)))
                 .hasErrorCode(GENERIC_USER_ERROR)
-                .hasMessage("Materialized view '%s' does not exist, but a view with that name exists. Did you mean DROP VIEW %s?", viewName, viewName);
+                .hasMessageContaining("Materialized view '%s' does not exist, but a view with that name exists. Did you mean DROP VIEW %s?", viewName, viewName);
     }
 
     private ListenableFuture<Void> executeDropMaterializedView(QualifiedName viewName, boolean exists)
     {
         return new DropMaterializedViewTask(metadata, new AllowAllAccessControl())
-                .execute(new DropMaterializedView(viewName, exists), queryStateMachine, ImmutableList.of(), WarningCollector.NOOP);
+                .execute(new DropMaterializedView(new NodeLocation(1, 1), viewName, exists), queryStateMachine, ImmutableList.of(), WarningCollector.NOOP);
     }
 }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AddColumn.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AddColumn.java
@@ -30,19 +30,9 @@ public class AddColumn
     private final boolean tableExists;
     private final boolean columnNotExists;
 
-    public AddColumn(QualifiedName name, ColumnDefinition column, boolean tableExists, boolean columnNotExists)
-    {
-        this(Optional.empty(), name, column, tableExists, columnNotExists);
-    }
-
     public AddColumn(NodeLocation location, QualifiedName name, ColumnDefinition column, boolean tableExists, boolean columnNotExists)
     {
-        this(Optional.of(location), name, column, tableExists, columnNotExists);
-    }
-
-    private AddColumn(Optional<NodeLocation> location, QualifiedName name, ColumnDefinition column, boolean tableExists, boolean columnNotExists)
-    {
-        super(location);
+        super(Optional.of(location));
         this.name = requireNonNull(name, "name is null");
         this.column = requireNonNull(column, "column is null");
         this.tableExists = tableExists;

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/BinaryLiteral.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/BinaryLiteral.java
@@ -34,28 +34,18 @@ public class BinaryLiteral
 
     private final byte[] value;
 
-    public BinaryLiteral(String value)
+    public BinaryLiteral(NodeLocation location, String value)
     {
-        this(Optional.empty(), value);
-    }
-
-    public BinaryLiteral(Optional<NodeLocation> location, String value)
-    {
-        super(location);
+        super(Optional.of(location));
         requireNonNull(value, "value is null");
         String hexString = WHITESPACE_MATCHER.removeFrom(value).toUpperCase(ENGLISH);
         if (!HEX_DIGIT_MATCHER.matchesAllOf(hexString)) {
-            throw new ParsingException("Binary literal can only contain hexadecimal digits", location.get());
+            throw new ParsingException("Binary literal can only contain hexadecimal digits", location);
         }
         if (hexString.length() % 2 != 0) {
-            throw new ParsingException("Binary literal must contain an even number of digits", location.get());
+            throw new ParsingException("Binary literal must contain an even number of digits", location);
         }
         this.value = BaseEncoding.base16().decode(hexString);
-    }
-
-    public BinaryLiteral(NodeLocation location, String value)
-    {
-        this(Optional.of(location), value);
     }
 
     /**

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Call.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Call.java
@@ -28,19 +28,9 @@ public final class Call
     private final QualifiedName name;
     private final List<CallArgument> arguments;
 
-    public Call(QualifiedName name, List<CallArgument> arguments)
-    {
-        this(Optional.empty(), name, arguments);
-    }
-
     public Call(NodeLocation location, QualifiedName name, List<CallArgument> arguments)
     {
-        this(Optional.of(location), name, arguments);
-    }
-
-    public Call(Optional<NodeLocation> location, QualifiedName name, List<CallArgument> arguments)
-    {
-        super(location);
+        super(Optional.of(location));
         this.name = requireNonNull(name, "name is null");
         this.arguments = ImmutableList.copyOf(requireNonNull(arguments, "arguments is null"));
     }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/CaseStatementWhenClause.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/CaseStatementWhenClause.java
@@ -28,19 +28,9 @@ public final class CaseStatementWhenClause
     private final Expression expression;
     private final List<ControlStatement> statements;
 
-    public CaseStatementWhenClause(Expression expression, List<ControlStatement> statements)
-    {
-        this(Optional.empty(), expression, statements);
-    }
-
     public CaseStatementWhenClause(NodeLocation location, Expression expression, List<ControlStatement> statements)
     {
-        this(Optional.of(location), expression, statements);
-    }
-
-    private CaseStatementWhenClause(Optional<NodeLocation> location, Expression expression, List<ControlStatement> statements)
-    {
-        super(location);
+        super(Optional.of(location));
         this.expression = requireNonNull(expression, "expression is null");
         this.statements = requireNonNull(statements, "statements is null");
     }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Comment.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Comment.java
@@ -34,19 +34,9 @@ public final class Comment
     private final QualifiedName name;
     private final Optional<String> comment;
 
-    public Comment(Type type, QualifiedName name, Optional<String> comment)
-    {
-        this(Optional.empty(), type, name, comment);
-    }
-
     public Comment(NodeLocation location, Type type, QualifiedName name, Optional<String> comment)
     {
-        this(Optional.of(location), type, name, comment);
-    }
-
-    private Comment(Optional<NodeLocation> location, Type type, QualifiedName name, Optional<String> comment)
-    {
-        super(location);
+        super(Optional.of(location));
         this.type = requireNonNull(type, "type is null");
         this.name = requireNonNull(name, "name is null");
         this.comment = requireNonNull(comment, "comment is null");

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/CommentCharacteristic.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/CommentCharacteristic.java
@@ -26,19 +26,9 @@ public final class CommentCharacteristic
 {
     private final String comment;
 
-    public CommentCharacteristic(String comment)
-    {
-        this(Optional.empty(), comment);
-    }
-
     public CommentCharacteristic(NodeLocation location, String comment)
     {
-        this(Optional.of(location), comment);
-    }
-
-    private CommentCharacteristic(Optional<NodeLocation> location, String comment)
-    {
-        super(location);
+        super(Optional.of(location));
         this.comment = requireNonNull(comment, "comment is null");
     }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DropFunction.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DropFunction.java
@@ -29,19 +29,9 @@ public class DropFunction
     private final List<ParameterDeclaration> parameters;
     private final boolean exists;
 
-    public DropFunction(QualifiedName name, List<ParameterDeclaration> parameters, boolean exists)
-    {
-        this(Optional.empty(), name, parameters, exists);
-    }
-
     public DropFunction(NodeLocation location, QualifiedName name, List<ParameterDeclaration> parameters, boolean exists)
     {
-        this(Optional.of(location), name, parameters, exists);
-    }
-
-    private DropFunction(Optional<NodeLocation> location, QualifiedName name, List<ParameterDeclaration> parameters, boolean exists)
-    {
-        super(location);
+        super(Optional.of(location));
         this.name = requireNonNull(name, "name is null");
         this.parameters = ImmutableList.copyOf(requireNonNull(parameters, "parameters is null"));
         this.exists = exists;

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DropMaterializedView.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DropMaterializedView.java
@@ -27,19 +27,9 @@ public class DropMaterializedView
     private final QualifiedName name;
     private final boolean exists;
 
-    public DropMaterializedView(QualifiedName name, boolean exists)
-    {
-        this(Optional.empty(), name, exists);
-    }
-
     public DropMaterializedView(NodeLocation location, QualifiedName name, boolean exists)
     {
-        this(Optional.of(location), name, exists);
-    }
-
-    private DropMaterializedView(Optional<NodeLocation> location, QualifiedName name, boolean exists)
-    {
-        super(location);
+        super(Optional.of(location));
         this.name = name;
         this.exists = exists;
     }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DropRole.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DropRole.java
@@ -29,19 +29,9 @@ public class DropRole
     private final Optional<Identifier> catalog;
     private final boolean exists;
 
-    public DropRole(Identifier name, Optional<Identifier> catalog)
-    {
-        this(Optional.empty(), name, catalog, false);
-    }
-
     public DropRole(NodeLocation location, Identifier name, Optional<Identifier> catalog, boolean exists)
     {
-        this(Optional.of(location), name, catalog, exists);
-    }
-
-    private DropRole(Optional<NodeLocation> location, Identifier name, Optional<Identifier> catalog, boolean exists)
-    {
-        super(location);
+        super(Optional.of(location));
         this.name = requireNonNull(name, "name is null");
         this.catalog = requireNonNull(catalog, "catalog is null");
         this.exists = exists;

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ElseClause.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ElseClause.java
@@ -25,19 +25,9 @@ public final class ElseClause
 {
     private final List<ControlStatement> statements;
 
-    public ElseClause(List<ControlStatement> statements)
-    {
-        this(Optional.empty(), statements);
-    }
-
     public ElseClause(NodeLocation location, List<ControlStatement> statements)
     {
-        this(Optional.of(location), statements);
-    }
-
-    private ElseClause(Optional<NodeLocation> location, List<ControlStatement> statements)
-    {
-        super(location);
+        super(Optional.of(location));
         this.statements = requireNonNull(statements, "statements is null");
     }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/EmptyPattern.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/EmptyPattern.java
@@ -25,12 +25,7 @@ public class EmptyPattern
 {
     public EmptyPattern(NodeLocation location)
     {
-        this(Optional.of(location));
-    }
-
-    private EmptyPattern(Optional<NodeLocation> location)
-    {
-        super(location);
+        super(Optional.of(location));
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Except.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Except.java
@@ -28,19 +28,9 @@ public class Except
     private final Relation left;
     private final Relation right;
 
-    public Except(Relation left, Relation right, boolean distinct)
-    {
-        this(Optional.empty(), left, right, distinct);
-    }
-
     public Except(NodeLocation location, Relation left, Relation right, boolean distinct)
     {
-        this(Optional.of(location), left, right, distinct);
-    }
-
-    private Except(Optional<NodeLocation> location, Relation left, Relation right, boolean distinct)
-    {
-        super(location, distinct);
+        super(Optional.of(location), distinct);
         requireNonNull(left, "left is null");
         requireNonNull(right, "right is null");
 

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ExcludedPattern.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ExcludedPattern.java
@@ -29,12 +29,7 @@ public class ExcludedPattern
 
     public ExcludedPattern(NodeLocation location, RowPattern pattern)
     {
-        this(Optional.of(location), pattern);
-    }
-
-    private ExcludedPattern(Optional<NodeLocation> location, RowPattern pattern)
-    {
-        super(location);
+        super(Optional.of(location));
         this.pattern = requireNonNull(pattern, "pattern is null");
     }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ExplainType.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ExplainType.java
@@ -35,19 +35,9 @@ public class ExplainType
 
     private final Type type;
 
-    public ExplainType(Type type)
-    {
-        this(Optional.empty(), type);
-    }
-
     public ExplainType(NodeLocation location, Type type)
     {
-        this(Optional.of(location), type);
-    }
-
-    private ExplainType(Optional<NodeLocation> location, Type type)
-    {
-        super(location);
+        super(Optional.of(location));
         this.type = requireNonNull(type, "type is null");
     }
 

--- a/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
@@ -443,6 +443,7 @@ public class TestSqlFormatter
     {
         assertThat(formatSql(
                 new AddColumn(
+                        new NodeLocation(1, 1),
                         QualifiedName.of("foo", "t"),
                         new ColumnDefinition(QualifiedName.of("c"),
                                 new GenericDataType(new NodeLocation(1, 1), new Identifier("VARCHAR", false), ImmutableList.of()),
@@ -453,6 +454,7 @@ public class TestSqlFormatter
                 .isEqualTo("ALTER TABLE foo.t ADD COLUMN c VARCHAR");
         assertThat(formatSql(
                 new AddColumn(
+                        new NodeLocation(1, 1),
                         QualifiedName.of("foo", "t"),
                         new ColumnDefinition(QualifiedName.of("c"),
                                 new GenericDataType(new NodeLocation(1, 1), new Identifier("VARCHAR", false), ImmutableList.of()),

--- a/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
@@ -469,10 +469,10 @@ public class TestSqlFormatter
     public void testCommentOnTable()
     {
         assertThat(formatSql(
-                new Comment(Comment.Type.TABLE, QualifiedName.of("a"), Optional.of("test"))))
+                new Comment(new NodeLocation(1, 1), Comment.Type.TABLE, QualifiedName.of("a"), Optional.of("test"))))
                 .isEqualTo("COMMENT ON TABLE a IS 'test'");
         assertThat(formatSql(
-                new Comment(Comment.Type.TABLE, QualifiedName.of("a"), Optional.of("攻殻機動隊"))))
+                new Comment(new NodeLocation(1, 1), Comment.Type.TABLE, QualifiedName.of("a"), Optional.of("攻殻機動隊"))))
                 .isEqualTo("COMMENT ON TABLE a IS '攻殻機動隊'");
     }
 
@@ -480,10 +480,10 @@ public class TestSqlFormatter
     public void testCommentOnView()
     {
         assertThat(formatSql(
-                new Comment(Comment.Type.VIEW, QualifiedName.of("a"), Optional.of("test"))))
+                new Comment(new NodeLocation(1, 1), Comment.Type.VIEW, QualifiedName.of("a"), Optional.of("test"))))
                 .isEqualTo("COMMENT ON VIEW a IS 'test'");
         assertThat(formatSql(
-                new Comment(Comment.Type.VIEW, QualifiedName.of("a"), Optional.of("攻殻機動隊"))))
+                new Comment(new NodeLocation(1, 1), Comment.Type.VIEW, QualifiedName.of("a"), Optional.of("攻殻機動隊"))))
                 .isEqualTo("COMMENT ON VIEW a IS '攻殻機動隊'");
     }
 
@@ -491,10 +491,10 @@ public class TestSqlFormatter
     public void testCommentOnColumn()
     {
         assertThat(formatSql(
-                new Comment(Comment.Type.COLUMN, QualifiedName.of("test", "a"), Optional.of("test"))))
+                new Comment(new NodeLocation(1, 1), Comment.Type.COLUMN, QualifiedName.of("test", "a"), Optional.of("test"))))
                 .isEqualTo("COMMENT ON COLUMN test.a IS 'test'");
         assertThat(formatSql(
-                new Comment(Comment.Type.COLUMN, QualifiedName.of("test", "a"), Optional.of("攻殻機動隊"))))
+                new Comment(new NodeLocation(1, 1), Comment.Type.COLUMN, QualifiedName.of("test", "a"), Optional.of("攻殻機動隊"))))
                 .isEqualTo("COMMENT ON COLUMN test.a IS '攻殻機動隊'");
     }
 

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -4542,12 +4542,12 @@ public class TestSqlParser
     @Test
     public void testDropRole()
     {
-        assertStatement("DROP ROLE role", new DropRole(new Identifier("role"), Optional.empty()));
-        assertStatement("DROP ROLE IF EXISTS role", new DropRole(new Identifier("role"), Optional.empty()));
-        assertStatement("DROP ROLE \"role\"", new DropRole(new Identifier("role"), Optional.empty()));
-        assertStatement("DROP ROLE \"ro le\"", new DropRole(new Identifier("ro le"), Optional.empty()));
-        assertStatement("DROP ROLE \"!@#$%^&*'ад\"\"мін\"", new DropRole(new Identifier("!@#$%^&*'ад\"мін"), Optional.empty()));
-        assertStatement("DROP ROLE role IN my_catalog", new DropRole(new Identifier("role"), Optional.of(new Identifier("my_catalog"))));
+        assertStatement("DROP ROLE role", new DropRole(location(1, 1), new Identifier("role"), Optional.empty(), false));
+        assertStatement("DROP ROLE IF EXISTS role", new DropRole(location(1, 1), new Identifier("role"), Optional.empty(), false));
+        assertStatement("DROP ROLE \"role\"", new DropRole(location(1, 1), new Identifier("role"), Optional.empty(), false));
+        assertStatement("DROP ROLE \"ro le\"", new DropRole(location(1, 1), new Identifier("ro le"), Optional.empty(), false));
+        assertStatement("DROP ROLE \"!@#$%^&*'ад\"\"мін\"", new DropRole(location(1, 1), new Identifier("!@#$%^&*'ад\"мін"), Optional.empty(), false));
+        assertStatement("DROP ROLE role IN my_catalog", new DropRole(location(1, 1), new Identifier("role"), Optional.of(new Identifier("my_catalog")), false));
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -4012,8 +4012,8 @@ public class TestSqlParser
     @Test
     public void testCall()
     {
-        assertStatement("CALL foo()", new Call(QualifiedName.of("foo"), ImmutableList.of()));
-        assertStatement("CALL foo(123, a => 1, b => 'go', 456)", new Call(QualifiedName.of("foo"), ImmutableList.of(
+        assertStatement("CALL foo()", new Call(location(1, 1), QualifiedName.of("foo"), ImmutableList.of()));
+        assertStatement("CALL foo(123, a => 1, b => 'go', 456)", new Call(location(1, 1), QualifiedName.of("foo"), ImmutableList.of(
                 new CallArgument(new LongLiteral("123")),
                 new CallArgument(identifier("a"), new LongLiteral("1")),
                 new CallArgument(identifier("b"), new StringLiteral("go")),

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -4966,13 +4966,13 @@ public class TestSqlParser
     @Test
     public void testDropMaterializedView()
     {
-        assertStatement("DROP MATERIALIZED VIEW a", new DropMaterializedView(QualifiedName.of("a"), false));
-        assertStatement("DROP MATERIALIZED VIEW a.b", new DropMaterializedView(QualifiedName.of("a", "b"), false));
-        assertStatement("DROP MATERIALIZED VIEW a.b.c", new DropMaterializedView(QualifiedName.of("a", "b", "c"), false));
+        assertStatement("DROP MATERIALIZED VIEW a", new DropMaterializedView(location(1, 1), QualifiedName.of("a"), false));
+        assertStatement("DROP MATERIALIZED VIEW a.b", new DropMaterializedView(location(1, 1), QualifiedName.of("a", "b"), false));
+        assertStatement("DROP MATERIALIZED VIEW a.b.c", new DropMaterializedView(location(1, 1), QualifiedName.of("a", "b", "c"), false));
 
-        assertStatement("DROP MATERIALIZED VIEW IF EXISTS a", new DropMaterializedView(QualifiedName.of("a"), true));
-        assertStatement("DROP MATERIALIZED VIEW IF EXISTS a.b", new DropMaterializedView(QualifiedName.of("a", "b"), true));
-        assertStatement("DROP MATERIALIZED VIEW IF EXISTS a.b.c", new DropMaterializedView(QualifiedName.of("a", "b", "c"), true));
+        assertStatement("DROP MATERIALIZED VIEW IF EXISTS a", new DropMaterializedView(location(1, 1), QualifiedName.of("a"), true));
+        assertStatement("DROP MATERIALIZED VIEW IF EXISTS a.b", new DropMaterializedView(location(1, 1), QualifiedName.of("a", "b"), true));
+        assertStatement("DROP MATERIALIZED VIEW IF EXISTS a.b.c", new DropMaterializedView(location(1, 1), QualifiedName.of("a", "b", "c"), true));
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -4005,7 +4005,7 @@ public class TestSqlParser
     public void testBinaryLiteralToHex()
     {
         // note that toHexString() always outputs in upper case
-        assertThat(new BinaryLiteral("ab 01").toHexString())
+        assertThat(new BinaryLiteral(location(1, 1), "ab 01").toHexString())
                 .isEqualTo("AB01");
     }
 

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -3746,12 +3746,12 @@ public class TestSqlParser
         assertStatement("EXPLAIN (TYPE LOGICAL) SELECT * FROM t",
                 new Explain(
                         simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))),
-                        ImmutableList.of(new ExplainType(ExplainType.Type.LOGICAL))));
+                        ImmutableList.of(new ExplainType(location(1, 1), ExplainType.Type.LOGICAL))));
         assertStatement("EXPLAIN (TYPE LOGICAL, FORMAT TEXT) SELECT * FROM t",
                 new Explain(
                         simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))),
                         ImmutableList.of(
-                                new ExplainType(ExplainType.Type.LOGICAL),
+                                new ExplainType(location(1, 1),ExplainType.Type.LOGICAL),
                                 new ExplainFormat(ExplainFormat.Type.TEXT))));
 
         assertStatementIsInvalid("EXPLAIN VERBOSE SELECT * FROM t")

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -3136,30 +3136,35 @@ public class TestSqlParser
         assertThat(statement("ALTER TABLE foo.t ADD COLUMN c bigint"))
                 .ignoringLocation()
                 .isEqualTo(new AddColumn(
+                        new NodeLocation(1, 1),
                         QualifiedName.of("foo", "t"),
                         new ColumnDefinition(QualifiedName.of("c"), simpleType(location(1, 31), "bigint"), true, emptyList(), Optional.empty()), false, false));
 
         assertThat(statement("ALTER TABLE foo.t ADD COLUMN d double NOT NULL"))
                 .ignoringLocation()
                 .isEqualTo(new AddColumn(
+                        location(1, 1),
                         QualifiedName.of("foo", "t"),
                         new ColumnDefinition(QualifiedName.of("d"), simpleType(location(1, 31), "double"), false, emptyList(), Optional.empty()), false, false));
 
         assertThat(statement("ALTER TABLE IF EXISTS foo.t ADD COLUMN d double NOT NULL"))
                 .ignoringLocation()
                 .isEqualTo(new AddColumn(
+                        location(1, 1),
                         QualifiedName.of("foo", "t"),
                         new ColumnDefinition(QualifiedName.of("d"), simpleType(location(1, 31), "double"), false, emptyList(), Optional.empty()), true, false));
 
         assertThat(statement("ALTER TABLE foo.t ADD COLUMN IF NOT EXISTS d double NOT NULL"))
                 .ignoringLocation()
                 .isEqualTo(new AddColumn(
+                        location(1, 1),
                         QualifiedName.of("foo", "t"),
                         new ColumnDefinition(QualifiedName.of("d"), simpleType(location(1, 31), "double"), false, emptyList(), Optional.empty()), false, true));
 
         assertThat(statement("ALTER TABLE IF EXISTS foo.t ADD COLUMN IF NOT EXISTS d double NOT NULL"))
                 .ignoringLocation()
                 .isEqualTo(new AddColumn(
+                        location(1, 1),
                         QualifiedName.of("foo", "t"),
                         new ColumnDefinition(QualifiedName.of("d"), simpleType(location(1, 31), "double"), false, emptyList(), Optional.empty()), true, true));
 

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -2928,29 +2928,29 @@ public class TestSqlParser
     @Test
     public void testCommentTable()
     {
-        assertStatement("COMMENT ON TABLE a IS 'test'", new Comment(Comment.Type.TABLE, QualifiedName.of("a"), Optional.of("test")));
-        assertStatement("COMMENT ON TABLE a IS ''", new Comment(Comment.Type.TABLE, QualifiedName.of("a"), Optional.of("")));
-        assertStatement("COMMENT ON TABLE a IS NULL", new Comment(Comment.Type.TABLE, QualifiedName.of("a"), Optional.empty()));
+        assertStatement("COMMENT ON TABLE a IS 'test'", new Comment(location(1, 1), Comment.Type.TABLE, QualifiedName.of("a"), Optional.of("test")));
+        assertStatement("COMMENT ON TABLE a IS ''", new Comment(location(1, 1), Comment.Type.TABLE, QualifiedName.of("a"), Optional.of("")));
+        assertStatement("COMMENT ON TABLE a IS NULL", new Comment(location(1, 1), Comment.Type.TABLE, QualifiedName.of("a"), Optional.empty()));
     }
 
     @Test
     public void testCommentView()
     {
-        assertStatement("COMMENT ON VIEW a IS 'test'", new Comment(Comment.Type.VIEW, QualifiedName.of("a"), Optional.of("test")));
-        assertStatement("COMMENT ON VIEW a IS ''", new Comment(Comment.Type.VIEW, QualifiedName.of("a"), Optional.of("")));
-        assertStatement("COMMENT ON VIEW a IS NULL", new Comment(Comment.Type.VIEW, QualifiedName.of("a"), Optional.empty()));
+        assertStatement("COMMENT ON VIEW a IS 'test'", new Comment(location(1, 1), Comment.Type.VIEW, QualifiedName.of("a"), Optional.of("test")));
+        assertStatement("COMMENT ON VIEW a IS ''", new Comment(location(1, 1), Comment.Type.VIEW, QualifiedName.of("a"), Optional.of("")));
+        assertStatement("COMMENT ON VIEW a IS NULL", new Comment(location(1, 1), Comment.Type.VIEW, QualifiedName.of("a"), Optional.empty()));
     }
 
     @Test
     public void testCommentColumn()
     {
-        assertStatement("COMMENT ON COLUMN a.b IS 'test'", new Comment(Comment.Type.COLUMN, QualifiedName.of("a", "b"), Optional.of("test")));
-        assertStatement("COMMENT ON COLUMN a.b IS ''", new Comment(Comment.Type.COLUMN, QualifiedName.of("a", "b"), Optional.of("")));
-        assertStatement("COMMENT ON COLUMN a.b IS NULL", new Comment(Comment.Type.COLUMN, QualifiedName.of("a", "b"), Optional.empty()));
+        assertStatement("COMMENT ON COLUMN a.b IS 'test'", new Comment(location(1, 1), Comment.Type.COLUMN, QualifiedName.of("a", "b"), Optional.of("test")));
+        assertStatement("COMMENT ON COLUMN a.b IS ''", new Comment(location(1, 1), Comment.Type.COLUMN, QualifiedName.of("a", "b"), Optional.of("")));
+        assertStatement("COMMENT ON COLUMN a.b IS NULL", new Comment(location(1, 1), Comment.Type.COLUMN, QualifiedName.of("a", "b"), Optional.empty()));
 
-        assertStatement("COMMENT ON COLUMN a IS 'test'", new Comment(Comment.Type.COLUMN, QualifiedName.of("a"), Optional.of("test")));
-        assertStatement("COMMENT ON COLUMN a.b.c IS 'test'", new Comment(Comment.Type.COLUMN, QualifiedName.of("a", "b", "c"), Optional.of("test")));
-        assertStatement("COMMENT ON COLUMN a.b.c.d IS 'test'", new Comment(Comment.Type.COLUMN, QualifiedName.of("a", "b", "c", "d"), Optional.of("test")));
+        assertStatement("COMMENT ON COLUMN a IS 'test'", new Comment(location(1, 1), Comment.Type.COLUMN, QualifiedName.of("a"), Optional.of("test")));
+        assertStatement("COMMENT ON COLUMN a.b.c IS 'test'", new Comment(location(1, 1), Comment.Type.COLUMN, QualifiedName.of("a", "b", "c"), Optional.of("test")));
+        assertStatement("COMMENT ON COLUMN a.b.c.d IS 'test'", new Comment(location(1, 1), Comment.Type.COLUMN, QualifiedName.of("a", "b", "c", "d"), Optional.of("test")));
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserRoutines.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserRoutines.java
@@ -121,7 +121,7 @@ class TestSqlParserRoutines
                                         new DeterministicCharacteristic(true),
                                         calledOnNullInput(),
                                         new SecurityCharacteristic(INVOKER),
-                                        new CommentCharacteristic("hello world function")),
+                                        new CommentCharacteristic(new NodeLocation(1, 1), "hello world function")),
                                 new ReturnStatement(location(), functionCall(
                                         "CONCAT",
                                         literal("Hello, "),


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
