### PR TITLE
Remove deprecated constructor from ConnectorTableLayout

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorTableLayout.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorTableLayout.java
@@ -27,14 +27,6 @@ public final class ConnectorTableLayout
     private final List<String> partitionColumns;
     private final boolean multipleWritersPerPartitionSupported;
 
-    @Deprecated
-    public ConnectorTableLayout(ConnectorPartitioningHandle partitioning, List<String> partitionColumns)
-    {
-        // Keep the value of multipleWritersPerPartitionSupported false by default if partitioning is present
-        // for backward compatibility.
-        this(partitioning, partitionColumns, false);
-    }
-
     public ConnectorTableLayout(ConnectorPartitioningHandle partitioning, List<String> partitionColumns, boolean multipleWritersPerPartitionSupported)
     {
         this.partitioning = Optional.of(requireNonNull(partitioning, "partitioning is null"));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The constructor has been deprecated since version 446. 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

```markdown
# General
* Remove the deprecated constructor from `ConnectorTableLayout` class. ({issue}`23395`)
```
