### PR TITLE
Print GitHub errors without logging prefixes

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/Environment.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/Environment.java
@@ -129,7 +129,7 @@ public final class Environment
                 .onSuccess(event -> log.info("Environment '%s' started in %s, %d attempt(s)", this, event.getElapsedTime(), event.getAttemptCount()))
                 .onFailure(event -> {
                     if (getenv("GITHUB_RUN_ID") != null) {
-                        log.info("::error title=Failed to start environment '%s'::%s", this, event.getException());
+                        System.out.printf("::error title=Failed to start environment '%s'::%s%n", this, event.getException());
                     }
                     log.info("Environment '%s' failed to start in attempt(s): %d: %s", this, event.getAttemptCount(), event.getException());
                 })


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Right now it gets printed with the prefixes, and it doesn't create any annotations:

```
2024-09-26T11:11:42.821Z	INFO	main	io.trino.tests.product.launcher.env.Environment	::error title=Failed to start environment 'singlenode-compatibility'::org.testcontainers.containers.ContainerFetchException: Can't get Docker image: RemoteDockerImage(imageName=trinodb/trino:459, imagePullPolicy=io.trino.testing.containers.ConditionalPullPolicy@19b02dfd, imageNameSubstitutor=org.testcontainers.utility.ImageNameSubstitutor$LogWrappedImageNameSubstitutor@3dce6dd8)
2024-09-26T11:11:42.821Z	INFO	main	io.trino.tests.product.launcher.env.Environment	Environment 'singlenode-compatibility' failed to start in attempt(s): 6: 
```

from https://github.com/trinodb/trino/actions/runs/11050681149/job/30699574020

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
