### PR TITLE
Do not retrieve Blob metadata on batch delete

### DIFF
--- a/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsFileSystem.java
+++ b/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsFileSystem.java
@@ -169,8 +169,8 @@ public class GcsFileSystem
             for (List<Location> locationBatch : partition(locations, batchSize)) {
                 StorageBatch batch = storage.batch();
                 for (Location location : locationBatch) {
-                    getBlob(storage, new GcsLocation(location))
-                            .ifPresent(blob -> batch.delete(blob.getBlobId()));
+                    GcsLocation gcsLocation = new GcsLocation(location);
+                    batch.delete(BlobId.of(gcsLocation.bucket(), gcsLocation.path()));
                 }
                 batchFutures.add(executorService.submit(batch::submit));
             }


### PR DESCRIPTION
This should make batch delete way faster as it won't resolve blob metadata.


<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
