### PR TITLE
Shorten name for Kafka event listener

### DIFF
--- a/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/KafkaEventListenerFactory.java
+++ b/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/KafkaEventListenerFactory.java
@@ -33,7 +33,7 @@ public class KafkaEventListenerFactory
     @Override
     public String getName()
     {
-        return "kafka-event-listener";
+        return "kafka";
     }
 
     @Override


### PR DESCRIPTION
## Description

All other event listeners just use the short name without `-event-listener`. For consistency we should change while the plugin is still relatively new. Its a breaking change at this stage but with very limited impact since there are barely any users.

For now I just pushed this .. not sure if any other changes are necessary. Running tests locally now - and they passed.

## Additional context and related issues

Found during work on #23158

I will update docs PR or docs here .. depending on what merges first.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
* Breaking: Shorten the event-listener name for the Kafka event listener to `kafka`.Fix some things. ({issue}`23308`)
```
