### PR TITLE
Add support for WASBS to native Azure file system implementation

### DIFF
--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureLocation.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureLocation.java
@@ -23,8 +23,8 @@ import static java.util.Objects.requireNonNull;
 
 class AzureLocation
 {
-    private static final String INVALID_ABFS_LOCATION_MESSAGE = "Invalid Azure ABFS location. Expected form is 'abfs://[<containerName>@]<accountName>.dfs.<endpoint>/<filePath>': %s";
-    private static final String INVALID_WASB_LOCATION_MESSAGE = "Invalid Azure WASB location. Expected form is 'wasb://[<containerName>@]<accountName>.blob.<endpoint>/<filePath>': %s";
+    private static final String INVALID_ABFS_LOCATION_MESSAGE = "Invalid Azure ABFS location. Expected form is 'abfs[s]://[<containerName>@]<accountName>.dfs.<endpoint>/<filePath>': %s";
+    private static final String INVALID_WASB_LOCATION_MESSAGE = "Invalid Azure WASB location. Expected form is 'wasb[s]://[<containerName>@]<accountName>.blob.<endpoint>/<filePath>': %s";
 
     // https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
     private static final CharMatcher CONTAINER_VALID_CHARACTERS = CharMatcher.inRange('a', 'z').or(CharMatcher.inRange('0', '9')).or(CharMatcher.is('-'));
@@ -40,18 +40,18 @@ class AzureLocation
      * <p>
      * Locations use the
      * <a href="https://docs.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction-abfs-uri">ABFS URI</a> syntax:
-     * <pre>{@code abfs://<container-name>@<storage-account-name>.dfs.<endpoint>/<blob_path>}</pre>
+     * <pre>{@code abfs[s]://<container-name>@<storage-account-name>.dfs.<endpoint>/<blob_path>}</pre>
      */
     public AzureLocation(Location location)
     {
         this.location = requireNonNull(location, "location is null");
-        // abfss and wasb are also supported but not documented
+        // wasb and wasbs are also supported but not documented
         scheme = location.scheme().orElseThrow(() -> new IllegalArgumentException(String.format(INVALID_ABFS_LOCATION_MESSAGE, location)));
         String invalidLocationMessage;
         if ("abfs".equals(scheme) || "abfss".equals(scheme)) {
             invalidLocationMessage = INVALID_ABFS_LOCATION_MESSAGE;
         }
-        else if ("wasb".equals(scheme)) {
+        else if ("wasb".equals(scheme) || "wasbs".equals(scheme)) {
             invalidLocationMessage = INVALID_WASB_LOCATION_MESSAGE;
         }
         else {
@@ -86,7 +86,7 @@ class AzureLocation
                 this.location);
         this.account = host.substring(0, accountSplit);
 
-        // abfs[s] host must contain ".dfs.", and wasb host must contain ".blob." before endpoint
+        // abfs[s] host must contain ".dfs.", and wasb[s] host must contain ".blob." before endpoint
         if (scheme.equals("abfs") || scheme.equals("abfss")) {
             checkArgument(host.substring(accountSplit).startsWith(".dfs."), invalidLocationMessage, location);
             // endpoint does not include dfs

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureLocation.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureLocation.java
@@ -29,6 +29,7 @@ class TestAzureLocation
         assertValid("abfs://container@account.dfs.core.windows.net/some/path/file", "account", "container", "some/path/file", "abfs", "core.windows.net");
         assertValid("abfss://container@account.dfs.core.windows.net/some/path/file", "account", "container", "some/path/file", "abfss", "core.windows.net");
         assertValid("wasb://container@account.blob.core.windows.net/some/path/file", "account", "container", "some/path/file", "wasb", "core.windows.net");
+        assertValid("wasbs://container@account.blob.core.windows.net/some/path/file", "account", "container", "some/path/file", "wasbs", "core.windows.net");
 
         assertValid("abfs://container-stuff@account.dfs.core.windows.net/some/path/file", "account", "container-stuff", "some/path/file", "abfs", "core.windows.net");
         assertValid("abfs://container2@account.dfs.core.windows.net/some/path/file", "account", "container2", "some/path/file", "abfs", "core.windows.net");
@@ -41,16 +42,18 @@ class TestAzureLocation
         assertValid("abfs://container@account.dfs.core.usgovcloudapi.net/some/path/file", "account", "container", "some/path/file", "abfs", "core.usgovcloudapi.net");
         assertValid("abfss://container@account.dfs.core.usgovcloudapi.net/some/path/file", "account", "container", "some/path/file", "abfss", "core.usgovcloudapi.net");
         assertValid("wasb://container@account.blob.core.usgovcloudapi.net/some/path/file", "account", "container", "some/path/file", "wasb", "core.usgovcloudapi.net");
+        assertValid("wasbs://container@account.blob.core.usgovcloudapi.net/some/path/file", "account", "container", "some/path/file", "wasbs", "core.usgovcloudapi.net");
 
-        // abfs[s] host must contain ".dfs.", and wasb host must contain ".blob." before endpoint
+        // abfs[s] host must contain ".dfs.", and wasb[s] host must contain ".blob." before endpoint
         assertInvalid("abfs://container@account.invalid.core.usgovcloudapi.net/some/path/file");
         assertInvalid("abfss://container@account.invalid.core.usgovcloudapi.net/some/path/file");
         assertInvalid("wasb://container@account.invalid.core.usgovcloudapi.net/some/path/file");
         assertInvalid("abfs://container@account.blob.core.usgovcloudapi.net/some/path/file");
         assertInvalid("abfss://container@account.blob.core.usgovcloudapi.net/some/path/file");
         assertInvalid("wasb://container@account.dfs.core.usgovcloudapi.net/some/path/file");
+        assertInvalid("wasbs://container@account.dfs.core.usgovcloudapi.net/some/path/file");
 
-        // only abfs, abfss, and wasb schemes allowed
+        // only abfs, abfss, wasb, wasbs schemes allowed
         assertInvalid("https://container@account.dfs.core.windows.net/some/path/file");
 
         // host must have at least to labels

--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemModule.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemModule.java
@@ -94,6 +94,7 @@ public class FileSystemModule
             factories.addBinding("abfs").to(AzureFileSystemFactory.class);
             factories.addBinding("abfss").to(AzureFileSystemFactory.class);
             factories.addBinding("wasb").to(AzureFileSystemFactory.class);
+            factories.addBinding("wasbs").to(AzureFileSystemFactory.class);
         }
 
         if (config.isNativeS3Enabled()) {


### PR DESCRIPTION
## Description
As a follow up to https://github.com/trinodb/trino/pull/23535, this PR adds the `wasbs` scheme as an alias for the Azure native file system implementation as recommended [here](https://github.com/trinodb/trino/pull/23535#pullrequestreview-2323115868).


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
The `s` in `wasbs` implies that TLS will be used, similar to abfss or https.  The code will function the same if a path uses `wasb` or `wasbs` since it will still leverage the Azure Data Lake Storage Gen2 REST APIs

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
