### PR TITLE
Raise default for jdbc domain-compaction-threshold

### DIFF
--- a/docs/src/main/sphinx/connector/druid.md
+++ b/docs/src/main/sphinx/connector/druid.md
@@ -1,7 +1,7 @@
 ---
 myst:
   substitutions:
-      default_domain_compaction_threshold: '`32`'
+      default_domain_compaction_threshold: '`256`'
 ---
 
 # Druid connector

--- a/docs/src/main/sphinx/connector/exasol.md
+++ b/docs/src/main/sphinx/connector/exasol.md
@@ -1,7 +1,7 @@
 ---
 myst:
   substitutions:
-    default_domain_compaction_threshold: '`32`'
+    default_domain_compaction_threshold: '`256`'
 ---
 
 # Exasol connector

--- a/docs/src/main/sphinx/connector/mariadb.md
+++ b/docs/src/main/sphinx/connector/mariadb.md
@@ -1,7 +1,7 @@
 ---
 myst:
   substitutions:
-    default_domain_compaction_threshold: '`32`'
+    default_domain_compaction_threshold: '`256`'
 ---
 
 # MariaDB connector

--- a/docs/src/main/sphinx/connector/mysql.md
+++ b/docs/src/main/sphinx/connector/mysql.md
@@ -1,7 +1,7 @@
 ---
 myst:
   substitutions:
-    default_domain_compaction_threshold: '`32`'
+    default_domain_compaction_threshold: '`256`'
 ---
 
 # MySQL connector

--- a/docs/src/main/sphinx/connector/oracle.md
+++ b/docs/src/main/sphinx/connector/oracle.md
@@ -1,7 +1,7 @@
 ---
 myst:
   substitutions:
-    default_domain_compaction_threshold: '`32`'
+    default_domain_compaction_threshold: '`256`'
 ---
 
 # Oracle connector

--- a/docs/src/main/sphinx/connector/postgresql.md
+++ b/docs/src/main/sphinx/connector/postgresql.md
@@ -1,7 +1,7 @@
 ---
 myst:
   substitutions:
-    default_domain_compaction_threshold: '`32`'
+    default_domain_compaction_threshold: '`256`'
 ---
 
 # PostgreSQL connector

--- a/docs/src/main/sphinx/connector/redshift.md
+++ b/docs/src/main/sphinx/connector/redshift.md
@@ -1,7 +1,7 @@
 ---
 myst:
   substitutions:
-    default_domain_compaction_threshold: '`32`'
+    default_domain_compaction_threshold: '`256`'
 ---
 
 # Redshift connector

--- a/docs/src/main/sphinx/connector/singlestore.md
+++ b/docs/src/main/sphinx/connector/singlestore.md
@@ -1,7 +1,7 @@
 ---
 myst:
   substitutions:
-    default_domain_compaction_threshold: '`32`'
+    default_domain_compaction_threshold: '`256`'
 ---
 
 # SingleStore connector

--- a/docs/src/main/sphinx/connector/sqlserver.md
+++ b/docs/src/main/sphinx/connector/sqlserver.md
@@ -1,7 +1,7 @@
 ---
 myst:
   substitutions:
-    default_domain_compaction_threshold: '`32`'
+    default_domain_compaction_threshold: '`256`'
 ---
 
 # SQL Server connector

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadataConfig.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadataConfig.java
@@ -41,9 +41,9 @@ public class JdbcMetadataConfig
     // Pushed domains are transformed into SQL IN lists
     // (or sequence of range predicates) in JDBC connectors.
     // Too large IN lists cause significant performance regression.
-    // Use 32 as compaction threshold as it provides reasonable balance
+    // Use 256 as compaction threshold as it provides reasonable balance
     // between performance and pushdown capabilities
-    private int domainCompactionThreshold = 32;
+    private int domainCompactionThreshold = 256;
 
     public boolean isComplexExpressionPushdownEnabled()
     {

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcMetadataConfig.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcMetadataConfig.java
@@ -34,7 +34,7 @@ public class TestJdbcMetadataConfig
                 .setAggregationPushdownEnabled(true)
                 .setTopNPushdownEnabled(true)
                 .setBulkListColumns(false)
-                .setDomainCompactionThreshold(32));
+                .setDomainCompactionThreshold(256));
     }
 
     @Test


### PR DESCRIPTION
## Description
Reduces data transfer out of remote systems.
Most systems can handle IN lists of a few hundered values.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# JDBC
* Reduce data transfer from remote systems for queries with large IN lists. ({issue}`23381`)
```
