### PR TITLE
Split construction of large rows into separate methods

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/gen/BytecodeGeneratorContext.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/BytecodeGeneratorContext.java
@@ -13,7 +13,10 @@
  */
 package io.trino.sql.gen;
 
+import com.google.common.collect.ImmutableList;
 import io.airlift.bytecode.BytecodeNode;
+import io.airlift.bytecode.ClassDefinition;
+import io.airlift.bytecode.Parameter;
 import io.airlift.bytecode.Scope;
 import io.airlift.bytecode.Variable;
 import io.trino.metadata.FunctionManager;
@@ -40,19 +43,24 @@ public class BytecodeGeneratorContext
     private final CachedInstanceBinder cachedInstanceBinder;
     private final FunctionManager functionManager;
     private final Variable wasNull;
+    private final ClassDefinition classDefinition;
+    private final List<Parameter> contextArguments;  // arguments that need to be propagated to generated methods to be able to resolve underlying references, session, etc.
 
     public BytecodeGeneratorContext(
             RowExpressionCompiler rowExpressionCompiler,
             Scope scope,
             CallSiteBinder callSiteBinder,
             CachedInstanceBinder cachedInstanceBinder,
-            FunctionManager functionManager)
+            FunctionManager functionManager,
+            ClassDefinition classDefinition,
+            List<Parameter> contextArguments)
     {
         requireNonNull(rowExpressionCompiler, "rowExpressionCompiler is null");
         requireNonNull(cachedInstanceBinder, "cachedInstanceBinder is null");
         requireNonNull(scope, "scope is null");
         requireNonNull(callSiteBinder, "callSiteBinder is null");
         requireNonNull(functionManager, "functionManager is null");
+        requireNonNull(classDefinition, "classDefinition is null");
 
         this.rowExpressionCompiler = rowExpressionCompiler;
         this.scope = scope;
@@ -60,6 +68,8 @@ public class BytecodeGeneratorContext
         this.cachedInstanceBinder = cachedInstanceBinder;
         this.functionManager = functionManager;
         this.wasNull = scope.getVariable("wasNull");
+        this.classDefinition = classDefinition;
+        this.contextArguments = ImmutableList.copyOf(contextArguments);
     }
 
     public Scope getScope()
@@ -109,5 +119,30 @@ public class BytecodeGeneratorContext
     public Variable wasNull()
     {
         return wasNull;
+    }
+
+    public ClassDefinition getClassDefinition()
+    {
+        return classDefinition;
+    }
+
+    public RowExpressionCompiler getRowExpressionCompiler()
+    {
+        return rowExpressionCompiler;
+    }
+
+    public CachedInstanceBinder getCachedInstanceBinder()
+    {
+        return cachedInstanceBinder;
+    }
+
+    public FunctionManager getFunctionManager()
+    {
+        return functionManager;
+    }
+
+    public List<Parameter> getContextArguments()
+    {
+        return contextArguments;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/gen/CursorProcessorCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/CursorProcessorCompiler.java
@@ -13,6 +13,7 @@
  */
 package io.trino.sql.gen;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.bytecode.BytecodeBlock;
@@ -236,11 +237,13 @@ public class CursorProcessorCompiler
         Variable wasNullVariable = scope.declareVariable(type(boolean.class), "wasNull");
 
         RowExpressionCompiler compiler = new RowExpressionCompiler(
+                classDefinition,
                 callSiteBinder,
                 cachedInstanceBinder,
                 fieldReferenceCompiler(cursor),
                 functionManager,
-                compiledLambdaMap);
+                compiledLambdaMap,
+                ImmutableList.of(session, cursor));
 
         LabelNode end = new LabelNode("end");
         method.getBody()
@@ -276,11 +279,13 @@ public class CursorProcessorCompiler
         Variable wasNullVariable = scope.declareVariable(type(boolean.class), "wasNull");
 
         RowExpressionCompiler compiler = new RowExpressionCompiler(
+                classDefinition,
                 callSiteBinder,
                 cachedInstanceBinder,
                 fieldReferenceCompiler(cursor),
                 functionManager,
-                compiledLambdaMap);
+                compiledLambdaMap,
+                ImmutableList.of(session, cursor, output));
 
         method.getBody()
                 .comment("boolean wasNull = false;")

--- a/core/trino-main/src/main/java/io/trino/sql/gen/JoinFilterFunctionCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/JoinFilterFunctionCompiler.java
@@ -194,11 +194,13 @@ public class JoinFilterFunctionCompiler
         scope.declareVariable("session", body, method.getThis().getField(sessionField));
 
         RowExpressionCompiler compiler = new RowExpressionCompiler(
+                classDefinition,
                 callSiteBinder,
                 cachedInstanceBinder,
                 fieldReferenceCompiler(callSiteBinder, leftPosition, leftPage, rightPosition, rightPage, leftBlocksSize),
                 functionManager,
-                compiledLambdaMap);
+                compiledLambdaMap,
+                ImmutableList.of(leftPage, leftPosition, rightPage, rightPosition));
 
         BytecodeNode visitorBody = compiler.compile(filter, scope);
 

--- a/core/trino-main/src/main/java/io/trino/sql/gen/PageFunctionCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/PageFunctionCompiler.java
@@ -359,11 +359,13 @@ public class PageFunctionCompiler
 
         Variable wasNullVariable = scope.declareVariable("wasNull", body, constantFalse());
         RowExpressionCompiler compiler = new RowExpressionCompiler(
+                classDefinition,
                 callSiteBinder,
                 cachedInstanceBinder,
                 fieldReferenceCompilerProjection(callSiteBinder),
                 functionManager,
-                compiledLambdaMap);
+                compiledLambdaMap,
+                ImmutableList.of(session, position));
 
         body.append(thisVariable.getField(blockBuilder))
                 .append(compiler.compile(projection, scope))
@@ -543,11 +545,13 @@ public class PageFunctionCompiler
 
         Variable wasNullVariable = scope.declareVariable("wasNull", body, constantFalse());
         RowExpressionCompiler compiler = new RowExpressionCompiler(
+                classDefinition,
                 callSiteBinder,
                 cachedInstanceBinder,
                 fieldReferenceCompiler(callSiteBinder),
                 functionManager,
-                compiledLambdaMap);
+                compiledLambdaMap,
+                ImmutableList.of(page, position));
 
         Variable result = scope.declareVariable(boolean.class, "result");
         body.append(compiler.compile(filter, scope))


### PR DESCRIPTION
Split the processing of fields into batches to reduce the size of a single generated method. This makes it possible to call ROW(...) with a large number of fields.

Relates to https://github.com/trinodb/trino/issues/15848

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix failure for MERGE queries on tables with large numbers of columns. ({issue}`15848`)
```
