### PR TITLE
Add Trino 462 release notes

### DIFF
--- a/docs/src/main/sphinx/admin/resource-groups.md
+++ b/docs/src/main/sphinx/admin/resource-groups.md
@@ -28,6 +28,7 @@ resource-groups.config-file=etc/resource-groups.json
 The path to the JSON file can be an absolute path, or a path relative to the Trino
 data directory. The JSON file only needs to be present on the coordinator.
 
+(db-resource-group-manager)=
 ## Database resource group manager
 
 The database resource group manager loads the configuration from a relational database. The

--- a/docs/src/main/sphinx/release.md
+++ b/docs/src/main/sphinx/release.md
@@ -6,6 +6,7 @@
 ```{toctree}
 :maxdepth: 1
 
+release/release-462
 release/release-461
 release/release-460
 release/release-459

--- a/docs/src/main/sphinx/release/release-462.md
+++ b/docs/src/main/sphinx/release/release-462.md
@@ -1,0 +1,34 @@
+# Release 462 (16 Oct 2024)
+
+## General
+
+* Allow adding subgroups to groups during query processing when using the
+  [](db-resource-group-manager). ({issue}`23727`)
+* Fix query failures for queries routed to a group whose subgroup is deleted
+  when using the [](db-resource-group-manager). ({issue}`23727`)
+* Fix wrong resource group configuration being applied if the group is changed
+  from a variable to fixed name or vice-versa when using the
+  [](db-resource-group-manager). ({issue}`23727`)
+* Fix resource group updates not being observed immediately for groups that use
+  variables when using the [](db-resource-group-manager). ({issue}`23727`)
+* Fix incorrect results for certain `CASE` expressions that return boolean
+  results. ({issue}`23787`)
+
+## JDBC driver
+
+* Improve performance and memory usage when decoding data. ({issue}`23754`)
+
+## CLI
+
+* Improve performance and memory usage when decoding data. ({issue}`23754`)
+
+## Iceberg connector
+
+* Add support for read operations when using the Unity catalog as Iceberg REST
+  catalog. ({issue}`22609`)
+* Improve planning time for insert operations. ({issue}`23757`)
+
+## Redshift connector
+
+* Improve performance for queries casting columns to smallint, integer, or
+  bigint. ({issue}`22951`)


### PR DESCRIPTION
## Description

Assemble the release notes for the upcoming Trino 462 release.

## Additional context and related issues

See https://github.com/trinodb/trino/pulls?q=is%3Apr+is%3Aclosed+milestone%3A462

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

## Verification for each pull request

Format: PR/issue number, ✅ / ❌ rn ✅ / ❌ docs
✅ rn - release note added and verified, or assessed to be not necessary, set to ❌ rn before completion
✅ docs - need for docs assessed and merged, or assessed to be not necessary, set to ❌ docs before completion

## 10 Oct 2024

* #23748 ✅ rn ✅ docs
* #23743 ✅ rn ✅ docs

## 11 Oct 2024

* #23611 ✅ rn ✅ docs
* #23751 ✅ rn ✅ docs
* #23737 ✅ rn ✅ docs
* #23754 ✅ rn ✅ docs
* #23755 ✅ rn ✅ docs

## 12 Oct 2024

* #23302 ✅ rn ✅ docs

## 13 Oct 2024

* #23757 ✅ rn ✅ docs
* #23769 ✅ rn ✅ docs

## 14 Oct 2024

* #23774 ✅ rn ✅ docs
* #23771 ✅ rn ✅ docs
* #23752 ✅ rn ✅ docs

## 15 Oct 2024

* #22632 ✅ rn ✅ docs
* #23727 ✅ rn ✅ docs
* #23782 ✅ rn ✅ docs
* #23767 ✅ rn ✅ docs
* #23790 ✅ rn ✅ docs
* #23784 ✅ rn ✅ docs
* #23794 ✅ rn ✅ docs
* #22951 ✅ rn ✅ docs

## 16 Oct 2024

* #23786 ✅ rn ✅ docs
* #23776 ✅ rn ✅ docs
* #23781 ✅ rn ✅ docs
* #23807 ✅ rn ✅ docs
* #23796 ✅ rn ✅ docs
* #23745 ✅ rn ✅ docs