### PR TITLE
Add support for SSE-C to native S3 filesystem

### DIFF
--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
@@ -41,7 +41,7 @@ public class S3FileSystemConfig
 {
     public enum S3SseType
     {
-        NONE, S3, KMS
+        NONE, S3, KMS, CUSTOMER;
     }
 
     public enum ObjectCannedAcl

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemLoader.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemLoader.java
@@ -79,6 +79,7 @@ final class S3FileSystemLoader
                 config.getSseType(),
                 config.getSseKmsKeyId(),
                 Optional.empty(),
+                Optional.empty(),
                 config.getCannedAcl(),
                 config.isSupportsExclusiveCreate());
     }

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3InputFile.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3InputFile.java
@@ -30,7 +30,9 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.time.Instant;
 
+import static io.trino.filesystem.s3.S3FileSystemConfig.S3SseType.CUSTOMER;
 import static java.util.Objects.requireNonNull;
+import static software.amazon.awssdk.services.s3.model.ServerSideEncryption.AES256;
 
 final class S3InputFile
         implements TrinoInputFile
@@ -104,6 +106,14 @@ final class S3InputFile
                 .requestPayer(requestPayer)
                 .bucket(location.bucket())
                 .key(location.key())
+                .applyMutation(builder -> {
+                    if (context.sseType() == CUSTOMER) {
+                        builder
+                                .sseCustomerKey(context.encryptionKey().get())
+                                .sseCustomerAlgorithm(AES256.toString())
+                                .sseCustomerKeyMD5(context.encryptionKeyMd5().get());
+                    }
+                })
                 .build();
     }
 
@@ -115,6 +125,14 @@ final class S3InputFile
                 .requestPayer(requestPayer)
                 .bucket(location.bucket())
                 .key(location.key())
+                .applyMutation(builder -> {
+                    if (context.sseType() == CUSTOMER) {
+                        builder
+                                .sseCustomerKey(context.encryptionKey().get())
+                                .sseCustomerAlgorithm(AES256.toString())
+                                .sseCustomerKeyMD5(context.encryptionKeyMd5().get());
+                    }
+                })
                 .build();
 
         try {

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3OutputStream.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3OutputStream.java
@@ -220,6 +220,10 @@ final class S3OutputStream
                             case NONE -> { /* ignored */ }
                             case S3 -> builder.serverSideEncryption(AES256);
                             case KMS -> builder.serverSideEncryption(AWS_KMS).ssekmsKeyId(sseKmsKeyId);
+                            case CUSTOMER -> builder
+                                    .sseCustomerAlgorithm(AES256.toString())
+                                    .sseCustomerKey(context.encryptionKey().orElseThrow())
+                                    .sseCustomerKeyMD5(context.encryptionKeyMd5().orElseThrow());
                         }
                     })
                     .build();
@@ -305,6 +309,10 @@ final class S3OutputStream
                             case NONE -> { /* ignored */ }
                             case S3 -> builder.serverSideEncryption(AES256);
                             case KMS -> builder.serverSideEncryption(AWS_KMS).ssekmsKeyId(sseKmsKeyId);
+                            case CUSTOMER -> builder
+                                    .sseCustomerAlgorithm(AES256.toString())
+                                    .sseCustomerKey(context.encryptionKey().orElseThrow())
+                                    .sseCustomerKeyMD5(context.encryptionKeyMd5().orElseThrow());
                         }
                     })
                     .build();

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/s3/S3FileSystemConstants.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/s3/S3FileSystemConstants.java
@@ -18,6 +18,7 @@ public final class S3FileSystemConstants
     public static final String EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY = "internal$s3_aws_access_key";
     public static final String EXTRA_CREDENTIALS_SECRET_KEY_PROPERTY = "internal$s3_aws_secret_key";
     public static final String EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY = "internal$s3_aws_session_token";
+    public static final String EXTRA_CREDENTIALS_SSEC_KEY = "internal$s3_sse_c_key";
 
     private S3FileSystemConstants() {}
 }


### PR DESCRIPTION
## Description

This is internal support for usage by [protocol spooling](https://github.com/trinodb/trino/pull/22995).

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
