### PR TITLE
Unconditionally pushdown varchar predicate to Clickhouse

### DIFF
--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
@@ -17,8 +17,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.plugin.jdbc.BaseJdbcConnectorTest;
-import io.trino.plugin.jdbc.JdbcTableHandle;
-import io.trino.spi.predicate.TupleDomain;
 import io.trino.sql.planner.plan.AggregationNode;
 import io.trino.sql.planner.plan.FilterNode;
 import io.trino.testing.MaterializedResult;
@@ -47,8 +45,6 @@ import static io.trino.plugin.clickhouse.ClickHouseTableProperties.SAMPLE_BY_PRO
 import static io.trino.plugin.clickhouse.TestingClickHouseServer.CLICKHOUSE_LATEST_IMAGE;
 import static io.trino.plugin.jdbc.JdbcMetadataSessionProperties.DOMAIN_COMPACTION_THRESHOLD;
 import static io.trino.spi.type.VarcharType.VARCHAR;
-import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
-import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
 import static io.trino.testing.MaterializedResult.resultBuilder;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
@@ -78,7 +74,6 @@ public class TestClickHouseConnectorTest
                  SUPPORTS_DELETE,
                  SUPPORTS_DROP_NOT_NULL_CONSTRAINT,
                  SUPPORTS_NEGATIVE_DATE,
-                 SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_INEQUALITY,
                  SUPPORTS_ROW_TYPE,
                  SUPPORTS_SET_COLUMN_TYPE,
                  SUPPORTS_UPDATE -> false;
@@ -827,7 +822,7 @@ public class TestClickHouseConnectorTest
         // varchar range
         assertThat(query("SELECT regionkey, nationkey, name FROM nation WHERE name BETWEEN 'POLAND' AND 'RPA'"))
                 .matches("VALUES (BIGINT '3', BIGINT '19', CAST('ROMANIA' AS varchar))")
-                .isNotFullyPushedDown(FilterNode.class);
+                .isFullyPushedDown();
 
         // varchar IN without domain compaction
         assertThat(query("SELECT regionkey, nationkey, name FROM nation WHERE name IN ('POLAND', 'ROMANIA', 'VIETNAM')"))
@@ -845,17 +840,10 @@ public class TestClickHouseConnectorTest
                 .matches("VALUES " +
                         "(BIGINT '3', BIGINT '19', CAST('ROMANIA' AS varchar)), " +
                         "(BIGINT '2', BIGINT '21', CAST('VIETNAM' AS varchar))")
-                // Filter node is retained as no constraint is pushed into connector.
+                // Filter node is retained as constraint is pushed into connector is simplified, and
                 // The compacted domain is a range predicate which can give wrong results
-                // if pushed down as ClickHouse has different sort ordering for letters from Trino
-                .isNotFullyPushedDown(
-                        node(
-                                FilterNode.class,
-                                // verify that no constraint is applied by the connector
-                                tableScan(
-                                        tableHandle -> ((JdbcTableHandle) tableHandle).getConstraint().isAll(),
-                                        TupleDomain.all(),
-                                        ImmutableMap.of())));
+                // so has to be filtered by trino too to ensure correct predicate.
+                .isNotFullyPushedDown(FilterNode.class);
 
         // varchar different case
         assertThat(query("SELECT regionkey, nationkey, name FROM nation WHERE name = 'romania'"))


### PR DESCRIPTION
ClickHouse collation is case-sensitive.
ClickHouse has same sort ordering as Trino.

Per https://clickhouse.com/docs/en/sql-reference/statements/show#show_columns
ClickHouse has no per-column collations
Clickhouse is UTF-8 encoded with byte-by-byte comparison.
https://clickhouse.com/docs/en/sql-reference/statements/select/order-by#collation-support
So exactly as trino.
https://github.com/airlift/slice/blob/2.2/src/main/java/io/airlift/slice/Slice.java#L1205
That’s why all operations on varchars may pushdown.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Addresses
- https://github.com/trinodb/trino/pull/22921#discussion_r1764535634

Extracted from
- https://github.com/trinodb/trino/pull/23460

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Pushdown varchar predicate to ClickHouse unconditionally. ({issue}`23516`)
```
