### PR TITLE
Add domain compaction to Snowflake docs

### DIFF
--- a/docs/src/main/sphinx/connector/snowflake.md
+++ b/docs/src/main/sphinx/connector/snowflake.md
@@ -1,3 +1,8 @@
+---
+myst:
+  substitutions:
+    default_domain_compaction_threshold: "`256`"
+---
 # Snowflake connector
 
 ```{raw} html
@@ -44,6 +49,10 @@ The Snowflake connector can only access a single database within
 a Snowflake account. Thus, if you have multiple Snowflake databases,
 or want to connect to multiple Snowflake accounts, you must configure
 multiple instances of the Snowflake connector.
+
+
+```{include} jdbc-domain-compaction-threshold.fragment
+```
 
 % snowflake-type-mapping:
 


### PR DESCRIPTION
## Description

I think we also need to add some of the other includes. I can add them in the PR but not sure which ones apply.

Typically this is what most of the JDBC connecters have:


```
{include} jdbc-common-configurations.fragment
{include} query-comment-format.fragment
{include} jdbc-domain-compaction-threshold.fragment
{include} jdbc-case-insensitive-matching.fragment
{include} non-transactional-insert.fragment
```


## Additional context and related issues

https://github.com/trinodb/trino/pull/23367
https://github.com/trinodb/trino/pull/23381

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

