### PR TITLE
Fix infinite loop in RemoveRedundantPredicateAboveTableScan

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionOptimizer.java
@@ -69,6 +69,7 @@ import io.trino.sql.ir.optimizer.rule.SimplifyStackedArithmeticNegation;
 import io.trino.sql.ir.optimizer.rule.SimplifyStackedNot;
 import io.trino.sql.ir.optimizer.rule.SpecializeCastWithJsonParse;
 import io.trino.sql.ir.optimizer.rule.SpecializeTransformWithJsonParse;
+import io.trino.sql.ir.optimizer.rule.UnwrapInCast;
 import io.trino.sql.planner.Symbol;
 
 import java.util.List;
@@ -106,6 +107,7 @@ public class IrExpressionOptimizer
                 new EvaluateCase(),
                 new EvaluateCall(context),
                 new EvaluateIn(context),
+                new UnwrapInCast(context),
                 new DesugarBetween(context),
                 new EvaluateCallWithNullInput(),
                 new RemoveRedundantSwitchClauses(context),

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/UnwrapInCast.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/UnwrapInCast.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.ir.optimizer.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.Session;
+import io.trino.metadata.Metadata;
+import io.trino.spi.TrinoException;
+import io.trino.sql.InterpretedFunctionInvoker;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.ir.Cast;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.In;
+import io.trino.sql.ir.optimizer.IrOptimizerRule;
+import io.trino.sql.planner.Symbol;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Collections.singletonList;
+
+/**
+ * Simplifies IN expression with a Cast on value by attempting to cast the values list to the value type. E.g.,
+ * <ul>
+ *     <li>{@code $in($cast(x, varchar), ['1', '2', '3', '4']) -> $in(x, 1, 2, 3, 4)}
+ * </ul>
+ */
+public class UnwrapInCast
+        implements IrOptimizerRule
+{
+    private final Metadata metadata;
+    private final InterpretedFunctionInvoker functionInvoker;
+
+    public UnwrapInCast(PlannerContext context)
+    {
+        metadata = context.getMetadata();
+        functionInvoker = new InterpretedFunctionInvoker(context.getFunctionManager());
+    }
+
+    @Override
+    public Optional<Expression> apply(Expression expression, Session session, Map<Symbol, Expression> bindings)
+    {
+        if (!(expression instanceof In(Cast cast, List<Expression> list))) {
+            return Optional.empty();
+        }
+
+        ImmutableList.Builder<Expression> builder = ImmutableList.builder();
+        for (Expression item : list) {
+            if (item instanceof Constant constant) {
+                try {
+                    builder.add(new Constant(
+                            cast.expression().type(),
+                            functionInvoker.invoke(
+                                    metadata.getCoercion(constant.type(), cast.expression().type()),
+                                    session.toConnectorSession(),
+                                    singletonList(constant.value()))));
+                }
+                catch (TrinoException _) {
+                    return Optional.empty();
+                }
+            }
+            else {
+                return Optional.empty();
+            }
+        }
+
+        return Optional.of(new In(cast.expression(), builder.build()));
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestUnwrapInCast.java
+++ b/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestUnwrapInCast.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.ir.optimizer;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.sql.ir.Cast;
+import io.trino.sql.ir.Coalesce;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.In;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.ir.optimizer.rule.UnwrapInCast;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
+import static io.trino.testing.TestingSession.testSession;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestUnwrapInCast
+{
+    @Test
+    void test()
+    {
+        assertThat(optimize(
+                new In(
+                        new Cast(new Reference(BIGINT, "x"), VARCHAR),
+                        ImmutableList.of(new Constant(VARCHAR, utf8Slice("1")), new Constant(VARCHAR, utf8Slice("2")), new Constant(VARCHAR, null)))))
+                .isEqualTo(Optional.of(
+                        new In(
+                                new Reference(BIGINT, "x"),
+                                ImmutableList.of(new Constant(BIGINT, 1L), new Constant(BIGINT, 2L), new Constant(BIGINT, null)))));
+
+        assertThat(optimize(
+                new In(
+                        new Cast(new Coalesce(new Constant(BIGINT, null), new Reference(BIGINT, "x")), VARCHAR),
+                        ImmutableList.of(new Constant(VARCHAR, utf8Slice("1")), new Constant(VARCHAR, utf8Slice("2"))))))
+                .isEqualTo(Optional.of(
+                        new In(
+                                new Coalesce(new Constant(BIGINT, null), new Reference(BIGINT, "x")),
+                                ImmutableList.of(new Constant(BIGINT, 1L), new Constant(BIGINT, 2L)))));
+
+        assertThat(optimize(
+                new In(
+                        new Cast(new Reference(BIGINT, "x"), VARCHAR),
+                        ImmutableList.of(new Constant(VARCHAR, utf8Slice("abc")), new Constant(VARCHAR, utf8Slice("xyz"))))))
+                .isEqualTo(Optional.empty());
+
+        assertThat(optimize(
+                new In(
+                        new Cast(new Reference(BIGINT, "x"), VARCHAR),
+                        ImmutableList.of(new Constant(VARCHAR, utf8Slice("1")), new Reference(VARCHAR, "y")))))
+                .isEqualTo(Optional.empty());
+    }
+
+    private static Optional<Expression> optimize(Expression expression)
+    {
+        return new UnwrapInCast(PLANNER_CONTEXT).apply(expression, testSession(), ImmutableMap.of());
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIssue23147.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIssue23147.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import io.trino.Session;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static io.trino.SystemSessionProperties.OPTIMIZE_METADATA_QUERIES;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+
+public class TestIssue23147
+        extends AbstractTestQueryFramework
+{
+    private static final String PARTITIONED_TABLE = "partitioned_table";
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return IcebergQueryRunner.builder().build();
+    }
+
+    @Test
+    @Timeout(30)
+    public void test()
+    {
+        assertUpdate("CREATE TABLE %s(id int, part_key bigint) WITH (partitioning = ARRAY ['part_key'])".formatted(PARTITIONED_TABLE));
+        assertUpdate("""
+                INSERT INTO %s
+                     VALUES
+                             (1, 1),
+                             (2, 3),
+                             (3, 4),
+                             (4, 5)
+                """.formatted(PARTITIONED_TABLE),
+                4);
+
+        Session session = testSessionBuilder(getSession())
+                .setSystemProperty(OPTIMIZE_METADATA_QUERIES, "true")
+                .build();
+        @Language("SQL") String query = """
+                     SELECT t0.*
+                     FROM (
+                             SELECT cast(part_key as varchar) part FROM %s
+                             WHERE part_key IN (SELECT part_key FROM %s)
+                     ) t0
+                     WHERE t0.part IN ('3', '4')
+                """.formatted(PARTITIONED_TABLE, PARTITIONED_TABLE);
+        assertQuery(session, query, "VALUES ('3'), ('4')");
+    }
+}


### PR DESCRIPTION
## Description
Added an IR rule UnwrapInCast which simplifies an In expression with Cast and enables it's pushdown into connector
E.g. the expression
`((CAST(part_key AS varchar) IN (varchar '3', varchar '4')) AND (part_key IN (bigint '1', bigint '3', bigint '4', bigint '5')) AND (part_key BETWEEN bigint '3' AND '4')`
can be simplified to `(part_key BETWEEN bigint '3' AND '4')`

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes #23147 


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix infinite loop in query planning on partitioned tables. ({issue}`23147`)
```
