### PR TITLE
Remove deprecated DecimalConversions.realToShortDecimal

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/type/DecimalConversions.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/DecimalConversions.java
@@ -24,7 +24,6 @@ import static io.trino.spi.type.Int128Math.compareAbsolute;
 import static io.trino.spi.type.Int128Math.rescale;
 import static java.lang.Double.parseDouble;
 import static java.lang.Float.floatToRawIntBits;
-import static java.lang.Float.intBitsToFloat;
 import static java.lang.Float.parseFloat;
 import static java.lang.String.format;
 import static java.math.RoundingMode.HALF_UP;
@@ -120,16 +119,6 @@ public final class DecimalConversions
         catch (ArithmeticException e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast DOUBLE '%s' to DECIMAL(%s, %s)", value, precision, scale));
         }
-    }
-
-    /**
-     * @deprecated Use {@link #realToShortDecimal(float, long, long)} instead
-     */
-    @Deprecated(forRemoval = true)
-    public static long realToShortDecimal(long value, long precision, long scale)
-    {
-        float floatValue = intBitsToFloat(intScale(value));
-        return realToShortDecimal(floatValue, precision, scale);
     }
 
     public static long realToShortDecimal(float value, long precision, long scale)


### PR DESCRIPTION
## Description

This method has been deprecated since version 415.

## Release notes

```markdown
# SPI
* Remove deprecated `DecimalConversions.realToShortDecimal` method. 
  Use `realToShortDecimal(float value, long precision, long scale)` instead. ({issue}`23275`)
```
