### PR TITLE
Avoid blocking in BigQuery split and page sources

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
@@ -417,10 +417,16 @@ public class BigQueryClient
 
     public TableResult executeQuery(ConnectorSession session, String sql)
     {
+        return executeQuery(session, sql, null);
+    }
+
+    public TableResult executeQuery(ConnectorSession session, String sql, Long maxResults)
+    {
         log.debug("Execute query: %s", sql);
         QueryJobConfiguration job = QueryJobConfiguration.newBuilder(sql)
                 .setUseQueryCache(isQueryResultsCacheEnabled(session))
                 .setCreateDisposition(createDisposition(session))
+                .setMaxResults(maxResults)
                 .build();
         return execute(session, job);
     }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorFactory.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorFactory.java
@@ -19,6 +19,7 @@ import io.airlift.json.JsonModule;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
 import io.trino.spi.NodeManager;
+import io.trino.spi.catalog.CatalogName;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorFactory;
@@ -53,6 +54,7 @@ public class BigQueryConnectorFactory
                     binder.bind(NodeManager.class).toInstance(context.getNodeManager());
                     binder.bind(OpenTelemetry.class).toInstance(context.getOpenTelemetry());
                     binder.bind(Tracer.class).toInstance(context.getTracer());
+                    binder.bind(CatalogName.class).toInstance(new CatalogName(catalogName));
                 });
 
         Injector injector = app

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitManager.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitManager.java
@@ -13,21 +13,10 @@
  */
 package io.trino.plugin.bigquery;
 
-import com.google.cloud.bigquery.BigQueryException;
-import com.google.cloud.bigquery.TableDefinition;
-import com.google.cloud.bigquery.TableId;
-import com.google.cloud.bigquery.TableInfo;
-import com.google.cloud.bigquery.TableResult;
-import com.google.cloud.bigquery.storage.v1.ReadSession;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
-import com.google.protobuf.ByteString;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
 import io.trino.spi.NodeManager;
-import io.trino.spi.TrinoException;
-import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorSplitSource;
@@ -35,31 +24,8 @@ import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.DynamicFilter;
-import io.trino.spi.connector.FixedSplitSource;
-import io.trino.spi.predicate.TupleDomain;
-import org.apache.arrow.vector.ipc.ReadChannel;
-import org.apache.arrow.vector.util.ByteArrayReadableSeekableByteChannel;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.util.List;
-import java.util.Optional;
-import java.util.OptionalInt;
-
-import static com.google.cloud.bigquery.TableDefinition.Type.EXTERNAL;
-import static com.google.cloud.bigquery.TableDefinition.Type.MATERIALIZED_VIEW;
-import static com.google.cloud.bigquery.TableDefinition.Type.VIEW;
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.Iterables.getOnlyElement;
-import static io.trino.plugin.bigquery.BigQueryClient.TABLE_TYPES;
-import static io.trino.plugin.bigquery.BigQueryClient.selectSql;
-import static io.trino.plugin.bigquery.BigQueryErrorCode.BIGQUERY_FAILED_TO_EXECUTE_QUERY;
-import static io.trino.plugin.bigquery.BigQuerySessionProperties.isSkipViewMaterialization;
-import static io.trino.plugin.bigquery.BigQueryUtil.isWildcardTable;
-import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.util.Objects.requireNonNull;
-import static org.apache.arrow.vector.ipc.message.MessageSerializer.deserializeSchema;
 
 public class BigQuerySplitManager
         implements ConnectorSplitManager
@@ -99,152 +65,15 @@ public class BigQuerySplitManager
             Constraint constraint)
     {
         log.debug("getSplits(transaction=%s, session=%s, table=%s)", transaction, session, table);
-        BigQueryTableHandle bigQueryTableHandle = (BigQueryTableHandle) table;
-
-        TupleDomain<ColumnHandle> tableConstraint = bigQueryTableHandle.constraint();
-        Optional<String> filter = BigQueryFilterQueryBuilder.buildFilter(tableConstraint);
-
-        if (bigQueryTableHandle.isQueryRelation()) {
-            BigQueryQueryRelationHandle bigQueryQueryRelationHandle = bigQueryTableHandle.getRequiredQueryRelation();
-            List<BigQueryColumnHandle> columns = bigQueryTableHandle.projectedColumns().orElse(ImmutableList.of());
-            boolean useStorageApi = bigQueryQueryRelationHandle.isUseStorageApi();
-
-            // projectedColumnsNames can not be used for generating select sql because the query fails if it does not
-            // include a column name. eg: query => 'SELECT 1'
-            String query = filter
-                    .map(whereClause -> "SELECT * FROM (" + bigQueryQueryRelationHandle.getQuery() + " ) WHERE " + whereClause)
-                    .orElseGet(bigQueryQueryRelationHandle::getQuery);
-
-            if (emptyProjectionIsRequired(bigQueryTableHandle.projectedColumns())) {
-                String sql = "SELECT COUNT(*) FROM (" + query + ")";
-                return new FixedSplitSource(createEmptyProjection(session, sql));
-            }
-
-            if (!useStorageApi) {
-                log.debug("Using Rest API for running query: %s", query);
-                return new FixedSplitSource(BigQuerySplit.forViewStream(columns, filter));
-            }
-
-            TableId destinationTable = bigQueryQueryRelationHandle.getDestinationTableName().toTableId();
-            TableInfo tableInfo = new ViewMaterializationCache.DestinationTableBuilder(bigQueryClientFactory.create(session), viewExpiration, query, destinationTable).get();
-
-            log.debug("Using Storage API for running query: %s", query);
-            // filter is already used while constructing the select query
-            ReadSession readSession = createReadSession(session, tableInfo.getTableId(), ImmutableList.copyOf(columns), Optional.empty());
-            return new FixedSplitSource(readSession.getStreamsList().stream()
-                    .map(stream -> BigQuerySplit.forStream(stream.getName(), getSchemaAsString(readSession), columns, OptionalInt.of(stream.getSerializedSize())))
-                    .collect(toImmutableList()));
-        }
-
-        TableId remoteTableId = bigQueryTableHandle.asPlainTable().getRemoteTableName().toTableId();
-        TableDefinition.Type tableType = TableDefinition.Type.valueOf(bigQueryTableHandle.asPlainTable().getType());
-        List<BigQuerySplit> splits = emptyProjectionIsRequired(bigQueryTableHandle.projectedColumns())
-                ? createEmptyProjection(session, tableType, remoteTableId, filter)
-                : readFromBigQuery(session, tableType, remoteTableId, bigQueryTableHandle.projectedColumns(), tableConstraint);
-        return new FixedSplitSource(splits);
-    }
-
-    private static boolean emptyProjectionIsRequired(Optional<List<BigQueryColumnHandle>> projectedColumns)
-    {
-        return projectedColumns.isPresent() && projectedColumns.get().isEmpty();
-    }
-
-    private List<BigQuerySplit> readFromBigQuery(
-            ConnectorSession session,
-            TableDefinition.Type type,
-            TableId remoteTableId,
-            Optional<List<BigQueryColumnHandle>> projectedColumns,
-            TupleDomain<ColumnHandle> tableConstraint)
-    {
-        checkArgument(projectedColumns.isPresent() && projectedColumns.get().size() > 0, "Projected column is empty");
-        Optional<String> filter = BigQueryFilterQueryBuilder.buildFilter(tableConstraint);
-
-        log.debug("readFromBigQuery(tableId=%s, projectedColumns=%s, filter=[%s])", remoteTableId, projectedColumns, filter);
-        List<BigQueryColumnHandle> columns = projectedColumns.get();
-        List<String> projectedColumnsNames = getProjectedColumnNames(columns);
-        ImmutableList.Builder<BigQueryColumnHandle> projectedColumnHandles = ImmutableList.builder();
-        projectedColumnHandles.addAll(columns);
-
-        if (isWildcardTable(type, remoteTableId.getTable())) {
-            // Storage API doesn't support reading wildcard tables
-            return ImmutableList.of(BigQuerySplit.forViewStream(columns, filter));
-        }
-        if (type == EXTERNAL) {
-            // Storage API doesn't support reading external tables
-            return ImmutableList.of(BigQuerySplit.forViewStream(columns, filter));
-        }
-        if (type == VIEW || type == MATERIALIZED_VIEW) {
-            if (isSkipViewMaterialization(session)) {
-                return ImmutableList.of(BigQuerySplit.forViewStream(columns, filter));
-            }
-            tableConstraint.getDomains().ifPresent(domains -> domains.keySet().stream()
-                    .map(BigQueryColumnHandle.class::cast)
-                    .filter(column -> !projectedColumnsNames.contains(column.name()))
-                    .forEach(projectedColumnHandles::add));
-        }
-        ReadSession readSession = createReadSession(session, remoteTableId, ImmutableList.copyOf(projectedColumnHandles.build()), filter);
-
-        String schemaString = getSchemaAsString(readSession);
-        return readSession.getStreamsList().stream()
-                .map(stream -> BigQuerySplit.forStream(stream.getName(), schemaString, columns, OptionalInt.of(stream.getSerializedSize())))
-                .collect(toImmutableList());
-    }
-
-    @VisibleForTesting
-    ReadSession createReadSession(ConnectorSession session, TableId remoteTableId, List<BigQueryColumnHandle> columns, Optional<String> filter)
-    {
-        ReadSessionCreator readSessionCreator = new ReadSessionCreator(bigQueryClientFactory, bigQueryReadClientFactory, viewEnabled, arrowSerializationEnabled, viewExpiration, maxReadRowsRetries);
-        return readSessionCreator.create(session, remoteTableId, columns, filter, nodeManager.getRequiredWorkerNodes().size());
-    }
-
-    private static List<String> getProjectedColumnNames(List<BigQueryColumnHandle> columns)
-    {
-        return columns.stream().map(BigQueryColumnHandle::name).collect(toImmutableList());
-    }
-
-    private List<BigQuerySplit> createEmptyProjection(ConnectorSession session, TableDefinition.Type tableType, TableId remoteTableId, Optional<String> filter)
-    {
-        if (!TABLE_TYPES.containsKey(tableType)) {
-            throw new TrinoException(NOT_SUPPORTED, "Unsupported table type: " + tableType);
-        }
-
-        // Note that we cannot use row count from TableInfo because for writes via insertAll/streaming API the number is incorrect until the streaming buffer is flushed
-        // (and there's no mechanism to trigger an on-demand flush). This can lead to incorrect results for queries with empty projections.
-        String sql = selectSql(remoteTableId, "COUNT(*)", filter);
-        return createEmptyProjection(session, sql);
-    }
-
-    private List<BigQuerySplit> createEmptyProjection(ConnectorSession session, String sql)
-    {
-        BigQueryClient client = bigQueryClientFactory.create(session);
-        log.debug("createEmptyProjection(sql=%s)", sql);
-        try {
-            TableResult result = client.executeQuery(session, sql);
-            long numberOfRows = getOnlyElement(getOnlyElement(result.iterateAll())).getLongValue();
-
-            return ImmutableList.of(BigQuerySplit.emptyProjection(numberOfRows));
-        }
-        catch (BigQueryException e) {
-            throw new TrinoException(BIGQUERY_FAILED_TO_EXECUTE_QUERY, "Failed to compute empty projection", e);
-        }
-    }
-
-    private String getSchemaAsString(ReadSession readSession)
-    {
-        if (arrowSerializationEnabled) {
-            return deserializeArrowSchema(readSession.getArrowSchema().getSerializedSchema());
-        }
-        return readSession.getAvroSchema().getSchema();
-    }
-
-    private static String deserializeArrowSchema(ByteString serializedSchema)
-    {
-        try {
-            return deserializeSchema(new ReadChannel(new ByteArrayReadableSeekableByteChannel(serializedSchema.toByteArray())))
-                    .toJson();
-        }
-        catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        return new BigQuerySplitSource(
+                session,
+                (BigQueryTableHandle) table,
+                bigQueryClientFactory,
+                bigQueryReadClientFactory,
+                viewEnabled,
+                arrowSerializationEnabled,
+                viewExpiration,
+                nodeManager,
+                maxReadRowsRetries);
     }
 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitSource.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitSource.java
@@ -1,0 +1,283 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery;
+
+import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.TableDefinition;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.TableInfo;
+import com.google.cloud.bigquery.TableResult;
+import com.google.cloud.bigquery.storage.v1.ReadSession;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
+import io.airlift.log.Logger;
+import io.airlift.units.Duration;
+import io.trino.spi.NodeManager;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.connector.ConnectorSplitSource;
+import io.trino.spi.predicate.TupleDomain;
+import jakarta.annotation.Nullable;
+import org.apache.arrow.vector.ipc.ReadChannel;
+import org.apache.arrow.vector.util.ByteArrayReadableSeekableByteChannel;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.concurrent.CompletableFuture;
+
+import static com.google.cloud.bigquery.TableDefinition.Type.EXTERNAL;
+import static com.google.cloud.bigquery.TableDefinition.Type.MATERIALIZED_VIEW;
+import static com.google.cloud.bigquery.TableDefinition.Type.VIEW;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.plugin.bigquery.BigQueryClient.TABLE_TYPES;
+import static io.trino.plugin.bigquery.BigQueryClient.selectSql;
+import static io.trino.plugin.bigquery.BigQueryErrorCode.BIGQUERY_FAILED_TO_EXECUTE_QUERY;
+import static io.trino.plugin.bigquery.BigQuerySessionProperties.isSkipViewMaterialization;
+import static io.trino.plugin.bigquery.BigQueryUtil.isWildcardTable;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.apache.arrow.vector.ipc.message.MessageSerializer.deserializeSchema;
+
+public class BigQuerySplitSource
+        implements ConnectorSplitSource
+{
+    private static final Logger log = Logger.get(BigQuerySplitSource.class);
+
+    private final ConnectorSession session;
+    private final BigQueryTableHandle table;
+    private final BigQueryClientFactory bigQueryClientFactory;
+    private final BigQueryReadClientFactory bigQueryReadClientFactory;
+    private final boolean viewEnabled;
+    private final boolean arrowSerializationEnabled;
+    private final Duration viewExpiration;
+    private final NodeManager nodeManager;
+    private final int maxReadRowsRetries;
+
+    @Nullable
+    private List<BigQuerySplit> splits;
+    private int offset;
+
+    public BigQuerySplitSource(ConnectorSession session,
+            BigQueryTableHandle table,
+            BigQueryClientFactory bigQueryClientFactory,
+            BigQueryReadClientFactory bigQueryReadClientFactory,
+            boolean viewEnabled,
+            boolean arrowSerializationEnabled,
+            Duration viewExpiration,
+            NodeManager nodeManager,
+            int maxReadRowsRetries)
+    {
+        this.session = requireNonNull(session, "session is null");
+        this.table = requireNonNull(table, "table is null");
+        this.bigQueryClientFactory = requireNonNull(bigQueryClientFactory, "bigQueryClientFactory cannot be null");
+        this.bigQueryReadClientFactory = requireNonNull(bigQueryReadClientFactory, "bigQueryReadClientFactory cannot be null");
+        this.viewEnabled = viewEnabled;
+        this.arrowSerializationEnabled = arrowSerializationEnabled;
+        this.viewExpiration = requireNonNull(viewExpiration, "viewExpiration is null");
+        this.nodeManager = requireNonNull(nodeManager, "nodeManager cannot be null");
+        this.maxReadRowsRetries = maxReadRowsRetries;
+    }
+
+    @Override
+    public CompletableFuture<ConnectorSplitBatch> getNextBatch(int maxSize)
+    {
+        if (splits == null) {
+            splits = getSplits(session, table);
+        }
+
+        return completedFuture(new ConnectorSplitBatch(prepareNextBatch(maxSize), isFinished()));
+    }
+
+    private List<ConnectorSplit> prepareNextBatch(int maxSize)
+    {
+        requireNonNull(splits, "splits is null");
+        int nextOffset = Math.min(splits.size(), offset + maxSize);
+        List<ConnectorSplit> results = splits.subList(offset, nextOffset).stream()
+                .map(ConnectorSplit.class::cast)
+                .collect(toImmutableList());
+        offset = nextOffset;
+        return results;
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return splits != null && offset >= splits.size();
+    }
+
+    @Override
+    public void close()
+    {
+        splits = null;
+    }
+
+    private List<BigQuerySplit> getSplits(
+            ConnectorSession session,
+            BigQueryTableHandle bigQueryTableHandle)
+    {
+        TupleDomain<ColumnHandle> tableConstraint = bigQueryTableHandle.constraint();
+        Optional<String> filter = BigQueryFilterQueryBuilder.buildFilter(tableConstraint);
+
+        if (bigQueryTableHandle.isQueryRelation()) {
+            BigQueryQueryRelationHandle bigQueryQueryRelationHandle = bigQueryTableHandle.getRequiredQueryRelation();
+            List<BigQueryColumnHandle> columns = bigQueryTableHandle.projectedColumns().orElse(ImmutableList.of());
+            boolean useStorageApi = bigQueryQueryRelationHandle.isUseStorageApi();
+
+            // projectedColumnsNames can not be used for generating select sql because the query fails if it does not
+            // include a column name. eg: query => 'SELECT 1'
+            String query = filter
+                    .map(whereClause -> "SELECT * FROM (" + bigQueryQueryRelationHandle.getQuery() + " ) WHERE " + whereClause)
+                    .orElseGet(bigQueryQueryRelationHandle::getQuery);
+
+            if (emptyProjectionIsRequired(bigQueryTableHandle.projectedColumns())) {
+                String sql = "SELECT COUNT(*) FROM (" + query + ")";
+                return createEmptyProjection(session, sql);
+            }
+
+            if (!useStorageApi) {
+                log.debug("Using Rest API for running query: %s", query);
+                return List.of(BigQuerySplit.forViewStream(columns, filter));
+            }
+
+            TableId destinationTable = bigQueryQueryRelationHandle.getDestinationTableName().toTableId();
+            TableInfo tableInfo = new ViewMaterializationCache.DestinationTableBuilder(bigQueryClientFactory.create(session), viewExpiration, query, destinationTable).get();
+
+            log.debug("Using Storage API for running query: %s", query);
+            // filter is already used while constructing the select query
+            ReadSession readSession = createReadSession(session, tableInfo.getTableId(), ImmutableList.copyOf(columns), Optional.empty());
+            return readSession.getStreamsList().stream()
+                    .map(stream -> BigQuerySplit.forStream(stream.getName(), getSchemaAsString(readSession), columns, OptionalInt.of(stream.getSerializedSize())))
+                    .collect(toImmutableList());
+        }
+
+        TableId remoteTableId = bigQueryTableHandle.asPlainTable().getRemoteTableName().toTableId();
+        TableDefinition.Type tableType = TableDefinition.Type.valueOf(bigQueryTableHandle.asPlainTable().getType());
+        return emptyProjectionIsRequired(bigQueryTableHandle.projectedColumns())
+                ? createEmptyProjection(session, tableType, remoteTableId, filter)
+                : readFromBigQuery(session, tableType, remoteTableId, bigQueryTableHandle.projectedColumns(), tableConstraint);
+    }
+
+    private static boolean emptyProjectionIsRequired(Optional<List<BigQueryColumnHandle>> projectedColumns)
+    {
+        return projectedColumns.isPresent() && projectedColumns.get().isEmpty();
+    }
+
+    private List<BigQuerySplit> readFromBigQuery(
+            ConnectorSession session,
+            TableDefinition.Type type,
+            TableId remoteTableId,
+            Optional<List<BigQueryColumnHandle>> projectedColumns,
+            TupleDomain<ColumnHandle> tableConstraint)
+    {
+        checkArgument(projectedColumns.isPresent() && projectedColumns.get().size() > 0, "Projected column is empty");
+        Optional<String> filter = BigQueryFilterQueryBuilder.buildFilter(tableConstraint);
+
+        log.debug("readFromBigQuery(tableId=%s, projectedColumns=%s, filter=[%s])", remoteTableId, projectedColumns, filter);
+        List<BigQueryColumnHandle> columns = projectedColumns.get();
+        List<String> projectedColumnsNames = getProjectedColumnNames(columns);
+        ImmutableList.Builder<BigQueryColumnHandle> projectedColumnHandles = ImmutableList.builder();
+        projectedColumnHandles.addAll(columns);
+
+        if (isWildcardTable(type, remoteTableId.getTable())) {
+            // Storage API doesn't support reading wildcard tables
+            return ImmutableList.of(BigQuerySplit.forViewStream(columns, filter));
+        }
+        if (type == EXTERNAL) {
+            // Storage API doesn't support reading external tables
+            return ImmutableList.of(BigQuerySplit.forViewStream(columns, filter));
+        }
+        if (type == VIEW || type == MATERIALIZED_VIEW) {
+            if (isSkipViewMaterialization(session)) {
+                return ImmutableList.of(BigQuerySplit.forViewStream(columns, filter));
+            }
+            tableConstraint.getDomains().ifPresent(domains -> domains.keySet().stream()
+                    .map(BigQueryColumnHandle.class::cast)
+                    .filter(column -> !projectedColumnsNames.contains(column.name()))
+                    .forEach(projectedColumnHandles::add));
+        }
+        ReadSession readSession = createReadSession(session, remoteTableId, ImmutableList.copyOf(projectedColumnHandles.build()), filter);
+
+        String schemaString = getSchemaAsString(readSession);
+        return readSession.getStreamsList().stream()
+                .map(stream -> BigQuerySplit.forStream(stream.getName(), schemaString, columns, OptionalInt.of(stream.getSerializedSize())))
+                .collect(toImmutableList());
+    }
+
+    @VisibleForTesting
+    ReadSession createReadSession(ConnectorSession session, TableId remoteTableId, List<BigQueryColumnHandle> columns, Optional<String> filter)
+    {
+        ReadSessionCreator readSessionCreator = new ReadSessionCreator(bigQueryClientFactory, bigQueryReadClientFactory, viewEnabled, arrowSerializationEnabled, viewExpiration, maxReadRowsRetries);
+        return readSessionCreator.create(session, remoteTableId, columns, filter, nodeManager.getRequiredWorkerNodes().size());
+    }
+
+    private static List<String> getProjectedColumnNames(List<BigQueryColumnHandle> columns)
+    {
+        return columns.stream().map(BigQueryColumnHandle::name).collect(toImmutableList());
+    }
+
+    private List<BigQuerySplit> createEmptyProjection(ConnectorSession session, TableDefinition.Type tableType, TableId remoteTableId, Optional<String> filter)
+    {
+        if (!TABLE_TYPES.containsKey(tableType)) {
+            throw new TrinoException(NOT_SUPPORTED, "Unsupported table type: " + tableType);
+        }
+
+        // Note that we cannot use row count from TableInfo because for writes via insertAll/streaming API the number is incorrect until the streaming buffer is flushed
+        // (and there's no mechanism to trigger an on-demand flush). This can lead to incorrect results for queries with empty projections.
+        String sql = selectSql(remoteTableId, "COUNT(*)", filter);
+        return createEmptyProjection(session, sql);
+    }
+
+    private List<BigQuerySplit> createEmptyProjection(ConnectorSession session, String sql)
+    {
+        BigQueryClient client = bigQueryClientFactory.create(session);
+        log.debug("createEmptyProjection(sql=%s)", sql);
+        try {
+            TableResult result = client.executeQuery(session, sql);
+            long numberOfRows = getOnlyElement(getOnlyElement(result.iterateAll())).getLongValue();
+
+            return ImmutableList.of(BigQuerySplit.emptyProjection(numberOfRows));
+        }
+        catch (BigQueryException e) {
+            throw new TrinoException(BIGQUERY_FAILED_TO_EXECUTE_QUERY, "Failed to compute empty projection", e);
+        }
+    }
+
+    private String getSchemaAsString(ReadSession readSession)
+    {
+        if (arrowSerializationEnabled) {
+            return deserializeArrowSchema(readSession.getArrowSchema().getSerializedSchema());
+        }
+        return readSession.getAvroSchema().getSchema();
+    }
+
+    private static String deserializeArrowSchema(ByteString serializedSchema)
+    {
+        try {
+            return deserializeSchema(new ReadChannel(new ByteArrayReadableSeekableByteChannel(serializedSchema.toByteArray())))
+                    .toJson();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryStorageAvroPageSource.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryStorageAvroPageSource.java
@@ -50,12 +50,16 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.plugin.bigquery.BigQueryTypeManager.toTrinoTimestamp;
 import static io.trino.plugin.bigquery.BigQueryUtil.toBigQueryColumnName;
@@ -85,6 +89,7 @@ public class BigQueryStorageAvroPageSource
     private static final AvroDecimalConverter DECIMAL_CONVERTER = new AvroDecimalConverter();
 
     private final BigQueryReadClient bigQueryReadClient;
+    private final ExecutorService executor;
     private final BigQueryTypeManager typeManager;
     private final BigQuerySplit split;
     private final List<BigQueryColumnHandle> columns;
@@ -92,14 +97,19 @@ public class BigQueryStorageAvroPageSource
     private final PageBuilder pageBuilder;
     private final Iterator<ReadRowsResponse> responses;
 
+    private CompletableFuture<ReadRowsResponse> nextResponse;
+    private boolean finished;
+
     public BigQueryStorageAvroPageSource(
             BigQueryReadClient bigQueryReadClient,
+            ExecutorService executor,
             BigQueryTypeManager typeManager,
             int maxReadRowsRetries,
             BigQuerySplit split,
             List<BigQueryColumnHandle> columns)
     {
         this.bigQueryReadClient = requireNonNull(bigQueryReadClient, "bigQueryReadClient is null");
+        this.executor = requireNonNull(executor, "executor is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.split = requireNonNull(split, "split is null");
         this.readBytes = new AtomicLong();
@@ -110,6 +120,7 @@ public class BigQueryStorageAvroPageSource
 
         log.debug("Starting to read from %s", split.getStreamName());
         responses = new ReadRowsHelper(bigQueryReadClient, split.getStreamName(), maxReadRowsRetries).readRows();
+        nextResponse = CompletableFuture.supplyAsync(this::getResponse, executor);
     }
 
     @Override
@@ -127,17 +138,22 @@ public class BigQueryStorageAvroPageSource
     @Override
     public boolean isFinished()
     {
-        return !responses.hasNext();
+        return finished;
     }
 
     @Override
     public Page getNextPage()
     {
         checkState(pageBuilder.isEmpty(), "PageBuilder is not empty at the beginning of a new page");
-        if (!responses.hasNext()) {
+        ReadRowsResponse response;
+        try {
+            response = getFutureValue(nextResponse);
+        }
+        catch (NoSuchElementException ignored) {
+            finished = true;
             return null;
         }
-        ReadRowsResponse response = responses.next();
+        nextResponse = CompletableFuture.supplyAsync(this::getResponse, executor);
         Iterable<GenericRecord> records = parse(response);
         for (GenericRecord record : records) {
             pageBuilder.declarePosition();
@@ -305,7 +321,20 @@ public class BigQueryStorageAvroPageSource
     @Override
     public void close()
     {
+        nextResponse.cancel(true);
         bigQueryReadClient.close();
+    }
+
+    @Override
+    public CompletableFuture<?> isBlocked()
+    {
+        return nextResponse;
+    }
+
+    private ReadRowsResponse getResponse()
+    {
+        ReadRowsResponse response = responses.next();
+        return response;
     }
 
     Iterable<GenericRecord> parse(ReadRowsResponse response)

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ForBigQueryPageSource.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ForBigQueryPageSource.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@BindingAnnotation
+public @interface ForBigQueryPageSource {}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Avoid blocking in BigQuery split and page source constructors, which execute queries, by starting them in a background thread. This should reduce congestion on busy clusters. 

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
