### PR TITLE
Fix writing of parquet bloom filters

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ColumnWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ColumnWriter.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public interface ColumnWriter
@@ -51,7 +50,6 @@ public interface ColumnWriter
             this.dictionaryPageSize = requireNonNull(dictionaryPageSize, "dictionaryPageSize is null");
             this.bloomFilter = requireNonNull(bloomFilter, "bloomFilter is null");
             this.metaData = requireNonNull(metaData, "metaData is null");
-            checkArgument(dictionaryPageSize.isEmpty() || bloomFilter.isEmpty(), "dictionaryPagesSize and bloomFilter cannot both be set");
         }
 
         public ColumnMetaData getMetaData()

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/BloomFilterValuesWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/BloomFilterValuesWriter.java
@@ -23,8 +23,6 @@ import org.apache.parquet.io.api.Binary;
 
 import java.util.Optional;
 
-import static java.lang.Math.toIntExact;
-
 public class BloomFilterValuesWriter
         extends ValuesWriter
 {
@@ -122,14 +120,14 @@ public class BloomFilterValuesWriter
     public void writeInteger(int v)
     {
         writer.writeInteger(v);
-        bloomFilter.insertHash(bloomFilter.hash(toIntExact(((Number) v).longValue())));
+        bloomFilter.insertHash(bloomFilter.hash(v));
     }
 
     @Override
     public void writeLong(long v)
     {
         writer.writeLong(v);
-        bloomFilter.insertHash(bloomFilter.hash(((Number) v).longValue()));
+        bloomFilter.insertHash(bloomFilter.hash(v));
     }
 
     @Override

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/BloomFilterValuesWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/BloomFilterValuesWriter.java
@@ -52,7 +52,7 @@ public class BloomFilterValuesWriter
     @Override
     public long getBufferedSize()
     {
-        return writer.getBufferedSize() + bloomFilter.getBitsetSize();
+        return writer.getBufferedSize();
     }
 
     @Override
@@ -94,7 +94,7 @@ public class BloomFilterValuesWriter
     @Override
     public long getAllocatedSize()
     {
-        return writer.getAllocatedSize();
+        return writer.getAllocatedSize() + bloomFilter.getBitsetSize();
     }
 
     @Override

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/TrinoValuesWriterFactory.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/TrinoValuesWriterFactory.java
@@ -66,38 +66,38 @@ public class TrinoValuesWriterFactory
 
     private ValuesWriter getBinaryValuesWriter(ColumnDescriptor path, Optional<BloomFilter> bloomFilter)
     {
-        ValuesWriter fallbackWriter = createBloomFilterValuesWriter(new PlainValuesWriter(INITIAL_SLAB_SIZE, maxPageSize, new HeapByteBufferAllocator()), bloomFilter);
-        return dictWriterWithFallBack(path, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter);
+        ValuesWriter fallbackWriter = new PlainValuesWriter(INITIAL_SLAB_SIZE, maxPageSize, new HeapByteBufferAllocator());
+        return createBloomFilterValuesWriter(dictWriterWithFallBack(path, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter), bloomFilter);
     }
 
     private ValuesWriter getInt32ValuesWriter(ColumnDescriptor path, Optional<BloomFilter> bloomFilter)
     {
-        ValuesWriter fallbackWriter = createBloomFilterValuesWriter(new PlainValuesWriter(INITIAL_SLAB_SIZE, maxPageSize, new HeapByteBufferAllocator()), bloomFilter);
-        return dictWriterWithFallBack(path, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter);
+        ValuesWriter fallbackWriter = new PlainValuesWriter(INITIAL_SLAB_SIZE, maxPageSize, new HeapByteBufferAllocator());
+        return createBloomFilterValuesWriter(dictWriterWithFallBack(path, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter), bloomFilter);
     }
 
     private ValuesWriter getInt64ValuesWriter(ColumnDescriptor path, Optional<BloomFilter> bloomFilter)
     {
-        ValuesWriter fallbackWriter = createBloomFilterValuesWriter(new PlainValuesWriter(INITIAL_SLAB_SIZE, maxPageSize, new HeapByteBufferAllocator()), bloomFilter);
-        return dictWriterWithFallBack(path, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter);
+        ValuesWriter fallbackWriter = new PlainValuesWriter(INITIAL_SLAB_SIZE, maxPageSize, new HeapByteBufferAllocator());
+        return createBloomFilterValuesWriter(dictWriterWithFallBack(path, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter), bloomFilter);
     }
 
     private ValuesWriter getInt96ValuesWriter(ColumnDescriptor path, Optional<BloomFilter> bloomFilter)
     {
-        ValuesWriter fallbackWriter = createBloomFilterValuesWriter(new FixedLenByteArrayPlainValuesWriter(12, INITIAL_SLAB_SIZE, maxPageSize, new HeapByteBufferAllocator()), bloomFilter);
-        return dictWriterWithFallBack(path, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter);
+        ValuesWriter fallbackWriter = new FixedLenByteArrayPlainValuesWriter(12, INITIAL_SLAB_SIZE, maxPageSize, new HeapByteBufferAllocator());
+        return createBloomFilterValuesWriter(dictWriterWithFallBack(path, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter), bloomFilter);
     }
 
     private ValuesWriter getDoubleValuesWriter(ColumnDescriptor path, Optional<BloomFilter> bloomFilter)
     {
-        ValuesWriter fallbackWriter = createBloomFilterValuesWriter(new PlainValuesWriter(INITIAL_SLAB_SIZE, maxPageSize, new HeapByteBufferAllocator()), bloomFilter);
-        return dictWriterWithFallBack(path, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter);
+        ValuesWriter fallbackWriter = new PlainValuesWriter(INITIAL_SLAB_SIZE, maxPageSize, new HeapByteBufferAllocator());
+        return createBloomFilterValuesWriter(dictWriterWithFallBack(path, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter), bloomFilter);
     }
 
     private ValuesWriter getFloatValuesWriter(ColumnDescriptor path, Optional<BloomFilter> bloomFilter)
     {
-        ValuesWriter fallbackWriter = createBloomFilterValuesWriter(new PlainValuesWriter(INITIAL_SLAB_SIZE, maxPageSize, new HeapByteBufferAllocator()), bloomFilter);
-        return dictWriterWithFallBack(path, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter);
+        ValuesWriter fallbackWriter = new PlainValuesWriter(INITIAL_SLAB_SIZE, maxPageSize, new HeapByteBufferAllocator());
+        return createBloomFilterValuesWriter(dictWriterWithFallBack(path, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter), bloomFilter);
     }
 
     @SuppressWarnings("deprecation")

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/AbstractColumnWriterBenchmark.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/AbstractColumnWriterBenchmark.java
@@ -57,7 +57,7 @@ public abstract class AbstractColumnWriterBenchmark
     @Param({
             "1", "1048576" // 1MB is default page size
     })
-    public int dictionaryPageSize;
+    public int maxDictionaryPageSize;
 
     public enum BloomFilterType
     {
@@ -94,7 +94,7 @@ public abstract class AbstractColumnWriterBenchmark
 
     private PrimitiveValueWriter createValuesWriter()
     {
-        TrinoValuesWriterFactory valuesWriterFactory = new TrinoValuesWriterFactory(1024 * 1024, dictionaryPageSize);
+        TrinoValuesWriterFactory valuesWriterFactory = new TrinoValuesWriterFactory(1024 * 1024, maxDictionaryPageSize);
         ColumnDescriptor columnDescriptor = new ColumnDescriptor(new String[] {"test"}, getParquetType(), 0, 0);
         return getValueWriter(valuesWriterFactory.newValuesWriter(columnDescriptor, bloomFilterType.getBloomFilter()), getTrinoType(), columnDescriptor.getPrimitiveType(), Optional.empty());
     }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestColumnWriterBenchmark.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestColumnWriterBenchmark.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.writer;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+final class TestColumnWriterBenchmark
+{
+    @Test
+    void testLongColumnWriterBenchmark()
+            throws IOException
+    {
+        for (int bitWidth = 1; bitWidth <= 64; bitWidth += 4) {
+            for (AbstractColumnWriterBenchmark.BloomFilterType bloomFilterType : AbstractColumnWriterBenchmark.BloomFilterType.values()) {
+                for (int maxDictionaryPageSize : ImmutableList.of(1, 1048576)) {
+                    BenchmarkLongColumnWriter benchmark = new BenchmarkLongColumnWriter();
+                    benchmark.bitWidth = bitWidth;
+                    benchmark.bloomFilterType = bloomFilterType;
+                    benchmark.maxDictionaryPageSize = maxDictionaryPageSize;
+                    benchmark.setup();
+                    benchmark.write();
+                }
+            }
+        }
+    }
+
+    @Test
+    void testBinaryColumnWriterBenchmark()
+            throws IOException
+    {
+        for (BenchmarkBinaryColumnWriter.FieldType fieldType : BenchmarkBinaryColumnWriter.FieldType.values()) {
+            for (BenchmarkBinaryColumnWriter.PositionLength positionLength : BenchmarkBinaryColumnWriter.PositionLength.values()) {
+                for (AbstractColumnWriterBenchmark.BloomFilterType bloomFilterType : AbstractColumnWriterBenchmark.BloomFilterType.values()) {
+                    for (int maxDictionaryPageSize : ImmutableList.of(1, 1048576)) {
+                        BenchmarkBinaryColumnWriter benchmark = new BenchmarkBinaryColumnWriter();
+                        benchmark.type = fieldType;
+                        benchmark.positionLength = positionLength;
+                        benchmark.bloomFilterType = bloomFilterType;
+                        benchmark.maxDictionaryPageSize = maxDictionaryPageSize;
+                        benchmark.setup();
+                        benchmark.write();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriter.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriter.java
@@ -69,6 +69,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.operator.scalar.CharacterStringCasts.varcharToVarcharSaturatedFloorCast;
+import static io.trino.parquet.BloomFilterStore.hasBloomFilter;
 import static io.trino.parquet.ParquetCompressionUtils.decompress;
 import static io.trino.parquet.ParquetTestUtils.createParquetReader;
 import static io.trino.parquet.ParquetTestUtils.createParquetWriter;
@@ -354,6 +355,10 @@ public class TestParquetWriter
             assertThat(chunkMetaData.getDictionaryPageOffset()).isGreaterThan(0);
             int dictionaryPageSize = toIntExact(chunkMetaData.getFirstDataPageOffset() - chunkMetaData.getDictionaryPageOffset());
             assertThat(dictionaryPageSize).isGreaterThan(0);
+            assertThat(chunkMetaData.getEncodingStats().hasDictionaryPages()).isTrue();
+            assertThat(chunkMetaData.getEncodingStats().hasDictionaryEncodedPages()).isTrue();
+            assertThat(chunkMetaData.getEncodingStats().hasNonDictionaryEncodedPages()).isFalse();
+            assertThat(hasBloomFilter(chunkMetaData)).isFalse();
 
             // verify reading dictionary page
             SliceInput inputStream = dataSource.readFully(chunkMetaData.getStartingPos(), dictionaryPageSize).getInput();
@@ -379,9 +384,8 @@ public class TestParquetWriter
     public void testWriteBloomFilters(Type type, List<?> data)
             throws IOException
     {
-        String columnName = "column";
-        List<String> columnNames = ImmutableList.of(columnName);
-        List<Type> types = ImmutableList.of(type);
+        List<String> columnNames = ImmutableList.of("columnA", "columnB");
+        List<Type> types = ImmutableList.of(type, type);
         ParquetDataSource dataSource = new TestingParquetDataSource(
                 writeParquetFile(
                         ParquetWriterOptions.builder()
@@ -397,9 +401,17 @@ public class TestParquetWriter
         // Check that bloom filters are right after each other
         int bloomFilterSize = Integer.highestOneBit(BlockSplitBloomFilter.optimalNumOfBits(BLOOM_FILTER_EXPECTED_ENTRIES, DEFAULT_BLOOM_FILTER_FPP) / 8) << 1;
         for (BlockMetadata block : parquetMetadata.getBlocks()) {
-            for (int i = 1; i < block.columns().size(); i++) {
-                assertThat(block.columns().get(i - 1).getBloomFilterOffset() + bloomFilterSize + 17) // + 17 bytes for Bloom filter metadata
-                        .isEqualTo(block.columns().get(i).getBloomFilterOffset());
+            for (int i = 0; i < block.columns().size(); i++) {
+                ColumnChunkMetadata chunkMetaData = block.columns().get(i);
+                assertThat(hasBloomFilter(chunkMetaData)).isTrue();
+                assertThat(chunkMetaData.getEncodingStats().hasDictionaryPages()).isFalse();
+                assertThat(chunkMetaData.getEncodingStats().hasDictionaryEncodedPages()).isFalse();
+                assertThat(chunkMetaData.getEncodingStats().hasNonDictionaryEncodedPages()).isTrue();
+
+                if (i < block.columns().size() - 1) {
+                    assertThat(chunkMetaData.getBloomFilterOffset() + bloomFilterSize + 17) // + 17 bytes for Bloom filter metadata
+                            .isEqualTo(block.columns().get(i + 1).getBloomFilterOffset());
+                }
             }
         }
         int rowGroupCount = parquetMetadata.getBlocks().size();
@@ -407,7 +419,7 @@ public class TestParquetWriter
 
         TupleDomain<String> predicate = TupleDomain.withColumnDomains(
                 ImmutableMap.of(
-                        columnName, Domain.singleValue(type, data.get(data.size() / 2))));
+                        "columnA", Domain.singleValue(type, data.get(data.size() / 2))));
         try (ParquetReader reader = createParquetReader(dataSource, parquetMetadata, new ParquetReaderOptions().withBloomFilter(true), newSimpleAggregatedMemoryContext(), types, columnNames, predicate)) {
             Page page = reader.nextPage();
             int rowsRead = 0;
@@ -427,6 +439,36 @@ public class TestParquetWriter
             }
             assertThat(rowsRead).isEqualTo(data.size());
         }
+    }
+
+    @Test
+    void testBloomFilterWithDictionaryFallback()
+            throws IOException
+    {
+        List<String> columnNames = ImmutableList.of("column");
+        List<Type> types = ImmutableList.of(BIGINT);
+        ParquetDataSource dataSource = new TestingParquetDataSource(
+                writeParquetFile(
+                        ParquetWriterOptions.builder()
+                                .setMaxPageValueCount(200)
+                                .setBloomFilterColumns(ImmutableSet.copyOf(columnNames))
+                                .build(),
+                        types,
+                        columnNames,
+                        ImmutableList.<io.trino.spi.Page>builder()
+                                .addAll(generateInputPages(types, 10, 10))
+                                // Max size of dictionary page is 1024 * 1024
+                                .addAll(generateInputPages(types, 200, shuffle(new Random(42), (1024 * 1025) / Long.BYTES)))
+                                .build()),
+                new ParquetReaderOptions());
+
+        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+        BlockMetadata blockMetaData = getOnlyElement(parquetMetadata.getBlocks());
+        ColumnChunkMetadata chunkMetaData = getOnlyElement(blockMetaData.columns());
+        assertThat(chunkMetaData.getEncodingStats().hasDictionaryPages()).isTrue();
+        assertThat(chunkMetaData.getEncodingStats().hasDictionaryEncodedPages()).isTrue();
+        assertThat(chunkMetaData.getEncodingStats().hasNonDictionaryEncodedPages()).isTrue();
+        assertThat(hasBloomFilter(chunkMetaData)).isTrue();
     }
 
     public static Stream<Arguments> testWriteBloomFiltersParams()

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestTrinoValuesWriterFactory.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestTrinoValuesWriterFactory.java
@@ -176,11 +176,11 @@ public class TestTrinoValuesWriterFactory
 
     private void validateFallbackWriterBloomFilter(ValuesWriter writer, Class<? extends ValuesWriter> initialWriterClass, Class<? extends ValuesWriter> fallbackWriterClass)
     {
-        validateWriterType(writer, DictionaryFallbackValuesWriter.class);
+        validateWriterType(writer, BloomFilterValuesWriter.class);
 
-        DictionaryFallbackValuesWriter fallbackValuesWriter = (DictionaryFallbackValuesWriter) writer;
+        BloomFilterValuesWriter bloomFilterValuesWriter = (BloomFilterValuesWriter) writer;
+        DictionaryFallbackValuesWriter fallbackValuesWriter = (DictionaryFallbackValuesWriter) bloomFilterValuesWriter.getWriter();
         validateWriterType(fallbackValuesWriter.getInitialWriter(), initialWriterClass);
-        BloomFilterValuesWriter bloomFilterValuesWriter = (BloomFilterValuesWriter) fallbackValuesWriter.getFallBackWriter();
-        validateWriterType(bloomFilterValuesWriter.getWriter(), fallbackWriterClass);
+        validateWriterType(fallbackValuesWriter.getFallBackWriter(), fallbackWriterClass);
     }
 }

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseTestParquetWithBloomFilters.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseTestParquetWithBloomFilters.java
@@ -13,6 +13,7 @@
  */
 package io.trino.testing;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
 import io.trino.spi.connector.CatalogSchemaTableName;
@@ -49,6 +50,12 @@ public abstract class BaseTestParquetWithBloomFilters
     {
         CatalogSchemaTableName tableName = createParquetTableWithBloomFilter(COLUMN_NAME, TEST_VALUES);
         testBloomFilterRowGroupPruning(tableName, COLUMN_NAME);
+    }
+
+    @Test
+    void testBloomFilterColumnWithDictionaryPage()
+    {
+        createParquetTableWithBloomFilter(COLUMN_NAME, ImmutableList.of(1, 1));
     }
 
     protected void testBloomFilterRowGroupPruning(CatalogSchemaTableName tableName, String columnName)


### PR DESCRIPTION
## Description
Current logic was failing to convert dictionary pages into bloom filter
when the fallback from dictionary to plain encoding happened after first page.
Bloom filter writing logic is changed to always collect a bloom filter and
discard it at the end if only dictionary encoded pages are present. This avoids
the need to depend on values writer fallback mechanism.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes https://github.com/trinodb/trino/issues/22701


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Delta, Iceberg, Hudi
* Fix writing of bloom filter columns in parquet files. ({issue}`22701`)
```
