### PR TITLE
Cleanup SpoolingOutputStats

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/buffer/SpoolingExchangeOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/SpoolingExchangeOutputBuffer.java
@@ -192,16 +192,17 @@ public class SpoolingExchangeOutputBuffer
         ExchangeSink sink = exchangeSink;
         checkState(sink != null, "exchangeSink is null");
         long dataSizeInBytes = 0;
+        long addedPositions = 0;
         for (Slice page : pages) {
             dataSizeInBytes += getSerializedPageUncompressedSizeInBytes(page);
+            addedPositions += getSerializedPagePositionCount(page);
             sink.add(partition, page);
-            int serializedPagePositionCount = getSerializedPagePositionCount(page);
-            totalRowsAdded.addAndGet(serializedPagePositionCount);
-            outputStats.updateRowCount(serializedPagePositionCount);
         }
-        updateMemoryUsage(sink.getMemoryUsage());
         totalPagesAdded.addAndGet(pages.size());
+        totalRowsAdded.addAndGet(addedPositions);
+        outputStats.updateRowCount(addedPositions);
         outputStats.updatePartitionDataSize(partition, dataSizeInBytes);
+        updateMemoryUsage(sink.getMemoryUsage());
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/SpoolingOutputStats.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/SpoolingOutputStats.java
@@ -34,16 +34,15 @@ import static java.util.Objects.requireNonNull;
 public class SpoolingOutputStats
 {
     private final int partitionCount;
+    private final AtomicLong rowCount = new AtomicLong();
     private volatile AtomicLongArray partitionDataSizes;
     private volatile Snapshot finalSnapshot;
-    private volatile AtomicLong rowCount;
 
     public SpoolingOutputStats(int partitionCount)
     {
         checkArgument(partitionCount > 0, "partitionCount must be greater than zero");
         this.partitionCount = partitionCount;
         partitionDataSizes = new AtomicLongArray(partitionCount);
-        rowCount = new AtomicLong();
     }
 
     public void updatePartitionDataSize(int partition, long dataSizeInBytes)
@@ -56,7 +55,7 @@ public class SpoolingOutputStats
         }
     }
 
-    public void updateRowCount(int rowCount)
+    public void updateRowCount(long rowCount)
     {
         this.rowCount.addAndGet(rowCount);
     }


### PR DESCRIPTION


<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Makes `rowCount` final instead of a volatile `AtomicLong`, and avoids repeated atomic updates inside of `SpoolingExchangeOutputBuffer` in favor of a single final update outside of the loop.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
