### PR TITLE
Clarify where to set legacy Hive properties for S3

### DIFF
--- a/docs/src/main/sphinx/object-storage/legacy-s3.md
+++ b/docs/src/main/sphinx/object-storage/legacy-s3.md
@@ -139,7 +139,8 @@ If you are running Trino on Amazon EKS, and authenticate using a Kubernetes
 service account, you can set the
 `trino.s3.use-web-identity-token-credentials-provider` to `true`, so Trino does
 not try using different credential providers from the default credential
-provider chain.
+provider chain. The property must be set in the Hadoop configuration files
+referenced by the `hive.config.resources` Hive connector property.
 
 ## Custom S3 credentials provider
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The `trino.s3.use-web-identity-token-credentials-provider` property must be set in the Hadoop config file, not as the connector property. This needs to be clarified in the docs.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Follow-up for #22162

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
