### PR TITLE
Avoid failures when redirecting from incomplete/invalid Delta Lake tables

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSharedGlueMetastoreWithTableRedirections.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSharedGlueMetastoreWithTableRedirections.java
@@ -20,13 +20,25 @@ import io.trino.plugin.hive.metastore.glue.GlueHiveMetastore;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import software.amazon.awssdk.services.glue.GlueClient;
+import software.amazon.awssdk.services.glue.model.Column;
+import software.amazon.awssdk.services.glue.model.CreateTableRequest;
+import software.amazon.awssdk.services.glue.model.DeleteTableRequest;
+import software.amazon.awssdk.services.glue.model.GetTableRequest;
+import software.amazon.awssdk.services.glue.model.GetTableResponse;
+import software.amazon.awssdk.services.glue.model.SerDeInfo;
+import software.amazon.awssdk.services.glue.model.StorageDescriptor;
+import software.amazon.awssdk.services.glue.model.TableInput;
 
 import java.nio.file.Path;
+import java.util.Map;
 
 import static io.trino.plugin.hive.metastore.glue.TestingGlueHiveMetastore.createTestingGlueHiveMetastore;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
 /**
@@ -107,5 +119,69 @@ public class TestDeltaLakeSharedGlueMetastoreWithTableRedirections
                 "   location = '%s'\n" +
                 ")";
         return format(expectedDeltaLakeCreateSchema, catalogName, schema, dataDirectory.toUri());
+    }
+
+    @Test
+    public void testUnsupportedHiveTypeRedirect()
+    {
+        String tableName = "unsupported_types";
+        // Use another complete table location so `SHOW CREATE TABLE` doesn't fail on reading metadata
+        String location;
+        try (GlueClient glueClient = GlueClient.create()) {
+            GetTableResponse existingTable = glueClient.getTable(GetTableRequest.builder()
+                    .databaseName(schema)
+                    .name("delta_table")
+                    .build());
+            location = existingTable.table().storageDescriptor().location();
+        }
+        // Create a table directly in Glue, simulating an external table being created in Spark,
+        // with a custom AWS data type not mapped to HiveType when
+        Column timestampColumn = Column.builder()
+                .name("last_hour_load")
+                .type("timestamp_ntz")
+                .build();
+        StorageDescriptor sd = StorageDescriptor.builder()
+                .columns(timestampColumn)
+                .location(location)
+                .inputFormat("org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe")
+                .outputFormat("org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat")
+                .serdeInfo(SerDeInfo.builder()
+                        .serializationLibrary("org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe")
+                        .parameters(Map.of(
+                                "serialization.format", "1",
+                                "path", location))
+                        .build())
+                .build();
+        TableInput tableInput = TableInput.builder()
+                .name(tableName)
+                .storageDescriptor(sd)
+                .parameters(Map.of(
+                        "spark.sql.sources.provider", "delta"))
+                .tableType("EXTERNAL_TABLE")
+                .partitionKeys(timestampColumn)
+                .build();
+
+        CreateTableRequest createTableRequest = CreateTableRequest.builder()
+                .databaseName(schema)
+                .tableInput(tableInput)
+                .build();
+        try (GlueClient glueClient = GlueClient.create()) {
+            glueClient.createTable(createTableRequest);
+
+            String tableDefinition = (String) computeScalar("SHOW CREATE TABLE hive_with_redirections." + schema + "." + tableName);
+            String expected = """
+                    CREATE TABLE delta_with_redirections.%s.%s (
+                       a_varchar varchar
+                    )
+                    WITH (
+                       location = '%s'
+                    )""";
+            assertThat(tableDefinition).isEqualTo(expected.formatted(schema, tableName, location));
+
+            glueClient.deleteTable(DeleteTableRequest.builder()
+                    .databaseName(schema)
+                    .name(tableInput.name())
+                    .build());
+        }
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueConverter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueConverter.java
@@ -164,7 +164,7 @@ final class GlueConverter
             storage = FAKE_PARQUET_STORAGE;
         }
         else if (isIcebergTable(tableParameters)) {
-            // todo: any reason to not do this for delta and trino mv?
+            // todo: any reason to not do this for trino mv?
             if (sd.columns() == null) {
                 dataColumns = ImmutableList.of(FAKE_COLUMN);
             }
@@ -173,6 +173,11 @@ final class GlueConverter
             }
             partitionColumns = ImmutableList.of();
             storage = FAKE_PARQUET_STORAGE;
+        }
+        else if (isDeltaLakeTable(tableParameters)) {
+            dataColumns = ImmutableList.of(FAKE_COLUMN);
+            partitionColumns = ImmutableList.of();
+            storage = fromGlueStorage(sd, databaseName + "." + glueTable.name());
         }
         else {
             boolean isCsv = sd.serdeInfo() != null && HiveStorageFormat.CSV.getSerde().equals(sd.serdeInfo().serializationLibrary());

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueConverter.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueConverter.java
@@ -219,7 +219,7 @@ class TestGlueConverter
                 .build();
         LanguageFunction actual = GlueConverter.fromGlueFunction(function);
 
-        assertThat(input.resourceUris().size()).isEqualTo(3);
+        assertThat(input.resourceUris()).hasSize(3);
         assertThat(actual).isEqualTo(expected);
 
         // verify that the owner comes from the metastore
@@ -281,7 +281,7 @@ class TestGlueConverter
         assertThat(trinoTable.getTableType()).isEqualTo(glueTable.tableType());
         assertThat(trinoTable.getOwner().orElse(null)).isEqualTo(glueTable.owner());
         assertThat(trinoTable.getParameters()).isEqualTo(glueTable.parameters());
-        assertThat(trinoTable.getDataColumns().size()).isEqualTo(1);
+        assertThat(trinoTable.getDataColumns()).hasSize(1);
         assertThat(trinoTable.getDataColumns().getFirst().getType()).isEqualTo(HIVE_STRING);
 
         assertColumnList(glueTable.partitionKeys(), trinoTable.getPartitionColumns());
@@ -369,7 +369,7 @@ class TestGlueConverter
                 .storageDescriptor((StorageDescriptor) null)
                 .build();
         io.trino.metastore.Table trinoTable = GlueConverter.fromGlueTable(table, table.databaseName());
-        assertThat(trinoTable.getDataColumns().size()).isEqualTo(1);
+        assertThat(trinoTable.getDataColumns()).hasSize(1);
     }
 
     @Test
@@ -380,7 +380,7 @@ class TestGlueConverter
                 .build();
         assertThat(table.storageDescriptor()).isNotNull();
         io.trino.metastore.Table trinoTable = GlueConverter.fromGlueTable(table, table.databaseName());
-        assertThat(trinoTable.getDataColumns().size()).isEqualTo(1);
+        assertThat(trinoTable.getDataColumns()).hasSize(1);
     }
 
     @Test
@@ -391,7 +391,7 @@ class TestGlueConverter
                 .storageDescriptor((StorageDescriptor) null)
                 .build();
         io.trino.metastore.Table trinoTable = GlueConverter.fromGlueTable(table, table.databaseName());
-        assertThat(trinoTable.getDataColumns().size()).isEqualTo(1);
+        assertThat(trinoTable.getDataColumns()).hasSize(1);
     }
 
     @Test
@@ -410,7 +410,7 @@ class TestGlueConverter
     {
         assertThat(glueMaterializedView.storageDescriptor()).isNull();
         Table trinoTable = GlueConverter.fromGlueTable(glueMaterializedView, glueMaterializedView.databaseName());
-        assertThat(trinoTable.getDataColumns().size()).isEqualTo(1);
+        assertThat(trinoTable.getDataColumns()).hasSize(1);
     }
 
     @Test
@@ -428,7 +428,7 @@ class TestGlueConverter
             assertThat(glueColumns).isNull();
         }
         assertThat(glueColumns).isNotNull();
-        assertThat(glueColumns.size()).isEqualTo(trinoColumns.size());
+        assertThat(glueColumns).hasSize(trinoColumns.size());
 
         for (int i = 0; i < trinoColumns.size(); i++) {
             assertColumn(glueColumns.get(i), trinoColumns.get(i));

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueConverter.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueConverter.java
@@ -41,7 +41,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.metastore.HiveType.HIVE_STRING;
 import static io.trino.metastore.Table.TABLE_COMMENT;
 import static io.trino.metastore.TableInfo.ICEBERG_MATERIALIZED_VIEW_COMMENT;
@@ -403,11 +402,7 @@ class TestGlueConverter
                 .build();
         assertThat(table.storageDescriptor()).isNotNull();
         io.trino.metastore.Table trinoTable = GlueConverter.fromGlueTable(table, table.databaseName());
-        assertThat(trinoTable.getDataColumns().stream()
-                .map(Column::getName)
-                .collect(toImmutableSet())).isEqualTo(glueTable.storageDescriptor().columns().stream()
-                .map(software.amazon.awssdk.services.glue.model.Column::name)
-                .collect(toImmutableSet()));
+        assertThat(trinoTable.getDataColumns()).hasSize(1);
     }
 
     @Test

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/v1/TestGlueToTrinoConverter.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/v1/TestGlueToTrinoConverter.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.amazonaws.util.CollectionUtils.isNullOrEmpty;
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.metastore.HiveType.HIVE_STRING;
 import static io.trino.plugin.hive.TableType.EXTERNAL_TABLE;
 import static io.trino.plugin.hive.metastore.glue.v1.TestingMetastoreObjects.getGlueTestColumn;
@@ -251,11 +250,7 @@ public class TestGlueToTrinoConverter
         testTable.setParameters(ImmutableMap.of(SPARK_TABLE_PROVIDER_KEY, DELTA_LAKE_PROVIDER));
         assertThat(getStorageDescriptor(testTable)).isPresent();
         io.trino.metastore.Table trinoTable = GlueToTrinoConverter.convertTable(testTable, testDatabase.getName());
-        assertThat(trinoTable.getDataColumns().stream()
-                .map(Column::getName)
-                .collect(toImmutableSet())).isEqualTo(getStorageDescriptor(testTable).orElseThrow().getColumns().stream()
-                .map(com.amazonaws.services.glue.model.Column::getName)
-                .collect(toImmutableSet()));
+        assertThat(trinoTable.getDataColumns()).hasSize(1);
     }
 
     @Test

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/v1/TestGlueToTrinoConverter.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/v1/TestGlueToTrinoConverter.java
@@ -118,7 +118,7 @@ public class TestGlueToTrinoConverter
         assertThat(trinoTable.getTableType()).isEqualTo(getTableTypeNullable(glueTable));
         assertThat(trinoTable.getOwner().orElse(null)).isEqualTo(glueTable.getOwner());
         assertThat(trinoTable.getParameters()).isEqualTo(getTableParameters(glueTable));
-        assertThat(trinoTable.getDataColumns().size()).isEqualTo(1);
+        assertThat(trinoTable.getDataColumns()).hasSize(1);
         assertThat(trinoTable.getDataColumns().get(0).getType()).isEqualTo(HIVE_STRING);
 
         assertColumnList(trinoTable.getPartitionColumns(), glueTable.getPartitionKeys());
@@ -223,7 +223,7 @@ public class TestGlueToTrinoConverter
         testTable.setParameters(ImmutableMap.of(ICEBERG_TABLE_TYPE_NAME, ICEBERG_TABLE_TYPE_VALUE));
         testTable.setStorageDescriptor(null);
         io.trino.metastore.Table trinoTable = GlueToTrinoConverter.convertTable(testTable, testDatabase.getName());
-        assertThat(trinoTable.getDataColumns().size()).isEqualTo(1);
+        assertThat(trinoTable.getDataColumns()).hasSize(1);
     }
 
     @Test
@@ -232,7 +232,7 @@ public class TestGlueToTrinoConverter
         testTable.setParameters(ImmutableMap.of(ICEBERG_TABLE_TYPE_NAME, ICEBERG_TABLE_TYPE_VALUE));
         assertThat(getStorageDescriptor(testTable)).isPresent();
         io.trino.metastore.Table trinoTable = GlueToTrinoConverter.convertTable(testTable, testDatabase.getName());
-        assertThat(trinoTable.getDataColumns().size()).isEqualTo(1);
+        assertThat(trinoTable.getDataColumns()).hasSize(1);
     }
 
     @Test
@@ -241,7 +241,7 @@ public class TestGlueToTrinoConverter
         testTable.setParameters(ImmutableMap.of(SPARK_TABLE_PROVIDER_KEY, DELTA_LAKE_PROVIDER));
         testTable.setStorageDescriptor(null);
         io.trino.metastore.Table trinoTable = GlueToTrinoConverter.convertTable(testTable, testDatabase.getName());
-        assertThat(trinoTable.getDataColumns().size()).isEqualTo(1);
+        assertThat(trinoTable.getDataColumns()).hasSize(1);
     }
 
     @Test
@@ -259,7 +259,7 @@ public class TestGlueToTrinoConverter
         Table testMaterializedView = getGlueTestTrinoMaterializedView(testDatabase.getName());
         assertThat(getStorageDescriptor(testMaterializedView)).isEmpty();
         io.trino.metastore.Table trinoTable = GlueToTrinoConverter.convertTable(testMaterializedView, testDatabase.getName());
-        assertThat(trinoTable.getDataColumns().size()).isEqualTo(1);
+        assertThat(trinoTable.getDataColumns()).hasSize(1);
     }
 
     @Test
@@ -274,7 +274,7 @@ public class TestGlueToTrinoConverter
         if (expected == null) {
             assertThat(actual).isNull();
         }
-        assertThat(actual.size()).isEqualTo(expected.size());
+        assertThat(actual).hasSize(expected.size());
 
         for (int i = 0; i < expected.size(); i++) {
             assertColumn(actual.get(i), expected.get(i));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Don't attempt to read Delta Lake table metadata when performing table redirect to a different catalog. This allows redirecting from incomplete or invalid Delta Lake tables.

Without the fix, queries fail with:
```
io.trino.testing.QueryFailedException: com.google.common.util.concurrent.UncheckedExecutionException: java.lang.IllegalArgumentException: Error: type expected at the position 0 of 'timestamp_ntz' but 'timestamp_ntz' is found.

	at io.trino.testing.AbstractTestingTrinoClient.execute(AbstractTestingTrinoClient.java:134)
	at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:565)
	at io.trino.testing.DistributedQueryRunner.execute(DistributedQueryRunner.java:548)
	at io.trino.testing.AbstractTestQueryFramework.computeActual(AbstractTestQueryFramework.java:313)
	at io.trino.testing.AbstractTestQueryFramework.computeActual(AbstractTestQueryFramework.java:308)
	at io.trino.plugin.deltalake.TestDeltaLakeSharedGlueMetastoreWithTableRedirections.testUnsupportedHiveTypeRedirect(TestDeltaLakeSharedGlueMetastoreWithTableRedirections.java:180)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:507)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1458)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2034)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:189)
	Suppressed: java.lang.Exception: SQL: SHOW CREATE TABLE hive_with_redirections.test_shared_schema_4jlq4sptnq.unsupported_types
		at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:572)
		... 9 more
Caused by: com.google.common.util.concurrent.UncheckedExecutionException: com.google.common.util.concurrent.UncheckedExecutionException: java.lang.IllegalArgumentException: Error: type expected at the position 0 of 'timestamp_ntz' but 'timestamp_ntz' is found.
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2085)
	at com.google.common.cache.LocalCache.get(LocalCache.java:4017)
	at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:4040)
	at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4989)
	at io.trino.cache.EvictableCache.get(EvictableCache.java:147)
	at com.google.common.cache.AbstractLoadingCache.getUnchecked(AbstractLoadingCache.java:53)
	at io.trino.plugin.hive.metastore.cache.CachingHiveMetastore.getOptional(CachingHiveMetastore.java:285)
	at io.trino.plugin.hive.metastore.cache.CachingHiveMetastore.getTable(CachingHiveMetastore.java:431)
	at io.trino.plugin.hive.metastore.SemiTransactionalHiveMetastore.getTable(SemiTransactionalHiveMetastore.java:276)
	at io.trino.plugin.hive.HiveMetadata.getView(HiveMetadata.java:2899)
	at io.trino.spi.connector.ConnectorMetadata.isView(ConnectorMetadata.java:1005)
	at io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata.isView(ClassLoaderSafeConnectorMetadata.java:721)
	at io.trino.tracing.TracingConnectorMetadata.isView(TracingConnectorMetadata.java:850)
	at io.trino.metadata.MetadataManager.lambda$isView$37(MetadataManager.java:1499)
	at java.base/java.util.Optional.map(Optional.java:260)
	at io.trino.metadata.MetadataManager.isView(MetadataManager.java:1495)
	at io.trino.tracing.TracingMetadata.isView(TracingMetadata.java:886)
	at io.trino.sql.rewrite.ShowQueriesRewrite$Visitor.showCreateTable(ShowQueriesRewrite.java:616)
	at io.trino.sql.rewrite.ShowQueriesRewrite$Visitor.visitShowCreate(ShowQueriesRewrite.java:519)
	at io.trino.sql.rewrite.ShowQueriesRewrite$Visitor.visitShowCreate(ShowQueriesRewrite.java:219)
	at io.trino.sql.tree.ShowCreate.accept(ShowCreate.java:60)
	at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)
	at io.trino.sql.rewrite.ShowQueriesRewrite.rewrite(ShowQueriesRewrite.java:216)
	at io.trino.sql.rewrite.StatementRewrite.rewrite(StatementRewrite.java:54)
	at io.trino.sql.analyzer.Analyzer.analyze(Analyzer.java:93)
	at io.trino.sql.analyzer.Analyzer.analyze(Analyzer.java:87)
	at io.trino.execution.SqlQueryExecution.analyze(SqlQueryExecution.java:289)
	at io.trino.execution.SqlQueryExecution.<init>(SqlQueryExecution.java:222)
	at io.trino.execution.SqlQueryExecution$SqlQueryExecutionFactory.createQueryExecution(SqlQueryExecution.java:892)
	at io.trino.dispatcher.LocalDispatchQueryFactory.lambda$createDispatchQuery$0(LocalDispatchQueryFactory.java:153)
	at io.trino.$gen.Trino_testversion____20241010_143532_71.call(Unknown Source)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:131)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:76)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:82)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1575)
Caused by: com.google.common.util.concurrent.UncheckedExecutionException: java.lang.IllegalArgumentException: Error: type expected at the position 0 of 'timestamp_ntz' but 'timestamp_ntz' is found.
	at io.trino.cache.EmptyCache.get(EmptyCache.java:100)
	at io.trino.cache.EmptyCache.get(EmptyCache.java:58)
	at com.google.common.cache.AbstractLoadingCache.getUnchecked(AbstractLoadingCache.java:53)
	at io.trino.plugin.hive.metastore.cache.CachingHiveMetastore.getOptional(CachingHiveMetastore.java:285)
	at io.trino.plugin.hive.metastore.cache.CachingHiveMetastore.getTable(CachingHiveMetastore.java:431)
	at io.trino.plugin.hive.metastore.cache.CachingHiveMetastore.loadTable(CachingHiveMetastore.java:436)
	at com.google.common.cache.CacheLoader$FunctionToCacheLoader.load(CacheLoader.java:169)
	at io.trino.cache.EvictableCache$TokenCacheLoader.load(EvictableCache.java:471)
	at io.trino.cache.EvictableCache$TokenCacheLoader.load(EvictableCache.java:457)
	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3574)
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2316)
	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2189)
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2079)
	... 36 more
Caused by: java.lang.IllegalArgumentException: Error: type expected at the position 0 of 'timestamp_ntz' but 'timestamp_ntz' is found.
	at io.trino.metastore.type.TypeInfoUtils$TypeInfoParser.expect(TypeInfoUtils.java:193)
	at io.trino.metastore.type.TypeInfoUtils$TypeInfoParser.expect(TypeInfoUtils.java:176)
	at io.trino.metastore.type.TypeInfoUtils$TypeInfoParser.parseType(TypeInfoUtils.java:232)
	at io.trino.metastore.type.TypeInfoUtils$TypeInfoParser.parseTypeInfos(TypeInfoUtils.java:154)
	at io.trino.metastore.type.TypeInfoUtils.getTypeInfosFromTypeString(TypeInfoUtils.java:357)
	at io.trino.metastore.type.TypeInfoUtils.getTypeInfoFromTypeString(TypeInfoUtils.java:362)
	at io.trino.metastore.HiveType.valueOf(HiveType.java:116)
	at io.trino.plugin.hive.metastore.glue.GlueConverter.fromGlueColumn(GlueConverter.java:284)
	at io.trino.plugin.hive.metastore.glue.GlueConverter.lambda$fromGlueColumns$1(GlueConverter.java:272)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:215)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1709)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:570)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:560)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:265)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:727)
	at io.trino.plugin.hive.metastore.glue.GlueConverter.fromGlueColumns(GlueConverter.java:273)
	at io.trino.plugin.hive.metastore.glue.GlueConverter.fromGlueTable(GlueConverter.java:188)
	at io.trino.plugin.hive.metastore.glue.GlueHiveMetastore.getTableInternal(GlueHiveMetastore.java:495)
	at io.trino.plugin.hive.metastore.glue.GlueHiveMetastore.lambda$getTable$18(GlueHiveMetastore.java:485)
	at io.trino.plugin.hive.metastore.glue.NoopGlueCache.getTable(NoopGlueCache.java:66)
	at io.trino.plugin.hive.metastore.glue.GlueHiveMetastore.getTable(GlueHiveMetastore.java:485)
	at io.trino.plugin.hive.metastore.cache.CachingHiveMetastore.loadTable(CachingHiveMetastore.java:436)
	at com.google.common.cache.CacheLoader$FunctionToCacheLoader.load(CacheLoader.java:169)
	at io.trino.cache.EmptyCache.lambda$get$0(EmptyCache.java:58)
	at io.trino.cache.EmptyCache.get(EmptyCache.java:94)
	... 48 more

```

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
