### PR TITLE
Add support for more BCrypt versions

### DIFF
--- a/plugin/trino-password-authenticators/src/test/java/io/trino/plugin/password/file/TestEncryptionUtil.java
+++ b/plugin/trino-password-authenticators/src/test/java/io/trino/plugin/password/file/TestEncryptionUtil.java
@@ -27,8 +27,10 @@ public class TestEncryptionUtil
     @Test
     public void testHashingAlgorithmBCrypt()
     {
-        String password = "$2y$10$BqTb8hScP5DfcpmHo5PeyugxHz5Ky/qf3wrpD7SNm8sWuA3VlGqsa";
-        assertThat(getHashingAlgorithm(password)).isEqualTo(BCRYPT);
+        assertThat(getHashingAlgorithm("$2x$10$BqTb8hScP5DfcpmHo5PeyugxHz5Ky/qf3wrpD7SNm8sWuA3VlGqsa")).isEqualTo(BCRYPT);
+        assertThat(getHashingAlgorithm("$2y$10$BqTb8hScP5DfcpmHo5PeyugxHz5Ky/qf3wrpD7SNm8sWuA3VlGqsa")).isEqualTo(BCRYPT);
+        assertThat(getHashingAlgorithm("$2a$10$BqTb8hScP5DfcpmHo5PeyugxHz5Ky/qf3wrpD7SNm8sWuA3VlGqsa")).isEqualTo(BCRYPT);
+        assertThat(getHashingAlgorithm("$2b$10$BqTb8hScP5DfcpmHo5PeyugxHz5Ky/qf3wrpD7SNm8sWuA3VlGqsa")).isEqualTo(BCRYPT);
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/trinodb/trino/issues/23648


<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Security
* Add support for BCrypt 2A, 2B, 2X versions ({issue}`issuenumber`)
```
