### PR TITLE
Add trino2:// and jdbc:trino2:// schemes

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
@@ -339,11 +339,11 @@ public class ClientOptions
 
     public ClientSession toClientSession(TrinoUri uri)
     {
-        return uri
+        ClientSession.Builder builder = uri
                 .toClientSessionBuilder()
-                .source(uri.getSource().orElse(SOURCE_DEFAULT))
-                .encoding(encoding)
-                .build();
+                .source(uri.getSource().orElse(SOURCE_DEFAULT));
+        encoding.ifPresent(value -> builder.encoding(Optional.of(value)));
+        return builder.build();
     }
 
     public TrinoUri getTrinoUri()
@@ -474,7 +474,10 @@ public class ClientOptions
     public static URI parseServer(String server)
     {
         String lowerServer = server.toLowerCase(ENGLISH);
-        if (lowerServer.startsWith("http://") || lowerServer.startsWith("https://") || lowerServer.startsWith("trino://")) {
+        if (lowerServer.startsWith("http://")
+                || lowerServer.startsWith("https://")
+                || lowerServer.startsWith("trino://")
+                || lowerServer.startsWith("trino2://")) {
             return URI.create(server);
         }
 

--- a/client/trino-cli/src/test/java/io/trino/cli/TestClientOptions.java
+++ b/client/trino-cli/src/test/java/io/trino/cli/TestClientOptions.java
@@ -32,6 +32,7 @@ import java.util.Set;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.cli.Trino.createCommandLine;
+import static io.trino.client.spooling.encoding.QueryDataDecoders.getPreferredEncodings;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -98,6 +99,21 @@ public class TestClientOptions
         ClientSession session = console.clientOptions.toClientSession(console.clientOptions.getTrinoUri());
         assertThat(session.getServer().toString()).isEqualTo("http://test:80");
         assertThat(session.getCatalog()).isEqualTo(Optional.of("foo"));
+    }
+
+    @Test
+    public void testServerTrinoUriSpooled()
+    {
+        Console console = createConsole("--server=trino2://test/foo");
+        ClientSession session = console.clientOptions.toClientSession(console.clientOptions.getTrinoUri());
+        assertThat(session.getServer().toString()).isEqualTo("http://test:80/foo");
+        assertThat(session.getCatalog()).isEmpty();
+
+        Console console2 = createConsole("--server=trino://test/foo?protocolScheme=spooled");
+        ClientSession session2 = console2.clientOptions.toClientSession(console.clientOptions.getTrinoUri());
+        assertThat(session2.getServer().toString()).isEqualTo("http://test:80/foo");
+        assertThat(session2.getCatalog()).isEmpty();
+        assertThat(session2.getEncoding()).hasValue(getPreferredEncodings());
     }
 
     @Test

--- a/client/trino-client/src/main/java/io/trino/client/Scheme.java
+++ b/client/trino-client/src/main/java/io/trino/client/Scheme.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client;
+
+import static java.util.Locale.ENGLISH;
+
+public enum Scheme
+{
+    DIRECT, SPOOLED;
+
+    public static Scheme fromString(String scheme)
+    {
+        switch (scheme.toLowerCase(ENGLISH)) {
+            case "direct":
+            case "v1":
+                return DIRECT;
+            case "spooled":
+            case "v2":
+                return SPOOLED;
+            default:
+                throw new IllegalArgumentException("Unsupported scheme " + scheme);
+        }
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/StatementClientV1.java
+++ b/client/trino-client/src/main/java/io/trino/client/StatementClientV1.java
@@ -148,7 +148,7 @@ class StatementClientV1
         if (url == null) {
             throw new ClientException("Invalid server URL: " + session.getServer());
         }
-        url = url.newBuilder().encodedPath("/v1/statement").build();
+        url = url.newBuilder().addPathSegments("v1/statement").build();
 
         Request.Builder builder = prepareRequest(url)
                 .post(RequestBody.create(query, MEDIA_TYPE_TEXT));

--- a/client/trino-client/src/main/java/io/trino/client/spooling/encoding/QueryDataDecoders.java
+++ b/client/trino-client/src/main/java/io/trino/client/spooling/encoding/QueryDataDecoders.java
@@ -23,13 +23,15 @@ import java.util.Set;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.joining;
 
 public class QueryDataDecoders
 {
+    /** This list is ordered from the most preferred encoding to a least one */
     private static final List<Factory> decoders = ImmutableList.of(
-            new JsonQueryDataDecoder.Factory(),
             new JsonQueryDataDecoder.ZstdFactory(),
-            new JsonQueryDataDecoder.Lz4Factory());
+            new JsonQueryDataDecoder.Lz4Factory(),
+            new JsonQueryDataDecoder.Factory());
 
     private static final Map<String, Factory> encodingMap = factoriesMap();
 
@@ -54,6 +56,13 @@ public class QueryDataDecoders
     public static Set<String> getSupportedEncodings()
     {
         return encodingMap.keySet();
+    }
+
+    public static String getPreferredEncodings()
+    {
+        return decoders.stream()
+                .map(Factory::encoding)
+                .collect(joining(","));
     }
 
     private static Map<String, Factory> factoriesMap()

--- a/client/trino-client/src/main/java/io/trino/client/uri/ConnectionProperties.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/ConnectionProperties.java
@@ -21,6 +21,7 @@ import com.google.common.net.HostAndPort;
 import io.airlift.units.Duration;
 import io.trino.client.ClientSelectedRole;
 import io.trino.client.DnsResolver;
+import io.trino.client.Scheme;
 import io.trino.client.auth.external.ExternalRedirectStrategy;
 import io.trino.client.spooling.encoding.QueryDataDecoders;
 import org.ietf.jgss.GSSCredential;
@@ -115,6 +116,7 @@ final class ConnectionProperties
     public static final ConnectionProperty<String, LoggingLevel> HTTP_LOGGING_LEVEL = new HttpLoggingLevel();
     public static final ConnectionProperty<String, Map<String, String>> RESOURCE_ESTIMATES = new ResourceEstimates();
     public static final ConnectionProperty<String, List<String>> SQL_PATH = new SqlPath();
+    public static final ConnectionProperty<String, Scheme> PROTOCOL_SCHEME = new ProtocolScheme();
 
     private static final Set<ConnectionProperty<?, ?>> ALL_PROPERTIES = ImmutableSet.<ConnectionProperty<?, ?>>builder()
             // Keep sorted
@@ -150,6 +152,7 @@ final class ConnectionProperties
             .add(KERBEROS_USE_CANONICAL_HOSTNAME)
             .add(LOCALE)
             .add(PASSWORD)
+            .add(PROTOCOL_SCHEME)
             .add(RESOURCE_ESTIMATES)
             .add(ROLES)
             .add(SCHEMA)
@@ -926,6 +929,15 @@ final class ConnectionProperties
         public TimeZone()
         {
             super(PropertyName.TIMEZONE, NOT_REQUIRED, ALLOWED, converter(ZoneId::of, ZoneId::getId));
+        }
+    }
+
+    private static class ProtocolScheme
+            extends AbstractConnectionProperty<String, Scheme>
+    {
+        public ProtocolScheme()
+        {
+            super(PropertyName.PROTOCOL_SCHEME, NOT_REQUIRED, ALLOWED, converter(Scheme::fromString, Scheme::name));
         }
     }
 

--- a/client/trino-client/src/main/java/io/trino/client/uri/PropertyName.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/PropertyName.java
@@ -54,6 +54,7 @@ public enum PropertyName
     KERBEROS_USE_CANONICAL_HOSTNAME("KerberosUseCanonicalHostname"),
     LOCALE("locale"),
     PASSWORD("password"),
+    PROTOCOL_SCHEME("protocolScheme"),
     SQL_PATH("path"),
     RESOURCE_ESTIMATES("resourceEstimates"),
     ROLES("roles"),

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
@@ -32,7 +32,8 @@ public final class TrinoDriverUri
         extends TrinoUri
 {
     private static final String JDBC_URL_PREFIX = "jdbc:";
-    private static final String JDBC_URL_START = JDBC_URL_PREFIX + "trino:";
+    private static final String JDBC_URL_START_V1 = JDBC_URL_PREFIX + URL_START_V1;
+    private static final String JDBC_URL_START_V2 = JDBC_URL_PREFIX + URL_START_V2;
 
     private TrinoDriverUri(String uri, Properties driverProperties)
             throws SQLException
@@ -53,7 +54,7 @@ public final class TrinoDriverUri
 
     public static boolean acceptsURL(String url)
     {
-        return url.startsWith(JDBC_URL_START);
+        return url.startsWith(JDBC_URL_START_V1) || url.startsWith(JDBC_URL_START_V2);
     }
 
     private static URI parseDriverUrl(String url)
@@ -85,11 +86,11 @@ public final class TrinoDriverUri
     private static void validatePrefix(String url)
             throws SQLException
     {
-        if (!url.startsWith(JDBC_URL_START)) {
+        if (!url.startsWith(JDBC_URL_START_V1) && !url.startsWith(JDBC_URL_START_V2)) {
             throw new SQLException("Invalid JDBC URL: " + url);
         }
 
-        if (url.equals(JDBC_URL_START)) {
+        if (url.equals(JDBC_URL_START_V1) || url.equals(JDBC_URL_START_V2)) {
             throw new SQLException("Empty JDBC URL: " + url);
         }
     }


### PR DESCRIPTION
This comes with support for X-Forwarded-Prefix and enables preferred spooled encodings by default.

Can be tested with 

```
./client/trino-cli/target/trino-cli-458-SNAPSHOT-executable.jar trino2://localhost:8080/my/path/to-trino --network-logging=BASIC
```

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
