### PR TITLE
Fix wrong issue number in 453 release note

### DIFF
--- a/docs/src/main/sphinx/release/release-453.md
+++ b/docs/src/main/sphinx/release/release-453.md
@@ -71,7 +71,7 @@
   configuration property. ({issue}`15267`)
 * Fix failure to read Hive tables migrated to Iceberg with Apache Spark. ({issue}`11338`)
 * Fix failure for `CREATE FUNCTION` with SQL routine storage in Glue when
-  `hive.metastore.glue.catalogid` is set. ({issue}`22813`)
+  `hive.metastore.glue.catalogid` is set. ({issue}`22717`)
 
 ## Hudi connector
 


### PR DESCRIPTION
## Description

The issue link should be https://github.com/trinodb/trino/pull/22717

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
