### PR TITLE
Add missing `changeDataFeed` writer feature when table version supports reader/writer features in Delta Lake

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeSchemaSupport.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeSchemaSupport.java
@@ -108,7 +108,7 @@ public final class DeltaLakeSchemaSupport
 
     // https://github.com/delta-io/delta/blob/master/PROTOCOL.md#valid-feature-names-in-table-features
     private static final String APPEND_ONLY_FEATURE_NAME = "appendOnly";
-    private static final String CHANGE_DATA_FEED_FEATURE_NAME = "changeDataFeed";
+    public static final String CHANGE_DATA_FEED_FEATURE_NAME = "changeDataFeed";
     private static final String CHECK_CONSTRAINTS_FEATURE_NAME = "checkConstraints";
     private static final String COLUMN_MAPPING_FEATURE_NAME = "columnMapping";
     public static final String DELETION_VECTORS_FEATURE_NAME = "deletionVectors";


### PR DESCRIPTION
## Description

Fixes #23622

## Release notes

- [x] This is not user-visible or is docs only, and no release notes are required.
