### PR TITLE
Add catalog and schema to `SHOW FUNCTIONS` results

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/query/TestShowQueries.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestShowQueries.java
@@ -111,11 +111,11 @@ public class TestShowQueries
         assertThat(assertions.query("SHOW FUNCTIONS LIKE 'split%'"))
                 .skippingTypesCheck()
                 .matches("VALUES " +
-                        "('split', 'array(varchar(x))', 'varchar(x), varchar(y)', 'scalar', true, '')," +
-                        "('split', 'array(varchar(x))', 'varchar(x), varchar(y), bigint', 'scalar', true, '')," +
-                        "('split_part', 'varchar(x)', 'varchar(x), varchar(y), bigint', 'scalar', true, 'Splits a string by a delimiter and returns the specified field (counting from one)')," +
-                        "('split_to_map', 'map(varchar,varchar)', 'varchar, varchar, varchar', 'scalar', true, 'Creates a map using entryDelimiter and keyValueDelimiter')," +
-                        "('split_to_multimap', 'map(varchar,array(varchar))', 'varchar, varchar, varchar', 'scalar', true, 'Creates a multimap by splitting a string into key/value pairs')");
+                        "('system', 'builtin', 'split', 'array(varchar(x))', 'varchar(x), varchar(y)', 'scalar', true, '')," +
+                        "('system', 'builtin', 'split', 'array(varchar(x))', 'varchar(x), varchar(y), bigint', 'scalar', true, '')," +
+                        "('system', 'builtin', 'split_part', 'varchar(x)', 'varchar(x), varchar(y), bigint', 'scalar', true, 'Splits a string by a delimiter and returns the specified field (counting from one)')," +
+                        "('system', 'builtin', 'split_to_map', 'map(varchar,varchar)', 'varchar, varchar, varchar', 'scalar', true, 'Creates a map using entryDelimiter and keyValueDelimiter')," +
+                        "('system', 'builtin', 'split_to_multimap', 'map(varchar,array(varchar))', 'varchar, varchar, varchar', 'scalar', true, 'Creates a multimap by splitting a string into key/value pairs')");
     }
 
     @Test
@@ -124,8 +124,8 @@ public class TestShowQueries
         assertThat(assertions.query("SHOW FUNCTIONS LIKE 'split$_to$_%' ESCAPE '$'"))
                 .skippingTypesCheck()
                 .matches("VALUES " +
-                        "('split_to_map', 'map(varchar,varchar)', 'varchar, varchar, varchar', 'scalar', true, 'Creates a map using entryDelimiter and keyValueDelimiter')," +
-                        "('split_to_multimap', 'map(varchar,array(varchar))', 'varchar, varchar, varchar', 'scalar', true, 'Creates a multimap by splitting a string into key/value pairs')");
+                        "('system', 'builtin', 'split_to_map', 'map(varchar,varchar)', 'varchar, varchar, varchar', 'scalar', true, 'Creates a map using entryDelimiter and keyValueDelimiter')," +
+                        "('system', 'builtin', 'split_to_multimap', 'map(varchar,array(varchar))', 'varchar, varchar, varchar', 'scalar', true, 'Creates a multimap by splitting a string into key/value pairs')");
     }
 
     @Test

--- a/docs/src/main/sphinx/sql/show-functions.md
+++ b/docs/src/main/sphinx/sql/show-functions.md
@@ -14,6 +14,8 @@ plugin](/develop/functions), and [SQL routines](/routines).
 
 For each function returned, the following information is displayed:
 
+- Catalog name
+- Schema name
 - Function name
 - Return type
 - Argument types
@@ -52,11 +54,11 @@ SHOW FUNCTIONS LIKE 'cf%';
 Example output:
 
 ```text
-     Function      | Return Type | Argument Types | Function Type | Deterministic |               Description
- ------------------+-------------+----------------+---------------+---------------+-----------------------------------------
- cf_getgroups      | varchar     |                | scalar        | true          | Returns the current session's groups
- cf_getprincipal   | varchar     |                | scalar        | true          | Returns the current session's principal
- cf_getuser        | varchar     |                | scalar        | true          | Returns the current session's user
+  Catalog |  Schema  |    Function      | Return Type | Argument Types | Function Type | Deterministic |               Description
+ ---------+----------+------------------+-------------+----------------+---------------+---------------+-----------------------------------------
+  example | default  | cf_getgroups     | varchar     |                | scalar        | true          | Returns the current session's groups
+  example | default  | cf_getprincipal  | varchar     |                | scalar        | true          | Returns the current session's principal
+  example | default  | cf_getuser       | varchar     |                | scalar        | true          | Returns the current session's user
 ```
 
 ## See also

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHive3OnDataLake.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHive3OnDataLake.java
@@ -1997,8 +1997,8 @@ public class TestHive3OnDataLake
                 .result()
                 .skippingTypesCheck()
                 .containsAll(resultBuilder(getSession())
-                        .row(name, "bigint", "integer", "scalar", true, "t42")
-                        .row(name, "double", "double", "scalar", true, "t88")
+                        .row("hive", "functions", name, "bigint", "integer", "scalar", true, "t42")
+                        .row("hive", "functions", name, "double", "double", "scalar", true, "t88")
                         .build());
 
         assertQuery("SELECT " + name + "(99)", "SELECT 4158");
@@ -2016,10 +2016,10 @@ public class TestHive3OnDataLake
                 .result()
                 .skippingTypesCheck()
                 .containsAll(resultBuilder(getSession())
-                        .row(name, "bigint", "integer", "scalar", true, "t42")
-                        .row(name, "bigint", "bigint", "scalar", true, "")
-                        .row(name, "double", "double", "scalar", true, "t88")
-                        .row(name2, "varchar", "varchar", "scalar", true, "")
+                        .row("hive", "functions", name, "bigint", "integer", "scalar", true, "t42")
+                        .row("hive", "functions", name, "bigint", "bigint", "scalar", true, "")
+                        .row("hive", "functions", name, "double", "double", "scalar", true, "t88")
+                        .row("hive", "functions", name2, "varchar", "varchar", "scalar", true, "")
                         .build());
 
         assertQuery("SELECT " + name + "(99)", "SELECT 4158");

--- a/testing/trino-product-tests/src/main/resources/sql-tests/testcases/array_functions/checkArrayFunctionsRegistered.result
+++ b/testing/trino-product-tests/src/main/resources/sql-tests/testcases/array_functions/checkArrayFunctionsRegistered.result
@@ -1,10 +1,10 @@
 -- delimiter: |; ignoreOrder: true; ignoreExcessRows: true; trimValues:true
- concat | array(E) | E, array(E) | scalar | true | Concatenates an element to an array |
- concat | array(E) | array(E), E | scalar | true | Concatenates an array to an element |
- concat | array(E) | array(E) | scalar | true | Concatenates given arrays |
- cardinality | bigint | array(e) | scalar | true | Returns the cardinality (length) of the array |
- contains | boolean | array(t), t | scalar | true | Determines whether given value exists in the array |
- array_sort | array(e) | array(e) | scalar | true | Sorts the given array in ascending order according to the natural ordering of its elements. |
- array_sort | array(t) | array(t), function(t,t,integer) | scalar | true | Sorts the given array with a lambda comparator. |
- array_intersect | array(e) | array(e), array(e) | scalar | true | Intersects elements of the two given arrays |
- array_distinct | array(e) | array(e) | scalar | true | Remove duplicate values from the given array |
+ system | builtin | concat | array(E) | E, array(E) | scalar | true | Concatenates an element to an array |
+ system | builtin | concat | array(E) | array(E), E | scalar | true | Concatenates an array to an element |
+ system | builtin | concat | array(E) | array(E) | scalar | true | Concatenates given arrays |
+ system | builtin | cardinality | bigint | array(e) | scalar | true | Returns the cardinality (length) of the array |
+ system | builtin | contains | boolean | array(t), t | scalar | true | Determines whether given value exists in the array |
+ system | builtin | array_sort | array(e) | array(e) | scalar | true | Sorts the given array in ascending order according to the natural ordering of its elements. |
+ system | builtin | array_sort | array(t) | array(t), function(t,t,integer) | scalar | true | Sorts the given array with a lambda comparator. |
+ system | builtin | array_intersect | array(e) | array(e), array(e) | scalar | true | Intersects elements of the two given arrays |
+ system | builtin | array_distinct | array(e) | array(e) | scalar | true | Remove duplicate values from the given array |

--- a/testing/trino-product-tests/src/main/resources/sql-tests/testcases/binary_functions/checkBinaryFunctionsRegistered.result
+++ b/testing/trino-product-tests/src/main/resources/sql-tests/testcases/binary_functions/checkBinaryFunctionsRegistered.result
@@ -1,9 +1,9 @@
 -- delimiter: |; ignoreOrder: true; ignoreExcessRows: true; trimValues:true
- length | bigint | varbinary | scalar | true | Length of the given binary |
- to_base64 | varchar | varbinary | scalar | true | Encode binary data as base64 |
- to_base64url | varchar | varbinary | scalar | true | Encode binary data as base64 using the URL safe alphabet |
- to_hex | varchar | varbinary | scalar | true | Encode binary data as hex |
- from_base64 | varbinary | varbinary | scalar | true | Decode base64 encoded binary data |
- from_base64 | varbinary | varchar(x) | scalar | true | Decode base64 encoded binary data |
- from_base64url | varbinary | varbinary | scalar | true | Decode URL safe base64 encoded binary data |
- from_base64url | varbinary | varchar(x) | scalar | true | Decode URL safe base64 encoded binary data |
+ system | builtin | length | bigint | varbinary | scalar | true | Length of the given binary |
+ system | builtin | to_base64 | varchar | varbinary | scalar | true | Encode binary data as base64 |
+ system | builtin | to_base64url | varchar | varbinary | scalar | true | Encode binary data as base64 using the URL safe alphabet |
+ system | builtin | to_hex | varchar | varbinary | scalar | true | Encode binary data as hex |
+ system | builtin | from_base64 | varbinary | varbinary | scalar | true | Decode base64 encoded binary data |
+ system | builtin | from_base64 | varbinary | varchar(x) | scalar | true | Decode base64 encoded binary data |
+ system | builtin | from_base64url | varbinary | varbinary | scalar | true | Decode URL safe base64 encoded binary data |
+ system | builtin | from_base64url | varbinary | varchar(x) | scalar | true | Decode URL safe base64 encoded binary data |

--- a/testing/trino-product-tests/src/main/resources/sql-tests/testcases/catalog/showFunctions.result
+++ b/testing/trino-product-tests/src/main/resources/sql-tests/testcases/catalog/showFunctions.result
@@ -1,4 +1,4 @@
 -- delimiter: |; ignoreOrder: true; ignoreExcessRows:true; trimValues:true;
- abs        | bigint   | bigint     | scalar        | true          | Absolute value     |
- abs        | double   | double     | scalar        | true          | Absolute value     |
- acos       | double   | double     | scalar        | true          | Arc cosine         |
+ system | builtin | abs        | bigint   | bigint     | scalar        | true          | Absolute value     |
+ system | builtin | abs        | double   | double     | scalar        | true          | Absolute value     |
+ system | builtin | acos       | double   | double     | scalar        | true          | Arc cosine         |

--- a/testing/trino-product-tests/src/main/resources/sql-tests/testcases/horology_functions/checkHorologyFunctionsRegistered.result
+++ b/testing/trino-product-tests/src/main/resources/sql-tests/testcases/horology_functions/checkHorologyFunctionsRegistered.result
@@ -1,86 +1,86 @@
 -- delimiter: |; ignoreOrder: true; ignoreExcessRows: true; trimValues:true
- current_date | date | | scalar | true | Current date |
- current_timezone | varchar | | scalar | true | Current time zone |
- date_add | date | varchar(x), bigint, date | scalar | true | Add the specified amount of date to the given date |
- date_add | time(p) | varchar(x), bigint, time(p) | scalar | true | Add the specified amount of time to the given time |
- date_add | time(p) with time zone | varchar(x), bigint, time(p) with time zone | scalar | true | Add the specified amount of time to the given time |
- date_add | timestamp(p) | varchar(x), bigint, timestamp(p) | scalar | true | Add the specified amount of time to the given timestamp |
- date_add | timestamp(p) with time zone | varchar(x), bigint, timestamp(p) with time zone | scalar | true | Add the specified amount of time to the given timestamp |
- date_diff | bigint | varchar(x), date, date | scalar | true | Difference of the given dates in the given unit |
- date_diff | bigint | varchar(x), time(p) with time zone, time(p) with time zone | scalar | true | Difference of the given times in the given unit |
- date_diff | bigint | varchar(x), time(p), time(p) | scalar | true | Difference of the given times in the given unit |
- date_diff | bigint | varchar(x), timestamp(p) with time zone, timestamp(p) with time zone | scalar | true | Difference of the given times in the given unit |
- date_diff | bigint | varchar(x), timestamp(p), timestamp(p) | scalar | true | Difference of the given times in the given unit |
- date_format | varchar | timestamp(p) with time zone, varchar(x) | scalar | true | Formats the given timestamp by the given format |
- date_format | varchar | timestamp(p), varchar(x) | scalar | true | Formats the given timestamp by the given format |
- date_parse | timestamp(3) | varchar(x), varchar(y) | scalar | true | |
- date_trunc | date | varchar(x), date | scalar | true | Truncate to the specified precision in the session timezone |
- date_trunc | time(p) | varchar(x), time(p) | scalar | true | Truncate to the specified precision |
- date_trunc | time(p) with time zone | varchar(x), time(p) with time zone | scalar | true | Truncate to the specified precision |
- date_trunc | timestamp(p) | varchar(x), timestamp(p) | scalar | true | Truncate to the specified precision in the session timezone |
- date_trunc | timestamp(p) with time zone | varchar(x), timestamp(p) with time zone | scalar | true | Truncate to the specified precision |
- day | bigint | date | scalar | true | Day of the month of the given date |
- day | bigint | interval day to second | scalar | true | Day of the month of the given interval |
- day | bigint | timestamp(p) | scalar | true | Day of the month of the given timestamp |
- day | bigint | timestamp(p) with time zone | scalar | true | Day of the month of the given timestamp |
- day_of_month | bigint | date | scalar | true | Day of the month of the given date |
- day_of_month | bigint | interval day to second | scalar | true | Day of the month of the given interval |
- day_of_month | bigint | timestamp(p) | scalar | true | Day of the month of the given timestamp |
- day_of_month | bigint | timestamp(p) with time zone | scalar | true | Day of the month of the given timestamp |
- day_of_week | bigint | date | scalar | true | Day of the week of the given date |
- day_of_week | bigint | timestamp(p) | scalar | true | Day of the week of the given timestamp |
- day_of_week | bigint | timestamp(p) with time zone | scalar | true | Day of the week of the given timestamp |
- day_of_year | bigint | date | scalar | true | Day of the year of the given date |
- day_of_year | bigint | timestamp(p) | scalar | true | Day of the year of the given timestamp |
- day_of_year | bigint | timestamp(p) with time zone | scalar | true | Day of the year of the given timestamp |
- dow | bigint | date | scalar | true | Day of the week of the given date |
- dow | bigint | timestamp(p) | scalar | true | Day of the week of the given timestamp |
- dow | bigint | timestamp(p) with time zone | scalar | true | Day of the week of the given timestamp |
- doy | bigint | date | scalar | true | Day of the year of the given date |
- doy | bigint | timestamp(p) | scalar | true | Day of the year of the given timestamp |
- doy | bigint | timestamp(p) with time zone | scalar | true | Day of the year of the given timestamp |
- e | double | | scalar | true | Euler's number |
- format_datetime | varchar | timestamp(p) with time zone, varchar(x) | scalar | true | Formats the given time by the given format |
- format_datetime | varchar | timestamp(p), varchar(x) | scalar | true | Formats the given time by the given format |
- from_iso8601_date | date | varchar(x) | scalar | true | |
- from_iso8601_timestamp | timestamp(3) with time zone | varchar(x) | scalar | true | |
- from_unixtime | timestamp(3) with time zone | double | scalar | true | |
- from_unixtime | timestamp(3) with time zone | double, bigint, bigint | scalar | true | |
- hour | bigint | interval day to second | scalar | true | Hour of the day of the given interval |
- hour | bigint | time(p) | scalar | true | Hour of the day of the given time |
- hour | bigint | time(p) with time zone | scalar | true | Hour of the day of the given time |
- hour | bigint | timestamp(p) | scalar | true | Hour of the day of the given timestamp |
- hour | bigint | timestamp(p) with time zone | scalar | true | Hour of the day of the given timestamp |
- minute | bigint | interval day to second | scalar | true | Minute of the hour of the given interval |
- minute | bigint | time(p) | scalar | true | Minute of the hour of the given time |
- minute | bigint | time(p) with time zone | scalar | true | Minute of the hour of the given time |
- minute | bigint | timestamp(p) | scalar | true | Minute of the hour of the given timestamp |
- minute | bigint | timestamp(p) with time zone | scalar | true | Minute of the hour of the given timestamp |
- month | bigint | date | scalar | true | Month of the year of the given date |
- month | bigint | interval year to month | scalar | true | Month of the year of the given interval |
- month | bigint | timestamp(p) | scalar | true | Month of the year of the given timestamp |
- month | bigint | timestamp(p) with time zone | scalar | true | Month of the year of the given timestamp |
- now | timestamp(3) with time zone | | scalar | true | Current timestamp with time zone |
- parse_datetime | timestamp(3) with time zone | varchar(x), varchar(y) | scalar | true | Parses the specified date/time by the given format |
- quarter | bigint | date | scalar | true | Quarter of the year of the given date |
- quarter | bigint | timestamp(p) | scalar | true | Quarter of the year of the given timestamp |
- quarter | bigint | timestamp(p) with time zone | scalar | true | Quarter of the year of the given timestamp |
- timezone_hour | bigint | timestamp(p) with time zone | scalar | true | Time zone hour of the given timestamp |
- timezone_minute | bigint | timestamp(p) with time zone | scalar | true | Time zone minute of the given timestamp |
- to_unixtime | double | timestamp(p) with time zone | scalar | true | |
- week | bigint | date | scalar | true | Week of the year of the given date |
- week | bigint | timestamp(p) | scalar | true | Week of the year of the given timestamp |
- week | bigint | timestamp(p) with time zone | scalar | true | Week of the year of the given timestamp |
- week_of_year | bigint | date | scalar | true | Week of the year of the given date |
- week_of_year | bigint | timestamp(p) | scalar | true | Week of the year of the given timestamp |
- week_of_year | bigint | timestamp(p) with time zone | scalar | true | Week of the year of the given timestamp |
- year | bigint | date | scalar | true | Year of the given date |
- year | bigint | interval year to month | scalar | true | Year of the given interval |
- year | bigint | timestamp(p) | scalar | true | Year of the given timestamp |
- year | bigint | timestamp(p) with time zone | scalar | true | Year of the given timestamp |
- year_of_week | bigint | date | scalar | true | Year of the ISO week of the given date |
- year_of_week | bigint | timestamp(p) | scalar | true | Year of the ISO week of the given timestamp |
- year_of_week | bigint | timestamp(p) with time zone | scalar | true | Year of the ISO week of the given timestamp |
- yow | bigint | date | scalar | true | Year of the ISO week of the given date |
- yow | bigint | timestamp(p) | scalar | true | Year of the ISO week of the given timestamp |
- yow | bigint | timestamp(p) with time zone | scalar | true | Year of the ISO week of the given timestamp |
+ system | builtin | current_date | date | | scalar | true | Current date |
+ system | builtin | current_timezone | varchar | | scalar | true | Current time zone |
+ system | builtin | date_add | date | varchar(x), bigint, date | scalar | true | Add the specified amount of date to the given date |
+ system | builtin | date_add | time(p) | varchar(x), bigint, time(p) | scalar | true | Add the specified amount of time to the given time |
+ system | builtin | date_add | time(p) with time zone | varchar(x), bigint, time(p) with time zone | scalar | true | Add the specified amount of time to the given time |
+ system | builtin | date_add | timestamp(p) | varchar(x), bigint, timestamp(p) | scalar | true | Add the specified amount of time to the given timestamp |
+ system | builtin | date_add | timestamp(p) with time zone | varchar(x), bigint, timestamp(p) with time zone | scalar | true | Add the specified amount of time to the given timestamp |
+ system | builtin | date_diff | bigint | varchar(x), date, date | scalar | true | Difference of the given dates in the given unit |
+ system | builtin | date_diff | bigint | varchar(x), time(p) with time zone, time(p) with time zone | scalar | true | Difference of the given times in the given unit |
+ system | builtin | date_diff | bigint | varchar(x), time(p), time(p) | scalar | true | Difference of the given times in the given unit |
+ system | builtin | date_diff | bigint | varchar(x), timestamp(p) with time zone, timestamp(p) with time zone | scalar | true | Difference of the given times in the given unit |
+ system | builtin | date_diff | bigint | varchar(x), timestamp(p), timestamp(p) | scalar | true | Difference of the given times in the given unit |
+ system | builtin | date_format | varchar | timestamp(p) with time zone, varchar(x) | scalar | true | Formats the given timestamp by the given format |
+ system | builtin | date_format | varchar | timestamp(p), varchar(x) | scalar | true | Formats the given timestamp by the given format |
+ system | builtin | date_parse | timestamp(3) | varchar(x), varchar(y) | scalar | true | |
+ system | builtin | date_trunc | date | varchar(x), date | scalar | true | Truncate to the specified precision in the session timezone |
+ system | builtin | date_trunc | time(p) | varchar(x), time(p) | scalar | true | Truncate to the specified precision |
+ system | builtin | date_trunc | time(p) with time zone | varchar(x), time(p) with time zone | scalar | true | Truncate to the specified precision |
+ system | builtin | date_trunc | timestamp(p) | varchar(x), timestamp(p) | scalar | true | Truncate to the specified precision in the session timezone |
+ system | builtin | date_trunc | timestamp(p) with time zone | varchar(x), timestamp(p) with time zone | scalar | true | Truncate to the specified precision |
+ system | builtin | day | bigint | date | scalar | true | Day of the month of the given date |
+ system | builtin | day | bigint | interval day to second | scalar | true | Day of the month of the given interval |
+ system | builtin | day | bigint | timestamp(p) | scalar | true | Day of the month of the given timestamp |
+ system | builtin | day | bigint | timestamp(p) with time zone | scalar | true | Day of the month of the given timestamp |
+ system | builtin | day_of_month | bigint | date | scalar | true | Day of the month of the given date |
+ system | builtin | day_of_month | bigint | interval day to second | scalar | true | Day of the month of the given interval |
+ system | builtin | day_of_month | bigint | timestamp(p) | scalar | true | Day of the month of the given timestamp |
+ system | builtin | day_of_month | bigint | timestamp(p) with time zone | scalar | true | Day of the month of the given timestamp |
+ system | builtin | day_of_week | bigint | date | scalar | true | Day of the week of the given date |
+ system | builtin | day_of_week | bigint | timestamp(p) | scalar | true | Day of the week of the given timestamp |
+ system | builtin | day_of_week | bigint | timestamp(p) with time zone | scalar | true | Day of the week of the given timestamp |
+ system | builtin | day_of_year | bigint | date | scalar | true | Day of the year of the given date |
+ system | builtin | day_of_year | bigint | timestamp(p) | scalar | true | Day of the year of the given timestamp |
+ system | builtin | day_of_year | bigint | timestamp(p) with time zone | scalar | true | Day of the year of the given timestamp |
+ system | builtin | dow | bigint | date | scalar | true | Day of the week of the given date |
+ system | builtin | dow | bigint | timestamp(p) | scalar | true | Day of the week of the given timestamp |
+ system | builtin | dow | bigint | timestamp(p) with time zone | scalar | true | Day of the week of the given timestamp |
+ system | builtin | doy | bigint | date | scalar | true | Day of the year of the given date |
+ system | builtin | doy | bigint | timestamp(p) | scalar | true | Day of the year of the given timestamp |
+ system | builtin | doy | bigint | timestamp(p) with time zone | scalar | true | Day of the year of the given timestamp |
+ system | builtin | e | double | | scalar | true | Euler's number |
+ system | builtin | format_datetime | varchar | timestamp(p) with time zone, varchar(x) | scalar | true | Formats the given time by the given format |
+ system | builtin | format_datetime | varchar | timestamp(p), varchar(x) | scalar | true | Formats the given time by the given format |
+ system | builtin | from_iso8601_date | date | varchar(x) | scalar | true | |
+ system | builtin | from_iso8601_timestamp | timestamp(3) with time zone | varchar(x) | scalar | true | |
+ system | builtin | from_unixtime | timestamp(3) with time zone | double | scalar | true | |
+ system | builtin | from_unixtime | timestamp(3) with time zone | double, bigint, bigint | scalar | true | |
+ system | builtin | hour | bigint | interval day to second | scalar | true | Hour of the day of the given interval |
+ system | builtin | hour | bigint | time(p) | scalar | true | Hour of the day of the given time |
+ system | builtin | hour | bigint | time(p) with time zone | scalar | true | Hour of the day of the given time |
+ system | builtin | hour | bigint | timestamp(p) | scalar | true | Hour of the day of the given timestamp |
+ system | builtin | hour | bigint | timestamp(p) with time zone | scalar | true | Hour of the day of the given timestamp |
+ system | builtin | minute | bigint | interval day to second | scalar | true | Minute of the hour of the given interval |
+ system | builtin | minute | bigint | time(p) | scalar | true | Minute of the hour of the given time |
+ system | builtin | minute | bigint | time(p) with time zone | scalar | true | Minute of the hour of the given time |
+ system | builtin | minute | bigint | timestamp(p) | scalar | true | Minute of the hour of the given timestamp |
+ system | builtin | minute | bigint | timestamp(p) with time zone | scalar | true | Minute of the hour of the given timestamp |
+ system | builtin | month | bigint | date | scalar | true | Month of the year of the given date |
+ system | builtin | month | bigint | interval year to month | scalar | true | Month of the year of the given interval |
+ system | builtin | month | bigint | timestamp(p) | scalar | true | Month of the year of the given timestamp |
+ system | builtin | month | bigint | timestamp(p) with time zone | scalar | true | Month of the year of the given timestamp |
+ system | builtin | now | timestamp(3) with time zone | | scalar | true | Current timestamp with time zone |
+ system | builtin | parse_datetime | timestamp(3) with time zone | varchar(x), varchar(y) | scalar | true | Parses the specified date/time by the given format |
+ system | builtin | quarter | bigint | date | scalar | true | Quarter of the year of the given date |
+ system | builtin | quarter | bigint | timestamp(p) | scalar | true | Quarter of the year of the given timestamp |
+ system | builtin | quarter | bigint | timestamp(p) with time zone | scalar | true | Quarter of the year of the given timestamp |
+ system | builtin | timezone_hour | bigint | timestamp(p) with time zone | scalar | true | Time zone hour of the given timestamp |
+ system | builtin | timezone_minute | bigint | timestamp(p) with time zone | scalar | true | Time zone minute of the given timestamp |
+ system | builtin | to_unixtime | double | timestamp(p) with time zone | scalar | true | |
+ system | builtin | week | bigint | date | scalar | true | Week of the year of the given date |
+ system | builtin | week | bigint | timestamp(p) | scalar | true | Week of the year of the given timestamp |
+ system | builtin | week | bigint | timestamp(p) with time zone | scalar | true | Week of the year of the given timestamp |
+ system | builtin | week_of_year | bigint | date | scalar | true | Week of the year of the given date |
+ system | builtin | week_of_year | bigint | timestamp(p) | scalar | true | Week of the year of the given timestamp |
+ system | builtin | week_of_year | bigint | timestamp(p) with time zone | scalar | true | Week of the year of the given timestamp |
+ system | builtin | year | bigint | date | scalar | true | Year of the given date |
+ system | builtin | year | bigint | interval year to month | scalar | true | Year of the given interval |
+ system | builtin | year | bigint | timestamp(p) | scalar | true | Year of the given timestamp |
+ system | builtin | year | bigint | timestamp(p) with time zone | scalar | true | Year of the given timestamp |
+ system | builtin | year_of_week | bigint | date | scalar | true | Year of the ISO week of the given date |
+ system | builtin | year_of_week | bigint | timestamp(p) | scalar | true | Year of the ISO week of the given timestamp |
+ system | builtin | year_of_week | bigint | timestamp(p) with time zone | scalar | true | Year of the ISO week of the given timestamp |
+ system | builtin | yow | bigint | date | scalar | true | Year of the ISO week of the given date |
+ system | builtin | yow | bigint | timestamp(p) | scalar | true | Year of the ISO week of the given timestamp |
+ system | builtin | yow | bigint | timestamp(p) with time zone | scalar | true | Year of the ISO week of the given timestamp |

--- a/testing/trino-product-tests/src/main/resources/sql-tests/testcases/json_functions/checkJsonFunctionsRegistered.result
+++ b/testing/trino-product-tests/src/main/resources/sql-tests/testcases/json_functions/checkJsonFunctionsRegistered.result
@@ -1,21 +1,21 @@
 -- delimiter: |; ignoreOrder: true; ignoreExcessRows: true; trimValues:true
- json_array_contains | boolean | json, bigint | scalar | true | |
- json_array_contains | boolean | json, boolean | scalar | true | |
- json_array_contains | boolean | json, double | scalar | true | |
- json_array_contains | boolean | json, varchar(x) | scalar | true | |
- json_array_contains | boolean | varchar(x), bigint | scalar | true | |
- json_array_contains | boolean | varchar(x), boolean | scalar | true | |
- json_array_contains | boolean | varchar(x), double | scalar | true | |
- json_array_contains | boolean | varchar(x), varchar(y) | scalar | true | |
- json_array_get | json | json, bigint | scalar | true | |
- json_array_get | json | varchar(x), bigint | scalar | true | |
- json_array_length | bigint | json | scalar | true | |
- json_array_length | bigint | varchar(x) | scalar | true | |
- json_extract | json | json, jsonpath | scalar | true | |
- json_extract | json | varchar(x), jsonpath | scalar | true | |
- json_extract_scalar | varchar | json, jsonpath | scalar | true | |
- json_extract_scalar | varchar(x) | varchar(x), jsonpath | scalar | true | |
- json_format | varchar | json | scalar | true | |
- json_parse | json | varchar(x) | scalar | true | |
- json_size | bigint | json, jsonpath | scalar | true | |
- json_size | bigint | varchar(x), jsonpath | scalar | true | |
+ system | builtin | json_array_contains | boolean | json, bigint | scalar | true | |
+ system | builtin | json_array_contains | boolean | json, boolean | scalar | true | |
+ system | builtin | json_array_contains | boolean | json, double | scalar | true | |
+ system | builtin | json_array_contains | boolean | json, varchar(x) | scalar | true | |
+ system | builtin | json_array_contains | boolean | varchar(x), bigint | scalar | true | |
+ system | builtin | json_array_contains | boolean | varchar(x), boolean | scalar | true | |
+ system | builtin | json_array_contains | boolean | varchar(x), double | scalar | true | |
+ system | builtin | json_array_contains | boolean | varchar(x), varchar(y) | scalar | true | |
+ system | builtin | json_array_get | json | json, bigint | scalar | true | |
+ system | builtin | json_array_get | json | varchar(x), bigint | scalar | true | |
+ system | builtin | json_array_length | bigint | json | scalar | true | |
+ system | builtin | json_array_length | bigint | varchar(x) | scalar | true | |
+ system | builtin | json_extract | json | json, jsonpath | scalar | true | |
+ system | builtin | json_extract | json | varchar(x), jsonpath | scalar | true | |
+ system | builtin | json_extract_scalar | varchar | json, jsonpath | scalar | true | |
+ system | builtin | json_extract_scalar | varchar(x) | varchar(x), jsonpath | scalar | true | |
+ system | builtin | json_format | varchar | json | scalar | true | |
+ system | builtin | json_parse | json | varchar(x) | scalar | true | |
+ system | builtin | json_size | bigint | json, jsonpath | scalar | true | |
+ system | builtin | json_size | bigint | varchar(x), jsonpath | scalar | true | |

--- a/testing/trino-product-tests/src/main/resources/sql-tests/testcases/map_functions/checkMapFunctionsRegistered.result
+++ b/testing/trino-product-tests/src/main/resources/sql-tests/testcases/map_functions/checkMapFunctionsRegistered.result
@@ -1,6 +1,6 @@
 -- delimiter: |; ignoreOrder: true; ignoreExcessRows: true; trimValues:true
- cardinality | bigint | map(k,v) | scalar | true | Returns the cardinality (the number of key-value pairs) of the map |
- map | map(K,V) | array(K), array(V) | scalar | true | Constructs a map from the given key/value arrays |
- map_agg | map(k,v) | k, v | aggregate | true | Aggregates all the rows (key/value pairs) into a single map |
- map_keys | array(k) | map(k,v) | scalar | true | Returns the keys of the given map(K,V) as an array |
- map_values | array(v) | map(k,v) | scalar | true | Returns the values of the given map(K,V) as an array |
+ system | builtin | cardinality | bigint | map(k,v) | scalar | true | Returns the cardinality (the number of key-value pairs) of the map |
+ system | builtin | map | map(K,V) | array(K), array(V) | scalar | true | Constructs a map from the given key/value arrays |
+ system | builtin | map_agg | map(k,v) | k, v | aggregate | true | Aggregates all the rows (key/value pairs) into a single map |
+ system | builtin | map_keys | array(k) | map(k,v) | scalar | true | Returns the keys of the given map(K,V) as an array |
+ system | builtin | map_values | array(v) | map(k,v) | scalar | true | Returns the values of the given map(K,V) as an array |

--- a/testing/trino-product-tests/src/main/resources/sql-tests/testcases/math_functions/checkMathFunctionsRegistered.result
+++ b/testing/trino-product-tests/src/main/resources/sql-tests/testcases/math_functions/checkMathFunctionsRegistered.result
@@ -1,91 +1,91 @@
 -- delimiter: |; ignoreOrder: true; ignoreExcessRows: true; trimValues:true
- abs | bigint | bigint | scalar | true | Absolute value |
- abs | double | double | scalar | true | Absolute value |
- acos | double | double | scalar | true | Arc cosine |
- approx_distinct | bigint | t | aggregate | true | |
- approx_distinct | bigint | t, double | aggregate | true | |
- approx_percentile | bigint | bigint, double, double | aggregate | true | |
- approx_percentile | bigint | bigint, double | aggregate | true | |
- approx_percentile | double | double, double, double | aggregate | true | |
- approx_percentile | double | double, double | aggregate | true | |
- approx_set | hyperloglog | bigint | aggregate | true | |
- approx_set | hyperloglog | double | aggregate | true | |
- arbitrary | t | t | aggregate | true | Return an arbitrary non-null input value |
- asin | double | double | scalar | true | Arc sine |
- atan | double | double | scalar | true | Arc tangent |
- atan2 | double | double, double | scalar | true | Arc tangent of given fraction |
- avg | double | bigint | aggregate | true | |
- avg | double | double | aggregate | true | |
- bool_and | boolean | boolean | aggregate | true | |
- bool_or | boolean | boolean | aggregate | true | |
- cbrt | double | double | scalar | true | Cube root |
- ceil | bigint | bigint | scalar | true | Round up to nearest integer |
- ceil | double | double | scalar | true | Round up to nearest integer |
- ceiling | bigint | bigint | scalar | true | Round up to nearest integer |
- ceiling | double | double | scalar | true | Round up to nearest integer |
- corr | double | double, double | aggregate | true | |
- cos | double | double | scalar | true | Cosine |
- cosh | double | double | scalar | true | Hyperbolic cosine |
- count | bigint | | aggregate | true | |
- count | bigint | t | aggregate | true | Counts the non-null values |
- count_if | bigint | boolean | aggregate | true | |
- covar_pop | double | double, double | aggregate | true | |
- covar_samp | double | double, double | aggregate | true | |
- cume_dist | double | | window | true | |
- degrees | double | double | scalar | true | Converts an angle in radians to degrees |
- dense_rank | bigint | | window | true | |
- e | double | | scalar | true | Euler's number |
- every | boolean | boolean | aggregate | true | |
- exp | double | double | scalar | true | Euler's number raised to the given power |
- floor | bigint | bigint | scalar | true | Round down to nearest integer |
- floor | double | double | scalar | true | Round down to nearest integer |
- geometric_mean | double | bigint | aggregate | true | |
- geometric_mean | double | double | aggregate | true | |
- greatest | E | E | scalar | true | Get the largest of the given values |
- infinity | double | | scalar | true | Infinity |
- ln | double | double | scalar | true | Natural logarithm |
- log10 | double | double | scalar | true | Logarithm to base 10 |
- log2 | double | double | scalar | true | Logarithm to base 2 |
- max | t | t | aggregate | true | Returns the maximum value of the argument |
- max_by | v | v, k | aggregate | true | Returns the value of the first argument, associated with the maximum value of the second argument |
- min | t | t | aggregate | true | Returns the minimum value of the argument |
- min_by | v | v, k | aggregate | true | Returns the value of the first argument, associated with the minimum value of the second argument |
- mod | bigint | bigint, bigint | scalar | true | Remainder of given quotient |
- mod | double | double, double | scalar | true | Remainder of given quotient |
- nan | double | | scalar | true | Constant representing not-a-number |
- nth_value | t | t, bigint | window | true | |
- ntile | bigint | bigint | window | true | |
- percent_rank | double | | window | true | |
- pi | double | | scalar | true | The constant Pi |
- pow | double | double, double | scalar | true | Value raised to the power of exponent |
- power | double | double, double | scalar | true | Value raised to the power of exponent |
- radians | double | double | scalar | true | Converts an angle in degrees to radians |
- rand | double | | scalar | false | A pseudo-random value |
- random | double | | scalar | false | A pseudo-random value |
- rank | bigint | | window | true | |
- regr_intercept | double | double, double | aggregate | true | |
- regr_slope | double | double, double | aggregate | true | |
- round | bigint | bigint | scalar | true | Round to nearest integer |
- round | bigint | bigint, integer | scalar | true | Round to nearest integer |
- round | double | double | scalar | true | Round to nearest integer |
- round | double | double, integer | scalar | true | Round to given number of decimal places |
- row_number | bigint | | window | true | |
- sin | double | double | scalar | true | Sine |
- sinh | double | double | scalar | true | Hyperbolic sine |
- sqrt | double | double | scalar | true | Square root |
- stddev | double | bigint | aggregate | true | Returns the sample standard deviation of the argument |
- stddev | double | double | aggregate | true | Returns the sample standard deviation of the argument |
- stddev_pop | double | bigint | aggregate | true | Returns the population standard deviation of the argument |
- stddev_pop | double | double | aggregate | true | Returns the population standard deviation of the argument |
- stddev_samp | double | bigint | aggregate | true | Returns the sample standard deviation of the argument |
- stddev_samp | double | double | aggregate | true | Returns the sample standard deviation of the argument |
- sum | bigint | bigint | aggregate | true | |
- sum | double | double | aggregate | true | |
- tan | double | double | scalar | true | Tangent |
- tanh | double | double | scalar | true | Hyperbolic tangent |
- var_pop | double | bigint | aggregate | true | Returns the population variance of the argument |
- var_pop | double | double | aggregate | true | Returns the population variance of the argument |
- var_samp | double | bigint | aggregate | true | Returns the sample variance of the argument |
- var_samp | double | double | aggregate | true | Returns the sample variance of the argument |
- variance | double | bigint | aggregate | true | Returns the sample variance of the argument |
- variance | double | double | aggregate | true | Returns the sample variance of the argument |
+ system | builtin | abs | bigint | bigint | scalar | true | Absolute value |
+ system | builtin | abs | double | double | scalar | true | Absolute value |
+ system | builtin | acos | double | double | scalar | true | Arc cosine |
+ system | builtin | approx_distinct | bigint | t | aggregate | true | |
+ system | builtin | approx_distinct | bigint | t, double | aggregate | true | |
+ system | builtin | approx_percentile | bigint | bigint, double, double | aggregate | true | |
+ system | builtin | approx_percentile | bigint | bigint, double | aggregate | true | |
+ system | builtin | approx_percentile | double | double, double, double | aggregate | true | |
+ system | builtin | approx_percentile | double | double, double | aggregate | true | |
+ system | builtin | approx_set | hyperloglog | bigint | aggregate | true | |
+ system | builtin | approx_set | hyperloglog | double | aggregate | true | |
+ system | builtin | arbitrary | t | t | aggregate | true | Return an arbitrary non-null input value |
+ system | builtin | asin | double | double | scalar | true | Arc sine |
+ system | builtin | atan | double | double | scalar | true | Arc tangent |
+ system | builtin | atan2 | double | double, double | scalar | true | Arc tangent of given fraction |
+ system | builtin | avg | double | bigint | aggregate | true | |
+ system | builtin | avg | double | double | aggregate | true | |
+ system | builtin | bool_and | boolean | boolean | aggregate | true | |
+ system | builtin | bool_or | boolean | boolean | aggregate | true | |
+ system | builtin | cbrt | double | double | scalar | true | Cube root |
+ system | builtin | ceil | bigint | bigint | scalar | true | Round up to nearest integer |
+ system | builtin | ceil | double | double | scalar | true | Round up to nearest integer |
+ system | builtin | ceiling | bigint | bigint | scalar | true | Round up to nearest integer |
+ system | builtin | ceiling | double | double | scalar | true | Round up to nearest integer |
+ system | builtin | corr | double | double, double | aggregate | true | |
+ system | builtin | cos | double | double | scalar | true | Cosine |
+ system | builtin | cosh | double | double | scalar | true | Hyperbolic cosine |
+ system | builtin | count | bigint | | aggregate | true | |
+ system | builtin | count | bigint | t | aggregate | true | Counts the non-null values |
+ system | builtin | count_if | bigint | boolean | aggregate | true | |
+ system | builtin | covar_pop | double | double, double | aggregate | true | |
+ system | builtin | covar_samp | double | double, double | aggregate | true | |
+ system | builtin | cume_dist | double | | window | true | |
+ system | builtin | degrees | double | double | scalar | true | Converts an angle in radians to degrees |
+ system | builtin | dense_rank | bigint | | window | true | |
+ system | builtin | e | double | | scalar | true | Euler's number |
+ system | builtin | every | boolean | boolean | aggregate | true | |
+ system | builtin | exp | double | double | scalar | true | Euler's number raised to the given power |
+ system | builtin | floor | bigint | bigint | scalar | true | Round down to nearest integer |
+ system | builtin | floor | double | double | scalar | true | Round down to nearest integer |
+ system | builtin | geometric_mean | double | bigint | aggregate | true | |
+ system | builtin | geometric_mean | double | double | aggregate | true | |
+ system | builtin | greatest | E | E | scalar | true | Get the largest of the given values |
+ system | builtin | infinity | double | | scalar | true | Infinity |
+ system | builtin | ln | double | double | scalar | true | Natural logarithm |
+ system | builtin | log10 | double | double | scalar | true | Logarithm to base 10 |
+ system | builtin | log2 | double | double | scalar | true | Logarithm to base 2 |
+ system | builtin | max | t | t | aggregate | true | Returns the maximum value of the argument |
+ system | builtin | max_by | v | v, k | aggregate | true | Returns the value of the first argument, associated with the maximum value of the second argument |
+ system | builtin | min | t | t | aggregate | true | Returns the minimum value of the argument |
+ system | builtin | min_by | v | v, k | aggregate | true | Returns the value of the first argument, associated with the minimum value of the second argument |
+ system | builtin | mod | bigint | bigint, bigint | scalar | true | Remainder of given quotient |
+ system | builtin | mod | double | double, double | scalar | true | Remainder of given quotient |
+ system | builtin | nan | double | | scalar | true | Constant representing not-a-number |
+ system | builtin | nth_value | t | t, bigint | window | true | |
+ system | builtin | ntile | bigint | bigint | window | true | |
+ system | builtin | percent_rank | double | | window | true | |
+ system | builtin | pi | double | | scalar | true | The constant Pi |
+ system | builtin | pow | double | double, double | scalar | true | Value raised to the power of exponent |
+ system | builtin | power | double | double, double | scalar | true | Value raised to the power of exponent |
+ system | builtin | radians | double | double | scalar | true | Converts an angle in degrees to radians |
+ system | builtin | rand | double | | scalar | false | A pseudo-random value |
+ system | builtin | random | double | | scalar | false | A pseudo-random value |
+ system | builtin | rank | bigint | | window | true | |
+ system | builtin | regr_intercept | double | double, double | aggregate | true | |
+ system | builtin | regr_slope | double | double, double | aggregate | true | |
+ system | builtin | round | bigint | bigint | scalar | true | Round to nearest integer |
+ system | builtin | round | bigint | bigint, integer | scalar | true | Round to nearest integer |
+ system | builtin | round | double | double | scalar | true | Round to nearest integer |
+ system | builtin | round | double | double, integer | scalar | true | Round to given number of decimal places |
+ system | builtin | row_number | bigint | | window | true | |
+ system | builtin | sin | double | double | scalar | true | Sine |
+ system | builtin | sinh | double | double | scalar | true | Hyperbolic sine |
+ system | builtin | sqrt | double | double | scalar | true | Square root |
+ system | builtin | stddev | double | bigint | aggregate | true | Returns the sample standard deviation of the argument |
+ system | builtin | stddev | double | double | aggregate | true | Returns the sample standard deviation of the argument |
+ system | builtin | stddev_pop | double | bigint | aggregate | true | Returns the population standard deviation of the argument |
+ system | builtin | stddev_pop | double | double | aggregate | true | Returns the population standard deviation of the argument |
+ system | builtin | stddev_samp | double | bigint | aggregate | true | Returns the sample standard deviation of the argument |
+ system | builtin | stddev_samp | double | double | aggregate | true | Returns the sample standard deviation of the argument |
+ system | builtin | sum | bigint | bigint | aggregate | true | |
+ system | builtin | sum | double | double | aggregate | true | |
+ system | builtin | tan | double | double | scalar | true | Tangent |
+ system | builtin | tanh | double | double | scalar | true | Hyperbolic tangent |
+ system | builtin | var_pop | double | bigint | aggregate | true | Returns the population variance of the argument |
+ system | builtin | var_pop | double | double | aggregate | true | Returns the population variance of the argument |
+ system | builtin | var_samp | double | bigint | aggregate | true | Returns the sample variance of the argument |
+ system | builtin | var_samp | double | double | aggregate | true | Returns the sample variance of the argument |
+ system | builtin | variance | double | bigint | aggregate | true | Returns the sample variance of the argument |
+ system | builtin | variance | double | double | aggregate | true | Returns the sample variance of the argument |

--- a/testing/trino-product-tests/src/main/resources/sql-tests/testcases/regex_functions/checkRegexFunctionsRegistered.result
+++ b/testing/trino-product-tests/src/main/resources/sql-tests/testcases/regex_functions/checkRegexFunctionsRegistered.result
@@ -1,9 +1,9 @@
 -- delimiter: |; ignoreOrder: true; ignoreExcessRows: true; trimValues:true
-regexp_extract | varchar(x) | varchar(x), joniregexp | scalar | true | String extracted using the given pattern |
-regexp_extract | varchar(x) | varchar(x), joniregexp, bigint | scalar | true | Returns regex group of extracted string with a pattern |
-regexp_extract_all | array(varchar(x)) | varchar(x), joniregexp | scalar | true | String(s) extracted using the given pattern |
-regexp_extract_all | array(varchar(x)) | varchar(x), joniregexp, bigint | scalar | true | Group(s) extracted using the given pattern |
-regexp_like | boolean | varchar(x), joniregexp | scalar | true | Returns whether the pattern is contained within the string |
-regexp_replace | varchar(x) | varchar(x), joniregexp | scalar | true | Removes substrings matching a regular expression |
-regexp_replace | varchar(z) | varchar(x), joniregexp, varchar(y) | scalar | true | Replaces substrings matching a regular expression by given string |
-regexp_split | array(varchar(x)) | varchar(x), joniregexp | scalar | true | Returns array of strings split by pattern |
+system | builtin | regexp_extract | varchar(x) | varchar(x), joniregexp | scalar | true | String extracted using the given pattern |
+system | builtin | regexp_extract | varchar(x) | varchar(x), joniregexp, bigint | scalar | true | Returns regex group of extracted string with a pattern |
+system | builtin | regexp_extract_all | array(varchar(x)) | varchar(x), joniregexp | scalar | true | String(s) extracted using the given pattern |
+system | builtin | regexp_extract_all | array(varchar(x)) | varchar(x), joniregexp, bigint | scalar | true | Group(s) extracted using the given pattern |
+system | builtin | regexp_like | boolean | varchar(x), joniregexp | scalar | true | Returns whether the pattern is contained within the string |
+system | builtin | regexp_replace | varchar(x) | varchar(x), joniregexp | scalar | true | Removes substrings matching a regular expression |
+system | builtin | regexp_replace | varchar(z) | varchar(x), joniregexp, varchar(y) | scalar | true | Replaces substrings matching a regular expression by given string |
+system | builtin | regexp_split | array(varchar(x)) | varchar(x), joniregexp | scalar | true | Returns array of strings split by pattern |

--- a/testing/trino-product-tests/src/main/resources/sql-tests/testcases/string_functions/checkStringFunctionsRegistered.result
+++ b/testing/trino-product-tests/src/main/resources/sql-tests/testcases/string_functions/checkStringFunctionsRegistered.result
@@ -1,19 +1,19 @@
 -- delimiter: |; ignoreOrder: true; ignoreExcessRows: true; trimValues:true
- chr | varchar(1) | bigint | scalar | true | Convert Unicode code point to a string |
- concat | varchar | varchar | scalar | true | Concatenates given strings |
- length | bigint | varchar(x) | scalar | true | Count of code points of the given string |
- lower | varchar(x)| varchar(x)| scalar | true | Converts the string to lower case |
- ltrim | varchar(x)| varchar(x)| scalar | true | Removes whitespace from the beginning of a string |
- replace | varchar(x) | varchar(x), varchar(y) | scalar | true | Greedily removes occurrences of a pattern in a string |
- replace | varchar(u) | varchar(x), varchar(y), varchar(z) | scalar | true | Greedily replaces occurrences of a pattern with a string |
- reverse | varchar(x) | varchar(x) | scalar | true | Reverse all code points in a given string |
- rtrim | varchar(x) | varchar(x) | scalar | true | Removes whitespace from the end of a string |
- split | array(varchar(x)) | varchar(x), varchar(y) | scalar | true | |
- split | array(varchar(x)) | varchar(x), varchar(y), bigint | scalar | true | |
- split_part | varchar(x) | varchar(x), varchar(y), bigint | scalar | true | Splits a string by a delimiter and returns the specified field (counting from one) |
- strpos | bigint | varchar(x), varchar(y) | scalar | true | Returns index of first occurrence of a substring (or 0 if not found) |
- strpos | bigint | varchar(x), varchar(y), bigint | scalar | true | Returns index of n-th occurrence of a substring (or 0 if not found) |
- substr | varchar(x) | varchar(x), bigint | scalar | true | Suffix starting at given index |
- substr | varchar(x) | varchar(x), bigint, bigint | scalar | true | Substring of given length starting at an index |
- trim | varchar(x) | varchar(x) | scalar | true | Removes whitespace from the beginning and end of a string |
- upper | varchar(x) | varchar(x) | scalar | true | Converts the string to upper case |
+ system | builtin | chr | varchar(1) | bigint | scalar | true | Convert Unicode code point to a string |
+ system | builtin | concat | varchar | varchar | scalar | true | Concatenates given strings |
+ system | builtin | length | bigint | varchar(x) | scalar | true | Count of code points of the given string |
+ system | builtin | lower | varchar(x)| varchar(x)| scalar | true | Converts the string to lower case |
+ system | builtin | ltrim | varchar(x)| varchar(x)| scalar | true | Removes whitespace from the beginning of a string |
+ system | builtin | replace | varchar(x) | varchar(x), varchar(y) | scalar | true | Greedily removes occurrences of a pattern in a string |
+ system | builtin | replace | varchar(u) | varchar(x), varchar(y), varchar(z) | scalar | true | Greedily replaces occurrences of a pattern with a string |
+ system | builtin | reverse | varchar(x) | varchar(x) | scalar | true | Reverse all code points in a given string |
+ system | builtin | rtrim | varchar(x) | varchar(x) | scalar | true | Removes whitespace from the end of a string |
+ system | builtin | split | array(varchar(x)) | varchar(x), varchar(y) | scalar | true | |
+ system | builtin | split | array(varchar(x)) | varchar(x), varchar(y), bigint | scalar | true | |
+ system | builtin | split_part | varchar(x) | varchar(x), varchar(y), bigint | scalar | true | Splits a string by a delimiter and returns the specified field (counting from one) |
+ system | builtin | strpos | bigint | varchar(x), varchar(y) | scalar | true | Returns index of first occurrence of a substring (or 0 if not found) |
+ system | builtin | strpos | bigint | varchar(x), varchar(y), bigint | scalar | true | Returns index of n-th occurrence of a substring (or 0 if not found) |
+ system | builtin | substr | varchar(x) | varchar(x), bigint | scalar | true | Suffix starting at given index |
+ system | builtin | substr | varchar(x) | varchar(x), bigint, bigint | scalar | true | Substring of given length starting at an index |
+ system | builtin | trim | varchar(x) | varchar(x) | scalar | true | Removes whitespace from the beginning and end of a string |
+ system | builtin | upper | varchar(x) | varchar(x) | scalar | true | Converts the string to upper case |

--- a/testing/trino-product-tests/src/main/resources/sql-tests/testcases/url_functions/checkUrlFunctionsRegistered.result
+++ b/testing/trino-product-tests/src/main/resources/sql-tests/testcases/url_functions/checkUrlFunctionsRegistered.result
@@ -1,8 +1,8 @@
 -- delimiter: |; ignoreOrder: true; ignoreExcessRows: true; trimValues:true
- url_extract_fragment | varchar(x) | varchar(x) | scalar | true | Extract fragment from url |
- url_extract_host | varchar(x) | varchar(x) | scalar | true | Extract host from url |
- url_extract_parameter | varchar(x) | varchar(x), varchar(y) | scalar | true | Extract query parameter from url |
- url_extract_path | varchar(x) | varchar(x) | scalar | true | Extract part from url |
- url_extract_port | bigint | varchar(x) | scalar | true | Extract port from url |
- url_extract_protocol | varchar(x) | varchar(x) | scalar | true | Extract protocol from url |
- url_extract_query | varchar(x) | varchar(x) | scalar | true | Extract query from url |
+ system | builtin | url_extract_fragment | varchar(x) | varchar(x) | scalar | true | Extract fragment from url |
+ system | builtin | url_extract_host | varchar(x) | varchar(x) | scalar | true | Extract host from url |
+ system | builtin | url_extract_parameter | varchar(x) | varchar(x), varchar(y) | scalar | true | Extract query parameter from url |
+ system | builtin | url_extract_path | varchar(x) | varchar(x) | scalar | true | Extract part from url |
+ system | builtin | url_extract_port | bigint | varchar(x) | scalar | true | Extract port from url |
+ system | builtin | url_extract_protocol | varchar(x) | varchar(x) | scalar | true | Extract protocol from url |
+ system | builtin | url_extract_query | varchar(x) | varchar(x) | scalar | true | Extract query from url |

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -6172,56 +6172,56 @@ public abstract class AbstractTestEngineOnlyQueries
     {
         MaterializedResult result = computeActual("SHOW FUNCTIONS");
         ImmutableMultimap<String, MaterializedRow> functions = Multimaps.index(result.getMaterializedRows(), input -> {
-            assertThat(input.getFieldCount()).isEqualTo(6);
-            return (String) input.getField(0);
+            assertThat(input.getFieldCount()).isEqualTo(8);
+            return (String) input.getField(2);
         });
 
         assertThat(functions.containsKey("avg"))
                 .describedAs("Expected function names " + functions + " to contain 'avg'")
                 .isTrue();
         assertThat(functions.get("avg").asList().size()).isEqualTo(6);
-        assertThat(functions.get("avg").asList().get(0).getField(1)).isEqualTo("decimal(p,s)");
-        assertThat(functions.get("avg").asList().get(0).getField(2)).isEqualTo("decimal(p,s)");
-        assertThat(functions.get("avg").asList().get(0).getField(3)).isEqualTo("aggregate");
-        assertThat(functions.get("avg").asList().get(1).getField(1)).isEqualTo("double");
-        assertThat(functions.get("avg").asList().get(1).getField(2)).isEqualTo("bigint");
-        assertThat(functions.get("avg").asList().get(1).getField(3)).isEqualTo("aggregate");
-        assertThat(functions.get("avg").asList().get(2).getField(1)).isEqualTo("double");
-        assertThat(functions.get("avg").asList().get(2).getField(2)).isEqualTo("double");
-        assertThat(functions.get("avg").asList().get(2).getField(3)).isEqualTo("aggregate");
-        assertThat(functions.get("avg").asList().get(3).getField(1)).isEqualTo("interval day to second");
-        assertThat(functions.get("avg").asList().get(3).getField(2)).isEqualTo("interval day to second");
-        assertThat(functions.get("avg").asList().get(3).getField(3)).isEqualTo("aggregate");
-        assertThat(functions.get("avg").asList().get(4).getField(1)).isEqualTo("interval year to month");
-        assertThat(functions.get("avg").asList().get(4).getField(2)).isEqualTo("interval year to month");
-        assertThat(functions.get("avg").asList().get(4).getField(3)).isEqualTo("aggregate");
-        assertThat(functions.get("avg").asList().get(5).getField(1)).isEqualTo("real");
-        assertThat(functions.get("avg").asList().get(5).getField(2)).isEqualTo("real");
-        assertThat(functions.get("avg").asList().get(5).getField(3)).isEqualTo("aggregate");
+        assertThat(functions.get("avg").asList().get(0).getField(3)).isEqualTo("decimal(p,s)");
+        assertThat(functions.get("avg").asList().get(0).getField(4)).isEqualTo("decimal(p,s)");
+        assertThat(functions.get("avg").asList().get(0).getField(5)).isEqualTo("aggregate");
+        assertThat(functions.get("avg").asList().get(1).getField(3)).isEqualTo("double");
+        assertThat(functions.get("avg").asList().get(1).getField(4)).isEqualTo("bigint");
+        assertThat(functions.get("avg").asList().get(1).getField(5)).isEqualTo("aggregate");
+        assertThat(functions.get("avg").asList().get(2).getField(3)).isEqualTo("double");
+        assertThat(functions.get("avg").asList().get(2).getField(4)).isEqualTo("double");
+        assertThat(functions.get("avg").asList().get(2).getField(5)).isEqualTo("aggregate");
+        assertThat(functions.get("avg").asList().get(3).getField(3)).isEqualTo("interval day to second");
+        assertThat(functions.get("avg").asList().get(3).getField(4)).isEqualTo("interval day to second");
+        assertThat(functions.get("avg").asList().get(3).getField(5)).isEqualTo("aggregate");
+        assertThat(functions.get("avg").asList().get(4).getField(3)).isEqualTo("interval year to month");
+        assertThat(functions.get("avg").asList().get(4).getField(4)).isEqualTo("interval year to month");
+        assertThat(functions.get("avg").asList().get(4).getField(5)).isEqualTo("aggregate");
+        assertThat(functions.get("avg").asList().get(5).getField(3)).isEqualTo("real");
+        assertThat(functions.get("avg").asList().get(5).getField(4)).isEqualTo("real");
+        assertThat(functions.get("avg").asList().get(5).getField(5)).isEqualTo("aggregate");
 
         assertThat(functions.containsKey("abs"))
                 .describedAs("Expected function names " + functions + " to contain 'abs'")
                 .isTrue();
-        assertThat(functions.get("abs").asList().get(0).getField(3)).isEqualTo("scalar");
-        assertThat(functions.get("abs").asList().get(0).getField(4)).isEqualTo(true);
+        assertThat(functions.get("abs").asList().get(0).getField(5)).isEqualTo("scalar");
+        assertThat(functions.get("abs").asList().get(0).getField(6)).isEqualTo(true);
 
         assertThat(functions.containsKey("rand"))
                 .describedAs("Expected function names " + functions + " to contain 'rand'")
                 .isTrue();
-        assertThat(functions.get("rand").asList().get(0).getField(3)).isEqualTo("scalar");
-        assertThat(functions.get("rand").asList().get(0).getField(4)).isEqualTo(false);
+        assertThat(functions.get("rand").asList().get(0).getField(5)).isEqualTo("scalar");
+        assertThat(functions.get("rand").asList().get(0).getField(6)).isEqualTo(false);
 
         assertThat(functions.containsKey("rank"))
                 .describedAs("Expected function names " + functions + " to contain 'rank'")
                 .isTrue();
-        assertThat(functions.get("rank").asList().get(0).getField(3)).isEqualTo("window");
+        assertThat(functions.get("rank").asList().get(0).getField(5)).isEqualTo("window");
 
         assertThat(functions.containsKey("rank"))
                 .describedAs("Expected function names " + functions + " to contain 'split_part'")
                 .isTrue();
-        assertThat(functions.get("split_part").asList().get(0).getField(1)).isEqualTo("varchar(x)");
-        assertThat(functions.get("split_part").asList().get(0).getField(2)).isEqualTo("varchar(x), varchar(y), bigint");
-        assertThat(functions.get("split_part").asList().get(0).getField(3)).isEqualTo("scalar");
+        assertThat(functions.get("split_part").asList().get(0).getField(3)).isEqualTo("varchar(x)");
+        assertThat(functions.get("split_part").asList().get(0).getField(4)).isEqualTo("varchar(x), varchar(y), bigint");
+        assertThat(functions.get("split_part").asList().get(0).getField(5)).isEqualTo("scalar");
 
         assertThat(functions.containsKey("like"))
                 .describedAs("Expected function names " + functions + " not to contain 'like'")
@@ -6593,7 +6593,7 @@ public abstract class AbstractTestEngineOnlyQueries
     public void testColumnNames()
     {
         MaterializedResult showFunctionsResult = computeActual("SHOW FUNCTIONS");
-        assertThat(showFunctionsResult.getColumnNames()).isEqualTo(ImmutableList.of("Function", "Return Type", "Argument Types", "Function Type", "Deterministic", "Description"));
+        assertThat(showFunctionsResult.getColumnNames()).isEqualTo(ImmutableList.of("Catalog", "Schema", "Function", "Return Type", "Argument Types", "Function Type", "Deterministic", "Description"));
 
         MaterializedResult showCatalogsResult = computeActual("SHOW CATALOGS");
         assertThat(showCatalogsResult.getColumnNames()).isEqualTo(ImmutableList.of("Catalog"));

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -6705,8 +6705,8 @@ public abstract class BaseConnectorTest
     @Test
     public void testCreateFunction()
     {
+        String catalog = getQueryRunner().getDefaultSession().getCatalog().orElseThrow();
         if (!hasBehavior(SUPPORTS_CREATE_FUNCTION)) {
-            String catalog = getQueryRunner().getDefaultSession().getCatalog().orElseThrow();
             String schema = getQueryRunner().getDefaultSession().getSchema().orElseThrow();
             assertQueryFails(
                     "CREATE FUNCTION " + catalog + "." + schema + ".test_create_function" + randomNameSuffix() + "(x integer) RETURNS bigint COMMENT 't42' RETURN x * 42",
@@ -6731,8 +6731,8 @@ public abstract class BaseConnectorTest
                 .result()
                 .skippingTypesCheck()
                 .containsAll(resultBuilder(getSession())
-                        .row(name, "bigint", "integer", "scalar", true, "t42")
-                        .row(name, "double", "double", "scalar", true, "t88")
+                        .row(catalog, "functions", name, "bigint", "integer", "scalar", true, "t42")
+                        .row(catalog, "functions", name, "double", "double", "scalar", true, "t88")
                         .build());
 
         String integerFunctionSql = """
@@ -6765,10 +6765,10 @@ public abstract class BaseConnectorTest
                 .result()
                 .skippingTypesCheck()
                 .containsAll(resultBuilder(getSession())
-                        .row(name, "bigint", "integer", "scalar", true, "t42")
-                        .row(name, "bigint", "bigint", "scalar", true, "")
-                        .row(name, "double", "double", "scalar", true, "t88")
-                        .row(name2, "varchar", "varchar", "scalar", true, "")
+                        .row(catalog, "functions", name, "bigint", "integer", "scalar", true, "t42")
+                        .row(catalog, "functions", name, "bigint", "bigint", "scalar", true, "")
+                        .row(catalog, "functions", name, "double", "double", "scalar", true, "t88")
+                        .row(catalog, "functions", name2, "varchar", "varchar", "scalar", true, "")
                         .build());
 
         String bigintFunctionSql = """
@@ -6792,18 +6792,18 @@ public abstract class BaseConnectorTest
                 .result()
                 .skippingTypesCheck()
                 .containsAll(resultBuilder(getSession())
-                        .row(name3, "double", "", "scalar", false, "")
+                        .row(catalog, "functions", name3, "double", "", "scalar", false, "")
                         .build());
 
         assertThat(query("SHOW FUNCTIONS FROM " + computeScalar("SELECT current_path")))
                 .result()
                 .skippingTypesCheck()
                 .matches(resultBuilder(getSession())
-                        .row(name, "bigint", "integer", "scalar", true, "t42")
-                        .row(name, "bigint", "bigint", "scalar", true, "")
-                        .row(name, "double", "double", "scalar", true, "t88")
-                        .row(name2, "varchar", "varchar", "scalar", true, "")
-                        .row(name3, "double", "", "scalar", false, "")
+                        .row(catalog, "functions", name, "bigint", "integer", "scalar", true, "t42")
+                        .row(catalog, "functions", name, "bigint", "bigint", "scalar", true, "")
+                        .row(catalog, "functions", name, "double", "double", "scalar", true, "t88")
+                        .row(catalog, "functions", name2, "varchar", "varchar", "scalar", true, "")
+                        .row(catalog, "functions", name3, "double", "", "scalar", false, "")
                         .build());
 
         assertThat(computeActual("SHOW CREATE FUNCTION " + name3).getOnlyValue())


### PR DESCRIPTION
## Description

Add `Catalog` and `Schema` fields to `SHOW FUNCTIONS` results.
https://github.com/trinodb/trino/pull/16107#discussion_r1106096831

## Release notes

```markdown
# General
* Add catalog and schema to `SHOW FUNCTIONS` results. ({issue}`issuenumber`)
```
