### PR TITLE
Do not normalize path with s3a/s3n scheme in Hadoop file system

### DIFF
--- a/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HadoopPaths.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HadoopPaths.java
@@ -14,14 +14,18 @@
 package io.trino.filesystem.hdfs;
 
 import com.google.common.base.VerifyException;
+import com.google.common.collect.ImmutableSet;
 import io.trino.filesystem.Location;
 import org.apache.hadoop.fs.Path;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Set;
 
 public final class HadoopPaths
 {
+    private static final Set<String> S3_SCHEMES = ImmutableSet.of("s3", "s3a", "s3n");
+
     private HadoopPaths() {}
 
     public static Path hadoopPath(Location location)
@@ -29,8 +33,10 @@ public final class HadoopPaths
         // hack to preserve the original path for S3 if necessary
         String path = location.toString();
         Path hadoopPath = new Path(path);
-        if ("s3".equals(hadoopPath.toUri().getScheme()) && !path.equals(hadoopPath.toString())) {
-            return new Path(toPathEncodedUri(location));
+        if (hadoopPath.toUri().getScheme() != null) {
+            if (S3_SCHEMES.contains(hadoopPath.toUri().getScheme()) && !path.equals(hadoopPath.toString())) {
+                return new Path(toPathEncodedUri(location));
+            }
         }
         return hadoopPath;
     }

--- a/lib/trino-hdfs/src/test/java/io/trino/hdfs/s3/TestS3HadoopPaths.java
+++ b/lib/trino-hdfs/src/test/java/io/trino/hdfs/s3/TestS3HadoopPaths.java
@@ -38,6 +38,14 @@ public class TestS3HadoopPaths
                 .isEqualTo(new Path("s3://test/abc/xyz.csv"))
                 .extracting(TrinoS3FileSystem::keyFromPath)
                 .isEqualTo("abc/xyz.csv");
+        assertThat(hadoopPath(Location.of("s3a://test/abc/xyz.csv")))
+                .isEqualTo(new Path("s3a://test/abc/xyz.csv"))
+                .extracting(TrinoS3FileSystem::keyFromPath)
+                .isEqualTo("abc/xyz.csv");
+        assertThat(hadoopPath(Location.of("s3n://test/abc/xyz.csv")))
+                .isEqualTo(new Path("s3n://test/abc/xyz.csv"))
+                .extracting(TrinoS3FileSystem::keyFromPath)
+                .isEqualTo("abc/xyz.csv");
     }
 
     @Test
@@ -55,6 +63,16 @@ public class TestS3HadoopPaths
         assertThat(hadoopPath(Location.of("s3://test/abc//xyz.csv")))
                 .isEqualTo(new Path(URI.create("s3://test/abc/xyz.csv#abc//xyz.csv")))
                 .hasToString("s3://test/abc/xyz.csv#abc//xyz.csv")
+                .extracting(TrinoS3FileSystem::keyFromPath)
+                .isEqualTo("abc//xyz.csv");
+        assertThat(hadoopPath(Location.of("s3a://test/abc//xyz.csv")))
+                .isEqualTo(new Path(URI.create("s3a://test/abc/xyz.csv#abc//xyz.csv")))
+                .hasToString("s3a://test/abc/xyz.csv#abc//xyz.csv")
+                .extracting(TrinoS3FileSystem::keyFromPath)
+                .isEqualTo("abc//xyz.csv");
+        assertThat(hadoopPath(Location.of("s3n://test/abc//xyz.csv")))
+                .isEqualTo(new Path(URI.create("s3n://test/abc/xyz.csv#abc//xyz.csv")))
+                .hasToString("s3n://test/abc/xyz.csv#abc//xyz.csv")
                 .extracting(TrinoS3FileSystem::keyFromPath)
                 .isEqualTo("abc//xyz.csv");
     }

--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -418,6 +418,12 @@
 
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>sdk-core</artifactId>
             <scope>runtime</scope>
         </dependency>
@@ -640,6 +646,18 @@
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-core</artifactId>
             <version>24.0.5</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>localstack</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergS3FileSystemCompatibility.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergS3FileSystemCompatibility.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static io.airlift.testing.Closeables.closeAllSuppress;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+@Testcontainers
+public class TestIcebergS3FileSystemCompatibility
+        extends AbstractTestQueryFramework
+{
+    private static final String ICEBERG_S3A_HADOOP_FS = "iceberg_s3_hadoop_fs";
+    private static final String ICEBERG_S3A_NATIVE_FS = "iceberg_s3_native_fs";
+    private static final String ACCESS_KEY = "accesskey";
+    private static final String SECRET_KEY = "secretkey";
+    private static final String BUCKET_NAME = "test-bucket";
+    private static final String SCHEMA_NAME = "test_schema";
+
+    @Container
+    private static final LocalStackContainer LOCALSTACK = new LocalStackContainer(DockerImageName.parse("localstack/localstack:3.3.0"))
+            .withServices(LocalStackContainer.Service.S3);
+
+    private S3Client s3;
+
+    @AfterAll
+    public void tearDown()
+    {
+        if (s3 != null) {
+            s3.close();
+            s3 = null;
+        }
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        s3 = S3Client.builder()
+                .endpointOverride(LOCALSTACK.getEndpointOverride(LocalStackContainer.Service.S3))
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(ACCESS_KEY, SECRET_KEY)))
+                .region(Region.of(LOCALSTACK.getRegion())).build();
+        s3.createBucket(builder -> builder.bucket(BUCKET_NAME));
+
+        QueryRunner queryRunner = DistributedQueryRunner.builder(testSessionBuilder()
+                        .setCatalog(ICEBERG_S3A_HADOOP_FS)
+                        .setSchema(SCHEMA_NAME)
+                        .build())
+                .build();
+
+        Map<String, String> icebergS3HadoopFsProperties = ImmutableMap.<String, String>builder()
+                .put("iceberg.catalog.type", "TESTING_FILE_METASTORE")
+                .put("hive.s3.aws-access-key", ACCESS_KEY)
+                .put("hive.s3.aws-secret-key", SECRET_KEY)
+                .put("hive.s3.endpoint", LOCALSTACK.getEndpointOverride(LocalStackContainer.Service.S3).toString())
+                .put("hive.s3.region", Region.of(LOCALSTACK.getRegion()).toString())
+                .put("fs.hadoop.enabled", "true")
+                .put("fs.native-s3.enabled", "false")
+                .buildOrThrow();
+
+        Map<String, String> icebergS3NativeFsProperties = ImmutableMap.<String, String>builder()
+                .put("iceberg.catalog.type", "TESTING_FILE_METASTORE")
+                .put("s3.aws-access-key", ACCESS_KEY)
+                .put("s3.aws-secret-key", SECRET_KEY)
+                .put("s3.endpoint", LOCALSTACK.getEndpointOverride(LocalStackContainer.Service.S3).toString())
+                .put("s3.region", Region.of(LOCALSTACK.getRegion()).toString())
+                .put("fs.hadoop.enabled", "false")
+                .put("fs.native-s3.enabled", "true")
+                .buildOrThrow();
+        try {
+            // Copied necessary code from IcebergQueryRunner to add multiple catalogs in queryRunner
+            Path dataDir = queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg_data");
+            queryRunner.installPlugin(new TestingIcebergPlugin(dataDir));
+            queryRunner.createCatalog(ICEBERG_S3A_HADOOP_FS, "iceberg", icebergS3HadoopFsProperties);
+            queryRunner.createCatalog(ICEBERG_S3A_NATIVE_FS, "iceberg", icebergS3NativeFsProperties);
+            return queryRunner;
+        }
+        catch (Exception e) {
+            closeAllSuppress(e, queryRunner);
+            throw e;
+        }
+    }
+
+    @Test
+    public void testS3FileSystemCompatibility()
+    {
+        assertUpdate("CREATE SCHEMA %s.%s".formatted(ICEBERG_S3A_HADOOP_FS, SCHEMA_NAME));
+        for (String s3Scheme : List.of("s3", "s3a", "s3n")) {
+            testS3FileSystemCompatibility(s3Scheme, true);
+            testS3FileSystemCompatibility(s3Scheme, false);
+        }
+    }
+
+    private void testS3FileSystemCompatibility(String s3Scheme, boolean isNonCanonicalPath)
+    {
+        String tableName = "sample_table";
+        String dir1 = "dir1";
+        String dir2 = "dir2";
+
+        if (isNonCanonicalPath) {
+            // Create table in HadoopFs
+            assertUpdate("CREATE TABLE %s.%s.%s WITH (location = '%s://%s/%s/%s//%s') AS SELECT 'test value' col".formatted(ICEBERG_S3A_HADOOP_FS, SCHEMA_NAME, tableName, s3Scheme, BUCKET_NAME, dir1, dir2, tableName), 1);
+            // Verify that table is created at correct location
+            assertThat(s3.listObjectsV2(builder -> builder.bucket(BUCKET_NAME).prefix("%s/%s//%s/".formatted(dir1, dir2, tableName))).contents().isEmpty()).isFalse();
+            assertThat(s3.listObjectsV2(builder -> builder.bucket(BUCKET_NAME).prefix("%s/%s/%s/".formatted(dir1, dir2, tableName))).contents().isEmpty()).isTrue();
+        }
+        else {
+            // Create table in HadoopFs
+            assertUpdate("CREATE TABLE %s.%s.%s WITH (location = '%s://%s/%s/%s/%s') AS SELECT 'test value' col".formatted(ICEBERG_S3A_HADOOP_FS, SCHEMA_NAME, tableName, s3Scheme, BUCKET_NAME, dir1, dir2, tableName), 1);
+            // Verify that table is created at correct location
+            assertThat(s3.listObjectsV2(builder -> builder.bucket(BUCKET_NAME).prefix("%s/%s/%s/".formatted(dir1, dir2, tableName))).contents().isEmpty()).isFalse();
+        }
+        // Query table in HadoopFs
+        assertQuery("SELECT * FROM %s.%s.%s".formatted(ICEBERG_S3A_HADOOP_FS, SCHEMA_NAME, tableName), "VALUES 'test value'");
+
+        // Query the same table in NativeFs
+        assertQuery("SELECT * FROM %s.%s.%s".formatted(ICEBERG_S3A_NATIVE_FS, SCHEMA_NAME, tableName), "VALUES 'test value'");
+
+        assertUpdate("DROP TABLE %s.%s.%s".formatted(ICEBERG_S3A_HADOOP_FS, SCHEMA_NAME, tableName));
+    }
+}


### PR DESCRIPTION
Fixes problem reported through https://github.com/trinodb/trino/issues/23097 for tables created in future using HadoopFs with s3a/n scheme and having multiple slashes `//` in the path.

Currently, in HadoopFs path with s3 scheme is not normalized but path with s3a and s3n scheme is normalized causing tables with s3a/s3n scheme and having multiple slashes `///` created in HadoopFs in the path to be not queryable using NativeFs. With this change path with s3a/s3n scheme will also not be normalized, meaning will be kept as-is which would make the table with multiple slashes created in HadoopFs to be queryable using NativeFs.

Note that with this change previously created table using HadoopFs with s3a/n scheme and having multiple slashes will not be queryable in HadoopFs and NativeFs unless tables are moved from single slash path to multiple slashes path as suggested through https://github.com/trinodb/trino/issues/23097#issuecomment-2320657095

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
