### PR TITLE
Improve managing resource groups at runtime

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroup.java
+++ b/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroup.java
@@ -297,7 +297,7 @@ public class InternalResourceGroup
     {
         synchronized (root) {
             // For leaf group, when no queries can run, all queued queries are waiting for resources on this resource group.
-            if (subGroups.isEmpty()) {
+            if (isLeafGroup()) {
                 return queuedQueries.size();
             }
 
@@ -316,7 +316,7 @@ public class InternalResourceGroup
     public int getQueriesQueuedOnInternal()
     {
         synchronized (root) {
-            if (subGroups.isEmpty()) {
+            if (isLeafGroup()) {
                 return min(getQueuedQueries(), softConcurrencyLimit - getRunningQueries());
             }
 

--- a/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroupManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroupManager.java
@@ -282,25 +282,8 @@ public final class InternalResourceGroupManager<C>
     {
         int queriesQueuedInternal = 0;
         for (InternalResourceGroup rootGroup : rootGroups) {
-            synchronized (rootGroup) {
-                queriesQueuedInternal += getQueriesQueuedOnInternal(rootGroup);
-            }
+            queriesQueuedInternal += rootGroup.getQueriesQueuedOnInternal();
         }
-
-        return queriesQueuedInternal;
-    }
-
-    private static int getQueriesQueuedOnInternal(InternalResourceGroup resourceGroup)
-    {
-        if (resourceGroup.subGroups().isEmpty()) {
-            return Math.min(resourceGroup.getQueuedQueries(), resourceGroup.getSoftConcurrencyLimit() - resourceGroup.getRunningQueries());
-        }
-
-        int queriesQueuedInternal = 0;
-        for (InternalResourceGroup subGroup : resourceGroup.subGroups()) {
-            queriesQueuedInternal += getQueriesQueuedOnInternal(subGroup);
-        }
-
         return queriesQueuedInternal;
     }
 

--- a/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroupManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroupManager.java
@@ -232,7 +232,8 @@ public final class InternalResourceGroupManager<C>
     private synchronized void createGroupIfNecessary(SelectionContext<C> context, Executor executor)
     {
         ResourceGroupId id = context.getResourceGroupId();
-        if (!groups.containsKey(id)) {
+        InternalResourceGroup currentGroup = groups.get(id);
+        if (currentGroup == null) {
             InternalResourceGroup group;
             if (id.getParent().isPresent()) {
                 createGroupIfNecessary(configurationManager.get().parentGroupContext(context), executor);
@@ -247,6 +248,17 @@ public final class InternalResourceGroupManager<C>
             }
             configurationManager.get().configure(group, context);
             checkState(groups.put(id, group) == null, "Unexpected existing resource group");
+        }
+        else if (currentGroup.isDisabled()) {
+            if (id.getParent().isPresent()) {
+                createGroupIfNecessary(configurationManager.get().parentGroupContext(context), executor);
+                InternalResourceGroup parent = groups.get(id.getParent().get());
+                requireNonNull(parent, "parent is null");
+                InternalResourceGroup group = parent.getOrCreateSubGroup(id.getLastSegment());
+                checkState(group == currentGroup, "Unexpected resource group instance");
+            }
+            configurationManager.get().configure(currentGroup, context);
+            currentGroup.setDisabled(false);
         }
     }
 

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -285,6 +285,16 @@
                                     <code>java.method.removed</code>
                                     <old>method long io.trino.spi.block.RunLengthEncodedBlock::getLogicalSizeInBytes()</old>
                                 </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.addedToInterface</code>
+                                    <new>method boolean io.trino.spi.resourcegroups.ResourceGroup::isDisabled()</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.addedToInterface</code>
+                                    <new>method void io.trino.spi.resourcegroups.ResourceGroup::setDisabled(boolean)</new>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/resourcegroups/ResourceGroup.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/resourcegroups/ResourceGroup.java
@@ -94,4 +94,16 @@ public interface ResourceGroup
      * Whether to export statistics about this group and allow configuration via JMX.
      */
     void setJmxExport(boolean export);
+
+    boolean isDisabled();
+
+    /**
+     * Marks the group as disabled. Both queued and running queries already assigned to
+     * the group will not be affected by this change, i.e., they will run until completion,
+     * and the resources they consume will be considered when calculating overall resource
+     * utilization. Once its query queue is empty, the group is treated by the engine as
+     * non-existent. For example, if it was a leaf group, its parent now becomes a leaf,
+     * unless it has other active subgroups.
+     */
+    void setDisabled(boolean disabled);
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/resourcegroups/ResourceGroupConfigurationManager.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/resourcegroups/ResourceGroupConfigurationManager.java
@@ -33,7 +33,10 @@ public interface ResourceGroupConfigurationManager<C>
 {
     /**
      * Implementations may retain a reference to the group, and re-configure it asynchronously.
-     * This method is called, once, when the group is created.
+     * This method is called in two cases: when the group is created, and when it was previously
+     * disabled and is now reactivated. In the latter case, the reference passed to this method
+     * is the same as during creation, so implementations don’t need to invalidate retained
+     * references.
      */
     void configure(ResourceGroup group, SelectionContext<C> criteria);
 

--- a/plugin/trino-resource-group-managers/pom.xml
+++ b/plugin/trino-resource-group-managers/pom.xml
@@ -211,6 +211,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/DbResourceGroupConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/DbResourceGroupConfigurationManager.java
@@ -396,9 +396,7 @@ public class DbResourceGroupConfigurationManager
 
     private synchronized void disableGroup(ResourceGroup group)
     {
-        // Disable groups that are removed from the db
-        group.setHardConcurrencyLimit(0);
-        group.setMaxQueuedQueries(0);
+        group.setDisabled(true);
     }
 
     private ResourceGroup getRootGroup(ResourceGroupId groupId)

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestingResourceGroup.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestingResourceGroup.java
@@ -35,6 +35,7 @@ public class TestingResourceGroup
     private int schedulingWeight;
     private SchedulingPolicy policy;
     private boolean jmxExport;
+    private boolean disabled;
 
     public TestingResourceGroup(ResourceGroupId id)
     {
@@ -165,5 +166,17 @@ public class TestingResourceGroup
     public void setJmxExport(boolean export)
     {
         jmxExport = export;
+    }
+
+    @Override
+    public boolean isDisabled()
+    {
+        return disabled;
+    }
+
+    @Override
+    public void setDisabled(boolean disabled)
+    {
+        this.disabled = disabled;
     }
 }

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupConfigurationManager.java
@@ -28,6 +28,7 @@ import io.trino.spi.resourcegroups.SelectionCriteria;
 import io.trino.spi.session.ResourceEstimates;
 import org.h2.jdbc.JdbcException;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -36,6 +37,8 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.regex.Pattern;
 
@@ -43,6 +46,7 @@ import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.trino.execution.resourcegroups.InternalResourceGroup.DEFAULT_WEIGHT;
 import static io.trino.spi.resourcegroups.SchedulingPolicy.FAIR;
 import static io.trino.spi.resourcegroups.SchedulingPolicy.WEIGHTED;
+import static io.trino.testing.assertions.Assert.assertEventually;
 import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -377,6 +381,61 @@ public class TestDbResourceGroupConfigurationManager
         assertThat(manager.match(userAndUserGroupsSelectionCriteria("Matching user", "Matching group")))
                 .map(SelectionContext::getContext)
                 .isEqualTo(Optional.of(new ResourceGroupIdTemplate("group")));
+    }
+
+    @RepeatedTest(10)
+    public void testConfigurationUpdateIsNotLost()
+    {
+        // This test attempts to reproduce the following sequence:
+        // 1. Load resource group configuration C1, which includes template T1.
+        // 2. For query Q1, select template T1 and expand it into resource group R1.
+        // 3. For query Q1, obtain C1 in DbResourceGroupConfigurationManager#configure.
+        // 4. Load resource group configuration C2 with modified parameters for T1.
+        //
+        // If everything works correctly, C2 should eventually be applied to R1.
+        // We want to avoid the following scenarios:
+        // - C1, obtained in step 3, overwrites C2 applied to R1 in step 4, and no subsequent
+        //   'load' applies C2 again.
+        // - The 'load' in step 4 doesn't apply C2 to R1 because 'configure' hasn't created a
+        //   mapping between T1 and R1 yet, and no subsequent 'load' detects the configuration change for T1.
+
+        H2DaoProvider daoProvider = setup("test_lost_update");
+        H2ResourceGroupsDao dao = daoProvider.get();
+        dao.createResourceGroupsGlobalPropertiesTable();
+        dao.createResourceGroupsTable();
+        dao.createSelectorsTable();
+        dao.insertResourceGroup(1, "global", "80%", 10, null, 1, null, null, null, null, null, null, ENVIRONMENT);
+        dao.insertSelector(1, 1, null, "userGroup", null, null, null, null);
+        DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(_ -> {}, new DbResourceGroupConfig(), daoProvider.get(), ENVIRONMENT);
+
+        Optional<SelectionContext<ResourceGroupIdTemplate>> userGroup = manager.match(userGroupsSelectionCriteria("userGroup"));
+        assertThat(userGroup.isPresent()).isTrue();
+        SelectionContext<ResourceGroupIdTemplate> selectionContext = userGroup.get();
+
+        InternalResourceGroup resourceGroup = new InternalResourceGroup("global", (_, _) -> {}, directExecutor());
+
+        try (ExecutorService executor = Executors.newFixedThreadPool(2)) {
+            dao.updateResourceGroup(1, "global", "80%", 10, null, 10, null, null, null, null, null, null, ENVIRONMENT);
+
+            executor.submit(() -> {
+                synchronized (resourceGroup) {
+                    // Wait while holding the lock to increase the likelihood that 'load' and 'configure'
+                    // will attempt to update the configuration simultaneously. Both need to acquire this
+                    // lock to update the resource group.
+                    Thread.sleep(10);
+                }
+                return null;
+            });
+
+            executor.submit(manager::load);
+
+            manager.configure(resourceGroup, selectionContext);
+
+            assertEventually(() -> {
+                manager.load();
+                assertThat(resourceGroup.getHardConcurrencyLimit()).isEqualTo(10);
+            });
+        }
     }
 
     private static void assertEqualsResourceGroup(

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupConfigurationManager.java
@@ -211,7 +211,7 @@ public class TestDbResourceGroupConfigurationManager
         do {
             MILLISECONDS.sleep(500);
         }
-        while (globalSub.getMaxQueuedQueries() != 0 || globalSub.getHardConcurrencyLimit() != 0);
+        while (!globalSub.isDisabled());
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

This PR addresses several issues with managing resource groups at runtime:

### Problem 1: Adding a subgroup to a leaf group

Consider the following sequence:

1. Create a root resource group (let’s call it `groupA`).
2. Run a query that matches the root group.
3. Add a subgroup to the root group.
4. While the query is either queued or running, run another query that matches the subgroup. You will get the following error: `Cannot add subgroup to groupA while queries are running`.

This means that a subgroup becomes operational only after all queries from its parent have finished. In some cases, this can take a considerable amount of time. Waiting until there are no queued queries assigned to the parent is understandable, as it prevents subgroups from starving. However, why can't we speed this up by allowing queries to be assigned to subgroups once their parent no longer has queued queries, even if it still has running queries?

### Problem 2: Removing a subgroup

Consider the following sequence:

1. Create a root resource group (let’s call it `groupA`).
2. Add a subgroup to the root group.
3. Run a query that matches the subgroup.
4. Remove the subgroup.
5. Attempt to run a query that matches the root group. You will get the following error: `Cannot add queries to groupA. It is not a leaf group`.

Currently, it is not possible to entirely remove a subgroup. The `DbResourceGroupConfigurationManager` only [sets hardConcurrencyLimit and maxQueuedQueries to zero](https://github.com/trinodb/trino/blob/59d01811dd4f59278ddd28cbcb80ca87828ba9e6/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/DbResourceGroupConfigurationManager.java#L397-L402) for groups marked for removal, but this is not interpreted by the engine as an actual removal. Additionally, if a subgroup with queued queries is marked for removal, those queries will never be executed.

### Problem 3: Switching group name between template and fixed value

Consider the following sequence: 

1. Create a root resource group with a template name (e.g., `${USER}`).
2. Run a query (e.g., as user `alice`) that matches the root group.
3. Update the group configuration, changing its name from `${USER}` to `alice` and modifying some limits.
4. Run another query as `alice`. The limits set in step 3 will not be applied; the group will still use the limits from step 1.

In this case, the engine matches the second query with resource group `alice` but applies the configuration of the now non-existent group `${USER}`.

### Problem 4: Lost configuration updates

Consider the following sequence:

1. Start with [configuredGroups](https://github.com/trinodb/trino/blob/ae96ba108799ed3a16340f26da4775bf50bcc641/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/DbResourceGroupConfigurationManager.java#L80) being empty.
2. Load resource group configuration C1, which includes template T1.
3. Select template T1 and expand it into resource group R1.
4. Obtain C1 in [DbResourceGroupConfigurationManager#configure](https://github.com/trinodb/trino/blob/ae96ba108799ed3a16340f26da4775bf50bcc641/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/DbResourceGroupConfigurationManager.java#L179).
5. Load resource group configuration C2 with modified parameters for T1.
6. Create a new mapping: configuredGroups[T1 -> R1], then configure R1 using C1.

As a result, R1 will miss C2. Another configuration update (C3) will be required to apply changes.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Database-based Resource Group Manager
* Allow adding subgroups to groups without waiting for running queries to finish.
* Fix query failures for queries routed to a group whose subgroup has been deleted.
* Fix wrong resource group configuration being applied if the group is changed from a variable to fixed name or vice-versa.
* Fix resource group updates not being observed immediately for groups that use variables.
```
