### PR TITLE
Support s3 cross region bucket access

### DIFF
--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
@@ -519,7 +519,7 @@ public class S3FileSystemConfig
     }
 
     @Config("s3.cross-region-access-enabled")
-    @ConfigDescription("Whether to allow cross-region bucket access. No s3 endpoint should be set when this is enabled")
+    @ConfigDescription("Whether to allow cross-region bucket access. This will be ignored when s3 endpoint is set")
     public S3FileSystemConfig setCrossRegionAccessEnabled(boolean crossRegionAccessEnabled)
     {
         this.crossRegionAccessEnabled = crossRegionAccessEnabled;

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
@@ -115,6 +115,7 @@ public class S3FileSystemConfig
     private RetryMode retryMode = RetryMode.LEGACY;
     private int maxErrorRetries = 10;
     private boolean supportsExclusiveCreate = true;
+    private boolean crossRegionAccessEnabled;
 
     public String getAwsAccessKey()
     {
@@ -509,6 +510,19 @@ public class S3FileSystemConfig
     public S3FileSystemConfig setSupportsExclusiveCreate(boolean supportsExclusiveCreate)
     {
         this.supportsExclusiveCreate = supportsExclusiveCreate;
+        return this;
+    }
+
+    public boolean isCrossRegionAccessEnabled()
+    {
+        return crossRegionAccessEnabled;
+    }
+
+    @Config("s3.cross-region-access-enabled")
+    @ConfigDescription("Whether to allow cross-region bucket access")
+    public S3FileSystemConfig setCrossRegionAccessEnabled(boolean crossRegionAccessEnabled)
+    {
+        this.crossRegionAccessEnabled = crossRegionAccessEnabled;
         return this;
     }
 }

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
@@ -519,7 +519,7 @@ public class S3FileSystemConfig
     }
 
     @Config("s3.cross-region-access-enabled")
-    @ConfigDescription("Whether to allow cross-region bucket access")
+    @ConfigDescription("Whether to allow cross-region bucket access. No s3 endpoint should be set when this is enabled")
     public S3FileSystemConfig setCrossRegionAccessEnabled(boolean crossRegionAccessEnabled)
     {
         this.crossRegionAccessEnabled = crossRegionAccessEnabled;

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemLoader.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemLoader.java
@@ -166,8 +166,6 @@ final class S3FileSystemLoader
                 s3.crossRegionAccessEnabled(true);
             }
 
-            region.map(Region::of).ifPresent(s3::region);
-            endpoint.map(URI::create).ifPresent(s3::endpointOverride);
             s3.forcePathStyle(pathStyleAccess);
 
             if (useWebIdentityTokenCredentialsProvider) {

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemConfig.java
@@ -67,7 +67,8 @@ public class TestS3FileSystemConfig
                 .setHttpProxyUsername(null)
                 .setHttpProxyPassword(null)
                 .setHttpProxyPreemptiveBasicProxyAuth(false)
-                .setSupportsExclusiveCreate(true));
+                .setSupportsExclusiveCreate(true)
+                .setCrossRegionAccessEnabled(false));
     }
 
     @Test
@@ -105,6 +106,7 @@ public class TestS3FileSystemConfig
                 .put("s3.http-proxy.password", "test")
                 .put("s3.http-proxy.preemptive-basic-auth", "true")
                 .put("s3.exclusive-create", "false")
+                .put("s3.cross-region-access-enabled", "true")
                 .buildOrThrow();
 
         S3FileSystemConfig expected = new S3FileSystemConfig()
@@ -138,7 +140,8 @@ public class TestS3FileSystemConfig
                 .setHttpProxyUsername("test")
                 .setHttpProxyPassword("test")
                 .setHttpProxyPreemptiveBasicProxyAuth(true)
-                .setSupportsExclusiveCreate(false);
+                .setSupportsExclusiveCreate(false)
+                .setCrossRegionAccessEnabled(true);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Support s3 cross region bucket access

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

In the legacy filesystem, this is not configurable but when region and endpoint is not set, us-east-1 will be set (which is also the default when setting aws-global) and cross region bucket access is allowed. The sdk v2 does not have this option earlier and now it supports it. 

With this PR, we want to make this is configurable, while also set region and cross region access when no region nor endpoint is defined. When region is defined, and endpoint is not, then we will look at this config to determine if cross region access is allowed. 

We need this config to guard that in certain regions, no cross region access is allowed, while in some other regions, cross region access can be done


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( X) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
