### PR TITLE
Fix for SystemTables in allowSplittingReadIntoMultipleSubQueries

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -4058,8 +4058,8 @@ public class DeltaLakeMetadata
     @Override
     public boolean allowSplittingReadIntoMultipleSubQueries(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        // delta lake supports only a columnar (parquet) storage format
-        return true;
+        // dont split to subqueries if tableHandle is systemTableHandle, delta lake supports only a columnar (parquet) storage format
+        return tableHandle instanceof DeltaLakeTableHandle;
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -3984,7 +3984,12 @@ public class HiveMetadata
     @Override
     public boolean allowSplittingReadIntoMultipleSubQueries(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        SchemaTableName tableName = ((HiveTableHandle) tableHandle).getSchemaTableName();
+        // dont split to subqueries if tableHandle is systemTableHandle
+        if (!(tableHandle instanceof HiveTableHandle hiveTableHandle)) {
+            return false;
+        }
+
+        SchemaTableName tableName = hiveTableHandle.getSchemaTableName();
 
         Table table = metastore.getTable(tableName.getSchemaName(), tableName.getTableName())
                 .orElseThrow(() -> new TableNotFoundException(tableName));

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveDistributedAggregations.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveDistributedAggregations.java
@@ -15,6 +15,10 @@ package io.trino.plugin.hive;
 
 import io.trino.testing.AbstractTestAggregations;
 import io.trino.testing.QueryRunner;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.testing.TestingNames.randomNameSuffix;
 
 public class TestHiveDistributedAggregations
         extends AbstractTestAggregations
@@ -26,5 +30,21 @@ public class TestHiveDistributedAggregations
         return HiveQueryRunner.builder()
                 .setInitialTables(REQUIRED_TPCH_TABLES)
                 .build();
+    }
+
+    @Test
+    public void testDistinctAggregationWithSystemTable()
+    {
+        String tableName = "test_dist_aggr_" + randomNameSuffix();
+        @Language("SQL") String createTable = """
+                CREATE TABLE %s
+                WITH (
+                partitioned_by = ARRAY[ 'regionkey', 'nationkey' ]
+                ) AS (SELECT name, comment, regionkey, nationkey FROM nation)
+                """.formatted(tableName);
+
+        assertUpdate(getSession(), createTable, 25);
+
+        assertQuerySucceeds("SELECT count(distinct regionkey), count(distinct nationkey) FROM \"%s$partitions\"".formatted(tableName));
     }
 }

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiMetadata.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiMetadata.java
@@ -290,8 +290,8 @@ public class HudiMetadata
     @Override
     public boolean allowSplittingReadIntoMultipleSubQueries(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        // hudi supports only a columnar (parquet) storage format
-        return true;
+        // dont split to subqueries if tableHandle is systemTableHandle, hudi supports only a columnar (parquet) storage format
+        return tableHandle instanceof HudiTableHandle;
     }
 
     HiveMetastore getMetastore()

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -3312,8 +3312,11 @@ public class IcebergMetadata
     @Override
     public boolean allowSplittingReadIntoMultipleSubQueries(ConnectorSession session, ConnectorTableHandle connectorTableHandle)
     {
-        IcebergTableHandle tableHandle = (IcebergTableHandle) connectorTableHandle;
-        IcebergFileFormat storageFormat = getFileFormat(tableHandle.getStorageProperties());
+        // dont split to subqueries if tableHandle is systemTableHandle
+        if (!(connectorTableHandle instanceof IcebergTableHandle icebergTableHandle)) {
+            return false;
+        }
+        IcebergFileFormat storageFormat = getFileFormat(icebergTableHandle.getStorageProperties());
 
         return storageFormat == IcebergFileFormat.ORC || storageFormat == IcebergFileFormat.PARQUET;
     }

--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryMetadata.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryMetadata.java
@@ -640,7 +640,8 @@ public class MemoryMetadata
     @Override
     public boolean allowSplittingReadIntoMultipleSubQueries(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        return true;
+        // dont split to subqueries if tableHandle is systemTableHandle
+        return tableHandle instanceof MemoryTableHandle;
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Fix for cannot cast `SystemTableHandle` to `ConnectorTableHandle` in allowSplittingReadIntoMultipleSubQueries.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(X) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

