### PR TITLE
Optimize large IN filters on integer data types

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/SimplifyContinuousInValues.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/SimplifyContinuousInValues.java
@@ -58,7 +58,7 @@ public class SimplifyContinuousInValues
         }
 
         Type valueType = in.value().type();
-        if (!isDirectLongComparisonValidType(valueType)) {
+        if (!isDirectLongComparisonValidForContinuousValues(valueType)) {
             return Optional.empty();
         }
 
@@ -96,10 +96,11 @@ public class SimplifyContinuousInValues
         return Optional.empty();
     }
 
-    private static boolean isDirectLongComparisonValidType(Type type)
+    private static boolean isDirectLongComparisonValidForContinuousValues(Type type)
     {
         // Types for which we can safely use equality and comparison on the stored long value
-        // instead of going through type specific methods
+        // instead of going through type specific methods and where the next consecutive value
+        // can be obtained by incrementing the stored long value by 1
         return type instanceof TinyintType ||
                 type instanceof SmallintType ||
                 type instanceof IntegerType ||

--- a/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkDynamicPageFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkDynamicPageFilter.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.gen;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.FullConnectorSession;
+import io.trino.operator.project.SelectedPositions;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.LazyBlock;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.TestingColumnHandle;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.spi.type.Type;
+import io.trino.sql.gen.columnar.FilterEvaluator;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.options.WarmupMode;
+
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.jmh.Benchmarks.benchmark;
+import static io.trino.operator.project.SelectedPositions.positionsRange;
+import static io.trino.spi.predicate.Domain.DiscreteSet;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.TypeUtils.readNativeValue;
+import static io.trino.spi.type.TypeUtils.writeNativeValue;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.util.DynamicFiltersTestUtil.createDynamicFilterEvaluator;
+import static java.lang.Float.floatToIntBits;
+import static java.util.Objects.requireNonNull;
+import static org.openjdk.jmh.annotations.Scope.Thread;
+
+@State(Thread)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(2)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+public class BenchmarkDynamicPageFilter
+{
+    private static final int MAX_ROWS = 200_000;
+    private static final FullConnectorSession FULL_CONNECTOR_SESSION = new FullConnectorSession(
+            testSessionBuilder().build(),
+            ConnectorIdentity.ofUser("test"));
+
+    @Param("0.05")
+    public double inputNullChance = 0.05;
+
+    @Param("0.2")
+    public double nonNullsSelectivity = 0.2;
+
+    @Param({"100", "1000", "5000"})
+    public int filterSize = 100;
+
+    @Param("false")
+    public boolean nullsAllowed;
+
+    @Param({
+            "INT32_RANDOM",
+            "INT64_RANDOM",
+            "INT64_FIXED_32K", // LongBitSetFilter
+            "REAL_RANDOM",
+    })
+    public DataSet inputDataSet;
+
+    private List<Page> inputData;
+    private FilterEvaluator filterEvaluator;
+
+    public enum DataSet
+    {
+        INT32_RANDOM(INTEGER, (block, r) -> INTEGER.writeLong(block, r.nextInt())),
+        INT64_RANDOM(BIGINT, (block, r) -> BIGINT.writeLong(block, r.nextLong())),
+        INT64_FIXED_32K(BIGINT, (block, r) -> BIGINT.writeLong(block, r.nextLong() % 32768)),
+        REAL_RANDOM(REAL, (block, r) -> REAL.writeLong(block, floatToIntBits(r.nextFloat()))),
+        /**/;
+
+        private final Type type;
+        private final ValueWriter valueWriter;
+
+        DataSet(Type type, ValueWriter valueWriter)
+        {
+            this.type = requireNonNull(type, "type is null");
+            this.valueWriter = requireNonNull(valueWriter, "valueWriter is null");
+        }
+
+        public TupleDomain<ColumnHandle> createFilterTupleDomain(int filterSize, boolean nullsAllowed)
+        {
+            List<Page> filterValues = createSingleColumnData(valueWriter, type, 0, filterSize);
+            ImmutableList.Builder<Object> valuesBuilder = ImmutableList.builder();
+            for (Page page : filterValues) {
+                Block block = page.getBlock(0).getLoadedBlock();
+                for (int position = 0; position < block.getPositionCount(); position++) {
+                    valuesBuilder.add(readNativeValue(type, block, position));
+                }
+            }
+            return TupleDomain.withColumnDomains(ImmutableMap.of(
+                    new TestingColumnHandle("dummy"),
+                    Domain.create(ValueSet.copyOf(type, valuesBuilder.build()), nullsAllowed)));
+        }
+
+        private List<Page> createInputTestData(
+                TupleDomain<ColumnHandle> filter,
+                double inputNullChance,
+                double nonNullsSelectivity,
+                long inputRows)
+        {
+            List<Object> nonNullValues = filter.getDomains().orElseThrow()
+                    .values().stream()
+                    .flatMap(domain -> {
+                        DiscreteSet nullableDiscreteSet = domain.getNullableDiscreteSet();
+                        return nullableDiscreteSet.getNonNullValues().stream();
+                    })
+                    .collect(toImmutableList());
+
+            // pick a random value from the filter
+            return createSingleColumnData(
+                    (block, r) -> {
+                        if (isTrue(r, nonNullsSelectivity)) {
+                            // pick a random value from the filter
+                            Object value = nonNullValues.get(r.nextInt(nonNullValues.size()));
+                            writeNativeValue(type, block, value);
+                            return;
+                        }
+                        valueWriter.write(block, r);
+                    },
+                    type,
+                    inputNullChance,
+                    inputRows);
+        }
+    }
+
+    @Setup
+    public void setup()
+    {
+        TupleDomain<ColumnHandle> filterPredicate = inputDataSet.createFilterTupleDomain(filterSize, nullsAllowed);
+        inputData = inputDataSet.createInputTestData(filterPredicate, inputNullChance, nonNullsSelectivity, MAX_ROWS);
+        filterEvaluator = createDynamicFilterEvaluator(
+                filterPredicate,
+                ImmutableMap.of(new TestingColumnHandle("dummy"), 0),
+                1);
+    }
+
+    @Benchmark
+    public double filterPages()
+    {
+        long rowsProcessed = 0;
+        long rowsFiltered = 0;
+        for (Page page : inputData) {
+            FilterEvaluator.SelectionResult result = filterEvaluator.evaluate(FULL_CONNECTOR_SESSION, positionsRange(0, page.getPositionCount()), page);
+            SelectedPositions selectedPositions = result.selectedPositions();
+            int selectedPositionCount = selectedPositions.size();
+            rowsProcessed += page.getPositionCount();
+            rowsFiltered += page.getPositionCount() - selectedPositionCount;
+        }
+        return ((double) rowsFiltered / rowsProcessed) * 100;
+    }
+
+    private static List<Page> createSingleColumnData(ValueWriter valueWriter, Type type, double nullChance, long rows)
+    {
+        ImmutableList.Builder<Page> pages = ImmutableList.builder();
+        Random random = new Random(32167);
+        int batchSize = 1;
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, batchSize);
+        for (int i = 0; i < rows; i++) {
+            if (isTrue(random, nullChance)) {
+                blockBuilder.appendNull();
+            }
+            else {
+                valueWriter.write(blockBuilder, random);
+            }
+
+            if (blockBuilder.getPositionCount() >= batchSize) {
+                Block block = blockBuilder.build();
+                pages.add(new Page(new LazyBlock(block.getPositionCount(), () -> block)));
+                batchSize = Math.min(1024, batchSize * 2);
+                blockBuilder = type.createBlockBuilder(null, batchSize);
+            }
+        }
+        if (blockBuilder.getPositionCount() > 0) {
+            Block block = blockBuilder.build();
+            pages.add(new Page(new LazyBlock(block.getPositionCount(), () -> block)));
+        }
+        return pages.build();
+    }
+
+    @FunctionalInterface
+    private interface ValueWriter
+    {
+        void write(BlockBuilder blockBuilder, Random r);
+    }
+
+    private static boolean isTrue(Random random, double chance)
+    {
+        double value = 0;
+        // chance has to be 0 to 1 exclusive.
+        while (value == 0) {
+            value = random.nextDouble();
+        }
+        return value < chance;
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        benchmark(BenchmarkDynamicPageFilter.class, WarmupMode.BULK)
+                .withOptions(optionsBuilder -> optionsBuilder.jvmArgsAppend("-Xmx4g", "-Xms4g"))
+                .run();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestBenchmarkDynamicPageFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestBenchmarkDynamicPageFilter.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.gen;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+
+public class TestBenchmarkDynamicPageFilter
+{
+    @Test
+    public void testBenchmarkDynamicPageFilter()
+    {
+        for (BenchmarkDynamicPageFilter.DataSet inputDataSet : BenchmarkDynamicPageFilter.DataSet.values()) {
+            for (boolean nullsAllowed : ImmutableList.of(true, false)) {
+                BenchmarkDynamicPageFilter benchmark = new BenchmarkDynamicPageFilter();
+                benchmark.nullsAllowed = nullsAllowed;
+                benchmark.inputDataSet = inputDataSet;
+                benchmark.setup();
+                benchmark.filterPages();
+            }
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/util/DynamicFiltersTestUtil.java
+++ b/core/trino-main/src/test/java/io/trino/util/DynamicFiltersTestUtil.java
@@ -13,13 +13,31 @@
  */
 package io.trino.util;
 
+import com.google.common.collect.ImmutableMap;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.predicate.SortedRangeSet;
+import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.Type;
+import io.trino.sql.gen.columnar.ColumnarFilterCompiler;
+import io.trino.sql.gen.columnar.DynamicPageFilter;
+import io.trino.sql.gen.columnar.FilterEvaluator;
+import io.trino.sql.planner.Symbol;
 
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.StringJoiner;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.airlift.concurrent.MoreFutures.unmodifiableFuture;
+import static io.trino.metadata.FunctionManager.createTestingFunctionManager;
+import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
+import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.lang.String.format;
 
 public final class DynamicFiltersTestUtil
@@ -52,5 +70,119 @@ public final class DynamicFiltersTestUtil
                         .add("ranges=" + rangeCount)
                         .add(formattedValues) +
                 " ]";
+    }
+
+    public static FilterEvaluator createDynamicFilterEvaluator(
+            TupleDomain<ColumnHandle> tupleDomain,
+            Map<ColumnHandle, Integer> channels)
+    {
+        return createDynamicFilterEvaluator(tupleDomain, channels, 1);
+    }
+
+    public static FilterEvaluator createDynamicFilterEvaluator(
+            TupleDomain<ColumnHandle> tupleDomain,
+            Map<ColumnHandle, Integer> channels,
+            double selectivityThreshold)
+    {
+        TestingDynamicFilter dynamicFilter = new TestingDynamicFilter(1);
+        dynamicFilter.update(tupleDomain);
+        Map<ColumnHandle, Type> types = tupleDomain.getDomains().orElse(ImmutableMap.of())
+                .entrySet().stream()
+                .collect(toImmutableMap(Map.Entry::getKey, entry -> entry.getValue().getType()));
+        int index = 0;
+        ImmutableMap.Builder<Symbol, ColumnHandle> columns = ImmutableMap.builder();
+        ImmutableMap.Builder<Symbol, Integer> layout = ImmutableMap.builder();
+        for (Map.Entry<ColumnHandle, Integer> entry : channels.entrySet()) {
+            ColumnHandle column = entry.getKey();
+            Symbol symbol = new Symbol(types.get(column), "col" + index++);
+            columns.put(symbol, column);
+            int channel = entry.getValue();
+            layout.put(symbol, channel);
+        }
+        return new DynamicPageFilter(
+                PLANNER_CONTEXT,
+                testSessionBuilder().build(),
+                columns.buildOrThrow(),
+                layout.buildOrThrow(),
+                selectivityThreshold)
+                .createDynamicPageFilterEvaluator(new ColumnarFilterCompiler(createTestingFunctionManager(), 0), dynamicFilter)
+                .get();
+    }
+
+    public static class TestingDynamicFilter
+            implements DynamicFilter
+    {
+        private CompletableFuture<?> isBlocked;
+        private TupleDomain<ColumnHandle> currentPredicate;
+        private int futuresLeft;
+
+        public TestingDynamicFilter(int expectedFilters)
+        {
+            this.futuresLeft = expectedFilters;
+            this.isBlocked = expectedFilters == 0 ? NOT_BLOCKED : new CompletableFuture<>();
+            this.currentPredicate = TupleDomain.all();
+        }
+
+        public void update(TupleDomain<ColumnHandle> predicate)
+        {
+            futuresLeft -= 1;
+            verify(futuresLeft >= 0);
+            currentPredicate = currentPredicate.intersect(predicate);
+            CompletableFuture<?> currentFuture = isBlocked;
+            // create next blocking future (if needed)
+            isBlocked = isComplete() ? NOT_BLOCKED : new CompletableFuture<>();
+            verify(currentFuture.complete(null));
+        }
+
+        @Override
+        public Set<ColumnHandle> getColumnsCovered()
+        {
+            return currentPredicate.getDomains().orElseThrow().keySet();
+        }
+
+        @Override
+        public CompletableFuture<?> isBlocked()
+        {
+            return unmodifiableFuture(isBlocked);
+        }
+
+        @Override
+        public boolean isComplete()
+        {
+            return futuresLeft == 0;
+        }
+
+        @Override
+        public boolean isAwaitable()
+        {
+            return futuresLeft > 0;
+        }
+
+        @Override
+        public TupleDomain<ColumnHandle> getCurrentPredicate()
+        {
+            return currentPredicate;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            TestingDynamicFilter that = (TestingDynamicFilter) o;
+            return futuresLeft == that.futuresLeft
+                    && Objects.equals(isBlocked, that.isBlocked)
+                    && Objects.equals(currentPredicate, that.currentPredicate);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(isBlocked, currentPredicate, futuresLeft);
+        }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/util/TestFastutilSetHelper.java
+++ b/core/trino-main/src/test/java/io/trino/util/TestFastutilSetHelper.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.util;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.type.SqlTime;
+import io.trino.spi.type.SqlTimestamp;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeOperators;
+import it.unimi.dsi.fastutil.longs.AbstractLongSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
+import static io.trino.spi.function.InvocationConvention.simpleConvention;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimeType.TIME_MICROS;
+import static io.trino.spi.type.TimeType.TIME_MILLIS;
+import static io.trino.spi.type.TimeType.TIME_NANOS;
+import static io.trino.spi.type.TimeType.TIME_PICOS;
+import static io.trino.spi.type.TimeType.TIME_SECONDS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_SECONDS;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.TypeUtils.writeNativeValue;
+import static io.trino.util.FastutilSetHelper.toFastutilHashSet;
+import static java.lang.Float.floatToRawIntBits;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestFastutilSetHelper
+{
+    private static final TypeOperators TYPE_OPERATORS = new TypeOperators();
+
+    @Test
+    void testCreateTupleDomainFilters()
+    {
+        for (TestInput testInput : testInputs()) {
+            for (Block inputValues : testInput.getInputs()) {
+                Type type = testInput.getType();
+                List<Long> values = IntStream.range(0, inputValues.getPositionCount())
+                        .mapToLong(index -> type.getLong(inputValues, index))
+                        .boxed()
+                        .collect(toImmutableList());
+                @SuppressWarnings("unchecked")
+                Set<Long> filter = (Set<Long>) toFastutilHashSet(
+                        ImmutableSet.copyOf(values),
+                        type,
+                        TYPE_OPERATORS.getHashCodeOperator(type, simpleConvention(FAIL_ON_NULL, NEVER_NULL)),
+                        TYPE_OPERATORS.getEqualOperator(type, simpleConvention(NULLABLE_RETURN, NEVER_NULL, NEVER_NULL)));
+                assertThat(filter).isInstanceOf(AbstractLongSet.class);
+                for (Object value : values) {
+                    assertThat(filter.contains((long) value)).isTrue();
+                }
+
+                long minValue = ((Number) type.getRange().map(Type.Range::getMin).orElse(Long.MIN_VALUE)).longValue();
+                long maxValue = ((Number) type.getRange().map(Type.Range::getMax).orElse(Long.MAX_VALUE)).longValue();
+                assertThat(filter.contains(minValue)).isFalse();
+                assertThat(filter.contains(maxValue)).isFalse();
+
+                long min = values.get(0);
+                long max = min;
+                for (int i = 1; i < values.size(); i++) {
+                    min = Math.min(min, values.get(i));
+                    max = Math.max(max, values.get(i));
+                }
+                assertThat(filter.contains(min - 1)).isFalse();
+                assertThat(filter.contains(max + 1)).isFalse();
+            }
+        }
+    }
+
+    private static List<TestInput> testInputs()
+    {
+        return ImmutableList.of(
+                new TestInput(INTEGER, longInputValues()),
+                new TestInput(BIGINT, longInputValues()),
+                new TestInput(SMALLINT, longInputValues()),
+                new TestInput(TINYINT, ImmutableList.of(ImmutableList.of(-100L, 100L, 120L), ImmutableList.of(100L, 102L, 104L, 105L))),
+                new TestInput(REAL, floatInputValues()),
+                new TestInput(TIMESTAMP_SECONDS, timestampInputValues(0)),
+                new TestInput(TIMESTAMP_MILLIS, timestampInputValues(3)),
+                new TestInput(TIMESTAMP_MICROS, timestampInputValues(6)),
+                new TestInput(TIME_SECONDS, timeInputValues(0)),
+                new TestInput(TIME_MILLIS, timeInputValues(3)),
+                new TestInput(TIME_MICROS, timeInputValues(6)),
+                new TestInput(TIME_NANOS, timeInputValues(9)),
+                new TestInput(TIME_PICOS, timeInputValues(12)),
+                new TestInput(DATE, longInputValues()),
+                new TestInput(createDecimalType(5, 0), longInputValues()),
+                new TestInput(createDecimalType(7, 2), longInputValues()));
+    }
+
+    private static List<List<?>> longInputValues()
+    {
+        return ImmutableList.of(
+                ImmutableList.of(-100L, 0L, 1L, 3L, 500L, 7000L),
+                ImmutableList.of(1L, 3L, 7L, 12L, 14L));
+    }
+
+    private static List<List<?>> floatInputValues()
+    {
+        return ImmutableList.of(
+                ImmutableList.of((long) floatToRawIntBits(-123122.03f), (long) floatToRawIntBits(3424.4f), (long) floatToRawIntBits(989.998f)),
+                ImmutableList.of((long) floatToRawIntBits(1.2342f), (long) floatToRawIntBits(3.56f), (long) floatToRawIntBits(7.4f), (long) floatToRawIntBits(12.1f), (long) floatToRawIntBits(14.0f)));
+    }
+
+    private static List<List<?>> timeInputValues(int precision)
+    {
+        return ImmutableList.of(
+                        ImmutableList.of(1000_000_000_000L, 1000_000_003_000L, 1000_004_000_000L, 1005_000_000_000L, 1060_000_000_000L),
+                        ImmutableList.of(1000_000_000_001L, 1000_000_000_003L, 1000_000_000_007L, 1000_000_000_012L, 1000_000_000_014L))
+                .stream()
+                .map(inputs -> inputs.stream()
+                        .map(value -> SqlTime.newInstance(12, value).roundTo(precision).getPicos())
+                        .collect(toImmutableList()))
+                .collect(toImmutableList());
+    }
+
+    private static List<List<?>> timestampInputValues(int precision)
+    {
+        return ImmutableList.of(
+                        ImmutableList.of(1000_000_000_000L, 1000_000_003_000L, 1000_004_000_000L, 1005_000_000_000L, 1060_000_000_000L),
+                        ImmutableList.of(1000_000_000_001L, 1000_000_000_003L, 1000_000_000_007L, 1000_000_000_012L, 1000_000_000_014L))
+                .stream()
+                .map(inputs -> inputs.stream()
+                        .map(value -> SqlTimestamp.newInstance(12, value, 0).roundTo(precision).getEpochMicros())
+                        .collect(toImmutableList()))
+                .collect(toImmutableList());
+    }
+
+    private static class TestInput
+    {
+        private final Type type;
+        private final List<Block> inputs;
+
+        private TestInput(Type type, List<List<?>> inputs)
+        {
+            this.type = type;
+            ImmutableList.Builder<Block> builder = ImmutableList.builder();
+            for (List<?> values : inputs) {
+                BlockBuilder blockBuilder = type.createBlockBuilder(null, inputs.size());
+                for (Object value : values) {
+                    writeNativeValue(type, blockBuilder, value);
+                }
+                builder.add(blockBuilder.build());
+            }
+            this.inputs = builder.build();
+        }
+
+        public Type getType()
+        {
+            return type;
+        }
+
+        public List<Block> getInputs()
+        {
+            return inputs;
+        }
+    }
+}


### PR DESCRIPTION
## Description
Use a bitset based filter instead of a hash set when the range of
values is narrow enough. We use bitset only when it would occupy
lesser space than the equivalent open hash set.
This is useful for making evaluation of dynamic filter more efficient
as we often collect large integer sets in dynamic filters.

```
    BenchmarkDynamicPageFilter.filterPages
    (filterSize)   (inputDataSet)  (nonNullsSelectivity)   Mode  Cnt  Before score      After score
             100  INT64_FIXED_32K                    0.2  thrpt   30  446.174 ? 10.598   449.113 ?  5.323 ops/s
            1000  INT64_FIXED_32K                    0.2  thrpt   30  407.625 ?  3.139  1379.767 ? 19.318 ops/s
            5000  INT64_FIXED_32K                    0.2  thrpt   30  426.413 ?  6.485  1254.731 ? 11.685 ops/s
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
