### PR TITLE
Fix docs build

### DIFF
--- a/docs/src/main/sphinx/optimizer.md
+++ b/docs/src/main/sphinx/optimizer.md
@@ -7,4 +7,5 @@ optimizer/statistics
 optimizer/cost-in-explain
 optimizer/cost-based-optimizations
 optimizer/pushdown
+optimizer/adaptive-plan-optimizations
 ```


### PR DESCRIPTION
Fix broken build on master.  `./mvnw clean install -pl :trino-docs` was failing, and so the CI build.

Relates to https://github.com/trinodb/trino/pull/23270