### PR TITLE
Optimize column listing to not require fetching table properties

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
@@ -1082,7 +1082,7 @@ public class DefaultJdbcMetadata
         for (SchemaTableName tableName : tables) {
             try {
                 jdbcClient.getTableHandle(session, tableName)
-                        .ifPresent(tableHandle -> columns.put(tableName, getTableMetadata(session, tableHandle).getColumns()));
+                        .ifPresent(tableHandle -> columns.put(tableName, getColumnMetadata(session, tableHandle)));
             }
             catch (TableNotFoundException | AccessDeniedException e) {
                 // table disappeared during listing operation or user is not allowed to access it
@@ -1090,6 +1090,15 @@ public class DefaultJdbcMetadata
             }
         }
         return columns.buildOrThrow();
+    }
+
+    public List<ColumnMetadata> getColumnMetadata(ConnectorSession session, JdbcTableHandle tableHandle)
+    {
+        return getColumnHandles(session, tableHandle).values()
+                .stream()
+                .map(JdbcColumnHandle.class::cast)
+                .map(JdbcColumnHandle::getColumnMetadata)
+                .collect(toImmutableList());
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcConnectionAccesses.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcConnectionAccesses.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import io.trino.plugin.base.mapping.IdentifierMapping;
+import io.trino.plugin.jdbc.credential.EmptyCredentialProvider;
+import io.trino.testing.QueryRunner;
+import org.h2.Driver;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.trino.plugin.jdbc.H2QueryRunner.createH2QueryRunner;
+import static io.trino.plugin.jdbc.TestingH2JdbcModule.createH2ConnectionUrl;
+import static io.trino.spi.connector.ConnectorMetadata.MODIFYING_ROWS_MESSAGE;
+import static io.trino.tpch.TpchTable.NATION;
+import static io.trino.tpch.TpchTable.REGION;
+import static java.util.Objects.requireNonNull;
+
+// TODO: Implement dedicated test to count number of queries executed.
+// This test approximates the number of I/O operations by counting number of times connection is opened since we almost always open a new connection to execute a query.
+public class TestJdbcConnectionAccesses
+        extends BaseJdbcConnectionCreationTest
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        String connectionUrl = createH2ConnectionUrl();
+        DriverConnectionFactory delegate = DriverConnectionFactory.builder(new Driver(), connectionUrl, new EmptyCredentialProvider()).build();
+        this.connectionFactory = new ConnectionCountingConnectionFactory(delegate);
+        return createH2QueryRunner(
+                ImmutableList.of(NATION, REGION),
+                ImmutableMap.of("connection-url", connectionUrl,
+                        // disables connection reuse to approximate number of I/O operations since we almost always open a new connection to execute a query
+                        "query.reuse-connection", "false"),
+                // to make sure we always open connections in the same way
+                ImmutableMap.of("node-scheduler.include-coordinator", "false"),
+                new TestingConnectionH2Module(connectionFactory));
+    }
+
+    @Test
+    public void testJdbcConnectionCreations()
+    {
+        assertJdbcConnections("SELECT * FROM nation LIMIT 1", 3, Optional.empty());
+        assertJdbcConnections("SELECT * FROM nation ORDER BY nationkey LIMIT 1", 3, Optional.empty());
+        assertJdbcConnections("SELECT * FROM nation WHERE nationkey = 1", 3, Optional.empty());
+        assertJdbcConnections("SELECT avg(nationkey) FROM nation", 3, Optional.empty());
+        assertJdbcConnections("SELECT * FROM nation, region", 6, Optional.empty());
+        assertJdbcConnections("SELECT * FROM nation n, region r WHERE n.regionkey = r.regionkey", 6, Optional.empty());
+        assertJdbcConnections("SELECT * FROM nation JOIN region USING(regionkey)", 6, Optional.empty());
+        assertJdbcConnections("SELECT * FROM information_schema.schemata", 1, Optional.empty());
+        assertJdbcConnections("SELECT * FROM information_schema.tables", 1, Optional.empty());
+        assertJdbcConnections("SELECT * FROM information_schema.columns", 5, Optional.empty());
+        assertJdbcConnections("SELECT * FROM nation", 3, Optional.empty());
+        assertJdbcConnections("CREATE TABLE copy_of_nation AS SELECT * FROM nation", 11, Optional.empty());
+        assertJdbcConnections("INSERT INTO copy_of_nation SELECT * FROM nation", 12, Optional.empty());
+        assertJdbcConnections("DELETE FROM copy_of_nation WHERE nationkey = 3", 3, Optional.empty());
+        assertJdbcConnections("UPDATE copy_of_nation SET name = 'POLAND' WHERE nationkey = 1", 3, Optional.empty());
+        assertJdbcConnections("MERGE INTO copy_of_nation n USING region r ON r.regionkey= n.regionkey WHEN MATCHED THEN DELETE", 4, Optional.of(MODIFYING_ROWS_MESSAGE));
+        assertJdbcConnections("DROP TABLE copy_of_nation", 2, Optional.empty());
+        assertJdbcConnections("SHOW SCHEMAS", 1, Optional.empty());
+        assertJdbcConnections("SHOW TABLES", 2, Optional.empty());
+        assertJdbcConnections("SHOW STATS FOR nation", 2, Optional.empty());
+        assertJdbcConnections("SELECT * FROM system.jdbc.columns WHERE table_cat = 'jdbc'", 5, Optional.empty());
+    }
+
+    private static class TestingConnectionH2Module
+            implements Module
+    {
+        private final ConnectionCountingConnectionFactory connectionCountingConnectionFactory;
+
+        TestingConnectionH2Module(ConnectionCountingConnectionFactory connectionCountingConnectionFactory)
+        {
+            this.connectionCountingConnectionFactory = requireNonNull(connectionCountingConnectionFactory, "connectionCountingConnectionFactory is null");
+        }
+
+        @Override
+        public void configure(Binder binder) {}
+
+        @Provides
+        @Singleton
+        @ForBaseJdbc
+        public static JdbcClient provideJdbcClient(BaseJdbcConfig config, ConnectionFactory connectionFactory, QueryBuilder queryBuilder, IdentifierMapping identifierMapping)
+        {
+            return new TestingH2JdbcClient(config, connectionFactory, queryBuilder, identifierMapping);
+        }
+
+        @Provides
+        @Singleton
+        @ForBaseJdbc
+        public ConnectionFactory getConnectionFactory()
+        {
+            return connectionCountingConnectionFactory;
+        }
+    }
+}

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcConnectionCreation.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcConnectionCreation.java
@@ -75,6 +75,7 @@ public class TestJdbcConnectionCreation
         assertJdbcConnections("SHOW SCHEMAS", 1, Optional.empty());
         assertJdbcConnections("SHOW TABLES", 1, Optional.empty());
         assertJdbcConnections("SHOW STATS FOR nation", 1, Optional.empty());
+        assertJdbcConnections("SELECT * FROM system.jdbc.columns WHERE table_cat = 'jdbc'", 1, Optional.empty());
     }
 
     private static class TestingConnectionH2Module

--- a/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteMetadata.java
+++ b/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteMetadata.java
@@ -134,7 +134,8 @@ public class IgniteMetadata
                 igniteClient.getTableProperties(session, handle));
     }
 
-    private List<ColumnMetadata> getColumnMetadata(ConnectorSession session, JdbcTableHandle handle)
+    @Override
+    public List<ColumnMetadata> getColumnMetadata(ConnectorSession session, JdbcTableHandle handle)
     {
         return igniteClient.getColumns(session, handle).stream()
                 .filter(column -> !IGNITE_DUMMY_ID.equalsIgnoreCase(column.getColumnName()))

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
@@ -156,7 +156,8 @@ public class PhoenixMetadata
                 phoenixClient.getTableProperties(session, handle));
     }
 
-    private List<ColumnMetadata> getColumnMetadata(ConnectorSession session, JdbcTableHandle handle)
+    @Override
+    public List<ColumnMetadata> getColumnMetadata(ConnectorSession session, JdbcTableHandle handle)
     {
         return phoenixClient.getColumns(session, handle).stream()
                 .filter(column -> !ROWKEY.equalsIgnoreCase(column.getColumnName()))

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlJdbcConnectionAccesses.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlJdbcConnectionAccesses.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.postgresql;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Binder;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.plugin.jdbc.BaseJdbcConnectionCreationTest;
+import io.trino.plugin.jdbc.ConnectionFactory;
+import io.trino.plugin.jdbc.DriverConnectionFactory;
+import io.trino.plugin.jdbc.ForBaseJdbc;
+import io.trino.plugin.jdbc.JdbcPlugin;
+import io.trino.plugin.jdbc.credential.CredentialProvider;
+import io.trino.plugin.jdbc.credential.StaticCredentialProvider;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+import org.postgresql.Driver;
+
+import java.util.Optional;
+import java.util.Properties;
+
+import static io.airlift.configuration.ConfigurationAwareModule.combine;
+import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static io.trino.spi.connector.ConnectorMetadata.MODIFYING_ROWS_MESSAGE;
+import static io.trino.testing.QueryAssertions.copyTpchTables;
+import static io.trino.tpch.TpchTable.NATION;
+import static io.trino.tpch.TpchTable.REGION;
+import static java.util.Objects.requireNonNull;
+
+// TODO: Implement dedicated test to count number of queries executed.
+// This test approximates the number of I/O operations by counting number of times connection is opened since we almost always open a new connection to execute a query.
+public class TestPostgreSqlJdbcConnectionAccesses
+        extends BaseJdbcConnectionCreationTest
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        TestingPostgreSqlServer postgreSqlServer = closeAfterClass(new TestingPostgreSqlServer());
+        this.connectionFactory = getConnectionCountingConnectionFactory(postgreSqlServer);
+        DistributedQueryRunner queryRunner = PostgreSqlQueryRunner.builder(postgreSqlServer)
+                // to make sure we always open connections in the same way
+                .addCoordinatorProperty("node-scheduler.include-coordinator", "false")
+                .amendSession(sessionBuilder -> sessionBuilder.setCatalog("counting_postgresql"))
+                .setAdditionalSetup(runner -> {
+                    runner.installPlugin(new JdbcPlugin(
+                            "counting_postgresql",
+                            combine(new PostgreSqlClientModule(), new TestingPostgreSqlModule(connectionFactory))));
+                    runner.createCatalog("counting_postgresql", "counting_postgresql", ImmutableMap.of(
+                            "connection-url", postgreSqlServer.getJdbcUrl(),
+                            "connection-user", postgreSqlServer.getUser(),
+                            "connection-password", postgreSqlServer.getPassword(),
+                            // disables connection reuse to approximate number of I/O operations since we almost always open a new connection to execute a query
+                            "query.reuse-connection", "false"));
+                })
+                .build();
+        copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, ImmutableList.of(NATION, REGION));
+        return queryRunner;
+    }
+
+    private static ConnectionCountingConnectionFactory getConnectionCountingConnectionFactory(TestingPostgreSqlServer postgreSqlServer)
+    {
+        Properties connectionProperties = new Properties();
+        CredentialProvider credentialProvider = new StaticCredentialProvider(
+                Optional.of(postgreSqlServer.getUser()),
+                Optional.of(postgreSqlServer.getPassword()));
+        DriverConnectionFactory delegate = DriverConnectionFactory.builder(new Driver(), postgreSqlServer.getJdbcUrl(), credentialProvider)
+                .setConnectionProperties(connectionProperties)
+                .build();
+        return new ConnectionCountingConnectionFactory(delegate);
+    }
+
+    @Test
+    public void testJdbcConnectionCreations()
+    {
+        assertJdbcConnections("SELECT * FROM nation LIMIT 1", 5, Optional.empty());
+        assertJdbcConnections("SELECT * FROM nation ORDER BY nationkey LIMIT 1", 5, Optional.empty());
+        assertJdbcConnections("SELECT * FROM nation WHERE nationkey = 1", 5, Optional.empty());
+        assertJdbcConnections("SELECT avg(nationkey) FROM nation", 4, Optional.empty());
+        assertJdbcConnections("SELECT * FROM nation, region", 6, Optional.empty());
+        assertJdbcConnections("SELECT * FROM nation n, region r WHERE n.regionkey = r.regionkey", 9, Optional.empty());
+        assertJdbcConnections("SELECT * FROM nation JOIN region USING(regionkey)", 10, Optional.empty());
+        assertJdbcConnections("SELECT * FROM information_schema.schemata", 1, Optional.empty());
+        assertJdbcConnections("SELECT * FROM information_schema.tables", 1, Optional.empty());
+        assertJdbcConnections("SELECT * FROM information_schema.columns", 5, Optional.empty());
+        assertJdbcConnections("SELECT * FROM nation", 3, Optional.empty());
+        assertJdbcConnections("SELECT * FROM TABLE (system.query(query => 'SELECT * FROM tpch.nation'))", 2, Optional.empty());
+        assertJdbcConnections("CREATE TABLE copy_of_nation AS SELECT * FROM nation", 15, Optional.empty());
+        assertJdbcConnections("INSERT INTO copy_of_nation SELECT * FROM nation", 13, Optional.empty());
+        assertJdbcConnections("DELETE FROM copy_of_nation WHERE nationkey = 3", 4, Optional.empty());
+        assertJdbcConnections("UPDATE copy_of_nation SET name = 'POLAND' WHERE nationkey = 1", 4, Optional.empty());
+        assertJdbcConnections("MERGE INTO copy_of_nation n USING region r ON r.regionkey= n.regionkey WHEN MATCHED THEN DELETE", 5, Optional.of(MODIFYING_ROWS_MESSAGE));
+        assertJdbcConnections("DROP TABLE copy_of_nation", 2, Optional.empty());
+        assertJdbcConnections("SHOW SCHEMAS", 1, Optional.empty());
+        assertJdbcConnections("SHOW TABLES", 2, Optional.empty());
+        assertJdbcConnections("SHOW STATS FOR nation", 4, Optional.empty());
+        assertJdbcConnections("SELECT * FROM system.jdbc.columns WHERE table_cat = 'counting_postgresql'", 5, Optional.empty());
+    }
+
+    private static final class TestingPostgreSqlModule
+            extends AbstractConfigurationAwareModule
+    {
+        private final ConnectionCountingConnectionFactory connectionCountingConnectionFactory;
+
+        private TestingPostgreSqlModule(ConnectionCountingConnectionFactory connectionCountingConnectionFactory)
+        {
+            this.connectionCountingConnectionFactory = requireNonNull(connectionCountingConnectionFactory, "connectionCountingConnectionFactory is null");
+        }
+
+        @Override
+        protected void setup(Binder binder) {}
+
+        @Provides
+        @Singleton
+        @ForBaseJdbc
+        public ConnectionFactory getConnectionFactory()
+        {
+            return connectionCountingConnectionFactory;
+        }
+    }
+}

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlJdbcConnectionCreation.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlJdbcConnectionCreation.java
@@ -26,10 +26,8 @@ import io.trino.plugin.jdbc.ForBaseJdbc;
 import io.trino.plugin.jdbc.JdbcPlugin;
 import io.trino.plugin.jdbc.credential.CredentialProvider;
 import io.trino.plugin.jdbc.credential.StaticCredentialProvider;
-import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
-import io.trino.tpch.TpchTable;
 import org.junit.jupiter.api.Test;
 import org.postgresql.Driver;
 
@@ -37,11 +35,9 @@ import java.util.Optional;
 import java.util.Properties;
 
 import static io.airlift.configuration.ConfigurationAwareModule.combine;
-import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.spi.connector.ConnectorMetadata.MODIFYING_ROWS_MESSAGE;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
-import static io.trino.testing.TestingSession.testSessionBuilder;
 import static io.trino.tpch.TpchTable.NATION;
 import static io.trino.tpch.TpchTable.REGION;
 import static java.util.Objects.requireNonNull;
@@ -55,7 +51,22 @@ public class TestPostgreSqlJdbcConnectionCreation
     {
         TestingPostgreSqlServer postgreSqlServer = closeAfterClass(new TestingPostgreSqlServer());
         this.connectionFactory = getConnectionCountingConnectionFactory(postgreSqlServer);
-        return createPostgreSqlQueryRunner(postgreSqlServer, ImmutableList.of(NATION, REGION), connectionFactory);
+        DistributedQueryRunner queryRunner = PostgreSqlQueryRunner.builder(postgreSqlServer)
+                // to make sure we always open connections in the same way
+                .addCoordinatorProperty("node-scheduler.include-coordinator", "false")
+                .amendSession(sessionBuilder -> sessionBuilder.setCatalog("counting_postgresql"))
+                .setAdditionalSetup(runner -> {
+                    runner.installPlugin(new JdbcPlugin(
+                            "counting_postgresql",
+                            combine(new PostgreSqlClientModule(), new TestingPostgreSqlModule(connectionFactory))));
+                    runner.createCatalog("counting_postgresql", "counting_postgresql", ImmutableMap.of(
+                            "connection-url", postgreSqlServer.getJdbcUrl(),
+                            "connection-user", postgreSqlServer.getUser(),
+                            "connection-password", postgreSqlServer.getPassword()));
+                })
+                .build();
+        copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, ImmutableList.of(NATION, REGION));
+        return queryRunner;
     }
 
     private static ConnectionCountingConnectionFactory getConnectionCountingConnectionFactory(TestingPostgreSqlServer postgreSqlServer)
@@ -94,38 +105,6 @@ public class TestPostgreSqlJdbcConnectionCreation
         assertJdbcConnections("SHOW SCHEMAS", 1, Optional.empty());
         assertJdbcConnections("SHOW TABLES", 1, Optional.empty());
         assertJdbcConnections("SHOW STATS FOR nation", 2, Optional.empty());
-    }
-
-    private static QueryRunner createPostgreSqlQueryRunner(
-            TestingPostgreSqlServer server,
-            Iterable<TpchTable<?>> tables,
-            ConnectionCountingConnectionFactory connectionCountingConnectionFactory)
-            throws Exception
-    {
-        QueryRunner queryRunner = DistributedQueryRunner.builder(testSessionBuilder()
-                        .setCatalog("postgresql")
-                        .setSchema("tpch")
-                        .build())
-                // to make sure we always open connections in the same way
-                .setCoordinatorProperties(ImmutableMap.of("node-scheduler.include-coordinator", "false"))
-                .build();
-        try {
-            queryRunner.installPlugin(new TpchPlugin());
-            queryRunner.installPlugin(new JdbcPlugin(
-                    "postgresql",
-                    combine(new PostgreSqlClientModule(), new TestingPostgreSqlModule(connectionCountingConnectionFactory))));
-            queryRunner.createCatalog("tpch", "tpch");
-            queryRunner.createCatalog("postgresql", "postgresql", ImmutableMap.of(
-                    "connection-url", server.getJdbcUrl(),
-                    "connection-user", server.getUser(),
-                    "connection-password", server.getPassword()));
-            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, tables);
-            return queryRunner;
-        }
-        catch (Throwable e) {
-            closeAllSuppress(e, queryRunner);
-            throw e;
-        }
     }
 
     private static final class TestingPostgreSqlModule

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlJdbcConnectionCreation.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlJdbcConnectionCreation.java
@@ -54,6 +54,12 @@ public class TestPostgreSqlJdbcConnectionCreation
             throws Exception
     {
         TestingPostgreSqlServer postgreSqlServer = closeAfterClass(new TestingPostgreSqlServer());
+        this.connectionFactory = getConnectionCountingConnectionFactory(postgreSqlServer);
+        return createPostgreSqlQueryRunner(postgreSqlServer, ImmutableList.of(NATION, REGION), connectionFactory);
+    }
+
+    private static ConnectionCountingConnectionFactory getConnectionCountingConnectionFactory(TestingPostgreSqlServer postgreSqlServer)
+    {
         Properties connectionProperties = new Properties();
         CredentialProvider credentialProvider = new StaticCredentialProvider(
                 Optional.of(postgreSqlServer.getUser()),
@@ -61,8 +67,7 @@ public class TestPostgreSqlJdbcConnectionCreation
         DriverConnectionFactory delegate = DriverConnectionFactory.builder(new Driver(), postgreSqlServer.getJdbcUrl(), credentialProvider)
                 .setConnectionProperties(connectionProperties)
                 .build();
-        this.connectionFactory = new ConnectionCountingConnectionFactory(delegate);
-        return createPostgreSqlQueryRunner(postgreSqlServer, ImmutableList.of(NATION, REGION), connectionFactory);
+        return new ConnectionCountingConnectionFactory(delegate);
     }
 
     @Test

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlJdbcConnectionCreation.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlJdbcConnectionCreation.java
@@ -105,6 +105,7 @@ public class TestPostgreSqlJdbcConnectionCreation
         assertJdbcConnections("SHOW SCHEMAS", 1, Optional.empty());
         assertJdbcConnections("SHOW TABLES", 1, Optional.empty());
         assertJdbcConnections("SHOW STATS FOR nation", 2, Optional.empty());
+        assertJdbcConnections("SELECT * FROM system.jdbc.columns WHERE table_cat = 'counting_postgresql'", 1, Optional.empty());
     }
 
     private static final class TestingPostgreSqlModule

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClientModule.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClientModule.java
@@ -15,21 +15,13 @@ package io.trino.plugin.sqlserver;
 
 import com.google.inject.Binder;
 import com.google.inject.Key;
-import com.google.inject.Provides;
 import com.google.inject.Scopes;
-import com.google.inject.Singleton;
-import com.microsoft.sqlserver.jdbc.SQLServerDriver;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
-import io.opentelemetry.api.OpenTelemetry;
-import io.trino.plugin.jdbc.BaseJdbcConfig;
-import io.trino.plugin.jdbc.ConnectionFactory;
-import io.trino.plugin.jdbc.DriverConnectionFactory;
 import io.trino.plugin.jdbc.ForBaseJdbc;
 import io.trino.plugin.jdbc.JdbcClient;
 import io.trino.plugin.jdbc.JdbcJoinPushdownSupportModule;
 import io.trino.plugin.jdbc.JdbcStatisticsConfig;
 import io.trino.plugin.jdbc.MaxDomainCompactionThreshold;
-import io.trino.plugin.jdbc.credential.CredentialProvider;
 import io.trino.plugin.jdbc.ptf.Procedure;
 import io.trino.plugin.jdbc.ptf.Query;
 import io.trino.spi.function.table.ConnectorTableFunction;
@@ -61,21 +53,5 @@ public class SqlServerClientModule
                 SqlServerConfig.class,
                 SqlServerConfig::isStoredProcedureTableFunctionEnabled,
                 internalBinder -> newSetBinder(internalBinder, ConnectorTableFunction.class).addBinding().toProvider(Procedure.class).in(Scopes.SINGLETON)));
-    }
-
-    @Provides
-    @Singleton
-    @ForBaseJdbc
-    public static ConnectionFactory getConnectionFactory(
-            BaseJdbcConfig config,
-            SqlServerConfig sqlServerConfig,
-            CredentialProvider credentialProvider,
-            OpenTelemetry openTelemetry)
-    {
-        return new SqlServerConnectionFactory(
-                DriverConnectionFactory.builder(new SQLServerDriver(), config.getConnectionUrl(), credentialProvider)
-                        .setOpenTelemetry(openTelemetry)
-                        .build(),
-                sqlServerConfig.isSnapshotIsolationDisabled());
     }
 }

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerConnectionFactoryModule.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerConnectionFactoryModule.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.sqlserver;
+
+import com.google.inject.Binder;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.microsoft.sqlserver.jdbc.SQLServerDriver;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.opentelemetry.api.OpenTelemetry;
+import io.trino.plugin.jdbc.BaseJdbcConfig;
+import io.trino.plugin.jdbc.ConnectionFactory;
+import io.trino.plugin.jdbc.DriverConnectionFactory;
+import io.trino.plugin.jdbc.ForBaseJdbc;
+import io.trino.plugin.jdbc.credential.CredentialProvider;
+
+public class SqlServerConnectionFactoryModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder) {}
+
+    @Provides
+    @Singleton
+    @ForBaseJdbc
+    public static ConnectionFactory getConnectionFactory(
+            BaseJdbcConfig config,
+            SqlServerConfig sqlServerConfig,
+            CredentialProvider credentialProvider,
+            OpenTelemetry openTelemetry)
+    {
+        return new SqlServerConnectionFactory(
+                DriverConnectionFactory.builder(new SQLServerDriver(), config.getConnectionUrl(), credentialProvider)
+                        .setOpenTelemetry(openTelemetry)
+                        .build(),
+                sqlServerConfig.isSnapshotIsolationDisabled());
+    }
+}

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerPlugin.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerPlugin.java
@@ -15,11 +15,13 @@ package io.trino.plugin.sqlserver;
 
 import io.trino.plugin.jdbc.JdbcPlugin;
 
+import static io.airlift.configuration.ConfigurationAwareModule.combine;
+
 public class SqlServerPlugin
         extends JdbcPlugin
 {
     public SqlServerPlugin()
     {
-        super("sqlserver", new SqlServerClientModule());
+        super("sqlserver", combine(new SqlServerClientModule(), new SqlServerConnectionFactoryModule()));
     }
 }

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerJdbcConnectionAccesses.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerJdbcConnectionAccesses.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.sqlserver;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Binder;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.microsoft.sqlserver.jdbc.SQLServerDriver;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.plugin.jdbc.BaseJdbcConnectionCreationTest;
+import io.trino.plugin.jdbc.ConnectionFactory;
+import io.trino.plugin.jdbc.DriverConnectionFactory;
+import io.trino.plugin.jdbc.ForBaseJdbc;
+import io.trino.plugin.jdbc.JdbcPlugin;
+import io.trino.plugin.jdbc.credential.CredentialProvider;
+import io.trino.plugin.jdbc.credential.StaticCredentialProvider;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.Properties;
+
+import static io.airlift.configuration.ConfigurationAwareModule.combine;
+import static io.trino.plugin.sqlserver.TestingSqlServer.LATEST_VERSION;
+import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static io.trino.spi.connector.ConnectorMetadata.MODIFYING_ROWS_MESSAGE;
+import static io.trino.testing.QueryAssertions.copyTpchTables;
+import static io.trino.tpch.TpchTable.NATION;
+import static io.trino.tpch.TpchTable.REGION;
+import static java.util.Objects.requireNonNull;
+
+// TODO: Implement dedicated test to count number of queries executed.
+// This test approximates the number of I/O operations by counting number of times connection is opened since we almost always open a new connection to execute a query.
+public class TestSqlServerJdbcConnectionAccesses
+        extends BaseJdbcConnectionCreationTest
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        TestingSqlServer sqlServer = closeAfterClass(new TestingSqlServer(LATEST_VERSION));
+        this.connectionFactory = getConnectionCountingConnectionFactory(sqlServer);
+        DistributedQueryRunner queryRunner = SqlServerQueryRunner.builder(sqlServer)
+                // to make sure we always open connections in the same way
+                .addCoordinatorProperty("node-scheduler.include-coordinator", "false")
+                .amendSession(sessionBuilder -> sessionBuilder.setCatalog("counting_sqlserver"))
+                .setAdditionalSetup(runner -> {
+                    runner.installPlugin(new JdbcPlugin(
+                            "counting_sqlserver",
+                            combine(new SqlServerClientModule(), new TestingSqlServerModule(connectionFactory))));
+                    runner.createCatalog("counting_sqlserver", "counting_sqlserver", ImmutableMap.of(
+                            "connection-url", sqlServer.getJdbcUrl(),
+                            "connection-user", sqlServer.getUsername(),
+                            "connection-password", sqlServer.getPassword(),
+                            // disables connection reuse to approximate number of I/O operations since we almost always open a new connection to execute a query
+                            "query.reuse-connection", "false"));
+                })
+                .build();
+        copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, ImmutableList.of(NATION, REGION));
+        return queryRunner;
+    }
+
+    private static ConnectionCountingConnectionFactory getConnectionCountingConnectionFactory(TestingSqlServer sqlServer)
+    {
+        Properties connectionProperties = new Properties();
+        CredentialProvider credentialProvider = new StaticCredentialProvider(
+                Optional.of(sqlServer.getUsername()),
+                Optional.of(sqlServer.getPassword()));
+        DriverConnectionFactory delegate = DriverConnectionFactory.builder(new SQLServerDriver(), sqlServer.getJdbcUrl(), credentialProvider)
+                .setConnectionProperties(connectionProperties)
+                .build();
+        return new ConnectionCountingConnectionFactory(delegate);
+    }
+
+    @Test
+    public void testJdbcConnectionCreations()
+    {
+        assertJdbcConnections("SELECT * FROM nation LIMIT 1", 5, Optional.empty());
+        assertJdbcConnections("SELECT * FROM nation ORDER BY nationkey LIMIT 1", 5, Optional.empty());
+        assertJdbcConnections("SELECT * FROM nation WHERE nationkey = 1", 5, Optional.empty());
+        assertJdbcConnections("SELECT avg(nationkey) FROM nation", 4, Optional.empty());
+        assertJdbcConnections("SELECT * FROM nation, region", 6, Optional.empty());
+        assertJdbcConnections("SELECT * FROM nation n, region r WHERE n.regionkey = r.regionkey", 9, Optional.empty());
+        assertJdbcConnections("SELECT * FROM nation JOIN region USING(regionkey)", 10, Optional.empty());
+        assertJdbcConnections("SELECT * FROM information_schema.schemata", 1, Optional.empty());
+        assertJdbcConnections("SELECT * FROM information_schema.tables", 1, Optional.empty());
+        assertJdbcConnections("SELECT * FROM information_schema.columns", 1560, Optional.empty());
+        assertJdbcConnections("SELECT * FROM nation", 3, Optional.empty());
+        assertJdbcConnections("SELECT * FROM TABLE (system.query(query => 'SELECT * FROM dbo.nation'))", 2, Optional.empty());
+        assertJdbcConnections("CREATE TABLE copy_of_nation AS SELECT * FROM nation", 15, Optional.empty());
+        assertJdbcConnections("INSERT INTO copy_of_nation SELECT * FROM nation", 14, Optional.empty());
+        assertJdbcConnections("DELETE FROM copy_of_nation WHERE nationkey = 3", 6, Optional.empty());
+        assertJdbcConnections("UPDATE copy_of_nation SET name = 'POLAND' WHERE nationkey = 1", 5, Optional.empty());
+        assertJdbcConnections("MERGE INTO copy_of_nation n USING region r ON r.regionkey= n.regionkey WHEN MATCHED THEN DELETE", 6, Optional.of(MODIFYING_ROWS_MESSAGE));
+        assertJdbcConnections("DROP TABLE copy_of_nation", 2, Optional.empty());
+        assertJdbcConnections("SHOW SCHEMAS", 1, Optional.empty());
+        assertJdbcConnections("SHOW TABLES", 2, Optional.empty());
+        assertJdbcConnections("SHOW STATS FOR nation", 4, Optional.empty());
+        assertJdbcConnections("SELECT * FROM system.jdbc.columns WHERE table_cat = 'counting_sqlserver'", 1560, Optional.empty());
+    }
+
+    private static final class TestingSqlServerModule
+            extends AbstractConfigurationAwareModule
+    {
+        private final ConnectionCountingConnectionFactory connectionCountingConnectionFactory;
+
+        private TestingSqlServerModule(ConnectionCountingConnectionFactory connectionCountingConnectionFactory)
+        {
+            this.connectionCountingConnectionFactory = requireNonNull(connectionCountingConnectionFactory, "connectionCountingConnectionFactory is null");
+        }
+
+        @Override
+        protected void setup(Binder binder) {}
+
+        @Provides
+        @Singleton
+        @ForBaseJdbc
+        public ConnectionFactory getConnectionFactory()
+        {
+            return connectionCountingConnectionFactory;
+        }
+    }
+}

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerJdbcConnectionAccesses.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerJdbcConnectionAccesses.java
@@ -98,7 +98,7 @@ public class TestSqlServerJdbcConnectionAccesses
         assertJdbcConnections("SELECT * FROM nation JOIN region USING(regionkey)", 10, Optional.empty());
         assertJdbcConnections("SELECT * FROM information_schema.schemata", 1, Optional.empty());
         assertJdbcConnections("SELECT * FROM information_schema.tables", 1, Optional.empty());
-        assertJdbcConnections("SELECT * FROM information_schema.columns", 1560, Optional.empty());
+        assertJdbcConnections("SELECT * FROM information_schema.columns", 1041, Optional.empty());
         assertJdbcConnections("SELECT * FROM nation", 3, Optional.empty());
         assertJdbcConnections("SELECT * FROM TABLE (system.query(query => 'SELECT * FROM dbo.nation'))", 2, Optional.empty());
         assertJdbcConnections("CREATE TABLE copy_of_nation AS SELECT * FROM nation", 15, Optional.empty());
@@ -110,7 +110,7 @@ public class TestSqlServerJdbcConnectionAccesses
         assertJdbcConnections("SHOW SCHEMAS", 1, Optional.empty());
         assertJdbcConnections("SHOW TABLES", 2, Optional.empty());
         assertJdbcConnections("SHOW STATS FOR nation", 4, Optional.empty());
-        assertJdbcConnections("SELECT * FROM system.jdbc.columns WHERE table_cat = 'counting_sqlserver'", 1560, Optional.empty());
+        assertJdbcConnections("SELECT * FROM system.jdbc.columns WHERE table_cat = 'counting_sqlserver'", 1041, Optional.empty());
     }
 
     private static final class TestingSqlServerModule

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerJdbcConnectionCreation.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerJdbcConnectionCreation.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.sqlserver;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Binder;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.microsoft.sqlserver.jdbc.SQLServerDriver;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.plugin.jdbc.BaseJdbcConnectionCreationTest;
+import io.trino.plugin.jdbc.ConnectionFactory;
+import io.trino.plugin.jdbc.DriverConnectionFactory;
+import io.trino.plugin.jdbc.ForBaseJdbc;
+import io.trino.plugin.jdbc.JdbcPlugin;
+import io.trino.plugin.jdbc.credential.CredentialProvider;
+import io.trino.plugin.jdbc.credential.StaticCredentialProvider;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.Properties;
+
+import static io.airlift.configuration.ConfigurationAwareModule.combine;
+import static io.trino.plugin.sqlserver.TestingSqlServer.LATEST_VERSION;
+import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static io.trino.spi.connector.ConnectorMetadata.MODIFYING_ROWS_MESSAGE;
+import static io.trino.testing.QueryAssertions.copyTpchTables;
+import static io.trino.tpch.TpchTable.NATION;
+import static io.trino.tpch.TpchTable.REGION;
+import static java.util.Objects.requireNonNull;
+
+public class TestSqlServerJdbcConnectionCreation
+        extends BaseJdbcConnectionCreationTest
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        TestingSqlServer sqlServer = closeAfterClass(new TestingSqlServer(LATEST_VERSION));
+        this.connectionFactory = getConnectionCountingConnectionFactory(sqlServer);
+        DistributedQueryRunner queryRunner = SqlServerQueryRunner.builder(sqlServer)
+                // to make sure we always open connections in the same way
+                .addCoordinatorProperty("node-scheduler.include-coordinator", "false")
+                .amendSession(sessionBuilder -> sessionBuilder.setCatalog("counting_sqlserver"))
+                .setAdditionalSetup(runner -> {
+                    runner.installPlugin(new JdbcPlugin(
+                            "counting_sqlserver",
+                            combine(new SqlServerClientModule(), new TestingSqlServerModule(connectionFactory))));
+                    runner.createCatalog("counting_sqlserver", "counting_sqlserver", ImmutableMap.of(
+                            "connection-url", sqlServer.getJdbcUrl(),
+                            "connection-user", sqlServer.getUsername(),
+                            "connection-password", sqlServer.getPassword()));
+                })
+                .build();
+        copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, ImmutableList.of(NATION, REGION));
+        return queryRunner;
+    }
+
+    private static ConnectionCountingConnectionFactory getConnectionCountingConnectionFactory(TestingSqlServer sqlServer)
+    {
+        Properties connectionProperties = new Properties();
+        CredentialProvider credentialProvider = new StaticCredentialProvider(
+                Optional.of(sqlServer.getUsername()),
+                Optional.of(sqlServer.getPassword()));
+        DriverConnectionFactory delegate = DriverConnectionFactory.builder(new SQLServerDriver(), sqlServer.getJdbcUrl(), credentialProvider)
+                .setConnectionProperties(connectionProperties)
+                .build();
+        return new ConnectionCountingConnectionFactory(delegate);
+    }
+
+    @Test
+    public void testJdbcConnectionCreations()
+    {
+        assertJdbcConnections("SELECT * FROM nation LIMIT 1", 3, Optional.empty());
+        assertJdbcConnections("SELECT * FROM nation ORDER BY nationkey LIMIT 1", 3, Optional.empty());
+        assertJdbcConnections("SELECT * FROM nation WHERE nationkey = 1", 3, Optional.empty());
+        assertJdbcConnections("SELECT avg(nationkey) FROM nation", 2, Optional.empty());
+        assertJdbcConnections("SELECT * FROM nation, region", 3, Optional.empty());
+        assertJdbcConnections("SELECT * FROM nation n, region r WHERE n.regionkey = r.regionkey", 3, Optional.empty());
+        assertJdbcConnections("SELECT * FROM nation JOIN region USING(regionkey)", 5, Optional.empty());
+        assertJdbcConnections("SELECT * FROM information_schema.schemata", 1, Optional.empty());
+        assertJdbcConnections("SELECT * FROM information_schema.tables", 1, Optional.empty());
+        assertJdbcConnections("SELECT * FROM information_schema.columns", 1, Optional.empty());
+        assertJdbcConnections("SELECT * FROM nation", 2, Optional.empty());
+        assertJdbcConnections("SELECT * FROM TABLE (system.query(query => 'SELECT * FROM dbo.nation'))", 2, Optional.empty());
+        assertJdbcConnections("CREATE TABLE copy_of_nation AS SELECT * FROM nation", 6, Optional.empty());
+        assertJdbcConnections("INSERT INTO copy_of_nation SELECT * FROM nation", 6, Optional.empty());
+        assertJdbcConnections("DELETE FROM copy_of_nation WHERE nationkey = 3", 1, Optional.empty());
+        assertJdbcConnections("UPDATE copy_of_nation SET name = 'POLAND' WHERE nationkey = 1", 1, Optional.empty());
+        assertJdbcConnections("MERGE INTO copy_of_nation n USING region r ON r.regionkey= n.regionkey WHEN MATCHED THEN DELETE", 1, Optional.of(MODIFYING_ROWS_MESSAGE));
+        assertJdbcConnections("DROP TABLE copy_of_nation", 1, Optional.empty());
+        assertJdbcConnections("SHOW SCHEMAS", 1, Optional.empty());
+        assertJdbcConnections("SHOW TABLES", 1, Optional.empty());
+        assertJdbcConnections("SHOW STATS FOR nation", 2, Optional.empty());
+        assertJdbcConnections("SELECT * FROM system.jdbc.columns WHERE table_cat = 'counting_sqlserver'", 1, Optional.empty());
+    }
+
+    private static final class TestingSqlServerModule
+            extends AbstractConfigurationAwareModule
+    {
+        private final ConnectionCountingConnectionFactory connectionCountingConnectionFactory;
+
+        private TestingSqlServerModule(ConnectionCountingConnectionFactory connectionCountingConnectionFactory)
+        {
+            this.connectionCountingConnectionFactory = requireNonNull(connectionCountingConnectionFactory, "connectionCountingConnectionFactory is null");
+        }
+
+        @Override
+        protected void setup(Binder binder) {}
+
+        @Provides
+        @Singleton
+        @ForBaseJdbc
+        public ConnectionFactory getConnectionFactory()
+        {
+            return connectionCountingConnectionFactory;
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Before this change table metadata was fetched when listing columns which
ended up fetching table properties for JDBC connectors which incurs I/O
in connectors which support them.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# ClickHouse, SQL Server
* Improve performance of listing columns. ({issue}`23429`)
```
