### PR TITLE
Clarify the s3.endpoint is an URL in migration guide

### DIFF
--- a/docs/src/main/sphinx/object-storage/legacy-s3.md
+++ b/docs/src/main/sphinx/object-storage/legacy-s3.md
@@ -380,7 +380,7 @@ the following edits to your catalog configuration:
      -
    * - `hive.s3.endpoint`
      - `s3.endpoint`
-     -
+     - Add the `https://` prefix to make the value a correct URL.
    * - `hive.s3.region`
      - `s3.region`
      -


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The migration guide is not easy to find, but I'm not sure where to link it. It's only mentioned in the 458 release notes, and users have to browse release notes of multiple versions to find it.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
