### PR TITLE
Adjust height of query display box

### DIFF
--- a/core/trino-web-ui/src/main/resources/webapp/assets/trino.css
+++ b/core/trino-web-ui/src/main/resources/webapp/assets/trino.css
@@ -379,7 +379,7 @@ pre {
 }
 
 .query-snippet {
-    height: 138px;
+    height: 160px;
     overflow: hidden;
 }
 


### PR DESCRIPTION
## Description

In the query list to be the same height as the overview/stats display.

Before

<img width="835" alt="Screenshot 2024-10-10 at 4 22 34 PM" src="https://github.com/user-attachments/assets/b63bd21a-26d3-4c4b-94d7-e3e408848fa2">

After

<img width="886" alt="Screenshot 2024-10-10 at 4 22 46 PM" src="https://github.com/user-attachments/assets/710dddc9-4005-433b-a6fe-4324928dc034">

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Fixes #23746

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

The change it too minor .. users probably didnt notice the issue in the first place
