### PR TITLE
change client_info column_type to MEDIUMTEXT

### DIFF
--- a/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/QueryDao.java
+++ b/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/QueryDao.java
@@ -32,7 +32,7 @@ public interface QueryDao
             "  trace_token VARCHAR(255) NULL,\n" +
             "  remote_client_address VARCHAR(255) NULL,\n" +
             "  user_agent VARCHAR(255) NULL,\n" +
-            "  client_info VARCHAR(255) NULL,\n" +
+            "  client_info MEDIUMTEXT NULL,\n" +
             "  client_tags_json MEDIUMTEXT NOT NULL,\n" +
             "  source VARCHAR(255) NULL,\n" +
             "  catalog VARCHAR(255) NULL,\n" +


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
Fixes #22362 
Changed the column data-type for `client_info` from `varchar(255)` to `MEDIUMTEXT` in mysql event listener. This will allow for a larger payload to be stored, and is also inline with other columns(possibly big) in the table.



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( X ) Release notes are required, with the following suggested text:

```markdown
# MySQL Event Listener 
* Change data type for client_info in mysql event listener to MEDIUMTEXT ({issue}`22362`)
```
