### PR TITLE
Improve hashCode() for char and varchar types

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/type/CharType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/CharType.java
@@ -24,7 +24,6 @@ import io.trino.spi.block.VariableWidthBlockBuilder;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.function.ScalarOperator;
 
-import java.util.Objects;
 import java.util.Optional;
 
 import static io.airlift.slice.SliceUtf8.countCodePoints;
@@ -212,7 +211,7 @@ public final class CharType
     @Override
     public int hashCode()
     {
-        return Objects.hash(length);
+        return (length * 31) + getClass().hashCode();
     }
 
     @ScalarOperator(COMPARISON_UNORDERED_LAST)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/VarcharType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/VarcharType.java
@@ -23,7 +23,6 @@ import io.trino.spi.block.VariableWidthBlock;
 import io.trino.spi.block.VariableWidthBlockBuilder;
 import io.trino.spi.connector.ConnectorSession;
 
-import java.util.Objects;
 import java.util.Optional;
 
 import static io.airlift.slice.SliceUtf8.countCodePoints;
@@ -224,6 +223,6 @@ public final class VarcharType
     @Override
     public int hashCode()
     {
-        return Objects.hash(length);
+        return (length * 31) + getClass().hashCode();
     }
 }


### PR DESCRIPTION
## Description
The previous implementations for `VarcharType` and `CharType` would only hash the length parameter, which `Integer#hashCode()` defines to simply be the value itself. This resulted in a very poor distribution of hash code values while also incurring the overhead of boxing to `Integer` and constructing single element varargs arrays on each call.

The new implementation avoids the boxing and varargs overheads and includes the classes hashCode to achieve a better distribution of output values.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
