### PR TITLE
Add projection push down for STRUCT field in big-query connector

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
@@ -246,7 +246,7 @@ public class BigQueryClient
         }
     }
 
-    public TableInfo getCachedTable(Duration viewExpiration, TableInfo remoteTableId, List<String> requiredColumns, Optional<String> filter)
+    public TableInfo getCachedTable(Duration viewExpiration, TableInfo remoteTableId, List<BigQueryColumnHandle> requiredColumns, Optional<String> filter)
     {
         String query = selectSql(remoteTableId.getTableId(), requiredColumns, filter);
         log.debug("query is %s", query);
@@ -466,9 +466,9 @@ public class BigQueryClient
         return requireNonNull(((QueryJobConfiguration) jobConfiguration).getDestinationTable(), "Cannot determine destination table for query");
     }
 
-    public static String selectSql(TableId table, List<String> requiredColumns, Optional<String> filter)
+    public static String selectSql(TableId table, List<BigQueryColumnHandle> requiredColumns, Optional<String> filter)
     {
-        String columns = requiredColumns.stream().map(column -> format("`%s`", column)).collect(joining(","));
+        String columns = requiredColumns.stream().map(column -> format("`%s`", column.name())).collect(joining(","));
         return selectSql(table, columns, filter);
     }
 

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryColumnHandle.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryColumnHandle.java
@@ -16,6 +16,7 @@ package io.trino.plugin.bigquery;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
@@ -30,6 +31,7 @@ import static java.util.Objects.requireNonNull;
 
 public record BigQueryColumnHandle(
         String name,
+        List<String> dereferenceNames,
         Type trinoType,
         StandardSQLTypeName bigqueryType,
         boolean isPushdownSupported,
@@ -44,6 +46,7 @@ public record BigQueryColumnHandle(
     public BigQueryColumnHandle
     {
         requireNonNull(name, "name is null");
+        dereferenceNames = ImmutableList.copyOf(requireNonNull(dereferenceNames, "dereferenceNames is null"));
         requireNonNull(trinoType, "trinoType is null");
         requireNonNull(bigqueryType, "bigqueryType is null");
         requireNonNull(mode, "mode is null");
@@ -60,6 +63,16 @@ public record BigQueryColumnHandle(
                 .setNullable(mode == Field.Mode.NULLABLE)
                 .setHidden(hidden)
                 .build();
+    }
+
+    @JsonIgnore
+    public String getQualifiedName()
+    {
+        return Joiner.on('.')
+                .join(ImmutableList.<String>builder()
+                        .add(name)
+                        .addAll(dereferenceNames)
+                        .build());
     }
 
     @JsonIgnore

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConfig.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConfig.java
@@ -63,6 +63,7 @@ public class BigQueryConfig
     private String queryLabelName;
     private String queryLabelFormat;
     private boolean proxyEnabled;
+    private boolean projectionPushDownEnabled = true;
     private int metadataParallelism = 2;
 
     public Optional<String> getProjectId()
@@ -339,6 +340,19 @@ public class BigQueryConfig
     public BigQueryConfig setProxyEnabled(boolean proxyEnabled)
     {
         this.proxyEnabled = proxyEnabled;
+        return this;
+    }
+
+    public boolean isProjectionPushdownEnabled()
+    {
+        return projectionPushDownEnabled;
+    }
+
+    @Config("bigquery.projection-pushdown-enabled")
+    @ConfigDescription("Dereference push down for ROW type")
+    public BigQueryConfig setProjectionPushdownEnabled(boolean projectionPushDownEnabled)
+    {
+        this.projectionPushDownEnabled = projectionPushDownEnabled;
         return this;
     }
 

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryPageSourceProvider.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryPageSourceProvider.java
@@ -121,8 +121,7 @@ public class BigQueryPageSourceProvider
                 typeManager,
                 bigQueryClientFactory.create(session),
                 table,
-                columnHandles.stream().map(BigQueryColumnHandle::name).collect(toImmutableList()),
-                columnHandles.stream().map(BigQueryColumnHandle::trinoType).collect(toImmutableList()),
+                columnHandles,
                 filter);
     }
 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryPageSourceProvider.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryPageSourceProvider.java
@@ -26,6 +26,8 @@ import io.trino.spi.connector.DynamicFilter;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -68,10 +70,12 @@ public class BigQueryPageSourceProvider
         log.debug("createPageSource(transaction=%s, session=%s, split=%s, table=%s, columns=%s)", transaction, session, split, table, columns);
         BigQuerySplit bigQuerySplit = (BigQuerySplit) split;
 
-        // We expect columns list requested here to match list passed to ConnectorMetadata.applyProjection.
-        checkArgument(bigQuerySplit.getColumns().isEmpty() || bigQuerySplit.getColumns().equals(columns),
-                "Requested columns %s do not match list in split %s", columns, bigQuerySplit.getColumns());
-
+        Set<String> projectedColumnNames = bigQuerySplit.getColumns().stream().map(BigQueryColumnHandle::name).collect(Collectors.toSet());
+        // because we apply logic (download only parent columns - BigQueryMetadata.projectParentColumns)
+        // columns and split columns could differ
+        columns.stream()
+                .map(BigQueryColumnHandle.class::cast)
+                .forEach(column -> checkArgument(projectedColumnNames.contains(column.name()), "projected columns should contain all reader columns"));
         if (bigQuerySplit.representsEmptyProjection()) {
             return new BigQueryEmptyProjectionPageSource(bigQuerySplit.getEmptyRowsToGenerate());
         }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryPseudoColumn.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryPseudoColumn.java
@@ -54,6 +54,7 @@ public enum BigQueryPseudoColumn
     {
         return new BigQueryColumnHandle(
                 trinoColumnName,
+                ImmutableList.of(),
                 trinoType,
                 bigqueryType,
                 true,

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryQueryPageSource.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryQueryPageSource.java
@@ -45,8 +45,8 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.util.List;
 import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.plugin.bigquery.BigQueryClient.selectSql;
 import static io.trino.plugin.bigquery.BigQueryTypeManager.toTrinoTimestamp;
@@ -75,8 +75,7 @@ public class BigQueryQueryPageSource
             .toFormatter();
 
     private final BigQueryTypeManager typeManager;
-    private final List<String> columnNames;
-    private final List<Type> columnTypes;
+    private final List<BigQueryColumnHandle> columnHandles;
     private final PageBuilder pageBuilder;
     private final TableResult tableResult;
 
@@ -87,25 +86,20 @@ public class BigQueryQueryPageSource
             BigQueryTypeManager typeManager,
             BigQueryClient client,
             BigQueryTableHandle table,
-            List<String> columnNames,
-            List<Type> columnTypes,
+            List<BigQueryColumnHandle> columnHandles,
             Optional<String> filter)
     {
         requireNonNull(client, "client is null");
         requireNonNull(table, "table is null");
-        requireNonNull(columnNames, "columnNames is null");
-        requireNonNull(columnTypes, "columnTypes is null");
         requireNonNull(filter, "filter is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
-        checkArgument(columnNames.size() == columnTypes.size(), "columnNames and columnTypes sizes don't match");
-        this.columnNames = ImmutableList.copyOf(columnNames);
-        this.columnTypes = ImmutableList.copyOf(columnTypes);
-        this.pageBuilder = new PageBuilder(columnTypes);
-        String sql = buildSql(table, client.getProjectId(), ImmutableList.copyOf(columnNames), filter);
+        this.columnHandles = requireNonNull(columnHandles, "columnHandles is null");
+        this.pageBuilder = new PageBuilder(columnHandles.stream().map(BigQueryColumnHandle::trinoType).collect(toImmutableList()));
+        String sql = buildSql(table, client.getProjectId(), columnHandles, filter);
         this.tableResult = client.executeQuery(session, sql);
     }
 
-    private static String buildSql(BigQueryTableHandle table, String projectId, List<String> columnNames, Optional<String> filter)
+    private static String buildSql(BigQueryTableHandle table, String projectId, List<BigQueryColumnHandle> columns, Optional<String> filter)
     {
         if (table.relationHandle() instanceof BigQueryQueryRelationHandle queryRelationHandle) {
             if (filter.isEmpty()) {
@@ -114,7 +108,7 @@ public class BigQueryQueryPageSource
             return "SELECT * FROM (" + queryRelationHandle.getQuery() + " ) WHERE " + filter.get();
         }
         TableId tableId = TableId.of(projectId, table.asPlainTable().getRemoteTableName().datasetName(), table.asPlainTable().getRemoteTableName().tableName());
-        return selectSql(tableId, ImmutableList.copyOf(columnNames), filter);
+        return selectSql(tableId, ImmutableList.copyOf(columns), filter);
     }
 
     @Override
@@ -147,9 +141,10 @@ public class BigQueryQueryPageSource
         verify(pageBuilder.isEmpty());
         for (FieldValueList record : tableResult.iterateAll()) {
             pageBuilder.declarePosition();
-            for (int column = 0; column < columnTypes.size(); column++) {
+            for (int column = 0; column < columnHandles.size(); column++) {
+                BigQueryColumnHandle columnHandle = columnHandles.get(column);
                 BlockBuilder output = pageBuilder.getBlockBuilder(column);
-                appendTo(columnTypes.get(column), record.get(columnNames.get(column)), output);
+                appendTo(columnHandle.trinoType(), record.get(columnHandle.name()), output);
             }
         }
         finished = true;

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySessionProperties.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySessionProperties.java
@@ -32,6 +32,7 @@ public final class BigQuerySessionProperties
     private static final String VIEW_MATERIALIZATION_WITH_FILTER = "view_materialization_with_filter";
     private static final String QUERY_RESULTS_CACHE_ENABLED = "query_results_cache_enabled";
     private static final String CREATE_DISPOSITION_TYPE = "create_disposition_type";
+    private static final String PROJECTION_PUSHDOWN_ENABLED = "projection_pushdown_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -60,6 +61,11 @@ public final class BigQuerySessionProperties
                         CreateDisposition.class,
                         CreateDisposition.CREATE_IF_NEEDED, // https://cloud.google.com/bigquery/docs/cached-results
                         true))
+                .add(booleanProperty(
+                        PROJECTION_PUSHDOWN_ENABLED,
+                        "Dereference push down for STRUCT type",
+                        config.isProjectionPushdownEnabled(),
+                        false))
                 .build();
     }
 
@@ -87,5 +93,10 @@ public final class BigQuerySessionProperties
     public static CreateDisposition createDisposition(ConnectorSession session)
     {
         return session.getProperty(CREATE_DISPOSITION_TYPE, CreateDisposition.class);
+    }
+
+    public static boolean isProjectionPushdownEnabled(ConnectorSession session)
+    {
+        return session.getProperty(PROJECTION_PUSHDOWN_ENABLED, Boolean.class);
     }
 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitManager.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitManager.java
@@ -162,8 +162,8 @@ public class BigQuerySplitManager
         log.debug("readFromBigQuery(tableId=%s, projectedColumns=%s, filter=[%s])", remoteTableId, projectedColumns, filter);
         List<BigQueryColumnHandle> columns = projectedColumns.get();
         List<String> projectedColumnsNames = getProjectedColumnNames(columns);
-        ImmutableList.Builder<BigQueryColumnHandle> additionalDomainColumns = ImmutableList.builder();
-        additionalDomainColumns.addAll(columns);
+        ImmutableList.Builder<BigQueryColumnHandle> projectedColumnHandles = ImmutableList.builder();
+        projectedColumnHandles.addAll(columns);
 
         if (isWildcardTable(type, remoteTableId.getTable())) {
             // Storage API doesn't support reading wildcard tables
@@ -180,9 +180,9 @@ public class BigQuerySplitManager
             tableConstraint.getDomains().ifPresent(domains -> domains.keySet().stream()
                     .map(BigQueryColumnHandle.class::cast)
                     .filter(column -> !projectedColumnsNames.contains(column.name()))
-                    .forEach(additionalDomainColumns::add));
+                    .forEach(projectedColumnHandles::add));
         }
-        ReadSession readSession = createReadSession(session, remoteTableId, ImmutableList.copyOf(additionalDomainColumns.build()), filter);
+        ReadSession readSession = createReadSession(session, remoteTableId, ImmutableList.copyOf(projectedColumnHandles.build()), filter);
 
         String schemaString = getSchemaAsString(readSession);
         return readSession.getStreamsList().stream()

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitManager.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitManager.java
@@ -42,7 +42,6 @@ import org.apache.arrow.vector.util.ByteArrayReadableSeekableByteChannel;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -109,7 +108,6 @@ public class BigQuerySplitManager
             BigQueryQueryRelationHandle bigQueryQueryRelationHandle = bigQueryTableHandle.getRequiredQueryRelation();
             List<BigQueryColumnHandle> columns = bigQueryTableHandle.projectedColumns().orElse(ImmutableList.of());
             boolean useStorageApi = bigQueryQueryRelationHandle.isUseStorageApi();
-            List<String> projectedColumnsNames = getProjectedColumnNames(columns);
 
             // projectedColumnsNames can not be used for generating select sql because the query fails if it does not
             // include a column name. eg: query => 'SELECT 1'
@@ -132,7 +130,7 @@ public class BigQuerySplitManager
 
             log.debug("Using Storage API for running query: %s", query);
             // filter is already used while constructing the select query
-            ReadSession readSession = createReadSession(session, tableInfo.getTableId(), ImmutableList.copyOf(projectedColumnsNames), Optional.empty());
+            ReadSession readSession = createReadSession(session, tableInfo.getTableId(), ImmutableList.copyOf(columns), Optional.empty());
             return new FixedSplitSource(readSession.getStreamsList().stream()
                     .map(stream -> BigQuerySplit.forStream(stream.getName(), getSchemaAsString(readSession), columns, OptionalInt.of(stream.getSerializedSize())))
                     .collect(toImmutableList()));
@@ -163,7 +161,9 @@ public class BigQuerySplitManager
 
         log.debug("readFromBigQuery(tableId=%s, projectedColumns=%s, filter=[%s])", remoteTableId, projectedColumns, filter);
         List<BigQueryColumnHandle> columns = projectedColumns.get();
-        List<String> projectedColumnsNames = new ArrayList<>(getProjectedColumnNames(columns));
+        List<String> projectedColumnsNames = getProjectedColumnNames(columns);
+        ImmutableList.Builder<BigQueryColumnHandle> additionalDomainColumns = ImmutableList.builder();
+        additionalDomainColumns.addAll(columns);
 
         if (isWildcardTable(type, remoteTableId.getTable())) {
             // Storage API doesn't support reading wildcard tables
@@ -178,11 +178,11 @@ public class BigQuerySplitManager
                 return ImmutableList.of(BigQuerySplit.forViewStream(columns, filter));
             }
             tableConstraint.getDomains().ifPresent(domains -> domains.keySet().stream()
-                    .map(column -> ((BigQueryColumnHandle) column).name())
-                    .filter(columnName -> !projectedColumnsNames.contains(columnName))
-                    .forEach(projectedColumnsNames::add));
+                    .map(BigQueryColumnHandle.class::cast)
+                    .filter(column -> !projectedColumnsNames.contains(column.name()))
+                    .forEach(additionalDomainColumns::add));
         }
-        ReadSession readSession = createReadSession(session, remoteTableId, ImmutableList.copyOf(projectedColumnsNames), filter);
+        ReadSession readSession = createReadSession(session, remoteTableId, ImmutableList.copyOf(additionalDomainColumns.build()), filter);
 
         String schemaString = getSchemaAsString(readSession);
         return readSession.getStreamsList().stream()
@@ -191,10 +191,10 @@ public class BigQuerySplitManager
     }
 
     @VisibleForTesting
-    ReadSession createReadSession(ConnectorSession session, TableId remoteTableId, List<String> projectedColumnsNames, Optional<String> filter)
+    ReadSession createReadSession(ConnectorSession session, TableId remoteTableId, List<BigQueryColumnHandle> columns, Optional<String> filter)
     {
         ReadSessionCreator readSessionCreator = new ReadSessionCreator(bigQueryClientFactory, bigQueryReadClientFactory, viewEnabled, arrowSerializationEnabled, viewExpiration, maxReadRowsRetries);
-        return readSessionCreator.create(session, remoteTableId, projectedColumnsNames, filter, nodeManager.getRequiredWorkerNodes().size());
+        return readSessionCreator.create(session, remoteTableId, columns, filter, nodeManager.getRequiredWorkerNodes().size());
     }
 
     private static List<String> getProjectedColumnNames(List<BigQueryColumnHandle> columns)

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTypeManager.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTypeManager.java
@@ -248,7 +248,7 @@ public final class BigQueryTypeManager
         return FieldList.of(fields.build());
     }
 
-    private StandardSQLTypeName toStandardSqlTypeName(Type type)
+    StandardSQLTypeName toStandardSqlTypeName(Type type)
     {
         if (type == BooleanType.BOOLEAN) {
             return StandardSQLTypeName.BOOL;
@@ -392,6 +392,7 @@ public final class BigQueryTypeManager
         ColumnMapping columnMapping = toTrinoType(field).orElseThrow(() -> new IllegalArgumentException("Unsupported type: " + field));
         return new BigQueryColumnHandle(
                 field.getName(),
+                ImmutableList.of(),
                 columnMapping.type(),
                 field.getType().getStandardType(),
                 columnMapping.isPushdownSupported(),

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ReadSessionCreator.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ReadSessionCreator.java
@@ -84,7 +84,7 @@ public class ReadSessionCreator
         TableInfo actualTable = getActualTable(client, tableDetails, selectedFields, isViewMaterializationWithFilter(session) ? filter : Optional.empty());
 
         List<String> filteredSelectedFields = selectedFields.stream()
-                .map(BigQueryColumnHandle::name)
+                .map(BigQueryColumnHandle::getQualifiedName)
                 .map(BigQueryUtil::toBigQueryColumnName)
                 .collect(toList());
 

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ReadSessionCreator.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ReadSessionCreator.java
@@ -75,7 +75,7 @@ public class ReadSessionCreator
         this.maxCreateReadSessionRetries = maxCreateReadSessionRetries;
     }
 
-    public ReadSession create(ConnectorSession session, TableId remoteTable, List<String> selectedFields, Optional<String> filter, int currentWorkerCount)
+    public ReadSession create(ConnectorSession session, TableId remoteTable, List<BigQueryColumnHandle> selectedFields, Optional<String> filter, int currentWorkerCount)
     {
         BigQueryClient client = bigQueryClientFactory.create(session);
         TableInfo tableDetails = client.getTable(remoteTable)
@@ -84,6 +84,7 @@ public class ReadSessionCreator
         TableInfo actualTable = getActualTable(client, tableDetails, selectedFields, isViewMaterializationWithFilter(session) ? filter : Optional.empty());
 
         List<String> filteredSelectedFields = selectedFields.stream()
+                .map(BigQueryColumnHandle::name)
                 .map(BigQueryUtil::toBigQueryColumnName)
                 .collect(toList());
 
@@ -134,7 +135,7 @@ public class ReadSessionCreator
     private TableInfo getActualTable(
             BigQueryClient client,
             TableInfo remoteTable,
-            List<String> requiredColumns,
+            List<BigQueryColumnHandle> requiredColumns,
             Optional<String> filter)
     {
         TableDefinition tableDefinition = remoteTable.getDefinition();

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
@@ -82,7 +82,6 @@ public abstract class BaseBigQueryConnectorTest
             case SUPPORTS_ADD_COLUMN,
                     SUPPORTS_CREATE_MATERIALIZED_VIEW,
                     SUPPORTS_CREATE_VIEW,
-                    SUPPORTS_DEREFERENCE_PUSHDOWN,
                     SUPPORTS_MERGE,
                     SUPPORTS_NEGATIVE_DATE,
                     SUPPORTS_NOT_NULL_CONSTRAINT,

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryAvroConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryAvroConnectorTest.java
@@ -13,14 +13,21 @@
  */
 package io.trino.plugin.bigquery;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.airlift.units.DataSize;
+import io.trino.Session;
+import io.trino.sql.planner.plan.ProjectNode;
+import io.trino.testing.MaterializedResult;
 import io.trino.testing.QueryRunner;
+import io.trino.testing.sql.TestTable;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 import java.util.Set;
 
+import static io.trino.testing.QueryAssertions.assertEqualsIgnoreOrder;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -81,6 +88,185 @@ public class TestBigQueryAvroConnectorTest
             finally {
                 assertUpdate("DROP TABLE " + tableName);
             }
+        }
+    }
+
+    @Override
+    @Test
+    public void testProjectionPushdown()
+    {
+        try (TestTable testTable = new TestTable(
+                getQueryRunner()::execute,
+                "test_projection_pushdown_",
+                "(id BIGINT, root ROW(f1 BIGINT, f2 BIGINT))",
+                ImmutableList.of("(1, ROW(1, 2))", "(2, NULl)", "(3, ROW(NULL, 4))"))) {
+            String selectQuery = "SELECT id, root.f1 FROM " + testTable.getName();
+            String expectedResult = "VALUES (BIGINT '1', BIGINT '1'), (BIGINT '2', NULL), (BIGINT '3', NULL)";
+
+            // With Projection Pushdown enabled
+            assertThat(query(selectQuery))
+                    .matches(expectedResult)
+                    .isFullyPushedDown();
+
+            // With Projection Pushdown disabled
+            Session sessionWithoutPushdown = sessionWithProjectionPushdownDisabled(getSession());
+            assertThat(query(sessionWithoutPushdown, selectQuery))
+                    .matches(expectedResult)
+                    .isNotFullyPushedDown(ProjectNode.class);
+        }
+    }
+
+    @Override
+    @Test
+    public void testProjectionWithCaseSensitiveField()
+    {
+        try (TestTable testTable = new TestTable(
+                getQueryRunner()::execute,
+                "test_projection_with_case_sensitive_field_",
+                "(id INT, a ROW(\"UPPER_CASE\" INT, \"lower_case\" INT, \"MiXeD_cAsE\" INT))",
+                ImmutableList.of("(1, ROW(2, 3, 4))", "(5, ROW(6, 7, 8))"))) {
+            // shippriority column is bigint (not integer) in BigQuery connector
+            String expected = "VALUES (BIGINT '2', BIGINT '3', BIGINT '4'), (BIGINT '6', BIGINT '7', BIGINT '8')";
+            assertThat(query("SELECT \"a\".\"UPPER_CASE\", \"a\".\"lower_case\", \"a\".\"MiXeD_cAsE\" FROM " + testTable.getName()))
+                    .matches(expected)
+                    .isFullyPushedDown();
+            assertThat(query("SELECT \"a\".\"upper_case\", \"a\".\"lower_case\", \"a\".\"mixed_case\" FROM " + testTable.getName()))
+                    .matches(expected)
+                    .isFullyPushedDown();
+            assertThat(query("SELECT \"a\".\"UPPER_CASE\", \"a\".\"LOWER_CASE\", \"a\".\"MIXED_CASE\" FROM " + testTable.getName()))
+                    .matches(expected)
+                    .isFullyPushedDown();
+        }
+    }
+
+    @Override
+    @Test
+    public void testProjectionPushdownMultipleRows()
+    {
+        try (TestTable testTable = new TestTable(
+                getQueryRunner()::execute,
+                "test_projection_pushdown_multiple_rows_",
+                "(id INT, nested1 ROW(child1 INT, child2 VARCHAR, child3 INT), nested2 ROW(child1 DOUBLE, child2 BOOLEAN, child3 DATE))",
+                ImmutableList.of(
+                        "(1, ROW(10, 'a', 100), ROW(10.10, true, DATE '2023-04-19'))",
+                        "(2, ROW(20, 'b', 200), ROW(20.20, false, DATE '1990-04-20'))",
+                        "(4, ROW(40, NULL, 400), NULL)",
+                        "(5, NULL, ROW(NULL, true, NULL))"))) {
+            // Select one field from one row field
+            assertThat(query("SELECT id, nested1.child1 FROM " + testTable.getName()))
+                    .matches("VALUES (BIGINT '1', BIGINT '10'), (BIGINT '2', BIGINT '20'), (BIGINT '4', BIGINT '40'), (BIGINT '5', NULL)")
+                    .isFullyPushedDown();
+            assertThat(query("SELECT nested2.child3, id FROM " + testTable.getName()))
+                    .matches("VALUES (DATE '2023-04-19', BIGINT '1'), (DATE '1990-04-20', BIGINT '2'), (NULL, BIGINT '4'), (NULL, BIGINT '5')")
+                    .isFullyPushedDown();
+
+            // Select one field each from multiple row fields
+            assertThat(query("SELECT nested2.child1, id, nested1.child2 FROM " + testTable.getName()))
+                    .skippingTypesCheck()
+                    .matches("VALUES (DOUBLE '10.10', BIGINT '1', 'a'), (DOUBLE '20.20', BIGINT '2', 'b'), (NULL, BIGINT '4', NULL), (NULL, BIGINT '5', NULL)")
+                    .isFullyPushedDown();
+
+            // Select multiple fields from one row field
+            assertThat(query("SELECT nested1.child3, id, nested1.child2 FROM " + testTable.getName()))
+                    .skippingTypesCheck()
+                    .matches("VALUES (BIGINT '100', BIGINT '1', 'a'), (BIGINT '200', BIGINT '2', 'b'), (BIGINT '400', BIGINT '4', NULL), (NULL, BIGINT '5', NULL)")
+                    .isFullyPushedDown();
+            assertThat(query("SELECT nested2.child2, nested2.child3, id FROM " + testTable.getName()))
+                    .matches("VALUES (true, DATE '2023-04-19' , BIGINT '1'), (false, DATE '1990-04-20', BIGINT '2'), (NULL, NULL, BIGINT '4'), (true, NULL, BIGINT '5')")
+                    .isFullyPushedDown();
+
+            // Select multiple fields from multiple row fields
+            assertThat(query("SELECT id, nested2.child1, nested1.child3, nested2.child2, nested1.child1 FROM " + testTable.getName()))
+                    .matches("VALUES (BIGINT '1', DOUBLE '10.10', BIGINT '100', true, BIGINT '10'), (BIGINT '2', DOUBLE '20.20', BIGINT '200', false, BIGINT '20'), (BIGINT '4', NULL, BIGINT '400', NULL, BIGINT '40'), (BIGINT '5', NULL, NULL, true, NULL)")
+                    .isFullyPushedDown();
+
+            // Select only nested fields
+            assertThat(query("SELECT nested2.child2, nested1.child3 FROM " + testTable.getName()))
+                    .matches("VALUES (true, BIGINT '100'), (false, BIGINT '200'), (NULL, BIGINT '400'), (true, NULL)")
+                    .isFullyPushedDown();
+        }
+    }
+
+    @Override
+    @Test
+    public void testProjectionPushdownReadsLessData()
+    {
+        try (TestTable testTable = new TestTable(
+                getQueryRunner()::execute,
+                "test_projection_pushdown_reads_less_data_",
+                "AS SELECT val AS id, CAST(ROW(val + 1, val + 2) AS ROW(leaf1 BIGINT, leaf2 BIGINT)) AS root FROM UNNEST(SEQUENCE(1, 10)) AS t(val)")) {
+            MaterializedResult expectedResult = computeActual("SELECT val + 2 FROM UNNEST(SEQUENCE(1, 10)) AS t(val)");
+            String selectQuery = "SELECT root.leaf2 FROM " + testTable.getName();
+            Session sessionWithoutPushdown = sessionWithProjectionPushdownDisabled(getSession());
+
+            assertQueryStats(
+                    getSession(),
+                    selectQuery,
+                    statsWithPushdown -> {
+                        DataSize physicalInputDataSizeWithPushdown = statsWithPushdown.getPhysicalInputDataSize();
+                        DataSize processedDataSizeWithPushdown = statsWithPushdown.getProcessedInputDataSize();
+                        assertQueryStats(
+                                sessionWithoutPushdown,
+                                selectQuery,
+                                statsWithoutPushdown -> {
+                                    if (supportsPhysicalPushdown()) {
+                                        assertThat(statsWithoutPushdown.getPhysicalInputDataSize()).isGreaterThan(physicalInputDataSizeWithPushdown);
+                                    }
+                                    else {
+                                        // TODO https://github.com/trinodb/trino/issues/17201
+                                        assertThat(statsWithoutPushdown.getPhysicalInputDataSize()).isEqualTo(physicalInputDataSizeWithPushdown);
+                                    }
+                                    assertThat(statsWithoutPushdown.getProcessedInputDataSize()).isGreaterThan(processedDataSizeWithPushdown);
+                                },
+                                results -> assertThat(results.getOnlyColumnAsSet()).isEqualTo(expectedResult.getOnlyColumnAsSet()));
+                    },
+                    results -> assertThat(results.getOnlyColumnAsSet()).isEqualTo(expectedResult.getOnlyColumnAsSet()));
+        }
+    }
+
+    @Override
+    @Test
+    public void testProjectionPushdownPhysicalInputSize()
+    {
+        try (TestTable testTable = new TestTable(
+                getQueryRunner()::execute,
+                "test_projection_pushdown_physical_input_size_",
+                "AS SELECT val AS id, CAST(ROW(val + 1, val + 2) AS ROW(leaf1 BIGINT, leaf2 BIGINT)) AS root FROM UNNEST(SEQUENCE(1, 10)) AS t(val)")) {
+            // Verify that the physical input size is smaller when reading the root.leaf1 field compared to reading the root field
+            assertQueryStats(
+                    getSession(),
+                    "SELECT root FROM " + testTable.getName(),
+                    statsWithSelectRootField -> {
+                        assertQueryStats(
+                                getSession(),
+                                "SELECT root.leaf1 FROM " + testTable.getName(),
+                                statsWithSelectLeafField -> {
+                                    if (supportsPhysicalPushdown()) {
+                                        assertThat(statsWithSelectLeafField.getPhysicalInputDataSize()).isLessThan(statsWithSelectRootField.getPhysicalInputDataSize());
+                                    }
+                                    else {
+                                        // TODO https://github.com/trinodb/trino/issues/17201
+                                        assertThat(statsWithSelectLeafField.getPhysicalInputDataSize()).isEqualTo(statsWithSelectRootField.getPhysicalInputDataSize());
+                                    }
+                                },
+                                results -> assertThat(results.getOnlyColumnAsSet()).isEqualTo(computeActual("SELECT val + 1 FROM UNNEST(SEQUENCE(1, 10)) AS t(val)").getOnlyColumnAsSet()));
+                    },
+                    results -> assertThat(results.getOnlyColumnAsSet()).isEqualTo(computeActual("SELECT ROW(val + 1, val + 2) FROM UNNEST(SEQUENCE(1, 10)) AS t(val)").getOnlyColumnAsSet()));
+
+            // Verify that the physical input size is the same when reading the root field compared to reading both the root and root.leaf1 fields
+            assertQueryStats(
+                    getSession(),
+                    "SELECT root FROM " + testTable.getName(),
+                    statsWithSelectRootField -> {
+                        assertQueryStats(
+                                getSession(),
+                                "SELECT root, root.leaf1 FROM " + testTable.getName(),
+                                statsWithSelectRootAndLeafField -> {
+                                    assertThat(statsWithSelectRootAndLeafField.getPhysicalInputDataSize()).isEqualTo(statsWithSelectRootField.getPhysicalInputDataSize());
+                                },
+                                results -> assertEqualsIgnoreOrder(results.getMaterializedRows(), computeActual("SELECT ROW(val + 1, val + 2), val + 1 FROM UNNEST(SEQUENCE(1, 10)) AS t(val)").getMaterializedRows()));
+                    },
+                    results -> assertThat(results.getOnlyColumnAsSet()).isEqualTo(computeActual("SELECT ROW(val + 1, val + 2) FROM UNNEST(SEQUENCE(1, 10)) AS t(val)").getOnlyColumnAsSet()));
         }
     }
 }

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConfig.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConfig.java
@@ -54,6 +54,7 @@ public class TestBigQueryConfig
                 .setQueryLabelName(null)
                 .setQueryLabelFormat(null)
                 .setProxyEnabled(false)
+                .setProjectionPushdownEnabled(true)
                 .setMetadataParallelism(2));
     }
 
@@ -82,6 +83,7 @@ public class TestBigQueryConfig
                 .put("bigquery.job.label-format", "$TRACE_TOKEN")
                 .put("bigquery.rpc-proxy.enabled", "true")
                 .put("bigquery.metadata.parallelism", "31")
+                .put("bigquery.projection-pushdown-enabled", "false")
                 .buildOrThrow();
 
         BigQueryConfig expected = new BigQueryConfig()
@@ -105,6 +107,7 @@ public class TestBigQueryConfig
                 .setQueryLabelName("trino_job_name")
                 .setQueryLabelFormat("$TRACE_TOKEN")
                 .setProxyEnabled(true)
+                .setProjectionPushdownEnabled(false)
                 .setMetadataParallelism(31);
 
         assertFullMapping(properties, expected);

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryMetadata.java
@@ -15,9 +15,17 @@ package io.trino.plugin.bigquery;
 
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryException;
+import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
+import static com.google.cloud.bigquery.Field.Mode.NULLABLE;
+import static com.google.cloud.bigquery.StandardSQLTypeName.BIGNUMERIC;
+import static io.trino.plugin.bigquery.BigQueryMetadata.projectParentColumns;
 import static io.trino.plugin.bigquery.BigQueryQueryRunner.BigQuerySqlExecutor;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class TestBigQueryMetadata
@@ -30,5 +38,90 @@ public class TestBigQueryMetadata
         assertThatExceptionOfType(BigQueryException.class)
                 .isThrownBy(() -> bigQuery.listTables("test_dataset_not_found"))
                 .matches(e -> e.getCode() == 404 && e.getMessage().contains("Not found: Dataset"));
+    }
+
+    @Test
+    public void testProjectParentColumnsSingleParent()
+    {
+        BigQueryColumnHandle parentColumn = testingColumn("a", ImmutableList.of());
+        List<BigQueryColumnHandle> columns = ImmutableList.of(
+                parentColumn,
+                testingColumn("a", ImmutableList.of("b")),
+                testingColumn("a", ImmutableList.of("b", "c", "d")),
+                testingColumn("a", ImmutableList.of("b", "c")));
+
+        List<BigQueryColumnHandle> parentColumns = projectParentColumns(columns);
+        assertThat(parentColumns).size().isEqualTo(1);
+        assertThat(parentColumns.getFirst()).isEqualTo(parentColumn);
+    }
+
+    @Test
+    public void testProjectParentColumnsSingleParentDifferentOrder()
+    {
+        BigQueryColumnHandle parentColumn = testingColumn("a", ImmutableList.of());
+        List<BigQueryColumnHandle> columns = ImmutableList.of(
+                parentColumn,
+                testingColumn("a", ImmutableList.of("b")),
+                testingColumn("a", ImmutableList.of("d", "c", "b")),
+                testingColumn("a", ImmutableList.of("b", "c", "d")),
+                testingColumn("a", ImmutableList.of("b", "c")));
+
+        List<BigQueryColumnHandle> parentColumns = projectParentColumns(columns);
+        assertThat(parentColumns).size().isEqualTo(1);
+        assertThat(parentColumns.getFirst()).isEqualTo(parentColumn);
+    }
+
+    @Test
+    public void testProjectParentColumnsNoParentDifferentOrder()
+    {
+        List<BigQueryColumnHandle> columns = ImmutableList.of(
+                testingColumn("a", ImmutableList.of("b", "c", "d")),
+                testingColumn("a", ImmutableList.of("d", "c", "b")));
+
+        List<BigQueryColumnHandle> parentColumns = projectParentColumns(columns);
+        assertThat(parentColumns).size().isEqualTo(2);
+    }
+
+    @Test
+    public void testProjectParentColumnsSingleParentSuddenJump()
+    {
+        BigQueryColumnHandle parentColumn = testingColumn("a", ImmutableList.of());
+        List<BigQueryColumnHandle> columns = ImmutableList.of(
+                parentColumn,
+                testingColumn("a", ImmutableList.of("d", "c", "b")));
+
+        List<BigQueryColumnHandle> parentColumns = projectParentColumns(columns);
+        assertThat(parentColumns).size().isEqualTo(1);
+        assertThat(parentColumns.getFirst()).isEqualTo(parentColumn);
+    }
+
+    @Test
+    public void testProjectParentColumnsMultipleParent()
+    {
+        BigQueryColumnHandle parentColumn = testingColumn("a", ImmutableList.of());
+        BigQueryColumnHandle anotherParentColumn = testingColumn("a1", ImmutableList.of());
+        List<BigQueryColumnHandle> columns = ImmutableList.of(
+                parentColumn,
+                anotherParentColumn,
+                testingColumn("a", ImmutableList.of("b", "c", "d")),
+                testingColumn("a", ImmutableList.of("b", "c")));
+
+        List<BigQueryColumnHandle> parentColumns = projectParentColumns(columns);
+        assertThat(parentColumns).size().isEqualTo(2);
+        assertThat(parentColumns).containsExactlyInAnyOrder(parentColumn, anotherParentColumn);
+    }
+
+    private static BigQueryColumnHandle testingColumn(String name, List<String> dereferenceNames)
+    {
+        return new BigQueryColumnHandle(
+                name,
+                dereferenceNames,
+                BIGINT,
+                BIGNUMERIC,
+                false,
+                NULLABLE,
+                ImmutableList.of(),
+                "description",
+                false);
     }
 }

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQuerySplitManager.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQuerySplitManager.java
@@ -80,7 +80,7 @@ public class TestBigQuerySplitManager
             assertThat(readSession.getTable()).contains(TEMP_TABLE_PREFIX);
 
             // Ignore constraints when creating temporary tables by default (view_materialization_with_filter is false)
-            BigQueryColumnHandle column = new BigQueryColumnHandle("cnt", BIGINT, INT64, true, REQUIRED, ImmutableList.of(), null, false);
+            BigQueryColumnHandle column = new BigQueryColumnHandle("cnt", ImmutableList.of(), BIGINT, INT64, true, REQUIRED, ImmutableList.of(), null, false);
             BigQueryTableHandle tableDifferentFilter = new BigQueryTableHandle(table.relationHandle(), TupleDomain.fromFixedValues(ImmutableMap.of(column, new NullableValue(BIGINT, 0L))), table.projectedColumns());
             assertThat(createReadSession(session, tableDifferentFilter).getTable())
                     .isEqualTo(readSession.getTable());

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQuerySplitManager.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQuerySplitManager.java
@@ -35,7 +35,6 @@ import java.util.Optional;
 
 import static com.google.cloud.bigquery.Field.Mode.REQUIRED;
 import static com.google.cloud.bigquery.StandardSQLTypeName.INT64;
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.bigquery.BigQueryFilterQueryBuilder.buildFilter;
 import static io.trino.plugin.bigquery.ViewMaterializationCache.TEMP_TABLE_PREFIX;
 import static io.trino.spi.transaction.IsolationLevel.READ_UNCOMMITTED;
@@ -110,9 +109,7 @@ public class TestBigQuerySplitManager
         return splitManager.createReadSession(
                 session,
                 table.asPlainTable().getRemoteTableName().toTableId(),
-                table.projectedColumns().orElseThrow().stream()
-                        .map(BigQueryColumnHandle::name)
-                        .collect(toImmutableList()),
+                table.projectedColumns().orElseThrow(),
                 buildFilter(table.constraint()));
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This PR implements dereference projection pushdown for BigQuery connector(similar to https://github.com/trinodb/trino/pull/17085).

This adds significant performance improvements for queries accessing nested fields inside struct/row columns. They have been optimized through the pushdown of dereference expressions. With this feature, the query execution prunes structural data eagerly, extracting the necessary fields.

### For Example:
I have a table having a nested field `root`. When perform selecting `root.f1`, we can see the difference in `Input` and `Physical Input` values in the query plan when running with and without dereference pushdown.

Table Schema as below:

```
trino:tpch> SHOW COLUMNS FROM test_projection_pushdown_f1xy74161o;
 Column |           Type            | Extra | Comment
--------+---------------------------+-------+---------
 id     | bigint                    |       |
 root   | row(f1 bigint, f2 bigint) |       |
(2 rows)
```

**Query Plan without Dereference pushdown:**

```
trino:tpch> SET SESSION bigquery.projection_pushdown_enabled=false;
SET SESSION
trino:tpch> EXPLAIN ANALYZE SELECT root.f1 FROM test_projection_pushdown_f1xy74161o;
                                                                                                                                                                                                                                                                                                          >
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
 Trino version: testversion                                                                                                                                                                                                                                                                               >
 Queued: 336.83us, Analysis: 542.43ms, Planning: 13.13ms, Execution: 1.73s                                                                                                                                                                                                                                >
 Fragment 1 [SOURCE]                                                                                                                                                                                                                                                                                      >
     CPU: 10.98ms, Scheduled: 582.58ms, Blocked 0.00ns (Input: 0.00ns, Output: 0.00ns), Input: 7 rows (133B); per task: avg.: 7.00 std.dev.: 0.00, Output: 7 rows (63B)                                                                                                                                   >
     Output layout: [expr]                                                                                                                                                                                                                                                                                >
     Output partitioning: SINGLE []                                                                                                                                                                                                                                                                       >
     ScanProject[table = bigquery:BigQueryTableHandle[relationHandle=BigQueryNamedRelationHandle{remoteTableName=sep-bq-cicd.tpch.test_projection_pushdown_f1xy74161o, schemaTableName=tpch.test_projection_pushdown_f1xy74161o, type=TABLE, comment=Optional.empty}, constraint=ALL, projectedColumns=Opt>
         Layout: [expr:bigint]                                                                                                                                                                                                                                                                            >
         Estimates: {rows: ? (?), cpu: ?, memory: 0B, network: 0B}/{rows: ? (?), cpu: ?, memory: 0B, network: 0B}                                                                                                                                                                                         >
         CPU: 11.00ms (100.00%), Scheduled: 581.00ms (100.00%), Blocked: 0.00ns (?%), Output: 7 rows (63B)                                                                                                                                                                                                >
         Input avg.: 7.00 rows, Input std.dev.: 0.00%                                                                                                                                                                                                                                                     >
         expr := root.0                                                                                                                                                                                                                                                                                   >
         root := BigQueryColumnHandle[name=root, dereferenceNames=[], trinoType=row(f1 bigint, f2 bigint), bigqueryType=STRUCT, isPushdownSupported=false, mode=NULLABLE, subColumns=[BigQueryColumnHandle[name=f1, dereferenceNames=[], trinoType=bigint, bigqueryType=INT64, isPushdownSupported=true, m>
         Input: 7 rows (133B), Filtered: 0.00%, Physical input: 82B, Physical input time: 0.00ns
```

**Query Plan with Dereference pushdown:**

```
trino:tpch> SET SESSION bigquery.projection_pushdown_enabled=true;
SET SESSION
trino:tpch> EXPLAIN ANALYZE SELECT root.f1 FROM test_projection_pushdown_f1xy74161o;

---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
 Trino version: testversion                                                                                                                                                                                                                                                                               >
 Queued: 451.58us, Analysis: 323.33ms, Planning: 10.90ms, Execution: 2.09s                                                                                                                                                                                                                                >
 Fragment 1 [SOURCE]                                                                                                                                                                                                                                                                                      >
     CPU: 10.60ms, Scheduled: 746.95ms, Blocked 0.00ns (Input: 0.00ns, Output: 0.00ns), Input: 7 rows (63B); per task: avg.: 7.00 std.dev.: 0.00, Output: 7 rows (63B)                                                                                                                                    >
     Output layout: [root_f1]                                                                                                                                                                                                                                                                             >
     Output partitioning: SINGLE []                                                                                                                                                                                                                                                                       >
     TableScan[table = bigquery:BigQueryTableHandle[relationHandle=BigQueryNamedRelationHandle{remoteTableName=sep-bq-cicd.tpch.test_projection_pushdown_f1xy74161o, schemaTableName=tpch.test_projection_pushdown_f1xy74161o, type=TABLE, comment=Optional.empty}, constraint=ALL, projectedColumns=Optio>
         Layout: [root_f1:bigint]                                                                                                                                                                                                                                                                         >
         Estimates: {rows: ? (?), cpu: ?, memory: 0B, network: 0B}                                                                                                                                                                                                                                        >
         CPU: 9.00ms (100.00%), Scheduled: 746.00ms (100.00%), Blocked: 0.00ns (?%), Output: 7 rows (63B)                                                                                                                                                                                                 >
         Input avg.: 7.00 rows, Input std.dev.: 0.00%                                                                                                                                                                                                                                                     >
         root_f1 := BigQueryColumnHandle[name=root, dereferenceNames=[f1], trinoType=bigint, bigqueryType=INT64, isPushdownSupported=false, mode=NULLABLE, subColumns=[BigQueryColumnHandle[name=f1, dereferenceNames=[], trinoType=bigint, bigqueryType=INT64, isPushdownSupported=true, mode=NULLABLE, s>
         Input: 7 rows (63B), Physical input: 47B, Physical input time: 0.00ns
```


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

The feature is enabled by default.

The feature can be disabled by setting bigquery.projection-pushdown-enabled configuration property or bigquery.projection_pushdown_enabled session property to false.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) Release notes are required, with the following suggested text:

```markdown
# BigQuery
* Add support for dereference pushdown. 
```
