### PR TITLE
Decouple caching columns from caching table comments in glue for Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -182,6 +182,7 @@ import static org.apache.iceberg.util.PropertyUtil.propertyAsBoolean;
 public final class IcebergUtil
 {
     public static final String TRINO_TABLE_METADATA_INFO_VALID_FOR = "trino_table_metadata_info_valid_for";
+    public static final String TRINO_TABLE_COMMENT_CACHE_PREVENTED = "trino_table_comment_cache_prevented";
     public static final String COLUMN_TRINO_NOT_NULL_PROPERTY = "trino_not_null";
     public static final String COLUMN_TRINO_TYPE_ID_PROPERTY = "trino_type_id";
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergUtil.java
@@ -41,6 +41,7 @@ import static io.trino.plugin.hive.TableType.EXTERNAL_TABLE;
 import static io.trino.plugin.hive.TableType.VIRTUAL_VIEW;
 import static io.trino.plugin.iceberg.IcebergUtil.COLUMN_TRINO_NOT_NULL_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergUtil.COLUMN_TRINO_TYPE_ID_PROPERTY;
+import static io.trino.plugin.iceberg.IcebergUtil.TRINO_TABLE_COMMENT_CACHE_PREVENTED;
 import static io.trino.plugin.iceberg.IcebergUtil.TRINO_TABLE_METADATA_INFO_VALID_FOR;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
@@ -85,25 +86,27 @@ public final class GlueIcebergUtil
 
         if (cacheTableMetadata) {
             // Store table metadata sufficient to answer information_schema.columns and system.metadata.table_comments queries, which are often queried in bulk by e.g. BI tools
-            String comment = metadata.properties().get(TABLE_COMMENT);
             Optional<List<Column>> glueColumns = glueColumns(typeManager, metadata);
 
-            boolean canPersistComment = (comment == null || comment.length() <= GLUE_TABLE_PARAMETER_LENGTH_LIMIT);
-            boolean canPersistColumnInfo = glueColumns.isPresent();
-            boolean canPersistMetadata = canPersistComment && canPersistColumnInfo;
+            glueColumns.ifPresent(columns -> tableInput.withStorageDescriptor(new StorageDescriptor()
+                    .withColumns(columns)));
 
-            if (canPersistMetadata) {
-                tableInput.withStorageDescriptor(new StorageDescriptor()
-                        .withColumns(glueColumns.get()));
-
-                if (comment != null) {
+            String comment = metadata.properties().get(TABLE_COMMENT);
+            if (comment != null) {
+                if (comment.length() <= GLUE_TABLE_PARAMETER_LENGTH_LIMIT) {
                     parameters.put(TABLE_COMMENT, comment);
+                    parameters.remove(TRINO_TABLE_COMMENT_CACHE_PREVENTED);
                 }
                 else {
                     parameters.remove(TABLE_COMMENT);
+                    parameters.put(TRINO_TABLE_COMMENT_CACHE_PREVENTED, "true");
                 }
-                parameters.put(TRINO_TABLE_METADATA_INFO_VALID_FOR, newMetadataLocation);
             }
+            else {
+                parameters.remove(TABLE_COMMENT);
+                parameters.remove(TRINO_TABLE_COMMENT_CACHE_PREVENTED);
+            }
+            parameters.put(TRINO_TABLE_METADATA_INFO_VALID_FOR, newMetadataLocation);
         }
 
         tableInput.withParameters(parameters);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -141,6 +141,7 @@ import static io.trino.plugin.iceberg.IcebergSchemaProperties.LOCATION_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableName.tableNameWithType;
 import static io.trino.plugin.iceberg.IcebergUtil.COLUMN_TRINO_NOT_NULL_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergUtil.COLUMN_TRINO_TYPE_ID_PROPERTY;
+import static io.trino.plugin.iceberg.IcebergUtil.TRINO_TABLE_COMMENT_CACHE_PREVENTED;
 import static io.trino.plugin.iceberg.IcebergUtil.TRINO_TABLE_METADATA_INFO_VALID_FOR;
 import static io.trino.plugin.iceberg.IcebergUtil.getColumnMetadatas;
 import static io.trino.plugin.iceberg.IcebergUtil.getIcebergTableWithMetadata;
@@ -501,7 +502,8 @@ public class TrinoGlueCatalog
                     else {
                         String metadataLocation = tableParameters.get(METADATA_LOCATION_PROP);
                         String metadataValidForMetadata = tableParameters.get(TRINO_TABLE_METADATA_INFO_VALID_FOR);
-                        if (metadataValidForMetadata != null && metadataValidForMetadata.equals(metadataLocation)) {
+                        boolean tableCommentWasCached = tableParameters.getOrDefault(TRINO_TABLE_COMMENT_CACHE_PREVENTED, "false").equals("false");
+                        if (metadataValidForMetadata != null && metadataValidForMetadata.equals(metadataLocation) && tableCommentWasCached) {
                             Optional<String> comment = Optional.ofNullable(tableParameters.get(TABLE_COMMENT));
                             unfilteredResult.add(RelationCommentMetadata.forRelation(name, comment));
                         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Currently, when `iceberg.glue.cache-table-metadata` is set to true, columns and table comment are either stored together in Glue or none of them is stored.

The goal of this change is to prevent `TrinoGlueCatalog` from not caching table columns in glue when table comment is too long. It seems wrong that a decision to cache columns depends on the length of the table comment.

This commit changes that and makes storing them in Glue independent from each other. 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:
Decouple storing columns definition from storing table comments in glue

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
