### PR TITLE
Add properties to reduce the amount of data fetching from prometheus.

### DIFF
--- a/docs/src/main/sphinx/connector/prometheus.md
+++ b/docs/src/main/sphinx/connector/prometheus.md
@@ -91,6 +91,14 @@ The following configuration properties are available:
      with the values as `value1` and `value2`. Escape comma (`,`) or colon(`:`)
      characters in a header name or value with a backslash (`\`).
   -
+* - `prometheus.query.match.string`
+  -  Match string to send as part of query to Prometheus to filter the data on Prometheus server.
+     The equivalent catalog session property is `query_match_string`.
+  -
+* - `prometheus.query.functions`
+  -  Comma separated list of functions to be sent to Prometheus HTTP API as part of query.
+     The equivalent catalog session property is `query_functions`.
+  -
 :::
 
 ## Not exhausting your Trino available heap

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusConnectorConfig.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusConnectorConfig.java
@@ -15,6 +15,7 @@ package io.trino.plugin.prometheus;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HttpHeaders;
 import com.google.inject.ConfigurationException;
 import com.google.inject.spi.Message;
@@ -29,11 +30,15 @@ import jakarta.validation.constraints.NotNull;
 import java.io.File;
 import java.net.URI;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
 
 public class PrometheusConnectorConfig
 {
@@ -48,6 +53,8 @@ public class PrometheusConnectorConfig
     private String password;
     private boolean caseInsensitiveNameMatching;
     private Map<String, String> additionalHeaders = ImmutableMap.of();
+    private String matchString;
+    private Set<String> queryFunctions = ImmutableSet.of();
 
     @NotNull
     public URI getPrometheusURI()
@@ -213,6 +220,34 @@ public class PrometheusConnectorConfig
         catch (IndexOutOfBoundsException e) {
             throw new IllegalArgumentException(format("Invalid format for 'prometheus.http.additional-headers' because %s. Value provided is %s", e.getMessage(), httpHeaders), e);
         }
+        return this;
+    }
+
+    public Optional<String> getMatchString()
+    {
+        return Optional.ofNullable(matchString);
+    }
+
+    @Config("prometheus.query.match.string")
+    @ConfigDescription("match[] filter to be used in Prometheus HTTP API")
+    public PrometheusConnectorConfig setMatchString(String matchString)
+    {
+        this.matchString = matchString;
+        return this;
+    }
+
+    public Set<String> getQueryFunctions()
+    {
+        return queryFunctions;
+    }
+
+    @Config("prometheus.query.functions")
+    @ConfigDescription("Comma separated list of functions to be sent to Prometheus HTTP API as part of query")
+    public PrometheusConnectorConfig setQueryFunctions(List<String> queryFunctions)
+    {
+        this.queryFunctions = queryFunctions.stream()
+            .map(value -> value.toLowerCase(ENGLISH))
+            .collect(toImmutableSet());
         return this;
     }
 

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusSessionProperties.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusSessionProperties.java
@@ -17,18 +17,32 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import io.airlift.units.Duration;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
+import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.session.PropertyMetadata;
+import io.trino.spi.type.ArrayType;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.plugin.base.session.PropertyMetadataUtil.durationProperty;
+import static io.trino.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
+import static io.trino.spi.session.PropertyMetadata.stringProperty;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
 
 public final class PrometheusSessionProperties
         implements SessionPropertiesProvider
 {
     private static final String QUERY_CHUNK_SIZE_DURATION = "query_chunk_size_duration";
     private static final String MAX_QUERY_RANGE_DURATION = "max_query_range_duration";
+    private static final String MATCH_FILTER = "query_match_filter";
+    private static final String QUERY_FUNCTIONS = "query_functions";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -46,6 +60,28 @@ public final class PrometheusSessionProperties
                         "Width of overall query to Prometheus, will be divided into query_chunk_size_duration queries",
                         connectorConfig.getMaxQueryRangeDuration(),
                         false))
+                .add(stringProperty(
+                        MATCH_FILTER,
+                        "query match filter for Prometheus HTTP API",
+                        connectorConfig.getMatchString().orElse(""),
+                        false))
+                .add(new PropertyMetadata<>(
+                        QUERY_FUNCTIONS,
+                        "List of functions that can be used in Prometheus queries",
+                        new ArrayType(VARCHAR),
+                        Set.class,
+                        connectorConfig.getQueryFunctions(),
+                        false,
+                        object -> ((Collection<?>) object).stream()
+                                .map(String.class::cast)
+                                .peek(property -> {
+                                    if (isNullOrEmpty(property)) {
+                                        throw new TrinoException(INVALID_SESSION_PROPERTY, format("Invalid null or empty value in %s property", QUERY_FUNCTIONS));
+                                    }
+                                })
+                                .map(schema -> schema.toLowerCase(ENGLISH))
+                                .collect(toImmutableSet()),
+                        value -> value))
                 .build();
     }
 
@@ -63,5 +99,16 @@ public final class PrometheusSessionProperties
     public static Duration getMaxQueryRange(ConnectorSession session)
     {
         return session.getProperty(MAX_QUERY_RANGE_DURATION, Duration.class);
+    }
+
+    public static Optional<String> getMatchFilter(ConnectorSession session)
+    {
+        return Optional.ofNullable(session.getProperty(MATCH_FILTER, String.class));
+    }
+
+    @SuppressWarnings("unchecked cast")
+    public static Set<String> getQueryFunctions(ConnectorSession session)
+    {
+        return (Set<String>) session.getProperty(QUERY_FUNCTIONS, Set.class);
     }
 }

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusConnectorConfig.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusConnectorConfig.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.prometheus;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HttpHeaders;
 import com.google.inject.ConfigurationException;
@@ -21,6 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
@@ -46,7 +48,9 @@ public class TestPrometheusConnectorConfig
                 .setPassword(null)
                 .setReadTimeout(new Duration(10, SECONDS))
                 .setCaseInsensitiveNameMatching(false)
-                .setAdditionalHeaders(null));
+                .setAdditionalHeaders(null)
+                .setMatchString(null)
+                .setQueryFunctions(ImmutableList.of()));
     }
 
     @Test
@@ -64,6 +68,8 @@ public class TestPrometheusConnectorConfig
                 .put("prometheus.read-timeout", "30s")
                 .put("prometheus.case-insensitive-name-matching", "true")
                 .put("prometheus.http.additional-headers", "key\\:1:value\\,1, key\\,2:value\\:2")
+                .put("prometheus.query.match.string", "{}")
+                .put("prometheus.query.functions", "max_over_time,min_over_time,count_over_time,sum_over_time")
                 .buildOrThrow();
 
         URI uri = URI.create("file://test.json");
@@ -79,6 +85,8 @@ public class TestPrometheusConnectorConfig
         expected.setReadTimeout(new Duration(30, SECONDS));
         expected.setCaseInsensitiveNameMatching(true);
         expected.setAdditionalHeaders("key\\:1:value\\,1, key\\,2:value\\:2");
+        expected.setMatchString("{}");
+        expected.setQueryFunctions(List.of("max_over_time", "min_over_time", "count_over_time", "sum_over_time"));
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION


<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

To reduce the amount of data fetched by Prometheus connector, adding to new config and session properties

1. prometheus.match_filter = this will add match filter to prometheus query string, for example up{instance="localhost:9090"}[1d]
2. prometheus.query_functions = we can pass the functions offered by prometheus APIs to do aggregation on the prometheus server and reduce the amount of data sent over the network. 

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`22416`)
```
