### PR TITLE
Disable legacy filesystem implementation by default

### DIFF
--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcConnection.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcConnection.java
@@ -96,6 +96,7 @@ public class TestJdbcConnection
                 .put("hive.metastore", "file")
                 .put("hive.metastore.catalog.dir", server.getBaseDataDir().resolve("hive").toAbsolutePath().toString())
                 .put("hive.security", "sql-standard")
+                .put("fs.hadoop.enabled", "true")
                 .buildOrThrow());
         server.installPlugin(new BlackHolePlugin());
         server.createCatalog("blackhole", "blackhole", ImmutableMap.of());

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
@@ -121,6 +121,7 @@ public class TestTrinoDatabaseMetaData
                 .put("hive.metastore.catalog.dir", server.getBaseDataDir().resolve("hive").toAbsolutePath().toString())
                 .put("hive.security", "sql-standard")
                 .put("bootstrap.quiet", "true")
+                .put("fs.hadoop.enabled", "true")
                 .buildOrThrow());
 
         countingMockConnector = new CountingMockConnector();

--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemConfig.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemConfig.java
@@ -17,7 +17,7 @@ import io.airlift.configuration.Config;
 
 public class FileSystemConfig
 {
-    private boolean hadoopEnabled = true;
+    private boolean hadoopEnabled;
     private boolean nativeAzureEnabled;
     private boolean nativeS3Enabled;
     private boolean nativeGcsEnabled;

--- a/lib/trino-filesystem-manager/src/test/java/io/trino/filesystem/manager/TestFileSystemConfig.java
+++ b/lib/trino-filesystem-manager/src/test/java/io/trino/filesystem/manager/TestFileSystemConfig.java
@@ -28,7 +28,7 @@ public class TestFileSystemConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(FileSystemConfig.class)
-                .setHadoopEnabled(true)
+                .setHadoopEnabled(false)
                 .setNativeAzureEnabled(false)
                 .setNativeS3Enabled(false)
                 .setNativeGcsEnabled(false)
@@ -39,7 +39,7 @@ public class TestFileSystemConfig
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
-                .put("fs.hadoop.enabled", "false")
+                .put("fs.hadoop.enabled", "true")
                 .put("fs.native-azure.enabled", "true")
                 .put("fs.native-s3.enabled", "true")
                 .put("fs.native-gcs.enabled", "true")
@@ -47,7 +47,7 @@ public class TestFileSystemConfig
                 .buildOrThrow();
 
         FileSystemConfig expected = new FileSystemConfig()
-                .setHadoopEnabled(false)
+                .setHadoopEnabled(true)
                 .setNativeAzureEnabled(true)
                 .setNativeS3Enabled(true)
                 .setNativeGcsEnabled(true)

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeSharedMetastoreViewsTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeSharedMetastoreViewsTest.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.deltalake;
 
+import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.metastore.HiveMetastore;
 import io.trino.plugin.deltalake.metastore.TestingDeltaLakeMetastoreModule;
@@ -65,11 +66,11 @@ public abstract class BaseDeltaLakeSharedMetastoreViewsTest
         this.metastore = createTestMetastore(dataDirectory);
 
         queryRunner.installPlugin(new TestingDeltaLakePlugin(dataDirectory, Optional.of(new TestingDeltaLakeMetastoreModule(metastore))));
-        queryRunner.createCatalog(DELTA_CATALOG_NAME, "delta_lake");
+        queryRunner.createCatalog(DELTA_CATALOG_NAME, "delta_lake", ImmutableMap.of("fs.hadoop.enabled", "true"));
 
         queryRunner.installPlugin(new TestingHivePlugin(dataDirectory, metastore));
 
-        queryRunner.createCatalog(HIVE_CATALOG_NAME, "hive");
+        queryRunner.createCatalog(HIVE_CATALOG_NAME, "hive", ImmutableMap.of("fs.hadoop.enabled", "true"));
         queryRunner.execute("CREATE SCHEMA " + SCHEMA);
 
         return queryRunner;

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
@@ -161,6 +161,10 @@ public final class DeltaLakeQueryRunner
                 if (!deltaProperties.containsKey("hive.metastore") && !deltaProperties.containsKey("hive.metastore.uri")) {
                     deltaProperties.put("hive.metastore", "file");
                 }
+
+                if (!deltaProperties.containsKey("fs.hadoop.enabled")) {
+                    deltaProperties.put("fs.hadoop.enabled", "true");
+                }
                 queryRunner.createCatalog(DELTA_CATALOG, CONNECTOR_NAME, deltaProperties);
 
                 String schemaName = queryRunner.getDefaultSession().getSchema().orElseThrow();

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeProjectionPushdownPlans.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeProjectionPushdownPlans.java
@@ -105,6 +105,7 @@ public class TestDeltaLakeProjectionPushdownPlans
         planTester.createCatalog(DELTA_CATALOG, "delta_lake", ImmutableMap.<String, String>builder()
                 .put("hive.metastore", "file")
                 .put("hive.metastore.catalog.dir", baseDir.toString())
+                .put("fs.hadoop.enabled", "true")
                 .buildOrThrow());
 
         HiveMetastore metastore = TestingDeltaLakeUtils.getConnectorService(planTester, HiveMetastoreFactory.class)

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSharedFileMetastoreWithTableRedirections.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSharedFileMetastoreWithTableRedirections.java
@@ -53,6 +53,7 @@ public class TestDeltaLakeSharedFileMetastoreWithTableRedirections
                 .put("hive.metastore.catalog.dir", dataDirectory.toString())
                 .put("delta.enable-non-concurrent-writes", "true")
                 .put("delta.hive-catalog-name", "hive_with_redirections")
+                .put("fs.hadoop.enabled", "true")
                 .buildOrThrow();
 
         queryRunner.createCatalog("delta_with_redirections", CONNECTOR_NAME, deltaLakeProperties);
@@ -67,6 +68,7 @@ public class TestDeltaLakeSharedFileMetastoreWithTableRedirections
                         .put("hive.metastore", "file")
                         .put("hive.metastore.catalog.dir", dataDirectory.toString())
                         .put("hive.delta-lake-catalog-name", "delta_with_redirections")
+                        .put("fs.hadoop.enabled", "true")
                         .buildOrThrow());
 
         queryRunner.execute("CREATE TABLE hive_with_redirections." + schema + ".hive_table (a_integer) WITH (format='PARQUET') AS VALUES 1, 2, 3");

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSharedGlueMetastoreWithTableRedirections.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSharedGlueMetastoreWithTableRedirections.java
@@ -63,6 +63,7 @@ public class TestDeltaLakeSharedGlueMetastoreWithTableRedirections
                         .put("hive.metastore", "glue")
                         .put("hive.metastore.glue.default-warehouse-dir", dataDirectory.toUri().toString())
                         .put("delta.hive-catalog-name", "hive_with_redirections")
+                        .put("fs.hadoop.enabled", "true")
                         .buildOrThrow());
 
         this.glueMetastore = createTestingGlueHiveMetastore(dataDirectory, this::closeAfterClass);
@@ -70,7 +71,7 @@ public class TestDeltaLakeSharedGlueMetastoreWithTableRedirections
         queryRunner.createCatalog(
                 "hive_with_redirections",
                 "hive",
-                ImmutableMap.of("hive.delta-lake-catalog-name", "delta_with_redirections"));
+                ImmutableMap.of("hive.delta-lake-catalog-name", "delta_with_redirections", "fs.hadoop.enabled", "true"));
 
         queryRunner.execute("CREATE SCHEMA " + schema + " WITH (location = '" + dataDirectory.toUri() + "')");
         queryRunner.execute("CREATE TABLE hive_with_redirections." + schema + ".hive_table (a_integer) WITH (format='PARQUET') AS VALUES 1, 2, 3");

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaLakeGlueMetastore.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaLakeGlueMetastore.java
@@ -109,6 +109,7 @@ public class TestDeltaLakeGlueMetastore
         Map<String, String> config = ImmutableMap.<String, String>builder()
                 .put("hive.metastore", "glue")
                 .put("delta.hide-non-delta-lake-tables", "true")
+                .put("fs.hadoop.enabled", "true")
                 .buildOrThrow();
 
         ConnectorContext context = new TestingConnectorContext();

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
@@ -222,6 +222,9 @@ public final class HiveQueryRunner
                     hiveProperties.put("hive.metastore", "file");
                     hiveProperties.put("hive.metastore.catalog.dir", queryRunner.getCoordinator().getBaseDataDir().resolve("hive_data").toString());
                 }
+                if (!hiveProperties.buildOrThrow().containsKey("fs.hadoop.enabled")) {
+                    hiveProperties.put("fs.hadoop.enabled", "true");
+                }
 
                 queryRunner.installPlugin(new TestingHivePlugin(dataDir, metastore));
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -7626,7 +7626,8 @@ public abstract class BaseIcebergConnectorTest
                 "iceberg",
                 ImmutableMap.of(
                         "iceberg.catalog.type", "TESTING_FILE_METASTORE",
-                        "hive.metastore.catalog.dir", dataDirectory.getPath()));
+                        "hive.metastore.catalog.dir", dataDirectory.getPath(),
+                        "fs.hadoop.enabled", "true"));
 
         queryRunner.installPlugin(new TestingHivePlugin(dataDirectory.toPath()));
         queryRunner.createCatalog(

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
@@ -148,6 +148,10 @@ public final class IcebergQueryRunner
                 queryRunner.installPlugin(new TpchPlugin());
                 queryRunner.createCatalog("tpch", "tpch");
 
+                if (!icebergProperties.buildOrThrow().containsKey("fs.hadoop.enabled")) {
+                    icebergProperties.put("fs.hadoop.enabled", "true");
+                }
+
                 Path dataDir = metastoreDirectory.map(File::toPath).orElseGet(() -> queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg_data"));
                 queryRunner.installPlugin(new TestingIcebergPlugin(dataDir));
                 queryRunner.createCatalog(ICEBERG_CATALOG, "iceberg", icebergProperties.buildOrThrow());

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMaterializedView.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMaterializedView.java
@@ -49,7 +49,8 @@ public class TestIcebergMaterializedView
             queryRunner.createCatalog("iceberg2", "iceberg", Map.of(
                     "iceberg.catalog.type", "TESTING_FILE_METASTORE",
                     "hive.metastore.catalog.dir", queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg2-catalog").toString(),
-                    "iceberg.hive-catalog-name", "hive"));
+                    "iceberg.hive-catalog-name", "hive",
+                    "fs.hadoop.enabled", "true"));
 
             secondIceberg = Session.builder(queryRunner.getDefaultSession())
                     .setCatalog("iceberg2")
@@ -59,7 +60,8 @@ public class TestIcebergMaterializedView
                     "iceberg.catalog.type", "TESTING_FILE_METASTORE",
                     "hive.metastore.catalog.dir", queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg_data").toString(),
                     "iceberg.hive-catalog-name", "hive",
-                    "iceberg.materialized-views.hide-storage-table", "false"));
+                    "iceberg.materialized-views.hide-storage-table", "false",
+                    "fs.hadoop.enabled", "true"));
 
             queryRunner.execute(secondIceberg, "CREATE SCHEMA " + secondIceberg.getSchema().orElseThrow());
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergRegisterTableProcedure.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergRegisterTableProcedure.java
@@ -94,7 +94,7 @@ public class TestIcebergRegisterTableProcedure
 
         dataDir = queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg_data");
         queryRunner.installPlugin(new TestingIcebergPlugin(dataDir, Optional.of(new TestingIcebergFileMetastoreCatalogModule(metastore))));
-        queryRunner.createCatalog(ICEBERG_CATALOG, "iceberg", ImmutableMap.of("iceberg.register-table-procedure.enabled", "true"));
+        queryRunner.createCatalog(ICEBERG_CATALOG, "iceberg", ImmutableMap.of("fs.hadoop.enabled", "true", "iceberg.register-table-procedure.enabled", "true"));
         queryRunner.execute("CREATE SCHEMA iceberg.tpch");
         return queryRunner;
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestSharedHiveMetastore.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestSharedHiveMetastore.java
@@ -70,14 +70,16 @@ public class TestSharedHiveMetastore
                 "iceberg",
                 ImmutableMap.of(
                         "iceberg.catalog.type", "TESTING_FILE_METASTORE",
-                        "hive.metastore.catalog.dir", dataDirectory.toString()));
+                        "hive.metastore.catalog.dir", dataDirectory.toString(),
+                        "fs.hadoop.enabled", "true"));
         queryRunner.createCatalog(
                 "iceberg_with_redirections",
                 "iceberg",
                 ImmutableMap.of(
                         "iceberg.catalog.type", "TESTING_FILE_METASTORE",
                         "hive.metastore.catalog.dir", dataDirectory.toString(),
-                        "iceberg.hive-catalog-name", "hive"));
+                        "iceberg.hive-catalog-name", "hive",
+                        "fs.hadoop.enabled", "true"));
 
         queryRunner.installPlugin(new TestingHivePlugin(dataDirectory));
         queryRunner.createCatalog(HIVE_CATALOG, "hive");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogMaterializedView.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogMaterializedView.java
@@ -62,7 +62,8 @@ public class TestIcebergGlueCatalogMaterializedView
                 .setIcebergProperties(
                         ImmutableMap.of(
                                 "iceberg.catalog.type", "glue",
-                                "hive.metastore.glue.default-warehouse-dir", schemaDirectory.getAbsolutePath()))
+                                "hive.metastore.glue.default-warehouse-dir", schemaDirectory.getAbsolutePath(),
+                                "fs.hadoop.enabled", "true"))
                 .setSchemaInitializer(
                         SchemaInitializer.builder()
                                 .withClonedTpchTables(ImmutableList.of())
@@ -73,7 +74,8 @@ public class TestIcebergGlueCatalogMaterializedView
             queryRunner.createCatalog("iceberg_legacy_mv", "iceberg", Map.of(
                     "iceberg.catalog.type", "glue",
                     "hive.metastore.glue.default-warehouse-dir", schemaDirectory.getAbsolutePath(),
-                    "iceberg.materialized-views.hide-storage-table", "false"));
+                    "iceberg.materialized-views.hide-storage-table", "false",
+                    "fs.hadoop.enabled", "true"));
 
             queryRunner.installPlugin(createMockConnectorPlugin());
             queryRunner.createCatalog("mock", "mock");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueTableOperationsInsertFailure.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueTableOperationsInsertFailure.java
@@ -89,7 +89,7 @@ public class TestIcebergGlueTableOperationsInsertFailure
         dataDirectory.toFile().deleteOnExit();
 
         queryRunner.installPlugin(new TestingIcebergPlugin(dataDirectory, Optional.of(new TestingIcebergGlueCatalogModule(awsGlueAsyncAdapterProvider))));
-        queryRunner.createCatalog(ICEBERG_CATALOG, "iceberg", ImmutableMap.of());
+        queryRunner.createCatalog(ICEBERG_CATALOG, "iceberg", ImmutableMap.of("fs.hadoop.enabled", "true"));
 
         glueHiveMetastore = createTestingGlueHiveMetastore(dataDirectory, this::closeAfterClass);
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestSharedGlueMetastore.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestSharedGlueMetastore.java
@@ -84,22 +84,24 @@ public class TestSharedGlueMetastore
                 "iceberg",
                 ImmutableMap.of(
                         "iceberg.catalog.type", "glue",
-                        "hive.metastore.glue.default-warehouse-dir", dataDirectory.toString()));
+                        "hive.metastore.glue.default-warehouse-dir", dataDirectory.toString(),
+                        "fs.hadoop.enabled", "true"));
         queryRunner.createCatalog(
                 "iceberg_with_redirections",
                 "iceberg",
                 ImmutableMap.of(
                         "iceberg.catalog.type", "glue",
                         "hive.metastore.glue.default-warehouse-dir", dataDirectory.toString(),
-                        "iceberg.hive-catalog-name", "hive"));
+                        "iceberg.hive-catalog-name", "hive",
+                        "fs.hadoop.enabled", "true"));
 
         this.glueMetastore = createTestingGlueHiveMetastore(dataDirectory, this::closeAfterClass);
         queryRunner.installPlugin(new TestingHivePlugin(queryRunner.getCoordinator().getBaseDataDir().resolve("hive_data"), glueMetastore));
-        queryRunner.createCatalog(HIVE_CATALOG, "hive");
+        queryRunner.createCatalog(HIVE_CATALOG, "hive", ImmutableMap.of("fs.hadoop.enabled", "true"));
         queryRunner.createCatalog(
                 "hive_with_redirections",
                 "hive",
-                ImmutableMap.of("hive.iceberg-catalog-name", "iceberg"));
+                ImmutableMap.of("hive.iceberg-catalog-name", "iceberg", "fs.hadoop.enabled", "true"));
 
         queryRunner.execute("CREATE SCHEMA " + tpchSchema + " WITH (location = '" + dataDirectory.toUri() + "')");
         copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, icebergSession, ImmutableList.of(TpchTable.NATION));

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeCompatibility.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeCompatibility.java
@@ -77,7 +77,7 @@ public class EnvSinglenodeCompatibility
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath(jvmConfig)), containerConfigDir + "jvm.config")
                 .withCopyFileToContainer(forHostPath(configDir.getPath(getConfigFileFor(dockerImage))), containerConfigDir + "config.properties")
                 .withCopyFileToContainer(forHostPath(configDir.getPath(getHiveConfigFor(dockerImage))), containerConfigDir + "catalog/hive.properties")
-                .withCopyFileToContainer(forHostPath(configDir.getPath("iceberg.properties")), containerConfigDir + "catalog/iceberg.properties")
+                .withCopyFileToContainer(forHostPath(configDir.getPath(getIcebergConfigFor(dockerImage))), containerConfigDir + "catalog/iceberg.properties")
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath()), "/docker/presto-product-tests")
                 .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
                 .waitingForAll(forLogMessage(".*======== SERVER STARTED ========.*", 1), forHealthcheck())
@@ -118,6 +118,14 @@ public class EnvSinglenodeCompatibility
             return "hive-hadoop2.properties";
         }
         return "hive.properties";
+    }
+
+    private String getIcebergConfigFor(String dockerImage)
+    {
+        if (getVersionFromDockerImageName(dockerImage) < 359) {
+            return "iceberg_old.properties";
+        }
+        return "iceberg.properties";
     }
 
     private void configureTestsContainer(Environment.Builder builder, Config config)

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop/hive.properties
@@ -11,3 +11,4 @@ hive.parquet.time-zone=UTC
 hive.rcfile.time-zone=UTC
 # Using smaller than default parquet.small-file-threshold to get better code coverage in tests
 parquet.small-file-threshold=100kB
+fs.hadoop.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop/hive_timestamp_nanos.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop/hive_timestamp_nanos.properties
@@ -6,3 +6,4 @@ hive.hive-views.enabled=true
 hive.timestamp-precision=NANOSECONDS
 hive.parquet.time-zone=UTC
 hive.rcfile.time-zone=UTC
+fs.hadoop.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop/hive_with_external_writes.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop/hive_with_external_writes.properties
@@ -10,3 +10,4 @@ hive.hive-views.enabled=true
 hive.non-managed-table-writes-enabled=true
 hive.parquet.time-zone=UTC
 hive.rcfile.time-zone=UTC
+fs.hadoop.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop/hive_with_run_view_as_invoker.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop/hive_with_run_view_as_invoker.properties
@@ -8,3 +8,4 @@ hive.hive-views.run-as-invoker=true
 hive.security=sql-standard
 hive.parquet.time-zone=UTC
 hive.rcfile.time-zone=UTC
+fs.hadoop.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop/iceberg.properties
@@ -3,3 +3,4 @@ hive.metastore.uri=thrift://hadoop-master:9083
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
 iceberg.file-format=PARQUET
 iceberg.register-table-procedure.enabled=true
+fs.hadoop.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-all/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-all/hive.properties
@@ -1,2 +1,3 @@
 connector.name=hive
 hive.metastore.uri=thrift://host1.invalid:9083
+fs.hadoop.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-hive-cached/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-hive-cached/hive.properties
@@ -1,6 +1,7 @@
 connector.name=hive
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
 hive.metastore.uri=thrift://hadoop-master:9083
+fs.hadoop.enabled=true
 fs.cache.enabled=true
 fs.cache.directories=/tmp/cache/hive
 fs.cache.max-disk-usage-percentages=90

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-tls-kerberos/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-tls-kerberos/hive.properties
@@ -4,6 +4,7 @@ hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-
 hive.metastore-cache-ttl=0s
 hive.parquet.time-zone=UTC
 hive.rcfile.time-zone=UTC
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.service.principal=hive/hadoop-master@LABS.TERADATA.COM

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-tls-kerberos/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-tls-kerberos/iceberg.properties
@@ -1,6 +1,7 @@
 connector.name=iceberg
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.service.principal=hive/hadoop-master@LABS.TERADATA.COM

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-compatibility/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-compatibility/hive.properties
@@ -2,3 +2,4 @@ connector.name=hive
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.parquet.time-zone=UTC
 hive.rcfile.time-zone=UTC
+fs.hadoop.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-compatibility/iceberg_old.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-compatibility/iceberg_old.properties
@@ -1,3 +1,2 @@
 connector.name=iceberg
 hive.metastore.uri=thrift://hadoop-master:9083
-fs.hadoop.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-delta-lake-kerberized-hdfs/delta.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-delta-lake-kerberized-hdfs/delta.properties
@@ -1,5 +1,6 @@
 connector.name=delta_lake
 hive.metastore.uri=thrift://hadoop-master:9083
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.service.principal=hive/hadoop-master@LABS.TERADATA.COM

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hdfs-impersonation/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hdfs-impersonation/hive.properties
@@ -10,3 +10,4 @@ hive.max-partitions-for-eager-load=100
 hive.non-managed-table-writes-enabled=true
 hive.parquet.time-zone=UTC
 hive.rcfile.time-zone=UTC
+fs.hadoop.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hdfs-impersonation/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hdfs-impersonation/iceberg.properties
@@ -1,6 +1,7 @@
 connector.name=iceberg
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
+fs.hadoop.enabled=true
 
 hive.hdfs.authentication.type=NONE
 hive.hdfs.impersonation.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hive-hudi-redirections/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hive-hudi-redirections/hive.properties
@@ -5,3 +5,4 @@ hive.hudi-catalog-name=hudi
 hive.hive-views.enabled=true
 hive.parquet.time-zone=UTC
 hive.rcfile.time-zone=UTC
+fs.hadoop.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hive-iceberg-redirections/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hive-iceberg-redirections/hive.properties
@@ -5,3 +5,4 @@ hive.iceberg-catalog-name=iceberg
 hive.hive-views.enabled=true
 hive.parquet.time-zone=UTC
 hive.rcfile.time-zone=UTC
+fs.hadoop.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hive-iceberg-redirections/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hive-iceberg-redirections/iceberg.properties
@@ -2,3 +2,4 @@ connector.name=iceberg
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
 iceberg.hive-catalog-name=hive
+fs.hadoop.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hive-impersonation/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hive-impersonation/hive.properties
@@ -13,3 +13,4 @@ hive.max-partitions-for-eager-load=100
 hive.non-managed-table-writes-enabled=true
 hive.parquet.time-zone=UTC
 hive.rcfile.time-zone=UTC
+fs.hadoop.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hive-impersonation/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hive-impersonation/iceberg.properties
@@ -4,5 +4,6 @@ hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-
 hive.metastore.thrift.impersonation.enabled=true
 hive.hdfs.authentication.type=NONE
 hive.hdfs.impersonation.enabled=true
+fs.hadoop.enabled=true
 
 iceberg.file-format=PARQUET

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hudi/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hudi/hive.properties
@@ -3,3 +3,4 @@ hive.metastore.uri=thrift://hadoop-master:9083
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
 hive.parquet.time-zone=UTC
 hive.rcfile.time-zone=UTC
+fs.hadoop.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation-cross-realm/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation-cross-realm/hive.properties
@@ -10,6 +10,7 @@ hive.metastore.uri=thrift://hadoop-master:9083
 hive.metastore-cache-ttl=0s
 hive.parquet.time-zone=UTC
 hive.rcfile.time-zone=UTC
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.service.principal=hive/hadoop-master@LABS.TERADATA.COM

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation-cross-realm/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation-cross-realm/iceberg.properties
@@ -7,6 +7,7 @@
 
 connector.name=iceberg
 hive.metastore.uri=thrift://hadoop-master:9083
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.service.principal=hive/hadoop-master@LABS.TERADATA.COM

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation-with-data-protection/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation-with-data-protection/hive.properties
@@ -4,6 +4,7 @@ hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-
 hive.metastore-cache-ttl=0s
 hive.parquet.time-zone=UTC
 hive.rcfile.time-zone=UTC
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.service.principal=hive/hadoop-master@LABS.TERADATA.COM

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation-with-wire-encryption/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation-with-wire-encryption/hive.properties
@@ -4,6 +4,7 @@ hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-
 hive.metastore-cache-ttl=0s
 hive.parquet.time-zone=UTC
 hive.rcfile.time-zone=UTC
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.service.principal=hive/hadoop-master@LABS.TERADATA.COM

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation-with-wire-encryption/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation-with-wire-encryption/iceberg.properties
@@ -1,6 +1,7 @@
 connector.name=iceberg
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.service.principal=hive/hadoop-master@LABS.TERADATA.COM

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation/hive.properties
@@ -4,6 +4,7 @@ hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-
 hive.metastore-cache-ttl=0s
 hive.parquet.time-zone=UTC
 hive.rcfile.time-zone=UTC
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.service.principal=hive/hadoop-master@LABS.TERADATA.COM

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation/iceberg.properties
@@ -1,6 +1,7 @@
 connector.name=iceberg
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.service.principal=hive/hadoop-master@LABS.TERADATA.COM

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-no-impersonation/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-no-impersonation/hive.properties
@@ -4,6 +4,7 @@ hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-
 hive.metastore-cache-ttl=0s
 hive.parquet.time-zone=UTC
 hive.rcfile.time-zone=UTC
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.service.principal=hive/hadoop-master@LABS.TERADATA.COM

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-no-impersonation/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-no-impersonation/iceberg.properties
@@ -1,6 +1,7 @@
 connector.name=iceberg
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.service.principal=hive/hadoop-master@LABS.TERADATA.COM

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hive-impersonation-with-credential-cache/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hive-impersonation-with-credential-cache/hive.properties
@@ -4,6 +4,7 @@ hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-
 hive.metastore-cache-ttl=0s
 hive.parquet.time-zone=UTC
 hive.rcfile.time-zone=UTC
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.thrift.impersonation.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hive-impersonation-with-credential-cache/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hive-impersonation-with-credential-cache/iceberg.properties
@@ -1,6 +1,7 @@
 connector.name=iceberg
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.thrift.impersonation.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hive-impersonation/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hive-impersonation/hive.properties
@@ -4,6 +4,7 @@ hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-
 hive.metastore-cache-ttl=0s
 hive.parquet.time-zone=UTC
 hive.rcfile.time-zone=UTC
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.thrift.impersonation.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hive-impersonation/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hive-impersonation/iceberg.properties
@@ -1,6 +1,7 @@
 connector.name=iceberg
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.thrift.impersonation.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hive-no-impersonation-with-credential-cache/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hive-no-impersonation-with-credential-cache/hive.properties
@@ -4,6 +4,7 @@ hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-
 hive.metastore-cache-ttl=0s
 hive.parquet.time-zone=UTC
 hive.rcfile.time-zone=UTC
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.service.principal=hive/hadoop-master@LABS.TERADATA.COM

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hive-no-impersonation-with-credential-cache/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hive-no-impersonation-with-credential-cache/iceberg.properties
@@ -1,6 +1,7 @@
 connector.name=iceberg
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.service.principal=hive/hadoop-master@LABS.TERADATA.COM

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-kms-hdfs-impersonation-with-credential-cache/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-kms-hdfs-impersonation-with-credential-cache/hive.properties
@@ -2,6 +2,7 @@ connector.name=hive
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.parquet.time-zone=UTC
 hive.rcfile.time-zone=UTC
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.service.principal=hive/_HOST@LABS.TERADATA.COM

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-kms-hdfs-impersonation-with-credential-cache/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-kms-hdfs-impersonation-with-credential-cache/iceberg.properties
@@ -1,5 +1,6 @@
 connector.name=iceberg
 hive.metastore.uri=thrift://hadoop-master:9083
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.service.principal=hive/_HOST@LABS.TERADATA.COM

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-kms-hdfs-impersonation/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-kms-hdfs-impersonation/hive.properties
@@ -2,6 +2,7 @@ connector.name=hive
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.parquet.time-zone=UTC
 hive.rcfile.time-zone=UTC
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.service.principal=hive/_HOST@LABS.TERADATA.COM

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-kms-hdfs-impersonation/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-kms-hdfs-impersonation/iceberg.properties
@@ -1,5 +1,6 @@
 connector.name=iceberg
 hive.metastore.uri=thrift://hadoop-master:9083
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.service.principal=hive/_HOST@LABS.TERADATA.COM

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-kms-hdfs-no-impersonation-with-credential-cache/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-kms-hdfs-no-impersonation-with-credential-cache/hive.properties
@@ -2,6 +2,7 @@ connector.name=hive
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.parquet.time-zone=UTC
 hive.rcfile.time-zone=UTC
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.service.principal=hive/_HOST@LABS.TERADATA.COM

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-kms-hdfs-no-impersonation-with-credential-cache/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-kms-hdfs-no-impersonation-with-credential-cache/iceberg.properties
@@ -1,5 +1,6 @@
 connector.name=iceberg
 hive.metastore.uri=thrift://hadoop-master:9083
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.service.principal=hive/_HOST@LABS.TERADATA.COM

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-kms-hdfs-no-impersonation/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-kms-hdfs-no-impersonation/hive.properties
@@ -2,6 +2,7 @@ connector.name=hive
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.parquet.time-zone=UTC
 hive.rcfile.time-zone=UTC
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.service.principal=hive/_HOST@LABS.TERADATA.COM

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-kms-hdfs-no-impersonation/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-kms-hdfs-no-impersonation/iceberg.properties
@@ -1,5 +1,6 @@
 connector.name=iceberg
 hive.metastore.uri=thrift://hadoop-master:9083
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.service.principal=hive/_HOST@LABS.TERADATA.COM

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-hive-no-stats-fallback/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-hive-no-stats-fallback/hive.properties
@@ -2,6 +2,7 @@ connector.name=hive
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.metastore.thrift.use-spark-table-statistics-fallback=false
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
+fs.hadoop.enabled=true
 
 # Note: it's currently unclear why this one is needed, while also hive.orc.time-zone=UTC is not needed.
 hive.parquet.time-zone=UTC

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-hive/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-hive/hive.properties
@@ -2,6 +2,7 @@ connector.name=hive
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
 hive.non-managed-table-writes-enabled=true
+fs.hadoop.enabled=true
 
 # Note: it's currently unclear why this one is needed, while also hive.orc.time-zone=UTC is not needed.
 hive.parquet.time-zone=UTC

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg-jdbc-catalog/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg-jdbc-catalog/iceberg.properties
@@ -7,3 +7,4 @@ iceberg.jdbc-catalog.connection-password=test
 iceberg.jdbc-catalog.catalog-name=iceberg_test
 iceberg.jdbc-catalog.default-warehouse-dir=hdfs://hadoop-master:9000/user/hive/warehouse
 hive.hdfs.socks-proxy=hadoop-master:1180
+fs.hadoop.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg-nessie/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg-nessie/iceberg.properties
@@ -2,3 +2,4 @@ connector.name=iceberg
 iceberg.catalog.type=nessie
 iceberg.nessie-catalog.uri=http://nessie-server:19120/api/v2
 iceberg.nessie-catalog.default-warehouse-dir=hdfs://hadoop-master:9000/user/hive/warehouse
+fs.hadoop.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg-rest/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg-rest/iceberg.properties
@@ -1,3 +1,4 @@
 connector.name=iceberg
 iceberg.catalog.type=rest
 iceberg.rest-catalog.uri=http://iceberg-with-rest:8181/
+fs.hadoop.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg/iceberg.properties
@@ -1,3 +1,4 @@
 connector.name=iceberg
 hive.metastore.uri=thrift://hadoop-master:9083
 iceberg.register-table-procedure.enabled=true
+fs.hadoop.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/two-kerberos-hives/hive1.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/two-kerberos-hives/hive1.properties
@@ -4,6 +4,7 @@ hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-
 hive.metastore-cache-ttl=0s
 hive.parquet.time-zone=UTC
 hive.rcfile.time-zone=UTC
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.thrift.impersonation.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/two-kerberos-hives/hive2.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/two-kerberos-hives/hive2.properties
@@ -5,6 +5,7 @@ hive.config.resources=/docker/presto-product-tests/conf/environment/two-kerberos
 hive.metastore-cache-ttl=0s
 hive.parquet.time-zone=UTC
 hive.rcfile.time-zone=UTC
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.service.principal=hive/hadoop-master-2@OTHERREALM.COM

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/two-kerberos-hives/iceberg1.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/two-kerberos-hives/iceberg1.properties
@@ -1,6 +1,7 @@
 connector.name=iceberg
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.thrift.impersonation.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/two-kerberos-hives/iceberg2.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/two-kerberos-hives/iceberg2.properties
@@ -2,6 +2,7 @@ connector.name=iceberg
 hive.metastore.uri=thrift://hadoop-master-2:9083
 hive.config.resources=/docker/presto-product-tests/conf/environment/two-kerberos-hives/hive2-default-fs-site.xml,\
   /docker/presto-product-tests/conf/environment/two-kerberos-hives/auth-to-local.xml
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.service.principal=hive/hadoop-master-2@OTHERREALM.COM

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/two-mixed-hives/hive1.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/two-mixed-hives/hive1.properties
@@ -4,6 +4,7 @@ hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-
 hive.metastore-cache-ttl=0s
 hive.parquet.time-zone=UTC
 hive.rcfile.time-zone=UTC
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.thrift.impersonation.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/two-mixed-hives/hive2.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/two-mixed-hives/hive2.properties
@@ -7,3 +7,4 @@ hive.max-partitions-per-scan=100
 hive.max-partitions-for-eager-load=100
 hive.parquet.time-zone=UTC
 hive.rcfile.time-zone=UTC
+fs.hadoop.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/two-mixed-hives/iceberg1.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/two-mixed-hives/iceberg1.properties
@@ -1,6 +1,7 @@
 connector.name=iceberg
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
+fs.hadoop.enabled=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.thrift.impersonation.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/two-mixed-hives/iceberg2.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/two-mixed-hives/iceberg2.properties
@@ -1,5 +1,6 @@
 connector.name=iceberg
 hive.metastore.uri=thrift://hadoop-master-2:9083
 hive.config.resources=/docker/presto-product-tests/conf/environment/two-mixed-hives/hive2-default-fs-site.xml
+fs.hadoop.enabled=true
 
 iceberg.file-format=PARQUET


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Docs must be ready and merged at the same time so change lands in a release with the required docs. This is a breaking change for most users.

#23366
<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Hive,  Delta Lake, Iceberg, and Hudi connector

* {{breaking}} Deactivate legacy file system support for all catalogs. You must 
  activate the desired [file system support](file-system-configuration) with 
  `fs.native-azure.enabled`,`fs.native-gcs.enabled`, `fs.native-s3.enabled`, or 
  `fs.hadoop.enabled` in each catalog. Use the migration guides for Azure Storage, 
  Google Cloud Storage, and S3 to assist if you have not switched from legacy support.
```

and link to migration guides