### PR TITLE
Add run-views-as-invoker configuration property 

### DIFF
--- a/core/trino-main/src/main/java/io/trino/FeaturesConfig.java
+++ b/core/trino-main/src/main/java/io/trino/FeaturesConfig.java
@@ -122,6 +122,8 @@ public class FeaturesConfig
 
     private boolean faultTolerantExecutionExchangeEncryptionEnabled = true;
 
+    private boolean runViewsAsInvokerEnabled;
+
     public enum DataIntegrityVerification
     {
         NONE,
@@ -517,5 +519,17 @@ public class FeaturesConfig
     public void applyFaultTolerantExecutionDefaults()
     {
         exchangeCompressionCodec = LZ4;
+    }
+
+    public boolean isRunViewsAsInvokerEnabled()
+    {
+        return runViewsAsInvokerEnabled;
+    }
+
+    @Config("run-views-as-invoker")
+    public FeaturesConfig setRunViewsAsInvokerEnabled(boolean runViewsAsInvokerEnabled)
+    {
+        this.runViewsAsInvokerEnabled = runViewsAsInvokerEnabled;
+        return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -219,6 +219,7 @@ public final class SystemSessionProperties
     public static final String IDLE_WRITER_MIN_DATA_SIZE_THRESHOLD = "idle_writer_min_data_size_threshold";
     public static final String CLOSE_IDLE_WRITERS_TRIGGER_DURATION = "close_idle_writers_trigger_duration";
     public static final String COLUMNAR_FILTER_EVALUATION_ENABLED = "columnar_filter_evaluation_enabled";
+    public static final String RUN_VIEWS_AS_INVOKER_ENABLED = "run-views-as-invoker";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -1128,7 +1129,12 @@ public final class SystemSessionProperties
                         ALLOW_UNSAFE_PUSHDOWN,
                         "Allow pushing down expressions that may fail for some inputs",
                         optimizerConfig.isUnsafePushdownAllowed(),
-                        true));
+                        true),
+                booleanProperty(
+                        RUN_VIEWS_AS_INVOKER_ENABLED,
+                        "Execute all views with permissions of the invoker",
+                        featuresConfig.isRunViewsAsInvokerEnabled(),
+                        false));
     }
 
     @Override
@@ -2021,5 +2027,10 @@ public final class SystemSessionProperties
     public static boolean isUnsafePushdownAllowed(Session session)
     {
         return session.getSystemProperty(ALLOW_UNSAFE_PUSHDOWN, Boolean.class);
+    }
+
+    public static boolean isRunViewsAsInvokerEnabled(Session session)
+    {
+        return session.getSystemProperty(RUN_VIEWS_AS_INVOKER_ENABLED, Boolean.class);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -149,6 +149,7 @@ import static com.google.common.collect.Streams.stream;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.toListenableFuture;
 import static io.trino.SystemSessionProperties.getRetryPolicy;
+import static io.trino.SystemSessionProperties.isRunViewsAsInvokerEnabled;
 import static io.trino.metadata.CatalogMetadata.SecurityManagement.CONNECTOR;
 import static io.trino.metadata.CatalogMetadata.SecurityManagement.SYSTEM;
 import static io.trino.metadata.GlobalFunctionCatalog.BUILTIN_SCHEMA;
@@ -1592,7 +1593,12 @@ public final class MetadataManager
             ConnectorMetadata metadata = catalogMetadata.getMetadataFor(session, catalogHandle);
 
             ConnectorSession connectorSession = session.toConnectorSession(catalogHandle);
-            return metadata.getView(connectorSession, viewName.asSchemaTableName());
+            if (isRunViewsAsInvokerEnabled(session)) {
+                return metadata.getView(connectorSession, viewName.asSchemaTableName()).map(view -> view.withRunAsInvoker());
+            }
+            else {
+                return metadata.getView(connectorSession, viewName.asSchemaTableName());
+            }
         }
         return Optional.empty();
     }

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestFeaturesConfig.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestFeaturesConfig.java
@@ -66,7 +66,8 @@ public class TestFeaturesConfig
                 .setHideInaccessibleColumns(false)
                 .setForceSpillingJoin(false)
                 .setColumnarFilterEvaluationEnabled(true)
-                .setFaultTolerantExecutionExchangeEncryptionEnabled(true));
+                .setFaultTolerantExecutionExchangeEncryptionEnabled(true)
+                .setRunViewsAsInvokerEnabled(false));
     }
 
     @Test
@@ -101,6 +102,7 @@ public class TestFeaturesConfig
                 .put("force-spilling-join-operator", "true")
                 .put("experimental.columnar-filter-evaluation.enabled", "false")
                 .put("fault-tolerant-execution-exchange-encryption-enabled", "false")
+                .put("run-views-as-invoker", "true")
                 .buildOrThrow();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -131,7 +133,8 @@ public class TestFeaturesConfig
                 .setHideInaccessibleColumns(true)
                 .setForceSpillingJoin(true)
                 .setColumnarFilterEvaluationEnabled(false)
-                .setFaultTolerantExecutionExchangeEncryptionEnabled(false);
+                .setFaultTolerantExecutionExchangeEncryptionEnabled(false)
+                .setRunViewsAsInvokerEnabled(true);
         assertFullMapping(properties, expected);
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorViewDefinition.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorViewDefinition.java
@@ -126,6 +126,19 @@ public class ConnectorViewDefinition
                 path);
     }
 
+    public ConnectorViewDefinition withRunAsInvoker()
+    {
+        return new ConnectorViewDefinition(
+                originalSql,
+                catalog,
+                schema,
+                columns,
+                comment,
+                Optional.empty(),
+                true,
+                path);
+    }
+
     @Override
     public String toString()
     {

--- a/core/trino-spi/src/test/java/io/trino/spi/connector/TestConnectorViewDefinition.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/connector/TestConnectorViewDefinition.java
@@ -68,6 +68,23 @@ public class TestConnectorViewDefinition
     }
 
     @Test
+    public void testViewWithRunAsInvoker()
+    {
+        ConnectorViewDefinition viewWithRunAsInvoker;
+        ConnectorViewDefinition definerView = CODEC.fromJson("{" + BASE_JSON + ", \"owner\": \"abc\", \"runAsInvoker\": false}");
+        viewWithRunAsInvoker = definerView.withRunAsInvoker();
+        assertBaseView(viewWithRunAsInvoker);
+        assertThat(viewWithRunAsInvoker.getOwner().isPresent()).isFalse();
+        assertThat(viewWithRunAsInvoker.isRunAsInvoker()).isTrue();
+
+        ConnectorViewDefinition invokerView = CODEC.fromJson("{" + BASE_JSON + ", \"runAsInvoker\": true}");
+        viewWithRunAsInvoker = invokerView.withRunAsInvoker();
+        assertBaseView(viewWithRunAsInvoker);
+        assertThat(viewWithRunAsInvoker.getOwner().isPresent()).isFalse();
+        assertThat(viewWithRunAsInvoker.isRunAsInvoker()).isTrue();
+    }
+
+    @Test
     public void testViewComment()
     {
         ConnectorViewDefinition view = CODEC.fromJson("{" + BASE_JSON + ", \"comment\": \"hello\"}");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
This PR adds a new system session property run-views-as-invoker. 

If set, this property makes it so that any view is granted access based on the permissions of the user who is querying the view, assuming that the security permission checks are enabled. 

This is useful for platform administrators who don't want to enable DEFINER mode and want to force all view authorization to use INVOKER due to platform security decisions or changing access of definers.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Something similar was already implemented for the Hive connector in #12221. 
Some discussion in #14817 and #14790.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Add  `run-views-as-invoker` configuration property to force all views to run in INVOKER mode.
```
