### PR TITLE
Simplify CredentialPropertiesProvider

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DriverConnectionFactory.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DriverConnectionFactory.java
@@ -34,14 +34,14 @@ public class DriverConnectionFactory
     private final Driver driver;
     private final String connectionUrl;
     private final Properties connectionProperties;
-    private final CredentialPropertiesProvider<String, String> credentialPropertiesProvider;
+    private final CredentialPropertiesProvider credentialPropertiesProvider;
     private final TracingDataSource dataSource;
 
     public DriverConnectionFactory(
             Driver driver,
             String connectionUrl,
             Properties connectionProperties,
-            CredentialPropertiesProvider<String, String> credentialPropertiesProvider,
+            CredentialPropertiesProvider credentialPropertiesProvider,
             OpenTelemetry openTelemetry)
     {
         this.driver = requireNonNull(driver, "driver is null");
@@ -80,7 +80,7 @@ public class DriverConnectionFactory
         private final Driver driver;
         private final String connectionUrl;
         private Properties connectionProperties = new Properties();
-        private CredentialPropertiesProvider<String, String> credentialPropertiesProvider;
+        private CredentialPropertiesProvider credentialPropertiesProvider;
         private OpenTelemetry openTelemetry = OpenTelemetry.noop();
 
         private Builder(Driver driver, String connectionUrl, CredentialProvider credentialProvider)
@@ -96,7 +96,7 @@ public class DriverConnectionFactory
             return this;
         }
 
-        public Builder setCredentialPropertiesProvider(CredentialPropertiesProvider<String, String> credentialPropertiesProvider)
+        public Builder setCredentialPropertiesProvider(CredentialPropertiesProvider credentialPropertiesProvider)
         {
             this.credentialPropertiesProvider = credentialPropertiesProvider;
             return this;

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/credential/CredentialPropertiesProvider.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/credential/CredentialPropertiesProvider.java
@@ -20,7 +20,7 @@ import java.util.Map;
 /**
  * Extracts properties needed for authentication for a JDBC connection.
  */
-public interface CredentialPropertiesProvider<K, V>
+public interface CredentialPropertiesProvider
 {
-    Map<K, V> getCredentialProperties(ConnectorIdentity identity);
+    Map<String, Object> getCredentialProperties(ConnectorIdentity identity);
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/credential/DefaultCredentialPropertiesProvider.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/credential/DefaultCredentialPropertiesProvider.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 import static java.util.Objects.requireNonNull;
 
 public class DefaultCredentialPropertiesProvider
-        implements CredentialPropertiesProvider<String, String>
+        implements CredentialPropertiesProvider
 {
     private final CredentialProvider provider;
 
@@ -32,9 +32,9 @@ public class DefaultCredentialPropertiesProvider
     }
 
     @Override
-    public Map<String, String> getCredentialProperties(ConnectorIdentity identity)
+    public Map<String, Object> getCredentialProperties(ConnectorIdentity identity)
     {
-        ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
+        ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
         provider.getConnectionUser(Optional.of(identity)).ifPresent(user -> properties.put("user", user));
         provider.getConnectionPassword(Optional.of(identity)).ifPresent(password -> properties.put("password", password));
         return properties.buildOrThrow();


### PR DESCRIPTION
Previously we used generics for injecting non String property, but it might not be required as all JDBC properties key are of String type and value could be generic Object type.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
