### PR TITLE
Allow skipping over tasks in schedulingQueue if wait limits hit

### DIFF
--- a/core/trino-main/src/main/java/io/trino/FeaturesConfig.java
+++ b/core/trino-main/src/main/java/io/trino/FeaturesConfig.java
@@ -506,7 +506,8 @@ public class FeaturesConfig
         return faultTolerantExecutionExchangeEncryptionEnabled;
     }
 
-    @Config("fault-tolerant-execution.exchange-encryption-enabled")
+    @Config("fault-tolerant-execution-exchange-encryption-enabled")
+    @LegacyConfig("fault-tolerant-execution.exchange-encryption-enabled")
     public FeaturesConfig setFaultTolerantExecutionExchangeEncryptionEnabled(boolean faultTolerantExecutionExchangeEncryptionEnabled)
     {
         this.faultTolerantExecutionExchangeEncryptionEnabled = faultTolerantExecutionExchangeEncryptionEnabled;

--- a/core/trino-main/src/main/java/io/trino/execution/resourcegroups/IndexedPriorityQueue.java
+++ b/core/trino-main/src/main/java/io/trino/execution/resourcegroups/IndexedPriorityQueue.java
@@ -217,25 +217,11 @@ public final class IndexedPriorityQueue<E>
         }
     }
 
-    public static class Prioritized<V>
+    public record Prioritized<V>(V value, long priority)
     {
-        private final V value;
-        private final long priority;
-
-        public Prioritized(V value, long priority)
+        public Prioritized
         {
-            this.value = requireNonNull(value, "value is null");
-            this.priority = priority;
-        }
-
-        public V getValue()
-        {
-            return value;
-        }
-
-        public long getPriority()
-        {
-            return priority;
+            requireNonNull(value, "value is null");
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/resourcegroups/IndexedPriorityQueue.java
+++ b/core/trino-main/src/main/java/io/trino/execution/resourcegroups/IndexedPriorityQueue.java
@@ -188,6 +188,11 @@ public final class IndexedPriorityQueue<E>
         return transform(queue.iterator(), Entry::getValue);
     }
 
+    public Iterator<Prioritized<E>> iteratorPrioritized()
+    {
+        return transform(queue.iterator(), entry -> new Prioritized<>(entry.getValue(), entry.getPriority()));
+    }
+
     private static final class Entry<E>
     {
         private final E value;

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeSchedulerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeSchedulerConfig.java
@@ -53,6 +53,7 @@ public class NodeSchedulerConfig
     private SplitsBalancingPolicy splitsBalancingPolicy = SplitsBalancingPolicy.STAGE;
     private int maxUnacknowledgedSplitsPerTask = 2000;
     private Duration allowedNoMatchingNodePeriod = new Duration(2, TimeUnit.MINUTES);
+    private Duration exhaustedNodeWaitPeriod = new Duration(2, TimeUnit.MINUTES);
 
     @NotNull
     public NodeSchedulerPolicy getNodeSchedulerPolicy()
@@ -192,5 +193,18 @@ public class NodeSchedulerConfig
     public Duration getAllowedNoMatchingNodePeriod()
     {
         return allowedNoMatchingNodePeriod;
+    }
+
+    @Config("node-scheduler.exhausted-node-wait-period")
+    @ConfigDescription("How long scheduler should wait before choosing non-designated node if designated node is out of resources and remote access is possible")
+    public NodeSchedulerConfig setExhaustedNodeWaitPeriod(Duration exhaustedNodeWaitPeriod)
+    {
+        this.exhaustedNodeWaitPeriod = exhaustedNodeWaitPeriod;
+        return this;
+    }
+
+    public Duration getExhaustedNodeWaitPeriod()
+    {
+        return exhaustedNodeWaitPeriod;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
@@ -3112,7 +3112,7 @@ public class EventDrivenFaultTolerantQueryScheduler
 
         private static PrioritizedScheduledTask getPrioritizedTask(TaskExecutionClass executionClass, IndexedPriorityQueue.Prioritized<ScheduledTask> task)
         {
-            return new PrioritizedScheduledTask(task.getValue(), executionClass, toIntExact(task.getPriority()));
+            return new PrioritizedScheduledTask(task.value(), executionClass, toIntExact(task.priority()));
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
@@ -119,6 +119,7 @@ import java.io.UncheckedIOException;
 import java.lang.ref.SoftReference;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -731,7 +732,7 @@ public class EventDrivenFaultTolerantQueryScheduler
         private final SchedulingQueue schedulingQueue = new SchedulingQueue();
         private int nextSchedulingPriority;
 
-        private final Map<ScheduledTask, PreSchedulingTaskContext> preSchedulingTaskContexts = new HashMap<>();
+        private final PreSchedulingTaskContexts preSchedulingTaskContexts = new PreSchedulingTaskContexts();
 
         private final SchedulingDelayer schedulingDelayer;
 
@@ -853,7 +854,7 @@ public class EventDrivenFaultTolerantQueryScheduler
             for (StageExecution execution : stageExecutions.values()) {
                 failure = closeAndAddSuppressed(failure, execution::abort);
             }
-            for (PreSchedulingTaskContext context : preSchedulingTaskContexts.values()) {
+            for (PreSchedulingTaskContext context : preSchedulingTaskContexts.listContexts()) {
                 failure = closeAndAddSuppressed(failure, context.getNodeLease()::release);
             }
             preSchedulingTaskContexts.clear();
@@ -1252,7 +1253,7 @@ public class EventDrivenFaultTolerantQueryScheduler
         private IsReadyForExecutionResult isReadyForExecution(SubPlan subPlan)
         {
             boolean standardTasksInQueue = schedulingQueue.getTaskCount(STANDARD) > 0;
-            boolean standardTasksWaitingForNode = preSchedulingTaskContexts.values().stream()
+            boolean standardTasksWaitingForNode = preSchedulingTaskContexts.listContexts().stream()
                     .anyMatch(task -> task.getExecutionClass() == STANDARD && !task.getNodeLease().getNode().isDone());
 
             boolean eager = stageEstimationForEagerParentEnabled && shouldScheduleEagerly(subPlan);
@@ -1588,7 +1589,7 @@ public class EventDrivenFaultTolerantQueryScheduler
                 MemoryRequirements memoryRequirements = stageExecution.getMemoryRequirements(partitionId);
                 NodeLease lease = nodeAllocator.acquire(nodeRequirements.get(), memoryRequirements.getRequiredMemory(), scheduledTask.getExecutionClass());
                 lease.getNode().addListener(() -> eventQueue.add(Event.WAKE_UP), queryExecutor);
-                preSchedulingTaskContexts.put(scheduledTask.task(), new PreSchedulingTaskContext(lease, scheduledTask.getExecutionClass()));
+                preSchedulingTaskContexts.addContext(scheduledTask.task(), new PreSchedulingTaskContext(lease, scheduledTask.getExecutionClass()));
 
                 switch (scheduledTask.getExecutionClass()) {
                     case STANDARD -> standardTasksWaitingForNode++;
@@ -1601,7 +1602,7 @@ public class EventDrivenFaultTolerantQueryScheduler
 
         private long getWaitingForNodeTasksCount(TaskExecutionClass executionClass)
         {
-            return preSchedulingTaskContexts.values().stream()
+            return preSchedulingTaskContexts.listContexts().stream()
                     .filter(context -> !context.getNodeLease().getNode().isDone())
                     .filter(context -> context.getExecutionClass() == executionClass)
                     .count();
@@ -1609,7 +1610,7 @@ public class EventDrivenFaultTolerantQueryScheduler
 
         private void processNodeAcquisitions()
         {
-            Iterator<Map.Entry<ScheduledTask, PreSchedulingTaskContext>> iterator = preSchedulingTaskContexts.entrySet().iterator();
+            Iterator<Map.Entry<ScheduledTask, PreSchedulingTaskContext>> iterator = preSchedulingTaskContexts.contextEntries().iterator();
             while (iterator.hasNext()) {
                 Map.Entry<ScheduledTask, PreSchedulingTaskContext> entry = iterator.next();
                 ScheduledTask scheduledTask = entry.getKey();
@@ -1661,7 +1662,7 @@ public class EventDrivenFaultTolerantQueryScheduler
             }
 
             // update pending acquires
-            for (Map.Entry<ScheduledTask, PreSchedulingTaskContext> entry : preSchedulingTaskContexts.entrySet()) {
+            for (Map.Entry<ScheduledTask, PreSchedulingTaskContext> entry : preSchedulingTaskContexts.contextEntries()) {
                 ScheduledTask scheduledTask = entry.getKey();
                 PreSchedulingTaskContext taskContext = entry.getValue();
 
@@ -1674,7 +1675,7 @@ public class EventDrivenFaultTolerantQueryScheduler
         public Void onSinkInstanceHandleAcquired(SinkInstanceHandleAcquiredEvent sinkInstanceHandleAcquiredEvent)
         {
             ScheduledTask scheduledTask = new ScheduledTask(sinkInstanceHandleAcquiredEvent.getStageId(), sinkInstanceHandleAcquiredEvent.getPartitionId());
-            PreSchedulingTaskContext context = preSchedulingTaskContexts.remove(scheduledTask);
+            PreSchedulingTaskContext context = preSchedulingTaskContexts.removeContext(scheduledTask);
             verify(context != null, "expected %s in preSchedulingTaskContexts", scheduledTask);
             verify(context.getNodeLease().getNode().isDone(), "expected node set for %s", scheduledTask);
             verify(context.isWaitingForSinkInstanceHandle(), "expected isWaitingForSinkInstanceHandle set for %s", scheduledTask);
@@ -1843,7 +1844,7 @@ public class EventDrivenFaultTolerantQueryScheduler
             assignment.sealedPartitions().forEach(partitionId -> {
                 Optional<PrioritizedScheduledTask> scheduledTask = stageExecution.sealPartition(partitionId);
                 scheduledTask.ifPresent(prioritizedTask -> {
-                    PreSchedulingTaskContext context = preSchedulingTaskContexts.get(prioritizedTask.task());
+                    PreSchedulingTaskContext context = preSchedulingTaskContexts.getContext(prioritizedTask.task());
                     if (context != null) {
                         // task is already waiting for node or for sink instance handle
                         // update speculative flag
@@ -1896,6 +1897,41 @@ public class EventDrivenFaultTolerantQueryScheduler
                     executionFailureInfo.getErrorLocation(),
                     REMOTE_HOST_GONE.toErrorCode(),
                     executionFailureInfo.getRemoteHost());
+        }
+
+        private static class PreSchedulingTaskContexts
+        {
+            private final Map<ScheduledTask, PreSchedulingTaskContext> contexts = new HashMap<>();
+
+            public Collection<PreSchedulingTaskContext> listContexts()
+            {
+                return contexts.values();
+            }
+
+            public Set<Map.Entry<ScheduledTask, PreSchedulingTaskContext>> contextEntries()
+            {
+                return contexts.entrySet();
+            }
+
+            public void clear()
+            {
+                contexts.clear();
+            }
+
+            public PreSchedulingTaskContext getContext(ScheduledTask task)
+            {
+                return contexts.get(task);
+            }
+
+            public void addContext(ScheduledTask task, PreSchedulingTaskContext context)
+            {
+                contexts.put(task, context);
+            }
+
+            public PreSchedulingTaskContext removeContext(ScheduledTask task)
+            {
+                return contexts.remove(task);
+            }
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
@@ -1253,8 +1253,7 @@ public class EventDrivenFaultTolerantQueryScheduler
         private IsReadyForExecutionResult isReadyForExecution(SubPlan subPlan)
         {
             boolean standardTasksInQueue = schedulingQueue.getTaskCount(STANDARD) > 0;
-            boolean standardTasksWaitingForNode = preSchedulingTaskContexts.listContexts().stream()
-                    .anyMatch(task -> task.getExecutionClass() == STANDARD && !task.getNodeLease().getNode().isDone());
+            boolean standardTasksWaitingForNode = preSchedulingTaskContexts.getWaitingForNodeTasksCount(STANDARD) > 0;
 
             boolean eager = stageEstimationForEagerParentEnabled && shouldScheduleEagerly(subPlan);
             boolean speculative = false;

--- a/core/trino-main/src/main/java/io/trino/memory/MemoryManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/memory/MemoryManagerConfig.java
@@ -16,6 +16,7 @@ package io.trino.memory;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.DefunctConfig;
+import io.airlift.configuration.LegacyConfig;
 import io.airlift.units.DataSize;
 import jakarta.validation.constraints.NotNull;
 
@@ -151,7 +152,8 @@ public class MemoryManagerConfig
         return faultTolerantExecutionMemoryRequirementIncreaseOnWorkerCrashEnabled;
     }
 
-    @Config("fault-tolerant-execution.memory-requirement-increase-on-worker-crash-enabled")
+    @Config("fault-tolerant-execution-memory-requirement-increase-on-worker-crash-enabled")
+    @LegacyConfig("fault-tolerant-execution.memory-requirement-increase-on-worker-crash-enabled")
     @ConfigDescription("Increase memory requirement for tasks failed due to a suspected worker crash")
     public MemoryManagerConfig setFaultTolerantExecutionMemoryRequirementIncreaseOnWorkerCrashEnabled(boolean faultTolerantExecutionMemoryRequirementIncreaseOnWorkerCrashEnabled)
     {

--- a/core/trino-main/src/test/java/io/trino/execution/TestNodeSchedulerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestNodeSchedulerConfig.java
@@ -42,7 +42,8 @@ public class TestNodeSchedulerConfig
                 .setIncludeCoordinator(true)
                 .setSplitsBalancingPolicy(NodeSchedulerConfig.SplitsBalancingPolicy.STAGE)
                 .setOptimizedLocalScheduling(true)
-                .setAllowedNoMatchingNodePeriod(new Duration(2, MINUTES)));
+                .setAllowedNoMatchingNodePeriod(new Duration(2, MINUTES))
+                .setExhaustedNodeWaitPeriod(new Duration(2, MINUTES)));
     }
 
     @Test
@@ -59,6 +60,7 @@ public class TestNodeSchedulerConfig
                 .put("node-scheduler.splits-balancing-policy", "node")
                 .put("node-scheduler.optimized-local-scheduling", "false")
                 .put("node-scheduler.allowed-no-matching-node-period", "1m")
+                .put("node-scheduler.exhausted-node-wait-period", "3m")
                 .buildOrThrow();
 
         NodeSchedulerConfig expected = new NodeSchedulerConfig()
@@ -71,7 +73,8 @@ public class TestNodeSchedulerConfig
                 .setMinCandidates(11)
                 .setSplitsBalancingPolicy(NODE)
                 .setOptimizedLocalScheduling(false)
-                .setAllowedNoMatchingNodePeriod(new Duration(1, MINUTES));
+                .setAllowedNoMatchingNodePeriod(new Duration(1, MINUTES))
+                .setExhaustedNodeWaitPeriod(new Duration(3, MINUTES));
 
         assertFullMapping(properties, expected);
     }

--- a/core/trino-main/src/test/java/io/trino/execution/resourcegroups/TestUpdateablePriorityQueue.java
+++ b/core/trino-main/src/test/java/io/trino/execution/resourcegroups/TestUpdateablePriorityQueue.java
@@ -47,25 +47,25 @@ public class TestUpdateablePriorityQueue
         queue.addOrUpdate("c", 2);
 
         IndexedPriorityQueue.Prioritized<Object> peek1 = queue.peekPrioritized();
-        assertThat(peek1.getValue()).isEqualTo("b");
-        assertThat(peek1.getPriority()).isEqualTo(3);
+        assertThat(peek1.value()).isEqualTo("b");
+        assertThat(peek1.priority()).isEqualTo(3);
         IndexedPriorityQueue.Prioritized<Object> poll1 = queue.pollPrioritized();
-        assertThat(poll1.getValue()).isEqualTo("b");
-        assertThat(poll1.getPriority()).isEqualTo(3);
+        assertThat(poll1.value()).isEqualTo("b");
+        assertThat(poll1.priority()).isEqualTo(3);
 
         IndexedPriorityQueue.Prioritized<Object> peek2 = queue.peekPrioritized();
-        assertThat(peek2.getValue()).isEqualTo("c");
-        assertThat(peek2.getPriority()).isEqualTo(2);
+        assertThat(peek2.value()).isEqualTo("c");
+        assertThat(peek2.priority()).isEqualTo(2);
         IndexedPriorityQueue.Prioritized<Object> poll2 = queue.pollPrioritized();
-        assertThat(poll2.getValue()).isEqualTo("c");
-        assertThat(poll2.getPriority()).isEqualTo(2);
+        assertThat(poll2.value()).isEqualTo("c");
+        assertThat(poll2.priority()).isEqualTo(2);
 
         IndexedPriorityQueue.Prioritized<Object> peek3 = queue.peekPrioritized();
-        assertThat(peek3.getValue()).isEqualTo("a");
-        assertThat(peek3.getPriority()).isEqualTo(1);
+        assertThat(peek3.value()).isEqualTo("a");
+        assertThat(peek3.priority()).isEqualTo(1);
         IndexedPriorityQueue.Prioritized<Object> poll3 = queue.pollPrioritized();
-        assertThat(poll3.getValue()).isEqualTo("a");
-        assertThat(poll3.getPriority()).isEqualTo(1);
+        assertThat(poll3.value()).isEqualTo("a");
+        assertThat(poll3.priority()).isEqualTo(1);
 
         assertThat(queue.peekPrioritized()).isNull();
         assertThat(queue.pollPrioritized()).isNull();

--- a/core/trino-main/src/test/java/io/trino/execution/resourcegroups/TestUpdateablePriorityQueue.java
+++ b/core/trino-main/src/test/java/io/trino/execution/resourcegroups/TestUpdateablePriorityQueue.java
@@ -14,6 +14,7 @@
 package io.trino.execution.resourcegroups;
 
 import com.google.common.collect.ImmutableList;
+import io.trino.execution.resourcegroups.IndexedPriorityQueue.Prioritized;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -46,27 +47,12 @@ public class TestUpdateablePriorityQueue
         queue.addOrUpdate("b", 3);
         queue.addOrUpdate("c", 2);
 
-        IndexedPriorityQueue.Prioritized<Object> peek1 = queue.peekPrioritized();
-        assertThat(peek1.value()).isEqualTo("b");
-        assertThat(peek1.priority()).isEqualTo(3);
-        IndexedPriorityQueue.Prioritized<Object> poll1 = queue.pollPrioritized();
-        assertThat(poll1.value()).isEqualTo("b");
-        assertThat(poll1.priority()).isEqualTo(3);
-
-        IndexedPriorityQueue.Prioritized<Object> peek2 = queue.peekPrioritized();
-        assertThat(peek2.value()).isEqualTo("c");
-        assertThat(peek2.priority()).isEqualTo(2);
-        IndexedPriorityQueue.Prioritized<Object> poll2 = queue.pollPrioritized();
-        assertThat(poll2.value()).isEqualTo("c");
-        assertThat(poll2.priority()).isEqualTo(2);
-
-        IndexedPriorityQueue.Prioritized<Object> peek3 = queue.peekPrioritized();
-        assertThat(peek3.value()).isEqualTo("a");
-        assertThat(peek3.priority()).isEqualTo(1);
-        IndexedPriorityQueue.Prioritized<Object> poll3 = queue.pollPrioritized();
-        assertThat(poll3.value()).isEqualTo("a");
-        assertThat(poll3.priority()).isEqualTo(1);
-
+        assertThat(queue.peekPrioritized()).isEqualTo(new Prioritized<>("b", 3));
+        assertThat(queue.pollPrioritized()).isEqualTo(new Prioritized<>("b", 3));
+        assertThat(queue.peekPrioritized()).isEqualTo(new Prioritized<>("c", 2));
+        assertThat(queue.pollPrioritized()).isEqualTo(new Prioritized<>("c", 2));
+        assertThat(queue.peekPrioritized()).isEqualTo(new Prioritized<>("a", 1));
+        assertThat(queue.pollPrioritized()).isEqualTo(new Prioritized<>("a", 1));
         assertThat(queue.peekPrioritized()).isNull();
         assertThat(queue.pollPrioritized()).isNull();
     }

--- a/core/trino-main/src/test/java/io/trino/execution/resourcegroups/TestUpdateablePriorityQueue.java
+++ b/core/trino-main/src/test/java/io/trino/execution/resourcegroups/TestUpdateablePriorityQueue.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import io.trino.execution.resourcegroups.IndexedPriorityQueue.Prioritized;
 import org.junit.jupiter.api.Test;
 
+import java.util.Iterator;
 import java.util.List;
 
 import static io.trino.execution.resourcegroups.IndexedPriorityQueue.PriorityOrdering.HIGH_TO_LOW;
@@ -55,6 +56,31 @@ public class TestUpdateablePriorityQueue
         assertThat(queue.pollPrioritized()).isEqualTo(new Prioritized<>("a", 1));
         assertThat(queue.peekPrioritized()).isNull();
         assertThat(queue.pollPrioritized()).isNull();
+    }
+
+    @Test
+    public void testPrioritizedIteratorIndexedPriorityQueue()
+    {
+        IndexedPriorityQueue<Object> queue = new IndexedPriorityQueue<>();
+        queue.addOrUpdate("a", 1);
+        queue.addOrUpdate("b", 3);
+        queue.addOrUpdate("c", 2);
+
+        assertThat(ImmutableList.copyOf(queue.iteratorPrioritized()))
+                .containsExactly(
+                        new Prioritized<>("b", 3),
+                        new Prioritized<>("c", 2),
+                        new Prioritized<>("a", 1));
+
+        Iterator<Prioritized<Object>> iterator = queue.iteratorPrioritized();
+        iterator.next();
+        iterator.next();
+        iterator.remove();
+
+        assertThat(ImmutableList.copyOf(queue.iteratorPrioritized()))
+                .containsExactly(
+                        new Prioritized<>("b", 3),
+                        new Prioritized<>("a", 1));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/memory/TestMemoryManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/memory/TestMemoryManagerConfig.java
@@ -57,7 +57,7 @@ public class TestMemoryManagerConfig
                 .put("fault-tolerant-execution-task-memory-growth-factor", "17.3")
                 .put("fault-tolerant-execution-task-memory-estimation-quantile", "0.7")
                 .put("fault-tolerant-execution-task-runtime-memory-estimation-overhead", "300MB")
-                .put("fault-tolerant-execution.memory-requirement-increase-on-worker-crash-enabled", "false")
+                .put("fault-tolerant-execution-memory-requirement-increase-on-worker-crash-enabled", "false")
                 .put("fault-tolerant-execution-eager-speculative-tasks-node_memory-overcommit", "21GB")
                 .put("query.low-memory-killer.policy", "none")
                 .put("task.low-memory-killer.policy", "none")

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestFeaturesConfig.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestFeaturesConfig.java
@@ -100,7 +100,7 @@ public class TestFeaturesConfig
                 .put("hide-inaccessible-columns", "true")
                 .put("force-spilling-join-operator", "true")
                 .put("experimental.columnar-filter-evaluation.enabled", "false")
-                .put("fault-tolerant-execution.exchange-encryption-enabled", "false")
+                .put("fault-tolerant-execution-exchange-encryption-enabled", "false")
                 .buildOrThrow();
 
         FeaturesConfig expected = new FeaturesConfig()

--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.md
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.md
@@ -76,7 +76,7 @@ execution on a Trino cluster:
     the failure recovery capabilities to be fully functional" error message unless an 
     [exchange manager](fte-exchange-manager) is configured.
   - `32MB`
-* - `fault-tolerant-execution.exchange-encryption-enabled`
+* - `fault-tolerant-execution-exchange-encryption-enabled`
   - Enable encryption of spooling data, see [Encryption](fte-encryption) for details. 
     Setting this property to false is not recommended if Trino processes sensitive data.
   - ``true``


### PR DESCRIPTION
## Description

If we are iterating over tasks in scheduling queue we may see that
there are already many tasks waiting for node lease for given requirements.
In such case we are skipping a task and move to the next one, so one node does not block
scheduling other tasks in queue which may have different node requirements.

We are limiting how many tasks may be skipped to 20. This is to avoid pessimistic case that we
are iterating over whole scheduling queue on each change in the cluster when it is highly utilized.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
