### PR TITLE
Tweak validation of missing data columns in Iceberg `add_files_from_table` procedure

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrationUtils.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrationUtils.java
@@ -274,9 +274,10 @@ public final class MigrationUtils
 
         if (!requiredFields.isEmpty()) {
             for (DataFile dataFile : dataFiles) {
-                Map<Integer, Long> nullValueCounts = dataFile.nullValueCounts();
+                Map<Integer, Long> nullValueCounts = firstNonNull(dataFile.nullValueCounts(), Map.of());
                 for (Integer field : requiredFields) {
-                    if (nullValueCounts.get(field) > 0) {
+                    Long nullCount = nullValueCounts.get(field);
+                    if (nullCount == null || nullCount > 0) {
                         throw new TrinoException(CONSTRAINT_VIOLATION, "NULL value not allowed for NOT NULL column: " + schema.findField(field).name());
                     }
                 }


### PR DESCRIPTION
## Description

Relates to #23677

Still disllowing the following situation:
* Partition column doesn't exist
* All source columns don't exist in the target table
* Source table has more columns than target table
  * Probably, this can be allowed in the future after updating `MigrationUtils#loadMetrics` implementation

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
