### PR TITLE
Pushdown lpad string function in Redshift

### DIFF
--- a/plugin/trino-redshift/pom.xml
+++ b/plugin/trino-redshift/pom.xml
@@ -265,6 +265,7 @@
                                 <!-- JDBC operations performed on the ephemeral AWS Redshift cluster.  -->
                                 <include>**/TestRedshiftCastPushdown.java</include>
                                 <include>**/TestRedshiftConnectorSmokeTest.java</include>
+                                <include>**/TestRedshiftConnectorTest.java</include>
                             </includes>
                         </configuration>
                     </plugin>

--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftClient.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftClient.java
@@ -667,7 +667,7 @@ public class RedshiftClient
                         RedshiftClient::writeChar));
 
             case Types.VARCHAR: {
-                int length = type.columnSize().orElse(REDSHIFT_MAX_VARCHAR);
+                int length = type.columnSize().orElse(VarcharType.MAX_LENGTH);
                 return Optional.of(varcharColumnMapping(
                         length < VarcharType.MAX_LENGTH
                                 ? createVarcharType(length)

--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RewriteCast.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RewriteCast.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
 
-import static io.trino.plugin.redshift.RedshiftClient.REDSHIFT_MAX_VARCHAR;
 import static java.sql.Types.BIGINT;
 import static java.sql.Types.BIT;
 import static java.sql.Types.CHAR;
@@ -79,7 +78,7 @@ public class RewriteCast
             case CharType _ -> CHAR == sourceType.jdbcType();
             // char -> varchar is not supported as Redshift doesn't pad char value with blanks whereas Trino pads char value with blanks.
             // cast to unbounded varchar is unsupported as Redshift doesn't support unbounded varchar
-            case VarcharType varcharType -> VARCHAR == sourceType.jdbcType() && !varcharType.isUnbounded() && varcharType.getBoundedLength() <= REDSHIFT_MAX_VARCHAR;
+            case VarcharType _ -> VARCHAR == sourceType.jdbcType();
             default -> false;
         };
     }

--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RewriteLpad.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RewriteLpad.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.redshift;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.projection.ProjectFunctionRule;
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcExpression;
+import io.trino.plugin.jdbc.JdbcTypeHandle;
+import io.trino.plugin.jdbc.QueryParameter;
+import io.trino.plugin.jdbc.expression.ParameterizedExpression;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.expression.Variable;
+import io.trino.spi.type.BigintType;
+import io.trino.spi.type.VarcharType;
+
+import java.util.Optional;
+
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argument;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argumentCount;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.constant;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.variable;
+import static io.trino.spi.type.IntegerType.INTEGER;
+
+public class RewriteLpad
+        implements ProjectFunctionRule<JdbcExpression, ParameterizedExpression>
+{
+    private static final Capture<Variable> ARGUMENT1 = newCapture();
+    private static final Capture<Constant> ARGUMENT2 = newCapture();
+    private static final Capture<Constant> ARGUMENT3 = newCapture();
+
+    private static final Pattern<Call> PATTERN = call()
+            .with(functionName().equalTo(new FunctionName("lpad")))
+            .with(type().matching(type -> type instanceof VarcharType))
+            .with(argumentCount().equalTo(3))
+            .with(argument(0).matching(variable().capturedAs(ARGUMENT1).with(type().matching(type -> type instanceof VarcharType))))
+            .with(argument(1).matching(constant().capturedAs(ARGUMENT2).with(type().matching(type -> type instanceof BigintType))))
+            .with(argument(2).matching(constant().capturedAs(ARGUMENT3).with(type().matching(type -> type instanceof VarcharType))));
+
+    @Override
+    public Pattern<? extends ConnectorExpression> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<JdbcExpression> rewrite(ConnectorTableHandle handle, ConnectorExpression projectionExpression, Captures captures, RewriteContext<ParameterizedExpression> context)
+    {
+        Variable argument1 = captures.get(ARGUMENT1);
+        Constant argument2 = captures.get(ARGUMENT2);
+        Constant argument3 = captures.get(ARGUMENT3);
+
+        JdbcTypeHandle typeHandle = ((JdbcColumnHandle) context.getAssignment(argument1.getName())).getJdbcTypeHandle();
+
+        ParameterizedExpression translatedArgument1 = context.rewriteExpression(argument1).orElseThrow();
+        ParameterizedExpression translatedArgument2 = context.rewriteExpression(argument2).orElseThrow();
+        ParameterizedExpression translatedArgument3 = context.rewriteExpression(argument3).orElseThrow();
+
+        // Pass empty columnSize to match unbounded varchar type created for synthetic column created for lpad expression.
+        JdbcTypeHandle updatedTypeHandle = new JdbcTypeHandle(typeHandle.jdbcType(), typeHandle.jdbcTypeName(), Optional.empty(), typeHandle.decimalDigits(), typeHandle.arrayDimensions(), typeHandle.caseSensitivity());
+
+        QueryParameter queryParameter = translatedArgument2.parameters().getFirst();
+        // Redshift requires integer type for size parameter. With bigint, driver throws `function lpad(character varying, bigint, "unknown") does not exist`
+        QueryParameter updatedQueryParameter = new QueryParameter(INTEGER, queryParameter.getValue());
+
+        return Optional.of(new JdbcExpression(
+                "lpad(%s, %s, %s)".formatted(translatedArgument1.expression(), translatedArgument2.expression(), translatedArgument3.expression()),
+                ImmutableList.<QueryParameter>builder()
+                        .addAll(translatedArgument1.parameters())
+                        .add(updatedQueryParameter)
+                        .addAll(translatedArgument3.parameters())
+                        .build(),
+                updatedTypeHandle));
+    }
+}

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConnectorTest.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConnectorTest.java
@@ -803,6 +803,36 @@ public class TestRedshiftConnectorTest
         }
     }
 
+    @Test
+    public void testLpadPushdown()
+    {
+        try (TestTable leftTable = new TestTable(
+                getQueryRunner()::execute,
+                "left_table_",
+                "(c_varchar_50 varchar(50))",
+                ImmutableList.of("('Value')", "('Valuea')"));
+                TestTable rightTable = new TestTable(
+                        getQueryRunner()::execute,
+                        "right_table_",
+                        "(c_varchar varchar)",
+                        ImmutableList.of("('aaaValue')", "('aaaValuea')"))) {
+            Session session = joinPushdownEnabled(getSession());
+
+            String joinConditionWithLpad = "SELECT * FROM %s l %s %s r ON lpad(l.c_varchar_50, 8, 'aaa') = r.c_varchar".formatted(leftTable.getName(), "%s", rightTable.getName());
+            assertThat(query(session, joinConditionWithLpad.formatted("LEFT JOIN")))
+                    .isFullyPushedDown();
+            assertThat(query(session, joinConditionWithLpad.formatted("RIGHT JOIN")))
+                    .isFullyPushedDown();
+            assertThat(query(session, joinConditionWithLpad.formatted("INNER JOIN")))
+                    .isFullyPushedDown();
+
+            assertThat(query(session, "SELECT *, lpad(c_varchar_50, 20, 'aaa') FROM " + leftTable.getName()))
+                    .isFullyPushedDown();
+            assertThat(query(session, "SELECT *, lpad(c_varchar_50, 100, 'aaa') FROM " + leftTable.getName()))
+                    .isFullyPushedDown();
+        }
+    }
+
     @Override
     protected Session joinPushdownEnabled(Session session)
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Adds support for lpad string function pushdown as join condition can have a string functions such as `lpad(t1.col1, 6, 'x')=t2.col2` which if not pushed down, would not allow join to be pusheddown. There could be other string functions in join as well but we are interested in lpad atm.

This PR adds only last commit. Other dependent commits comes from https://github.com/trinodb/trino/pull/23490. 

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Pushdown lpad string function in Redshift . ({issue}`issuenumber`)
```
