### PR TITLE
Avoid extra TrinoInputFile#lastModified calls in hive filesystem cache

### DIFF
--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystem.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystem.java
@@ -43,6 +43,7 @@ import io.trino.filesystem.TrinoInputFile;
 import io.trino.filesystem.TrinoOutputFile;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -96,7 +97,7 @@ public class AzureFileSystem
     {
         AzureLocation azureLocation = new AzureLocation(location);
         BlobClient client = createBlobClient(azureLocation);
-        return new AzureInputFile(azureLocation, OptionalLong.empty(), client, readBlockSizeBytes);
+        return new AzureInputFile(azureLocation, OptionalLong.empty(), Optional.empty(), client, readBlockSizeBytes);
     }
 
     @Override
@@ -104,7 +105,15 @@ public class AzureFileSystem
     {
         AzureLocation azureLocation = new AzureLocation(location);
         BlobClient client = createBlobClient(azureLocation);
-        return new AzureInputFile(azureLocation, OptionalLong.of(length), client, readBlockSizeBytes);
+        return new AzureInputFile(azureLocation, OptionalLong.of(length), Optional.empty(), client, readBlockSizeBytes);
+    }
+
+    @Override
+    public TrinoInputFile newInputFile(Location location, long length, Instant lastModified)
+    {
+        AzureLocation azureLocation = new AzureLocation(location);
+        BlobClient client = createBlobClient(azureLocation);
+        return new AzureInputFile(azureLocation, OptionalLong.of(length), Optional.of(lastModified), client, readBlockSizeBytes);
     }
 
     @Override

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureInputFile.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureInputFile.java
@@ -37,13 +37,14 @@ class AzureInputFile
     private final int readBlockSizeBytes;
 
     private OptionalLong length;
-    private Optional<Instant> lastModified = Optional.empty();
+    private Optional<Instant> lastModified;
 
-    public AzureInputFile(AzureLocation location, OptionalLong length, BlobClient blobClient, int readBlockSizeBytes)
+    public AzureInputFile(AzureLocation location, OptionalLong length, Optional<Instant> lastModified, BlobClient blobClient, int readBlockSizeBytes)
     {
         this.location = requireNonNull(location, "location is null");
         location.location().verifyValidFileLocation();
         this.length = requireNonNull(length, "length is null");
+        this.lastModified = requireNonNull(lastModified, "lastModified is null");
         this.blobClient = requireNonNull(blobClient, "blobClient is null");
         checkArgument(readBlockSizeBytes >= 0, "readBlockSizeBytes is negative");
         this.readBlockSizeBytes = readBlockSizeBytes;

--- a/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsFileSystem.java
+++ b/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsFileSystem.java
@@ -37,6 +37,7 @@ import io.trino.filesystem.UriLocation;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -84,7 +85,7 @@ public class GcsFileSystem
     {
         GcsLocation gcsLocation = new GcsLocation(location);
         checkIsValidFile(gcsLocation);
-        return new GcsInputFile(gcsLocation, storage, readBlockSizeBytes, OptionalLong.empty());
+        return new GcsInputFile(gcsLocation, storage, readBlockSizeBytes, OptionalLong.empty(), Optional.empty());
     }
 
     @Override
@@ -92,7 +93,15 @@ public class GcsFileSystem
     {
         GcsLocation gcsLocation = new GcsLocation(location);
         checkIsValidFile(gcsLocation);
-        return new GcsInputFile(gcsLocation, storage, readBlockSizeBytes, OptionalLong.of(length));
+        return new GcsInputFile(gcsLocation, storage, readBlockSizeBytes, OptionalLong.of(length), Optional.empty());
+    }
+
+    @Override
+    public TrinoInputFile newInputFile(Location location, long length, Instant lastModified)
+    {
+        GcsLocation gcsLocation = new GcsLocation(location);
+        checkIsValidFile(gcsLocation);
+        return new GcsInputFile(gcsLocation, storage, readBlockSizeBytes, OptionalLong.of(length), Optional.of(lastModified));
     }
 
     @Override

--- a/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsInputFile.java
+++ b/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsInputFile.java
@@ -38,15 +38,16 @@ public class GcsInputFile
     private final int readBlockSize;
     private final OptionalLong predeclaredLength;
     private OptionalLong length;
-    private Optional<Instant> lastModified = Optional.empty();
+    private Optional<Instant> lastModified;
 
-    public GcsInputFile(GcsLocation location, Storage storage, int readBockSize, OptionalLong predeclaredLength)
+    public GcsInputFile(GcsLocation location, Storage storage, int readBockSize, OptionalLong predeclaredLength, Optional<Instant> lastModified)
     {
         this.location = requireNonNull(location, "location is null");
         this.storage = requireNonNull(storage, "storage is null");
         this.readBlockSize = readBockSize;
         this.predeclaredLength = requireNonNull(predeclaredLength, "length is null");
         this.length = OptionalLong.empty();
+        this.lastModified = requireNonNull(lastModified, "lastModified is null");
     }
 
     @Override
@@ -108,7 +109,9 @@ public class GcsInputFile
         Blob blob = getBlobOrThrow(storage, location);
         try {
             length = OptionalLong.of(blob.getSize());
-            lastModified = Optional.of(Instant.from(blob.getUpdateTimeOffsetDateTime()));
+            if (lastModified.isEmpty()) {
+                lastModified = Optional.of(Instant.from(blob.getUpdateTimeOffsetDateTime()));
+            }
         }
         catch (RuntimeException e) {
             throw handleGcsException(e, "fetching properties for file", location);

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystem.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystem.java
@@ -41,6 +41,7 @@ import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequ
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -79,13 +80,19 @@ final class S3FileSystem
     @Override
     public TrinoInputFile newInputFile(Location location)
     {
-        return new S3InputFile(client, context, new S3Location(location), null);
+        return new S3InputFile(client, context, new S3Location(location), null, null);
     }
 
     @Override
     public TrinoInputFile newInputFile(Location location, long length)
     {
-        return new S3InputFile(client, context, new S3Location(location), length);
+        return new S3InputFile(client, context, new S3Location(location), length, null);
+    }
+
+    @Override
+    public TrinoInputFile newInputFile(Location location, long length, Instant lastModified)
+    {
+        return new S3InputFile(client, context, new S3Location(location), length, lastModified);
     }
 
     @Override

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3InputFile.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3InputFile.java
@@ -42,13 +42,14 @@ final class S3InputFile
     private Long length;
     private Instant lastModified;
 
-    public S3InputFile(S3Client client, S3Context context, S3Location location, Long length)
+    public S3InputFile(S3Client client, S3Context context, S3Location location, Long length, Instant lastModified)
     {
         this.client = requireNonNull(client, "client is null");
         this.location = requireNonNull(location, "location is null");
         this.context = requireNonNull(context, "context is null");
         this.requestPayer = context.requestPayer();
         this.length = length;
+        this.lastModified = lastModified;
         location.location().verifyValidFileLocation();
     }
 

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/TrinoFileSystem.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/TrinoFileSystem.java
@@ -18,6 +18,7 @@ import io.airlift.units.Duration;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
@@ -71,6 +72,17 @@ public interface TrinoFileSystem
      * @throws IllegalArgumentException if location is not valid for this file system
      */
     TrinoInputFile newInputFile(Location location, long length);
+
+    /**
+     * Creates a TrinoInputFile with a predeclared length and lastModifiedTime which can be used to read the file data.
+     * The length will be returned from {@link TrinoInputFile#length()} and the actual file length
+     * will never be checked. The lastModified will be returned from {@link TrinoInputFile#lastModified()} and the
+     * actual file last modified time will never be checked. The file location path cannot be empty, and must not end
+     * with a slash or whitespace.
+     *
+     * @throws IllegalArgumentException if location is not valid for this file system
+     */
+    TrinoInputFile newInputFile(Location location, long length, Instant lastModified);
 
     /**
      * Creates a TrinoOutputFile which can be used to create or overwrite the file. The file

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/CacheFileSystem.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/CacheFileSystem.java
@@ -21,6 +21,7 @@ import io.trino.filesystem.TrinoOutputFile;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -45,13 +46,19 @@ public final class CacheFileSystem
     @Override
     public TrinoInputFile newInputFile(Location location)
     {
-        return new CacheInputFile(delegate.newInputFile(location), cache, keyProvider, OptionalLong.empty());
+        return new CacheInputFile(delegate.newInputFile(location), cache, keyProvider, OptionalLong.empty(), Optional.empty());
     }
 
     @Override
     public TrinoInputFile newInputFile(Location location, long length)
     {
-        return new CacheInputFile(delegate.newInputFile(location, length), cache, keyProvider, OptionalLong.of(length));
+        return new CacheInputFile(delegate.newInputFile(location, length), cache, keyProvider, OptionalLong.of(length), Optional.empty());
+    }
+
+    @Override
+    public TrinoInputFile newInputFile(Location location, long length, Instant lastModified)
+    {
+        return new CacheInputFile(delegate.newInputFile(location, length, lastModified), cache, keyProvider, OptionalLong.of(length), Optional.of(lastModified));
     }
 
     @Override

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/CacheInputFile.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/CacheInputFile.java
@@ -32,13 +32,15 @@ public final class CacheInputFile
     private final TrinoFileSystemCache cache;
     private final CacheKeyProvider keyProvider;
     private OptionalLong length;
+    private Optional<Instant> lastModified;
 
-    public CacheInputFile(TrinoInputFile delegate, TrinoFileSystemCache cache, CacheKeyProvider keyProvider, OptionalLong length)
+    public CacheInputFile(TrinoInputFile delegate, TrinoFileSystemCache cache, CacheKeyProvider keyProvider, OptionalLong length, Optional<Instant> lastModified)
     {
         this.delegate = requireNonNull(delegate, "delegate is null");
         this.cache = requireNonNull(cache, "cache is null");
         this.keyProvider = requireNonNull(keyProvider, "keyProvider is null");
         this.length = requireNonNull(length, "length is null");
+        this.lastModified = requireNonNull(lastModified, "lastModified is null");
     }
 
     @Override
@@ -83,7 +85,10 @@ public final class CacheInputFile
     public Instant lastModified()
             throws IOException
     {
-        return delegate.lastModified();
+        if (lastModified.isEmpty()) {
+            lastModified = Optional.of(delegate.lastModified());
+        }
+        return lastModified.orElseThrow();
     }
 
     @Override

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/local/LocalFileSystem.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/local/LocalFileSystem.java
@@ -27,6 +27,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -60,7 +61,13 @@ public class LocalFileSystem
     @Override
     public TrinoInputFile newInputFile(Location location, long length)
     {
-        return new LocalInputFile(location, toFilePath(location), length);
+        return new LocalInputFile(location, toFilePath(location), length, null);
+    }
+
+    @Override
+    public TrinoInputFile newInputFile(Location location, long length, Instant lastModified)
+    {
+        return new LocalInputFile(location, toFilePath(location), length, lastModified);
     }
 
     @Override

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/local/LocalInputFile.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/local/LocalInputFile.java
@@ -35,21 +35,24 @@ public class LocalInputFile
 {
     private final Location location;
     private final Path path;
-    private OptionalLong length = OptionalLong.empty();
-    private Optional<Instant> lastModified = Optional.empty();
+    private OptionalLong length;
+    private Optional<Instant> lastModified;
 
     public LocalInputFile(Location location, Path path)
     {
         this.location = requireNonNull(location, "location is null");
         this.path = requireNonNull(path, "path is null");
+        this.length = OptionalLong.empty();
+        this.lastModified = Optional.empty();
     }
 
-    public LocalInputFile(Location location, Path path, long length)
+    public LocalInputFile(Location location, Path path, long length, Instant lastModified)
     {
         this.location = requireNonNull(location, "location is null");
         this.path = requireNonNull(path, "path is null");
         checkArgument(length >= 0, "length is negative");
         this.length = OptionalLong.of(length);
+        this.lastModified = Optional.ofNullable(lastModified);
     }
 
     public LocalInputFile(File file)

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/memory/MemoryFileSystem.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/memory/MemoryFileSystem.java
@@ -26,6 +26,7 @@ import io.trino.filesystem.memory.MemoryOutputFile.OutputBlob;
 
 import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
+import java.time.Instant;
 import java.util.Iterator;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -54,14 +55,21 @@ public class MemoryFileSystem
     public TrinoInputFile newInputFile(Location location)
     {
         String key = toBlobKey(location);
-        return new MemoryInputFile(location, () -> blobs.get(key), OptionalLong.empty());
+        return new MemoryInputFile(location, () -> blobs.get(key), OptionalLong.empty(), Optional.empty());
     }
 
     @Override
     public TrinoInputFile newInputFile(Location location, long length)
     {
         String key = toBlobKey(location);
-        return new MemoryInputFile(location, () -> blobs.get(key), OptionalLong.of(length));
+        return new MemoryInputFile(location, () -> blobs.get(key), OptionalLong.of(length), Optional.empty());
+    }
+
+    @Override
+    public TrinoInputFile newInputFile(Location location, long length, Instant lastModified)
+    {
+        String key = toBlobKey(location);
+        return new MemoryInputFile(location, () -> blobs.get(key), OptionalLong.of(length), Optional.of(lastModified));
     }
 
     @Override

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/memory/MemoryInputFile.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/memory/MemoryInputFile.java
@@ -34,18 +34,19 @@ public class MemoryInputFile
     private final Location location;
     private final Supplier<MemoryBlob> dataSupplier;
     private OptionalLong length;
-    private Optional<Instant> lastModified = Optional.empty();
+    private Optional<Instant> lastModified;
 
     public MemoryInputFile(Location location, Slice data)
     {
-        this(location, () -> new MemoryBlob(data), OptionalLong.of(data.length()));
+        this(location, () -> new MemoryBlob(data), OptionalLong.of(data.length()), Optional.empty());
     }
 
-    public MemoryInputFile(Location location, Supplier<MemoryBlob> dataSupplier, OptionalLong length)
+    public MemoryInputFile(Location location, Supplier<MemoryBlob> dataSupplier, OptionalLong length, Optional<Instant> lastModified)
     {
         this.location = requireNonNull(location, "location is null");
         this.dataSupplier = requireNonNull(dataSupplier, "dataSupplier is null");
         this.length = requireNonNull(length, "length is null");
+        this.lastModified = requireNonNull(lastModified, "lastModified is null");
     }
 
     @Override

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/switching/SwitchingFileSystem.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/switching/SwitchingFileSystem.java
@@ -23,6 +23,7 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.security.ConnectorIdentity;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
@@ -60,6 +61,12 @@ final class SwitchingFileSystem
     public TrinoInputFile newInputFile(Location location, long length)
     {
         return fileSystem(location).newInputFile(location, length);
+    }
+
+    @Override
+    public TrinoInputFile newInputFile(Location location, long length, Instant lastModified)
+    {
+        return fileSystem(location).newInputFile(location, length, lastModified);
     }
 
     @Override

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/TracingFileSystem.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/TracingFileSystem.java
@@ -24,6 +24,7 @@ import io.trino.filesystem.TrinoOutputFile;
 import io.trino.filesystem.UriLocation;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
@@ -46,13 +47,19 @@ final class TracingFileSystem
     @Override
     public TrinoInputFile newInputFile(Location location)
     {
-        return new TracingInputFile(tracer, delegate.newInputFile(location), Optional.empty());
+        return new TracingInputFile(tracer, delegate.newInputFile(location), Optional.empty(), Optional.empty());
     }
 
     @Override
     public TrinoInputFile newInputFile(Location location, long length)
     {
-        return new TracingInputFile(tracer, delegate.newInputFile(location, length), Optional.of(length));
+        return new TracingInputFile(tracer, delegate.newInputFile(location, length), Optional.of(length), Optional.empty());
+    }
+
+    @Override
+    public TrinoInputFile newInputFile(Location location, long length, Instant lastModified)
+    {
+        return new TracingInputFile(tracer, delegate.newInputFile(location, length, lastModified), Optional.of(length), Optional.of(lastModified));
     }
 
     @Override

--- a/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HdfsFileSystem.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HdfsFileSystem.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hdfs.DistributedFileSystem;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -81,13 +82,19 @@ class HdfsFileSystem
     @Override
     public TrinoInputFile newInputFile(Location location)
     {
-        return new HdfsInputFile(location, null, environment, context, stats.getOpenFileCalls());
+        return new HdfsInputFile(location, null, null, environment, context, stats.getOpenFileCalls());
     }
 
     @Override
     public TrinoInputFile newInputFile(Location location, long length)
     {
-        return new HdfsInputFile(location, length, environment, context, stats.getOpenFileCalls());
+        return new HdfsInputFile(location, length, null, environment, context, stats.getOpenFileCalls());
+    }
+
+    @Override
+    public TrinoInputFile newInputFile(Location location, long length, Instant lastModified)
+    {
+        return new HdfsInputFile(location, length, lastModified, environment, context, stats.getOpenFileCalls());
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceFactory.java
@@ -31,6 +31,7 @@ public interface HivePageSourceFactory
             long start,
             long length,
             long estimatedFileSize,
+            long fileModifiedTime,
             Map<String, String> schema,
             List<HiveColumnHandle> columns,
             TupleDomain<HiveColumnHandle> effectivePredicate,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceProvider.java
@@ -144,6 +144,7 @@ public class HivePageSourceProvider
                 hiveSplit.getStart(),
                 hiveSplit.getLength(),
                 hiveSplit.getEstimatedFileSize(),
+                hiveSplit.getFileModifiedTime(),
                 hiveSplit.getSchema(),
                 hiveTable.getCompactEffectivePredicate().intersect(
                                 dynamicFilter.getCurrentPredicate().transformKeys(HiveColumnHandle.class::cast))
@@ -175,6 +176,7 @@ public class HivePageSourceProvider
             long start,
             long length,
             long estimatedFileSize,
+            long fileModifiedTime,
             Map<String, String> schema,
             TupleDomain<HiveColumnHandle> effectivePredicate,
             TypeManager typeManager,
@@ -205,6 +207,7 @@ public class HivePageSourceProvider
                     start,
                     length,
                     estimatedFileSize,
+                    fileModifiedTime,
                     schema,
                     desiredColumns,
                     effectivePredicate,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/avro/AvroPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/avro/AvroPageSourceFactory.java
@@ -87,6 +87,7 @@ public class AvroPageSourceFactory
             long start,
             long length,
             long estimatedFileSize,
+            long fileModifiedTime,
             Map<String, String> schema,
             List<HiveColumnHandle> columns,
             TupleDomain<HiveColumnHandle> effectivePredicate,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/line/LinePageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/line/LinePageSourceFactory.java
@@ -82,6 +82,7 @@ public abstract class LinePageSourceFactory
             long start,
             long length,
             long estimatedFileSize,
+            long fileModifiedTime,
             Map<String, String> schema,
             List<HiveColumnHandle> columns,
             TupleDomain<HiveColumnHandle> effectivePredicate,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSourceFactory.java
@@ -55,6 +55,7 @@ import io.trino.spi.type.Type;
 import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -173,6 +174,7 @@ public class OrcPageSourceFactory
             long start,
             long length,
             long estimatedFileSize,
+            long fileModifiedTime,
             Map<String, String> schema,
             List<HiveColumnHandle> columns,
             TupleDomain<HiveColumnHandle> effectivePredicate,
@@ -200,6 +202,7 @@ public class OrcPageSourceFactory
                 start,
                 length,
                 estimatedFileSize,
+                fileModifiedTime,
                 readerColumnHandles,
                 columns,
                 isUseOrcColumnNames(session),
@@ -230,6 +233,7 @@ public class OrcPageSourceFactory
             long start,
             long length,
             long estimatedFileSize,
+            long fileModifiedTime,
             List<HiveColumnHandle> columns,
             List<HiveColumnHandle> projections,
             boolean useOrcColumnNames,
@@ -253,7 +257,7 @@ public class OrcPageSourceFactory
         boolean originalFilesPresent = acidInfo.isPresent() && !acidInfo.get().getOriginalFiles().isEmpty();
         try {
             TrinoFileSystem fileSystem = fileSystemFactory.create(session);
-            TrinoInputFile inputFile = fileSystem.newInputFile(path, estimatedFileSize);
+            TrinoInputFile inputFile = fileSystem.newInputFile(path, estimatedFileSize, Instant.ofEpochMilli(fileModifiedTime));
             orcDataSource = new HdfsOrcDataSource(
                     new OrcDataSourceId(path.toString()),
                     estimatedFileSize,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
@@ -61,6 +61,7 @@ import org.apache.parquet.schema.Type;
 import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -160,6 +161,7 @@ public class ParquetPageSourceFactory
             long start,
             long length,
             long estimatedFileSize,
+            long fileModifiedTime,
             Map<String, String> schema,
             List<HiveColumnHandle> columns,
             TupleDomain<HiveColumnHandle> effectivePredicate,
@@ -175,7 +177,7 @@ public class ParquetPageSourceFactory
         checkArgument(acidInfo.isEmpty(), "Acid is not supported");
 
         TrinoFileSystem fileSystem = fileSystemFactory.create(session);
-        TrinoInputFile inputFile = fileSystem.newInputFile(path, estimatedFileSize);
+        TrinoInputFile inputFile = fileSystem.newInputFile(path, estimatedFileSize, Instant.ofEpochMilli(fileModifiedTime));
 
         return Optional.of(createPageSource(
                 inputFile,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/rcfile/RcFilePageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/rcfile/RcFilePageSourceFactory.java
@@ -94,6 +94,7 @@ public class RcFilePageSourceFactory
             long start,
             long length,
             long estimatedFileSize,
+            long fileModifiedTime,
             Map<String, String> schema,
             List<HiveColumnHandle> columns,
             TupleDomain<HiveColumnHandle> effectivePredicate,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestBackgroundHiveSplitLoader.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestBackgroundHiveSplitLoader.java
@@ -1375,6 +1375,12 @@ public class TestBackgroundHiveSplitLoader
                 }
 
                 @Override
+                public TrinoInputFile newInputFile(Location location, long length, Instant lastModified)
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
                 public TrinoOutputFile newOutputFile(Location location)
                 {
                     throw new UnsupportedOperationException();

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveAlluxioCacheFileOperations.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveAlluxioCacheFileOperations.java
@@ -84,16 +84,12 @@ public class TestHiveAlluxioCacheFileOperations
                         .add(new CacheOperation("Input.readFully", "key=p2/"))
                         .add(new CacheOperation("Alluxio.writeCache", "key=p1/"))
                         .add(new CacheOperation("Alluxio.writeCache", "key=p2/"))
-                        .add(new CacheOperation("InputFile.lastModified", "key=p1/"))
-                        .add(new CacheOperation("InputFile.lastModified", "key=p2/"))
                         .build());
         assertFileSystemAccesses(
                 "SELECT * FROM test_cache_file_operations",
                 ImmutableMultiset.<CacheOperation>builder()
                         .add(new CacheOperation("Alluxio.readCached", "key=p1/"))
                         .add(new CacheOperation("Alluxio.readCached", "key=p2/"))
-                        .add(new CacheOperation("InputFile.lastModified", "key=p1/"))
-                        .add(new CacheOperation("InputFile.lastModified", "key=p2/"))
                         .build());
         assertUpdate("INSERT INTO test_cache_file_operations VALUES ('3-xyz', 'p3')", 1);
         assertUpdate("INSERT INTO test_cache_file_operations VALUES ('4-xyz', 'p4')", 1);
@@ -112,11 +108,6 @@ public class TestHiveAlluxioCacheFileOperations
                         .add(new CacheOperation("Alluxio.writeCache", "key=p3/"))
                         .add(new CacheOperation("Alluxio.writeCache", "key=p4/"))
                         .add(new CacheOperation("Alluxio.writeCache", "key=p5/"))
-                        .add(new CacheOperation("InputFile.lastModified", "key=p1/"))
-                        .add(new CacheOperation("InputFile.lastModified", "key=p2/"))
-                        .add(new CacheOperation("InputFile.lastModified", "key=p3/"))
-                        .add(new CacheOperation("InputFile.lastModified", "key=p4/"))
-                        .add(new CacheOperation("InputFile.lastModified", "key=p5/"))
                         .build());
         assertFileSystemAccesses(
                 "SELECT * FROM test_cache_file_operations",
@@ -126,11 +117,6 @@ public class TestHiveAlluxioCacheFileOperations
                         .add(new CacheOperation("Alluxio.readCached", "key=p3/"))
                         .add(new CacheOperation("Alluxio.readCached", "key=p4/"))
                         .add(new CacheOperation("Alluxio.readCached", "key=p5/"))
-                        .add(new CacheOperation("InputFile.lastModified", "key=p1/"))
-                        .add(new CacheOperation("InputFile.lastModified", "key=p2/"))
-                        .add(new CacheOperation("InputFile.lastModified", "key=p3/"))
-                        .add(new CacheOperation("InputFile.lastModified", "key=p4/"))
-                        .add(new CacheOperation("InputFile.lastModified", "key=p5/"))
                         .build());
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
@@ -1007,6 +1007,7 @@ public final class TestHiveFileFormats
                 0,
                 fileSize,
                 paddedFileSize,
+                12345,
                 splitProperties,
                 TupleDomain.all(),
                 TESTING_TYPE_MANAGER,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOrcPageSourceMemoryTracking.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOrcPageSourceMemoryTracking.java
@@ -577,6 +577,7 @@ public class TestOrcPageSourceMemoryTracking
                     fileSplit.getStart(),
                     fileSplit.getLength(),
                     fileSplit.getLength(),
+                    12345,
                     schema,
                     TupleDomain.all(),
                     TESTING_TYPE_MANAGER,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcPageSourceFactory.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcPageSourceFactory.java
@@ -256,6 +256,7 @@ public class TestOrcPageSourceFactory
                 0,
                 fileSize,
                 fileSize,
+                12345,
                 createSchema(),
                 columnHandles,
                 tupleDomain,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcPredicates.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcPredicates.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.filesystem.TrinoInputFile;
 import io.trino.filesystem.memory.MemoryFileSystemFactory;
 import io.trino.metastore.HiveType;
 import io.trino.orc.OrcReaderOptions;
@@ -160,7 +161,8 @@ class TestOrcPredicates
     {
         OrcPageSourceFactory readerFactory = new OrcPageSourceFactory(new OrcReaderOptions(), fileSystemFactory, STATS, UTC);
 
-        long length = fileSystemFactory.create(session).newInputFile(location).length();
+        TrinoInputFile inputFile = fileSystemFactory.create(session).newInputFile(location);
+        long length = inputFile.length();
         List<HivePageSourceProvider.ColumnMapping> columnMappings = buildColumnMappings(
                 "",
                 ImmutableList.of(),
@@ -180,6 +182,7 @@ class TestOrcPredicates
                         0,
                         length,
                         length,
+                        inputFile.lastModified().toEpochMilli(),
                         getTableProperties(),
                         effectivePredicate,
                         TESTING_TYPE_MANAGER,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetUtil.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetUtil.java
@@ -95,6 +95,7 @@ final class ParquetUtil
                         0,
                         parquetFile.length(),
                         parquetFile.length(),
+                        parquetFile.lastModified(),
                         ImmutableMap.of(SERIALIZATION_LIB, HiveStorageFormat.PARQUET.getSerde()),
                         columns,
                         domain,


### PR DESCRIPTION
## Description
Avoid extra TrinoInputFile#lastModified calls in hive filesystem cache


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Reduce filesystem accesses made when reading tables with filesystem caching enabled. ({issue}`23327`)
```
