### PR TITLE
Add support for `WITH SESSION` clause

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -199,11 +199,23 @@ statement
     ;
 
 rootQuery
-    : withFunction? query
+    : queryScoped? query
+    ;
+
+queryScoped
+    : WITH (SESSION withSession)? withFunction?
     ;
 
 withFunction
-    : WITH functionSpecification (',' functionSpecification)*
+    : functionSpecification (',' functionSpecification)*
+    ;
+
+withSession
+    : sessionSpecification (',' sessionSpecification)*
+    ;
+
+sessionSpecification
+    : qualifiedName EQ expression
     ;
 
 query

--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -203,18 +203,14 @@ rootQuery
     ;
 
 queryScoped
-    : WITH (SESSION withSession)? withFunction?
+    : WITH (SESSION sessionProperty (',' sessionProperty)*)? withFunction?
     ;
 
 withFunction
     : functionSpecification (',' functionSpecification)*
     ;
 
-withSession
-    : sessionSpecification (',' sessionSpecification)*
-    ;
-
-sessionSpecification
+sessionProperty
     : qualifiedName EQ expression
     ;
 

--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -178,7 +178,7 @@ statement
         (LIKE pattern=string (ESCAPE escape=string)?)?                 #showSession
     | SET SESSION AUTHORIZATION authorizationUser                      #setSessionAuthorization
     | RESET SESSION AUTHORIZATION                                      #resetSessionAuthorization
-    | SET SESSION qualifiedName EQ expression                          #setSession
+    | SET SESSION sessionProperty                                      #setSession
     | RESET SESSION qualifiedName                                      #resetSession
     | START TRANSACTION (transactionMode (',' transactionMode)*)?      #startTransaction
     | COMMIT WORK?                                                     #commit

--- a/core/trino-main/src/main/java/io/trino/Session.java
+++ b/core/trino-main/src/main/java/io/trino/Session.java
@@ -55,9 +55,11 @@ import java.util.stream.Collectors;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static io.trino.SystemSessionProperties.TIME_ZONE_ID;
 import static io.trino.client.ProtocolHeaders.TRINO_HEADERS;
 import static io.trino.spi.StandardErrorCode.CATALOG_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.NOT_FOUND;
+import static io.trino.spi.type.TimeZoneKey.getTimeZoneKey;
 import static io.trino.sql.SqlPath.EMPTY_PATH;
 import static io.trino.util.Failures.checkCondition;
 import static java.util.Objects.requireNonNull;
@@ -416,6 +418,11 @@ public final class Session
                     .putAll(catalogEntry.getValue());
         }
 
+        return withProperties(systemProperties, catalogProperties);
+    }
+
+    public Session withProperties(Map<String, String> systemProperties, Map<String, Map<String, String>> catalogProperties)
+    {
         return new Session(
                 queryId,
                 querySpan,
@@ -428,7 +435,9 @@ public final class Session
                 schema,
                 path,
                 traceToken,
-                timeZoneKey,
+                Optional.ofNullable(systemProperties.get(TIME_ZONE_ID))
+                        .map(TimeZoneKey::getTimeZoneKey)
+                        .orElse(timeZoneKey),
                 locale,
                 remoteUserAddress,
                 userAgent,

--- a/core/trino-main/src/main/java/io/trino/Session.java
+++ b/core/trino-main/src/main/java/io/trino/Session.java
@@ -59,7 +59,6 @@ import static io.trino.SystemSessionProperties.TIME_ZONE_ID;
 import static io.trino.client.ProtocolHeaders.TRINO_HEADERS;
 import static io.trino.spi.StandardErrorCode.CATALOG_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.NOT_FOUND;
-import static io.trino.spi.type.TimeZoneKey.getTimeZoneKey;
 import static io.trino.sql.SqlPath.EMPTY_PATH;
 import static io.trino.util.Failures.checkCondition;
 import static java.util.Objects.requireNonNull;
@@ -435,6 +434,7 @@ public final class Session
                 schema,
                 path,
                 traceToken,
+                // This is required to override a timezone using a WITH SESSION timezone
                 Optional.ofNullable(systemProperties.get(TIME_ZONE_ID))
                         .map(TimeZoneKey::getTimeZoneKey)
                         .orElse(timeZoneKey),

--- a/core/trino-main/src/main/java/io/trino/dispatcher/DispatchManager.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/DispatchManager.java
@@ -118,7 +118,7 @@ public class DispatchManager
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.sessionSupplier = requireNonNull(sessionSupplier, "sessionSupplier is null");
         this.sessionPropertyDefaults = requireNonNull(sessionPropertyDefaults, "sessionPropertyDefaults is null");
-        this.sessionPropertyManager = sessionPropertyManager;
+        this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
         this.tracer = requireNonNull(tracer, "tracer is null");
 
         this.maxQueryLength = queryManagerConfig.getMaxQueryLength();

--- a/core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQueryFactory.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQueryFactory.java
@@ -38,6 +38,7 @@ import io.trino.security.AccessControl;
 import io.trino.server.protocol.Slug;
 import io.trino.spi.TrinoException;
 import io.trino.spi.resourcegroups.ResourceGroupId;
+import io.trino.sql.SessionSpecificationEvaluator;
 import io.trino.sql.tree.Statement;
 import io.trino.transaction.TransactionId;
 import io.trino.transaction.TransactionManager;
@@ -59,6 +60,7 @@ public class LocalDispatchQueryFactory
     private final TransactionManager transactionManager;
     private final AccessControl accessControl;
     private final Metadata metadata;
+    private final SessionSpecificationEvaluator sessionSpecificationEvaluator;
     private final QueryMonitor queryMonitor;
     private final LocationFactory locationFactory;
 
@@ -77,6 +79,7 @@ public class LocalDispatchQueryFactory
             QueryManager queryManager,
             QueryManagerConfig queryManagerConfig,
             TransactionManager transactionManager,
+            SessionSpecificationEvaluator sessionSpecificationEvaluator,
             AccessControl accessControl,
             Metadata metadata,
             QueryMonitor queryMonitor,
@@ -92,6 +95,7 @@ public class LocalDispatchQueryFactory
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
+        this.sessionSpecificationEvaluator = requireNonNull(sessionSpecificationEvaluator, "sessionSpecificationEvaluator is null");
         this.queryMonitor = requireNonNull(queryMonitor, "queryMonitor is null");
         this.locationFactory = requireNonNull(locationFactory, "locationFactory is null");
         this.executionFactories = requireNonNull(executionFactories, "executionFactories is null");
@@ -132,6 +136,7 @@ public class LocalDispatchQueryFactory
                 planOptimizersStatsCollector,
                 getQueryType(preparedQuery.getStatement()),
                 faultTolerantExecutionExchangeEncryptionEnabled,
+                Optional.of(sessionSpecificationEvaluator.getSessionSpecificationApplier(preparedQuery)),
                 version);
 
         // It is important that `queryCreatedEvent` is called here. Moving it past the `executor.submit` below

--- a/core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQueryFactory.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQueryFactory.java
@@ -38,7 +38,7 @@ import io.trino.security.AccessControl;
 import io.trino.server.protocol.Slug;
 import io.trino.spi.TrinoException;
 import io.trino.spi.resourcegroups.ResourceGroupId;
-import io.trino.sql.SessionSpecificationEvaluator;
+import io.trino.sql.SessionPropertyInterpreter;
 import io.trino.sql.tree.Statement;
 import io.trino.transaction.TransactionId;
 import io.trino.transaction.TransactionManager;
@@ -60,7 +60,7 @@ public class LocalDispatchQueryFactory
     private final TransactionManager transactionManager;
     private final AccessControl accessControl;
     private final Metadata metadata;
-    private final SessionSpecificationEvaluator sessionSpecificationEvaluator;
+    private final SessionPropertyInterpreter sessionPropertyInterpreter;
     private final QueryMonitor queryMonitor;
     private final LocationFactory locationFactory;
 
@@ -79,7 +79,7 @@ public class LocalDispatchQueryFactory
             QueryManager queryManager,
             QueryManagerConfig queryManagerConfig,
             TransactionManager transactionManager,
-            SessionSpecificationEvaluator sessionSpecificationEvaluator,
+            SessionPropertyInterpreter sessionPropertyInterpreter,
             AccessControl accessControl,
             Metadata metadata,
             QueryMonitor queryMonitor,
@@ -95,7 +95,7 @@ public class LocalDispatchQueryFactory
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
-        this.sessionSpecificationEvaluator = requireNonNull(sessionSpecificationEvaluator, "sessionSpecificationEvaluator is null");
+        this.sessionPropertyInterpreter = requireNonNull(sessionPropertyInterpreter, "sessionPropertyInterpreter is null");
         this.queryMonitor = requireNonNull(queryMonitor, "queryMonitor is null");
         this.locationFactory = requireNonNull(locationFactory, "locationFactory is null");
         this.executionFactories = requireNonNull(executionFactories, "executionFactories is null");
@@ -136,7 +136,7 @@ public class LocalDispatchQueryFactory
                 planOptimizersStatsCollector,
                 getQueryType(preparedQuery.getStatement()),
                 faultTolerantExecutionExchangeEncryptionEnabled,
-                Optional.of(sessionSpecificationEvaluator.getSessionSpecificationApplier(preparedQuery)),
+                Optional.of(sessionPropertyInterpreter.getSessionPropertiesApplier(preparedQuery)),
                 version);
 
         // It is important that `queryCreatedEvent` is called here. Moving it past the `executor.submit` below

--- a/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
@@ -53,7 +53,7 @@ import io.trino.spi.resourcegroups.QueryType;
 import io.trino.spi.resourcegroups.ResourceGroupId;
 import io.trino.spi.security.SelectedRole;
 import io.trino.spi.type.Type;
-import io.trino.sql.SessionSpecificationEvaluator.SessionSpecificationsApplier;
+import io.trino.sql.SessionPropertyInterpreter.SessionPropertiesApplier;
 import io.trino.sql.analyzer.Output;
 import io.trino.sql.planner.PlanFragment;
 import io.trino.tracing.TrinoAttributes;
@@ -244,7 +244,7 @@ public class QueryStateMachine
             PlanOptimizersStatsCollector queryStatsCollector,
             Optional<QueryType> queryType,
             boolean faultTolerantExecutionExchangeEncryptionEnabled,
-            Optional<SessionSpecificationsApplier> sessionSpecificationsApplier,
+            Optional<SessionPropertiesApplier> sessionPropertiesApplier,
             NodeVersion version)
     {
         return beginWithTicker(
@@ -264,7 +264,7 @@ public class QueryStateMachine
                 queryStatsCollector,
                 queryType,
                 faultTolerantExecutionExchangeEncryptionEnabled,
-                sessionSpecificationsApplier,
+                sessionPropertiesApplier,
                 version);
     }
 
@@ -285,7 +285,7 @@ public class QueryStateMachine
             PlanOptimizersStatsCollector queryStatsCollector,
             Optional<QueryType> queryType,
             boolean faultTolerantExecutionExchangeEncryptionEnabled,
-            Optional<SessionSpecificationsApplier> sessionSpecificationsApplier,
+            Optional<SessionPropertiesApplier> sessionPropertiesApplier,
             NodeVersion version)
     {
         // if there is an existing transaction, activate it
@@ -312,9 +312,9 @@ public class QueryStateMachine
             session = session.withExchangeEncryption(serializeAesEncryptionKey(createRandomAesEncryptionKey()));
         }
 
-        // Apply WITH SESSION specifications which require transaction to be started to resolve catalog handles
-        if (sessionSpecificationsApplier.isPresent()) {
-            session = sessionSpecificationsApplier.orElseThrow().apply(session);
+        // Apply WITH SESSION properties which require transaction to be started to resolve catalog handles
+        if (sessionPropertiesApplier.isPresent()) {
+            session = sessionPropertiesApplier.orElseThrow().apply(session);
         }
 
         Span querySpan = session.getQuerySpan();

--- a/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
@@ -112,6 +112,7 @@ import io.trino.server.ui.WebUiModule;
 import io.trino.server.ui.WorkerResource;
 import io.trino.spi.VersionEmbedder;
 import io.trino.sql.PlannerContext;
+import io.trino.sql.SessionSpecificationEvaluator;
 import io.trino.sql.analyzer.AnalyzerFactory;
 import io.trino.sql.analyzer.QueryExplainerFactory;
 import io.trino.sql.planner.OptimizerStatsMBeanExporter;
@@ -210,6 +211,8 @@ public class CoordinatorModule
 
         // dispatcher
         binder.bind(DispatchManager.class).in(Scopes.SINGLETON);
+        // WITH SESSION interpreter
+        binder.bind(SessionSpecificationEvaluator.class).in(Scopes.SINGLETON);
         // export under the old name, for backwards compatibility
         newExporter(binder).export(DispatchManager.class).as(generator -> generator.generatedNameOf(QueryManager.class));
         binder.bind(FailedDispatchQueryFactory.class).in(Scopes.SINGLETON);

--- a/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
@@ -112,7 +112,7 @@ import io.trino.server.ui.WebUiModule;
 import io.trino.server.ui.WorkerResource;
 import io.trino.spi.VersionEmbedder;
 import io.trino.sql.PlannerContext;
-import io.trino.sql.SessionSpecificationEvaluator;
+import io.trino.sql.SessionPropertyInterpreter;
 import io.trino.sql.analyzer.AnalyzerFactory;
 import io.trino.sql.analyzer.QueryExplainerFactory;
 import io.trino.sql.planner.OptimizerStatsMBeanExporter;
@@ -212,7 +212,7 @@ public class CoordinatorModule
         // dispatcher
         binder.bind(DispatchManager.class).in(Scopes.SINGLETON);
         // WITH SESSION interpreter
-        binder.bind(SessionSpecificationEvaluator.class).in(Scopes.SINGLETON);
+        binder.bind(SessionPropertyInterpreter.class).in(Scopes.SINGLETON);
         // export under the old name, for backwards compatibility
         newExporter(binder).export(DispatchManager.class).as(generator -> generator.generatedNameOf(QueryManager.class));
         binder.bind(FailedDispatchQueryFactory.class).in(Scopes.SINGLETON);

--- a/core/trino-main/src/main/java/io/trino/sql/SessionPropertyInterpreter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/SessionPropertyInterpreter.java
@@ -31,7 +31,7 @@ import io.trino.sql.tree.NodeRef;
 import io.trino.sql.tree.Parameter;
 import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.Query;
-import io.trino.sql.tree.SessionSpecification;
+import io.trino.sql.tree.SessionProperty;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -52,21 +52,21 @@ import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
-public class SessionSpecificationEvaluator
+public class SessionPropertyInterpreter
 {
     private final PlannerContext plannerContext;
     private final AccessControl accessControl;
     private final SessionPropertyManager sessionPropertyManager;
 
     @Inject
-    public SessionSpecificationEvaluator(PlannerContext plannerContext, AccessControl accessControl, SessionPropertyManager sessionPropertyManager)
+    public SessionPropertyInterpreter(PlannerContext plannerContext, AccessControl accessControl, SessionPropertyManager sessionPropertyManager)
     {
         this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
     }
 
-    public SessionSpecificationsApplier getSessionSpecificationApplier(PreparedQuery preparedQuery)
+    public SessionPropertiesApplier getSessionPropertiesApplier(PreparedQuery preparedQuery)
     {
         if (!(preparedQuery.getStatement() instanceof Query queryStatement)) {
             return session -> session;
@@ -74,70 +74,70 @@ public class SessionSpecificationEvaluator
         return session -> prepareSession(session, queryStatement.getSessionProperties(), bindParameters(preparedQuery.getStatement(), preparedQuery.getParameters()));
     }
 
-    private Session prepareSession(Session session, List<SessionSpecification> specifications, Map<NodeRef<Parameter>, Expression> parameters)
+    private Session prepareSession(Session session, List<SessionProperty> sessionProperties, Map<NodeRef<Parameter>, Expression> parameters)
     {
-        ResolvedSessionSpecifications resolvedSessionSpecifications = resolve(session, parameters, specifications);
-        return overrideProperties(session, resolvedSessionSpecifications);
+        ResolvedSessionProperties resolvedSessionProperties = resolve(session, parameters, sessionProperties);
+        return overrideProperties(session, resolvedSessionProperties);
     }
 
-    private ResolvedSessionSpecifications resolve(Session session, Map<NodeRef<Parameter>, Expression> parameters, List<SessionSpecification> specifications)
+    private ResolvedSessionProperties resolve(Session session, Map<NodeRef<Parameter>, Expression> parameters, List<SessionProperty> sessionProperties)
     {
-        ImmutableMap.Builder<String, String> sessionProperties = ImmutableMap.builder();
+        ImmutableMap.Builder<String, String> systemProperties = ImmutableMap.builder();
         Table<String, String, String> catalogProperties = HashBasedTable.create();
         Set<QualifiedName> seenPropertyNames = new HashSet<>();
 
-        for (SessionSpecification specification : specifications) {
-            List<String> nameParts = specification.getName().getParts();
+        for (SessionProperty sessionProperty : sessionProperties) {
+            List<String> nameParts = sessionProperty.getName().getParts();
 
-            if (!seenPropertyNames.add(specification.getName())) {
-                throw semanticException(INVALID_SESSION_PROPERTY, specification, "Session property %s already set", specification.getName());
+            if (!seenPropertyNames.add(sessionProperty.getName())) {
+                throw semanticException(INVALID_SESSION_PROPERTY, sessionProperty, "Session property %s already set", sessionProperty.getName());
             }
 
             if (nameParts.size() == 1) {
                 Optional<PropertyMetadata<?>> systemSessionPropertyMetadata = sessionPropertyManager.getSystemSessionPropertyMetadata(nameParts.getFirst());
                 if (systemSessionPropertyMetadata.isEmpty()) {
-                    throw semanticException(INVALID_SESSION_PROPERTY, specification, "Session property %s does not exist", specification.getName());
+                    throw semanticException(INVALID_SESSION_PROPERTY, sessionProperty, "Session property %s does not exist", sessionProperty.getName());
                 }
-                sessionProperties.put(nameParts.getFirst(), toSessionValue(session, parameters, specification, systemSessionPropertyMetadata.get()));
+                systemProperties.put(nameParts.getFirst(), toSessionValue(session, parameters, sessionProperty, systemSessionPropertyMetadata.get()));
             }
             else if (nameParts.size() == 2) {
                 String catalogName = nameParts.getFirst();
                 String propertyName = nameParts.getLast();
 
-                CatalogHandle catalogHandle = getRequiredCatalogHandle(plannerContext.getMetadata(), session, specification, catalogName);
+                CatalogHandle catalogHandle = getRequiredCatalogHandle(plannerContext.getMetadata(), session, sessionProperty, catalogName);
                 Optional<PropertyMetadata<?>> connectorSessionPropertyMetadata = sessionPropertyManager.getConnectorSessionPropertyMetadata(catalogHandle, propertyName);
                 if (connectorSessionPropertyMetadata.isEmpty()) {
-                    throw semanticException(INVALID_SESSION_PROPERTY, specification, "Session property %s does not exist", specification.getName());
+                    throw semanticException(INVALID_SESSION_PROPERTY, sessionProperty, "Session property %s does not exist", sessionProperty.getName());
                 }
-                catalogProperties.put(catalogName, propertyName, toSessionValue(session, parameters, specification, connectorSessionPropertyMetadata.get()));
+                catalogProperties.put(catalogName, propertyName, toSessionValue(session, parameters, sessionProperty, connectorSessionPropertyMetadata.get()));
             }
             else {
-                throw semanticException(INVALID_SESSION_PROPERTY, specification, "Invalid session property '%s'", specification.getName());
+                throw semanticException(INVALID_SESSION_PROPERTY, sessionProperty, "Invalid session property '%s'", sessionProperty.getName());
             }
         }
 
-        return new ResolvedSessionSpecifications(sessionProperties.buildOrThrow(), catalogProperties.rowMap());
+        return new ResolvedSessionProperties(systemProperties.buildOrThrow(), catalogProperties.rowMap());
     }
 
-    private Session overrideProperties(Session session, ResolvedSessionSpecifications resolvedSessionSpecifications)
+    private Session overrideProperties(Session session, ResolvedSessionProperties resolvedSessionProperties)
     {
-        requireNonNull(resolvedSessionSpecifications, "resolvedSessionSpecifications is null");
+        requireNonNull(resolvedSessionProperties, "resolvedSessionProperties is null");
 
         // TODO Consider moving validation to Session.withProperties method
-        validateSystemProperties(session, resolvedSessionSpecifications.systemProperties());
+        validateSystemProperties(session, resolvedSessionProperties.systemProperties());
 
         // Catalog session properties were already evaluated so we need to evaluate overrides
         if (session.getTransactionId().isPresent()) {
-            validateCatalogProperties(session, resolvedSessionSpecifications.catalogProperties());
+            validateCatalogProperties(session, resolvedSessionProperties.catalogProperties());
         }
 
         // NOTE: properties are validated before calling overrideProperties
         Map<String, String> systemProperties = new HashMap<>();
         systemProperties.putAll(session.getSystemProperties());
-        systemProperties.putAll(resolvedSessionSpecifications.systemProperties());
+        systemProperties.putAll(resolvedSessionProperties.systemProperties());
 
         Map<String, Map<String, String>> catalogProperties = new HashMap<>(session.getCatalogProperties());
-        for (Map.Entry<String, Map<String, String>> catalogEntry : resolvedSessionSpecifications.catalogProperties().entrySet()) {
+        for (Map.Entry<String, Map<String, String>> catalogEntry : resolvedSessionProperties.catalogProperties().entrySet()) {
             catalogProperties.computeIfAbsent(catalogEntry.getKey(), id -> new HashMap<>())
                     .putAll(catalogEntry.getValue());
         }
@@ -146,18 +146,18 @@ public class SessionSpecificationEvaluator
     }
 
     // TODO Consider extracting a method from SetSessionTask and reusing it here
-    private String toSessionValue(Session session, Map<NodeRef<Parameter>, Expression> parameters, SessionSpecification specification, PropertyMetadata<?> propertyMetadata)
+    private String toSessionValue(Session session, Map<NodeRef<Parameter>, Expression> parameters, SessionProperty sessionProperty, PropertyMetadata<?> propertyMetadata)
     {
         Type type = propertyMetadata.getSqlType();
         Object objectValue;
 
         try {
-            objectValue = evaluatePropertyValue(specification.getValue(), type, session, plannerContext, accessControl, parameters);
+            objectValue = evaluatePropertyValue(sessionProperty.getValue(), type, session, plannerContext, accessControl, parameters);
         }
         catch (TrinoException e) {
             throw new TrinoException(
                     INVALID_SESSION_PROPERTY,
-                    format("Unable to set session property '%s' to '%s': %s", specification.getName(), specification.getValue(), e.getRawMessage()));
+                    format("Unable to set session property '%s' to '%s': %s", sessionProperty.getName(), sessionProperty.getValue(), e.getRawMessage()));
         }
 
         String value = serializeSessionProperty(type, objectValue);
@@ -166,7 +166,7 @@ public class SessionSpecificationEvaluator
             propertyMetadata.decode(objectValue);
         }
         catch (RuntimeException e) {
-            throw semanticException(INVALID_SESSION_PROPERTY, specification, "%s", e.getMessage());
+            throw semanticException(INVALID_SESSION_PROPERTY, sessionProperty, "%s", e.getMessage());
         }
 
         return value;
@@ -198,9 +198,9 @@ public class SessionSpecificationEvaluator
         }
     }
 
-    public record ResolvedSessionSpecifications(Map<String, String> systemProperties, Map<String, Map<String, String>> catalogProperties)
+    public record ResolvedSessionProperties(Map<String, String> systemProperties, Map<String, Map<String, String>> catalogProperties)
     {
-        public ResolvedSessionSpecifications
+        public ResolvedSessionProperties
         {
             systemProperties = ImmutableMap.copyOf(requireNonNull(systemProperties, "systemProperties is null"));
             catalogProperties = ImmutableMap.copyOf(requireNonNull(catalogProperties, "catalogProperties is null"));
@@ -208,7 +208,7 @@ public class SessionSpecificationEvaluator
     }
 
     @FunctionalInterface
-    public interface SessionSpecificationsApplier
+    public interface SessionPropertiesApplier
             extends Function<Session, Session>
     {
     }

--- a/core/trino-main/src/main/java/io/trino/sql/SessionSpecificationEvaluator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/SessionSpecificationEvaluator.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Table;
+import com.google.inject.Inject;
+import io.trino.Session;
+import io.trino.execution.QueryPreparer.PreparedQuery;
+import io.trino.metadata.SessionPropertyManager;
+import io.trino.security.AccessControl;
+import io.trino.security.SecurityContext;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.CatalogHandle;
+import io.trino.spi.session.PropertyMetadata;
+import io.trino.spi.type.Type;
+import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.NodeRef;
+import io.trino.sql.tree.Parameter;
+import io.trino.sql.tree.QualifiedName;
+import io.trino.sql.tree.Query;
+import io.trino.sql.tree.SessionSpecification;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.trino.execution.ParameterExtractor.bindParameters;
+import static io.trino.metadata.MetadataUtil.getRequiredCatalogHandle;
+import static io.trino.metadata.SessionPropertyManager.evaluatePropertyValue;
+import static io.trino.metadata.SessionPropertyManager.serializeSessionProperty;
+import static io.trino.spi.StandardErrorCode.CATALOG_NOT_FOUND;
+import static io.trino.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
+import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class SessionSpecificationEvaluator
+{
+    private final PlannerContext plannerContext;
+    private final AccessControl accessControl;
+    private final SessionPropertyManager sessionPropertyManager;
+
+    @Inject
+    public SessionSpecificationEvaluator(PlannerContext plannerContext, AccessControl accessControl, SessionPropertyManager sessionPropertyManager)
+    {
+        this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+        this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
+    }
+
+    public SessionSpecificationsApplier getSessionSpecificationApplier(PreparedQuery preparedQuery)
+    {
+        if (!(preparedQuery.getStatement() instanceof Query queryStatement)) {
+            return session -> session;
+        }
+        return session -> prepareSession(session, queryStatement.getSessionProperties(), bindParameters(preparedQuery.getStatement(), preparedQuery.getParameters()));
+    }
+
+    private Session prepareSession(Session session, List<SessionSpecification> specifications, Map<NodeRef<Parameter>, Expression> parameters)
+    {
+        ResolvedSessionSpecifications resolvedSessionSpecifications = resolve(session, parameters, specifications);
+        return overrideProperties(session, resolvedSessionSpecifications);
+    }
+
+    private ResolvedSessionSpecifications resolve(Session session, Map<NodeRef<Parameter>, Expression> parameters, List<SessionSpecification> specifications)
+    {
+        ImmutableMap.Builder<String, String> sessionProperties = ImmutableMap.builder();
+        Table<String, String, String> catalogProperties = HashBasedTable.create();
+        Set<QualifiedName> seenPropertyNames = new HashSet<>();
+
+        for (SessionSpecification specification : specifications) {
+            List<String> nameParts = specification.getName().getParts();
+
+            if (!seenPropertyNames.add(specification.getName())) {
+                throw semanticException(INVALID_SESSION_PROPERTY, specification, "Session property %s already set", specification.getName());
+            }
+
+            if (nameParts.size() == 1) {
+                Optional<PropertyMetadata<?>> systemSessionPropertyMetadata = sessionPropertyManager.getSystemSessionPropertyMetadata(nameParts.getFirst());
+                if (systemSessionPropertyMetadata.isEmpty()) {
+                    throw semanticException(INVALID_SESSION_PROPERTY, specification, "Session property %s does not exist", specification.getName());
+                }
+                sessionProperties.put(nameParts.getFirst(), toSessionValue(session, parameters, specification, systemSessionPropertyMetadata.get()));
+            }
+            else if (nameParts.size() == 2) {
+                String catalogName = nameParts.getFirst();
+                String propertyName = nameParts.getLast();
+
+                CatalogHandle catalogHandle = getRequiredCatalogHandle(plannerContext.getMetadata(), session, specification, catalogName);
+                Optional<PropertyMetadata<?>> connectorSessionPropertyMetadata = sessionPropertyManager.getConnectorSessionPropertyMetadata(catalogHandle, propertyName);
+                if (connectorSessionPropertyMetadata.isEmpty()) {
+                    throw semanticException(INVALID_SESSION_PROPERTY, specification, "Session property %s does not exist", specification.getName());
+                }
+                catalogProperties.put(catalogName, propertyName, toSessionValue(session, parameters, specification, connectorSessionPropertyMetadata.get()));
+            }
+            else {
+                throw semanticException(INVALID_SESSION_PROPERTY, specification, "Invalid session property '%s'", specification.getName());
+            }
+        }
+
+        return new ResolvedSessionSpecifications(sessionProperties.buildOrThrow(), catalogProperties.rowMap());
+    }
+
+    private Session overrideProperties(Session session, ResolvedSessionSpecifications resolvedSessionSpecifications)
+    {
+        requireNonNull(resolvedSessionSpecifications, "resolvedSessionSpecifications is null");
+
+        // TODO Consider moving validation to Session.withProperties method
+        validateSystemProperties(session, resolvedSessionSpecifications.systemProperties());
+
+        // Catalog session properties were already evaluated so we need to evaluate overrides
+        if (session.getTransactionId().isPresent()) {
+            validateCatalogProperties(session, resolvedSessionSpecifications.catalogProperties());
+        }
+
+        // NOTE: properties are validated before calling overrideProperties
+        Map<String, String> systemProperties = new HashMap<>();
+        systemProperties.putAll(session.getSystemProperties());
+        systemProperties.putAll(resolvedSessionSpecifications.systemProperties());
+
+        Map<String, Map<String, String>> catalogProperties = new HashMap<>(session.getCatalogProperties());
+        for (Map.Entry<String, Map<String, String>> catalogEntry : resolvedSessionSpecifications.catalogProperties().entrySet()) {
+            catalogProperties.computeIfAbsent(catalogEntry.getKey(), id -> new HashMap<>())
+                    .putAll(catalogEntry.getValue());
+        }
+
+        return session.withProperties(systemProperties, catalogProperties);
+    }
+
+    // TODO Consider extracting a method from SetSessionTask and reusing it here
+    private String toSessionValue(Session session, Map<NodeRef<Parameter>, Expression> parameters, SessionSpecification specification, PropertyMetadata<?> propertyMetadata)
+    {
+        Type type = propertyMetadata.getSqlType();
+        Object objectValue;
+
+        try {
+            objectValue = evaluatePropertyValue(specification.getValue(), type, session, plannerContext, accessControl, parameters);
+        }
+        catch (TrinoException e) {
+            throw new TrinoException(
+                    INVALID_SESSION_PROPERTY,
+                    format("Unable to set session property '%s' to '%s': %s", specification.getName(), specification.getValue(), e.getRawMessage()));
+        }
+
+        String value = serializeSessionProperty(type, objectValue);
+        // verify the SQL value can be decoded by the property
+        try {
+            propertyMetadata.decode(objectValue);
+        }
+        catch (RuntimeException e) {
+            throw semanticException(INVALID_SESSION_PROPERTY, specification, "%s", e.getMessage());
+        }
+
+        return value;
+    }
+
+    private void validateSystemProperties(Session session, Map<String, String> systemProperties)
+    {
+        for (Map.Entry<String, String> property : systemProperties.entrySet()) {
+            // verify permissions
+            accessControl.checkCanSetSystemSessionProperty(session.getIdentity(), session.getQueryId(), property.getKey());
+            // validate session property value
+            sessionPropertyManager.validateSystemSessionProperty(property.getKey(), property.getValue());
+        }
+    }
+
+    private void validateCatalogProperties(Session session, Map<String, Map<String, String>> catalogsProperties)
+    {
+        checkState(session.getTransactionId().isPresent(), "Not in transaction");
+        for (Map.Entry<String, Map<String, String>> catalogProperties : catalogsProperties.entrySet()) {
+            CatalogHandle catalogHandle = plannerContext.getMetadata().getCatalogHandle(session, catalogProperties.getKey())
+                    .orElseThrow(() -> new TrinoException(CATALOG_NOT_FOUND, "Catalog '%s' not found".formatted(catalogProperties.getKey())));
+
+            for (Map.Entry<String, String> catalogProperty : catalogProperties.getValue().entrySet()) {
+                // verify permissions
+                accessControl.checkCanSetCatalogSessionProperty(new SecurityContext(session.getRequiredTransactionId(), session.getIdentity(), session.getQueryId(), session.getStart()), catalogProperties.getKey(), catalogProperty.getKey());
+                // validate catalog session property value
+                sessionPropertyManager.validateCatalogSessionProperty(catalogProperties.getKey(), catalogHandle, catalogProperty.getKey(), catalogProperty.getValue());
+            }
+        }
+    }
+
+    public record ResolvedSessionSpecifications(Map<String, String> systemProperties, Map<String, Map<String, String>> catalogProperties)
+    {
+        public ResolvedSessionSpecifications
+        {
+            systemProperties = ImmutableMap.copyOf(requireNonNull(systemProperties, "systemProperties is null"));
+            catalogProperties = ImmutableMap.copyOf(requireNonNull(catalogProperties, "catalogProperties is null"));
+        }
+    }
+
+    @FunctionalInterface
+    public interface SessionSpecificationsApplier
+            extends Function<Session, Session>
+    {
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/dispatcher/TestLocalDispatchQuery.java
+++ b/core/trino-main/src/test/java/io/trino/dispatcher/TestLocalDispatchQuery.java
@@ -122,6 +122,7 @@ public class TestLocalDispatchQuery
                 createPlanOptimizersStatsCollector(),
                 Optional.of(QueryType.DATA_DEFINITION),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
         QueryMonitor queryMonitor = new QueryMonitor(
                 JsonCodec.jsonCodec(StageInfo.class),

--- a/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
+++ b/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
@@ -243,6 +243,7 @@ public abstract class BaseDataDefinitionTaskTest
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestCallTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCallTask.java
@@ -173,6 +173,7 @@ public class TestCallTask
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestCommitTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCommitTask.java
@@ -147,6 +147,7 @@ public class TestCommitTask
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateCatalogTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateCatalogTask.java
@@ -84,6 +84,7 @@ public class TestCreateCatalogTask
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
 
         this.queryRunner = queryRunner;

--- a/core/trino-main/src/test/java/io/trino/execution/TestDeallocateTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestDeallocateTask.java
@@ -116,6 +116,7 @@ public class TestDeallocateTask
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
         Deallocate deallocate = new Deallocate(new NodeLocation(1, 1), new Identifier(statementName));
         new DeallocateTask().execute(deallocate, stateMachine, emptyList(), WarningCollector.NOOP);

--- a/core/trino-main/src/test/java/io/trino/execution/TestDropCatalogTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestDropCatalogTask.java
@@ -129,6 +129,7 @@ public class TestDropCatalogTask
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/TestPrepareTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestPrepareTask.java
@@ -139,6 +139,7 @@ public class TestPrepareTask
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
         Prepare prepare = new Prepare(identifier(statementName), statement);
         new PrepareTask(new SqlParser()).execute(prepare, stateMachine, emptyList(), WarningCollector.NOOP);

--- a/core/trino-main/src/test/java/io/trino/execution/TestQueryStateMachine.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestQueryStateMachine.java
@@ -867,6 +867,7 @@ public class TestQueryStateMachine
                     createPlanOptimizersStatsCollector(),
                     QUERY_TYPE,
                     false,
+                    Optional.empty(),
                     new NodeVersion("test"));
             stateMachine.setInputs(INPUTS);
             stateMachine.setOutput(OUTPUT);

--- a/core/trino-main/src/test/java/io/trino/execution/TestResetSessionTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestResetSessionTask.java
@@ -120,6 +120,7 @@ public class TestResetSessionTask
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
 
         getFutureValue(new ResetSessionTask(metadata, sessionPropertyManager).execute(

--- a/core/trino-main/src/test/java/io/trino/execution/TestRoleTasks.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestRoleTasks.java
@@ -176,6 +176,7 @@ public class TestRoleTasks
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
         task.execute((T) parser.createStatement(statement), stateMachine, ImmutableList.of(), WarningCollector.NOOP);
         return stateMachine;

--- a/core/trino-main/src/test/java/io/trino/execution/TestRollbackTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestRollbackTask.java
@@ -137,6 +137,7 @@ public class TestRollbackTask
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetPathTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetPathTask.java
@@ -124,6 +124,7 @@ public class TestSetPathTask
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetSessionAuthorizationTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetSessionAuthorizationTask.java
@@ -124,6 +124,7 @@ public class TestSetSessionAuthorizationTask
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
         return stateMachine;
     }

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetSessionTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetSessionTask.java
@@ -208,6 +208,7 @@ public class TestSetSessionTask
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
         getFutureValue(new SetSessionTask(plannerContext, accessControl, sessionPropertyManager).execute(new SetSession(new NodeLocation(1, 1), qualifiedPropName, expression), stateMachine, parameters, WarningCollector.NOOP));
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetTimeZoneTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetTimeZoneTask.java
@@ -266,6 +266,7 @@ public class TestSetTimeZoneTask
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestStartTransactionTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestStartTransactionTask.java
@@ -268,6 +268,7 @@ public class TestStartTransactionTask
                 createPlanOptimizersStatsCollector(),
                 Optional.empty(),
                 true,
+                Optional.empty(),
                 new NodeVersion("test"));
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestingPlannerContext.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestingPlannerContext.java
@@ -77,14 +77,12 @@ public final class TestingPlannerContext
         public Builder withMetadata(Metadata metadata)
         {
             checkState(this.metadata == null, "metadata already set");
-            checkState(this.transactionManager == null, "transactionManager already set");
             this.metadata = requireNonNull(metadata, "metadata is null");
             return this;
         }
 
         public Builder withTransactionManager(TransactionManager transactionManager)
         {
-            checkState(this.metadata == null, "metadata already set");
             checkState(this.transactionManager == null, "transactionManager already set");
             this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
             return this;

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestSessionProperties.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestSessionProperties.java
@@ -32,7 +32,7 @@ import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.TypeOperators;
 import io.trino.sql.PlannerContext;
-import io.trino.sql.SessionSpecificationEvaluator;
+import io.trino.sql.SessionPropertyInterpreter;
 import io.trino.sql.parser.SqlParser;
 import io.trino.transaction.TestingTransactionManager;
 import io.trino.transaction.TransactionManager;
@@ -55,7 +55,7 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 @TestInstance(PER_CLASS)
 @Execution(CONCURRENT)
-final class TestSessionSpecifications
+final class TestSessionProperties
 {
     private static final SqlParser SQL_PARSER = new SqlParser();
     private static final SessionPropertyManager SESSION_PROPERTY_MANAGER = new SessionPropertyManager(
@@ -117,9 +117,9 @@ final class TestSessionSpecifications
 
         return transaction(transactionManager, plannerContext.getMetadata(), new AllowAllAccessControl())
                 .execute(testSession(), transactionSession -> {
-                    SessionSpecificationEvaluator evaluator = new SessionSpecificationEvaluator(plannerContext, new AllowAllAccessControl(), SESSION_PROPERTY_MANAGER);
+                    SessionPropertyInterpreter evaluator = new SessionPropertyInterpreter(plannerContext, new AllowAllAccessControl(), SESSION_PROPERTY_MANAGER);
                     QueryPreparer.PreparedQuery preparedQuery = new QueryPreparer.PreparedQuery(SQL_PARSER.createStatement(statement), ImmutableList.of(), Optional.empty());
-                    return evaluator.getSessionSpecificationApplier(preparedQuery).apply(transactionSession);
+                    return evaluator.getSessionPropertiesApplier(preparedQuery).apply(transactionSession);
                 });
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestSessionSpecifications.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestSessionSpecifications.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.trino.FeaturesConfig;
+import io.trino.Session;
+import io.trino.SystemSessionProperties;
+import io.trino.execution.QueryPreparer;
+import io.trino.metadata.AbstractMockMetadata;
+import io.trino.metadata.MetadataManager;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.metadata.SessionPropertyManager;
+import io.trino.metadata.TypeRegistry;
+import io.trino.security.AllowAllAccessControl;
+import io.trino.spi.connector.CatalogHandle;
+import io.trino.spi.function.OperatorType;
+import io.trino.spi.session.PropertyMetadata;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeManager;
+import io.trino.spi.type.TypeOperators;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.SessionSpecificationEvaluator;
+import io.trino.sql.parser.SqlParser;
+import io.trino.transaction.TestingTransactionManager;
+import io.trino.transaction.TransactionManager;
+import io.trino.type.InternalTypeManager;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.sql.planner.TestingPlannerContext.plannerContextBuilder;
+import static io.trino.testing.TestingSession.testSession;
+import static io.trino.testing.TransactionBuilder.transaction;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+final class TestSessionSpecifications
+{
+    private static final SqlParser SQL_PARSER = new SqlParser();
+    private static final SessionPropertyManager SESSION_PROPERTY_MANAGER = new SessionPropertyManager(
+            ImmutableSet.of(new SystemSessionProperties()),
+            _ -> Map.of("catalog_property", PropertyMetadata.stringProperty("catalog_property", "Test catalog property", "", false)));
+
+    @Test
+    void testParseSystemSessionProperty()
+    {
+        assertThatThrownBy(() -> analyze("WITH SESSION invalid_key = 'invalid_value' SELECT 1"))
+                .hasMessageContaining("line 1:14: Session property invalid_key does not exist");
+
+        assertThatThrownBy(() -> analyze("WITH SESSION optimize_hash_generation = 'invalid_value' SELECT 1"))
+                .hasMessageContaining("Unable to set session property 'optimize_hash_generation' to ''invalid_value'': Cannot cast type varchar(13) to boolean");
+
+        assertThat(analyze("WITH SESSION optimize_hash_generation = true SELECT 1").getSystemProperties())
+                .isEqualTo(Map.of("optimize_hash_generation", "true"));
+
+        assertThat(analyze("WITH SESSION optimize_hash_generation = CAST('true' AS boolean) SELECT 1").getSystemProperties())
+                .isEqualTo(Map.of("optimize_hash_generation", "true"));
+
+        assertThatThrownBy(() -> analyze("WITH SESSION optimize_hash_generation = true, optimize_hash_generation = false SELECT 1"))
+                .hasMessageContaining("line 1:47: Session property optimize_hash_generation already set");
+    }
+
+    @Test
+    void testCatalogSessionProperty()
+    {
+        assertThatThrownBy(() -> analyze("WITH SESSION test.invalid_key = 'invalid_value' SELECT 1"))
+                .hasMessageContaining("line 1:14: Session property test.invalid_key does not exist");
+
+        assertThatThrownBy(() -> analyze("WITH SESSION test.catalog_property = true SELECT 1"))
+                .hasMessageContaining("Unable to set session property 'test.catalog_property' to 'true': Cannot cast type boolean to varchar");
+
+        assertThat(analyze("WITH SESSION test.catalog_property = 'true' SELECT 1").getCatalogProperties("test"))
+                .isEqualTo(Map.of("catalog_property", "true"));
+
+        assertThat(analyze("WITH SESSION test.catalog_property = CAST(true AS varchar) SELECT 1").getCatalogProperties("test"))
+                .isEqualTo(Map.of("catalog_property", "true"));
+
+        assertThatThrownBy(() -> analyze("WITH SESSION test.catalog_property = 'true', test.catalog_property = 'false' SELECT 1").getCatalogProperties("test"))
+                .hasMessageContaining("line 1:46: Session property test.catalog_property already set");
+    }
+
+    @Test
+    void testInvalidSessionProperty()
+    {
+        assertThatThrownBy(() -> analyze("WITH SESSION test.schema.invalid_key = 'invalid_value' SELECT 1"))
+                .hasMessageContaining("line 1:14: Invalid session property 'test.schema.invalid_key'");
+    }
+
+    private static Session analyze(@Language("SQL") String statement)
+    {
+        TransactionManager transactionManager = new TestingTransactionManager();
+        PlannerContext plannerContext = plannerContextBuilder()
+                .withMetadata(new MockMetadata())
+                .withTransactionManager(transactionManager)
+                .build();
+
+        return transaction(transactionManager, plannerContext.getMetadata(), new AllowAllAccessControl())
+                .execute(testSession(), transactionSession -> {
+                    SessionSpecificationEvaluator evaluator = new SessionSpecificationEvaluator(plannerContext, new AllowAllAccessControl(), SESSION_PROPERTY_MANAGER);
+                    QueryPreparer.PreparedQuery preparedQuery = new QueryPreparer.PreparedQuery(SQL_PARSER.createStatement(statement), ImmutableList.of(), Optional.empty());
+                    return evaluator.getSessionSpecificationApplier(preparedQuery).apply(transactionSession);
+                });
+    }
+
+    private static class MockMetadata
+            extends AbstractMockMetadata
+    {
+        private final MetadataManager delegate;
+
+        public MockMetadata()
+        {
+            FeaturesConfig featuresConfig = new FeaturesConfig();
+            TypeOperators typeOperators = new TypeOperators();
+
+            TypeRegistry typeRegistry = new TypeRegistry(typeOperators, featuresConfig);
+            TypeManager typeManager = new InternalTypeManager(typeRegistry);
+            this.delegate = MetadataManager.testMetadataManagerBuilder()
+                    .withTypeManager(typeManager)
+                    .build();
+        }
+
+        @Override
+        public ResolvedFunction getCoercion(OperatorType operatorType, Type fromType, Type toType)
+        {
+            return delegate.getCoercion(operatorType, fromType, toType);
+        }
+
+        @Override
+        public Optional<CatalogHandle> getCatalogHandle(Session session, String catalogName)
+        {
+            return Optional.of(CatalogHandle.fromId(catalogName + ":NORMAL:v1"));
+        }
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/QueryUtil.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/QueryUtil.java
@@ -271,6 +271,7 @@ public final class QueryUtil
     {
         return new Query(
                 ImmutableList.of(),
+                ImmutableList.of(),
                 Optional.empty(),
                 body,
                 Optional.empty(),

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -137,6 +137,7 @@ import io.trino.sql.tree.SampledRelation;
 import io.trino.sql.tree.SecurityCharacteristic;
 import io.trino.sql.tree.Select;
 import io.trino.sql.tree.SelectItem;
+import io.trino.sql.tree.SessionSpecification;
 import io.trino.sql.tree.SetColumnType;
 import io.trino.sql.tree.SetPath;
 import io.trino.sql.tree.SetProperties;
@@ -640,8 +641,20 @@ public final class SqlFormatter
         @Override
         protected Void visitQuery(Query node, Integer indent)
         {
-            if (!node.getFunctions().isEmpty()) {
+            if (!node.getFunctions().isEmpty() || !node.getSessionProperties().isEmpty()) {
                 builder.append("WITH\n");
+                if (!node.getSessionProperties().isEmpty()) {
+                    append(indent + 1, "SESSION\n");
+                }
+                Iterator<SessionSpecification> sessionProperties = node.getSessionProperties().iterator();
+                while (sessionProperties.hasNext()) {
+                    process(sessionProperties.next(), indent + 2);
+                    if (sessionProperties.hasNext()) {
+                        builder.append(',');
+                    }
+                    builder.append('\n');
+                }
+
                 Iterator<FunctionSpecification> functions = node.getFunctions().iterator();
                 while (functions.hasNext()) {
                     process(functions.next(), indent + 1);
@@ -2297,6 +2310,16 @@ public final class SqlFormatter
                 builder.append("\n");
             }
             process(node.getStatement(), indent);
+            return null;
+        }
+
+        @Override
+        protected Void visitSessionSpecification(SessionSpecification node, Integer indent)
+        {
+            append(indent, "")
+                    .append(formatName(node.getName()))
+                    .append(" = ")
+                    .append(formatExpression(node.getValue()));
             return null;
         }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -137,7 +137,7 @@ import io.trino.sql.tree.SampledRelation;
 import io.trino.sql.tree.SecurityCharacteristic;
 import io.trino.sql.tree.Select;
 import io.trino.sql.tree.SelectItem;
-import io.trino.sql.tree.SessionSpecification;
+import io.trino.sql.tree.SessionProperty;
 import io.trino.sql.tree.SetColumnType;
 import io.trino.sql.tree.SetPath;
 import io.trino.sql.tree.SetProperties;
@@ -646,7 +646,7 @@ public final class SqlFormatter
                 if (!node.getSessionProperties().isEmpty()) {
                     append(indent + 1, "SESSION\n");
                 }
-                Iterator<SessionSpecification> sessionProperties = node.getSessionProperties().iterator();
+                Iterator<SessionProperty> sessionProperties = node.getSessionProperties().iterator();
                 while (sessionProperties.hasNext()) {
                     process(sessionProperties.next(), indent + 2);
                     if (sessionProperties.hasNext()) {
@@ -2314,7 +2314,7 @@ public final class SqlFormatter
         }
 
         @Override
-        protected Void visitSessionSpecification(SessionSpecification node, Integer indent)
+        protected Void visitSessionProperty(SessionProperty node, Integer indent)
         {
             append(indent, "")
                     .append(formatName(node.getName()))

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -238,7 +238,7 @@ import io.trino.sql.tree.SearchedCaseExpression;
 import io.trino.sql.tree.SecurityCharacteristic;
 import io.trino.sql.tree.Select;
 import io.trino.sql.tree.SelectItem;
-import io.trino.sql.tree.SessionSpecification;
+import io.trino.sql.tree.SessionProperty;
 import io.trino.sql.tree.SetColumnType;
 import io.trino.sql.tree.SetPath;
 import io.trino.sql.tree.SetProperties;
@@ -1099,9 +1099,8 @@ class AstBuilder
         return new Query(
                 getLocation(context),
                 Optional.ofNullable(context.queryScoped())
-                        .map(SqlBaseParser.QueryScopedContext::withSession)
-                        .map(SqlBaseParser.WithSessionContext::sessionSpecification)
-                        .map(contexts -> visit(contexts, SessionSpecification.class))
+                        .map(SqlBaseParser.QueryScopedContext::sessionProperty)
+                        .map(contexts -> visit(contexts, SessionProperty.class))
                         .orElseGet(ImmutableList::of),
                 Optional.ofNullable(context.queryScoped())
                         .map(SqlBaseParser.QueryScopedContext::withFunction)
@@ -3733,9 +3732,9 @@ class AstBuilder
     }
 
     @Override
-    public Node visitSessionSpecification(SqlBaseParser.SessionSpecificationContext context)
+    public Node visitSessionProperty(SqlBaseParser.SessionPropertyContext context)
     {
-        return new SessionSpecification(
+        return new SessionProperty(
                 getLocation(context),
                 getQualifiedName(context.qualifiedName()),
                 (Expression) visit(context.expression()));

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -1529,7 +1529,8 @@ class AstBuilder
     @Override
     public Node visitSetSession(SqlBaseParser.SetSessionContext context)
     {
-        return new SetSession(getLocation(context), getQualifiedName(context.qualifiedName()), (Expression) visit(context.expression()));
+        SessionProperty sessionProperty = (SessionProperty) visit(context.sessionProperty());
+        return new SetSession(getLocation(context), sessionProperty.getName(), sessionProperty.getValue());
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
@@ -1237,6 +1237,11 @@ public abstract class AstVisitor<R, C>
         return visitNode(node, context);
     }
 
+    protected R visitSessionSpecification(SessionSpecification node, C context)
+    {
+        return visitNode(node, context);
+    }
+
     protected R visitParameterDeclaration(ParameterDeclaration node, C context)
     {
         return visitNode(node, context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
@@ -1237,7 +1237,7 @@ public abstract class AstVisitor<R, C>
         return visitNode(node, context);
     }
 
-    protected R visitSessionSpecification(SessionSpecification node, C context)
+    protected R visitSessionProperty(SessionProperty node, C context)
     {
         return visitNode(node, context);
     }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Query.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Query.java
@@ -26,6 +26,7 @@ import static java.util.Objects.requireNonNull;
 public class Query
         extends Statement
 {
+    private final List<SessionSpecification> sessionProperties;
     private final List<FunctionSpecification> functions;
     private final Optional<With> with;
     private final QueryBody queryBody;
@@ -34,6 +35,7 @@ public class Query
     private final Optional<Node> limit;
 
     public Query(
+            List<SessionSpecification> sessionProperties,
             List<FunctionSpecification> functions,
             Optional<With> with,
             QueryBody queryBody,
@@ -41,11 +43,12 @@ public class Query
             Optional<Offset> offset,
             Optional<Node> limit)
     {
-        this(Optional.empty(), functions, with, queryBody, orderBy, offset, limit);
+        this(Optional.empty(), sessionProperties, functions, with, queryBody, orderBy, offset, limit);
     }
 
     public Query(
             NodeLocation location,
+            List<SessionSpecification> sessionProperties,
             List<FunctionSpecification> functions,
             Optional<With> with,
             QueryBody queryBody,
@@ -53,11 +56,12 @@ public class Query
             Optional<Offset> offset,
             Optional<Node> limit)
     {
-        this(Optional.of(location), functions, with, queryBody, orderBy, offset, limit);
+        this(Optional.of(location), sessionProperties, functions, with, queryBody, orderBy, offset, limit);
     }
 
     private Query(
             Optional<NodeLocation> location,
+            List<SessionSpecification> sessionProperties,
             List<FunctionSpecification> functions,
             Optional<With> with,
             QueryBody queryBody,
@@ -66,7 +70,8 @@ public class Query
             Optional<Node> limit)
     {
         super(location);
-        requireNonNull(functions, "function si snull");
+        requireNonNull(sessionProperties, "sessionProperties is null");
+        requireNonNull(functions, "functions is null");
         requireNonNull(with, "with is null");
         requireNonNull(queryBody, "queryBody is null");
         requireNonNull(orderBy, "orderBy is null");
@@ -74,12 +79,18 @@ public class Query
         requireNonNull(limit, "limit is null");
         checkArgument(!limit.isPresent() || limit.get() instanceof FetchFirst || limit.get() instanceof Limit, "limit must be optional of either FetchFirst or Limit type");
 
+        this.sessionProperties = ImmutableList.copyOf(sessionProperties);
         this.functions = ImmutableList.copyOf(functions);
         this.with = with;
         this.queryBody = queryBody;
         this.orderBy = orderBy;
         this.offset = offset;
         this.limit = limit;
+    }
+
+    public List<SessionSpecification> getSessionProperties()
+    {
+        return sessionProperties;
     }
 
     public List<FunctionSpecification> getFunctions()
@@ -123,6 +134,7 @@ public class Query
     {
         ImmutableList.Builder<Node> nodes = ImmutableList.builder();
         nodes.addAll(functions);
+        nodes.addAll(sessionProperties);
         with.ifPresent(nodes::add);
         nodes.add(queryBody);
         orderBy.ifPresent(nodes::add);
@@ -135,6 +147,7 @@ public class Query
     public String toString()
     {
         return toStringHelper(this)
+                .add("sessionProperties", sessionProperties.isEmpty() ? null : sessionProperties)
                 .add("functions", functions.isEmpty() ? null : functions)
                 .add("with", with.orElse(null))
                 .add("queryBody", queryBody)
@@ -155,7 +168,8 @@ public class Query
             return false;
         }
         Query o = (Query) obj;
-        return Objects.equals(functions, o.functions) &&
+        return Objects.equals(sessionProperties, o.sessionProperties) &&
+                Objects.equals(functions, o.functions) &&
                 Objects.equals(with, o.with) &&
                 Objects.equals(queryBody, o.queryBody) &&
                 Objects.equals(orderBy, o.orderBy) &&
@@ -166,7 +180,7 @@ public class Query
     @Override
     public int hashCode()
     {
-        return Objects.hash(functions, with, queryBody, orderBy, offset, limit);
+        return Objects.hash(sessionProperties, functions, with, queryBody, orderBy, offset, limit);
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Query.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Query.java
@@ -26,7 +26,7 @@ import static java.util.Objects.requireNonNull;
 public class Query
         extends Statement
 {
-    private final List<SessionSpecification> sessionProperties;
+    private final List<SessionProperty> sessionProperties;
     private final List<FunctionSpecification> functions;
     private final Optional<With> with;
     private final QueryBody queryBody;
@@ -35,7 +35,7 @@ public class Query
     private final Optional<Node> limit;
 
     public Query(
-            List<SessionSpecification> sessionProperties,
+            List<SessionProperty> sessionProperties,
             List<FunctionSpecification> functions,
             Optional<With> with,
             QueryBody queryBody,
@@ -48,7 +48,7 @@ public class Query
 
     public Query(
             NodeLocation location,
-            List<SessionSpecification> sessionProperties,
+            List<SessionProperty> sessionProperties,
             List<FunctionSpecification> functions,
             Optional<With> with,
             QueryBody queryBody,
@@ -61,7 +61,7 @@ public class Query
 
     private Query(
             Optional<NodeLocation> location,
-            List<SessionSpecification> sessionProperties,
+            List<SessionProperty> sessionProperties,
             List<FunctionSpecification> functions,
             Optional<With> with,
             QueryBody queryBody,
@@ -88,7 +88,7 @@ public class Query
         this.limit = limit;
     }
 
-    public List<SessionSpecification> getSessionProperties()
+    public List<SessionProperty> getSessionProperties()
     {
         return sessionProperties;
     }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/SessionProperty.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/SessionProperty.java
@@ -22,13 +22,13 @@ import java.util.Optional;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
-public class SessionSpecification
+public class SessionProperty
         extends Node
 {
     private final QualifiedName name;
     private final Expression value;
 
-    public SessionSpecification(NodeLocation location, QualifiedName name, Expression value)
+    public SessionProperty(NodeLocation location, QualifiedName name, Expression value)
     {
         super(Optional.of(location));
         this.name = requireNonNull(name, "name is null");
@@ -48,13 +48,13 @@ public class SessionSpecification
     @Override
     public List<? extends Node> getChildren()
     {
-        return ImmutableList.of();
+        return ImmutableList.of(value);
     }
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context)
     {
-        return visitor.visitSessionSpecification(this, context);
+        return visitor.visitSessionProperty(this, context);
     }
 
     @Override
@@ -66,7 +66,7 @@ public class SessionSpecification
     @Override
     public boolean equals(Object obj)
     {
-        return (obj instanceof SessionSpecification other) &&
+        return (obj instanceof SessionProperty other) &&
                 Objects.equals(name, other.name) &&
                 Objects.equals(value, other.value);
     }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/SessionSpecification.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/SessionSpecification.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class SessionSpecification
+        extends Node
+{
+    private final QualifiedName name;
+    private final Expression value;
+
+    public SessionSpecification(NodeLocation location, QualifiedName name, Expression value)
+    {
+        super(Optional.of(location));
+        this.name = requireNonNull(name, "name is null");
+        this.value = requireNonNull(value, "value is null");
+    }
+
+    public QualifiedName getName()
+    {
+        return name;
+    }
+
+    public Expression getValue()
+    {
+        return value;
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitSessionSpecification(this, context);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name, value);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        return (obj instanceof SessionSpecification other) &&
+                Objects.equals(name, other.name) &&
+                Objects.equals(value, other.value);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("name", name)
+                .add("value", value)
+                .toString();
+    }
+}

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -78,6 +78,7 @@ import io.trino.sql.tree.Format;
 import io.trino.sql.tree.FrameBound;
 import io.trino.sql.tree.FunctionCall;
 import io.trino.sql.tree.FunctionCall.NullTreatment;
+import io.trino.sql.tree.FunctionSpecification;
 import io.trino.sql.tree.GenericDataType;
 import io.trino.sql.tree.GenericLiteral;
 import io.trino.sql.tree.Grant;
@@ -164,6 +165,8 @@ import io.trino.sql.tree.RenameTable;
 import io.trino.sql.tree.RenameView;
 import io.trino.sql.tree.ResetSession;
 import io.trino.sql.tree.ResetSessionAuthorization;
+import io.trino.sql.tree.ReturnStatement;
+import io.trino.sql.tree.ReturnsClause;
 import io.trino.sql.tree.Revoke;
 import io.trino.sql.tree.RevokeRoles;
 import io.trino.sql.tree.Rollback;
@@ -171,6 +174,7 @@ import io.trino.sql.tree.Row;
 import io.trino.sql.tree.SearchedCaseExpression;
 import io.trino.sql.tree.Select;
 import io.trino.sql.tree.SelectItem;
+import io.trino.sql.tree.SessionSpecification;
 import io.trino.sql.tree.SetColumnType;
 import io.trino.sql.tree.SetPath;
 import io.trino.sql.tree.SetProperties;
@@ -226,6 +230,7 @@ import io.trino.sql.tree.With;
 import io.trino.sql.tree.WithQuery;
 import io.trino.sql.tree.ZeroOrMoreQuantifier;
 import io.trino.sql.tree.ZeroOrOneQuantifier;
+import org.assertj.core.api.AssertProvider;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -2148,6 +2153,7 @@ public class TestSqlParser
                 .isEqualTo(new CreateTableAsSelect(location(1, 1), qualifiedName(location(1, 14), "foo"), new Query(
                         location(1, 21),
                         ImmutableList.of(),
+                        ImmutableList.of(),
                         Optional.empty(),
                         new QuerySpecification(
                                 location(1, 21),
@@ -2173,6 +2179,7 @@ public class TestSqlParser
                 .isEqualTo(new CreateTableAsSelect(location(1, 1), qualifiedName(location(1, 14), "foo"), new Query(
                         location(1, 24),
                         ImmutableList.of(),
+                        ImmutableList.of(),
                         Optional.empty(),
                         new QuerySpecification(
                                 location(1, 24),
@@ -2197,6 +2204,7 @@ public class TestSqlParser
         assertThat(statement("CREATE TABLE foo(x,y) AS SELECT a,b FROM t"))
                 .isEqualTo(new CreateTableAsSelect(location(1, 1), qualifiedName(location(1, 14), "foo"), new Query(
                         location(1, 26),
+                        ImmutableList.of(),
                         ImmutableList.of(),
                         Optional.empty(),
                         new QuerySpecification(
@@ -2227,6 +2235,7 @@ public class TestSqlParser
                 .isEqualTo(new CreateTableAsSelect(location(1, 1), qualifiedName(location(1, 25), "foo"), new Query(
                         location(1, 32),
                         ImmutableList.of(),
+                        ImmutableList.of(),
                         Optional.empty(),
                         new QuerySpecification(
                                 location(1, 32),
@@ -2252,6 +2261,7 @@ public class TestSqlParser
                 .isEqualTo(new CreateTableAsSelect(location(1, 1), qualifiedName(location(1, 25), "foo"), new Query(
                         location(1, 35),
                         ImmutableList.of(),
+                        ImmutableList.of(),
                         Optional.empty(),
                         new QuerySpecification(
                                 location(1, 35),
@@ -2276,6 +2286,7 @@ public class TestSqlParser
         assertThat(statement("CREATE OR REPLACE TABLE foo(x,y) AS SELECT a,b FROM t"))
                 .isEqualTo(new CreateTableAsSelect(location(1, 1), qualifiedName(location(1, 25), "foo"), new Query(
                         location(1, 37),
+                        ImmutableList.of(),
                         ImmutableList.of(),
                         Optional.empty(),
                         new QuerySpecification(
@@ -2306,6 +2317,7 @@ public class TestSqlParser
                 .isEqualTo(new CreateTableAsSelect(location(1, 1), qualifiedName(location(1, 28), "foo"), new Query(
                         location(1, 35),
                         ImmutableList.of(),
+                        ImmutableList.of(),
                         Optional.empty(),
                         new QuerySpecification(
                                 location(1, 35),
@@ -2331,6 +2343,7 @@ public class TestSqlParser
                 .isEqualTo(new CreateTableAsSelect(location(1, 1), qualifiedName(location(1, 28), "foo"), new Query(
                         location(1, 38),
                         ImmutableList.of(),
+                        ImmutableList.of(),
                         Optional.empty(),
                         new QuerySpecification(
                                 location(1, 38),
@@ -2355,6 +2368,7 @@ public class TestSqlParser
         assertThat(statement("CREATE TABLE IF NOT EXISTS foo(x,y) AS SELECT a,b FROM t"))
                 .isEqualTo(new CreateTableAsSelect(location(1, 1), qualifiedName(location(1, 28), "foo"), new Query(
                         location(1, 40),
+                        ImmutableList.of(),
                         ImmutableList.of(),
                         Optional.empty(),
                         new QuerySpecification(
@@ -2385,6 +2399,7 @@ public class TestSqlParser
                 .isEqualTo(new CreateTableAsSelect(location(1, 1), qualifiedName(location(1, 14), "foo"), new Query(
                         location(1, 21),
                         ImmutableList.of(),
+                        ImmutableList.of(),
                         Optional.empty(),
                         new QuerySpecification(
                                 location(1, 21),
@@ -2410,6 +2425,7 @@ public class TestSqlParser
                 .isEqualTo(new CreateTableAsSelect(location(1, 1), qualifiedName(location(1, 14), "foo"), new Query(
                         location(1, 24),
                         ImmutableList.of(),
+                        ImmutableList.of(),
                         Optional.empty(),
                         new QuerySpecification(
                                 location(1, 24),
@@ -2434,6 +2450,7 @@ public class TestSqlParser
         assertThat(statement("CREATE TABLE foo(x,y) AS SELECT a,b FROM t WITH NO DATA"))
                 .isEqualTo(new CreateTableAsSelect(location(1, 1), qualifiedName(location(1, 14), "foo"), new Query(
                         location(1, 26),
+                        ImmutableList.of(),
                         ImmutableList.of(),
                         Optional.empty(),
                         new QuerySpecification(
@@ -2471,6 +2488,7 @@ public class TestSqlParser
                         qualifiedName(location(1, 14), "foo"),
                         new Query(
                                 location(4, 1),
+                                ImmutableList.of(),
                                 ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
@@ -2515,6 +2533,7 @@ public class TestSqlParser
                         new Query(
                                 location(4, 1),
                                 ImmutableList.of(),
+                                ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
                                         location(4, 1),
@@ -2554,6 +2573,7 @@ public class TestSqlParser
                         qualifiedName(location(1, 14), "foo"),
                         new Query(
                                 location(4, 1),
+                                ImmutableList.of(),
                                 ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
@@ -2596,6 +2616,7 @@ public class TestSqlParser
                         new Query(
                                 location(4, 1),
                                 ImmutableList.of(),
+                                ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
                                         location(4, 1),
@@ -2640,6 +2661,7 @@ public class TestSqlParser
                         new Query(
                                 location(4, 1),
                                 ImmutableList.of(),
+                                ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
                                         location(4, 1),
@@ -2680,6 +2702,7 @@ public class TestSqlParser
                         qualifiedName(location(1, 14), "foo"),
                         new Query(
                                 location(4, 1),
+                                ImmutableList.of(),
                                 ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
@@ -2721,6 +2744,7 @@ public class TestSqlParser
                         qualifiedName(location(1, 14), "foo"),
                         new Query(
                                 location(4, 1),
+                                ImmutableList.of(),
                                 ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
@@ -2766,6 +2790,7 @@ public class TestSqlParser
                         new Query(
                                 location(4, 1),
                                 ImmutableList.of(),
+                                ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
                                         location(4, 1),
@@ -2807,6 +2832,7 @@ public class TestSqlParser
                         new Query(
                                 location(4, 1),
                                 ImmutableList.of(),
+                                ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
                                         location(4, 1),
@@ -2847,6 +2873,7 @@ public class TestSqlParser
                         qualifiedName(location(1, 14), "foo"),
                         new Query(
                                 location(4, 1),
+                                ImmutableList.of(),
                                 ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
@@ -2912,6 +2939,7 @@ public class TestSqlParser
         QualifiedName table = QualifiedName.of("foo");
 
         Query query = new Query(
+                ImmutableList.of(),
                 ImmutableList.of(),
                 Optional.of(new With(false, ImmutableList.of(
                         new WithQuery(
@@ -4058,6 +4086,7 @@ public class TestSqlParser
         assertStatement("WITH a (t, u) AS (SELECT * FROM x), b AS (SELECT * FROM y) TABLE z",
                 new Query(
                         ImmutableList.of(),
+                        ImmutableList.of(),
                         Optional.of(new With(false, ImmutableList.of(
                                 new WithQuery(
                                         identifier("a"),
@@ -4078,6 +4107,7 @@ public class TestSqlParser
 
         assertStatement("WITH RECURSIVE a AS (SELECT * FROM x) TABLE y",
                 new Query(
+                        ImmutableList.of(),
                         ImmutableList.of(),
                         Optional.of(new With(true, ImmutableList.of(
                                 new WithQuery(
@@ -4637,6 +4667,7 @@ public class TestSqlParser
                                         new Query(
                                                 location(1, 17),
                                                 ImmutableList.of(),
+                                                ImmutableList.of(),
                                                 Optional.empty(),
                                                 new QuerySpecification(
                                                         location(1, 17),
@@ -4666,6 +4697,7 @@ public class TestSqlParser
                                 new TableSubquery(
                                         new Query(
                                                 location(1, 17),
+                                                ImmutableList.of(),
                                                 ImmutableList.of(),
                                                 Optional.empty(),
                                                 new QuerySpecification(
@@ -4702,6 +4734,7 @@ public class TestSqlParser
                                         new Query(
                                                 location(2, 4),
                                                 ImmutableList.of(),
+                                                ImmutableList.of(),
                                                 Optional.of(
                                                         new With(
                                                                 location(2, 4),
@@ -4712,6 +4745,7 @@ public class TestSqlParser
                                                                                 new Identifier(location(2, 9), "t", false),
                                                                                 new Query(
                                                                                         location(2, 15),
+                                                                                        ImmutableList.of(),
                                                                                         ImmutableList.of(),
                                                                                         Optional.empty(),
                                                                                         new QuerySpecification(
@@ -4812,6 +4846,7 @@ public class TestSqlParser
                         new SubqueryExpression(location(1, 13), new Query(
                                 location(1, 13),
                                 ImmutableList.of(),
+                                ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
                                         location(1, 13),
@@ -4836,6 +4871,7 @@ public class TestSqlParser
                         new SubqueryExpression(location(1, 13), new Query(
                                 location(1, 13),
                                 ImmutableList.of(),
+                                ImmutableList.of(),
                                 Optional.empty(),
                                 new Values(location(1, 13), ImmutableList.of(
                                         new Row(location(1, 20), ImmutableList.of(new LongLiteral(location(1, 24), "1"))),
@@ -4851,6 +4887,7 @@ public class TestSqlParser
                         new Identifier(location(1, 1), "col1", false),
                         new SubqueryExpression(location(1, 15), new Query(
                                 location(1, 15),
+                                ImmutableList.of(),
                                 ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
@@ -5174,6 +5211,7 @@ public class TestSqlParser
                         new Query(
                                 new NodeLocation(1, 31),
                                 ImmutableList.of(),
+                                ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
                                         new NodeLocation(1, 31),
@@ -5212,6 +5250,7 @@ public class TestSqlParser
                         new Query(
                                 new NodeLocation(1, 100),
                                 ImmutableList.of(),
+                                ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
                                         new NodeLocation(1, 100),
@@ -5248,6 +5287,7 @@ public class TestSqlParser
                         QualifiedName.of(ImmutableList.of(new Identifier(new NodeLocation(1, 26), "a", false))),
                         new Query(
                                 new NodeLocation(1, 61),
+                                ImmutableList.of(),
                                 ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
@@ -5289,6 +5329,7 @@ public class TestSqlParser
                                 new Identifier(new NodeLocation(1, 52), "matview", false))),
                         new Query(
                                 new NodeLocation(3, 5),
+                                ImmutableList.of(),
                                 ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
@@ -5339,6 +5380,7 @@ public class TestSqlParser
                         new Query(
                                 new NodeLocation(3, 5),
                                 ImmutableList.of(),
+                                ImmutableList.of(),
                                 Optional.of(new With(
                                         new NodeLocation(3, 5),
                                         false,
@@ -5348,6 +5390,7 @@ public class TestSqlParser
                                                         new Identifier(new NodeLocation(3, 10), "a", false),
                                                         new Query(
                                                                 new NodeLocation(3, 23),
+                                                                ImmutableList.of(),
                                                                 ImmutableList.of(),
                                                                 Optional.empty(),
                                                                 new QuerySpecification(
@@ -5377,6 +5420,7 @@ public class TestSqlParser
                                                         new Identifier(new NodeLocation(3, 41), "b", false),
                                                         new Query(
                                                                 new NodeLocation(3, 47),
+                                                                ImmutableList.of(),
                                                                 ImmutableList.of(),
                                                                 Optional.empty(),
                                                                 new QuerySpecification(
@@ -5856,6 +5900,7 @@ public class TestSqlParser
                         new Query(
                                 location(1, 1),
                                 ImmutableList.of(),
+                                ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
                                         location(1, 1),
@@ -5886,6 +5931,7 @@ public class TestSqlParser
                 .isEqualTo(
                         new Query(
                                 location(1, 1),
+                                ImmutableList.of(),
                                 ImmutableList.of(),
                                 Optional.empty(),
                                 new QuerySpecification(
@@ -6230,6 +6276,7 @@ public class TestSqlParser
         return new Query(
                 location(1, 1),
                 ImmutableList.of(),
+                ImmutableList.of(),
                 Optional.empty(),
                 new QuerySpecification(
                         location(1, 1),
@@ -6410,6 +6457,90 @@ public class TestSqlParser
                         Optional.of(JsonQuery.QuotesBehavior.OMIT),
                         JsonQuery.EmptyOrErrorBehavior.EMPTY_ARRAY,
                         JsonQuery.EmptyOrErrorBehavior.ERROR));
+    }
+
+    @Test
+    public void testSessionSpecification()
+    {
+        AssertProvider<ParserAssert> statement = statement("""
+                WITH SESSION
+                   key = 'value',
+                   catalog.key2 = DECIMAL '10.0'
+                SELECT 1
+                """);
+
+        assertThat(statement)
+                .isEqualTo(new Query(
+                        location(1, 1),
+                        ImmutableList.of(
+                                new SessionSpecification(
+                                        location(2, 4),
+                                        QualifiedName.of(ImmutableList.of(new Identifier(location(2, 4), "key", false))),
+                                        new StringLiteral(location(2, 10), "value")),
+                                new SessionSpecification(
+                                        location(3, 4),
+                                        QualifiedName.of(ImmutableList.of(new Identifier(location(3, 4), "catalog", false), new Identifier(location(3, 12), "key2", false))),
+                                        new DecimalLiteral(location(3, 19), "10.0"))),
+                        ImmutableList.of(),
+                        Optional.empty(),
+                        new QuerySpecification(
+                                location(4, 1),
+                                new Select(location(4, 1), false, ImmutableList.of(new SingleColumn(location(4, 8), new LongLiteral(location(4, 8),"1"), Optional.empty()))),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                ImmutableList.of(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty()),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()
+                ));
+    }
+
+    @Test
+    public void testWithSessionAndFunction()
+    {
+        AssertProvider<ParserAssert> statement = statement("""
+                WITH
+                   SESSION key = 'value'
+                   FUNCTION foo() RETURNS bigint RETURN 42
+                SELECT 1
+                """);
+
+        assertThat(statement)
+                .isEqualTo(new Query(
+                        location(1, 1),
+                        ImmutableList.of(
+                                new SessionSpecification(
+                                        location(2, 12),
+                                        QualifiedName.of(ImmutableList.of(new Identifier(location(2, 12), "key", false))),
+                                        new StringLiteral(location(2, 18), "value"))),
+                        ImmutableList.of(new FunctionSpecification(
+                                location(3, 4),
+                                QualifiedName.of(ImmutableList.of(new Identifier(location(3, 13), "foo", false))),
+                                ImmutableList.of(),
+                                new ReturnsClause(location(3, 19), simpleType(location(3, 27), "bigint")),
+                                ImmutableList.of(),
+                                new ReturnStatement(location(3, 34), new LongLiteral(location(3, 41), "42")))),
+                        Optional.empty(),
+                        new QuerySpecification(
+                                location(4, 1),
+                                new Select(location(4, 1), false, ImmutableList.of(new SingleColumn(location(4, 8), new LongLiteral(location(4, 8),"1"), Optional.empty()))),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                ImmutableList.of(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty()),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()
+                ));
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -174,7 +174,7 @@ import io.trino.sql.tree.Row;
 import io.trino.sql.tree.SearchedCaseExpression;
 import io.trino.sql.tree.Select;
 import io.trino.sql.tree.SelectItem;
-import io.trino.sql.tree.SessionSpecification;
+import io.trino.sql.tree.SessionProperty;
 import io.trino.sql.tree.SetColumnType;
 import io.trino.sql.tree.SetPath;
 import io.trino.sql.tree.SetProperties;
@@ -6460,7 +6460,7 @@ public class TestSqlParser
     }
 
     @Test
-    public void testSessionSpecification()
+    public void testSessionProperty()
     {
         AssertProvider<ParserAssert> statement = statement("""
                 WITH SESSION
@@ -6473,11 +6473,11 @@ public class TestSqlParser
                 .isEqualTo(new Query(
                         location(1, 1),
                         ImmutableList.of(
-                                new SessionSpecification(
+                                new SessionProperty(
                                         location(2, 4),
                                         QualifiedName.of(ImmutableList.of(new Identifier(location(2, 4), "key", false))),
                                         new StringLiteral(location(2, 10), "value")),
-                                new SessionSpecification(
+                                new SessionProperty(
                                         location(3, 4),
                                         QualifiedName.of(ImmutableList.of(new Identifier(location(3, 4), "catalog", false), new Identifier(location(3, 12), "key2", false))),
                                         new DecimalLiteral(location(3, 19), "10.0"))),
@@ -6514,7 +6514,7 @@ public class TestSqlParser
                 .isEqualTo(new Query(
                         location(1, 1),
                         ImmutableList.of(
-                                new SessionSpecification(
+                                new SessionProperty(
                                         location(2, 12),
                                         QualifiedName.of(ImmutableList.of(new Identifier(location(2, 12), "key", false))),
                                         new StringLiteral(location(2, 18), "value"))),

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserRoutines.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserRoutines.java
@@ -342,6 +342,7 @@ class TestSqlParserRoutines
     private static Query query(FunctionSpecification function, Select select)
     {
         return new Query(
+                ImmutableList.of(),
                 ImmutableList.of(function),
                 Optional.empty(),
                 new QuerySpecification(

--- a/docs/src/main/sphinx/sql/select.md
+++ b/docs/src/main/sphinx/sql/select.md
@@ -3,7 +3,7 @@
 ## Synopsis
 
 ```text
-[ WITH FUNCTION sql_routines ]
+[ WITH [ SESSION name = expression [, ...] ] [ FUNCTION sql_routines ] ]
 [ WITH [ RECURSIVE ] with_query [, ...] ]
 SELECT [ ALL | DISTINCT ] select_expression [, ...]
 [ FROM from_item [, ...] ]

--- a/service/trino-verifier/src/main/java/io/trino/verifier/QueryRewriter.java
+++ b/service/trino-verifier/src/main/java/io/trino/verifier/QueryRewriter.java
@@ -206,10 +206,10 @@ public class QueryRewriter
                     querySpecification.getOffset(),
                     Optional.of(new Limit(new LongLiteral("0"))));
 
-            zeroRowsQuery = new io.trino.sql.tree.Query(ImmutableList.of(), createSelectClause.getWith(), innerQuery, Optional.empty(), Optional.empty(), Optional.empty());
+            zeroRowsQuery = new io.trino.sql.tree.Query(ImmutableList.of(), ImmutableList.of(), createSelectClause.getWith(), innerQuery, Optional.empty(), Optional.empty(), Optional.empty());
         }
         else {
-            zeroRowsQuery = new io.trino.sql.tree.Query(ImmutableList.of(), createSelectClause.getWith(), innerQuery, Optional.empty(), Optional.empty(), Optional.of(new Limit(new LongLiteral("0"))));
+            zeroRowsQuery = new io.trino.sql.tree.Query(ImmutableList.of(), ImmutableList.of(), createSelectClause.getWith(), innerQuery, Optional.empty(), Optional.empty(), Optional.of(new Limit(new LongLiteral("0"))));
         }
 
         ImmutableList.Builder<Column> columns = ImmutableList.builder();


### PR DESCRIPTION
## Description

Add support for `WITH SESSION` clause:
```sql
WITH SESSION
    session_key = 'property',
    catalog.catalog_session_key = 'catalog_property'
SELECT 1
```

The syntax with both sessions and SQL functions:
```sql
WITH 
  SESSION a = 1
  FUNCTION x(a BIGINT) RETURNS BIGINT RETURN 1
SELECT x()
```

`WITH SESSION` with DML is unsupported in this PR. 

Supersedes #21303

## Release notes

```markdown
# General
* Add support for `WITH SESSION` clause. ({issue}`23474`)
```
