### PR TITLE
Split channel fields initialization in JoinCompiler into multiple methods to avoid byte-code size limit error

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestJoinCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestJoinCompiler.java
@@ -158,7 +158,7 @@ public class TestJoinCompiler
             List<Integer> joinChannels = Ints.asList(1, 2, 3, 4);
             List<Integer> outputChannels = Ints.asList(1, 2, 3, 4, 0);
 
-            // crate hash strategy with a single channel blocks -- make sure there is some overlap in values
+            // create hash strategy with a single channel blocks -- make sure there is some overlap in values
             ObjectArrayList<Block> extraChannel = new ObjectArrayList<>();
             extraChannel.add(BlockAssertions.createStringSequenceBlock(10, 20));
             extraChannel.add(BlockAssertions.createStringSequenceBlock(20, 30));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
We face the following error when there are many columns in a join:
```
com.google.common.util.concurrent.UncheckedExecutionException: io.airlift.bytecode.CompilationException: Error compiling class: io/trino/$gen/PagesHashStrategy_20241006_053537_38
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2085)
	at com.google.common.cache.LocalCache.get(LocalCache.java:4017)
	at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:4040)
	at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4989)
	at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:4996)
	at com.google.common.cache.ForwardingLoadingCache.getUnchecked(ForwardingLoadingCache.java:54)
	at io.trino.sql.gen.JoinCompiler.compileLookupSourceFactory(JoinCompiler.java:152)
	at io.trino.operator.PagesIndex.createLookupSourceSupplier(PagesIndex.java:537)
	at io.trino.operator.join.unspilled.HashBuilderOperator.buildLookupSource(HashBuilderOperator.java:357)
	at io.trino.operator.join.unspilled.HashBuilderOperator.finishInput(HashBuilderOperator.java:335)
	at io.trino.operator.join.unspilled.HashBuilderOperator.finish(HashBuilderOperator.java:303)
	at io.trino.operator.Driver.processInternal(Driver.java:421)
	at io.trino.operator.Driver.lambda$process$8(Driver.java:306)
	at io.trino.operator.Driver.tryWithLock(Driver.java:709)
	at io.trino.operator.Driver.process(Driver.java:298)
	at io.trino.operator.Driver.processForDuration(Driver.java:269)
	at io.trino.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:890)
	at io.trino.execution.executor.dedicated.SplitProcessor.run(SplitProcessor.java:77)
	at io.trino.execution.executor.dedicated.TaskEntry$VersionEmbedderBridge.lambda$run$0(TaskEntry.java:201)
	at io.trino.$gen.Trino_dev____20241006_053305_2.run(Unknown Source)
	at io.trino.execution.executor.dedicated.TaskEntry$VersionEmbedderBridge.run(TaskEntry.java:202)
	at io.trino.execution.executor.scheduler.FairScheduler.runTask(FairScheduler.java:172)
	at io.trino.execution.executor.scheduler.FairScheduler.lambda$submit$0(FairScheduler.java:159)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:131)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:76)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:82)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1570)
Caused by: io.airlift.bytecode.CompilationException: Error compiling class: io/trino/$gen/PagesHashStrategy_20241006_053537_38
	at io.airlift.bytecode.ByteCodeGenerator.generateByteCode(ByteCodeGenerator.java:106)
	at io.airlift.bytecode.ClassGenerator.defineClasses(ClassGenerator.java:100)
	at io.airlift.bytecode.ClassGenerator.defineClass(ClassGenerator.java:90)
	at io.trino.util.CompilerUtils.defineClass(CompilerUtils.java:81)
	at io.trino.util.CompilerUtils.defineClass(CompilerUtils.java:75)
	at io.trino.sql.gen.JoinCompiler.internalCompileHashStrategy(JoinCompiler.java:260)
	at io.trino.sql.gen.JoinCompiler.internalCompileLookupSourceFactory(JoinCompiler.java:186)
	at io.trino.sql.gen.JoinCompiler.lambda$new$0(JoinCompiler.java:114)
	at com.google.common.cache.CacheLoader$FunctionToCacheLoader.load(CacheLoader.java:169)
	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3574)
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2316)
	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2189)
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2079)
	... 29 more
Caused by: org.objectweb.asm.MethodTooLargeException: Method too large: io/trino/$gen/PagesHashStrategy_20241006_053537_38.<init> (Ljava/util/List;Ljava/util/OptionalInt;)V
	at org.objectweb.asm.MethodWriter.computeMethodInfoSize(MethodWriter.java:2088)
	at org.objectweb.asm.ClassWriter.toByteArray(ClassWriter.java:512)
	at io.airlift.bytecode.ByteCodeGenerator.generateByteCode(ByteCodeGenerator.java:103)
	... 41 more
```
Confirmed that this error happens if the build side of join selects (more than 600-700 columns, as far as I have tested) because too long byte-code is generated in the following loop:
https://github.com/trinodb/trino/blob/012cd0252aa0dcbea16393096734fff653f6d388/core/trino-main/src/main/java/io/trino/sql/gen/JoinCompiler.java#L290-L324

Another solution is fallback to an interpreter as proposed in https://github.com/trinodb/trino/pull/12117. I'm not sure which is a better way.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
- https://github.com/trinodb/trino/pull/12117


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
