### PR TITLE
Fix NPE in ThriftMetastoreUtil to provide proper error message

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -485,8 +485,12 @@ public final class ThriftMetastoreUtil
         if (storageDescriptor == null) {
             throw new TrinoException(HIVE_INVALID_METADATA, "Partition does not contain a storage descriptor: " + partition);
         }
+        List<FieldSchema> schema = storageDescriptor.getCols();
+        if (schema == null) {
+            throw new TrinoException(HIVE_INVALID_METADATA, "Partition storage descriptor does not contain columns to derive a schema: " + partition);
+        }
 
-        return fromMetastoreApiPartition(partition, storageDescriptor.getCols());
+        return fromMetastoreApiPartition(partition, schema);
     }
 
     public static Partition fromMetastoreApiPartition(io.trino.hive.thrift.metastore.Partition partition, List<FieldSchema> schema)


### PR DESCRIPTION
## Description

Currently in some cases when Hive partition metadata is corrupted such that a storage descriptor is present, but it doesn't have `columns` set, you will get an NPE thrown from Trino:
```
2024-09-06T21:31:06.172Z        ERROR   query-execution-2177492 io.trino.execution.scheduler.PipelinedQueryScheduler    Failure in distributed stage for query 20240906_213105_35785_ujj3t
io.trino.spi.TrinoException: java.lang.NullPointerException: Cannot invoke "java.util.List.stream()" because "schema" is null
```

This PR adds a check to confirm the value is non-null, and throws `HIVE_INVALID_METADATA` in case it is corrupted instead of NPE, to give a more clear error message and provide more information on which partition's metadata is corrupted.

## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: