### PR TITLE
Allow configuring User-Assigned Managed Identity in AzureFS

### DIFF
--- a/docs/src/main/sphinx/object-storage/file-system-azure.md
+++ b/docs/src/main/sphinx/object-storage/file-system-azure.md
@@ -24,8 +24,9 @@ system support:
     `false`. Set to `true` to use Azure Storage and enable all other properties.
 * - `azure.auth-type`
   - Authentication type to use for Azure Storage access. Defaults to `DEFAULT` which
-    uses system level credentials. Use `ACCESS_KEY` for [](azure-access-key-authentication) 
-    or and `OAUTH` for [](azure-oauth-authentication).
+    loads from environment variables if configured or [](azure-user-assigned-managed-identity-authentication). 
+    Use `ACCESS_KEY` for [](azure-access-key-authentication) or and `OAUTH` 
+    for [](azure-oauth-authentication).
 * - `azure.endpoint`
   - Hostname suffix of the Azure storage endpoint.
     Defaults to `core.windows.net` for the global Azure cloud.
@@ -51,6 +52,30 @@ system support:
   - Specify the application identifier appended to the `User-Agent` header
     for all requests sent to Azure Storage. Defaults to `Trino`. 
 :::
+
+(azure-user-assigned-managed-identity-authentication)=
+## User-assigned managed identity authentication
+
+Use the following properties to configure [user-assigned managed 
+identity](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/) 
+authentication to Azure Storage:
+
+:::{list-table}
+:widths: 40, 60
+:header-rows: 1
+
+* - Property
+  - Description
+* - `azure.auth-type`
+  - Must be set to `DEFAULT`.
+* - `azure.user-assigned-managed-identity.client-id`
+  - Specifies the client ID of user-assigned managed identity.
+* - `azure.user-assigned-managed-identity.resource-id`
+  - Specifies the resource ID of user-assigned managed identity.
+:::
+
+Only one of `azure.user-assigned-managed-identity.client-id` or `azure.user-assigned-managed-identity.resource-id` can be 
+specified.
 
 (azure-access-key-authentication)=
 ## Access key authentication

--- a/docs/src/main/sphinx/object-storage/file-system-azure.md
+++ b/docs/src/main/sphinx/object-storage/file-system-azure.md
@@ -23,10 +23,9 @@ system support:
   - Activate the native implementation for Azure Storage support. Defaults to
     `false`. Set to `true` to use Azure Storage and enable all other properties.
 * - `azure.auth-type`
-  - Authentication type to use for Azure Storage access. Defaults no
-    authentication used with `NONE`. Use `ACCESS_KEY` for
-    [](azure-access-key-authentication) or and `OAUTH` for
-    [](azure-oauth-authentication).
+  - Authentication type to use for Azure Storage access. Defaults to `DEFAULT` which
+    uses system level credentials. Use `ACCESS_KEY` for [](azure-access-key-authentication) 
+    or and `OAUTH` for [](azure-oauth-authentication).
 * - `azure.endpoint`
   - Hostname suffix of the Azure storage endpoint.
     Defaults to `core.windows.net` for the global Azure cloud.

--- a/lib/trino-filesystem-azure/pom.xml
+++ b/lib/trino-filesystem-azure/pom.xml
@@ -159,6 +159,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-filesystem</artifactId>
             <version>${project.version}</version>

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureAuthDefault.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureAuthDefault.java
@@ -17,11 +17,21 @@ import com.azure.core.credential.TokenCredential;
 import com.azure.identity.DefaultAzureCredentialBuilder;
 import com.azure.storage.blob.BlobContainerClientBuilder;
 import com.azure.storage.file.datalake.DataLakeServiceClientBuilder;
+import com.google.inject.Inject;
 
 public final class AzureAuthDefault
         implements AzureAuth
 {
-    private final TokenCredential credential = new DefaultAzureCredentialBuilder().build();
+    private final TokenCredential credential;
+
+    @Inject
+    public AzureAuthDefault(AzureAuthManagedIdentityConfig config)
+    {
+        DefaultAzureCredentialBuilder builder = new DefaultAzureCredentialBuilder();
+        config.getClientId().ifPresent(builder::managedIdentityClientId);
+        config.getResourceId().ifPresent(builder::managedIdentityResourceId);
+        credential = builder.build();
+    }
 
     @Override
     public void setAuth(String storageAccount, BlobContainerClientBuilder builder)

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureAuthDefaultModule.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureAuthDefaultModule.java
@@ -16,12 +16,15 @@ package io.trino.filesystem.azure;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
 public class AzureAuthDefaultModule
         implements Module
 {
     @Override
     public void configure(Binder binder)
     {
+        configBinder(binder).bindConfig(AzureAuthManagedIdentityConfig.class);
         binder.bind(AzureAuth.class).to(AzureAuthDefault.class);
     }
 }

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureAuthManagedIdentityConfig.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureAuthManagedIdentityConfig.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigSecuritySensitive;
+import jakarta.validation.constraints.AssertTrue;
+
+import java.util.Optional;
+
+public class AzureAuthManagedIdentityConfig
+{
+    private Optional<String> clientId = Optional.empty();
+    private Optional<String> resourceId = Optional.empty();
+
+    public Optional<String> getClientId()
+    {
+        return clientId;
+    }
+
+    @ConfigSecuritySensitive
+    @Config("azure.user-assigned-managed-identity.client-id")
+    public AzureAuthManagedIdentityConfig setClientId(String clientId)
+    {
+        this.clientId = Optional.ofNullable(clientId);
+        return this;
+    }
+
+    public Optional<String> getResourceId()
+    {
+        return resourceId;
+    }
+
+    @ConfigSecuritySensitive
+    @Config("azure.user-assigned-managed-identity.resource-id")
+    public AzureAuthManagedIdentityConfig setResourceId(String resourceId)
+    {
+        this.resourceId = Optional.ofNullable(resourceId);
+        return this;
+    }
+
+    @AssertTrue(message = "Both azure.user-assigned-managed-identity.client-id and azure.user-assigned-managed-identity.resource-id cannot be set")
+    public boolean isConfigValid()
+    {
+        return clientId.isEmpty() || resourceId.isEmpty();
+    }
+}

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureAuthManagedIdentityConfig.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureAuthManagedIdentityConfig.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.configuration.ConfigurationFactory;
+import jakarta.validation.constraints.AssertTrue;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.airlift.testing.ValidationAssertions.assertFailsValidation;
+import static io.airlift.testing.ValidationAssertions.assertValidates;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestAzureAuthManagedIdentityConfig
+{
+    @Test
+    void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(AzureAuthManagedIdentityConfig.class)
+                .setClientId(null)
+                .setResourceId(null));
+    }
+
+    @Test
+    void testClientIdPropertyMapping()
+    {
+        AzureAuthManagedIdentityConfig actual = buildManagedConfig(ImmutableMap.<String, String>builder()
+                .put("azure.user-assigned-managed-identity.client-id", "clientId")
+                .buildOrThrow());
+
+        assertThat(actual.getClientId()).hasValue("clientId");
+        assertThat(actual.getResourceId()).isEmpty();
+    }
+
+    @Test
+    void testResourceIdPropertyMapping()
+    {
+        AzureAuthManagedIdentityConfig actual = buildManagedConfig(ImmutableMap.<String, String>builder()
+                .put("azure.user-assigned-managed-identity.resource-id", "resourceId")
+                .buildOrThrow());
+
+        assertThat(actual.getClientId()).isEmpty();
+        assertThat(actual.getResourceId()).hasValue("resourceId");
+    }
+
+    @Test
+    void testValidation()
+    {
+        assertValidates(new AzureAuthManagedIdentityConfig());
+
+        assertFailsValidation(
+                new AzureAuthManagedIdentityConfig()
+                        .setClientId("clientId")
+                        .setResourceId("resourceId"),
+                "configValid",
+                "Both azure.user-assigned-managed-identity.client-id and azure.user-assigned-managed-identity.resource-id cannot be set",
+                AssertTrue.class);
+    }
+
+    private static AzureAuthManagedIdentityConfig buildManagedConfig(Map<String, String> properties)
+    {
+        ConfigurationFactory configurationFactory = new ConfigurationFactory(properties);
+        return configurationFactory.build(AzureAuthManagedIdentityConfig.class);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This PR allows us to configure [User-Assigned Managed Identity](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview) for Azure FS. 

Since User Managed Identity can be tested only in a environment specified in Azure - we are restricting the test cases to config specific one. I'll be validating this change on AKS to check if the proper APIs are invoked. 

I'm open with testing on additional testing mechanisms if required. 


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Allow configuring User-ManagedIdentity in AzureFS
```
