### PR TITLE
Add module info to SPI

### DIFF
--- a/core/trino-spi/src/main/java/module-info.java
+++ b/core/trino-spi/src/main/java/module-info.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module trino.spi {
+    requires transitive com.fasterxml.jackson.annotation;
+    requires transitive com.google.errorprone.annotations;
+    requires transitive io.opentelemetry.api;
+    requires transitive jakarta.annotation;
+    requires java.logging;
+    requires transitive slice;
+
+    exports io.trino.spi;
+    exports io.trino.spi.block;
+    exports io.trino.spi.catalog;
+    exports io.trino.spi.classloader;
+    exports io.trino.spi.connector;
+    exports io.trino.spi.eventlistener;
+    exports io.trino.spi.exchange;
+    exports io.trino.spi.expression;
+    exports io.trino.spi.function;
+    exports io.trino.spi.function.table;
+    exports io.trino.spi.memory;
+    exports io.trino.spi.metrics;
+    exports io.trino.spi.predicate;
+    exports io.trino.spi.resourcegroups;
+    exports io.trino.spi.security;
+    exports io.trino.spi.session;
+    exports io.trino.spi.statistics;
+    exports io.trino.spi.transaction;
+    exports io.trino.spi.type;
+}


### PR DESCRIPTION
## Description

This is the first step to convert the SPI and generally the plugin system into Java modules.  This allows for better encapsulation of the plugins and Trino internals.  For example, as a module the SPI can have a non-exported package containing internal utility classes shared across SPI packages.  Additionally, in an automatic module, like the SPI, sealed class hiearchies can must be contained in a single package.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
