### PR TITLE
12195 - add user\pass to kafka schema registry

### DIFF
--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/KafkaSchemaRegistryClientPropertiesProvider.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/KafkaSchemaRegistryClientPropertiesProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.kafka.schema;
+
+import com.google.inject.Inject;
+import io.trino.plugin.kafka.schema.confluent.ConfluentSchemaRegistryConfig;
+import io.trino.plugin.kafka.schema.confluent.SchemaRegistryClientPropertiesProvider;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class KafkaSchemaRegistryClientPropertiesProvider
+        implements SchemaRegistryClientPropertiesProvider
+{
+    public final String username;
+    public final String password;
+
+    @Inject
+    public KafkaSchemaRegistryClientPropertiesProvider(ConfluentSchemaRegistryConfig confluentConfig)
+    {
+        this.username = confluentConfig.getConfluentSchemaRegistryUsername();
+        this.password = confluentConfig.getConfluentSchemaRegistryPassword();
+    }
+
+    @Override
+    public Map<String, Object> getSchemaRegistryClientProperties()
+    {
+        Map<String, Object> result = new HashMap<>();
+        if (username != null) {
+            result.put("basic.auth.credentials.source", "USER_INFO");
+            result.put("basic.auth.user.info", username + ":" + password);
+        }
+        return result;
+    }
+}

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentModule.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentModule.java
@@ -52,6 +52,7 @@ import io.trino.plugin.kafka.encoder.avro.AvroRowEncoder;
 import io.trino.plugin.kafka.encoder.protobuf.ProtobufRowEncoder;
 import io.trino.plugin.kafka.encoder.protobuf.ProtobufSchemaParser;
 import io.trino.plugin.kafka.schema.ContentSchemaProvider;
+import io.trino.plugin.kafka.schema.KafkaSchemaRegistryClientPropertiesProvider;
 import io.trino.plugin.kafka.schema.ProtobufAnySupportConfig;
 import io.trino.plugin.kafka.schema.TableDescriptionSupplier;
 import io.trino.spi.HostAddress;
@@ -97,7 +98,7 @@ public class ConfluentModule
         install(new ConfluentDecoderModule());
         install(new ConfluentEncoderModule());
         binder.bind(ContentSchemaProvider.class).to(AvroConfluentContentSchemaProvider.class).in(Scopes.SINGLETON);
-        newSetBinder(binder, SchemaRegistryClientPropertiesProvider.class);
+        newSetBinder(binder, SchemaRegistryClientPropertiesProvider.class).addBinding().to(KafkaSchemaRegistryClientPropertiesProvider.class).in(Scopes.SINGLETON);
         newSetBinder(binder, SchemaProvider.class).addBinding().to(AvroSchemaProvider.class).in(Scopes.SINGLETON);
         // Each SchemaRegistry object should have a new instance of SchemaProvider
         newSetBinder(binder, SchemaProvider.class).addBinding().to(LazyLoadedProtobufSchemaProvider.class);

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentSchemaRegistryConfig.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentSchemaRegistryConfig.java
@@ -16,6 +16,7 @@ package io.trino.plugin.kafka.schema.confluent;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.units.Duration;
 import io.airlift.units.MaxDuration;
 import io.airlift.units.MinDuration;
@@ -34,6 +35,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public class ConfluentSchemaRegistryConfig
 {
     private Set<HostAddress> confluentSchemaRegistryUrls = ImmutableSet.of();
+    private String confluentSchemaRegistryUsername;
+    private String confluentSchemaRegistryPassword;
     private int confluentSchemaRegistryClientCacheSize = 1000;
     private EmptyFieldStrategy emptyFieldStrategy = IGNORE;
     private Duration confluentSubjectsCacheRefreshInterval = new Duration(1, SECONDS);
@@ -51,6 +54,35 @@ public class ConfluentSchemaRegistryConfig
         this.confluentSchemaRegistryUrls = confluentSchemaRegistryUrls.stream()
                 .map(ConfluentSchemaRegistryConfig::toHostAddress)
                 .collect(toImmutableSet());
+        return this;
+    }
+
+    @Size(min = 1)
+    public String getConfluentSchemaRegistryUsername()
+    {
+        return confluentSchemaRegistryUsername;
+    }
+
+    @Config("kafka.confluent-schema-registry-username")
+    @ConfigDescription("The username for the Confluent Schema Registry")
+    public ConfluentSchemaRegistryConfig setConfluentSchemaRegistryUsername(String confluentSchemaRegistryUsername)
+    {
+        this.confluentSchemaRegistryUsername = confluentSchemaRegistryUsername;
+        return this;
+    }
+
+    @Size(min = 1)
+    public String getConfluentSchemaRegistryPassword()
+    {
+        return confluentSchemaRegistryPassword;
+    }
+
+    @ConfigSecuritySensitive
+    @Config("kafka.confluent-schema-registry-password")
+    @ConfigDescription("The password for the Confluent Schema Registry")
+    public ConfluentSchemaRegistryConfig setConfluentSchemaRegistryPassword(String confluentSchemaRegistryPassword)
+    {
+        this.confluentSchemaRegistryPassword = confluentSchemaRegistryPassword;
         return this;
     }
 

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestConfluentSchemaRegistryConfig.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestConfluentSchemaRegistryConfig.java
@@ -47,6 +47,8 @@ public class TestConfluentSchemaRegistryConfig
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("kafka.confluent-schema-registry-url", "http://schema-registry-a:8081, http://schema-registry-b:8081")
                 .put("kafka.confluent-schema-registry-client-cache-size", "1500")
+                .put("kafka.confluent-schema-registry-username", null)
+                .put("kafka.confluent-schema-registry-password", null)
                 .put("kafka.empty-field-strategy", "MARK")
                 .put("kafka.confluent-subjects-cache-refresh-interval", "2s")
                 .buildOrThrow();

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestConfluentSchemaRegistryConfig.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestConfluentSchemaRegistryConfig.java
@@ -34,6 +34,8 @@ public class TestConfluentSchemaRegistryConfig
     {
         assertRecordedDefaults(recordDefaults(ConfluentSchemaRegistryConfig.class)
                 .setConfluentSchemaRegistryUrls(ImmutableSet.of())
+                .setConfluentSchemaRegistryUsername(null)
+                .setConfluentSchemaRegistryPassword(null)
                 .setConfluentSchemaRegistryClientCacheSize(1000)
                 .setEmptyFieldStrategy(IGNORE)
                 .setConfluentSubjectsCacheRefreshInterval(new Duration(1, SECONDS)));

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestConfluentSchemaRegistryConfig.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestConfluentSchemaRegistryConfig.java
@@ -42,7 +42,7 @@ public class TestConfluentSchemaRegistryConfig
     }
 
     @Test
-    public void testExplicitPropertyMappings()
+    public void testExplicitPropertyMappingsWithoutAuthorization()
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("kafka.confluent-schema-registry-url", "http://schema-registry-a:8081, http://schema-registry-b:8081")
@@ -61,7 +61,7 @@ public class TestConfluentSchemaRegistryConfig
     }
 
     @Test
-    public void testExplicitPropertyMappingsWithAuthorization()
+    public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("kafka.confluent-schema-registry-url", "http://schema-registry-a:8081, http://schema-registry-b:8081")

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestConfluentSchemaRegistryConfig.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestConfluentSchemaRegistryConfig.java
@@ -57,4 +57,27 @@ public class TestConfluentSchemaRegistryConfig
 
         assertFullMapping(properties, expected);
     }
+
+    @Test
+    public void testExplicitPropertyMappingsWithAuthorization()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("kafka.confluent-schema-registry-url", "http://schema-registry-a:8081, http://schema-registry-b:8081")
+                .put("kafka.confluent-schema-registry-username", "user")
+                .put("kafka.confluent-schema-registry-password", "31337")
+                .put("kafka.confluent-schema-registry-client-cache-size", "1500")
+                .put("kafka.empty-field-strategy", "MARK")
+                .put("kafka.confluent-subjects-cache-refresh-interval", "2s")
+                .buildOrThrow();
+
+        ConfluentSchemaRegistryConfig expected = new ConfluentSchemaRegistryConfig()
+                .setConfluentSchemaRegistryUrls(ImmutableSet.of("http://schema-registry-a:8081", "http://schema-registry-b:8081"))
+                .setConfluentSchemaRegistryClientCacheSize(1500)
+                .setConfluentSchemaRegistryUsername("user")
+                .setConfluentSchemaRegistryPassword("31337")
+                .setEmptyFieldStrategy(MARK)
+                .setConfluentSubjectsCacheRefreshInterval(new Duration(2, SECONDS));
+
+        assertFullMapping(properties, expected);
+    }
 }


### PR DESCRIPTION
## Description
add config options to pass username\password to confluent schema registry for kafka plugin

## Additional context and related issues
resolves https://github.com/trinodb/trino/issues/12195 and https://github.com/trinodb/trino/issues/22679



## Release notes
Release notes are required. Please propose a release note for me.