### PR TITLE
Remove deprecated constructor from ConstraintApplicationResult

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConstraintApplicationResult.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConstraintApplicationResult.java
@@ -29,18 +29,6 @@ public class ConstraintApplicationResult<T>
     private final boolean precalculateStatistics;
 
     /**
-     * @param precalculateStatistics Indicates whether engine should consider calculating statistics based on the plan before pushdown,
-     * as the connector may be unable to provide good table statistics for {@code handle}.
-     *
-     * @deprecated Use {@link #ConstraintApplicationResult(Object, TupleDomain, ConnectorExpression, boolean)}.
-     */
-    @Deprecated
-    public ConstraintApplicationResult(T handle, TupleDomain<ColumnHandle> remainingFilter, boolean precalculateStatistics)
-    {
-        this(handle, remainingFilter, Optional.empty(), precalculateStatistics);
-    }
-
-    /**
      * @param remainingExpression the remaining expression, which will be AND-ed with {@code remainingFilter},
      * @param precalculateStatistics Indicates whether engine should consider calculating statistics based on the plan before pushdown,
      * as the connector may be unable to provide good table statistics for {@code handle}.


### PR DESCRIPTION
## Description

This constructor has been deprecated since version 434. 

## Release notes

```markdown
# SPI
* Remove the deprecated constructor from `ConstraintApplicationResult` class. ({issue}`23272`)
```
