### PR TITLE
Add logging for get-functions failure in glue metastore

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -1459,6 +1459,7 @@ public class GlueHiveMetastore
                     .collect(toImmutableList()));
         }
         catch (software.amazon.awssdk.services.glue.model.EntityNotFoundException | AccessDeniedException e) {
+            log.warn(e, "Failed to get SQL routines for pattern: %s in schema: %s", functionNamePattern, databaseName);
             return ImmutableList.of();
         }
         catch (SdkException e) {


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
