### PR TITLE
Alter allowSplittingReadIntoMultipleSubQueries check for systemTables

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -2803,6 +2803,9 @@ public final class MetadataManager
     public boolean allowSplittingReadIntoMultipleSubQueries(Session session, TableHandle tableHandle)
     {
         CatalogHandle catalogHandle = tableHandle.catalogHandle();
+        if (catalogHandle.getType().isInternal()) {
+            return false;
+        }
         CatalogMetadata catalogMetadata = getCatalogMetadata(session, catalogHandle);
         ConnectorSession connectorSession = session.toConnectorSession(catalogHandle);
         return catalogMetadata.getMetadata(session).allowSplittingReadIntoMultipleSubQueries(connectorSession, tableHandle.connectorHandle());

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -4061,8 +4061,8 @@ public class DeltaLakeMetadata
     @Override
     public boolean allowSplittingReadIntoMultipleSubQueries(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        // dont split to subqueries if tableHandle is systemTableHandle, delta lake supports only a columnar (parquet) storage format
-        return tableHandle instanceof DeltaLakeTableHandle;
+        // delta lake supports only a columnar (parquet) storage format
+        return true;
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -3990,12 +3990,7 @@ public class HiveMetadata
     @Override
     public boolean allowSplittingReadIntoMultipleSubQueries(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        // dont split to subqueries if tableHandle is systemTableHandle
-        if (!(tableHandle instanceof HiveTableHandle hiveTableHandle)) {
-            return false;
-        }
-
-        SchemaTableName tableName = hiveTableHandle.getSchemaTableName();
+        SchemaTableName tableName = ((HiveTableHandle) tableHandle).getSchemaTableName();
 
         Table table = metastore.getTable(tableName.getSchemaName(), tableName.getTableName())
                 .orElseThrow(() -> new TableNotFoundException(tableName));

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiMetadata.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiMetadata.java
@@ -290,8 +290,8 @@ public class HudiMetadata
     @Override
     public boolean allowSplittingReadIntoMultipleSubQueries(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        // dont split to subqueries if tableHandle is systemTableHandle, hudi supports only a columnar (parquet) storage format
-        return tableHandle instanceof HudiTableHandle;
+        // hudi supports only a columnar (parquet) storage format
+        return true;
     }
 
     HiveMetastore getMetastore()

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -3314,11 +3314,8 @@ public class IcebergMetadata
     @Override
     public boolean allowSplittingReadIntoMultipleSubQueries(ConnectorSession session, ConnectorTableHandle connectorTableHandle)
     {
-        // dont split to subqueries if tableHandle is systemTableHandle
-        if (!(connectorTableHandle instanceof IcebergTableHandle icebergTableHandle)) {
-            return false;
-        }
-        IcebergFileFormat storageFormat = getFileFormat(icebergTableHandle.getStorageProperties());
+        IcebergTableHandle tableHandle = (IcebergTableHandle) connectorTableHandle;
+        IcebergFileFormat storageFormat = getFileFormat(tableHandle.getStorageProperties());
 
         return storageFormat == IcebergFileFormat.ORC || storageFormat == IcebergFileFormat.PARQUET;
     }

--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryMetadata.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryMetadata.java
@@ -640,8 +640,7 @@ public class MemoryMetadata
     @Override
     public boolean allowSplittingReadIntoMultipleSubQueries(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        // dont split to subqueries if tableHandle is systemTableHandle
-        return tableHandle instanceof MemoryTableHandle;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

 It moves check from Metadata to MetadataManager as it could potentially cause problem for other connectors with DistinctAggregationStrategyChooser when accessing SystemTables.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

