### PR TITLE
Fix casting from varchar to numeric with spaces

### DIFF
--- a/core/trino-main/src/main/java/io/trino/type/VarcharOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/VarcharOperators.java
@@ -77,7 +77,7 @@ public final class VarcharOperators
     public static double castToDouble(@SqlType("varchar(x)") Slice slice)
     {
         try {
-            return Double.parseDouble(slice.toStringUtf8());
+            return Double.parseDouble(slice.toStringUtf8().trim());
         }
         catch (Exception e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to DOUBLE", slice.toStringUtf8()));
@@ -90,7 +90,7 @@ public final class VarcharOperators
     public static long castToFloat(@SqlType("varchar(x)") Slice slice)
     {
         try {
-            return toReal(Float.parseFloat(slice.toStringUtf8()));
+            return toReal(Float.parseFloat(slice.toStringUtf8().trim()));
         }
         catch (Exception e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to REAL", slice.toStringUtf8()));
@@ -103,7 +103,7 @@ public final class VarcharOperators
     public static long castToBigint(@SqlType("varchar(x)") Slice slice)
     {
         try {
-            return Long.parseLong(slice.toStringUtf8());
+            return Long.parseLong(slice.toStringUtf8().trim());
         }
         catch (Exception e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to BIGINT", slice.toStringUtf8()));
@@ -116,7 +116,7 @@ public final class VarcharOperators
     public static long castToInteger(@SqlType("varchar(x)") Slice slice)
     {
         try {
-            return Integer.parseInt(slice.toStringUtf8());
+            return Integer.parseInt(slice.toStringUtf8().trim());
         }
         catch (Exception e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to INT", slice.toStringUtf8()));
@@ -129,7 +129,7 @@ public final class VarcharOperators
     public static long castToSmallint(@SqlType("varchar(x)") Slice slice)
     {
         try {
-            return Short.parseShort(slice.toStringUtf8());
+            return Short.parseShort(slice.toStringUtf8().trim());
         }
         catch (Exception e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to SMALLINT", slice.toStringUtf8()));
@@ -142,7 +142,7 @@ public final class VarcharOperators
     public static long castToTinyint(@SqlType("varchar(x)") Slice slice)
     {
         try {
-            return Byte.parseByte(slice.toStringUtf8());
+            return Byte.parseByte(slice.toStringUtf8().trim());
         }
         catch (Exception e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to TINYINT", slice.toStringUtf8()));

--- a/core/trino-main/src/test/java/io/trino/type/TestVarcharOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestVarcharOperators.java
@@ -25,6 +25,12 @@ import static io.trino.spi.function.OperatorType.IDENTICAL;
 import static io.trino.spi.function.OperatorType.INDETERMINATE;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -80,6 +86,58 @@ public class TestVarcharOperators
         assertThat(assertions.expression("VARCHAR ''"))
                 .hasType(VARCHAR)
                 .isEqualTo("");
+    }
+
+    @Test
+    public void testVarcharCast()
+    {
+        assertThat(assertions.expression("CAST(VARCHAR '1.0' AS DOUBLE)"))
+                .hasType(DOUBLE)
+                .isEqualTo(1.0d);
+
+        assertThat(assertions.expression("CAST(VARCHAR ' 1.0 ' AS DOUBLE)"))
+                .hasType(DOUBLE)
+                .isEqualTo(1.0d);
+
+        assertThat(assertions.expression("CAST(VARCHAR '13.37' AS REAL)"))
+                .hasType(REAL)
+                .isEqualTo(13.37f);
+
+        assertThat(assertions.expression("CAST(VARCHAR ' 13.37 ' AS REAL)"))
+                .hasType(REAL)
+                .isEqualTo(13.37f);
+
+        assertThat(assertions.expression("CAST(VARCHAR '1337' AS BIGINT)"))
+                .hasType(BIGINT)
+                .isEqualTo(1337L);
+
+        assertThat(assertions.expression("CAST(VARCHAR ' 1337 ' AS BIGINT)"))
+                .hasType(BIGINT)
+                .isEqualTo(1337L);
+
+        assertThat(assertions.expression("CAST(VARCHAR '1337' AS INTEGER)"))
+                .hasType(INTEGER)
+                .isEqualTo(1337);
+
+        assertThat(assertions.expression("CAST(VARCHAR ' 1337 ' AS INTEGER)"))
+                .hasType(INTEGER)
+                .isEqualTo(1337);
+
+        assertThat(assertions.expression("CAST(VARCHAR '1337' AS SMALLINT)"))
+                .hasType(SMALLINT)
+                .isEqualTo((short) 1337);
+
+        assertThat(assertions.expression("CAST(VARCHAR ' 1337 ' AS SMALLINT)"))
+                .hasType(SMALLINT)
+                .isEqualTo((short) 1337);
+
+        assertThat(assertions.expression("CAST(VARCHAR '21' AS TINYINT)"))
+                .hasType(TINYINT)
+                .isEqualTo((byte) 21);
+
+        assertThat(assertions.expression("CAST(VARCHAR ' 21 ' AS TINYINT)"))
+                .hasType(TINYINT)
+                .isEqualTo((byte) 21);
     }
 
     @Test


### PR DESCRIPTION
Java has inconsistent behaviour of the [Primitive].parse* methods:

Long.parseLong(" 1337 ") throws the NumberFormatException, while Float.parseFloat(" 1337 ") parses successfully.

FloatingDecimal class has the following code:

```
            in = in.trim(); // don't fool around with white space.
```

Let's not fool around and trim every varchar before parsing.

Fixes https://github.com/trinodb/trino/issues/23359

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(X) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
