### PR TITLE
Remove deprecated `ConnectorSplit.getInfo` method

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorSplit.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorSplit.java
@@ -48,13 +48,6 @@ public interface ConnectorSplit
         return Map.of();
     }
 
-    @Deprecated(forRemoval = true)
-    @JsonIgnore
-    default Object getInfo()
-    {
-        throw new UnsupportedOperationException("getInfo is deprecated and will be removed in the future. Use getSplitInfo instead.");
-    }
-
     default SplitWeight getSplitWeight()
     {
         return SplitWeight.standard();


### PR DESCRIPTION
## Description

This method has been deprecated since version 445. 

## Release notes

```markdown
# SPI
* Remove the deprecated `ConnectorSplit.getInfo method` method.
  Use `getSplitInfo` method instead. ({issue}`23271`)
```
