### PR TITLE
Expand stale PR timeframe

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,7 +20,7 @@ jobs:
           close-pr-message: 'Closing this pull request, as it has been stale for six weeks. Feel free to re-open at any time.'
           stale-pr-label: 'stale'
           exempt-pr-labels: 'stale-ignore'
-          start-date: '2023-01-01T00:00:00Z'
+          start-date: '2020-01-01T00:00:00Z'
           exempt-draft-pr: true
           operations-per-run: 200
           # Avoid processing issues completely, see https://github.com/actions/stale/issues/1112


### PR DESCRIPTION
## Description

Initially we had too many open PRs for that expanded timeframe that covers all open PRs. We are now at 300 so we can activate this. It will cause messages for the older open PRs and we can then triage them easier .. just like all the others that are live now.

## Additional context and related issues

Also a model for what we will do with issues soonish.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
