### PR TITLE
Move dynamic filter evaluation ahead of static filter

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
@@ -113,16 +113,16 @@ public class PageProcessor
         }
 
         SelectedPositions activePositions = positionsRange(0, page.getPositionCount());
-        FilterEvaluator.SelectionResult staticFilterResult = new FilterEvaluator.SelectionResult(activePositions, 0);
-        if (filterEvaluator.isPresent()) {
-            staticFilterResult = filterEvaluator.get().evaluate(session, activePositions, page);
-            metrics.recordFilterTime(staticFilterResult.filterTimeNanos());
+        FilterEvaluator.SelectionResult dynamicFilterResult = new FilterEvaluator.SelectionResult(activePositions, 0);
+        if (dynamicFilterEvaluator.isPresent()) {
+            dynamicFilterResult = dynamicFilterEvaluator.get().evaluate(session, activePositions, page);
+            metrics.recordDynamicFilterMetrics(dynamicFilterResult.filterTimeNanos(), dynamicFilterResult.selectedPositions().size());
         }
 
-        FilterEvaluator.SelectionResult result = staticFilterResult;
-        if (dynamicFilterEvaluator.isPresent()) {
-            result = dynamicFilterEvaluator.get().evaluate(session, staticFilterResult.selectedPositions(), page);
-            metrics.recordDynamicFilterMetrics(result.filterTimeNanos(), staticFilterResult.selectedPositions().size());
+        FilterEvaluator.SelectionResult result = dynamicFilterResult;
+        if (filterEvaluator.isPresent()) {
+            result = filterEvaluator.get().evaluate(session, dynamicFilterResult.selectedPositions(), page);
+            metrics.recordFilterTime(result.filterTimeNanos());
         }
         SelectedPositions selectedPositions = result.selectedPositions();
 

--- a/core/trino-main/src/main/java/io/trino/operator/project/PageProcessorMetrics.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/PageProcessorMetrics.java
@@ -27,14 +27,14 @@ public class PageProcessorMetrics
     private static final String FILTER_TIME = "Filter CPU time";
     private static final String PROJECTION_TIME = "Projection CPU time";
     public static final String DYNAMIC_FILTER_TIME = "Dynamic Filter CPU time";
-    public static final String DYNAMIC_FILTER_INPUT_POSITIONS = "Dynamic Filter input positions";
+    public static final String DYNAMIC_FILTER_OUTPUT_POSITIONS = "Dynamic Filter output positions";
 
     private long filterTimeNanos;
     private boolean hasFilter;
     private long projectionTimeNanos;
     private boolean hasProjection;
     private long dynamicFilterTimeNanos;
-    private long dynamicFilterInputPositions;
+    private long dynamicFilterOutputPositions;
 
     public void recordFilterTime(long filterTimeNanos)
     {
@@ -42,10 +42,10 @@ public class PageProcessorMetrics
         hasFilter = true;
     }
 
-    public void recordDynamicFilterMetrics(long filterTimeNanos, long inputPositions)
+    public void recordDynamicFilterMetrics(long filterTimeNanos, long outputPositions)
     {
         dynamicFilterTimeNanos += filterTimeNanos;
-        dynamicFilterInputPositions += inputPositions;
+        dynamicFilterOutputPositions += outputPositions;
     }
 
     public void recordProjectionTime(long projectionTimeNanos)
@@ -60,9 +60,9 @@ public class PageProcessorMetrics
         if (hasFilter) {
             builder.put(FILTER_TIME, new DurationTiming(new Duration(filterTimeNanos, NANOSECONDS)));
         }
-        if (dynamicFilterInputPositions > 0) {
+        if (dynamicFilterOutputPositions > 0) {
             builder.put(DYNAMIC_FILTER_TIME, new DurationTiming(new Duration(dynamicFilterTimeNanos, NANOSECONDS)));
-            builder.put(DYNAMIC_FILTER_INPUT_POSITIONS, new LongCount(dynamicFilterInputPositions));
+            builder.put(DYNAMIC_FILTER_OUTPUT_POSITIONS, new LongCount(dynamicFilterOutputPositions));
         }
         if (hasProjection) {
             builder.put(PROJECTION_TIME, new DurationTiming(new Duration(projectionTimeNanos, NANOSECONDS)));

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestDynamicRowFiltering.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestDynamicRowFiltering.java
@@ -38,7 +38,7 @@ import java.util.Map;
 
 import static io.trino.SystemSessionProperties.DYNAMIC_ROW_FILTERING_SELECTIVITY_THRESHOLD;
 import static io.trino.SystemSessionProperties.ENABLE_DYNAMIC_ROW_FILTERING;
-import static io.trino.operator.project.PageProcessorMetrics.DYNAMIC_FILTER_INPUT_POSITIONS;
+import static io.trino.operator.project.PageProcessorMetrics.DYNAMIC_FILTER_OUTPUT_POSITIONS;
 import static io.trino.operator.project.PageProcessorMetrics.DYNAMIC_FILTER_TIME;
 import static io.trino.sql.DynamicFilters.extractDynamicFilters;
 import static io.trino.testing.QueryAssertions.assertEqualsIgnoreOrder;
@@ -159,8 +159,8 @@ public abstract class AbstractTestDynamicRowFiltering
                 .isLessThan(noRowFilteringProbeStats.getOutputPositions());
 
         Map<String, Metric<?>> metrics = rowFilteringProbeStats.getMetrics().getMetrics();
-        long filterInputPositions = ((Count<?>) metrics.get(DYNAMIC_FILTER_INPUT_POSITIONS)).getTotal();
-        assertThat(rowFilteringProbeStats.getOutputPositions()).isLessThan(filterInputPositions);
+        long filterOutputPositions = ((Count<?>) metrics.get(DYNAMIC_FILTER_OUTPUT_POSITIONS)).getTotal();
+        assertThat(filterOutputPositions).isLessThan(rowFilteringProbeStats.getInputPositions());
         assertThat(((DurationTiming) metrics.get(DYNAMIC_FILTER_TIME)).getDuration())
                 .isGreaterThan(Duration.ZERO);
     }
@@ -188,7 +188,7 @@ public abstract class AbstractTestDynamicRowFiltering
                 .isEqualTo(rowFilteringProbeStats.getPhysicalInputPositions());
 
         Map<String, Metric<?>> metrics = rowFilteringProbeStats.getMetrics().getMetrics();
-        long filterInputPositions = ((Count<?>) metrics.get(DYNAMIC_FILTER_INPUT_POSITIONS)).getTotal();
+        long filterInputPositions = ((Count<?>) metrics.get(DYNAMIC_FILTER_OUTPUT_POSITIONS)).getTotal();
         assertThat(rowFilteringProbeStats.getOutputPositions()).isEqualTo(filterInputPositions);
         assertThat(((DurationTiming) metrics.get(DYNAMIC_FILTER_TIME)).getDuration())
                 .isGreaterThan(Duration.ZERO);


### PR DESCRIPTION
## Description
Dynamic filter evaluation can turn itself off when it's selectivity is low. 
So it is better to evaluate it before the static filter as only selective dynamic filters 
will be retained after processing a few input pages.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
