### PR TITLE
Load only required projected columns in Iceberg connector

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -98,6 +98,7 @@ import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.builderWithExpectedSize;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -238,32 +239,46 @@ public final class IcebergUtil
 
     public static List<IcebergColumnHandle> getProjectedColumns(Schema schema, TypeManager typeManager)
     {
-        ImmutableList.Builder<IcebergColumnHandle> projectedColumns = ImmutableList.builder();
-        StructType schemaAsStruct = schema.asStruct();
-        Map<Integer, NestedField> indexById = TypeUtil.indexById(schemaAsStruct);
-        Map<Integer, Integer> indexParents = TypeUtil.indexParents(schemaAsStruct);
-        Map<Integer, List<Integer>> indexPaths = indexById.entrySet().stream()
-                .collect(toImmutableMap(Entry::getKey, e -> ImmutableList.copyOf(buildPath(indexParents, e.getKey()))));
-
-        for (Map.Entry<Integer, NestedField> entry : indexById.entrySet()) {
-            int fieldId = entry.getKey();
-            NestedField childField = entry.getValue();
-            NestedField baseField = childField;
-
-            List<Integer> path = requireNonNull(indexPaths.get(fieldId));
-            if (!path.isEmpty()) {
-                baseField = indexById.get(path.getFirst());
-                path = ImmutableList.<Integer>builder()
-                        .addAll(path.subList(1, path.size())) // Base column id shouldn't exist in IcebergColumnHandle.path
-                        .add(fieldId) // Append the leaf field id
-                        .build();
-            }
-            projectedColumns.add(createColumnHandle(baseField, childField, typeManager, path));
-        }
-        return projectedColumns.build();
+        Map<Integer, NestedField> indexById = TypeUtil.indexById(schema.asStruct());
+        return getProjectedColumns(schema, typeManager, indexById, indexById.keySet() /* project all columns */);
     }
 
-    private static List<Integer> buildPath(Map<Integer, Integer> indexParents, int fieldId)
+    public static List<IcebergColumnHandle> getProjectedColumns(Schema schema, TypeManager typeManager, Set<Integer> fieldIds)
+    {
+        Map<Integer, NestedField> indexById = TypeUtil.indexById(schema.asStruct());
+        return getProjectedColumns(schema, typeManager, indexById, fieldIds /* project selected columns */);
+    }
+
+    private static List<IcebergColumnHandle> getProjectedColumns(Schema schema, TypeManager typeManager, Map<Integer, NestedField> indexById, Set<Integer> fieldIds)
+    {
+        ImmutableList.Builder<IcebergColumnHandle> columns = builderWithExpectedSize(fieldIds.size());
+        Map<Integer, Integer> indexParents = TypeUtil.indexParents(schema.asStruct());
+        Map<Integer, List<Integer>> indexPaths = indexById.entrySet().stream()
+                .collect(toImmutableMap(Entry::getKey, entry -> ImmutableList.copyOf(buildPath(indexParents, entry.getKey()))));
+
+        for (int fieldId : fieldIds) {
+            columns.add(createColumnHandle(typeManager, fieldId, indexById, indexPaths));
+        }
+        return columns.build();
+    }
+
+    public static IcebergColumnHandle createColumnHandle(TypeManager typeManager, int fieldId, Map<Integer, NestedField> indexById, Map<Integer, List<Integer>> indexPaths)
+    {
+        NestedField childField = indexById.get(fieldId);
+        NestedField baseField = childField;
+
+        List<Integer> path = requireNonNull(indexPaths.get(fieldId));
+        if (!path.isEmpty()) {
+            baseField = indexById.get(path.getFirst());
+            path = ImmutableList.<Integer>builder()
+                    .addAll(path.subList(1, path.size())) // Base column id shouldn't exist in IcebergColumnHandle.path
+                    .add(fieldId) // Append the leaf field id
+                    .build();
+        }
+        return createColumnHandle(baseField, childField, typeManager, path);
+    }
+
+    public static List<Integer> buildPath(Map<Integer, Integer> indexParents, int fieldId)
     {
         List<Integer> path = new ArrayList<>();
         while (indexParents.containsKey(fieldId)) {
@@ -356,7 +371,7 @@ public final class IcebergUtil
     public static List<ColumnMetadata> getColumnMetadatas(Schema schema, TypeManager typeManager)
     {
         List<NestedField> icebergColumns = schema.columns();
-        ImmutableList.Builder<ColumnMetadata> columns = ImmutableList.builderWithExpectedSize(icebergColumns.size() + 2);
+        ImmutableList.Builder<ColumnMetadata> columns = builderWithExpectedSize(icebergColumns.size() + 2);
 
         icebergColumns.stream()
                 .map(column ->

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergUtil.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergUtil.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
@@ -85,5 +86,40 @@ public class TestIcebergUtil
                         tuple(5, "element", 2, ImmutableList.of(4, 5)),
                         tuple(6, "nested", 2, ImmutableList.of(6)),
                         tuple(7, "value", 2, ImmutableList.of(6, 7)));
+
+        assertThat(getProjectedColumns(schema, TESTING_TYPE_MANAGER, ImmutableSet.of(1)))
+                .extracting(IcebergColumnHandle::getId, IcebergColumnHandle::getName, column -> column.getBaseColumn().getId(), IcebergColumnHandle::getPath)
+                .containsExactly(tuple(1, "id", 1, ImmutableList.of()));
+        assertThat(getProjectedColumns(schema, TESTING_TYPE_MANAGER, ImmutableSet.of(2)))
+                .extracting(IcebergColumnHandle::getId, IcebergColumnHandle::getName, column -> column.getBaseColumn().getId(), IcebergColumnHandle::getPath)
+                .containsExactly(tuple(2, "nested", 2, ImmutableList.of()));
+        assertThat(getProjectedColumns(schema, TESTING_TYPE_MANAGER, ImmutableSet.of(3)))
+                .extracting(IcebergColumnHandle::getId, IcebergColumnHandle::getName, column -> column.getBaseColumn().getId(), IcebergColumnHandle::getPath)
+                .containsExactly(tuple(3, "value", 2, ImmutableList.of(3)));
+        assertThat(getProjectedColumns(schema, TESTING_TYPE_MANAGER, ImmutableSet.of(4)))
+                .extracting(IcebergColumnHandle::getId, IcebergColumnHandle::getName, column -> column.getBaseColumn().getId(), IcebergColumnHandle::getPath)
+                .containsExactly(tuple(4, "list", 2, ImmutableList.of(4)));
+        assertThat(getProjectedColumns(schema, TESTING_TYPE_MANAGER, ImmutableSet.of(5)))
+                .extracting(IcebergColumnHandle::getId, IcebergColumnHandle::getName, column -> column.getBaseColumn().getId(), IcebergColumnHandle::getPath)
+                .containsExactly(tuple(5, "element", 2, ImmutableList.of(4, 5)));
+        assertThat(getProjectedColumns(schema, TESTING_TYPE_MANAGER, ImmutableSet.of(6)))
+                .extracting(IcebergColumnHandle::getId, IcebergColumnHandle::getName, column -> column.getBaseColumn().getId(), IcebergColumnHandle::getPath)
+                .containsExactly(tuple(6, "nested", 2, ImmutableList.of(6)));
+        assertThat(getProjectedColumns(schema, TESTING_TYPE_MANAGER, ImmutableSet.of(7)))
+                .extracting(IcebergColumnHandle::getId, IcebergColumnHandle::getName, column -> column.getBaseColumn().getId(), IcebergColumnHandle::getPath)
+                .containsExactly(tuple(7, "value", 2, ImmutableList.of(6, 7)));
+
+        assertThat(getProjectedColumns(schema, TESTING_TYPE_MANAGER, ImmutableSet.of(3, 7)))
+                .extracting(IcebergColumnHandle::getId, IcebergColumnHandle::getName, column -> column.getBaseColumn().getId(), IcebergColumnHandle::getPath)
+                .containsExactly(
+                        tuple(3, "value", 2, ImmutableList.of(3)),
+                        tuple(7, "value", 2, ImmutableList.of(6, 7)));
+
+        assertThat(getProjectedColumns(schema, TESTING_TYPE_MANAGER, ImmutableSet.of(1, 4, 5)))
+                .extracting(IcebergColumnHandle::getId, IcebergColumnHandle::getName, column -> column.getBaseColumn().getId(), IcebergColumnHandle::getPath)
+                .containsExactly(
+                        tuple(1, "id", 1, ImmutableList.of()),
+                        tuple(4, "list", 2, ImmutableList.of(4)),
+                        tuple(5, "element", 2, ImmutableList.of(4, 5)));
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Should fix https://github.com/trinodb/trino/issues/23451

Loading the only required fields in the map.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Fix Iceberg queries stuck in the planning phase for long time when there are large number of fields in the table. ({issue}`23451`)
```
