### PR TITLE
Minor improvement to Assignments.Builder

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/Assignments.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/Assignments.java
@@ -35,7 +35,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collector;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
 
@@ -257,16 +256,11 @@ public class Assignments
         {
             checkArgument(symbol.type().equals(expression.type()), "Types don't match: %s vs %s, for %s and %s", symbol.type(), expression.type(), symbol, expression);
 
-            if (assignments.containsKey(symbol)) {
-                Expression assignment = assignments.get(symbol);
-                checkState(
-                        assignment.equals(expression),
-                        "Symbol %s already has assignment %s, while adding %s",
-                        symbol.name(),
-                        assignment,
-                        expression);
+            Expression replaced = assignments.put(symbol, expression);
+            if (replaced != null && !replaced.equals(expression)) {
+                assignments.put(symbol, replaced); // restore previous value
+                throw new IllegalStateException("Symbol %s already has assignment %s, while adding %s".formatted(symbol.name(), replaced, expression));
             }
-            assignments.put(symbol, expression);
             return this;
         }
 


### PR DESCRIPTION
## Description
Avoids redundant `containsKey` / `get` calls in favor of a direct call to `put`, followed by a check on the result.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
