### PR TITLE
Add Trino 461 release notes

### DIFF
--- a/docs/src/main/sphinx/release.md
+++ b/docs/src/main/sphinx/release.md
@@ -6,6 +6,7 @@
 ```{toctree}
 :maxdepth: 1
 
+release/release-461
 release/release-460
 release/release-459
 release/release-458

--- a/docs/src/main/sphinx/release/release-461.md
+++ b/docs/src/main/sphinx/release/release-461.md
@@ -1,0 +1,44 @@
+# Release 461 (10 Oct 2024)
+
+## General
+
+* Rename the configuration property `max-tasks-waiting-for-execution-per-stage`
+  to `max-tasks-waiting-for-execution-per-query` and the session property
+  `max_tasks_waiting_for_node_per_stage` to
+  `max_tasks_waiting_for_node_per_query` to match implemented semantics. ({issue}`23585`)
+* Fix failure when joining tables with large numbers of columns. ({issue}`23720`)
+* Fix failure for `MERGE` queries on tables with large numbers of columns. ({issue}`15848`)
+
+## Security
+
+* Add support for BCrypt versions 2A, 2B, and 2X usage in password database files
+  used with file-based authentication. ({issue}`23648`)
+
+## Web UI
+
+* Add buttons on the query list to access query details. ({issue}`22831`)
+* Add syntax highlighting to query display on query list. ({issue}`22831`)
+
+## BigQuery connector
+
+* Fix failure when `bigquery.case-insensitive-name-matching` is enabled and
+  `bigquery.case-insensitive-name-matching.cache-ttl` is `0m`. ({issue}`23698`)
+
+## Delta Lake connector
+
+* Enforce access control for new tables in the `register_table` procedure. ({issue}`23728`)
+
+## Hive connector
+
+* Add support for reading Hive tables that use `CombineTextInputFormat`. ({issue}`21842`)
+* Improve performance of queries with selective joins. ({issue}`23687`)
+
+## Iceberg connector
+
+* Add support for the `add_files` and `add_files_from_table` procedures. ({issue}`11744`)
+* Support `timestamp` type columns with the `migrate` procedure. ({issue}`17006`)
+* Enforce access control for new tables in the `register_table` procedure. ({issue}`23728`)
+
+## Redshift connector
+
+* Improve performance of queries with range filters on integers. ({issue}`23417`)


### PR DESCRIPTION
## Description

Assemble the release notes for the upcoming Trino 461 release.

## Additional context and related issues

See https://github.com/trinodb/trino/pulls?q=is%3Apr+is%3Aclosed+milestone%3A461

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

## Verification for each pull request

Format: PR/issue number, ✅ / ❌ rn ✅ / ❌ docs
✅ rn - release note added and verified, or assessed to be not necessary, set to ❌ rn before completion
✅ docs - need for docs assessed and merged, or assessed to be not necessary, set to ❌ docs before completion

## 3 Oct 2024

* #23668 ✅ rn ✅ docs
* #23672 ✅ rn ✅ docs
* #23670 ✅ rn ✅ docs

## 4 Oct 2024

* #23594 ✅ rn ✅ docs
* #22751 ✅ rn ❌  docs (mosabua to review/edit)
* #23663 ✅ rn ✅ docs
* #23665 ✅ rn ✅ docs
* #23676 ✅ rn ✅ docs
* #23585 ✅ rn ✅ docs
* #23675 ✅ rn ✅ docs
* #23679 ✅ rn ✅ docs
* #23681 ✅ rn ✅ docs
* #23680 ✅ rn ✅ docs
* #23671 ✅ rn ✅ docs
* #23683 ✅ rn ✅ docs

## 5 Oct 2024

No merged PRs.

## 6 Oct 2024

* #23693 ✅ rn ✅ docs
* #23690 ✅ rn ✅ docs

## 7 Oct 2024

* #23562 ✅ rn ✅ docs
* #23695 ✅ rn ✅ docs
* #23687 ✅ rn ✅ docs
* #23702 ✅ rn ✅ docs
* #23701 ✅ rn ✅ docs
* #23417 ✅ rn ✅ docs
* #23688 ✅ rn ✅ docs

## 8 Oct 2024

* #23657 ✅ rn ✅ docs
* #23662 ✅ rn ✅ docs
* #23699 ✅ rn ✅ docs
* #23707 ✅ rn ✅ docs
* #23072 ✅ rn ✅ docs
* #17391 ✅ rn ✅ docs
* #23716 ✅ rn ✅ docs
* #23698 ✅ rn ✅ docs
* #23717 ✅ rn ✅ docs
* #23720 ✅ rn ✅ docs

## 9 Oct 2024

* #23711 ✅ rn ✅ docs
* #23728 ✅ rn ✅ docs
* #23696 ✅ rn ✅ docs
* #23729 ✅ rn ✅ docs
* #23731 ✅ rn ✅ docs
* #23732 ✅ rn ✅ docs
* #23710 ✅ rn ✅ docs
* #22831 ✅ rn ✅ docs
* #23713 ✅ rn ✅ docs
* #23725 ✅ rn ✅ docs
* #23694 ✅ rn ✅ docs

## 10 Oct 2024

* #23738 ✅ rn ✅ docs