### PR TITLE
Support setting content md5 to validate upload content

### DIFF
--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3Context.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3Context.java
@@ -30,7 +30,7 @@ import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_SEC
 import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY;
 import static java.util.Objects.requireNonNull;
 
-record S3Context(int partSize, boolean requesterPays, S3SseType sseType, String sseKmsKeyId, Optional<AwsCredentialsProvider> credentialsProviderOverride, ObjectCannedAcl cannedAcl, boolean exclusiveWriteSupported)
+record S3Context(int partSize, boolean requesterPays, S3SseType sseType, String sseKmsKeyId, Optional<AwsCredentialsProvider> credentialsProviderOverride, ObjectCannedAcl cannedAcl, boolean exclusiveWriteSupported, boolean enableSetContentMd5)
 {
     private static final int MIN_PART_SIZE = 5 * 1024 * 1024; // S3 requirement
 
@@ -49,7 +49,7 @@ record S3Context(int partSize, boolean requesterPays, S3SseType sseType, String 
 
     public S3Context withKmsKeyId(String kmsKeyId)
     {
-        return new S3Context(partSize, requesterPays, S3SseType.KMS, kmsKeyId, credentialsProviderOverride, cannedAcl, exclusiveWriteSupported);
+        return new S3Context(partSize, requesterPays, S3SseType.KMS, kmsKeyId, credentialsProviderOverride, cannedAcl, exclusiveWriteSupported, enableSetContentMd5);
     }
 
     public S3Context withCredentials(ConnectorIdentity identity)
@@ -73,7 +73,8 @@ record S3Context(int partSize, boolean requesterPays, S3SseType sseType, String 
                 sseKmsKeyId,
                 Optional.of(credentialsProviderOverride),
                 cannedAcl,
-                exclusiveWriteSupported);
+                exclusiveWriteSupported,
+                enableSetContentMd5);
     }
 
     public void applyCredentialProviderOverride(AwsRequestOverrideConfiguration.Builder builder)

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
@@ -519,7 +519,7 @@ public class S3FileSystemConfig
     }
 
     @Config("s3.enable-set-content-md5")
-    @ConfigDescription("Whether to set content md5 for s3 write requests")
+    @ConfigDescription("Whether to set content md5 header for the s3 write requests. The header can be used to provide end-to-end integrity check, but it introduces additional latency to compute the MD5 digest")
     public S3FileSystemConfig setEnableSetContentMd5(boolean setContentMd5)
     {
         this.enableSetContentMd5 = setContentMd5;

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
@@ -115,6 +115,7 @@ public class S3FileSystemConfig
     private RetryMode retryMode = RetryMode.LEGACY;
     private int maxErrorRetries = 10;
     private boolean supportsExclusiveCreate = true;
+    private boolean enableSetContentMd5;
 
     public String getAwsAccessKey()
     {
@@ -509,6 +510,19 @@ public class S3FileSystemConfig
     public S3FileSystemConfig setSupportsExclusiveCreate(boolean supportsExclusiveCreate)
     {
         this.supportsExclusiveCreate = supportsExclusiveCreate;
+        return this;
+    }
+
+    public boolean isEnableSetContentMd5()
+    {
+        return enableSetContentMd5;
+    }
+
+    @Config("s3.enable-set-content-md5")
+    @ConfigDescription("Whether to set content md5 for s3 write requests")
+    public S3FileSystemConfig setEnableSetContentMd5(boolean setContentMd5)
+    {
+        this.enableSetContentMd5 = setContentMd5;
         return this;
     }
 }

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
@@ -115,7 +115,7 @@ public class S3FileSystemConfig
     private RetryMode retryMode = RetryMode.LEGACY;
     private int maxErrorRetries = 10;
     private boolean supportsExclusiveCreate = true;
-    private boolean enableSetContentMd5;
+    private boolean enableSetContentMd5 = true;
 
     public String getAwsAccessKey()
     {

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemLoader.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemLoader.java
@@ -89,7 +89,8 @@ final class S3FileSystemLoader
                 config.getSseKmsKeyId(),
                 Optional.empty(),
                 config.getCannedAcl(),
-                config.isSupportsExclusiveCreate());
+                config.isSupportsExclusiveCreate(),
+                config.isEnableSetContentMd5());
     }
 
     @Override

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemConfig.java
@@ -67,7 +67,8 @@ public class TestS3FileSystemConfig
                 .setHttpProxyUsername(null)
                 .setHttpProxyPassword(null)
                 .setHttpProxyPreemptiveBasicProxyAuth(false)
-                .setSupportsExclusiveCreate(true));
+                .setSupportsExclusiveCreate(true)
+                .setEnableSetContentMd5(false));
     }
 
     @Test
@@ -105,6 +106,7 @@ public class TestS3FileSystemConfig
                 .put("s3.http-proxy.password", "test")
                 .put("s3.http-proxy.preemptive-basic-auth", "true")
                 .put("s3.exclusive-create", "false")
+                .put("s3.enable-set-content-md5", "true")
                 .buildOrThrow();
 
         S3FileSystemConfig expected = new S3FileSystemConfig()
@@ -138,7 +140,8 @@ public class TestS3FileSystemConfig
                 .setHttpProxyUsername("test")
                 .setHttpProxyPassword("test")
                 .setHttpProxyPreemptiveBasicProxyAuth(true)
-                .setSupportsExclusiveCreate(false);
+                .setSupportsExclusiveCreate(false)
+                .setEnableSetContentMd5(true);
 
         assertFullMapping(properties, expected);
     }

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemConfig.java
@@ -68,7 +68,7 @@ public class TestS3FileSystemConfig
                 .setHttpProxyPassword(null)
                 .setHttpProxyPreemptiveBasicProxyAuth(false)
                 .setSupportsExclusiveCreate(true)
-                .setEnableSetContentMd5(false));
+                .setEnableSetContentMd5(true));
     }
 
     @Test
@@ -106,7 +106,7 @@ public class TestS3FileSystemConfig
                 .put("s3.http-proxy.password", "test")
                 .put("s3.http-proxy.preemptive-basic-auth", "true")
                 .put("s3.exclusive-create", "false")
-                .put("s3.enable-set-content-md5", "true")
+                .put("s3.enable-set-content-md5", "false")
                 .buildOrThrow();
 
         S3FileSystemConfig expected = new S3FileSystemConfig()
@@ -141,7 +141,7 @@ public class TestS3FileSystemConfig
                 .setHttpProxyPassword("test")
                 .setHttpProxyPreemptiveBasicProxyAuth(true)
                 .setSupportsExclusiveCreate(false)
-                .setEnableSetContentMd5(true);
+                .setEnableSetContentMd5(false);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Support setting content md5 to validate upload content



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

According to AWS's public doc, it is recommended to set content md5 when sending put requests. https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/model/PutObjectRequest.html#contentMD5()

This is also supported in the legacy filesystem. Because this will also introduce latencies to each request, setting this to false by default and provide this as optional to users


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(X ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
