### PR TITLE
Avoid reading min/max/null statistics for planning iceberg inserts

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TableStatisticsReader.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TableStatisticsReader.java
@@ -240,7 +240,7 @@ public final class TableStatisticsReader
         return new TableStatistics(Estimate.of(recordCount), columnHandleBuilder.buildOrThrow());
     }
 
-    private static Map<Integer, Long> readNdvs(Table icebergTable, long snapshotId, Set<Integer> columnIds, boolean extendedStatisticsEnabled)
+    public static Map<Integer, Long> readNdvs(Table icebergTable, long snapshotId, Set<Integer> columnIds, boolean extendedStatisticsEnabled)
     {
         if (!extendedStatisticsEnabled) {
             return ImmutableMap.of();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergAlluxioCacheFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergAlluxioCacheFileOperations.java
@@ -97,9 +97,9 @@ public class TestIcebergAlluxioCacheFileOperations
                         .add(new CacheOperation("Alluxio.writeCache", METADATA_JSON))
                         .addCopies(new CacheOperation("Alluxio.readCached", SNAPSHOT), 2)
                         .add(new CacheOperation("InputFile.length", SNAPSHOT))
-                        .add(new CacheOperation("Alluxio.readExternalStream", MANIFEST))
+                        .addCopies(new CacheOperation("Alluxio.readExternalStream", MANIFEST), 2)
                         .addCopies(new CacheOperation("Alluxio.readCached", MANIFEST), 4)
-                        .add(new CacheOperation("Alluxio.writeCache", MANIFEST))
+                        .addCopies(new CacheOperation("Alluxio.writeCache", MANIFEST), 2)
                         .build());
 
         assertFileSystemAccesses(
@@ -129,9 +129,9 @@ public class TestIcebergAlluxioCacheFileOperations
                         .add(new CacheOperation("Alluxio.writeCache", METADATA_JSON))
                         .addCopies(new CacheOperation("Alluxio.readCached", SNAPSHOT), 2)
                         .add(new CacheOperation("InputFile.length", SNAPSHOT))
-                        .add(new CacheOperation("Alluxio.readExternalStream", MANIFEST))
+                        .addCopies(new CacheOperation("Alluxio.readExternalStream", MANIFEST), 3)
                         .addCopies(new CacheOperation("Alluxio.readCached", MANIFEST), 10)
-                        .add(new CacheOperation("Alluxio.writeCache", MANIFEST))
+                        .addCopies(new CacheOperation("Alluxio.writeCache", MANIFEST), 3)
                         .build());
         assertFileSystemAccesses(
                 "SELECT * FROM test_cache_file_operations",

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergFileOperations.java
@@ -198,11 +198,10 @@ public class TestIcebergFileOperations
                 ImmutableMultiset.<FileOperation>builder()
                         .addCopies(new FileOperation(METADATA_JSON, "OutputFile.create"), 2)
                         .addCopies(new FileOperation(METADATA_JSON, "InputFile.newStream"), 2)
-                        .addCopies(new FileOperation(SNAPSHOT, "InputFile.newStream"), 2)
-                        .addCopies(new FileOperation(SNAPSHOT, "InputFile.length"), 2)
+                        .add(new FileOperation(SNAPSHOT, "InputFile.newStream"))
+                        .add(new FileOperation(SNAPSHOT, "InputFile.length"))
                         .add(new FileOperation(SNAPSHOT, "OutputFile.create"))
                         .add(new FileOperation(MANIFEST, "OutputFile.create"))
-                        .add(new FileOperation(MANIFEST, "InputFile.newStream"))
                         .add(new FileOperation(STATS, "OutputFile.create"))
                         .build());
     }
@@ -234,7 +233,6 @@ public class TestIcebergFileOperations
                         .add(new FileOperation(STATS, "InputFile.newStream"))
                         .add(new FileOperation(SNAPSHOT, "OutputFile.create"))
                         .add(new FileOperation(MANIFEST, "OutputFile.create"))
-                        .add(new FileOperation(MANIFEST, "InputFile.newStream"))
                         .add(new FileOperation(STATS, "OutputFile.create"))
                         .build());
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergFileOperations.java
@@ -208,6 +208,38 @@ public class TestIcebergFileOperations
     }
 
     @Test
+    public void testInsert()
+    {
+        assertUpdate("CREATE TABLE test_insert (id VARCHAR, age INT)");
+
+        assertFileSystemAccesses(
+                "INSERT INTO test_insert VALUES('a', 1)",
+                ImmutableMultiset.<FileOperation>builder()
+                        .addCopies(new FileOperation(METADATA_JSON, "OutputFile.create"), 2)
+                        .addCopies(new FileOperation(METADATA_JSON, "InputFile.newStream"), 3)
+                        .addCopies(new FileOperation(SNAPSHOT, "InputFile.length"), 3)
+                        .addCopies(new FileOperation(SNAPSHOT, "InputFile.newStream"), 3)
+                        .add(new FileOperation(SNAPSHOT, "OutputFile.create"))
+                        .add(new FileOperation(MANIFEST, "OutputFile.create"))
+                        .add(new FileOperation(STATS, "OutputFile.create"))
+                        .build());
+
+        assertFileSystemAccesses(
+                "INSERT INTO test_insert VALUES('b', 2)",
+                ImmutableMultiset.<FileOperation>builder()
+                        .addCopies(new FileOperation(METADATA_JSON, "OutputFile.create"), 2)
+                        .addCopies(new FileOperation(METADATA_JSON, "InputFile.newStream"), 3)
+                        .addCopies(new FileOperation(SNAPSHOT, "InputFile.newStream"), 3)
+                        .addCopies(new FileOperation(SNAPSHOT, "InputFile.length"), 3)
+                        .add(new FileOperation(STATS, "InputFile.newStream"))
+                        .add(new FileOperation(SNAPSHOT, "OutputFile.create"))
+                        .add(new FileOperation(MANIFEST, "OutputFile.create"))
+                        .add(new FileOperation(MANIFEST, "InputFile.newStream"))
+                        .add(new FileOperation(STATS, "OutputFile.create"))
+                        .build());
+    }
+
+    @Test
     public void testSelect()
     {
         assertUpdate("CREATE TABLE test_select AS SELECT 1 col_name", 1);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMemoryCacheFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMemoryCacheFileOperations.java
@@ -88,7 +88,7 @@ public class TestIcebergMemoryCacheFileOperations
                         .add(new CacheOperation("FileSystemCache.cacheStream", METADATA_JSON))
                         .add(new CacheOperation("FileSystemCache.cacheLength", SNAPSHOT))
                         .add(new CacheOperation("FileSystemCache.cacheStream", SNAPSHOT))
-                        .add(new CacheOperation("Input.readTail", MANIFEST))
+                        .addCopies(new CacheOperation("Input.readTail", MANIFEST), 2)
                         .addCopies(new CacheOperation("FileSystemCache.cacheStream", MANIFEST), 2)
                         .build());
 
@@ -116,7 +116,7 @@ public class TestIcebergMemoryCacheFileOperations
                         .add(new CacheOperation("FileSystemCache.cacheStream", METADATA_JSON))
                         .add(new CacheOperation("FileSystemCache.cacheLength", SNAPSHOT))
                         .add(new CacheOperation("FileSystemCache.cacheStream", SNAPSHOT))
-                        .add(new CacheOperation("Input.readTail", MANIFEST))
+                        .addCopies(new CacheOperation("Input.readTail", MANIFEST), 3)
                         .addCopies(new CacheOperation("FileSystemCache.cacheStream", MANIFEST), 5)
                         .build());
 


### PR DESCRIPTION
<!-- Provide an overview for maintainers and reviewers. -->
## Description
For large tables going through statistics for all files can be slow.
The calling code in getStatisticsCollectionMetadataForWrite was not
using all the statistics and is simplified to only fetch NDVs.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Improve planning time for iceberg inserts. ({issue}`23757`)
```
