### PR TITLE
Do not allow users to send internal extra credentials

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/HttpRequestSessionContextFactory.java
+++ b/core/trino-main/src/main/java/io/trino/server/HttpRequestSessionContextFactory.java
@@ -323,7 +323,11 @@ public class HttpRequestSessionContextFactory
 
     private static Map<String, String> parseExtraCredentials(ProtocolHeaders protocolHeaders, MultivaluedMap<String, String> headers)
     {
-        return parseProperty(headers, protocolHeaders.requestExtraCredential());
+        Map<String, String> credentials = parseProperty(headers, protocolHeaders.requestExtraCredential());
+        for (String name : credentials.keySet()) {
+            assertRequest(!name.startsWith("internal$"), "Invalid extra credential name: %s", name);
+        }
+        return credentials;
     }
 
     private static Map<String, String> parseProperty(MultivaluedMap<String, String> headers, String headerName)

--- a/core/trino-main/src/test/java/io/trino/server/TestHttpRequestSessionContextFactory.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestHttpRequestSessionContextFactory.java
@@ -164,6 +164,18 @@ public class TestHttpRequestSessionContextFactory
                 .hasMessageMatching("Invalid " + protocolHeaders.requestPreparedStatement() + " header: line 1:1: mismatched input 'abcdefg'. Expecting: .*");
     }
 
+    @Test
+    public void testInternalExtraCredentialName()
+    {
+        MultivaluedMap<String, String> headers = new GuavaMultivaluedMap<>(ImmutableListMultimap.<String, String>builder()
+                .put(TRINO_HEADERS.requestUser(), "testUser")
+                .put(TRINO_HEADERS.requestExtraCredential(), "internal$abc=xyz")
+                .build());
+
+        assertInvalidSession(TRINO_HEADERS, headers)
+                .hasMessage("Invalid extra credential name: internal$abc");
+    }
+
     private static AbstractThrowableAssert<?, ? extends Throwable> assertInvalidSession(ProtocolHeaders protocolHeaders, MultivaluedMap<String, String> headers)
     {
         return assertThatThrownBy(


### PR DESCRIPTION
## Description

Extra credential names starting with `internal$` are reserved.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
