### PR TITLE
Shade opentelemetry-okhttp-instrumentation

### DIFF
--- a/client/trino-jdbc/pom.xml
+++ b/client/trino-jdbc/pom.xml
@@ -64,6 +64,17 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-okhttp-3.0</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-client</artifactId>
         </dependency>
@@ -89,12 +100,6 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-context</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.opentelemetry.instrumentation</groupId>
-            <artifactId>opentelemetry-okhttp-3.0</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -431,6 +436,10 @@
                                 <relocation>
                                     <pattern>io.trino.client</pattern>
                                     <shadedPattern>${shadeBase}.client</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.opentelemetry.instrumentation.okhttp.v3_0</pattern>
+                                    <shadedPattern>${shadeBase}.opentelemetry.okhttp.v3_0</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>com.fasterxml.jackson</pattern>

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/JdbcDriverIT.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/JdbcDriverIT.java
@@ -61,6 +61,7 @@ public class JdbcDriverIT
                     .filter(value -> !value.isDirectory())
                     .map(ZipEntry::getName)
                     .filter(name -> name.contains("io/opentelemetry"))
+                    .filter(name -> !name.contains("io/opentelemetry/instrumentation/okhttp/v3_0"))
                     .collect(toImmutableList());
 
             assertThat(openTelemetryFiles)


### PR DESCRIPTION
OkHttp is shaded which requires OkHttp instrumentation to be shaded too.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
