### PR TITLE
Revert "Adjust PR template to use checkbox"

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,9 +16,9 @@ and contact us on #core-dev in Slack. -->
 More info at https://trino.io/development/process#release-note -->
 ## Release notes
 
-- [ ] This is not user-visible or is docs only, and no release notes are required.
-- [ ] Release notes are required. Please propose a release note for me.
-- [ ] Release notes are required, with the following suggested text:
+( ) This is not user-visible or is docs only, and no release notes are required.
+( ) Release notes are required. Please propose a release note for me.
+( ) Release notes are required, with the following suggested text:
 
 ```markdown
 ## Section


### PR DESCRIPTION
## Description

This reverts commit 7ba7299e562c1241dbc2ef957b82edaf39828059.

The problem is that checkboxes are converted into a task list automatically. It does not prevent the build or anything like that but since we always only want to check one of them its invalid as a task list and it does show up as such in the List of PRs.

See for example

<img width="724" alt="image" src="https://github.com/user-attachments/assets/1141aad4-f004-4776-9942-f37fc3607203">

It works fine if users delete the other two tasks in the template.. but thats kinda odd as well. I am not sure but maybe we need to rethink this even more over time. For now .. lets revert.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

- [x] This is not user-visible or is docs only, and no release notes are required.
