### PR TITLE
Fix naming pattern for exposed statistics

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/BinPackingNodeAllocatorService.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/BinPackingNodeAllocatorService.java
@@ -342,14 +342,14 @@ public class BinPackingNodeAllocatorService
 
     @Managed
     @Nested
-    public CounterStat processCalls()
+    public CounterStat getProcessCalls()
     {
         return processCalls;
     }
 
     @Managed
     @Nested
-    public CounterStat processPending()
+    public CounterStat getProcessPending()
     {
         return processPending;
     }


### PR DESCRIPTION
Statistics without get prefix are not exposed.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

