### PR TITLE
Deduce correct partition location in Hive partition projection

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/projection/PartitionProjection.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/projection/PartitionProjection.java
@@ -102,10 +102,18 @@ public final class PartitionProjection
                                         table.getPartitionColumns().stream()
                                                 .map(Column::getName).collect(Collectors.toList()),
                                         partitionValues))
-                                .orElseGet(() -> format("%s/%s/", table.getStorage().getLocation(), partitionName)))
+                                .orElseGet(() -> getPartitionLocation(table.getStorage().getLocation(), partitionName)))
                         .setBucketProperty(table.getStorage().getBucketProperty())
                         .setSerdeParameters(table.getStorage().getSerdeParameters()))
                 .build();
+    }
+
+    private static String getPartitionLocation(String tableLocation, String partitionName)
+    {
+        if (tableLocation.endsWith("/")) {
+            return format("%s%s/", tableLocation, partitionName);
+        }
+        return format("%s/%s/", tableLocation, partitionName);
     }
 
     private static String expandStorageLocationTemplate(String template, List<String> partitionColumns, List<String> partitionValues)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

If table location ends with `/` then, the partition location is incorrectly calculated when using partition projection in Hive leading to no data returned from the query.
PR aims to add slash between table location and partition name only if in case table location doesn't end with slash.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
