### PR TITLE
Fix broken testJmxTablesExposedByDeltaLakeConnectorBackedByGlueMetastore

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeJmx.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeJmx.java
@@ -34,6 +34,7 @@ public class TestDeltaLakeJmx
     public void testJmxTablesExposedByDeltaLakeConnectorBackedByGlueMetastore()
     {
         assertThat(onTrino().executeQuery("SHOW TABLES IN jmx.current LIKE '%name=delta%'")).containsOnly(
+                row("io.trino.filesystem.s3:name=delta,type=s3filesystemstats"),
                 row("io.trino.plugin.hive.metastore.cache:name=delta,type=cachinghivemetastore"),
                 row("io.trino.plugin.hive.metastore.glue:name=delta,type=gluehivemetastore"),
                 row("io.trino.plugin.hive.metastore.glue:name=delta,type=gluemetastorestats"),


### PR DESCRIPTION
## Description

Example failure https://github.com/trinodb/trino/actions/runs/10853271030/job/30121744630

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
