### PR TITLE
Fix multiple sources build side in AdaptiveReorderPartitionedJoin

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestAdaptiveReorderPartitionedJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestAdaptiveReorderPartitionedJoin.java
@@ -31,6 +31,8 @@ import java.util.Optional;
 import static io.trino.SystemSessionProperties.RETRY_POLICY;
 import static io.trino.operator.RetryPolicy.TASK;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_ARBITRARY_DISTRIBUTION;
+import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.aggregation;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.exchange;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
@@ -88,6 +90,101 @@ public class TestAdaptiveReorderPartitionedJoin
                                         remoteSource(
                                                 ImmutableList.of(new PlanFragmentId("1")),
                                                 ImmutableList.of("probeSymbol", "symbol2"),
+                                                REPARTITION)))));
+    }
+
+    @Test
+    public void testReorderPartitionedJoinWithMultipleSources()
+    {
+        assertWithPartialAggAndMultipleSources(20_000_000_000L, 10_000_000_000L)
+                .matches(
+                        join(INNER, builder -> builder
+                                .equiCriteria("buildSymbol", "probeSymbol")
+                                .distributionType(PARTITIONED)
+                                .left(aggregation(
+                                        ImmutableMap.of(),
+                                        PARTIAL,
+                                        exchange(
+                                                LOCAL,
+                                                Optional.of(REPARTITION),
+                                                Optional.of(FIXED_ARBITRARY_DISTRIBUTION),
+                                                ImmutableList.of(),
+                                                ImmutableSet.of(),
+                                                Optional.of(ImmutableList.of(
+                                                        ImmutableList.of("buildSymbol1", "symbol11"),
+                                                        ImmutableList.of("buildSymbol2", "symbol12"))),
+                                                ImmutableList.of("buildSymbol", "symbol1"),
+                                                Optional.empty(),
+                                                remoteSource(
+                                                        ImmutableList.of(new PlanFragmentId("3")),
+                                                        ImmutableList.of("buildSymbol1", "symbol11"),
+                                                        REPARTITION),
+                                                remoteSource(
+                                                        ImmutableList.of(new PlanFragmentId("4")),
+                                                        ImmutableList.of("buildSymbol2", "symbol12"),
+                                                        REPARTITION))))
+                                .right(exchange(
+                                        LOCAL,
+                                        Optional.of(REPARTITION),
+                                        Optional.of(FIXED_HASH_DISTRIBUTION),
+                                        ImmutableList.of(),
+                                        ImmutableSet.of("probeSymbol"),
+                                        Optional.of(ImmutableList.of(
+                                                ImmutableList.of("probeSymbol1", "symbol21"),
+                                                ImmutableList.of("probeSymbol2", "symbol22"))),
+                                        ImmutableList.of("probeSymbol", "symbol2"),
+                                        Optional.empty(),
+                                        remoteSource(
+                                                ImmutableList.of(new PlanFragmentId("1")),
+                                                ImmutableList.of("probeSymbol1", "symbol21"),
+                                                REPARTITION),
+                                        remoteSource(
+                                                ImmutableList.of(new PlanFragmentId("2")),
+                                                ImmutableList.of("probeSymbol2", "symbol22"),
+                                                REPARTITION)))));
+
+        assertWithoutPartialAggAndMultipleSources(20_000_000_000L, 10_000_000_000L)
+                .matches(
+                        join(INNER, builder -> builder
+                                .equiCriteria("buildSymbol", "probeSymbol")
+                                .distributionType(PARTITIONED)
+                                .left(exchange(
+                                        LOCAL,
+                                        Optional.of(REPARTITION),
+                                        Optional.of(FIXED_ARBITRARY_DISTRIBUTION),
+                                        ImmutableList.of(),
+                                        ImmutableSet.of(),
+                                        Optional.of(ImmutableList.of(
+                                                ImmutableList.of("buildSymbol1", "symbol11"),
+                                                ImmutableList.of("buildSymbol2", "symbol12"))),
+                                        ImmutableList.of("buildSymbol", "symbol1"),
+                                        Optional.empty(),
+                                        remoteSource(
+                                                ImmutableList.of(new PlanFragmentId("3")),
+                                                ImmutableList.of("buildSymbol1", "symbol11"),
+                                                REPARTITION),
+                                        remoteSource(
+                                                ImmutableList.of(new PlanFragmentId("4")),
+                                                ImmutableList.of("buildSymbol2", "symbol12"),
+                                                REPARTITION)))
+                                .right(exchange(
+                                        LOCAL,
+                                        Optional.of(REPARTITION),
+                                        Optional.of(FIXED_HASH_DISTRIBUTION),
+                                        ImmutableList.of(),
+                                        ImmutableSet.of("probeSymbol"),
+                                        Optional.of(ImmutableList.of(
+                                                ImmutableList.of("probeSymbol1", "symbol21"),
+                                                ImmutableList.of("probeSymbol2", "symbol22"))),
+                                        ImmutableList.of("probeSymbol", "symbol2"),
+                                        Optional.empty(),
+                                        remoteSource(
+                                                ImmutableList.of(new PlanFragmentId("1")),
+                                                ImmutableList.of("probeSymbol1", "symbol21"),
+                                                REPARTITION),
+                                        remoteSource(
+                                                ImmutableList.of(new PlanFragmentId("2")),
+                                                ImmutableList.of("probeSymbol2", "symbol22"),
                                                 REPARTITION)))));
     }
 
@@ -166,6 +263,177 @@ public class TestAdaptiveReorderPartitionedJoin
                                                     ImmutableList.of(buildSymbol))
                                             .type(REPARTITION)
                                             .scope(LOCAL)))),
+                            new JoinNode.EquiJoinClause(probeSymbol, buildSymbol));
+                });
+    }
+
+    private RuleAssert assertWithPartialAggAndMultipleSources(double buildRowCount, double probeRowCount)
+    {
+        RuleTester ruleTester = tester();
+        String buildRemoteSourceA = "buildRemoteSourceA";
+        String buildRemoteSourceB = "buildRemoteSourceB";
+        String probeRemoteSourceA = "probeRemoteSourceA";
+        String probeRemoteSourceB = "probeRemoteSourceB";
+        return ruleTester.assertThat(new AdaptiveReorderPartitionedJoin(ruleTester.getMetadata()))
+                .setSystemProperty(RETRY_POLICY, TASK.name())
+                .overrideStats("buildRemoteSourceA", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(buildRowCount)
+                        .build())
+                .overrideStats("buildRemoteSourceB", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(buildRowCount)
+                        .build())
+                .overrideStats("probeRemoteSourceA", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(probeRowCount)
+                        .build())
+                .overrideStats("probeRemoteSourceB", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(probeRowCount)
+                        .build())
+                .on(p -> {
+                    Symbol buildSymbol = p.symbol("buildSymbol", BIGINT);
+                    Symbol symbol1 = p.symbol("symbol1", BIGINT);
+                    Symbol buildSymbol1 = p.symbol("buildSymbol1", BIGINT);
+                    Symbol symbol11 = p.symbol("symbol11", BIGINT);
+                    Symbol buildSymbol2 = p.symbol("buildSymbol2", BIGINT);
+                    Symbol symbol12 = p.symbol("symbol12", BIGINT);
+
+                    Symbol probeSymbol = p.symbol("probeSymbol", BIGINT);
+                    Symbol symbol2 = p.symbol("symbol2", BIGINT);
+                    Symbol probeSymbol1 = p.symbol("probeSymbol1", BIGINT);
+                    Symbol symbol21 = p.symbol("symbol21", BIGINT);
+                    Symbol probeSymbol2 = p.symbol("probeSymbol2", BIGINT);
+                    Symbol symbol22 = p.symbol("symbol22", BIGINT);
+                    return p.join(
+                            INNER,
+                            PARTITIONED,
+                            p.exchange(builder -> builder
+                                    .addSource(p.remoteSource(
+                                            new PlanNodeId(probeRemoteSourceA),
+                                            ImmutableList.of(new PlanFragmentId("1")),
+                                            ImmutableList.of(probeSymbol1, symbol21),
+                                            Optional.empty(),
+                                            REPARTITION,
+                                            TASK))
+                                    .addInputsSet(ImmutableList.of(probeSymbol1, symbol21))
+                                    .addSource(p.remoteSource(
+                                            new PlanNodeId(probeRemoteSourceB),
+                                            ImmutableList.of(new PlanFragmentId("2")),
+                                            ImmutableList.of(probeSymbol2, symbol22),
+                                            Optional.empty(),
+                                            REPARTITION,
+                                            TASK))
+                                    .addInputsSet(ImmutableList.of(probeSymbol2, symbol22))
+                                    .fixedArbitraryDistributionPartitioningScheme(ImmutableList.of(probeSymbol, symbol2), 2)
+                                    .type(REPARTITION)
+                                    .scope(LOCAL)),
+                            p.aggregation(ab -> ab
+                                    .step(PARTIAL)
+                                    .singleGroupingSet(buildSymbol, symbol1)
+                                    .source(p.exchange(builder -> builder
+                                            .addSource(p.remoteSource(
+                                                    new PlanNodeId(buildRemoteSourceA),
+                                                    ImmutableList.of(new PlanFragmentId("3")),
+                                                    ImmutableList.of(buildSymbol1, symbol11),
+                                                    Optional.empty(),
+                                                    REPARTITION,
+                                                    TASK))
+                                            .addInputsSet(ImmutableList.of(buildSymbol1, symbol11))
+                                            .addSource(p.remoteSource(
+                                                    new PlanNodeId(buildRemoteSourceB),
+                                                    ImmutableList.of(new PlanFragmentId("4")),
+                                                    ImmutableList.of(buildSymbol2, symbol12),
+                                                    Optional.empty(),
+                                                    REPARTITION,
+                                                    TASK))
+                                            .addInputsSet(ImmutableList.of(buildSymbol2, symbol12))
+                                            .fixedHashDistributionPartitioningScheme(
+                                                    ImmutableList.of(buildSymbol, symbol1),
+                                                    ImmutableList.of(buildSymbol))
+                                            .type(REPARTITION)
+                                            .scope(LOCAL)))),
+                            new JoinNode.EquiJoinClause(probeSymbol, buildSymbol));
+                });
+    }
+
+    private RuleAssert assertWithoutPartialAggAndMultipleSources(double buildRowCount, double probeRowCount)
+    {
+        RuleTester ruleTester = tester();
+        String buildRemoteSourceA = "buildRemoteSourceA";
+        String buildRemoteSourceB = "buildRemoteSourceB";
+        String probeRemoteSourceA = "probeRemoteSourceA";
+        String probeRemoteSourceB = "probeRemoteSourceB";
+        return ruleTester.assertThat(new AdaptiveReorderPartitionedJoin(ruleTester.getMetadata()))
+                .setSystemProperty(RETRY_POLICY, TASK.name())
+                .overrideStats("buildRemoteSourceA", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(buildRowCount)
+                        .build())
+                .overrideStats("buildRemoteSourceB", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(buildRowCount)
+                        .build())
+                .overrideStats("probeRemoteSourceA", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(probeRowCount)
+                        .build())
+                .overrideStats("probeRemoteSourceB", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(probeRowCount)
+                        .build())
+                .on(p -> {
+                    Symbol buildSymbol = p.symbol("buildSymbol", BIGINT);
+                    Symbol symbol1 = p.symbol("symbol1", BIGINT);
+                    Symbol buildSymbol1 = p.symbol("buildSymbol1", BIGINT);
+                    Symbol symbol11 = p.symbol("symbol11", BIGINT);
+                    Symbol buildSymbol2 = p.symbol("buildSymbol2", BIGINT);
+                    Symbol symbol12 = p.symbol("symbol12", BIGINT);
+
+                    Symbol probeSymbol = p.symbol("probeSymbol", BIGINT);
+                    Symbol symbol2 = p.symbol("symbol2", BIGINT);
+                    Symbol probeSymbol1 = p.symbol("probeSymbol1", BIGINT);
+                    Symbol symbol21 = p.symbol("symbol21", BIGINT);
+                    Symbol probeSymbol2 = p.symbol("probeSymbol2", BIGINT);
+                    Symbol symbol22 = p.symbol("symbol22", BIGINT);
+                    return p.join(
+                            INNER,
+                            PARTITIONED,
+                            p.exchange(builder -> builder
+                                    .addSource(p.remoteSource(
+                                            new PlanNodeId(probeRemoteSourceA),
+                                            ImmutableList.of(new PlanFragmentId("1")),
+                                            ImmutableList.of(probeSymbol1, symbol21),
+                                            Optional.empty(),
+                                            REPARTITION,
+                                            TASK))
+                                    .addInputsSet(ImmutableList.of(probeSymbol1, symbol21))
+                                    .addSource(p.remoteSource(
+                                            new PlanNodeId(probeRemoteSourceB),
+                                            ImmutableList.of(new PlanFragmentId("2")),
+                                            ImmutableList.of(probeSymbol2, symbol22),
+                                            Optional.empty(),
+                                            REPARTITION,
+                                            TASK))
+                                    .addInputsSet(ImmutableList.of(probeSymbol2, symbol22))
+                                    .fixedArbitraryDistributionPartitioningScheme(ImmutableList.of(probeSymbol, symbol2), 2)
+                                    .type(REPARTITION)
+                                    .scope(LOCAL)),
+                            p.exchange(builder -> builder
+                                    .addSource(p.remoteSource(
+                                            new PlanNodeId(buildRemoteSourceA),
+                                            ImmutableList.of(new PlanFragmentId("3")),
+                                            ImmutableList.of(buildSymbol1, symbol11),
+                                            Optional.empty(),
+                                            REPARTITION,
+                                            TASK))
+                                    .addInputsSet(ImmutableList.of(buildSymbol1, symbol11))
+                                    .addSource(p.remoteSource(
+                                            new PlanNodeId(buildRemoteSourceB),
+                                            ImmutableList.of(new PlanFragmentId("4")),
+                                            ImmutableList.of(buildSymbol2, symbol12),
+                                            Optional.empty(),
+                                            REPARTITION,
+                                            TASK))
+                                    .addInputsSet(ImmutableList.of(buildSymbol2, symbol12))
+                                    .fixedHashDistributionPartitioningScheme(
+                                            ImmutableList.of(buildSymbol, symbol1),
+                                            ImmutableList.of(buildSymbol))
+                                    .type(REPARTITION)
+                                    .scope(LOCAL)),
                             new JoinNode.EquiJoinClause(probeSymbol, buildSymbol));
                 });
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Fix: https://github.com/trinodb/trino/issues/23407

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix possible query failure when `retry_policy` is set to `TASK` and when adaptive join reordering is enabled . ({issue}`23407`)
```
