### PR TITLE
Remove unnecessary Block getLogicalSizeInBytes

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
@@ -51,7 +51,14 @@ import io.trino.server.protocol.spooling.QueryDataProducer;
 import io.trino.spi.ErrorCode;
 import io.trino.spi.Page;
 import io.trino.spi.QueryId;
+import io.trino.spi.block.ArrayBlock;
+import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockEncodingSerde;
+import io.trino.spi.block.DictionaryBlock;
+import io.trino.spi.block.MapBlock;
+import io.trino.spi.block.RowBlock;
+import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.spi.block.ValueBlock;
 import io.trino.spi.exchange.ExchangeId;
 import io.trino.spi.security.SelectedRole;
 import io.trino.spi.type.Type;
@@ -562,7 +569,9 @@ class Query
                 }
 
                 Page page = deserializer.deserialize(serializedPage);
-                bytes += page.getLogicalSizeInBytes();
+                // page should already be loaded since it was just deserialized
+                page = page.getLoadedPage();
+                bytes += estimateJsonSize(page);
                 resultBuilder.addPage(page);
             }
             if (exchangeDataSource.isFinished()) {
@@ -575,6 +584,38 @@ class Query
         }
 
         return resultBuilder.build();
+    }
+
+    private static long estimateJsonSize(Page page)
+    {
+        long estimatedSize = 0;
+        for (int i = 0; i < page.getChannelCount(); i++) {
+            estimatedSize += estimateJsonSize(page.getBlock(i));
+        }
+        return estimatedSize;
+    }
+
+    private static long estimateJsonSize(Block block)
+    {
+        switch (block) {
+            case RunLengthEncodedBlock rleBlock:
+                return estimateJsonSize(rleBlock.getValue()) * rleBlock.getPositionCount();
+            case DictionaryBlock dictionaryBlock:
+                ValueBlock dictionary = dictionaryBlock.getDictionary();
+                double averageSizePerEntry = (double) estimateJsonSize(dictionary) / dictionary.getPositionCount();
+                return (long) (averageSizePerEntry * block.getPositionCount());
+            case RowBlock rowBlock:
+                return rowBlock.getFieldBlocks().stream()
+                        .mapToLong(Query::estimateJsonSize)
+                        .sum();
+            case ArrayBlock arrayBlock:
+                return estimateJsonSize(arrayBlock.getElementsBlock());
+            case MapBlock mapBlock:
+                return estimateJsonSize(mapBlock.getKeyBlock()) +
+                        estimateJsonSize(mapBlock.getValueBlock());
+            default:
+                return block.getSizeInBytes();
+        }
     }
 
     private void closeExchangeIfNecessary(ResultQueryInfo queryInfo)

--- a/core/trino-main/src/test/java/io/trino/block/TestDictionaryBlock.java
+++ b/core/trino-main/src/test/java/io/trino/block/TestDictionaryBlock.java
@@ -85,31 +85,6 @@ public class TestDictionaryBlock
     }
 
     @Test
-    public void testLogicalSizeInBytes()
-    {
-        // The 10 Slices in the array will be of lengths 0 to 9.
-        Slice[] expectedValues = createExpectedValues(10);
-
-        // The dictionary within the dictionary block is expected to be a VariableWidthBlock of size 95 bytes.
-        // 45 bytes for the expectedValues Slices (sum of seq(0,9)) and 50 bytes for the position and isNull array (total 10 positions).
-        DictionaryBlock dictionaryBlock = createDictionaryBlock(expectedValues, 100);
-        assertThat(dictionaryBlock.getDictionary().getLogicalSizeInBytes()).isEqualTo(95);
-
-        // The 100 positions in the dictionary block index to 10 positions in the underlying dictionary (10 each).
-        // Logical size calculation accounts for 4 bytes of offset and 1 byte of isNull. Therefore the expected unoptimized
-        // size is 10 times the size of the underlying dictionary (VariableWidthBlock).
-        assertThat(dictionaryBlock.getLogicalSizeInBytes()).isEqualTo(95 * 10);
-
-        // With alternating nulls, we have 21 positions, with the same size calculation as above.
-        dictionaryBlock = createDictionaryBlock(alternatingNullValues(expectedValues), 210);
-        assertThat(dictionaryBlock.getDictionary().getPositionCount()).isEqualTo(21);
-        assertThat(dictionaryBlock.getDictionary().getLogicalSizeInBytes()).isEqualTo(150);
-
-        // The null positions should be included in the logical size.
-        assertThat(dictionaryBlock.getLogicalSizeInBytes()).isEqualTo(150 * 10);
-    }
-
-    @Test
     public void testCopyRegionCreatesCompactBlock()
     {
         Slice[] expectedValues = createExpectedValues(10);

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -265,6 +265,26 @@
                                     <old>interface io.trino.spi.protocol.SpoolingManagerFactory</old>
                                     <justification>Spooling SPI marked as experimental</justification>
                                 </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method long io.trino.spi.Page::getLogicalSizeInBytes()</old>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method long io.trino.spi.block.Block::getLogicalSizeInBytes()</old>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method long io.trino.spi.block.DictionaryBlock::getLogicalSizeInBytes()</old>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method long io.trino.spi.block.RunLengthEncodedBlock::getLogicalSizeInBytes()</old>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/Page.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/Page.java
@@ -51,7 +51,6 @@ public final class Page
     private final int positionCount;
     private volatile long sizeInBytes = -1;
     private volatile long retainedSizeInBytes = -1;
-    private volatile long logicalSizeInBytes = -1;
 
     public Page(Block... blocks)
     {
@@ -78,7 +77,6 @@ public final class Page
         if (blocks.length == 0) {
             this.blocks = EMPTY_BLOCKS;
             this.sizeInBytes = 0;
-            this.logicalSizeInBytes = 0;
             // Empty blocks are not considered "retained" by any particular page
             this.retainedSizeInBytes = INSTANCE_SIZE;
         }
@@ -112,19 +110,6 @@ public final class Page
             this.sizeInBytes = sizeInBytes;
         }
         return sizeInBytes;
-    }
-
-    public long getLogicalSizeInBytes()
-    {
-        long logicalSizeInBytes = this.logicalSizeInBytes;
-        if (logicalSizeInBytes < 0) {
-            logicalSizeInBytes = 0;
-            for (Block block : blocks) {
-                logicalSizeInBytes += block.getLogicalSizeInBytes();
-            }
-            this.logicalSizeInBytes = logicalSizeInBytes;
-        }
-        return logicalSizeInBytes;
     }
 
     public long getRetainedSizeInBytes()

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlock.java
@@ -165,6 +165,13 @@ public final class ArrayBlock
         consumer.accept(this, INSTANCE_SIZE);
     }
 
+    public Block getElementsBlock()
+    {
+        int start = offsets[arrayOffset];
+        int end = offsets[arrayOffset + positionCount];
+        return values.getRegion(start, end - start);
+    }
+
     Block getRawElementBlock()
     {
         return values;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Block.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Block.java
@@ -47,20 +47,6 @@ public sealed interface Block
     long getSizeInBytes();
 
     /**
-     * Returns the size of the block contents, regardless of internal representation.
-     * The same logical data values should always have the same size, no matter
-     * what block type is used or how they are represented within a specific block.
-     * <p>
-     * This can differ substantially from {@link #getSizeInBytes} for certain block
-     * types. For RLE, it will be {@code N} times larger. For dictionary, it will be
-     * larger based on how many times dictionary entries are reused.
-     */
-    default long getLogicalSizeInBytes()
-    {
-        return getSizeInBytes();
-    }
-
-    /**
      * Returns the size of {@code block.getRegion(position, length)}.
      * The method can be expensive. Do not use it outside an implementation of Block.
      */

--- a/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
@@ -42,7 +42,6 @@ public final class DictionaryBlock
     private final int[] ids;
     private final long retainedSizeInBytes;
     private volatile long sizeInBytes = -1;
-    private volatile long logicalSizeInBytes = -1;
     private volatile int uniqueIds = -1;
     // isSequentialIds is only valid when uniqueIds is computed
     private volatile boolean isSequentialIds;
@@ -190,36 +189,6 @@ public final class DictionaryBlock
         this.sizeInBytes = getSizeInBytesForSelectedPositions(used, uniqueIds, positionCount);
         this.uniqueIds = uniqueIds;
         this.isSequentialIds = isSequentialIds;
-    }
-
-    @Override
-    public long getLogicalSizeInBytes()
-    {
-        if (logicalSizeInBytes >= 0) {
-            return logicalSizeInBytes;
-        }
-
-        OptionalInt dictionarySizePerPosition = dictionary.fixedSizeInBytesPerPosition();
-        if (dictionarySizePerPosition.isPresent()) {
-            logicalSizeInBytes = dictionarySizePerPosition.getAsInt() * (long) getPositionCount();
-            return logicalSizeInBytes;
-        }
-
-        // Calculation of logical size can be performed as part of calculateCompactSize() with minor modifications.
-        // Keeping this calculation separate as this is a little more expensive and may not be called as often.
-        long sizeInBytes = 0;
-        long[] seenSizes = new long[dictionary.getPositionCount()];
-        Arrays.fill(seenSizes, -1L);
-        for (int i = 0; i < getPositionCount(); i++) {
-            int position = getId(i);
-            if (seenSizes[position] < 0) {
-                seenSizes[position] = dictionary.getRegionSizeInBytes(position, 1);
-            }
-            sizeInBytes += seenSizes[position];
-        }
-
-        logicalSizeInBytes = sizeInBytes;
-        return sizeInBytes;
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/MapBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/MapBlock.java
@@ -186,6 +186,20 @@ public final class MapBlock
         this.retainedSizeInBytes = INSTANCE_SIZE + sizeOf(offsets) + sizeOf(mapIsNull);
     }
 
+    public Block getKeyBlock()
+    {
+        int start = offsets[startOffset];
+        int end = offsets[startOffset + positionCount];
+        return keyBlock.getRegion(start, end - start);
+    }
+
+    public Block getValueBlock()
+    {
+        int start = offsets[startOffset];
+        int end = offsets[startOffset + positionCount];
+        return valueBlock.getRegion(start, end - start);
+    }
+
     Block getRawKeyBlock()
     {
         return keyBlock;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
@@ -119,12 +119,6 @@ public final class RunLengthEncodedBlock
     }
 
     @Override
-    public long getLogicalSizeInBytes()
-    {
-        return positionCount * value.getLogicalSizeInBytes();
-    }
-
-    @Override
     public long getRetainedSizeInBytes()
     {
         return INSTANCE_SIZE + value.getRetainedSizeInBytes();

--- a/core/trino-spi/src/test/java/io/trino/spi/TestPage.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/TestPage.java
@@ -68,8 +68,6 @@ public class TestPage
     {
         Page page = new Page(100);
         assertThat(page.getSizeInBytes()).isEqualTo(0);
-        assertThat(page.getLogicalSizeInBytes()).isEqualTo(0);
-        assertThat(page.getRetainedSizeInBytes()).isEqualTo(Page.INSTANCE_SIZE); // does not include the blocks array
     }
 
     @Test

--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/SliceDictionaryColumnWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/SliceDictionaryColumnWriter.java
@@ -69,7 +69,7 @@ public class SliceDictionaryColumnWriter
         implements ColumnWriter, DictionaryColumn
 {
     private static final int INSTANCE_SIZE = instanceSize(SliceDictionaryColumnWriter.class);
-    private static final int DIRECT_CONVERSION_CHUNK_MAX_LOGICAL_BYTES = toIntExact(DataSize.of(32, MEGABYTE).toBytes());
+    private static final int DIRECT_CONVERSION_CHUNK_MAX_BYTES = toIntExact(DataSize.of(32, MEGABYTE).toBytes());
 
     private final OrcColumnId columnId;
     private final Type type;
@@ -224,7 +224,7 @@ public class SliceDictionaryColumnWriter
                 Block chunk = block.getRegion(0, chunkPositionCount);
 
                 // avoid chunk with huge logical size
-                while (chunkPositionCount > 1 && chunk.getLogicalSizeInBytes() > DIRECT_CONVERSION_CHUNK_MAX_LOGICAL_BYTES) {
+                while (chunkPositionCount > 1 && chunk.getSizeInBytes() > DIRECT_CONVERSION_CHUNK_MAX_BYTES) {
                     chunkPositionCount /= 2;
                     chunk = chunk.getRegion(0, chunkPositionCount);
                 }


### PR DESCRIPTION
## Description
This was only used in a few places, and was not implement correctly in several container block implementations.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Remove `Block.getLogicalSizeInBytes`. ({issue}`23688`)
```
