### PR TITLE
Simplify schema field in HiveSplit for ORC, Parquet and RCFile tables

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
@@ -115,11 +115,11 @@ import static io.trino.plugin.hive.util.AcidTables.readAcidVersionFile;
 import static io.trino.plugin.hive.util.HiveBucketing.getBucketingVersion;
 import static io.trino.plugin.hive.util.HiveTypeUtil.typeSupported;
 import static io.trino.plugin.hive.util.HiveUtil.checkCondition;
-import static io.trino.plugin.hive.util.HiveUtil.getDeserializerClassName;
 import static io.trino.plugin.hive.util.HiveUtil.getFooterCount;
 import static io.trino.plugin.hive.util.HiveUtil.getHeaderCount;
 import static io.trino.plugin.hive.util.HiveUtil.getInputFormatName;
 import static io.trino.plugin.hive.util.HiveUtil.getPartitionKeyColumnHandles;
+import static io.trino.plugin.hive.util.HiveUtil.getSerializationLibraryName;
 import static io.trino.plugin.hive.util.PartitionMatchSupplier.createPartitionMatchSupplier;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.lang.Integer.parseInt;
@@ -414,7 +414,7 @@ public class BackgroundHiveSplitLoader
             if (tableBucketInfo.isPresent()) {
                 throw new TrinoException(NOT_SUPPORTED, "Bucketed table in SymlinkTextInputFormat is not yet supported");
             }
-            HiveStorageFormat targetStorageFormat = getSymlinkStorageFormat(getDeserializerClassName(schema));
+            HiveStorageFormat targetStorageFormat = getSymlinkStorageFormat(getSerializationLibraryName(schema));
             ListMultimap<Location, Location> targets = getTargetLocationsByParentFromSymlink(location);
 
             InternalHiveSplitFactory splitFactory = new InternalHiveSplitFactory(

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceFactory.java
@@ -19,7 +19,6 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.predicate.TupleDomain;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
@@ -32,7 +31,7 @@ public interface HivePageSourceFactory
             long length,
             long estimatedFileSize,
             long fileModifiedTime,
-            Map<String, String> schema,
+            Schema schema,
             List<HiveColumnHandle> columns,
             TupleDomain<HiveColumnHandle> effectivePredicate,
             Optional<AcidInfo> acidInfo,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplit.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplit.java
@@ -34,7 +34,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static io.trino.plugin.hive.util.HiveUtil.getDeserializerClassName;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
@@ -49,7 +48,7 @@ public class HiveSplit
     private final long length;
     private final long estimatedFileSize;
     private final long fileModifiedTime;
-    private final Map<String, String> schema;
+    private final Schema schema;
     private final List<HivePartitionKey> partitionKeys;
     private final List<HostAddress> addresses;
     private final String partitionName;
@@ -70,7 +69,7 @@ public class HiveSplit
             @JsonProperty("length") long length,
             @JsonProperty("estimatedFileSize") long estimatedFileSize,
             @JsonProperty("fileModifiedTime") long fileModifiedTime,
-            @JsonProperty("schema") Map<String, String> schema,
+            @JsonProperty("schema") Schema schema,
             @JsonProperty("partitionKeys") List<HivePartitionKey> partitionKeys,
             @JsonProperty("readBucketNumber") OptionalInt readBucketNumber,
             @JsonProperty("tableBucketNumber") OptionalInt tableBucketNumber,
@@ -108,7 +107,7 @@ public class HiveSplit
             long length,
             long estimatedFileSize,
             long fileModifiedTime,
-            Map<String, String> schema,
+            Schema schema,
             List<HivePartitionKey> partitionKeys,
             List<HostAddress> addresses,
             OptionalInt readBucketNumber,
@@ -191,7 +190,7 @@ public class HiveSplit
     }
 
     @JsonProperty
-    public Map<String, String> getSchema()
+    public Schema getSchema()
     {
         return schema;
     }
@@ -270,7 +269,7 @@ public class HiveSplit
     {
         return INSTANCE_SIZE
                 + estimatedSizeOf(path)
-                + estimatedSizeOf(schema, key -> estimatedSizeOf((String) key), value -> estimatedSizeOf((String) value))
+                + schema.getRetainedSizeInBytes()
                 + estimatedSizeOf(partitionKeys, HivePartitionKey::estimatedSizeInBytes)
                 + estimatedSizeOf(addresses, HostAddress::getRetainedSizeInBytes)
                 + estimatedSizeOf(partitionName)
@@ -294,7 +293,7 @@ public class HiveSplit
                 .put("hosts", addresses.stream().map(HostAddress::toString).collect(joining(",")))
                 .put("forceLocalScheduling", String.valueOf(forceLocalScheduling))
                 .put("partitionName", partitionName)
-                .put("deserializerClassName", getDeserializerClassName(schema))
+                .put("serializationLibraryName", schema.serializationLibraryName())
                 .buildOrThrow();
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/InternalHiveSplit.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/InternalHiveSplit.java
@@ -46,7 +46,7 @@ public class InternalHiveSplit
     private final long end;
     private final long estimatedFileSize;
     private final long fileModifiedTime;
-    private final Map<String, String> schema;
+    private final Schema schema;
     private final List<HivePartitionKey> partitionKeys;
     private final List<InternalHiveBlock> blocks;
     private final String partitionName;
@@ -70,7 +70,7 @@ public class InternalHiveSplit
             long end,
             long estimatedFileSize,
             long fileModifiedTime,
-            Map<String, String> schema,
+            Schema schema,
             List<HivePartitionKey> partitionKeys,
             List<InternalHiveBlock> blocks,
             OptionalInt readBucketNumber,
@@ -144,7 +144,7 @@ public class InternalHiveSplit
         return fileModifiedTime;
     }
 
-    public Map<String, String> getSchema()
+    public Schema getSchema()
     {
         return schema;
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/Schema.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/Schema.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import io.airlift.slice.SizeOf;
+
+import java.util.Map;
+
+import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
+import static java.util.Objects.requireNonNull;
+
+public record Schema(
+        String serializationLibraryName,
+        boolean isFullAcidTable,
+        Map<String, String> serdeProperties)
+{
+    private static final int INSTANCE_SIZE = instanceSize(Schema.class);
+
+    public Schema
+    {
+        requireNonNull(serializationLibraryName, "serializationLibraryName is null");
+        requireNonNull(serdeProperties, "serdeProperties is null");
+    }
+
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE
+                + estimatedSizeOf(serializationLibraryName)
+                + estimatedSizeOf(serdeProperties, SizeOf::estimatedSizeOf, SizeOf::estimatedSizeOf);
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/line/LinePageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/line/LinePageSourceFactory.java
@@ -31,6 +31,7 @@ import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.plugin.hive.HivePageSourceFactory;
 import io.trino.plugin.hive.ReaderColumns;
 import io.trino.plugin.hive.ReaderPageSource;
+import io.trino.plugin.hive.Schema;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
@@ -39,7 +40,6 @@ import io.trino.spi.predicate.TupleDomain;
 
 import java.io.InputStream;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
@@ -50,7 +50,6 @@ import static io.trino.hive.thrift.metastore.hive_metastoreConstants.FILE_INPUT_
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_CANNOT_OPEN_SPLIT;
 import static io.trino.plugin.hive.HivePageSourceProvider.projectBaseColumns;
 import static io.trino.plugin.hive.ReaderPageSource.noProjectionAdaptation;
-import static io.trino.plugin.hive.util.HiveUtil.getDeserializerClassName;
 import static io.trino.plugin.hive.util.HiveUtil.getFooterCount;
 import static io.trino.plugin.hive.util.HiveUtil.getHeaderCount;
 import static io.trino.plugin.hive.util.HiveUtil.splitError;
@@ -83,7 +82,7 @@ public abstract class LinePageSourceFactory
             long length,
             long estimatedFileSize,
             long fileModifiedTime,
-            Map<String, String> schema,
+            Schema schema,
             List<HiveColumnHandle> columns,
             TupleDomain<HiveColumnHandle> effectivePredicate,
             Optional<AcidInfo> acidInfo,
@@ -91,19 +90,19 @@ public abstract class LinePageSourceFactory
             boolean originalFile,
             AcidTransaction transaction)
     {
-        if (!lineReaderFactory.getHiveInputFormatClassNames().contains(schema.get(FILE_INPUT_FORMAT)) ||
-                !lineDeserializerFactory.getHiveSerDeClassNames().contains(getDeserializerClassName(schema))) {
+        if (!lineReaderFactory.getHiveInputFormatClassNames().contains(schema.serdeProperties().get(FILE_INPUT_FORMAT)) ||
+                !lineDeserializerFactory.getHiveSerDeClassNames().contains(schema.serializationLibraryName())) {
             return Optional.empty();
         }
 
         checkArgument(acidInfo.isEmpty(), "Acid is not supported");
 
         // get header and footer count
-        int headerCount = getHeaderCount(schema);
+        int headerCount = getHeaderCount(schema.serdeProperties());
         if (headerCount > 1) {
             checkArgument(start == 0, "Multiple header rows are not supported for a split file");
         }
-        int footerCount = getFooterCount(schema);
+        int footerCount = getFooterCount(schema.serdeProperties());
         if (footerCount > 0) {
             checkArgument(start == 0, "Footer not supported for a split file");
         }
@@ -124,7 +123,7 @@ public abstract class LinePageSourceFactory
                     projectedReaderColumns.stream()
                             .map(column -> new Column(column.getName(), column.getType(), column.getBaseHiveColumnIndex()))
                             .collect(toImmutableList()),
-                    schema);
+                    schema.serdeProperties());
         }
 
         // Skip empty inputs

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
@@ -207,7 +207,7 @@ public final class HiveUtil
         return HIVE_TIMESTAMP_PARSER.parseMillis(value) * MICROSECONDS_PER_MILLISECOND;
     }
 
-    public static String getDeserializerClassName(Map<String, String> schema)
+    public static String getSerializationLibraryName(Map<String, String> schema)
     {
         String name = schema.get(SERIALIZATION_LIB);
         checkCondition(name != null, HIVE_INVALID_METADATA, "Table or partition is missing Hive deserializer property: %s", SERIALIZATION_LIB);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
@@ -155,7 +155,6 @@ import static io.trino.plugin.hive.acid.AcidTransaction.NO_ACID_TRANSACTION;
 import static io.trino.plugin.hive.util.HiveTypeTranslator.toHiveType;
 import static io.trino.plugin.hive.util.SerdeConstants.LIST_COLUMNS;
 import static io.trino.plugin.hive.util.SerdeConstants.LIST_COLUMN_TYPES;
-import static io.trino.plugin.hive.util.SerdeConstants.SERIALIZATION_LIB;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.CharType.createCharType;
@@ -974,7 +973,6 @@ public final class TestHiveFileFormats
 
         Map<String, String> splitProperties = ImmutableMap.<String, String>builder()
                 .put(FILE_INPUT_FORMAT, storageFormat.getInputFormat())
-                .put(SERIALIZATION_LIB, storageFormat.getSerde())
                 .put(LIST_COLUMNS, String.join(",", splitPropertiesColumnNames.build()))
                 .put(LIST_COLUMN_TYPES, String.join(",", splitPropertiesColumnTypes.build()))
                 .buildOrThrow();
@@ -1008,7 +1006,7 @@ public final class TestHiveFileFormats
                 fileSize,
                 paddedFileSize,
                 12345,
-                splitProperties,
+                new Schema(storageFormat.getSerde(), false, splitProperties),
                 TupleDomain.all(),
                 TESTING_TYPE_MANAGER,
                 Optional.empty(),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSink.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSink.java
@@ -85,7 +85,6 @@ import static io.trino.plugin.hive.metastore.file.TestingFileHiveMetastore.creat
 import static io.trino.plugin.hive.util.HiveTypeTranslator.toHiveType;
 import static io.trino.plugin.hive.util.SerdeConstants.LIST_COLUMNS;
 import static io.trino.plugin.hive.util.SerdeConstants.LIST_COLUMN_TYPES;
-import static io.trino.plugin.hive.util.SerdeConstants.SERIALIZATION_LIB;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DoubleType.DOUBLE;
@@ -329,7 +328,6 @@ public class TestHivePageSink
         long length = fileSystemFactory.create(ConnectorIdentity.ofUser("test")).newInputFile(location).length();
         Map<String, String> splitProperties = ImmutableMap.<String, String>builder()
                 .put(FILE_INPUT_FORMAT, config.getHiveStorageFormat().getInputFormat())
-                .put(SERIALIZATION_LIB, config.getHiveStorageFormat().getSerde())
                 .put(LIST_COLUMNS, Joiner.on(',').join(getColumnHandles().stream().map(HiveColumnHandle::getName).collect(toImmutableList())))
                 .put(LIST_COLUMN_TYPES, Joiner.on(',').join(getColumnHandles().stream().map(HiveColumnHandle::getHiveType).map(hiveType -> hiveType.getHiveTypeName().toString()).collect(toImmutableList())))
                 .buildOrThrow();
@@ -340,7 +338,7 @@ public class TestHivePageSink
                 length,
                 length,
                 0,
-                splitProperties,
+                new Schema(config.getHiveStorageFormat().getSerde(), false, splitProperties),
                 ImmutableList.of(),
                 ImmutableList.of(),
                 OptionalInt.empty(),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveSplit.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveSplit.java
@@ -68,7 +68,7 @@ public class TestHiveSplit
                 87,
                 88,
                 Instant.now().toEpochMilli(),
-                schema,
+                new Schema("abc", true, schema),
                 partitionKeys,
                 addresses,
                 OptionalInt.empty(),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveSplitSource.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveSplitSource.java
@@ -236,7 +236,7 @@ public class TestHiveSplitSource
 
             // wait for thread to get the split
             ConnectorSplit split = splits.get(800, TimeUnit.MILLISECONDS);
-            assertThat(((HiveSplit) split).getSchema()).containsEntry("id", "33");
+            assertThat(((HiveSplit) split).getSchema().serdeProperties()).containsEntry("id", "33");
         }
         finally {
             // make sure the thread exits
@@ -331,7 +331,7 @@ public class TestHiveSplitSource
                     fileSize.toBytes(),
                     fileSize.toBytes(),
                     Instant.now().toEpochMilli(),
-                    ImmutableMap.of("id", String.valueOf(id)),
+                    new Schema("abc", false, ImmutableMap.of("id", String.valueOf(id))),
                     ImmutableList.of(),
                     ImmutableList.of(new InternalHiveBlock(0, fileSize.toBytes(), ImmutableList.of())),
                     bucketNumber,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestNodeLocalDynamicSplitPruning.java
@@ -48,12 +48,10 @@ import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
 import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static io.trino.plugin.hive.HiveTestUtils.getDefaultHivePageSourceFactories;
 import static io.trino.plugin.hive.util.HiveBucketing.BucketingVersion.BUCKETING_V1;
-import static io.trino.plugin.hive.util.SerdeConstants.SERIALIZATION_LIB;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.testing.TestingHandles.TEST_CATALOG_HANDLE;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.FILE_INPUT_FORMAT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class TestNodeLocalDynamicSplitPruning
@@ -117,10 +115,6 @@ class TestNodeLocalDynamicSplitPruning
         TrinoFileSystemFactory fileSystemFactory = new MemoryFileSystemFactory();
         fileSystemFactory.create(ConnectorIdentity.ofUser("test")).newOutputFile(location).create().close();
 
-        Map<String, String> splitProperties = ImmutableMap.<String, String>builder()
-                .put(FILE_INPUT_FORMAT, hiveConfig.getHiveStorageFormat().getInputFormat())
-                .put(SERIALIZATION_LIB, hiveConfig.getHiveStorageFormat().getSerde())
-                .buildOrThrow();
         HiveSplit split = new HiveSplit(
                 "",
                 location.toString(),
@@ -128,7 +122,7 @@ class TestNodeLocalDynamicSplitPruning
                 0,
                 0,
                 0,
-                splitProperties,
+                new Schema(hiveConfig.getHiveStorageFormat().getSerde(), false, ImmutableMap.of()),
                 ImmutableList.of(new HivePartitionKey(PARTITION_COLUMN.getName(), "42")),
                 ImmutableList.of(),
                 OptionalInt.of(1),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcPageSourceFactory.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcPageSourceFactory.java
@@ -26,6 +26,7 @@ import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.plugin.hive.HiveConfig;
 import io.trino.plugin.hive.HivePageSourceFactory;
 import io.trino.plugin.hive.ReaderPageSource;
+import io.trino.plugin.hive.Schema;
 import io.trino.spi.Page;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.predicate.Domain;
@@ -51,15 +52,12 @@ import java.util.function.LongPredicate;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.io.Resources.getResource;
-import static io.trino.hive.thrift.metastore.hive_metastoreConstants.FILE_INPUT_FORMAT;
 import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static io.trino.plugin.hive.HiveColumnHandle.createBaseColumn;
 import static io.trino.plugin.hive.HiveStorageFormat.ORC;
-import static io.trino.plugin.hive.HiveTableProperties.TRANSACTIONAL;
 import static io.trino.plugin.hive.HiveTestUtils.SESSION;
 import static io.trino.plugin.hive.acid.AcidTransaction.NO_ACID_TRANSACTION;
 import static io.trino.plugin.hive.util.HiveTypeTranslator.toHiveType;
-import static io.trino.plugin.hive.util.SerdeConstants.SERIALIZATION_LIB;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.VarcharType.VARCHAR;
@@ -328,13 +326,9 @@ public class TestOrcPageSourceFactory
                 Optional.empty());
     }
 
-    private static Map<String, String> createSchema()
+    private static Schema createSchema()
     {
-        return ImmutableMap.<String, String>builder()
-                .put(SERIALIZATION_LIB, ORC.getSerde())
-                .put(FILE_INPUT_FORMAT, ORC.getInputFormat())
-                .put(TRANSACTIONAL, "true")
-                .buildOrThrow();
+        return new Schema(ORC.getSerde(), true, ImmutableMap.of());
     }
 
     private static void assertEqualsByColumns(Set<NationColumn> columns, List<Nation> actualRows, List<Nation> expectedRows)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcPredicates.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcPredicates.java
@@ -31,6 +31,7 @@ import io.trino.plugin.hive.HiveCompressionCodec;
 import io.trino.plugin.hive.HiveConfig;
 import io.trino.plugin.hive.HivePageSourceProvider;
 import io.trino.plugin.hive.NodeVersion;
+import io.trino.plugin.hive.Schema;
 import io.trino.plugin.hive.WriterKind;
 import io.trino.plugin.hive.util.HiveTypeTranslator;
 import io.trino.spi.Page;
@@ -183,7 +184,13 @@ class TestOrcPredicates
                         length,
                         length,
                         inputFile.lastModified().toEpochMilli(),
-                        getTableProperties(),
+                        new Schema(
+                                ORC.getSerde(),
+                                false,
+                                ImmutableMap.<String, String>builder()
+                                        .put(LIST_COLUMNS, COLUMNS.stream().map(HiveColumnHandle::getName).collect(Collectors.joining(",")))
+                                        .put(LIST_COLUMN_TYPES, COLUMNS.stream().map(HiveColumnHandle::getHiveType).map(HiveType::toString).collect(Collectors.joining(",")))
+                                        .buildOrThrow()),
                         effectivePredicate,
                         TESTING_TYPE_MANAGER,
                         Optional.empty(),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetUtil.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetUtil.java
@@ -21,6 +21,7 @@ import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.plugin.hive.HiveConfig;
 import io.trino.plugin.hive.HivePageSourceFactory;
 import io.trino.plugin.hive.HiveStorageFormat;
+import io.trino.plugin.hive.Schema;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.predicate.TupleDomain;
@@ -43,7 +44,6 @@ import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static io.trino.plugin.hive.HiveColumnHandle.createBaseColumn;
 import static io.trino.plugin.hive.acid.AcidTransaction.NO_ACID_TRANSACTION;
 import static io.trino.plugin.hive.util.HiveTypeTranslator.toHiveType;
-import static io.trino.plugin.hive.util.SerdeConstants.SERIALIZATION_LIB;
 
 final class ParquetUtil
 {
@@ -96,7 +96,7 @@ final class ParquetUtil
                         parquetFile.length(),
                         parquetFile.length(),
                         parquetFile.lastModified(),
-                        ImmutableMap.of(SERIALIZATION_LIB, HiveStorageFormat.PARQUET.getSerde()),
+                        new Schema(HiveStorageFormat.PARQUET.getSerde(), false, ImmutableMap.of()),
                         columns,
                         domain,
                         Optional.empty(),


### PR DESCRIPTION
## Description
Extract the required properties for ORC, Parquet and RCFile into explicit fields and use a Map only when necessary.
This avoids repeated look-ups in schema Map and reduces size of HiveSplit for the more common cases.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
