### PR TITLE
Fix BigQuery case-insensitive-cache

### DIFF
--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryCaseInsensitiveMapping.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryCaseInsensitiveMapping.java
@@ -46,7 +46,6 @@ public class TestBigQueryCaseInsensitiveMapping
                 .setConnectorProperties(ImmutableMap.<String, String>builder()
                         .put("bigquery.case-insensitive-name-matching", "true")
                         .put("bigquery.case-insensitive-name-matching.cache-ttl", "1m")
-                        .put("bigquery.service-cache-ttl", "0ms") // Disable service cache to focus on metadata cache
                         .buildOrThrow())
                 .build();
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Right now `case-insensitive-cache` may contain only one value (in most cases) with `projectId` as key and names mapping as value. This causes cache to be build once and is never updated until it's invalidated. Also it's build with values available from one query only. It's not big problem for schema as for all queries we always supply cache from `client.listDatasetIds(projectId)`. 
For table it's buggy as some queries have limited information.
For example:
- select from single table will return only one list element with selected table from BigQuery, we will store only this table in cache mapping
- next select for another table will fetch mapping from cache and as new table is not present there it will return empty result
- empty result will cause table not found exception

This PR changes cache structure to be based on table/schema name as key. Also cache is updated on every query if key is not found.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Change in test to remove ` .put("bigquery.service-cache-ttl", "0ms") ` is needed to get cache working. With this property set to 0. `BigQueryClient` is initialised for each query, which results in building cache from scratch for each query.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# BigQuery
* Fix query failure when `bigquery.service-cache-ttl` config property isn't `0ms` and 
  case insensitive name matching is enabled ({issue}`23481`)
```
