### PR TITLE
Improve input validation for approx_percentile

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/ApproximateDoublePercentileAggregations.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/ApproximateDoublePercentileAggregations.java
@@ -25,6 +25,7 @@ import io.trino.spi.function.SqlType;
 import io.trino.spi.type.StandardTypes;
 
 import static com.google.common.base.Preconditions.checkState;
+import static io.trino.operator.scalar.TDigestFunctions.verifyValue;
 import static io.trino.operator.scalar.TDigestFunctions.verifyWeight;
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.trino.spi.type.DoubleType.DOUBLE;
@@ -38,6 +39,7 @@ public final class ApproximateDoublePercentileAggregations
     @InputFunction
     public static void input(@AggregationState TDigestAndPercentileState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.DOUBLE) double percentile)
     {
+        verifyValue(value);
         TDigest digest = state.getDigest();
 
         if (digest == null) {
@@ -57,6 +59,7 @@ public final class ApproximateDoublePercentileAggregations
     @InputFunction
     public static void weightedInput(@AggregationState TDigestAndPercentileState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.DOUBLE) double weight, @SqlType(StandardTypes.DOUBLE) double percentile)
     {
+        verifyValue(value);
         verifyWeight(weight);
 
         TDigest digest = state.getDigest();

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/ApproximateDoublePercentileArrayAggregations.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/ApproximateDoublePercentileArrayAggregations.java
@@ -30,6 +30,7 @@ import io.trino.spi.type.StandardTypes;
 
 import java.util.List;
 
+import static io.trino.operator.scalar.TDigestFunctions.verifyValue;
 import static io.trino.operator.scalar.TDigestFunctions.verifyWeight;
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.trino.spi.type.DoubleType.DOUBLE;
@@ -43,6 +44,8 @@ public final class ApproximateDoublePercentileArrayAggregations
     @InputFunction
     public static void input(@AggregationState TDigestAndPercentileArrayState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType("array(double)") Block percentilesArrayBlock)
     {
+        verifyValue(value);
+
         initializePercentilesArray(state, percentilesArrayBlock);
         initializeDigest(state);
 
@@ -55,6 +58,7 @@ public final class ApproximateDoublePercentileArrayAggregations
     @InputFunction
     public static void weightedInput(@AggregationState TDigestAndPercentileArrayState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.DOUBLE) double weight, @SqlType("array(double)") Block percentilesArrayBlock)
     {
+        verifyValue(value);
         verifyWeight(weight);
 
         initializePercentilesArray(state, percentilesArrayBlock);

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/ApproximateLongPercentileAggregations.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/ApproximateLongPercentileAggregations.java
@@ -70,7 +70,7 @@ public final class ApproximateLongPercentileAggregations
     public static double toDoubleExact(long value)
     {
         double doubleValue = (double) value;
-        checkCondition((long) doubleValue == value, INVALID_FUNCTION_ARGUMENT, "no exact double representation for long: %s", value);
+        checkCondition((long) doubleValue == value, INVALID_FUNCTION_ARGUMENT, () -> String.format("no exact double representation for long: %s", value));
         return doubleValue;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/LegacyApproximateLongPercentileAggregations.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/LegacyApproximateLongPercentileAggregations.java
@@ -15,6 +15,7 @@ package io.trino.operator.aggregation;
 
 import io.airlift.stats.QuantileDigest;
 import io.trino.operator.aggregation.state.QuantileDigestAndPercentileState;
+import io.trino.spi.TrinoException;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.function.AggregationFunction;
 import io.trino.spi.function.AggregationState;
@@ -50,7 +51,7 @@ public final class LegacyApproximateLongPercentileAggregations
                 digest = new QuantileDigest(accuracy);
             }
             else {
-                throw new IllegalArgumentException("Percentile accuracy must be strictly between 0 and 1");
+                throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "Percentile accuracy must be strictly between 0 and 1");
             }
             state.setDigest(digest);
             state.addMemoryUsage(digest.estimatedInMemorySizeInBytes());

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayCombinationsFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayCombinationsFunction.java
@@ -56,8 +56,8 @@ public final class ArrayCombinationsFunction
     {
         int arrayLength = array.getPositionCount();
         int combinationLength = toIntExact(n);
-        checkCondition(combinationLength >= 0, INVALID_FUNCTION_ARGUMENT, "combination size must not be negative: %s", combinationLength);
-        checkCondition(combinationLength <= MAX_COMBINATION_LENGTH, INVALID_FUNCTION_ARGUMENT, "combination size must not exceed %s: %s", MAX_COMBINATION_LENGTH, combinationLength);
+        checkCondition(combinationLength >= 0, INVALID_FUNCTION_ARGUMENT, () -> String.format("combination size must not be negative: %s", combinationLength));
+        checkCondition(combinationLength <= MAX_COMBINATION_LENGTH, INVALID_FUNCTION_ARGUMENT, () -> String.format("combination size must not exceed %s: %s", MAX_COMBINATION_LENGTH, combinationLength));
 
         ArrayType arrayType = new ArrayType(elementType);
         if (combinationLength > arrayLength) {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayTrimFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayTrimFunction.java
@@ -38,8 +38,8 @@ public final class ArrayTrimFunction
             @SqlType("array(E)") Block array,
             @SqlType(StandardTypes.BIGINT) long size)
     {
-        checkCondition(size >= 0, INVALID_FUNCTION_ARGUMENT, "size must not be negative: %s", size);
-        checkCondition(size <= array.getPositionCount(), INVALID_FUNCTION_ARGUMENT, "size must not exceed array cardinality %s: %s", array.getPositionCount(), size);
+        checkCondition(size >= 0, INVALID_FUNCTION_ARGUMENT, () -> String.format("size must not be negative: %s", size));
+        checkCondition(size <= array.getPositionCount(), INVALID_FUNCTION_ARGUMENT, () -> String.format("size must not exceed array cardinality %s: %s", array.getPositionCount(), size));
 
         return array.getRegion(0, toIntExact(array.getPositionCount() - size));
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/QuantileDigestFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/QuantileDigestFunctions.java
@@ -141,13 +141,13 @@ public final class QuantileDigestFunctions
 
     public static double verifyAccuracy(double accuracy)
     {
-        checkCondition(accuracy > 0 && accuracy < 1, INVALID_FUNCTION_ARGUMENT, "Percentile accuracy must be exclusively between 0 and 1, was %s", accuracy);
+        checkCondition(accuracy > 0 && accuracy < 1, INVALID_FUNCTION_ARGUMENT, () -> String.format("Percentile accuracy must be exclusively between 0 and 1, was %s", accuracy));
         return accuracy;
     }
 
     public static long verifyWeight(long weight)
     {
-        checkCondition(weight > 0, INVALID_FUNCTION_ARGUMENT, "Percentile weight must be > 0, was %s", weight);
+        checkCondition(weight > 0, INVALID_FUNCTION_ARGUMENT, () -> String.format("Percentile weight must be > 0, was %s", weight));
         return weight;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/TDigestFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/TDigestFunctions.java
@@ -61,7 +61,7 @@ public final class TDigestFunctions
 
     public static double verifyWeight(double weight)
     {
-        checkCondition(weight >= 1, INVALID_FUNCTION_ARGUMENT, "weight must be >= 1, was %s", weight);
+        checkCondition(weight >= 1, INVALID_FUNCTION_ARGUMENT, () -> String.format("weight must be >= 1, was %s", weight));
         return weight;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/TDigestFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/TDigestFunctions.java
@@ -59,8 +59,14 @@ public final class TDigestFunctions
         return output.build();
     }
 
+    public static void verifyValue(double value)
+    {
+        checkCondition(Double.isFinite(value), INVALID_FUNCTION_ARGUMENT, () -> String.format("value must be finite; was %s", value));
+    }
+
     public static double verifyWeight(double weight)
     {
+        checkCondition(Double.isFinite(weight), INVALID_FUNCTION_ARGUMENT, () -> String.format("weight must be finite, was %s", weight));
         checkCondition(weight >= 1, INVALID_FUNCTION_ARGUMENT, () -> String.format("weight must be >= 1, was %s", weight));
         return weight;
     }

--- a/core/trino-main/src/main/java/io/trino/type/DecimalCasts.java
+++ b/core/trino-main/src/main/java/io/trino/type/DecimalCasts.java
@@ -573,7 +573,7 @@ public final class DecimalCasts
         try (JsonParser parser = createJsonParser(JSON_FACTORY, json)) {
             parser.nextToken();
             Int128 result = currentTokenAsLongDecimal(parser, intPrecision(precision), DecimalConversions.intScale(scale));
-            checkCondition(parser.nextToken() == null, INVALID_CAST_ARGUMENT, "Cannot cast input json to DECIMAL(%s,%s)", precision, scale); // check no trailing token
+            checkCondition(parser.nextToken() == null, INVALID_CAST_ARGUMENT, () -> String.format("Cannot cast input json to DECIMAL(%s,%s)", precision, scale)); // check no trailing token
             return result;
         }
         catch (IOException | NumberFormatException | JsonCastException e) {
@@ -587,7 +587,7 @@ public final class DecimalCasts
         try (JsonParser parser = createJsonParser(JSON_FACTORY, json)) {
             parser.nextToken();
             Long result = currentTokenAsShortDecimal(parser, intPrecision(precision), DecimalConversions.intScale(scale));
-            checkCondition(parser.nextToken() == null, INVALID_CAST_ARGUMENT, "Cannot cast input json to DECIMAL(%s,%s)", precision, scale); // check no trailing token
+            checkCondition(parser.nextToken() == null, INVALID_CAST_ARGUMENT, () -> String.format("Cannot cast input json to DECIMAL(%s,%s)", precision, scale)); // check no trailing token
             return result;
         }
         catch (IOException | NumberFormatException | JsonCastException e) {

--- a/core/trino-main/src/main/java/io/trino/util/Failures.java
+++ b/core/trino-main/src/main/java/io/trino/util/Failures.java
@@ -13,6 +13,7 @@
  */
 package io.trino.util;
 
+import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.FormatMethod;
 import io.trino.client.ErrorLocation;
@@ -61,8 +62,13 @@ public final class Failures
     @FormatMethod
     public static void checkCondition(boolean condition, ErrorCodeSupplier errorCode, String formatString, Object... args)
     {
+        checkCondition(condition, errorCode, () -> format(formatString, args));
+    }
+
+    public static void checkCondition(boolean condition, ErrorCodeSupplier errorCode, Supplier<String> errorMessage)
+    {
         if (!condition) {
-            throw new TrinoException(errorCode, format(formatString, args));
+            throw new TrinoException(errorCode, errorMessage.get());
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/AggregationTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/AggregationTestUtils.java
@@ -24,6 +24,7 @@ import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.type.BooleanType;
 import io.trino.spi.type.Type;
 import io.trino.sql.analyzer.TypeSignatureProvider;
+import io.trino.testing.assertions.TrinoExceptionAssert;
 import org.apache.commons.math3.util.Precision;
 
 import java.util.Arrays;
@@ -38,6 +39,7 @@ import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.sql.planner.plan.AggregationNode.Step.FINAL;
 import static io.trino.sql.planner.plan.AggregationNode.Step.PARTIAL;
 import static io.trino.sql.planner.plan.AggregationNode.Step.SINGLE;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
@@ -56,6 +58,11 @@ public final class AggregationTestUtils
         BiFunction<Object, Object, Boolean> equalAssertion = makeValidityAssertion(expectedValue);
 
         assertAggregation(functionResolution, name, parameterTypes, equalAssertion, null, page, expectedValue);
+    }
+
+    public static TrinoExceptionAssert assertAggregationFails(TestingFunctionResolution functionResolution, String name, List<TypeSignatureProvider> parameterTypes, Block... blocks)
+    {
+        return assertTrinoExceptionThrownBy(() -> assertAggregation(functionResolution, name, parameterTypes, null, blocks));
     }
 
     public static BiFunction<Object, Object, Boolean> makeValidityAssertion(Object expectedValue)


### PR DESCRIPTION
Ensure that approx_percentile performs explicit input validation and throw TrinoException with proper error code.

Relates to https://github.com/trinodb/trino/issues/11156

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Improve error reporting on input validation for `approx_percentile` function ({issue}`23546`)
```
