### PR TITLE
Fix create table if not exists failure when using shared metastore

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/CreateTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateTableTask.java
@@ -133,9 +133,9 @@ public class CreateTableTask
 
         Map<NodeRef<Parameter>, Expression> parameterLookup = bindParameters(statement, parameters);
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getName());
-        Optional<TableHandle> tableHandle;
+        RedirectionAwareTableHandle tableHandle;
         try {
-            tableHandle = plannerContext.getMetadata().getTableHandle(session, tableName);
+            tableHandle = plannerContext.getMetadata().getRedirectionAwareTableHandle(session, tableName);
         }
         catch (TrinoException e) {
             if (e.getErrorCode().equals(UNSUPPORTED_TABLE_TYPE.toErrorCode())) {
@@ -143,7 +143,7 @@ public class CreateTableTask
             }
             throw e;
         }
-        if (tableHandle.isPresent() && statement.getSaveMode() != REPLACE) {
+        if (tableHandle.tableHandle().isPresent() && statement.getSaveMode() != REPLACE) {
             if (statement.getSaveMode() == FAIL) {
                 throw semanticException(TABLE_ALREADY_EXISTS, statement, "Table '%s' already exists", tableName);
             }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -907,8 +907,8 @@ class StatementAnalyzer
             // turn this into a query that has a new table writer node on top.
             QualifiedObjectName targetTable = createQualifiedObjectName(session, node, node.getName());
 
-            Optional<TableHandle> targetTableHandle = metadata.getTableHandle(session, targetTable);
-            if (targetTableHandle.isPresent() && node.getSaveMode() != REPLACE) {
+            RedirectionAwareTableHandle tableHandle = metadata.getRedirectionAwareTableHandle(session, targetTable);
+            if (tableHandle.tableHandle().isPresent() && node.getSaveMode() != REPLACE) {
                 if (node.getSaveMode() == IGNORE) {
                     analysis.setCreate(new Analysis.Create(
                             Optional.of(targetTable),
@@ -918,7 +918,7 @@ class StatementAnalyzer
                             true,
                             false));
                     analysis.setUpdateType("CREATE TABLE");
-                    analysis.setUpdateTarget(targetTableHandle.get().catalogHandle().getVersion(), targetTable, Optional.empty(), Optional.of(ImmutableList.of()));
+                    analysis.setUpdateTarget(tableHandle.tableHandle().get().catalogHandle().getVersion(), targetTable, Optional.empty(), Optional.of(ImmutableList.of()));
                     return createAndAssignScope(node, scope, Field.newUnqualified("rows", BIGINT));
                 }
                 throw semanticException(TABLE_ALREADY_EXISTS, node, "Destination table '%s' already exists", targetTable);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Fix create table if not exists failure when using shared metastore

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
When using shared metastore, e.g. Hive <> Iceberg,
CREATE IF NOT EXISTS in Hive will fail if table with same name exists in Iceberg.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
