### PR TITLE
Wrap ParsingException in TypeRegistry in a TypeNotFoundException

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/TypeRegistry.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/TypeRegistry.java
@@ -33,6 +33,7 @@ import io.trino.spi.type.TypeOperators;
 import io.trino.spi.type.TypeParameter;
 import io.trino.spi.type.TypeSignature;
 import io.trino.spi.type.TypeSignatureParameter;
+import io.trino.sql.parser.ParsingException;
 import io.trino.sql.parser.SqlParser;
 import io.trino.type.CharParametricType;
 import io.trino.type.DecimalParametricType;
@@ -196,7 +197,12 @@ public final class TypeRegistry
 
     public Type fromSqlType(String sqlType)
     {
-        return getType(toTypeSignature(SQL_PARSER.createType(sqlType)));
+        try {
+            return getType(toTypeSignature(SQL_PARSER.createType(sqlType)));
+        }
+        catch (ParsingException e) {
+            throw new TypeNotFoundException(sqlType, e);
+        }
     }
 
     private Type instantiateParametricType(TypeSignature signature)

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -595,6 +595,12 @@
                                     <old>interface io.trino.spi.exchange.ExchangeManagerHandleResolver</old>
                                     <justification>cleanup</justification>
                                 </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method io.trino.spi.type.TypeSignature io.trino.spi.type.TypeNotFoundException::getType()</old>
+                                    <justification>remove unused method to expand constructor parameters</justification>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeNotFoundException.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeNotFoundException.java
@@ -16,13 +16,10 @@ package io.trino.spi.type;
 import io.trino.spi.TrinoException;
 
 import static io.trino.spi.StandardErrorCode.TYPE_NOT_FOUND;
-import static java.util.Objects.requireNonNull;
 
 public class TypeNotFoundException
         extends TrinoException
 {
-    private final TypeSignature type;
-
     public TypeNotFoundException(TypeSignature type)
     {
         this(type, null);
@@ -30,12 +27,11 @@ public class TypeNotFoundException
 
     public TypeNotFoundException(TypeSignature type, Throwable cause)
     {
-        super(TYPE_NOT_FOUND, "Unknown type: " + type, cause);
-        this.type = requireNonNull(type, "type is null");
+        this(type.toString(), cause);
     }
 
-    public TypeSignature getType()
+    public TypeNotFoundException(String type, Throwable cause)
     {
-        return type;
+        super(TYPE_NOT_FOUND, "Unknown type: " + type, cause);
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This change fixes the error code that is reported when a TrinoView type cannot be parsed and causes a `ParsingException` within the TypeRegistry.  This will get converted to a generic `TrinoException` with GENERIC_INTERNAL_ERROR.  This change wraps the exception in a `TypeNotFoundException`, which will be handled by the `MetadataManager` with an existing catch block.

Issue: https://github.com/trinodb/trino/issues/23285

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.