### PR TITLE
Fix encoding for Elasticsearch count pushdown

### DIFF
--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/ElasticsearchClient.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/ElasticsearchClient.java
@@ -666,7 +666,7 @@ public class ElasticsearchClient
                                 "GET",
                                 format("/%s/_count?preference=_shards:%s", index, shard),
                                 ImmutableMap.of(),
-                                new StringEntity(sourceBuilder.toString()),
+                                new StringEntity(sourceBuilder.toString(), UTF_8),
                                 new BasicHeader("Content-Type", "application/json"));
             }
             catch (ResponseException e) {

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
@@ -1537,6 +1537,38 @@ public abstract class BaseElasticsearchConnectorTest
     }
 
     @Test
+    public void testFiltersCharset()
+            throws IOException
+    {
+        String indexName = "filter_charset_pushdown";
+
+        @Language("JSON")
+        String mappings = """
+                {
+                  "properties": {
+                    "keyword_column":   { "type": "keyword" },
+                    "text_column":      { "type": "text" }
+                  }
+                }
+                """;
+
+        createIndex(indexName, mappings);
+
+        index(indexName, ImmutableMap.<String, Object>builder()
+                .put("keyword_column", "Türkiye")
+                .put("text_column", "Türkiye")
+                .buildOrThrow());
+
+        assertQuery("SELECT count(*) FROM filter_charset_pushdown WHERE keyword_column = 'Türkiye'", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_charset_pushdown WHERE keyword_column = 'bar'", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_charset_pushdown WHERE text_column = 'Türkiye'", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_charset_pushdown WHERE text_column = 'some'", "VALUES 0");
+
+        assertQuery("SELECT keyword_column FROM filter_charset_pushdown WHERE keyword_column = 'Türkiye'", "VALUES ('Türkiye')");
+        assertQuery("SELECT text_column FROM filter_charset_pushdown WHERE text_column = 'Türkiye'", "VALUES ('Türkiye')");
+    }
+
+    @Test
     public void testLimitPushdown()
             throws IOException
     {

--- a/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/client/OpenSearchClient.java
+++ b/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/client/OpenSearchClient.java
@@ -667,7 +667,7 @@ public class OpenSearchClient
                                 "GET",
                                 format("/%s/_count?preference=_shards:%s", index, shard),
                                 ImmutableMap.of(),
-                                new StringEntity(sourceBuilder.toString()),
+                                new StringEntity(sourceBuilder.toString(), UTF_8),
                                 new BasicHeader("Content-Type", "application/json"));
             }
             catch (ResponseException e) {

--- a/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
+++ b/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
@@ -1584,6 +1584,38 @@ public abstract class BaseOpenSearchConnectorTest
     }
 
     @Test
+    public void testFiltersCharset()
+            throws IOException
+    {
+        String indexName = "filter_charset_pushdown";
+
+        @Language("JSON")
+        String mappings = """
+                {
+                  "properties": {
+                    "keyword_column":   { "type": "keyword" },
+                    "text_column":      { "type": "text" }
+                  }
+                }
+                """;
+
+        createIndex(indexName, mappings);
+
+        index(indexName, ImmutableMap.<String, Object>builder()
+                .put("keyword_column", "Türkiye")
+                .put("text_column", "Türkiye")
+                .buildOrThrow());
+
+        assertQuery("SELECT count(*) FROM filter_charset_pushdown WHERE keyword_column = 'Türkiye'", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_charset_pushdown WHERE keyword_column = 'bar'", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_charset_pushdown WHERE text_column = 'Türkiye'", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_charset_pushdown WHERE text_column = 'some'", "VALUES 0");
+
+        assertQuery("SELECT keyword_column FROM filter_charset_pushdown WHERE keyword_column = 'Türkiye'", "VALUES ('Türkiye')");
+        assertQuery("SELECT text_column FROM filter_charset_pushdown WHERE text_column = 'Türkiye'", "VALUES ('Türkiye')");
+    }
+
+    @Test
     public void testLimitPushdown()
             throws IOException
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

We've identified that when a COUNT(*) query was pushed down and contained special characters, the QueryBuilder string was being handled as ISO-8859-1 and causing parsing issues for Elasticsearch.

## Additional context and related issues

For example, this query:
```
SELECT COUNT(*) FROM catalog.default.users where country = 'Türkiye';
```

In case the "country" field is a keyword, would result in:

> {"error":{"root_cause":[{"type":"parsing_exception","reason":"Failed to parse","line":1,"col":53}],"type":"parsing_exception","reason":"Failed to parse","line":1,"col":53,"caused_by":{"type":"x_content_parse_exception","reason":"[1:53] [bool] failed to parse field [filter]","caused_by":{"type":"json_parse_exception","reason":"Invalid UTF-8 middle byte 0x73\n at [Source: (org.elasticsearch.common.io.stream.ByteBufferStreamInput); line: 1, column: 64]"}}},"status":400}


The source for the problem was the `new StringEntity(sourceBuilder.toString())`, which uses https://github.com/apache/httpcomponents-core/blob/rel/v4.4.16/httpcore/src/main/java/org/apache/http/entity/ContentType.java#L106-L107 and defaults to ISO.

![image](https://github.com/user-attachments/assets/678ca3e3-fc55-439c-b0d5-ca7df11e3c0b)



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
