### PR TITLE
Throw TrinoException when Iceberg commit fails

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1624,7 +1624,7 @@ public class IcebergMetadata
             commit(update, session);
             commitTransaction(transaction, operation);
         }
-        catch (UncheckedIOException e) {
+        catch (UncheckedIOException | ValidationException e) {
             throw new TrinoException(ICEBERG_COMMIT_ERROR, format("Failed to commit during %s: %s", operation, firstNonNull(e.getMessage(), e)), e);
         }
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
@@ -132,7 +132,9 @@ public abstract class BaseIcebergConnectorSmokeTest
         ExecutorService executor = newFixedThreadPool(threads);
         List<String> rows = ImmutableList.of("(1, 0, 0, 0)", "(0, 1, 0, 0)", "(0, 0, 1, 0)", "(0, 0, 0, 1)");
 
-        String[] expectedErrors = new String[] {"Failed to commit the transaction during write:", "Failed to replace table due to concurrent updates:"};
+        String[] expectedErrors = new String[] {"Failed to commit the transaction during write:",
+                "Failed to replace table due to concurrent updates:",
+                "Failed to commit during write:"};
         try (TestTable table = new TestTable(
                 getQueryRunner()::execute,
                 "test_concurrent_delete",

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -275,7 +275,8 @@ public abstract class BaseIcebergConnectorTest
     @Override
     protected void verifyConcurrentUpdateFailurePermissible(Exception e)
     {
-        assertThat(e).hasMessageContaining("Failed to commit the transaction during write");
+        assertThat(e).hasMessageMatching("Failed to commit the transaction during write.*|" +
+                "Failed to commit during write.*");
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

In case Iceberg commit fails throw TrinoException with clear error type.

Improvement for https://github.com/trinodb/trino/pull/23008 where only `Transaction.commitTransaction()` was considered. `IcebergUtil.commit()` can throw the same exception.

Addresses also flakiness of `testDeleteRowsConcurrently` and `testUpdateRowConcurrently` Iceberg tests related to type and message of exception.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Example stack trace:
```
2024-09-05T16:32:38.8843159Z Caused by: org.apache.iceberg.exceptions.ValidationException: Found conflicting files that can contain records matching true: [s3://test-bucket-a94uh2d33c/tpch/test_concurrent_updatevwdljsy51o-6bb6f3a9a4d343798b94bd88ba4f52c1/data/20240905_162843_02756_a284y-89d536c1-54b9-4d5e-aa19-dc2154d5c5e8.parquet]
2024-09-05T16:32:38.8851856Z 	at org.apache.iceberg.MergingSnapshotProducer.validateAddedDataFiles(MergingSnapshotProducer.java:347)
2024-09-05T16:32:38.8858939Z 	at org.apache.iceberg.BaseRowDelta.validate(BaseRowDelta.java:130)
2024-09-05T16:32:38.8864641Z 	at org.apache.iceberg.SnapshotProducer.apply(SnapshotProducer.java:235)
2024-09-05T16:32:38.8870758Z 	at org.apache.iceberg.SnapshotProducer.lambda$commit$2(SnapshotProducer.java:386)
2024-09-05T16:32:38.8876812Z 	at org.apache.iceberg.util.Tasks$Builder.runTaskWithRetry(Tasks.java:413)
2024-09-05T16:32:38.8882044Z 	at org.apache.iceberg.util.Tasks$Builder.runSingleThreaded(Tasks.java:219)
2024-09-05T16:32:38.8885484Z 	at org.apache.iceberg.util.Tasks$Builder.run(Tasks.java:203)
2024-09-05T16:32:38.8888431Z 	at org.apache.iceberg.util.Tasks$Builder.run(Tasks.java:196)
2024-09-05T16:32:38.8892052Z 	at org.apache.iceberg.SnapshotProducer.commit(SnapshotProducer.java:384)
2024-09-05T16:32:38.8895306Z 	at io.trino.plugin.iceberg.IcebergUtil.commit(IcebergUtil.java:979)
```


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
