### PR TITLE
Add length to file cache key to reduce collision possibility

### DIFF
--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/DefaultCacheKeyProvider.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/DefaultCacheKeyProvider.java
@@ -25,6 +25,6 @@ public final class DefaultCacheKeyProvider
     public Optional<String> getCacheKey(TrinoInputFile inputFile)
             throws IOException
     {
-        return Optional.of(inputFile.location().path() + inputFile.lastModified());
+        return Optional.of(inputFile.location().path() + "#" + inputFile.lastModified() + "#" + inputFile.length());
     }
 }

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/cache/TestCacheFileSystemAccessOperations.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/cache/TestCacheFileSystemAccessOperations.java
@@ -87,6 +87,7 @@ public class TestCacheFileSystemAccessOperations
                         .build());
         assertReadOperations(location, content,
                 ImmutableMultiset.<FileOperation>builder()
+                        .add(new FileOperation(location, "InputFile.length"))
                         .add(new FileOperation(location, "InputFile.lastModified"))
                         .build());
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Fixes https://github.com/trinodb/trino/issues/22861

In case file is updated in the same millisecond cache key may collide. Adding length to key computation reduce chance of this collision.

It also caused flakiness of `TestHiveAlluxioCacheFileOperations.testCacheFileOperations` with about 10% rate, after this change it passed 20 times in row.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
