### PR TITLE
Add note about removed *.http-client.max-connections properties

### DIFF
--- a/docs/src/main/sphinx/release/release-440.md
+++ b/docs/src/main/sphinx/release/release-440.md
@@ -7,6 +7,8 @@
 * Improve performance of {func}`arrays_overlap`. ({issue}`20900`)
 * Export JMX statistics for resource groups by default. This can be disabled
   with the `jmxExport` resource group property. ({issue}`20810`)
+* {{breaking}} Remove the defunct `*.http-client.max-connections` properties.
+  ({issue}`20966`)
 * Fix query failure when a check constraint is null. ({issue}`20906`)
 * Fix query failure for aggregations over `CASE` expressions when the input
   evaluation could throw an error. ({issue}`20652`)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

The linked airlift PR removed the `http-client.max-connections` property. This was reflected in the Trino documentation with #20101 but should have been given a breaking change since the property was applied by some users.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

#20966 
#20797 

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text: Note in PR contents

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
