### PR TITLE
Add session property to configure ORC rowGroupMaxRowCount in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
@@ -61,6 +61,7 @@ import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_WRITE_VALIDATION_
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getCompressionCodec;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getOrcStringStatisticsLimit;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getOrcWriterMaxDictionaryMemory;
+import static io.trino.plugin.iceberg.IcebergSessionProperties.getOrcWriterMaxRowGroupRows;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getOrcWriterMaxStripeRows;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getOrcWriterMaxStripeSize;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getOrcWriterMinStripeSize;
@@ -244,6 +245,7 @@ public class IcebergFileWriterFactory
                             .withStripeMinSize(getOrcWriterMinStripeSize(session))
                             .withStripeMaxSize(getOrcWriterMaxStripeSize(session))
                             .withStripeMaxRowCount(getOrcWriterMaxStripeRows(session))
+                            .withRowGroupMaxRowCount(getOrcWriterMaxRowGroupRows(session))
                             .withDictionaryMaxMemory(getOrcWriterMaxDictionaryMemory(session))
                             .withMaxStringStatisticsLimit(stringStatisticsLimit),
                     IntStream.range(0, fileColumnNames.size()).toArray(),

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -81,6 +81,7 @@ public final class IcebergSessionProperties
     private static final String ORC_WRITER_MIN_STRIPE_SIZE = "orc_writer_min_stripe_size";
     private static final String ORC_WRITER_MAX_STRIPE_SIZE = "orc_writer_max_stripe_size";
     private static final String ORC_WRITER_MAX_STRIPE_ROWS = "orc_writer_max_stripe_rows";
+    private static final String ORC_WRITER_MAX_ROW_GROUP_ROWS = "orc_writer_max_row_group_rows";
     private static final String ORC_WRITER_MAX_DICTIONARY_MEMORY = "orc_writer_max_dictionary_memory";
     private static final String PARQUET_MAX_READ_BLOCK_SIZE = "parquet_max_read_block_size";
     private static final String PARQUET_USE_BLOOM_FILTER = "parquet_use_bloom_filter";
@@ -216,6 +217,11 @@ public final class IcebergSessionProperties
                         ORC_WRITER_MAX_STRIPE_ROWS,
                         "ORC: Max stripe row count",
                         orcWriterConfig.getStripeMaxRowCount(),
+                        false))
+                .add(integerProperty(
+                        ORC_WRITER_MAX_ROW_GROUP_ROWS,
+                        "ORC: Max number of rows in a row group",
+                        orcWriterConfig.getRowGroupMaxRowCount(),
                         false))
                 .add(dataSizeProperty(
                         ORC_WRITER_MAX_DICTIONARY_MEMORY,
@@ -470,6 +476,11 @@ public final class IcebergSessionProperties
     public static int getOrcWriterMaxStripeRows(ConnectorSession session)
     {
         return session.getProperty(ORC_WRITER_MAX_STRIPE_ROWS, Integer.class);
+    }
+
+    public static int getOrcWriterMaxRowGroupRows(ConnectorSession session)
+    {
+        return session.getProperty(ORC_WRITER_MAX_ROW_GROUP_ROWS, Integer.class);
     }
 
     public static DataSize getOrcWriterMaxDictionaryMemory(ConnectorSession session)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

This PR adds support for configuring max rows per "row group" in an ORC file via a session property – today this is configurable only at the catalog level. This is useful for to make it easy for different jobs in the same catalog to write files that may have different optimal row group sizes based on the shape of the underlying data they're writing. 

Also, I've submitted my CLA request via email, but looks like it hasn't been approved just yet.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Fixes https://github.com/trinodb/trino/issues/23722

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Add support for configuring max rows per row-group in the ORC writer via a session property ({issue}`23722`)
```
