### PR TITLE
Update SQL Server docker to 2017-latest

### DIFF
--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestingSqlServer.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestingSqlServer.java
@@ -64,7 +64,7 @@ public final class TestingSqlServer
             .build();
 
     private static final DockerImageName IMAGE_NAME = DockerImageName.parse("mcr.microsoft.com/mssql/server");
-    public static final String DEFAULT_VERSION = "2017-CU13";
+    public static final String DEFAULT_VERSION = "2017-latest";
     public static final String LATEST_VERSION = "2019-CU13-ubuntu-20.04";
 
     private final MSSQLServerContainer<?> container;


### PR DESCRIPTION
## Description

Same change as https://github.com/trinodb/trino/pull/23464

The example failure: https://github.com/trinodb/trino/actions/runs/10912509097/job/30287354222?pr=23471

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
