### PR TITLE
Update queryType list in selector rules docs

### DIFF
--- a/docs/src/main/sphinx/admin/resource-groups.md
+++ b/docs/src/main/sphinx/admin/resource-groups.md
@@ -171,15 +171,22 @@ documentation](https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java
 
 - `queryType` (optional): string to match against the type of the query submitted:
 
-  - `SELECT`: `SELECT` queries.
-  - `EXPLAIN`: `EXPLAIN` queries (but not `EXPLAIN ANALYZE`).
-  - `DESCRIBE`: `DESCRIBE`, `DESCRIBE INPUT`, `DESCRIBE OUTPUT`, and `SHOW` queries.
-  - `INSERT`: `INSERT`, `CREATE TABLE AS`, and `REFRESH MATERIALIZED VIEW` queries.
-  - `UPDATE`: `UPDATE` queries.
-  - `DELETE`: `DELETE` queries.
-  - `ANALYZE`: `ANALYZE` queries.
-  - `DATA_DEFINITION`: Queries that alter/create/drop the metadata of schemas/tables/views,
-    and that manage prepared statements, privileges, sessions, and transactions.
+  - `SELECT`: [SELECT](/sql/select) queries.
+  - `EXPLAIN`: [EXPLAIN](/sql/explain) queries, but not [EXPLAIN
+    ANALYZE](/sql/explain-analyze) queries.
+  - `DESCRIBE`: [DESCRIBE](/sql/describe), [DESCRIBE
+    INPUT](/sql/describe-input), [DESCRIBE OUTPUT](/sql/describe-output), and
+    `SHOW` queries such as [SHOW CATALOGS](/sql/show-catalogs), [SHOW
+    SCHEMAS](/sql/show-schemas), and [SHOW TABLES](/sql/show-tables).
+  - `INSERT`: [INSERT](/sql/insert), [CREATE TABLE AS](/sql/create-table-as),
+    and [REFRESH MATERIALIZED VIEW](/sql/refresh-materialized-view) queries.
+  - `UPDATE`: [UPDATE](/sql/update) queries.
+  - `DELETE`: [DELETE](/sql/delete) queries.
+  - `ANALYZE`: [ANALYZE](/sql/analyze) queries.
+  - `DATA_DEFINITION`: Queries that affect the data definition. These include
+    `CREATE`, `ALTER`, and `DROP` statements for schemas, tables, views, and
+    materialized views, as well as statements that manage prepared statements,
+    privileges, sessions, and transactions.
 
 - `clientTags` (optional): list of tags. To match, every tag in this list must be in the list of
   client-provided tags associated with the query.

--- a/docs/src/main/sphinx/admin/resource-groups.md
+++ b/docs/src/main/sphinx/admin/resource-groups.md
@@ -181,12 +181,15 @@ documentation](https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java
   - `INSERT`: [INSERT](/sql/insert), [CREATE TABLE AS](/sql/create-table-as),
     and [REFRESH MATERIALIZED VIEW](/sql/refresh-materialized-view) queries.
   - `UPDATE`: [UPDATE](/sql/update) queries.
+  - `MERGE`: [MERGE](/sql/merge) queries.
   - `DELETE`: [DELETE](/sql/delete) queries.
   - `ANALYZE`: [ANALYZE](/sql/analyze) queries.
   - `DATA_DEFINITION`: Queries that affect the data definition. These include
     `CREATE`, `ALTER`, and `DROP` statements for schemas, tables, views, and
     materialized views, as well as statements that manage prepared statements,
     privileges, sessions, and transactions.
+  - `ALTER_TABLE_EXECUTE`: Queries that execute table procedures with [ALTER
+    TABLE EXECUTE](alter-table-execute).
 
 - `clientTags` (optional): list of tags. To match, every tag in this list must be in the list of
   client-provided tags associated with the query.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

* Adds `MERGE` and `ALTER_TABLE_EXECUTE` to list of queryType options for resource group selector rules.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

* https://github.com/trinodb/trino/blob/460beff1f72c3056035f820e047d23c96fb90915/core/trino-spi/src/main/java/io/trino/spi/resourcegroups/QueryType.java#L16

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
