### PR TITLE
Add support for WASB to native Azure file system implementation

### DIFF
--- a/lib/trino-filesystem-azure/pom.xml
+++ b/lib/trino-filesystem-azure/pom.xml
@@ -154,6 +154,12 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>junit-extensions</artifactId>
             <scope>test</scope>
         </dependency>

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureLocation.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureLocation.java
@@ -28,6 +28,7 @@ class TestAzureLocation
     {
         assertValid("abfs://container@account.dfs.core.windows.net/some/path/file", "account", "container", "some/path/file", "abfs", "core.windows.net");
         assertValid("abfss://container@account.dfs.core.windows.net/some/path/file", "account", "container", "some/path/file", "abfss", "core.windows.net");
+        assertValid("wasb://container@account.blob.core.windows.net/some/path/file", "account", "container", "some/path/file", "wasb", "core.windows.net");
 
         assertValid("abfs://container-stuff@account.dfs.core.windows.net/some/path/file", "account", "container-stuff", "some/path/file", "abfs", "core.windows.net");
         assertValid("abfs://container2@account.dfs.core.windows.net/some/path/file", "account", "container2", "some/path/file", "abfs", "core.windows.net");
@@ -39,8 +40,17 @@ class TestAzureLocation
         // other endpoints are allowed
         assertValid("abfs://container@account.dfs.core.usgovcloudapi.net/some/path/file", "account", "container", "some/path/file", "abfs", "core.usgovcloudapi.net");
         assertValid("abfss://container@account.dfs.core.usgovcloudapi.net/some/path/file", "account", "container", "some/path/file", "abfss", "core.usgovcloudapi.net");
+        assertValid("wasb://container@account.blob.core.usgovcloudapi.net/some/path/file", "account", "container", "some/path/file", "wasb", "core.usgovcloudapi.net");
 
-        // only abfs and abfss schemes allowed
+        // abfs[s] host must contain ".dfs.", and wasb host must contain ".blob." before endpoint
+        assertInvalid("abfs://container@account.invalid.core.usgovcloudapi.net/some/path/file");
+        assertInvalid("abfss://container@account.invalid.core.usgovcloudapi.net/some/path/file");
+        assertInvalid("wasb://container@account.invalid.core.usgovcloudapi.net/some/path/file");
+        assertInvalid("abfs://container@account.blob.core.usgovcloudapi.net/some/path/file");
+        assertInvalid("abfss://container@account.blob.core.usgovcloudapi.net/some/path/file");
+        assertInvalid("wasb://container@account.dfs.core.usgovcloudapi.net/some/path/file");
+
+        // only abfs, abfss, and wasb schemes allowed
         assertInvalid("https://container@account.dfs.core.windows.net/some/path/file");
 
         // host must have at least to labels

--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemModule.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemModule.java
@@ -93,6 +93,7 @@ public class FileSystemModule
             install(new AzureFileSystemModule());
             factories.addBinding("abfs").to(AzureFileSystemFactory.class);
             factories.addBinding("abfss").to(AzureFileSystemFactory.class);
+            factories.addBinding("wasb").to(AzureFileSystemFactory.class);
         }
 
         if (config.isNativeS3Enabled()) {


### PR DESCRIPTION
## Description
Add support for WASB to native Azure file system implementation.  WASB urls can be supported by simply modifying the Azure location parsing code as the underlying Azure storage APIs are set by the storage account type.  The main difference to a ABFS url is the scheme is `wasb` and the `blob` endpoint is referenced instead of `dfs`.

Fixes #23511

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Add support for WASB to native Azure file system implementation. ({issue}`23511`)
```
