### PR TITLE
Remove redundant constructors in a parser

### DIFF
--- a/core/trino-main/src/test/java/io/trino/execution/TestCommitTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCommitTask.java
@@ -27,6 +27,7 @@ import io.trino.security.AccessControlConfig;
 import io.trino.security.AccessControlManager;
 import io.trino.spi.resourcegroups.ResourceGroupId;
 import io.trino.sql.tree.Commit;
+import io.trino.sql.tree.NodeLocation;
 import io.trino.transaction.TransactionId;
 import io.trino.transaction.TransactionManager;
 import org.junit.jupiter.api.AfterAll;
@@ -82,7 +83,7 @@ public class TestCommitTask
         assertThat(stateMachine.getSession().getTransactionId().isPresent()).isTrue();
         assertThat(transactionManager.getAllTransactionInfos().size()).isEqualTo(1);
 
-        getFutureValue(new CommitTask(transactionManager).execute(new Commit(), stateMachine, emptyList(), WarningCollector.NOOP));
+        getFutureValue(new CommitTask(transactionManager).execute(new Commit(new NodeLocation(1, 1)), stateMachine, emptyList(), WarningCollector.NOOP));
         assertThat(stateMachine.getQueryInfo(Optional.empty()).isClearTransactionId()).isTrue();
         assertThat(stateMachine.getQueryInfo(Optional.empty()).getStartedTransactionId().isPresent()).isFalse();
 
@@ -99,7 +100,7 @@ public class TestCommitTask
         QueryStateMachine stateMachine = createQueryStateMachine("COMMIT", session, transactionManager);
 
         assertTrinoExceptionThrownBy(
-                () -> getFutureValue(new CommitTask(transactionManager).execute(new Commit(), stateMachine, emptyList(), WarningCollector.NOOP)))
+                () -> getFutureValue(new CommitTask(transactionManager).execute(new Commit(new NodeLocation(1, 1)), stateMachine, emptyList(), WarningCollector.NOOP)))
                 .hasErrorCode(NOT_IN_TRANSACTION);
 
         assertThat(stateMachine.getQueryInfo(Optional.empty()).isClearTransactionId()).isFalse();
@@ -118,7 +119,7 @@ public class TestCommitTask
                 .build();
         QueryStateMachine stateMachine = createQueryStateMachine("COMMIT", session, transactionManager);
 
-        Future<?> future = new CommitTask(transactionManager).execute(new Commit(), stateMachine, emptyList(), WarningCollector.NOOP);
+        Future<?> future = new CommitTask(transactionManager).execute(new Commit(new NodeLocation(1, 1)), stateMachine, emptyList(), WarningCollector.NOOP);
         assertTrinoExceptionThrownBy(() -> getFutureValue(future))
                 .hasErrorCode(UNKNOWN_TRANSACTION);
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateCatalogTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateCatalogTask.java
@@ -26,6 +26,7 @@ import io.trino.spi.connector.ConnectorFactory;
 import io.trino.spi.resourcegroups.ResourceGroupId;
 import io.trino.sql.tree.CreateCatalog;
 import io.trino.sql.tree.Identifier;
+import io.trino.sql.tree.NodeLocation;
 import io.trino.sql.tree.Property;
 import io.trino.sql.tree.Statement;
 import io.trino.sql.tree.StringLiteral;
@@ -100,7 +101,7 @@ public class TestCreateCatalogTask
     @Test
     public void testDuplicatedCreateCatalog()
     {
-        CreateCatalog statement = new CreateCatalog(new Identifier(TEST_CATALOG), false, new Identifier("tpch"), TPCH_PROPERTIES, Optional.empty(), Optional.empty());
+        CreateCatalog statement = new CreateCatalog(new NodeLocation(1, 1), new Identifier(TEST_CATALOG), false, new Identifier("tpch"), TPCH_PROPERTIES, Optional.empty(), Optional.empty());
         getFutureValue(task.execute(statement, queryStateMachine, emptyList(), WarningCollector.NOOP));
         assertThat(queryRunner.getPlannerContext().getMetadata().catalogExists(queryStateMachine.getSession(), TEST_CATALOG)).isTrue();
         assertThatExceptionOfType(TrinoException.class)
@@ -111,7 +112,7 @@ public class TestCreateCatalogTask
     @Test
     public void testCaseInsensitiveDuplicatedCreateCatalog()
     {
-        CreateCatalog statement = new CreateCatalog(new Identifier(TEST_CATALOG.toUpperCase(ENGLISH)), false, new Identifier("tpch"), TPCH_PROPERTIES, Optional.empty(), Optional.empty());
+        CreateCatalog statement = new CreateCatalog(new NodeLocation(1, 1), new Identifier(TEST_CATALOG.toUpperCase(ENGLISH)), false, new Identifier("tpch"), TPCH_PROPERTIES, Optional.empty(), Optional.empty());
         getFutureValue(task.execute(statement, queryStateMachine, emptyList(), WarningCollector.NOOP));
         assertThat(queryRunner.getPlannerContext().getMetadata().catalogExists(queryStateMachine.getSession(), TEST_CATALOG)).isTrue();
         assertThatExceptionOfType(TrinoException.class)
@@ -122,7 +123,7 @@ public class TestCreateCatalogTask
     @Test
     public void testDuplicatedCreateCatalogIfNotExists()
     {
-        CreateCatalog statement = new CreateCatalog(new Identifier(TEST_CATALOG), true, new Identifier("tpch"), TPCH_PROPERTIES, Optional.empty(), Optional.empty());
+        CreateCatalog statement = new CreateCatalog(new NodeLocation(1, 1), new Identifier(TEST_CATALOG), true, new Identifier("tpch"), TPCH_PROPERTIES, Optional.empty(), Optional.empty());
         getFutureValue(task.execute(statement, queryStateMachine, emptyList(), WarningCollector.NOOP));
         assertThat(queryRunner.getPlannerContext().getMetadata().catalogExists(queryStateMachine.getSession(), TEST_CATALOG)).isTrue();
         getFutureValue(task.execute(statement, queryStateMachine, emptyList(), WarningCollector.NOOP));
@@ -135,6 +136,7 @@ public class TestCreateCatalogTask
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> getFutureValue(task.execute(
                         new CreateCatalog(
+                                new NodeLocation(1, 1),
                                 new Identifier(TEST_CATALOG),
                                 true,
                                 new Identifier("fail"),

--- a/core/trino-main/src/test/java/io/trino/execution/TestDeallocateTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestDeallocateTask.java
@@ -28,6 +28,7 @@ import io.trino.security.AccessControlManager;
 import io.trino.spi.resourcegroups.ResourceGroupId;
 import io.trino.sql.tree.Deallocate;
 import io.trino.sql.tree.Identifier;
+import io.trino.sql.tree.NodeLocation;
 import io.trino.transaction.TransactionManager;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
@@ -116,7 +117,7 @@ public class TestDeallocateTask
                 Optional.empty(),
                 true,
                 new NodeVersion("test"));
-        Deallocate deallocate = new Deallocate(new Identifier(statementName));
+        Deallocate deallocate = new Deallocate(new NodeLocation(1, 1), new Identifier(statementName));
         new DeallocateTask().execute(deallocate, stateMachine, emptyList(), WarningCollector.NOOP);
         return stateMachine.getDeallocatedPreparedStatements();
     }

--- a/core/trino-main/src/test/java/io/trino/execution/TestDropCatalogTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestDropCatalogTask.java
@@ -22,6 +22,7 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.resourcegroups.ResourceGroupId;
 import io.trino.sql.tree.DropCatalog;
 import io.trino.sql.tree.Identifier;
+import io.trino.sql.tree.NodeLocation;
 import io.trino.sql.tree.Statement;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.StandaloneQueryRunner;
@@ -78,7 +79,7 @@ public class TestDropCatalogTask
         queryRunner.createCatalog(TEST_CATALOG, "tpch", ImmutableMap.of());
         assertThat(queryRunner.getPlannerContext().getMetadata().catalogExists(createNewQuery().getSession(), TEST_CATALOG)).isTrue();
 
-        DropCatalog statement = new DropCatalog(new Identifier(TEST_CATALOG), false, false);
+        DropCatalog statement = new DropCatalog(new NodeLocation(1, 1), new Identifier(TEST_CATALOG), false, false);
         getFutureValue(task.execute(statement, createNewQuery(), emptyList(), WarningCollector.NOOP));
         assertThat(queryRunner.getPlannerContext().getMetadata().catalogExists(createNewQuery().getSession(), TEST_CATALOG)).isFalse();
         assertThatExceptionOfType(TrinoException.class)
@@ -92,7 +93,7 @@ public class TestDropCatalogTask
         queryRunner.createCatalog(TEST_CATALOG, "tpch", ImmutableMap.of());
         assertThat(queryRunner.getPlannerContext().getMetadata().catalogExists(createNewQuery().getSession(), TEST_CATALOG)).isTrue();
 
-        DropCatalog statement = new DropCatalog(new Identifier(TEST_CATALOG), true, false);
+        DropCatalog statement = new DropCatalog(new NodeLocation(1, 1), new Identifier(TEST_CATALOG), true, false);
         getFutureValue(task.execute(statement, createNewQuery(), emptyList(), WarningCollector.NOOP));
         assertThat(queryRunner.getPlannerContext().getMetadata().catalogExists(createNewQuery().getSession(), TEST_CATALOG)).isFalse();
         getFutureValue(task.execute(statement, createNewQuery(), emptyList(), WarningCollector.NOOP));
@@ -105,7 +106,7 @@ public class TestDropCatalogTask
         queryRunner.createCatalog(TEST_CATALOG, "tpch", ImmutableMap.of());
         assertThat(queryRunner.getPlannerContext().getMetadata().catalogExists(createNewQuery().getSession(), TEST_CATALOG)).isTrue();
 
-        DropCatalog statement = new DropCatalog(new Identifier(TEST_CATALOG.toUpperCase(ENGLISH)), false, false);
+        DropCatalog statement = new DropCatalog(new NodeLocation(1, 1), new Identifier(TEST_CATALOG.toUpperCase(ENGLISH)), false, false);
         getFutureValue(task.execute(statement, createNewQuery(), emptyList(), WarningCollector.NOOP));
         assertThat(queryRunner.getPlannerContext().getMetadata().catalogExists(createNewQuery().getSession(), TEST_CATALOG)).isFalse();
     }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AnchorPattern.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AnchorPattern.java
@@ -35,12 +35,7 @@ public class AnchorPattern
 
     public AnchorPattern(NodeLocation location, Type type)
     {
-        this(Optional.of(location), type);
-    }
-
-    private AnchorPattern(Optional<NodeLocation> location, Type type)
-    {
-        super(location);
+        super(Optional.of(location));
         this.type = requireNonNull(type, "type is null");
     }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Commit.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Commit.java
@@ -21,19 +21,9 @@ import java.util.Optional;
 public final class Commit
         extends Statement
 {
-    public Commit()
-    {
-        this(Optional.empty());
-    }
-
     public Commit(NodeLocation location)
     {
-        this(Optional.of(location));
-    }
-
-    private Commit(Optional<NodeLocation> location)
-    {
-        super(location);
+        super(Optional.of(location));
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/CreateCatalog.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/CreateCatalog.java
@@ -33,17 +33,6 @@ public class CreateCatalog
     private final Optional<String> comment;
 
     public CreateCatalog(
-            Identifier catalogName,
-            boolean notExists,
-            Identifier connectorName,
-            List<Property> properties,
-            Optional<PrincipalSpecification> principal,
-            Optional<String> comment)
-    {
-        this(Optional.empty(), catalogName, notExists, connectorName, properties, principal, comment);
-    }
-
-    public CreateCatalog(
             NodeLocation location,
             Identifier catalogName,
             boolean notExists,
@@ -52,19 +41,7 @@ public class CreateCatalog
             Optional<PrincipalSpecification> principal,
             Optional<String> comment)
     {
-        this(Optional.of(location), catalogName, notExists, connectorName, properties, principal, comment);
-    }
-
-    private CreateCatalog(
-            Optional<NodeLocation> location,
-            Identifier catalogName,
-            boolean notExists,
-            Identifier connectorName,
-            List<Property> properties,
-            Optional<PrincipalSpecification> principal,
-            Optional<String> comment)
-    {
-        super(location);
+        super(Optional.of(location));
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.notExists = notExists;
         this.connectorName = requireNonNull(connectorName, "connectorName is null");

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/CreateFunction.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/CreateFunction.java
@@ -28,19 +28,9 @@ public final class CreateFunction
     private final FunctionSpecification specification;
     private final boolean replace;
 
-    public CreateFunction(FunctionSpecification specification, boolean replace)
-    {
-        this(Optional.empty(), specification, replace);
-    }
-
     public CreateFunction(NodeLocation location, FunctionSpecification specification, boolean replace)
     {
-        this(Optional.of(location), specification, replace);
-    }
-
-    private CreateFunction(Optional<NodeLocation> location, FunctionSpecification specification, boolean replace)
-    {
-        super(location);
+        super(Optional.of(location));
         this.specification = requireNonNull(specification, "specification is null");
         this.replace = replace;
     }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/CurrentCatalog.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/CurrentCatalog.java
@@ -23,12 +23,7 @@ public class CurrentCatalog
 {
     public CurrentCatalog(NodeLocation location)
     {
-        this(Optional.of(location));
-    }
-
-    private CurrentCatalog(Optional<NodeLocation> location)
-    {
-        super(location);
+        super(Optional.of(location));
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/CurrentPath.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/CurrentPath.java
@@ -23,12 +23,7 @@ public class CurrentPath
 {
     public CurrentPath(NodeLocation location)
     {
-        this(Optional.of(location));
-    }
-
-    private CurrentPath(Optional<NodeLocation> location)
-    {
-        super(location);
+        super(Optional.of(location));
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/CurrentSchema.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/CurrentSchema.java
@@ -23,12 +23,7 @@ public class CurrentSchema
 {
     public CurrentSchema(NodeLocation location)
     {
-        this(Optional.of(location));
-    }
-
-    private CurrentSchema(Optional<NodeLocation> location)
-    {
-        super(location);
+        super(Optional.of(location));
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/CurrentUser.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/CurrentUser.java
@@ -21,19 +21,9 @@ import java.util.Optional;
 public class CurrentUser
         extends Expression
 {
-    public CurrentUser()
-    {
-        this(Optional.empty());
-    }
-
     public CurrentUser(NodeLocation location)
     {
-        this(Optional.of(location));
-    }
-
-    private CurrentUser(Optional<NodeLocation> location)
-    {
-        super(location);
+        super(Optional.of(location));
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Deallocate.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Deallocate.java
@@ -29,17 +29,7 @@ public class Deallocate
 
     public Deallocate(NodeLocation location, Identifier name)
     {
-        this(Optional.of(location), name);
-    }
-
-    public Deallocate(Identifier name)
-    {
-        this(Optional.empty(), name);
-    }
-
-    private Deallocate(Optional<NodeLocation> location, Identifier name)
-    {
-        super(location);
+        super(Optional.of(location));
         this.name = requireNonNull(name, "name is null");
     }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Delete.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Delete.java
@@ -28,19 +28,9 @@ public class Delete
     private final Table table;
     private final Optional<Expression> where;
 
-    public Delete(Table table, Optional<Expression> where)
-    {
-        this(Optional.empty(), table, where);
-    }
-
     public Delete(NodeLocation location, Table table, Optional<Expression> where)
     {
-        this(Optional.of(location), table, where);
-    }
-
-    private Delete(Optional<NodeLocation> location, Table table, Optional<Expression> where)
-    {
-        super(location);
+        super(Optional.of(location));
         this.table = requireNonNull(table, "table is null");
         this.where = requireNonNull(where, "where is null");
     }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DescribeInput.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DescribeInput.java
@@ -28,17 +28,7 @@ public class DescribeInput
 
     public DescribeInput(NodeLocation location, Identifier name)
     {
-        this(Optional.of(location), name);
-    }
-
-    public DescribeInput(Identifier name)
-    {
-        this(Optional.empty(), name);
-    }
-
-    private DescribeInput(Optional<NodeLocation> location, Identifier name)
-    {
-        super(location);
+        super(Optional.of(location));
         this.name = name;
     }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DescribeOutput.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DescribeOutput.java
@@ -28,17 +28,7 @@ public class DescribeOutput
 
     public DescribeOutput(NodeLocation location, Identifier name)
     {
-        this(Optional.of(location), name);
-    }
-
-    public DescribeOutput(Identifier name)
-    {
-        this(Optional.empty(), name);
-    }
-
-    private DescribeOutput(Optional<NodeLocation> location, Identifier name)
-    {
-        super(location);
+        super(Optional.of(location));
         this.name = name;
     }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DeterministicCharacteristic.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DeterministicCharacteristic.java
@@ -26,19 +26,9 @@ public final class DeterministicCharacteristic
 {
     private final boolean deterministic;
 
-    public DeterministicCharacteristic(boolean deterministic)
-    {
-        this(Optional.empty(), deterministic);
-    }
-
     public DeterministicCharacteristic(NodeLocation location, boolean deterministic)
     {
-        this(Optional.of(location), deterministic);
-    }
-
-    private DeterministicCharacteristic(Optional<NodeLocation> location, boolean deterministic)
-    {
-        super(location);
+        super(Optional.of(location));
         this.deterministic = deterministic;
     }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DropCatalog.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DropCatalog.java
@@ -29,19 +29,9 @@ public final class DropCatalog
     private final boolean exists;
     private final boolean cascade;
 
-    public DropCatalog(Identifier catalogName, boolean exists, boolean cascade)
-    {
-        this(Optional.empty(), catalogName, exists, cascade);
-    }
-
     public DropCatalog(NodeLocation location, Identifier catalogName, boolean exists, boolean cascade)
     {
-        this(Optional.of(location), catalogName, exists, cascade);
-    }
-
-    private DropCatalog(Optional<NodeLocation> location, Identifier catalogName, boolean exists, boolean cascade)
-    {
-        super(location);
+        super(Optional.of(location));
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.exists = exists;
         this.cascade = cascade;

--- a/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
@@ -184,6 +184,7 @@ public class TestSqlFormatter
     {
         assertThat(formatSql(
                 new CreateCatalog(
+                        new NodeLocation(1, 1),
                         new Identifier("test"),
                         false,
                         new Identifier("conn"),
@@ -193,6 +194,7 @@ public class TestSqlFormatter
                 .isEqualTo("CREATE CATALOG test USING conn");
         assertThat(formatSql(
                 new CreateCatalog(
+                        new NodeLocation(1, 1),
                         new Identifier("test"),
                         false,
                         new Identifier("conn"),
@@ -203,6 +205,7 @@ public class TestSqlFormatter
                         "COMMENT 'test comment'");
         assertThat(formatSql(
                 new CreateCatalog(
+                        new NodeLocation(1, 1),
                         new Identifier("test"),
                         false,
                         new Identifier("conn"),

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -1739,28 +1739,30 @@ public class TestSqlParser
     @Test
     public void testCreateCatalog()
     {
-        assertStatement("CREATE CATALOG test USING conn",
-                new CreateCatalog(new Identifier("test"), false, new Identifier("conn"), ImmutableList.of(), Optional.empty(), Optional.empty()));
+        assertThat(statement("CREATE CATALOG test USING conn")).isEqualTo(
+                new CreateCatalog(location(1, 1), new Identifier(location(1, 16), "test", false), false, new Identifier(location(1, 27), "conn", false), ImmutableList.of(), Optional.empty(), Optional.empty()));
 
-        assertStatement("CREATE CATALOG IF NOT EXISTS test USING conn",
-                new CreateCatalog(new Identifier("test"), true, new Identifier("conn"), ImmutableList.of(), Optional.empty(), Optional.empty()));
+        assertThat(statement("CREATE CATALOG IF NOT EXISTS test USING conn")).isEqualTo(
+                new CreateCatalog(location(1, 1), new Identifier(location(1, 30), "test", false), true, new Identifier(location(1, 41), "conn", false), ImmutableList.of(), Optional.empty(), Optional.empty()));
 
-        assertStatement("CREATE CATALOG test USING conn COMMENT 'awesome' AUTHORIZATION ROLE dragon WITH (\"a\" = 'apple', \"b\" = 123)",
+        assertThat(statement("CREATE CATALOG test USING conn COMMENT 'awesome' AUTHORIZATION ROLE dragon WITH (\"a\" = 'apple', \"b\" = 123)")).isEqualTo(
                 new CreateCatalog(
-                        new Identifier("test"),
+                        location(1, 1),
+                        new Identifier(location(1, 16), "test", false),
                         false,
-                        new Identifier("conn"),
+                        new Identifier(location(1, 27), "conn", false),
                         ImmutableList.of(
-                                new Property(new Identifier("a"), new StringLiteral("apple")),
-                                new Property(new Identifier("b"), new LongLiteral("123"))),
-                        Optional.of(new PrincipalSpecification(Type.ROLE, new Identifier("dragon"))),
+                                new Property(location(1, 82), new Identifier(location(1, 82), "a", true), new StringLiteral(location(1, 88),  "apple")),
+                                new Property(location(1, 97), new Identifier(location(1, 97), "b", true), new LongLiteral(location(1, 103), "123"))),
+                        Optional.of(new PrincipalSpecification(Type.ROLE, new Identifier(location(1, 69), "dragon", false))),
                         Optional.of("awesome")));
 
-        assertStatement("CREATE CATALOG \"some name that contains space\" USING \"conn-with-dash\"",
+        assertThat(statement("CREATE CATALOG \"some name that contains space\" USING \"conn-with-dash\"")).isEqualTo(
                 new CreateCatalog(
-                        new Identifier("some name that contains space"),
+                        location(1, 1),
+                        new Identifier(location(1, 16), "some name that contains space", true),
                         false,
-                        new Identifier("conn-with-dash"),
+                        new Identifier(location(1, 54), "conn-with-dash", true),
                         ImmutableList.of(),
                         Optional.empty(),
                         Optional.empty()));

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -3917,8 +3917,8 @@ public class TestSqlParser
     @Test
     public void testCommit()
     {
-        assertStatement("COMMIT", new Commit());
-        assertStatement("COMMIT WORK", new Commit());
+        assertThat(statement("COMMIT")).isEqualTo(new Commit(location(1, 1)));
+        assertThat(statement("COMMIT WORK")).isEqualTo(new Commit(location(1, 1)));
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -4405,7 +4405,8 @@ public class TestSqlParser
     @Test
     public void testDescribeInput()
     {
-        assertStatement("DESCRIBE INPUT myquery", new DescribeInput(identifier("myquery")));
+        assertThat(statement("DESCRIBE INPUT myquery"))
+                .isEqualTo(new DescribeInput(location(1, 1), new Identifier(location(1, 16), "myquery", false)));
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -4130,7 +4130,8 @@ public class TestSqlParser
     @Test
     public void testDeallocatePrepare()
     {
-        assertStatement("DEALLOCATE PREPARE myquery", new Deallocate(identifier("myquery")));
+        assertThat(statement("DEALLOCATE PREPARE myquery"))
+                .isEqualTo(new Deallocate(location(1, 1), new Identifier(location(1, 20), "myquery", false)));
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -2855,13 +2855,18 @@ public class TestSqlParser
     @Test
     public void testDelete()
     {
-        assertStatement("DELETE FROM t", new Delete(table(QualifiedName.of("t")), Optional.empty()));
-        assertStatement("DELETE FROM \"awesome table\"", new Delete(table(QualifiedName.of("awesome table")), Optional.empty()));
+        assertThat(statement("DELETE FROM t"))
+                .isEqualTo(new Delete(location(1, 1), new Table(location(1, 1), QualifiedName.of(ImmutableList.of(new Identifier(location(1, 13), "t", false)))), Optional.empty()));
+        assertThat(statement("DELETE FROM \"awesome table\""))
+                .isEqualTo(new Delete(location(1, 1), new Table(location(1, 1), QualifiedName.of(ImmutableList.of(new Identifier(location(1, 13), "awesome table", true)))), Optional.empty()));
 
-        assertStatement("DELETE FROM t WHERE a = b", new Delete(table(QualifiedName.of("t")), Optional.of(
-                new ComparisonExpression(ComparisonExpression.Operator.EQUAL,
-                        new Identifier("a"),
-                        new Identifier("b")))));
+        assertThat(statement("DELETE FROM t WHERE a = b"))
+                .isEqualTo(new Delete(location(1, 1), new Table(location(1, 1), QualifiedName.of(ImmutableList.of(new Identifier(location(1, 13), "t", false)))), Optional.of(
+                        new ComparisonExpression(
+                                location(1, 23),
+                                ComparisonExpression.Operator.EQUAL,
+                                new Identifier(location(1, 21), "a", false),
+                                new Identifier(location(1, 25), "b", false)))));
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -1771,20 +1771,20 @@ public class TestSqlParser
     @Test
     public void testDropCatalog()
     {
-        assertStatement("DROP CATALOG test",
-                new DropCatalog(new Identifier("test"), false, false));
+        assertThat(statement("DROP CATALOG test")).isEqualTo(
+                new DropCatalog(location(1, 1), new Identifier(location(1, 14), "test", false), false, false));
 
-        assertStatement("DROP CATALOG test CASCADE",
-                new DropCatalog(new Identifier("test"), false, true));
+        assertThat(statement("DROP CATALOG test CASCADE")).isEqualTo(
+                new DropCatalog(location(1, 1), new Identifier(location(1, 14), "test", false), false, true));
 
-        assertStatement("DROP CATALOG IF EXISTS test",
-                new DropCatalog(new Identifier("test"), true, false));
+        assertThat(statement("DROP CATALOG IF EXISTS test")).isEqualTo(
+                new DropCatalog(location(1, 1), new Identifier(location(1, 24), "test", false), true, false));
 
-        assertStatement("DROP CATALOG IF EXISTS test RESTRICT",
-                new DropCatalog(new Identifier("test"), true, false));
+        assertThat(statement("DROP CATALOG IF EXISTS test RESTRICT")).isEqualTo(
+                new DropCatalog(location(1, 1), new Identifier(location(1, 24), "test", false), true, false));
 
-        assertStatement("DROP CATALOG \"some catalog that contains space\"",
-                new DropCatalog(new Identifier("some catalog that contains space"), false, false));
+        assertThat(statement("DROP CATALOG \"some catalog that contains space\"")).isEqualTo(
+                new DropCatalog(location(1, 1), new Identifier(location(1, 14), "some catalog that contains space", true), false, false));
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -4399,7 +4399,8 @@ public class TestSqlParser
     @Test
     public void testDescribeOutput()
     {
-        assertStatement("DESCRIBE OUTPUT myquery", new DescribeOutput(identifier("myquery")));
+        assertThat(statement("DESCRIBE OUTPUT myquery"))
+                .isEqualTo(new DescribeOutput(location(1, 1), new Identifier(location(1, 17), "myquery", false)));
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserRoutines.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserRoutines.java
@@ -112,6 +112,7 @@ class TestSqlParserRoutines
                 """))
                 .ignoringLocation()
                 .isEqualTo(new CreateFunction(
+                        location(),
                         new FunctionSpecification(
                                 QualifiedName.of("hello"),
                                 ImmutableList.of(parameter("s", type("VARCHAR"))),
@@ -140,6 +141,7 @@ class TestSqlParserRoutines
                 """))
                 .ignoringLocation()
                 .isEqualTo(new CreateFunction(
+                        location(),
                         new FunctionSpecification(
                                 QualifiedName.of("answer"),
                                 ImmutableList.of(),
@@ -173,6 +175,7 @@ class TestSqlParserRoutines
                 """))
                 .ignoringLocation()
                 .isEqualTo(new CreateFunction(
+                        location(),
                         new FunctionSpecification(
                                 QualifiedName.of("fib"),
                                 ImmutableList.of(parameter("n", type("bigint"))),
@@ -224,6 +227,7 @@ class TestSqlParserRoutines
                 """))
                 .ignoringLocation()
                 .isEqualTo(new CreateFunction(
+                        location(),
                         new FunctionSpecification(
                                 QualifiedName.of("CustomerLevel"),
                                 ImmutableList.of(parameter("p_creditLimit", type("DOUBLE"))),

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserRoutines.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserRoutines.java
@@ -119,7 +119,7 @@ class TestSqlParserRoutines
                                 returns(type("varchar")),
                                 ImmutableList.of(
                                         new LanguageCharacteristic(identifier("SQL")),
-                                        new DeterministicCharacteristic(true),
+                                        new DeterministicCharacteristic(location(), true),
                                         calledOnNullInput(),
                                         new SecurityCharacteristic(INVOKER),
                                         new CommentCharacteristic(new NodeLocation(1, 1), "hello world function")),


### PR DESCRIPTION
## Description

Remove redundant constructors in a parser

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
