### PR TITLE
Fix environment name in dev server config

### DIFF
--- a/testing/trino-server-dev/etc/catalog/cassandra.properties
+++ b/testing/trino-server-dev/etc/catalog/cassandra.properties
@@ -1,5 +1,5 @@
 connector.name=cassandra
-# Can be used with `bin/ptl env up --environment singlenode-cassandra --without-trino`
+# Can be used with `bin/ptl env up --environment multinode-cassandra --without-trino`
 cassandra.contact-points=localhost
 cassandra.allow-drop-table=true
 cassandra.load-policy.dc-aware.local-dc=datacenter1

--- a/testing/trino-server-dev/etc/catalog/hive.properties
+++ b/testing/trino-server-dev/etc/catalog/hive.properties
@@ -8,7 +8,7 @@
 connector.name=hive
 
 # Configuration appropriate for Hive as started by product test environment, e.g.
-#   trino-product-tests-launcher/bin/run-launcher env up --environment singlenode --without-trino
+#   trino-product-tests-launcher/bin/run-launcher env up --environment multinode --without-trino
 # On Mac, this additionally requires that you add "<your external IP> hadoop-master" to /etc/hosts
 hive.metastore.uri=thrift://localhost:9083
 hive.hdfs.socks-proxy=localhost:1180

--- a/testing/trino-server-dev/etc/catalog/iceberg.properties
+++ b/testing/trino-server-dev/etc/catalog/iceberg.properties
@@ -7,7 +7,7 @@
 connector.name=iceberg
 
 # Configuration appropriate for Hive as started by product test environment, e.g.
-#   trino-product-tests-launcher/bin/run-launcher env up --environment singlenode --without-trino
+#   trino-product-tests-launcher/bin/run-launcher env up --environment multinode --without-trino
 # On Mac, this additionally requires that you add "<your external IP> hadoop-master" to /etc/hosts
 hive.metastore.uri=thrift://localhost:9083
 hive.hdfs.socks-proxy=localhost:1180


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

These names were no longer correct

<details>
  <summary>Click me</summary>
Caused by: java.lang.IllegalArgumentException: No environment with name 'singlenode'. Those do exist, however: [multinode, multinode-all-connectors, multinode-azure, multinode-cassandra, multinode-clickhouse, multinode-confluent-kafka, multinode-databricks-http-hms, multinode-exasol, multinode-gcs, multinode-hive-caching, multinode-iceberg-minio-caching, multinode-ignite, multinode-kafka, multinode-kafka-sasl-plaintext, multinode-kafka-ssl, multinode-kerberos-kudu, multinode-mariadb, multinode-minio-data-lake, multinode-minio-data-lake-caching, multinode-minio-data-lake-task-retries-filesystem, multinode-mysql, multinode-parquet, multinode-phoenix5, multinode-postgresql, multinode-postgresql-spooling, multinode-secrets-provider, multinode-snowflake, multinode-sqlserver, multinode-tls, multinode-tls-kerberos, multinode-tls-kerberos-delegation, singlenode-compatibility, singlenode-delta-lake-databricks104, singlenode-delta-lake-databricks113, singlenode-delta-lake-databricks122, singlenode-delta-lake-databricks133, singlenode-delta-lake-databricks91, singlenode-delta-lake-kerberized-hdfs, singlenode-delta-lake-oss, singlenode-hdfs-impersonation, singlenode-hive-acid, singlenode-hive-hudi-redirections, singlenode-hive-iceberg-redirections, singlenode-hive-impersonation, singlenode-hudi, singlenode-kerberos-hdfs-impersonation, singlenode-kerberos-hdfs-impersonation-cross-realm, singlenode-kerberos-hdfs-impersonation-with-data-protection, singlenode-kerberos-hdfs-impersonation-with-wire-encryption, singlenode-kerberos-hdfs-no-impersonation, singlenode-kerberos-hive-impersonation, singlenode-kerberos-hive-impersonation-with-credential-cache, singlenode-kerberos-hive-no-impersonation-with-credential-cache, singlenode-kerberos-kms-hdfs-impersonation, singlenode-kerberos-kms-hdfs-impersonation-with-credential-cache, singlenode-kerberos-kms-hdfs-no-impersonation, singlenode-kerberos-kms-hdfs-no-impersonation-with-credential-cache, singlenode-ldap, singlenode-ldap-and-file, singlenode-ldap-bind-dn, singlenode-ldap-insecure, singlenode-ldap-referrals, singlenode-oauth2, singlenode-oauth2-authenticated-http-proxy, singlenode-oauth2-authenticated-https-proxy, singlenode-oauth2-http-proxy, singlenode-oauth2-https-proxy, singlenode-oauth2-refresh, singlenode-oidc, singlenode-oidc-refresh, singlenode-spark-hive, singlenode-spark-hive-no-stats-fallback, singlenode-spark-iceberg, singlenode-spark-iceberg-jdbc-catalog, singlenode-spark-iceberg-nessie, singlenode-spark-iceberg-rest, two-kerberos-hives, two-mixed-hives
</details>

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
