### PR TITLE
WIP: Page extends RowBlock

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
@@ -149,7 +149,7 @@ public class InformationSchemaPageSource
         projection = page -> {
             Block[] blocks = new Block[channels.size()];
             for (int i = 0; i < blocks.length; i++) {
-                blocks[i] = page.getBlock(channels.get(i));
+                blocks[i] = page.getFieldBlock(channels.get(i));
             }
             return new Page(page.getPositionCount(), blocks);
         };

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/PagesSerdeUtil.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/PagesSerdeUtil.java
@@ -65,7 +65,7 @@ public final class PagesSerdeUtil
     {
         output.writeInt(page.getChannelCount());
         for (int channel = 0; channel < page.getChannelCount(); channel++) {
-            writeBlock(serde, output, page.getBlock(channel));
+            writeBlock(serde, output, page.getFieldBlock(channel));
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/AssignUniqueIdOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/AssignUniqueIdOperator.java
@@ -134,7 +134,7 @@ public class AssignUniqueIdOperator
                 return finished();
             }
 
-            return ofResult(inputPage.appendColumn(generateIdColumn(inputPage.getPositionCount())));
+            return ofResult(inputPage.appendField(generateIdColumn(inputPage.getPositionCount())));
         }
 
         private Block generateIdColumn(int positionCount)

--- a/core/trino-main/src/main/java/io/trino/operator/BigintGroupByHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/BigintGroupByHash.java
@@ -136,7 +136,7 @@ public class BigintGroupByHash
     public Work<?> addPage(Page page)
     {
         currentPageSizeInBytes = page.getRetainedSizeInBytes();
-        Block block = page.getBlock(0);
+        Block block = page.getFieldBlock(0);
         if (block instanceof RunLengthEncodedBlock rleBlock) {
             return new AddRunLengthEncodedPageWork(rleBlock);
         }
@@ -151,7 +151,7 @@ public class BigintGroupByHash
     public Work<int[]> getGroupIds(Page page)
     {
         currentPageSizeInBytes = page.getRetainedSizeInBytes();
-        Block block = page.getBlock(0);
+        Block block = page.getFieldBlock(0);
         if (block instanceof RunLengthEncodedBlock rleBlock) {
             return new GetRunLengthEncodedGroupIdsWork(rleBlock);
         }

--- a/core/trino-main/src/main/java/io/trino/operator/ChangeOnlyUpdatedColumnsMergeProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ChangeOnlyUpdatedColumnsMergeProcessor.java
@@ -65,7 +65,7 @@ public class ChangeOnlyUpdatedColumnsMergeProcessor
         int positionCount = inputPage.getPositionCount();
         checkArgument(positionCount > 0, "positionCount should be > 0, but is %s", positionCount);
 
-        Block mergeRow = inputPage.getBlock(mergeRowChannel).getLoadedBlock();
+        Block mergeRow = inputPage.getFieldBlock(mergeRowChannel).getLoadedBlock();
         if (mergeRow.mayHaveNull()) {
             for (int position = 0; position < positionCount; position++) {
                 checkArgument(!mergeRow.isNull(position), "The mergeRow may not have null rows");
@@ -79,7 +79,7 @@ public class ChangeOnlyUpdatedColumnsMergeProcessor
         }
         Block operationChannelBlock = fields.get(fields.size() - 2);
         builder.add(operationChannelBlock);
-        builder.add(inputPage.getBlock(rowIdChannel));
+        builder.add(inputPage.getFieldBlock(rowIdChannel));
         builder.add(RunLengthEncodedBlock.create(INSERT_FROM_UPDATE_BLOCK, positionCount));
 
         Page result = new Page(builder.toArray(Block[]::new));

--- a/core/trino-main/src/main/java/io/trino/operator/DeleteAndInsertMergeProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DeleteAndInsertMergeProcessor.java
@@ -99,7 +99,7 @@ public class DeleteAndInsertMergeProcessor
         int originalPositionCount = inputPage.getPositionCount();
         checkArgument(originalPositionCount > 0, "originalPositionCount should be > 0, but is %s", originalPositionCount);
 
-        List<Block> fields = getRowFieldsFromBlock(inputPage.getBlock(mergeRowChannel));
+        List<Block> fields = getRowFieldsFromBlock(inputPage.getFieldBlock(mergeRowChannel));
         Block operationChannelBlock = fields.get(fields.size() - 2);
 
         int updatePositions = 0;
@@ -158,7 +158,7 @@ public class DeleteAndInsertMergeProcessor
             int redistributionChannelNumber = redistributionChannelNumbers.get(targetChannel);
             if (redistributionChannelNumbers.get(targetChannel) >= 0) {
                 // The value comes from that column of the page
-                columnType.appendTo(originalPage.getBlock(redistributionChannelNumber), position, targetBlock);
+                columnType.appendTo(originalPage.getFieldBlock(redistributionChannelNumber), position, targetBlock);
             }
             else {
                 // We don't care about the other data columns
@@ -170,7 +170,7 @@ public class DeleteAndInsertMergeProcessor
         TINYINT.writeLong(pageBuilder.getBlockBuilder(dataColumnChannels.size()), causedByUpdate ? UPDATE_DELETE_OPERATION_NUMBER : DELETE_OPERATION_NUMBER);
 
         // Copy row ID column
-        rowIdType.appendTo(originalPage.getBlock(rowIdChannel), position, pageBuilder.getBlockBuilder(dataColumnChannels.size() + 1));
+        rowIdType.appendTo(originalPage.getFieldBlock(rowIdChannel), position, pageBuilder.getBlockBuilder(dataColumnChannels.size() + 1));
 
         // Write 0, meaning this row is not an insert derived from an update
         TINYINT.writeLong(pageBuilder.getBlockBuilder(dataColumnChannels.size() + 2), 0);

--- a/core/trino-main/src/main/java/io/trino/operator/DistinctLimitOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DistinctLimitOperator.java
@@ -172,7 +172,7 @@ public class DistinctLimitOperator
     {
         checkState(needsInput());
 
-        inputPage = page.getColumns(inputChannels);
+        inputPage = page.getFields(inputChannels);
         unfinishedWork = groupByHash.getGroupIds(inputPage);
         processUnfinishedWork();
         updateMemoryReservation();

--- a/core/trino-main/src/main/java/io/trino/operator/DynamicFilterSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DynamicFilterSourceOperator.java
@@ -226,7 +226,7 @@ public class DynamicFilterSourceOperator
         // Collect only the columns which are relevant for the JOIN.
         long retainedSize = 0;
         for (int channelIndex = 0; channelIndex < channels.size(); ++channelIndex) {
-            Block block = page.getBlock(channels.get(channelIndex).index());
+            Block block = page.getFieldBlock(channels.get(channelIndex).index());
             joinDomainBuilders[channelIndex].add(block);
             if (isDomainCollectionComplete) {
                 return;

--- a/core/trino-main/src/main/java/io/trino/operator/FlatGroupByHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/FlatGroupByHash.java
@@ -190,7 +190,7 @@ public class FlatGroupByHash
         Block[] blocks = currentBlocks;
         checkArgument(page.getChannelCount() == blocks.length);
         for (int i = 0; i < blocks.length; i++) {
-            blocks[i] = page.getBlock(i);
+            blocks[i] = page.getFieldBlock(i);
         }
         return blocks;
     }

--- a/core/trino-main/src/main/java/io/trino/operator/GroupIdOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupIdOperator.java
@@ -181,7 +181,7 @@ public class GroupIdOperator
                 outputBlocks[i] = RunLengthEncodedBlock.create(nullBlocks[i], currentPage.getPositionCount());
             }
             else {
-                outputBlocks[i] = currentPage.getBlock(groupingSetInputs[currentGroupingSet][i]);
+                outputBlocks[i] = currentPage.getFieldBlock(groupingSetInputs[currentGroupingSet][i]);
             }
         }
 

--- a/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRankBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRankBuilder.java
@@ -103,7 +103,7 @@ public class GroupedTopNRankBuilder
     public Work<?> processPage(Page page)
     {
         return new TransformWork<>(
-                groupByHash.getGroupIds(page.getColumns(groupByChannels)),
+                groupByHash.getGroupIds(page.getFields(groupByChannels)),
                 groupIds -> {
                     processPage(page, groupByHash.getGroupCount(), groupIds);
                     return null;
@@ -187,7 +187,7 @@ public class GroupedTopNRankBuilder
                 Page page = pageManager.getPage(rowId);
                 int position = pageManager.getPosition(rowId);
                 for (int i = 0; i < sourceTypes.size(); i++) {
-                    sourceTypes.get(i).appendTo(page.getBlock(i), position, pageBuilder.getBlockBuilder(i));
+                    sourceTypes.get(i).appendTo(page.getFieldBlock(i), position, pageBuilder.getBlockBuilder(i));
                 }
                 if (produceRanking) {
                     BIGINT.writeLong(pageBuilder.getBlockBuilder(sourceTypes.size()), rankingOutput.get(currentIndexInGroup));

--- a/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRowNumberBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRowNumberBuilder.java
@@ -78,7 +78,7 @@ public class GroupedTopNRowNumberBuilder
     public Work<?> processPage(Page page)
     {
         return new TransformWork<>(
-                groupByHash.getGroupIds(page.getColumns(groupByChannels)),
+                groupByHash.getGroupIds(page.getFields(groupByChannels)),
                 groupIds -> {
                     processPage(page, groupByHash.getGroupCount(), groupIds);
                     return null;
@@ -165,7 +165,7 @@ public class GroupedTopNRowNumberBuilder
                 Page page = pageManager.getPage(rowId);
                 int position = pageManager.getPosition(rowId);
                 for (int i = 0; i < sourceTypes.size(); i++) {
-                    sourceTypes.get(i).appendTo(page.getBlock(i), position, pageBuilder.getBlockBuilder(i));
+                    sourceTypes.get(i).appendTo(page.getFieldBlock(i), position, pageBuilder.getBlockBuilder(i));
                 }
                 if (produceRowNumber) {
                     BIGINT.writeLong(pageBuilder.getBlockBuilder(sourceTypes.size()), currentIndexInGroup + 1);

--- a/core/trino-main/src/main/java/io/trino/operator/HashSemiJoinOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/HashSemiJoinOperator.java
@@ -188,9 +188,9 @@ public class HashSemiJoinOperator
             // we know the exact size required for the block
             BlockBuilder blockBuilder = BOOLEAN.createFixedSizeBlockBuilder(inputPage.getPositionCount());
 
-            Block probeBlock = inputPage.getBlock(probeJoinChannel).copyRegion(0, inputPage.getPositionCount());
+            Block probeBlock = inputPage.getFieldBlock(probeJoinChannel).copyRegion(0, inputPage.getPositionCount());
             boolean probeMayHaveNull = probeBlock.mayHaveNull();
-            Block hashBlock = probeHashChannel >= 0 ? inputPage.getBlock(probeHashChannel).copyRegion(0, inputPage.getPositionCount()) : null;
+            Block hashBlock = probeHashChannel >= 0 ? inputPage.getFieldBlock(probeHashChannel).copyRegion(0, inputPage.getPositionCount()) : null;
 
             // update hashing strategy to use probe cursor
             for (int position = 0; position < inputPage.getPositionCount(); position++) {
@@ -220,7 +220,7 @@ public class HashSemiJoinOperator
                 }
             }
             // add the new boolean column to the page
-            return ofResult(inputPage.appendColumn(blockBuilder.build()));
+            return ofResult(inputPage.appendField(blockBuilder.build()));
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/InterpretedHashGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/InterpretedHashGenerator.java
@@ -81,7 +81,7 @@ public class InterpretedHashGenerator
         // Note: this code is duplicated for performance but must logically match hashPosition(position, IntFunction<Block> blockProvider)
         long result = HashGenerationOptimizer.INITIAL_HASH_VALUE;
         for (int i = 0; i < hashCodeOperators.length; i++) {
-            Block block = page.getBlock(hashChannels == null ? i : hashChannels[i]);
+            Block block = page.getFieldBlock(hashChannels == null ? i : hashChannels[i]);
             result = CombineHashFunction.getHash(result, nullSafeHash(i, block, position));
         }
         return result;

--- a/core/trino-main/src/main/java/io/trino/operator/MarkDistinctOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/MarkDistinctOperator.java
@@ -155,7 +155,7 @@ public class MarkDistinctOperator
 
         inputPage = page;
 
-        unfinishedWork = markDistinctHash.markDistinctRows(page.getColumns(markDistinctChannels));
+        unfinishedWork = markDistinctHash.markDistinctRows(page.getFields(markDistinctChannels));
         updateMemoryReservation();
     }
 
@@ -171,7 +171,7 @@ public class MarkDistinctOperator
         }
 
         // add the new boolean column to the page
-        Page outputPage = inputPage.appendColumn(unfinishedWork.getResult());
+        Page outputPage = inputPage.appendField(unfinishedWork.getResult());
 
         unfinishedWork = null;
         inputPage = null;

--- a/core/trino-main/src/main/java/io/trino/operator/MergeWriterOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/MergeWriterOperator.java
@@ -142,13 +142,13 @@ public class MergeWriterOperator
         // The last block exists only to get the rowCount right.
         int outputChannelCount = page.getChannelCount() - 1;
         int[] columns = IntStream.range(0, outputChannelCount).toArray();
-        Page newPage = page.getColumns(columns);
+        Page newPage = page.getFields(columns);
 
         // Store the page
         mergeSink.storeMergedRows(newPage);
 
         // Calculate the amount to increment the rowCount
-        Block insertFromUpdateColumn = page.getBlock(page.getChannelCount() - 1);
+        Block insertFromUpdateColumn = page.getFieldBlock(page.getChannelCount() - 1);
         long insertsFromUpdates = 0;
         int positionCount = page.getPositionCount();
         for (int position = 0; position < positionCount; position++) {

--- a/core/trino-main/src/main/java/io/trino/operator/OrderByOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OrderByOperator.java
@@ -285,7 +285,7 @@ public class OrderByOperator
             return null;
         }
         Page nextPage = next.get();
-        return nextPage.getColumns(outputChannels);
+        return nextPage.getFields(outputChannels);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/PageSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PageSourceOperator.java
@@ -104,7 +104,7 @@ public class PageSourceOperator
         readTimeNanos = endReadTimeNanos;
 
         // assure the page is in memory before handing to another operator
-        page = page.getLoadedPage();
+        page = page.getLoadedBlock();
 
         return page;
     }

--- a/core/trino-main/src/main/java/io/trino/operator/PageUtils.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PageUtils.java
@@ -30,7 +30,7 @@ public final class PageUtils
         long loadedBlocksSizeInBytes = 0;
 
         for (int i = 0; i < page.getChannelCount(); ++i) {
-            Block block = page.getBlock(i);
+            Block block = page.getFieldBlock(i);
             long initialSize = block.getSizeInBytes();
             loadedBlocksSizeInBytes += initialSize;
             listenForLoads(block, loadedBlock -> sizeInBytesConsumer.accept(loadedBlock.getSizeInBytes()));

--- a/core/trino-main/src/main/java/io/trino/operator/PagesIndex.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PagesIndex.java
@@ -235,7 +235,7 @@ public class PagesIndex
 
         int pageIndex = (channels.length > 0) ? channels[0].size() : 0;
         for (int i = 0; i < channels.length; i++) {
-            Block block = page.getBlock(i);
+            Block block = page.getFieldBlock(i);
             if (eagerCompact) {
                 block = block.copyRegion(0, block.getPositionCount());
             }

--- a/core/trino-main/src/main/java/io/trino/operator/PagesRTreeIndex.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PagesRTreeIndex.java
@@ -145,7 +145,7 @@ public class PagesRTreeIndex
     @Override
     public int[] findJoinPositions(int position, Page probe, int probeGeometryChannel, Optional<Integer> probePartitionChannel)
     {
-        Block probeBlock = probe.getBlock(probeGeometryChannel);
+        Block probeBlock = probe.getFieldBlock(probeGeometryChannel);
         VariableWidthBlock probeGeometryBlock = (VariableWidthBlock) probeBlock.getUnderlyingValueBlock();
         int probePosition = probeBlock.getUnderlyingValuePosition(position);
 
@@ -153,7 +153,7 @@ public class PagesRTreeIndex
             return EMPTY_ADDRESSES;
         }
 
-        int probePartition = probePartitionChannel.map(channel -> INTEGER.getInt(probe.getBlock(channel), probePosition)).orElse(-1);
+        int probePartition = probePartitionChannel.map(channel -> INTEGER.getInt(probe.getFieldBlock(channel), probePosition)).orElse(-1);
 
         Slice slice = probeGeometryBlock.getSlice(probePosition);
         OGCGeometry probeGeometry = deserialize(slice);

--- a/core/trino-main/src/main/java/io/trino/operator/PrecomputedHashGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PrecomputedHashGenerator.java
@@ -32,7 +32,7 @@ public class PrecomputedHashGenerator
     @Override
     public long hashPosition(int position, Page page)
     {
-        Block hashBlock = page.getBlock(hashChannel);
+        Block hashBlock = page.getFieldBlock(hashChannel);
         return BIGINT.getLong(hashBlock, position);
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/RowNumberOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/RowNumberOperator.java
@@ -234,7 +234,7 @@ public class RowNumberOperator
         checkState(!hasUnfinishedInput());
         inputPage = page;
         if (groupByHash.isPresent()) {
-            unfinishedWork = groupByHash.get().getGroupIds(inputPage.getColumns(groupByChannels));
+            unfinishedWork = groupByHash.get().getGroupIds(inputPage.getFields(groupByChannels));
             processUnfinishedWork();
         }
         updateMemoryReservation();
@@ -308,7 +308,7 @@ public class RowNumberOperator
     {
         Block[] outputBlocks = new Block[inputPage.getChannelCount() + 1]; // +1 for the row number column
         for (int i = 0; i < outputChannels.length; i++) {
-            outputBlocks[i] = inputPage.getBlock(outputChannels[i]);
+            outputBlocks[i] = inputPage.getFieldBlock(outputChannels[i]);
         }
 
         outputBlocks[outputBlocks.length - 1] = createRowNumberBlock();
@@ -345,7 +345,7 @@ public class RowNumberOperator
             for (int i = 0; i < outputChannels.length; i++) {
                 int channel = outputChannels[i];
                 Type type = types.get(i);
-                type.appendTo(inputPage.getBlock(channel), currentPosition, pageBuilder.getBlockBuilder(i));
+                type.appendTo(inputPage.getFieldBlock(channel), currentPosition, pageBuilder.getBlockBuilder(i));
             }
             BIGINT.writeLong(pageBuilder.getBlockBuilder(rowNumberChannel), rowCount + 1);
             partitionRowCount.set(partitionId, rowCount + 1);

--- a/core/trino-main/src/main/java/io/trino/operator/RowReferencePageManager.java
+++ b/core/trino-main/src/main/java/io/trino/operator/RowReferencePageManager.java
@@ -318,7 +318,7 @@ public final class RowReferencePageManager
         public void loadPageLoadIfNeeded()
         {
             if (!isPageLoaded && activePositions > 0) {
-                page = page.getLoadedPage();
+                page = page.getLoadedBlock();
                 isPageLoaded = true;
             }
         }

--- a/core/trino-main/src/main/java/io/trino/operator/SetBuilderOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/SetBuilderOperator.java
@@ -189,7 +189,7 @@ public class SetBuilderOperator
         requireNonNull(page, "page is null");
         checkState(!isFinished(), "Operator is already finished");
 
-        channelSetBuilder.addAll(page.getBlock(setChannel), hashChannel == -1 ? null : page.getBlock(hashChannel));
+        channelSetBuilder.addAll(page.getFieldBlock(setChannel), hashChannel == -1 ? null : page.getFieldBlock(hashChannel));
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/SimplePageWithPositionComparator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/SimplePageWithPositionComparator.java
@@ -57,8 +57,8 @@ public class SimplePageWithPositionComparator
         try {
             for (int i = 0; i < sortChannels.size(); i++) {
                 int sortChannel = sortChannels.get(i);
-                Block leftBlock = left.getBlock(sortChannel);
-                Block rightBlock = right.getBlock(sortChannel);
+                Block leftBlock = left.getFieldBlock(sortChannel);
+                Block rightBlock = right.getFieldBlock(sortChannel);
 
                 MethodHandle orderingOperator = orderingOperators.get(i);
                 int compare = (int) orderingOperator.invokeExact(leftBlock, leftPosition, rightBlock, rightPosition);

--- a/core/trino-main/src/main/java/io/trino/operator/SimplePageWithPositionEqualsAndHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/SimplePageWithPositionEqualsAndHash.java
@@ -58,8 +58,8 @@ public class SimplePageWithPositionEqualsAndHash
     {
         for (int i = 0; i < equalityChannels.size(); i++) {
             int equalityChannel = equalityChannels.getInt(i);
-            Block leftBlock = left.getBlock(equalityChannel);
-            Block rightBlock = right.getBlock(equalityChannel);
+            Block leftBlock = left.getFieldBlock(equalityChannel);
+            Block rightBlock = right.getFieldBlock(equalityChannel);
             if (!identicalOperators.get(i).isIdentical(leftBlock, leftPosition, rightBlock, rightPosition)) {
                 return false;
             }
@@ -73,7 +73,7 @@ public class SimplePageWithPositionEqualsAndHash
         long hashCode = 0;
         for (int i = 0; i < equalityChannels.size(); i++) {
             int equalityChannel = equalityChannels.getInt(i);
-            Block block = page.getBlock(equalityChannel);
+            Block block = page.getFieldBlock(equalityChannel);
             hashCode = 31 * hashCode + hashOperators.get(i).hashCodeNullSafe(block, position);
         }
         return hashCode;

--- a/core/trino-main/src/main/java/io/trino/operator/SimplePagesHashStrategy.java
+++ b/core/trino-main/src/main/java/io/trino/operator/SimplePagesHashStrategy.java
@@ -139,7 +139,7 @@ public class SimplePagesHashStrategy
     {
         long result = 0;
         for (int i = 0; i < hashChannels.size(); i++) {
-            Block block = page.getBlock(i);
+            Block block = page.getFieldBlock(i);
             result = result * 31 + hashCodeOperators.get(i).hashCodeNullSafe(block, position);
         }
         return result;
@@ -149,8 +149,8 @@ public class SimplePagesHashStrategy
     public boolean rowEqualsRow(int leftPosition, Page leftPage, int rightPosition, Page rightPage)
     {
         for (int i = 0; i < hashChannels.size(); i++) {
-            Block leftBlock = leftPage.getBlock(i);
-            Block rightBlock = rightPage.getBlock(i);
+            Block leftBlock = leftPage.getFieldBlock(i);
+            Block rightBlock = rightPage.getFieldBlock(i);
             if (!equalOperators.get(i).equalNullSafe(leftBlock, leftPosition, rightBlock, rightPosition)) {
                 return false;
             }
@@ -162,8 +162,8 @@ public class SimplePagesHashStrategy
     public boolean rowIdenticalToRow(int leftPosition, Page leftPage, int rightPosition, Page rightPage)
     {
         for (int i = 0; i < hashChannels.size(); i++) {
-            Block leftBlock = leftPage.getBlock(i);
-            Block rightBlock = rightPage.getBlock(i);
+            Block leftBlock = leftPage.getFieldBlock(i);
+            Block rightBlock = rightPage.getFieldBlock(i);
             if (!identicalOperators.get(i).isIdentical(leftBlock, leftPosition, rightBlock, rightPosition)) {
                 return false;
             }
@@ -176,7 +176,7 @@ public class SimplePagesHashStrategy
     {
         for (int i = 0; i < hashChannels.size(); i++) {
             Block leftBlock = channels.get(hashChannels.get(i)).get(leftBlockIndex);
-            Block rightBlock = rightPage.getBlock(i);
+            Block rightBlock = rightPage.getFieldBlock(i);
             if (!equalOperators.get(i).equalNullSafe(leftBlock, leftPosition, rightBlock, rightPosition)) {
                 return false;
             }
@@ -189,7 +189,7 @@ public class SimplePagesHashStrategy
     {
         for (int i = 0; i < hashChannels.size(); i++) {
             Block leftBlock = channels.get(hashChannels.get(i)).get(leftBlockIndex);
-            Block rightBlock = rightPage.getBlock(i);
+            Block rightBlock = rightPage.getFieldBlock(i);
             if (!identicalOperators.get(i).isIdentical(leftBlock, leftPosition, rightBlock, rightPosition)) {
                 return false;
             }
@@ -203,7 +203,7 @@ public class SimplePagesHashStrategy
         for (int i = 0; i < hashChannels.size(); i++) {
             BlockPositionEqual equalOperator = equalOperators.get(i);
             Block leftBlock = channels.get(hashChannels.get(i)).get(leftBlockIndex);
-            Block rightBlock = rightPage.getBlock(i);
+            Block rightBlock = rightPage.getFieldBlock(i);
             if (!equalOperator.equal(leftBlock, leftPosition, rightBlock, rightPosition)) {
                 return false;
             }
@@ -217,7 +217,7 @@ public class SimplePagesHashStrategy
         for (int i = 0; i < hashChannels.size(); i++) {
             int hashChannel = hashChannels.get(i);
             Block leftBlock = channels.get(hashChannel).get(leftBlockIndex);
-            Block rightBlock = page.getBlock(rightChannels[i]);
+            Block rightBlock = page.getFieldBlock(rightChannels[i]);
             BlockPositionIsIdentical identical = identicalOperators.get(i);
             if (!identical.isIdentical(leftBlock, leftPosition, rightBlock, rightPosition)) {
                 return false;

--- a/core/trino-main/src/main/java/io/trino/operator/SpatialJoinOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/SpatialJoinOperator.java
@@ -303,7 +303,7 @@ public class SpatialJoinOperator
         int outputChannelOffset = 0;
         for (int outputIndex : probeOutputChannels) {
             Type type = probeTypes.get(outputIndex);
-            Block block = probe.getBlock(outputIndex);
+            Block block = probe.getFieldBlock(outputIndex);
             type.appendTo(block, probePosition, pageBuilder.getBlockBuilder(outputChannelOffset));
             outputChannelOffset++;
         }

--- a/core/trino-main/src/main/java/io/trino/operator/StatisticsWriterOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/StatisticsWriterOperator.java
@@ -167,15 +167,15 @@ public class StatisticsWriterOperator
         ImmutableList.Builder<Block> groupingValues = ImmutableList.builder();
         descriptor.getGrouping().forEach((column, channel) -> {
             groupingColumns.add(column);
-            groupingValues.add(page.getBlock(channel).getSingleValueBlock(position));
+            groupingValues.add(page.getFieldBlock(channel).getSingleValueBlock(position));
         });
 
         ComputedStatistics.Builder statistics = ComputedStatistics.builder(groupingColumns.build(), groupingValues.build());
 
         descriptor.getTableStatistics().forEach((type, channel) ->
-                statistics.addTableStatistic(type, page.getBlock(channel).getSingleValueBlock(position)));
+                statistics.addTableStatistic(type, page.getFieldBlock(channel).getSingleValueBlock(position)));
 
-        descriptor.getColumnStatistics().forEach((metadata, channel) -> statistics.addColumnStatistic(metadata, page.getBlock(channel).getSingleValueBlock(position)));
+        descriptor.getColumnStatistics().forEach((metadata, channel) -> statistics.addColumnStatistic(metadata, page.getFieldBlock(channel).getSingleValueBlock(position)));
 
         return statistics.build();
     }

--- a/core/trino-main/src/main/java/io/trino/operator/StreamingAggregationOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/StreamingAggregationOperator.java
@@ -262,9 +262,9 @@ public class StreamingAggregationOperator
         {
             requireNonNull(page, "page is null");
 
-            Page groupByPage = page.getColumns(groupByChannels);
+            Page groupByPage = page.getFields(groupByChannels);
             if (currentGroup != null) {
-                if (!pagesHashStrategy.rowIdenticalToRow(0, currentGroup.getColumns(groupByChannels), 0, groupByPage)) {
+                if (!pagesHashStrategy.rowIdenticalToRow(0, currentGroup.getFields(groupByChannels), 0, groupByPage)) {
                     // page starts with new group, so flush it
                     evaluateAndFlushGroup(currentGroup, 0);
                 }
@@ -284,7 +284,7 @@ public class StreamingAggregationOperator
                 }
                 else {
                     // late materialization requires that page being locally stored is materialized before the next one is fetched
-                    currentGroup = page.getRegion(page.getPositionCount() - 1, 1).getLoadedPage();
+                    currentGroup = page.getRegion(page.getPositionCount() - 1, 1).getLoadedBlock();
                     return;
                 }
             }
@@ -302,7 +302,7 @@ public class StreamingAggregationOperator
         {
             pageBuilder.declarePosition();
             for (int i = 0; i < groupByTypes.size(); i++) {
-                Block block = page.getBlock(groupByChannels[i]);
+                Block block = page.getFieldBlock(groupByChannels[i]);
                 Type type = groupByTypes.get(i);
                 type.appendTo(block, position, pageBuilder.getBlockBuilder(i));
             }

--- a/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
@@ -268,7 +268,7 @@ public class TableScanOperator
         Page page = source.getNextPage();
         if (page != null) {
             // assure the page is in memory before handing to another operator
-            page = page.getLoadedPage();
+            page = page.getLoadedBlock();
 
             // update operator stats
             long endCompletedBytes = source.getCompletedBytes();

--- a/core/trino-main/src/main/java/io/trino/operator/TableWriterOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableWriterOperator.java
@@ -270,7 +270,7 @@ public class TableWriterOperator
         statisticAggregationOperator.addInput(page);
         timer.end(statisticsTiming);
 
-        page = page.getColumns(columnChannels);
+        page = page.getFields(columnChannels);
 
         ListenableFuture<Void> blockedOnAggregation = statisticAggregationOperator.isBlocked();
         CompletableFuture<?> future = pageSink.appendPage(page);
@@ -315,7 +315,7 @@ public class TableWriterOperator
         Block[] outputBlocks = new Block[types.size()];
         for (int channel = 0; channel < types.size(); channel++) {
             if (channel < STATS_START_CHANNEL) {
-                outputBlocks[channel] = fragmentsPage.getBlock(channel);
+                outputBlocks[channel] = fragmentsPage.getFieldBlock(channel);
             }
             else {
                 outputBlocks[channel] = RunLengthEncodedBlock.create(types.get(channel), null, positionCount);
@@ -335,7 +335,7 @@ public class TableWriterOperator
                 outputBlocks[channel] = RunLengthEncodedBlock.create(types.get(channel), null, positionCount);
             }
             else {
-                outputBlocks[channel] = aggregationOutput.getBlock(channel - 2);
+                outputBlocks[channel] = aggregationOutput.getFieldBlock(channel - 2);
             }
         }
         return new Page(positionCount, outputBlocks);

--- a/core/trino-main/src/main/java/io/trino/operator/TopNRankingOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TopNRankingOperator.java
@@ -373,7 +373,7 @@ public class TopNRankingOperator
         Page output;
         if (outputIterator != null && outputIterator.hasNext()) {
             // rewrite to expected column ordering
-            output = outputIterator.next().getColumns(outputChannels);
+            output = outputIterator.next().getFields(outputChannels);
         }
         else {
             closeGroupedTopNBuilder();

--- a/core/trino-main/src/main/java/io/trino/operator/WindowOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WindowOperator.java
@@ -797,7 +797,7 @@ public class WindowOperator
             PeekingIterator<Page> sortedPages = peekingIterator(inMemoryPagesIndexWithHashStrategies.pagesIndex.getSortedPages());
             Page anyPage = sortedPages.peek();
             verify(anyPage.getPositionCount() != 0, "PagesIndex.getSortedPages returned an empty page");
-            currentSpillGroupRowPage = Optional.of(anyPage.getSingleValuePage(/* any */0));
+            currentSpillGroupRowPage = Optional.of(anyPage.getSingleValueBlock(/* any */0));
             spillInProgress = Optional.of(spiller.get().spill(sortedPages));
 
             return spillInProgress.get();
@@ -865,12 +865,12 @@ public class WindowOperator
         checkArgument(page.getPositionCount() > startPosition);
 
         // TODO: Fix pagesHashStrategy to allow specifying channels for comparison, it currently requires us to rearrange the right side blocks in consecutive channel order
-        Page preGroupedPage = page.getColumns(pagesIndexWithHashStrategies.preGroupedPartitionChannels);
+        Page preGroupedPage = page.getFields(pagesIndexWithHashStrategies.preGroupedPartitionChannels);
 
         PagesIndex pagesIndex = pagesIndexWithHashStrategies.pagesIndex;
         PagesHashStrategy preGroupedPartitionHashStrategy = pagesIndexWithHashStrategies.preGroupedPartitionHashStrategy;
         if (currentSpillGroupRowPage.isPresent()) {
-            if (!preGroupedPartitionHashStrategy.rowIdenticalToRow(0, currentSpillGroupRowPage.get().getColumns(pagesIndexWithHashStrategies.preGroupedPartitionChannels), startPosition, preGroupedPage)) {
+            if (!preGroupedPartitionHashStrategy.rowIdenticalToRow(0, currentSpillGroupRowPage.get().getFields(pagesIndexWithHashStrategies.preGroupedPartitionChannels), startPosition, preGroupedPage)) {
                 return startPosition;
             }
         }

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorSourceOperatorAdapter.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorSourceOperatorAdapter.java
@@ -66,7 +66,7 @@ public class WorkProcessorSourceOperatorAdapter
                         operatorContext.getDriverContext().getYieldSignal(),
                         WorkProcessor.create(splitBuffer));
         this.pages = sourceOperator.getOutputPages()
-                .map(Page::getLoadedPage)
+                .map(Page::getLoadedBlock)
                 .withProcessStateMonitor(state -> updateOperatorStats())
                 .finishWhen(() -> operatorFinishing);
         operatorContext.setInfoSupplier(() -> sourceOperator.getOperatorInfo().orElse(null));

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/AggregationUtils.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/AggregationUtils.java
@@ -32,7 +32,7 @@ public final class AggregationUtils
         if (maskChannel < 0) {
             return null;
         }
-        Block maskBlock = page.getBlock(maskChannel);
+        Block maskBlock = page.getFieldBlock(maskChannel);
         if (page.getPositionCount() > 0 && maskBlock instanceof RunLengthEncodedBlock && CompilerOperations.testMask(maskBlock, 0)) {
             return null; // filter out RLE true blocks to bypass unnecessary mask checks
         }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/Aggregator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/Aggregator.java
@@ -67,10 +67,10 @@ public class Aggregator
     public void processPage(Page page)
     {
         if (step.isInputRaw()) {
-            Page arguments = page.getColumns(inputChannels);
+            Page arguments = page.getFields(inputChannels);
             Optional<Block> maskBlock = Optional.empty();
             if (maskChannel.isPresent()) {
-                maskBlock = Optional.of(page.getBlock(maskChannel.getAsInt()));
+                maskBlock = Optional.of(page.getFieldBlock(maskChannel.getAsInt()));
             }
             AggregationMask mask = maskBuilder.buildAggregationMask(arguments, maskBlock);
 
@@ -80,7 +80,7 @@ public class Aggregator
             accumulator.addInput(arguments, mask);
         }
         else {
-            accumulator.addIntermediate(page.getBlock(inputChannels[0]));
+            accumulator.addIntermediate(page.getFieldBlock(inputChannels[0]));
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/DistinctAccumulatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/DistinctAccumulatorFactory.java
@@ -215,7 +215,7 @@ public class DistinctAccumulatorFactory
             page = mask.filterPage(page);
 
             // 2. compute a mask for the distinct rows (including the group id)
-            Work<Block> work = hash.markDistinctRows(page.prependColumn(new IntArrayBlock(page.getPositionCount(), Optional.empty(), groupIds)));
+            Work<Block> work = hash.markDistinctRows(page.prependField(new IntArrayBlock(page.getPositionCount(), Optional.empty(), groupIds)));
             checkState(work.process());
             Block distinctMask = work.getResult();
 

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/GroupedAggregator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/GroupedAggregator.java
@@ -75,10 +75,10 @@ public class GroupedAggregator
         accumulator.setGroupCount(groupCount);
 
         if (step.isInputRaw()) {
-            Page arguments = page.getColumns(inputChannels);
+            Page arguments = page.getFields(inputChannels);
             Optional<Block> maskBlock = Optional.empty();
             if (maskChannel.isPresent()) {
-                maskBlock = Optional.of(page.getBlock(maskChannel.getAsInt()).getLoadedBlock());
+                maskBlock = Optional.of(page.getFieldBlock(maskChannel.getAsInt()).getLoadedBlock());
             }
             AggregationMask mask = maskBuilder.buildAggregationMask(arguments, maskBlock);
 
@@ -86,11 +86,11 @@ public class GroupedAggregator
                 return;
             }
             // Unwrap any LazyBlock values before evaluating the accumulator
-            arguments = arguments.getLoadedPage();
+            arguments = arguments.getLoadedBlock();
             accumulator.addInput(groupIds, arguments, mask);
         }
         else {
-            accumulator.addIntermediate(groupIds, page.getBlock(inputChannels[0]));
+            accumulator.addIntermediate(groupIds, page.getFieldBlock(inputChannels[0]));
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedAccumulatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedAccumulatorFactory.java
@@ -164,7 +164,7 @@ public class OrderedAccumulatorFactory
             AggregationMask mask = AggregationMask.createSelectAll(0);
             pagesIterator.forEachRemaining(arguments -> {
                 mask.reset(arguments.getPositionCount());
-                accumulator.addInput(arguments.getColumns(argumentChannels), mask);
+                accumulator.addInput(arguments.getFields(argumentChannels), mask);
             });
             accumulator.evaluateFinal(blockBuilder);
         }
@@ -221,7 +221,7 @@ public class OrderedAccumulatorFactory
             }
 
             // Add group id block
-            page = page.appendColumn(new IntArrayBlock(page.getPositionCount(), Optional.empty(), groupIds));
+            page = page.appendField(new IntArrayBlock(page.getPositionCount(), Optional.empty(), groupIds));
 
             // mask page
             pagesIndex.addPage(mask.filterPage(page));
@@ -255,7 +255,7 @@ public class OrderedAccumulatorFactory
                 mask.reset(page.getPositionCount());
                 accumulator.addInput(
                         extractGroupIds(page),
-                        page.getColumns(argumentChannels),
+                        page.getFields(argumentChannels),
                         mask);
             });
         }
@@ -263,7 +263,7 @@ public class OrderedAccumulatorFactory
         private static int[] extractGroupIds(Page page)
         {
             // this works because getSortedPages copies data into new blocks
-            IntArrayBlock groupIdBlock = (IntArrayBlock) page.getBlock(page.getChannelCount() - 1);
+            IntArrayBlock groupIdBlock = (IntArrayBlock) page.getFieldBlock(page.getChannelCount() - 1);
             verify(groupIdBlock.getRawValuesOffset() == 0);
             return groupIdBlock.getRawValues();
         }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/partial/SkipAggregationBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/partial/SkipAggregationBuilder.java
@@ -118,7 +118,7 @@ public class SkipAggregationBuilder
         // Prefix the output with the hash channels
         Block[] outputBlocks = new Block[hashChannels.length + aggregatorFactories.size()];
         for (int i = 0; i < hashChannels.length; i++) {
-            outputBlocks[i] = page.getBlock(hashChannels[i]);
+            outputBlocks[i] = page.getFieldBlock(hashChannels[i]);
         }
 
         // Create a unique groupId mapping per row

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchange.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchange.java
@@ -230,7 +230,7 @@ public class LocalExchange
         }
         else {
             int[] partitionChannelsArray = Ints.toArray(partitionChannels);
-            partitionPagePreparer = page -> page.getColumns(partitionChannelsArray);
+            partitionPagePreparer = page -> page.getFields(partitionChannelsArray);
         }
         return partitionPagePreparer;
     }

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/PageChannelSelector.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/PageChannelSelector.java
@@ -24,7 +24,7 @@ public class PageChannelSelector
         implements Function<Page, Page>
 {
     // No channels need to be remapped, only ensure that all page blocks are loaded
-    private static final Function<Page, Page> GET_LOADED_PAGE = Page::getLoadedPage;
+    private static final Function<Page, Page> GET_LOADED_PAGE = Page::getLoadedBlock;
 
     private final int[] channels;
 

--- a/core/trino-main/src/main/java/io/trino/operator/function/EmptyTableFunctionPartition.java
+++ b/core/trino-main/src/main/java/io/trino/operator/function/EmptyTableFunctionPartition.java
@@ -92,7 +92,7 @@ public class EmptyTableFunctionPartition
 
         // proper outputs first
         for (int channel = 0; channel < properChannelsCount; channel++) {
-            resultBlocks[channel] = page.getBlock(channel);
+            resultBlocks[channel] = page.getFieldBlock(channel);
         }
 
         // pass-through columns next

--- a/core/trino-main/src/main/java/io/trino/operator/function/RegularTableFunctionPartition.java
+++ b/core/trino-main/src/main/java/io/trino/operator/function/RegularTableFunctionPartition.java
@@ -192,14 +192,14 @@ public class RegularTableFunctionPartition
                         // data for this source ends within the current page
                         for (int i = 0; i < channelsForSource.length; i++) {
                             int inputChannel = channelsForSource[i];
-                            sourceBlocks[i] = inputPage.getBlock(inputChannel).getRegion(0, endOfDataForSource - processedPositions);
+                            sourceBlocks[i] = inputPage.getFieldBlock(inputChannel).getRegion(0, endOfDataForSource - processedPositions);
                         }
                     }
                     else {
                         // data for this source does not end within the current page
                         for (int i = 0; i < channelsForSource.length; i++) {
                             int inputChannel = channelsForSource[i];
-                            sourceBlocks[i] = inputPage.getBlock(inputChannel);
+                            sourceBlocks[i] = inputPage.getFieldBlock(inputChannel);
                         }
                     }
                     sourcePages.add(Optional.of(new Page(sourceBlocks)));
@@ -247,7 +247,7 @@ public class RegularTableFunctionPartition
 
         // proper outputs first
         for (int channel = 0; channel < properChannelsCount; channel++) {
-            resultBlocks[channel] = page.getBlock(channel);
+            resultBlocks[channel] = page.getFieldBlock(channel);
         }
 
         // pass-through columns next
@@ -379,7 +379,7 @@ public class RegularTableFunctionPartition
         @Override
         public Block getPassThroughColumn(Page page)
         {
-            Block indexes = page.getBlock(indexChannel);
+            Block indexes = page.getFieldBlock(indexChannel);
             BlockBuilder builder = type.createBlockBuilder(null, page.getPositionCount());
             for (int position = 0; position < page.getPositionCount(); position++) {
                 if (indexes.isNull(position)) {

--- a/core/trino-main/src/main/java/io/trino/operator/function/TableFunctionOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/function/TableFunctionOperator.java
@@ -475,7 +475,7 @@ public class TableFunctionOperator
         checkArgument(page.getPositionCount() > startPosition);
 
         PagesHashStrategy prePartitionedStrategy = hashStrategies.prePartitionedStrategy;
-        Page prePartitionedPage = page.getColumns(hashStrategies.prePartitionedChannelsArray);
+        Page prePartitionedPage = page.getFields(hashStrategies.prePartitionedChannelsArray);
 
         if (pagesIndex.getPositionCount() == 0 || pagesIndex.positionIdenticalToRow(prePartitionedStrategy, 0, startPosition, prePartitionedPage)) {
             // we are within the current group. find the position where the pre-grouped columns change

--- a/core/trino-main/src/main/java/io/trino/operator/index/DynamicTupleFilterFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/index/DynamicTupleFilterFactory.java
@@ -89,7 +89,7 @@ public class DynamicTupleFilterFactory
 
     public OperatorFactory filterWithTuple(Page tuplePage)
     {
-        Supplier<PageProcessor> processor = createPageProcessor(tuplePage.getColumns(tupleFilterChannels), OptionalInt.empty());
+        Supplier<PageProcessor> processor = createPageProcessor(tuplePage.getFields(tupleFilterChannels), OptionalInt.empty());
         return FilterAndProjectOperator.createOperatorFactory(filterOperatorId, planNodeId, processor, outputTypes, DataSize.ofBytes(0), 0);
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/index/IndexSnapshotBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/index/IndexSnapshotBuilder.java
@@ -142,7 +142,7 @@ public class IndexSnapshotBuilder
             if (lookupSource.getJoinPosition(position, page, page) < 0) {
                 missingKeysPageBuilder.declarePosition();
                 for (int i = 0; i < page.getChannelCount(); i++) {
-                    Block block = page.getBlock(i);
+                    Block block = page.getFieldBlock(i);
                     Type type = indexKeysRecordCursor.getType(i);
                     type.appendTo(block, position, missingKeysPageBuilder.getBlockBuilder(i));
                 }

--- a/core/trino-main/src/main/java/io/trino/operator/index/PageRecordSet.java
+++ b/core/trino-main/src/main/java/io/trino/operator/index/PageRecordSet.java
@@ -96,7 +96,7 @@ public class PageRecordSet
             checkState(position >= 0, "Not yet advanced");
             checkState(position < page.getPositionCount(), "Already finished");
             Type type = types.get(field);
-            return type.getBoolean(page.getBlock(field), position);
+            return type.getBoolean(page.getFieldBlock(field), position);
         }
 
         @Override
@@ -105,7 +105,7 @@ public class PageRecordSet
             checkState(position >= 0, "Not yet advanced");
             checkState(position < page.getPositionCount(), "Already finished");
             Type type = types.get(field);
-            return type.getLong(page.getBlock(field), position);
+            return type.getLong(page.getFieldBlock(field), position);
         }
 
         @Override
@@ -114,7 +114,7 @@ public class PageRecordSet
             checkState(position >= 0, "Not yet advanced");
             checkState(position < page.getPositionCount(), "Already finished");
             Type type = types.get(field);
-            return type.getDouble(page.getBlock(field), position);
+            return type.getDouble(page.getFieldBlock(field), position);
         }
 
         @Override
@@ -123,7 +123,7 @@ public class PageRecordSet
             checkState(position >= 0, "Not yet advanced");
             checkState(position < page.getPositionCount(), "Already finished");
             Type type = types.get(field);
-            return type.getSlice(page.getBlock(field), position);
+            return type.getSlice(page.getFieldBlock(field), position);
         }
 
         @Override
@@ -132,7 +132,7 @@ public class PageRecordSet
             checkState(position >= 0, "Not yet advanced");
             checkState(position < page.getPositionCount(), "Already finished");
             Type type = types.get(field);
-            return type.getObject(page.getBlock(field), position);
+            return type.getObject(page.getFieldBlock(field), position);
         }
 
         @Override
@@ -140,7 +140,7 @@ public class PageRecordSet
         {
             checkState(position >= 0, "Not yet advanced");
             checkState(position < page.getPositionCount(), "Already finished");
-            return page.getBlock(field).isNull(position);
+            return page.getFieldBlock(field).isNull(position);
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/operator/index/StreamingIndexedData.java
+++ b/core/trino-main/src/main/java/io/trino/operator/index/StreamingIndexedData.java
@@ -72,7 +72,7 @@ public class StreamingIndexedData
     private boolean matchesExpectedKey(int position, Page page)
     {
         for (int i = 0; i < indexKeyEqualOperators.size(); i++) {
-            if (!indexKeyEqualOperators.get(i).equal(page.getBlock(i), position, indexKeyTuple.getBlock(i), 0)) {
+            if (!indexKeyEqualOperators.get(i).equal(page.getFieldBlock(i), position, indexKeyTuple.getFieldBlock(i), 0)) {
                 return false;
             }
         }
@@ -127,7 +127,7 @@ public class StreamingIndexedData
         int intPosition = toIntExact(position);
         for (int i = 0; i < outputTypes.size(); i++) {
             Type type = outputTypes.get(i);
-            Block block = currentPage.getBlock(i);
+            Block block = currentPage.getFieldBlock(i);
             BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(i + outputChannelOffset);
             type.appendTo(block, intPosition, blockBuilder);
         }

--- a/core/trino-main/src/main/java/io/trino/operator/index/TuplePageFilter.java
+++ b/core/trino-main/src/main/java/io/trino/operator/index/TuplePageFilter.java
@@ -83,8 +83,8 @@ public class TuplePageFilter
     {
         for (int channel = 0; channel < inputChannels.size(); channel++) {
             BlockPositionEqual equalOperator = equalOperators.get(channel);
-            Block outputBlock = page.getBlock(channel);
-            Block singleTupleBlock = tuplePage.getBlock(channel);
+            Block outputBlock = page.getFieldBlock(channel);
+            Block singleTupleBlock = tuplePage.getFieldBlock(channel);
             if (!equalOperator.equal(singleTupleBlock, 0, outputBlock, position)) {
                 return false;
             }

--- a/core/trino-main/src/main/java/io/trino/operator/index/UnloadedIndexKeyRecordSet.java
+++ b/core/trino-main/src/main/java/io/trino/operator/index/UnloadedIndexKeyRecordSet.java
@@ -71,12 +71,12 @@ public class UnloadedIndexKeyRecordSet
             Page page = request.getPage();
 
             // Move through the positions while advancing the cursors in lockstep
-            Work<int[]> work = groupByHash.getGroupIds(page.getColumns(distinctChannels));
+            Work<int[]> work = groupByHash.getGroupIds(page.getFields(distinctChannels));
             boolean done = work.process();
             // TODO: this class does not yield wrt memory limit; enable it
             verify(done);
             int[] groupIds = work.getResult();
-            int positionCount = page.getBlock(0).getPositionCount();
+            int positionCount = page.getFieldBlock(0).getPositionCount();
             int nextDistinctId = -1;
             int groupCount = groupByHash.getGroupCount();
             IntList positions = new IntArrayList(groupCount);
@@ -118,7 +118,7 @@ public class UnloadedIndexKeyRecordSet
     private static boolean containsNullValue(int position, Page page)
     {
         for (int channel = 0; channel < page.getChannelCount(); channel++) {
-            Block block = page.getBlock(channel);
+            Block block = page.getFieldBlock(channel);
             if (block.isNull(position)) {
                 return true;
             }
@@ -190,37 +190,37 @@ public class UnloadedIndexKeyRecordSet
         @Override
         public boolean getBoolean(int field)
         {
-            return types.get(field).getBoolean(page.getBlock(field), position);
+            return types.get(field).getBoolean(page.getFieldBlock(field), position);
         }
 
         @Override
         public long getLong(int field)
         {
-            return types.get(field).getLong(page.getBlock(field), position);
+            return types.get(field).getLong(page.getFieldBlock(field), position);
         }
 
         @Override
         public double getDouble(int field)
         {
-            return types.get(field).getDouble(page.getBlock(field), position);
+            return types.get(field).getDouble(page.getFieldBlock(field), position);
         }
 
         @Override
         public Slice getSlice(int field)
         {
-            return types.get(field).getSlice(page.getBlock(field), position);
+            return types.get(field).getSlice(page.getFieldBlock(field), position);
         }
 
         @Override
         public Object getObject(int field)
         {
-            return types.get(field).getObject(page.getBlock(field), position);
+            return types.get(field).getObject(page.getFieldBlock(field), position);
         }
 
         @Override
         public boolean isNull(int field)
         {
-            return page.getBlock(field).isNull(position);
+            return page.getFieldBlock(field).isNull(position);
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/operator/join/BigintPagesHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/BigintPagesHash.java
@@ -72,7 +72,7 @@ public final class BigintPagesHash
         requireNonNull(pages, "pages is null");
         ImmutableList.Builder<Block> joinChannelBlocksBuilder = ImmutableList.builder();
         for (Page page : pages) {
-            joinChannelBlocksBuilder.add(page.getBlock(joinChannel));
+            joinChannelBlocksBuilder.add(page.getFieldBlock(joinChannel));
         }
         joinChannelBlocks = joinChannelBlocksBuilder.build();
 
@@ -161,7 +161,7 @@ public final class BigintPagesHash
     @Override
     public int getAddressIndex(int position, Page hashChannelsPage)
     {
-        long value = BIGINT.getLong(hashChannelsPage.getBlock(0), position);
+        long value = BIGINT.getLong(hashChannelsPage.getFieldBlock(0), position);
         int pos = getHashPosition(value, mask);
 
         while (keys[pos] != -1) {
@@ -262,7 +262,7 @@ public final class BigintPagesHash
     private void extractAndHashValues(int[] positions, Page hashChannelsPage, int positionCount, long[] incomingValues, int[] hashPositions)
     {
         for (int i = 0; i < positionCount; i++) {
-            incomingValues[i] = BIGINT.getLong(hashChannelsPage.getBlock(0), positions[i]);
+            incomingValues[i] = BIGINT.getLong(hashChannelsPage.getFieldBlock(0), positions[i]);
             hashPositions[i] = getHashPosition(incomingValues[i], mask);
         }
     }

--- a/core/trino-main/src/main/java/io/trino/operator/join/DefaultPageJoiner.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/DefaultPageJoiner.java
@@ -442,7 +442,7 @@ public class DefaultPageJoiner
 
         public SavedRow(Page page, int position, long joinPositionWithinPartition, boolean currentProbePositionProducedRow, int joinSourcePositions)
         {
-            this.row = page.getSingleValuePage(position);
+            this.row = page.getSingleValueBlock(position);
 
             this.joinPositionWithinPartition = joinPositionWithinPartition;
             this.currentProbePositionProducedRow = currentProbePositionProducedRow;

--- a/core/trino-main/src/main/java/io/trino/operator/join/JoinProbe.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/JoinProbe.java
@@ -42,7 +42,7 @@ public class JoinProbe
         public JoinProbe createJoinProbe(Page page)
         {
             Page probePage = page.getLoadedPage(probeJoinChannels);
-            return new JoinProbe(probeOutputChannels, page, probePage, probeHashChannel >= 0 ? page.getBlock(probeHashChannel).getLoadedBlock() : null);
+            return new JoinProbe(probeOutputChannels, page, probePage, probeHashChannel >= 0 ? page.getFieldBlock(probeHashChannel).getLoadedBlock() : null);
         }
     }
 
@@ -106,7 +106,7 @@ public class JoinProbe
     private boolean currentRowContainsNull()
     {
         for (int i = 0; i < probePage.getChannelCount(); i++) {
-            if (probePage.getBlock(i).isNull(position)) {
+            if (probePage.getFieldBlock(i).isNull(position)) {
                 return true;
             }
         }
@@ -116,7 +116,7 @@ public class JoinProbe
     private static boolean probeMayHaveNull(Page probePage)
     {
         for (int i = 0; i < probePage.getChannelCount(); i++) {
-            if (probePage.getBlock(i).mayHaveNull()) {
+            if (probePage.getFieldBlock(i).mayHaveNull()) {
                 return true;
             }
         }

--- a/core/trino-main/src/main/java/io/trino/operator/join/LookupJoinPageBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/LookupJoinPageBuilder.java
@@ -111,7 +111,7 @@ public class LookupJoinPageBuilder
         if (!isSequentialProbeIndices || outputPositions == 0) {
             int[] probeIndices = probeIndexBuilder.toIntArray();
             for (int i = 0; i < probeOutputChannels.length; i++) {
-                blocks[i] = unwrapLoadedBlock(probePage.getBlock(probeOutputChannels[i]).getPositions(probeIndices, 0, outputPositions));
+                blocks[i] = unwrapLoadedBlock(probePage.getFieldBlock(probeOutputChannels[i]).getPositions(probeIndices, 0, outputPositions));
             }
         }
         else {
@@ -122,7 +122,7 @@ public class LookupJoinPageBuilder
             boolean outputProbeBlocksDirectly = startRegion == 0 && outputPositions == probePage.getPositionCount();
 
             for (int i = 0; i < probeOutputChannels.length; i++) {
-                Block block = probePage.getBlock(probeOutputChannels[i]);
+                Block block = probePage.getFieldBlock(probeOutputChannels[i]);
                 if (!outputProbeBlocksDirectly) {
                     // only a subregion of the block should be output
                     block = block.getRegion(startRegion, outputPositions);
@@ -204,7 +204,7 @@ public class LookupJoinPageBuilder
 
         long estimatedProbeRowSize = 0;
         for (int index : probe.getOutputChannels()) {
-            Block block = probe.getPage().getBlock(index);
+            Block block = probe.getPage().getFieldBlock(index);
             // Estimate the size of the probe row
             // TODO: improve estimation for unloaded blocks by making it similar as in PageProcessor
             estimatedProbeRowSize += block.getSizeInBytes() / block.getPositionCount();

--- a/core/trino-main/src/main/java/io/trino/operator/join/NestedLoopJoinOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/NestedLoopJoinOperator.java
@@ -268,10 +268,10 @@ public class NestedLoopJoinOperator
             return new PageRepeatingIterator(outputPage, min(probePositions, buildPositions));
         }
         if (probeChannels.length == 0 && probePage.getPositionCount() <= buildPage.getPositionCount()) {
-            return new PageRepeatingIterator(buildPage.getColumns(buildChannels), probePage.getPositionCount());
+            return new PageRepeatingIterator(buildPage.getFields(buildChannels), probePage.getPositionCount());
         }
         if (buildChannels.length == 0 && buildPage.getPositionCount() <= probePage.getPositionCount()) {
-            return new PageRepeatingIterator(probePage.getColumns(probeChannels), buildPage.getPositionCount());
+            return new PageRepeatingIterator(probePage.getFields(probeChannels), buildPage.getPositionCount());
         }
         return new NestedLoopPageBuilder(probePage, buildPage, probeChannels, buildChannels);
     }
@@ -366,12 +366,12 @@ public class NestedLoopJoinOperator
             this.resultBlockBuffer = new Block[channelsForLargePage.length + channelsForSmallPage.length];
             // Put the blocks from the page with more rows in the output buffer in order
             for (int i = 0; i < channelsForLargePage.length; i++) {
-                resultBlockBuffer[indexForPageBlocks + i] = largePage.getBlock(channelsForLargePage[i]);
+                resultBlockBuffer[indexForPageBlocks + i] = largePage.getFieldBlock(channelsForLargePage[i]);
             }
             // Extract the small page output blocks in order
             this.smallPageOutputBlocks = new Block[channelsForSmallPage.length];
             for (int i = 0; i < channelsForSmallPage.length; i++) {
-                this.smallPageOutputBlocks[i] = smallPage.getBlock(channelsForSmallPage[i]);
+                this.smallPageOutputBlocks[i] = smallPage.getFieldBlock(channelsForSmallPage[i]);
             }
         }
 

--- a/core/trino-main/src/main/java/io/trino/operator/join/unspilled/JoinProbe.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/unspilled/JoinProbe.java
@@ -52,7 +52,7 @@ public class JoinProbe
         public JoinProbe createJoinProbe(Page page, LookupSource lookupSource)
         {
             Page probePage = page.getLoadedPage(probeJoinChannels);
-            return new JoinProbe(probeOutputChannels, page, probePage, lookupSource, probeHashChannel >= 0 ? page.getBlock(probeHashChannel).getLoadedBlock() : null, hasFilter);
+            return new JoinProbe(probeOutputChannels, page, probePage, lookupSource, probeHashChannel >= 0 ? page.getFieldBlock(probeHashChannel).getLoadedBlock() : null, hasFilter);
         }
     }
 
@@ -126,7 +126,7 @@ public class JoinProbe
         Block[] nullableBlocks = new Block[probePage.getChannelCount()];
         int nullableBlocksCount = 0;
         for (int channel = 0; channel < probePage.getChannelCount(); channel++) {
-            Block probeBlock = probePage.getBlock(channel);
+            Block probeBlock = probePage.getFieldBlock(channel);
             if (probeBlock.mayHaveNull()) {
                 nullableBlocks[nullableBlocksCount++] = probeBlock;
             }
@@ -229,7 +229,7 @@ public class JoinProbe
         }
 
         for (int i = 0; i < probePage.getChannelCount(); i++) {
-            if (!(probePage.getBlock(i) instanceof RunLengthEncodedBlock)) {
+            if (!(probePage.getFieldBlock(i) instanceof RunLengthEncodedBlock)) {
                 return false;
             }
         }

--- a/core/trino-main/src/main/java/io/trino/operator/join/unspilled/LookupJoinPageBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/unspilled/LookupJoinPageBuilder.java
@@ -131,7 +131,7 @@ public class LookupJoinPageBuilder
         if (!isSequentialProbeIndices || outputPositions == 0) {
             int[] probeIndices = probeIndexBuilder.toIntArray();
             for (int i = 0; i < probeOutputChannels.length; i++) {
-                blocks[i] = unwrapLoadedBlock(probePage.getBlock(probeOutputChannels[i]).getPositions(probeIndices, 0, outputPositions));
+                blocks[i] = unwrapLoadedBlock(probePage.getFieldBlock(probeOutputChannels[i]).getPositions(probeIndices, 0, outputPositions));
             }
         }
         else {
@@ -142,7 +142,7 @@ public class LookupJoinPageBuilder
             boolean outputProbeBlocksDirectly = startRegion == 0 && outputPositions == probePage.getPositionCount();
 
             for (int i = 0; i < probeOutputChannels.length; i++) {
-                Block block = probePage.getBlock(probeOutputChannels[i]);
+                Block block = probePage.getFieldBlock(probeOutputChannels[i]);
                 if (!outputProbeBlocksDirectly) {
                     // only a subregion of the block should be output
                     block = block.getRegion(startRegion, outputPositions);
@@ -173,7 +173,7 @@ public class LookupJoinPageBuilder
         Block[] blocks = new Block[probeOutputChannels.length + buildOutputChannelCount];
 
         for (int i = 0; i < probeOutputChannels.length; i++) {
-            blocks[i] = probe.getPage().getBlock(probeOutputChannels[i]);
+            blocks[i] = probe.getPage().getFieldBlock(probeOutputChannels[i]);
         }
 
         int offset = probeOutputChannels.length;
@@ -250,7 +250,7 @@ public class LookupJoinPageBuilder
 
         long estimatedProbeRowSize = 0;
         for (int index : probe.getOutputChannels()) {
-            Block block = probe.getPage().getBlock(index);
+            Block block = probe.getPage().getFieldBlock(index);
             // Estimate the size of the probe row
             // TODO: improve estimation for unloaded blocks by making it similar as in PageProcessor
             estimatedProbeRowSize += block.getSizeInBytes() / block.getPositionCount();

--- a/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppenderPageBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppenderPageBuilder.java
@@ -78,7 +78,7 @@ public class PositionsAppenderPageBuilder
         declarePositions(positions.size());
 
         for (int channel = 0; channel < channelAppenders.length; channel++) {
-            Block block = page.getBlock(channel);
+            Block block = page.getFieldBlock(channel);
             channelAppenders[channel].append(positions, block);
         }
     }
@@ -88,7 +88,7 @@ public class PositionsAppenderPageBuilder
         declarePositions(1);
 
         for (int channel = 0; channel < channelAppenders.length; channel++) {
-            Block block = page.getBlock(channel);
+            Block block = page.getFieldBlock(channel);
             channelAppenders[channel].append(position, block);
         }
     }

--- a/core/trino-main/src/main/java/io/trino/operator/project/DictionaryAwarePageFilter.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/DictionaryAwarePageFilter.java
@@ -56,7 +56,7 @@ public class DictionaryAwarePageFilter
     @Override
     public SelectedPositions filter(ConnectorSession session, Page page)
     {
-        Block block = page.getBlock(0).getLoadedBlock();
+        Block block = page.getFieldBlock(0).getLoadedBlock();
 
         if (block instanceof RunLengthEncodedBlock runLengthEncodedBlock) {
             Block value = runLengthEncodedBlock.getValue();

--- a/core/trino-main/src/main/java/io/trino/operator/project/DictionaryAwarePageProjection.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/DictionaryAwarePageProjection.java
@@ -98,7 +98,7 @@ public class DictionaryAwarePageProjection
         public DictionaryAwarePageProjectionWork(@Nullable ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
         {
             this.session = session;
-            this.block = page.getBlock(0);
+            this.block = page.getFieldBlock(0);
             this.selectedPositions = requireNonNull(selectedPositions, "selectedPositions is null");
             this.produceLazyBlock = DictionaryAwarePageProjection.this.produceLazyBlock && !block.isLoaded();
 

--- a/core/trino-main/src/main/java/io/trino/operator/project/InputPageProjection.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/InputPageProjection.java
@@ -56,7 +56,7 @@ public class InputPageProjection
     @Override
     public Work<Block> project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
     {
-        Block block = page.getBlock(0);
+        Block block = page.getFieldBlock(0);
         requireNonNull(selectedPositions, "selectedPositions is null");
 
         // TODO: make it lazy when MergePages have better merging heuristics for small lazy pages

--- a/core/trino-main/src/main/java/io/trino/operator/project/MergePages.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/MergePages.java
@@ -207,7 +207,7 @@ public final class MergePages
             for (int channel = 0; channel < types.size(); channel++) {
                 appendBlock(
                         types.get(channel),
-                        page.getBlock(channel).getLoadedBlock(),
+                        page.getFieldBlock(channel).getLoadedBlock(),
                         pageBuilder.getBlockBuilder(channel));
             }
         }
@@ -231,7 +231,7 @@ public final class MergePages
         {
             // TODO: provide better heuristics there, e.g. check if last produced page was materialized
             for (int channel = 0; channel < page.getChannelCount(); ++channel) {
-                Block block = page.getBlock(channel);
+                Block block = page.getFieldBlock(channel);
                 if (!block.isLoaded()) {
                     return false;
                 }

--- a/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
@@ -263,7 +263,7 @@ public class PageProcessor
             retainedSizeInBytes = Page.getInstanceSizeInBytes(page.getChannelCount());
             ReferenceCountMap referenceCountMap = new ReferenceCountMap();
             for (int channel = 0; channel < page.getChannelCount(); channel++) {
-                Block block = page.getBlock(channel);
+                Block block = page.getFieldBlock(channel);
                 // TODO: block might be partially loaded
                 if (block.isLoaded()) {
                     block.retainedBytesForEachPart((object, size) -> {

--- a/core/trino-main/src/main/java/io/trino/operator/table/json/JsonTable.java
+++ b/core/trino-main/src/main/java/io/trino/operator/table/json/JsonTable.java
@@ -152,9 +152,9 @@ public class JsonTable
                         currentPosition = 0;
                         currentPositionAlreadyProduced = false;
                         totalPositionsProcessed++;
-                        SqlRow parametersRow = (SqlRow) readNativeValue(parametersType, inputPage.getBlock(1), currentPosition);
+                        SqlRow parametersRow = (SqlRow) readNativeValue(parametersType, inputPage.getFieldBlock(1), currentPosition);
                         executionPlan.resetRoot(
-                                (JsonNode) readNativeValue(JSON_2016, inputPage.getBlock(0), currentPosition),
+                                (JsonNode) readNativeValue(JSON_2016, inputPage.getFieldBlock(0), currentPosition),
                                 inputPage,
                                 currentPosition,
                                 getParametersArray(parametersType, parametersRow));
@@ -176,9 +176,9 @@ public class JsonTable
                     if (currentPosition < inputPage.getPositionCount()) {
                         currentPositionAlreadyProduced = false;
                         totalPositionsProcessed++;
-                        SqlRow parametersRow = (SqlRow) readNativeValue(parametersType, inputPage.getBlock(1), currentPosition);
+                        SqlRow parametersRow = (SqlRow) readNativeValue(parametersType, inputPage.getFieldBlock(1), currentPosition);
                         executionPlan.resetRoot(
-                                (JsonNode) readNativeValue(JSON_2016, inputPage.getBlock(0), currentPosition),
+                                (JsonNode) readNativeValue(JSON_2016, inputPage.getFieldBlock(0), currentPosition),
                                 inputPage,
                                 currentPosition,
                                 getParametersArray(parametersType, parametersRow));

--- a/core/trino-main/src/main/java/io/trino/operator/table/json/execution/ValueColumn.java
+++ b/core/trino-main/src/main/java/io/trino/operator/table/json/execution/ValueColumn.java
@@ -64,7 +64,7 @@ public class ValueColumn
             emptyDefault = null;
         }
         else {
-            emptyDefault = readNativeValue(resultType, input.getBlock(emptyDefaultInput), position);
+            emptyDefault = readNativeValue(resultType, input.getFieldBlock(emptyDefaultInput), position);
         }
 
         Object errorDefault;
@@ -72,7 +72,7 @@ public class ValueColumn
             errorDefault = null;
         }
         else {
-            errorDefault = readNativeValue(resultType, input.getBlock(errorDefaultInput), position);
+            errorDefault = readNativeValue(resultType, input.getFieldBlock(errorDefaultInput), position);
         }
 
         try {

--- a/core/trino-main/src/main/java/io/trino/operator/unnest/UnnestOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/unnest/UnnestOperator.java
@@ -187,7 +187,7 @@ public class UnnestOperator
     private void resetBlockBuilders()
     {
         for (int i = 0; i < replicateTypes.size(); i++) {
-            Block newInputBlock = currentPage.getBlock(replicateChannels.get(i));
+            Block newInputBlock = currentPage.getFieldBlock(replicateChannels.get(i));
             replicatedBlockBuilders.get(i).resetInputBlock(newInputBlock);
         }
 
@@ -196,7 +196,7 @@ public class UnnestOperator
 
         for (int i = 0; i < unnestTypes.size(); i++) {
             int inputChannel = unnestChannels.get(i);
-            Block unnestChannelInputBlock = currentPage.getBlock(inputChannel);
+            Block unnestChannelInputBlock = currentPage.getFieldBlock(inputChannel);
             Unnester unnester = unnesters.get(i);
             unnester.resetInput(unnestChannelInputBlock);
 

--- a/core/trino-main/src/main/java/io/trino/server/protocol/JsonArrayResultsIterator.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/JsonArrayResultsIterator.java
@@ -113,7 +113,7 @@ public class JsonArrayResultsIterator
         List<Object> row = new ArrayList<>(columns.size());
         for (OutputColumn outputColumn : columns) {
             Type type = outputColumn.type();
-            Block block = currentPage.getBlock(outputColumn.sourcePageChannel());
+            Block block = currentPage.getFieldBlock(outputColumn.sourcePageChannel());
 
             try {
                 Object value = type.getObjectValue(session.toConnectorSession(), block, inPageIndex);

--- a/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
@@ -570,7 +570,7 @@ class Query
 
                 Page page = deserializer.deserialize(serializedPage);
                 // page should already be loaded since it was just deserialized
-                page = page.getLoadedPage();
+                page = page.getLoadedBlock();
                 bytes += estimateJsonSize(page);
                 resultBuilder.addPage(page);
             }
@@ -590,7 +590,7 @@ class Query
     {
         long estimatedSize = 0;
         for (int i = 0; i < page.getChannelCount(); i++) {
-            estimatedSize += estimateJsonSize(page.getBlock(i));
+            estimatedSize += estimateJsonSize(page.getFieldBlock(i));
         }
         return estimatedSize;
     }

--- a/core/trino-main/src/main/java/io/trino/server/protocol/QueryResultRows.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/QueryResultRows.java
@@ -106,7 +106,7 @@ public class QueryResultRows
         }
 
         checkState(!pages.isEmpty(), "no data pages available");
-        Number value = (Number) columns.get(0).type().getObjectValue(session.toConnectorSession(), pages.getFirst().getBlock(0), 0);
+        Number value = (Number) columns.get(0).type().getObjectValue(session.toConnectorSession(), pages.getFirst().getFieldBlock(0), 0);
 
         return Optional.ofNullable(value).map(Number::longValue);
     }

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/SpooledBlock.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/SpooledBlock.java
@@ -59,7 +59,7 @@ public record SpooledBlock(SpooledLocation location, DataAttributes attributes)
     {
         verify(page.getPositionCount() == 1, "Spooling metadata block must have a single position");
         verify(hasMetadataBlock(page), "Spooling metadata block must have all but last channels null");
-        SqlRow row = SPOOLING_METADATA_TYPE.getObject(page.getBlock(page.getChannelCount() - 1), 0);
+        SqlRow row = SPOOLING_METADATA_TYPE.getObject(page.getFieldBlock(page.getChannelCount() - 1), 0);
 
         boolean isDirect = BOOLEAN.getBoolean(row.getRawFieldBlock(0), 0);
 
@@ -109,13 +109,13 @@ public record SpooledBlock(SpooledLocation location, DataAttributes attributes)
         for (int i = 0; i < page.getPositionCount(); i++) {
             rowBlockBuilder.appendNull();
         }
-        return page.appendColumn(rowBlockBuilder.build());
+        return page.appendField(rowBlockBuilder.build());
     }
 
     private static boolean hasMetadataBlock(Page page)
     {
         for (int channel = 0; channel < page.getChannelCount() - 1; channel++) {
-            if (!page.getBlock(channel).isNull(0)) {
+            if (!page.getFieldBlock(channel).isNull(0)) {
                 return false;
             }
         }

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/SpooledQueryDataProducer.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/SpooledQueryDataProducer.java
@@ -117,7 +117,7 @@ public class SpooledQueryDataProducer
 
     private boolean hasSpoolingMetadata(Page page, List<OutputColumn> outputColumns)
     {
-        return page.getChannelCount() == outputColumns.size() + 1 && page.getPositionCount() == 1 && !page.getBlock(outputColumns.size()).isNull(0);
+        return page.getChannelCount() == outputColumns.size() + 1 && page.getPositionCount() == 1 && !page.getFieldBlock(outputColumns.size()).isNull(0);
     }
 
     public static QueryDataProducer createSpooledQueryDataProducer(QueryDataEncoder.Factory encoder)

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/JsonQueryDataEncoder.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/JsonQueryDataEncoder.java
@@ -72,7 +72,7 @@ public class JsonQueryDataEncoder
                     for (OutputColumn column : columns) {
                         Object value = column
                                 .type()
-                                .getObjectValue(session.toConnectorSession(), page.getBlock(column.sourcePageChannel()), position);
+                                .getObjectValue(session.toConnectorSession(), page.getFieldBlock(column.sourcePageChannel()), position);
                         writeValue(mapper, generator, value);
                     }
                     generator.writeEndArray();

--- a/core/trino-main/src/main/java/io/trino/spiller/GenericPartitioningSpiller.java
+++ b/core/trino-main/src/main/java/io/trino/spiller/GenericPartitioningSpiller.java
@@ -136,7 +136,7 @@ public class GenericPartitioningSpiller
             pageBuilder.declarePosition();
             for (int channel = 0; channel < types.size(); channel++) {
                 Type type = types.get(channel);
-                type.appendTo(page.getBlock(channel), position, pageBuilder.getBlockBuilder(channel));
+                type.appendTo(page.getFieldBlock(channel), position, pageBuilder.getBlockBuilder(channel));
             }
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/DictionaryAwareColumnarFilter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/DictionaryAwareColumnarFilter.java
@@ -40,7 +40,7 @@ public final class DictionaryAwareColumnarFilter
     @Override
     public int filterPositionsRange(ConnectorSession session, int[] outputPositions, int offset, int size, Page loadedPage)
     {
-        Block block = loadedPage.getBlock(0);
+        Block block = loadedPage.getFieldBlock(0);
         if (block instanceof RunLengthEncodedBlock runLengthEncodedBlock) {
             return processRle(session, outputPositions, offset, size, runLengthEncodedBlock);
         }
@@ -62,7 +62,7 @@ public final class DictionaryAwareColumnarFilter
     @Override
     public int filterPositionsList(ConnectorSession session, int[] outputPositions, int[] activePositions, int offset, int size, Page loadedPage)
     {
-        Block block = loadedPage.getBlock(0);
+        Block block = loadedPage.getFieldBlock(0);
         if (block instanceof RunLengthEncodedBlock runLengthEncodedBlock) {
             return processRle(session, outputPositions, activePositions, offset, size, runLengthEncodedBlock);
         }

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/IsNotNullColumnarFilter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/IsNotNullColumnarFilter.java
@@ -60,7 +60,7 @@ public final class IsNotNullColumnarFilter
     @Override
     public int filterPositionsRange(ConnectorSession session, int[] outputPositions, int offset, int size, Page page)
     {
-        ValueBlock block = (ValueBlock) page.getBlock(0);
+        ValueBlock block = (ValueBlock) page.getFieldBlock(0);
         int nonNullPositionsCount = 0;
         int position;
         if (block.mayHaveNull()) {
@@ -85,7 +85,7 @@ public final class IsNotNullColumnarFilter
     @Override
     public int filterPositionsList(ConnectorSession session, int[] outputPositions, int[] activePositions, int offset, int size, Page page)
     {
-        ValueBlock block = (ValueBlock) page.getBlock(0);
+        ValueBlock block = (ValueBlock) page.getFieldBlock(0);
         if (block.mayHaveNull()) {
             Optional<ByteArrayBlock> isNullsBlock = block.getNulls();
             if (isNullsBlock.isPresent()) {

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/IsNullColumnarFilter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/IsNullColumnarFilter.java
@@ -59,7 +59,7 @@ public final class IsNullColumnarFilter
     @Override
     public int filterPositionsRange(ConnectorSession session, int[] outputPositions, int offset, int size, Page page)
     {
-        ValueBlock block = (ValueBlock) page.getBlock(0);
+        ValueBlock block = (ValueBlock) page.getFieldBlock(0);
         if (!block.mayHaveNull()) {
             return 0;
         }
@@ -82,7 +82,7 @@ public final class IsNullColumnarFilter
     @Override
     public int filterPositionsList(ConnectorSession session, int[] outputPositions, int[] activePositions, int offset, int size, Page page)
     {
-        ValueBlock block = (ValueBlock) page.getBlock(0);
+        ValueBlock block = (ValueBlock) page.getFieldBlock(0);
         if (!block.mayHaveNull()) {
             return 0;
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/MergePartitioningHandle.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/MergePartitioningHandle.java
@@ -211,11 +211,11 @@ public final class MergePartitioningHandle
         @Override
         public int getPartition(Page page, int position)
         {
-            Block operationBlock = page.getBlock(0);
+            Block operationBlock = page.getFieldBlock(0);
             byte operation = TINYINT.getByte(operationBlock, position);
             return switch (operation) {
-                case INSERT_OPERATION_NUMBER, UPDATE_INSERT_OPERATION_NUMBER -> insertFunction.getPartition(page.getColumns(insertColumns), position);
-                case UPDATE_OPERATION_NUMBER, DELETE_OPERATION_NUMBER, UPDATE_DELETE_OPERATION_NUMBER -> updateFunction.getPartition(page.getColumns(updateColumns), position);
+                case INSERT_OPERATION_NUMBER, UPDATE_INSERT_OPERATION_NUMBER -> insertFunction.getPartition(page.getFields(insertColumns), position);
+                case UPDATE_OPERATION_NUMBER, DELETE_OPERATION_NUMBER, UPDATE_DELETE_OPERATION_NUMBER -> updateFunction.getPartition(page.getFields(updateColumns), position);
                 default -> throw new VerifyException("Invalid merge operation number: " + operation);
             };
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ExtractSpatialJoins.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ExtractSpatialJoins.java
@@ -472,7 +472,7 @@ public class ExtractSpatialJoins
                             if (page != null && page.getPositionCount() > 0) {
                                 checkSpatialPartitioningTable(kdbTree.isEmpty(), "Expected exactly one row for table %s, but found more", name);
                                 checkSpatialPartitioningTable(page.getPositionCount() == 1, "Expected exactly one row for table %s, but found %s rows", name, page.getPositionCount());
-                                String kdbTreeJson = VARCHAR.getSlice(page.getBlock(0), 0).toStringUtf8();
+                                String kdbTreeJson = VARCHAR.getSlice(page.getFieldBlock(0), 0).toStringUtf8();
                                 try {
                                     kdbTree = Optional.of(KdbTreeUtils.fromJson(kdbTreeJson));
                                 }

--- a/core/trino-main/src/main/java/io/trino/testing/MaterializedResult.java
+++ b/core/trino-main/src/main/java/io/trino/testing/MaterializedResult.java
@@ -556,7 +556,7 @@ public class MaterializedResult
                 List<Object> values = new ArrayList<>(page.getChannelCount());
                 for (int channel = 0; channel < page.getChannelCount(); channel++) {
                     Type type = types.get(channel);
-                    Block block = page.getBlock(channel);
+                    Block block = page.getFieldBlock(channel);
                     values.add(type.getObjectValue(session, block, position));
                 }
                 values = Collections.unmodifiableList(values);

--- a/core/trino-main/src/main/java/io/trino/testing/TestingDirectTrinoClient.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingDirectTrinoClient.java
@@ -123,7 +123,7 @@ public class TestingDirectTrinoClient
                 List<Object> values = new ArrayList<>(page.getChannelCount());
                 for (int channel = 0; channel < page.getChannelCount(); channel++) {
                     Type type = types.get(channel);
-                    Block block = page.getBlock(channel);
+                    Block block = page.getFieldBlock(channel);
                     values.add(type.getObjectValue(session, block, position));
                 }
                 values = Collections.unmodifiableList(values);

--- a/core/trino-main/src/main/java/io/trino/util/MergeSortedPages.java
+++ b/core/trino-main/src/main/java/io/trino/util/MergeSortedPages.java
@@ -191,7 +191,7 @@ public final class MergeSortedPages
             pageBuilder.declarePosition();
             for (int i = 0; i < outputChannels.size(); i++) {
                 Type type = outputTypes.get(i);
-                Block block = page.getBlock(outputChannels.get(i));
+                Block block = page.getFieldBlock(outputChannels.get(i));
                 type.appendTo(block, position, pageBuilder.getBlockBuilder(i));
             }
         }

--- a/core/trino-main/src/test/java/io/trino/TestPagesIndexPageSorter.java
+++ b/core/trino-main/src/test/java/io/trino/TestPagesIndexPageSorter.java
@@ -168,7 +168,7 @@ public class TestPagesIndexPageSorter
             Page page = inputPages.get(index);
             for (int i = 0; i < types.size(); i++) {
                 Type type = types.get(i);
-                type.appendTo(page.getBlock(i), position, pageBuilder.getBlockBuilder(i));
+                type.appendTo(page.getFieldBlock(i), position, pageBuilder.getBlockBuilder(i));
             }
             pageBuilder.declarePosition();
         }

--- a/core/trino-main/src/test/java/io/trino/block/AbstractTestBlock.java
+++ b/core/trino-main/src/test/java/io/trino/block/AbstractTestBlock.java
@@ -124,6 +124,7 @@ public abstract class AbstractTestBlock
                 }
                 else if (type == Block[].class) {
                     Block[] blocks = (Block[]) field.get(block);
+                    retainedSize += sizeOf(blocks);
                     for (Block innerBlock : blocks) {
                         assertRetainedSize(innerBlock);
                         retainedSize += innerBlock.getRetainedSizeInBytes();

--- a/core/trino-main/src/test/java/io/trino/execution/buffer/TestPagesSerde.java
+++ b/core/trino-main/src/test/java/io/trino/execution/buffer/TestPagesSerde.java
@@ -278,8 +278,8 @@ public class TestPagesSerde
             Page deserialized = deserializer.deserialize(serialized);
             assertThat(deserialized.getChannelCount()).isEqualTo(1);
 
-            VariableWidthBlock expected = (VariableWidthBlock) page.getBlock(0);
-            VariableWidthBlock actual = (VariableWidthBlock) deserialized.getBlock(0);
+            VariableWidthBlock expected = (VariableWidthBlock) page.getFieldBlock(0);
+            VariableWidthBlock actual = (VariableWidthBlock) deserialized.getFieldBlock(0);
 
             assertThat(actual.getRawSlice().getBytes()).isEqualTo(expected.getRawSlice().getBytes());
         }

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupByHash.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupByHash.java
@@ -139,7 +139,7 @@ public class BenchmarkGroupByHash
                         // rle page
                         Block[] blocks = new Block[page.getChannelCount()];
                         for (int channel = 0; channel < blocks.length; ++channel) {
-                            blocks[channel] = RunLengthEncodedBlock.create(page.getBlock(channel).getSingleValueBlock(0), page.getPositionCount());
+                            blocks[channel] = RunLengthEncodedBlock.create(page.getFieldBlock(channel).getSingleValueBlock(0), page.getPositionCount());
                         }
                         pages.add(new Page(blocks));
                     }
@@ -148,7 +148,7 @@ public class BenchmarkGroupByHash
                         int[] positions = IntStream.range(0, page.getPositionCount()).toArray();
                         Block[] blocks = new Block[page.getChannelCount()];
                         for (int channel = 0; channel < page.getChannelCount(); ++channel) {
-                            blocks[channel] = DictionaryBlock.create(positions.length, page.getBlock(channel), positions);
+                            blocks[channel] = DictionaryBlock.create(positions.length, page.getFieldBlock(channel), positions);
                         }
                         pages.add(new Page(blocks));
                     }

--- a/core/trino-main/src/test/java/io/trino/operator/GroupByHashYieldAssertion.java
+++ b/core/trino-main/src/test/java/io/trino/operator/GroupByHashYieldAssertion.java
@@ -110,7 +110,7 @@ public final class GroupByHashYieldAssertion
             if (hashKeyType == VARCHAR) {
                 long oldVariableWidthSize = variableWidthData.getRetainedSizeBytes();
                 for (int position = 0; position < page.getPositionCount(); position++) {
-                    Block block = page.getBlock(0);
+                    Block block = page.getFieldBlock(0);
                     variableWidthData.allocate(pointer, 0, ((VariableWidthBlock) block.getUnderlyingValueBlock()).getSliceLength(block.getUnderlyingValuePosition(position)));
                 }
                 pageVariableWidthSize = variableWidthData.getRetainedSizeBytes() - oldVariableWidthSize;

--- a/core/trino-main/src/test/java/io/trino/operator/OperatorAssertion.java
+++ b/core/trino-main/src/test/java/io/trino/operator/OperatorAssertion.java
@@ -414,7 +414,7 @@ public final class OperatorAssertion
                 if (channels.contains(i)) {
                     continue;
                 }
-                blocks[channel++] = page.getBlock(i);
+                blocks[channel++] = page.getFieldBlock(i);
             }
             actualPages.add(new Page(blocks));
         }

--- a/core/trino-main/src/test/java/io/trino/operator/PageAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/PageAssertions.java
@@ -31,7 +31,7 @@ public final class PageAssertions
         assertThat(actualPage.getChannelCount()).isEqualTo(expectedPage.getChannelCount());
         assertThat(actualPage.getPositionCount()).isEqualTo(expectedPage.getPositionCount());
         for (int i = 0; i < actualPage.getChannelCount(); i++) {
-            assertBlockEquals(types.get(i), actualPage.getBlock(i), expectedPage.getBlock(i));
+            assertBlockEquals(types.get(i), actualPage.getFieldBlock(i), expectedPage.getFieldBlock(i));
         }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/TestDynamicFilterSourceOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestDynamicFilterSourceOperator.java
@@ -484,7 +484,7 @@ public class TestDynamicFilterSourceOperator
         int maxDistinctValues = 100;
         Page largePage = new Page(
                 createLongsBlock(Collections.nCopies(100, null)),
-                createLongSequenceBlock(200, 301));
+                createLongSequenceBlock(200, 300));
 
         assertDynamicFilters(
                 maxDistinctValues,
@@ -618,7 +618,7 @@ public class TestDynamicFilterSourceOperator
                 .isGreaterThan(initialMemoryUsage);
 
         inputPages = ImmutableList.of(new Page(
-                createLongSequenceBlock(0, 51),
+                createLongSequenceBlock(0, 50),
                 createLongSequenceBlock(51, 101)));
         toPagesPartial(operator, inputPages.iterator());
         long firstChannelStoppedMemoryUsage = operator.getOperatorContext().getOperatorMemoryContext().getUserMemory();

--- a/core/trino-main/src/test/java/io/trino/operator/TestFlatHashStrategy.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestFlatHashStrategy.java
@@ -95,7 +95,7 @@ class TestFlatHashStrategy
                 flatHashStrategy.readFlat(fixedChunk, FIXED_CHUNK_OFFSET, variableChunk, blockBuilders);
                 List<Block> output = Arrays.stream(blockBuilders).map(BlockBuilder::build).toList();
                 Page actualPage = new Page(output.toArray(Block[]::new));
-                Page expectedPage = new Page(blocks).getSingleValuePage(position);
+                Page expectedPage = new Page(blocks).getSingleValueBlock(position);
                 assertPageEquals(types, actualPage, expectedPage);
             }
         }

--- a/core/trino-main/src/test/java/io/trino/operator/TestGroupByHash.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestGroupByHash.java
@@ -236,11 +236,11 @@ public class TestGroupByHash
             Page page = pageBuilder.build();
             // Ensure that all blocks have the same positionCount
             for (int i = 0; i < page.getChannelCount(); i++) {
-                assertThat(page.getBlock(i).getPositionCount()).isEqualTo(100);
+                assertThat(page.getFieldBlock(i).getPositionCount()).isEqualTo(100);
             }
             assertThat(page.getPositionCount()).isEqualTo(100);
-            BlockAssertions.assertBlockEquals(BIGINT, page.getBlock(0), valuesBlock);
-            BlockAssertions.assertBlockEquals(BIGINT, page.getBlock(1), hashBlock);
+            BlockAssertions.assertBlockEquals(BIGINT, page.getFieldBlock(0), valuesBlock);
+            BlockAssertions.assertBlockEquals(BIGINT, page.getFieldBlock(1), hashBlock);
         }
     }
 
@@ -266,7 +266,7 @@ public class TestGroupByHash
             }
             Page outputPage = pageBuilder.build();
             assertThat(outputPage.getPositionCount()).isEqualTo(50);
-            BlockAssertions.assertBlockEquals(BIGINT, outputPage.getBlock(0), createLongSequenceBlock(0, 50));
+            BlockAssertions.assertBlockEquals(BIGINT, outputPage.getFieldBlock(0), createLongSequenceBlock(0, 50));
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRankBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRankBuilder.java
@@ -268,6 +268,6 @@ public class TestGroupedTopNRankBuilder
     private static Page dropLastColumn(Page page)
     {
         checkArgument(page.getChannelCount() > 0);
-        return page.getColumns(IntStream.range(0, page.getChannelCount() - 1).toArray());
+        return page.getFields(IntStream.range(0, page.getChannelCount() - 1).toArray());
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRowNumberBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRowNumberBuilder.java
@@ -118,7 +118,7 @@ public class TestGroupedTopNRowNumberBuilder
             assertPageEquals(ImmutableList.of(BIGINT, DOUBLE, BIGINT), output.get(0), expected);
         }
         else {
-            assertPageEquals(types, output.get(0), new Page(expected.getBlock(0), expected.getBlock(1)));
+            assertPageEquals(types, output.get(0), new Page(expected.getFieldBlock(0), expected.getFieldBlock(1)));
         }
     }
 
@@ -188,7 +188,7 @@ public class TestGroupedTopNRowNumberBuilder
             assertPageEquals(ImmutableList.of(BIGINT, DOUBLE, BIGINT), output.get(0), expected);
         }
         else {
-            assertPageEquals(types, output.get(0), new Page(expected.getBlock(0), expected.getBlock(1)));
+            assertPageEquals(types, output.get(0), new Page(expected.getFieldBlock(0), expected.getFieldBlock(1)));
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/TestHashAggregationOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestHashAggregationOperator.java
@@ -461,7 +461,7 @@ public class TestHashAggregationOperator
             // value + hash + aggregation result
             assertThat(page.getChannelCount()).isEqualTo(3);
             for (int i = 0; i < page.getPositionCount(); i++) {
-                assertThat(BIGINT.getLong(page.getBlock(2), i)).isEqualTo(1);
+                assertThat(BIGINT.getLong(page.getFieldBlock(2), i)).isEqualTo(1);
                 count++;
             }
         }

--- a/core/trino-main/src/test/java/io/trino/operator/TestMarkDistinctOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestMarkDistinctOperator.java
@@ -132,9 +132,9 @@ public class TestMarkDistinctOperator
         int maskChannel = firstInput.getChannelCount(); // mask channel is appended to the input
         try (Operator operator = operatorFactory.createOperator(driverContext)) {
             operator.addInput(firstInput);
-            Block allDistinctOutput = operator.getOutput().getBlock(maskChannel);
+            Block allDistinctOutput = operator.getOutput().getFieldBlock(maskChannel);
             operator.addInput(firstInput);
-            Block noDistinctOutput = operator.getOutput().getBlock(maskChannel);
+            Block noDistinctOutput = operator.getOutput().getFieldBlock(maskChannel);
             // all distinct and no distinct conditions produce RLE blocks
             assertInstanceOf(allDistinctOutput, RunLengthEncodedBlock.class);
             assertThat(BOOLEAN.getBoolean(allDistinctOutput, 0)).isTrue();
@@ -142,7 +142,7 @@ public class TestMarkDistinctOperator
             assertThat(BOOLEAN.getBoolean(noDistinctOutput, 0)).isFalse();
 
             operator.addInput(secondInput);
-            Block halfDistinctOutput = operator.getOutput().getBlock(maskChannel);
+            Block halfDistinctOutput = operator.getOutput().getFieldBlock(maskChannel);
             // [0,50) is not distinct
             for (int position = 0; position < 50; position++) {
                 assertThat(BOOLEAN.getBoolean(halfDistinctOutput, position)).isFalse();
@@ -152,14 +152,14 @@ public class TestMarkDistinctOperator
             }
 
             operator.addInput(singleDistinctPage);
-            Block singleDistinctBlock = operator.getOutput().getBlock(maskChannel);
+            Block singleDistinctBlock = operator.getOutput().getFieldBlock(maskChannel);
             assertThat(singleDistinctBlock instanceof RunLengthEncodedBlock)
                     .describedAs("single position inputs should not be RLE")
                     .isFalse();
             assertThat(BOOLEAN.getBoolean(singleDistinctBlock, 0)).isTrue();
 
             operator.addInput(singleNotDistinctPage);
-            Block singleNotDistinctBlock = operator.getOutput().getBlock(maskChannel);
+            Block singleNotDistinctBlock = operator.getOutput().getFieldBlock(maskChannel);
             assertThat(singleNotDistinctBlock instanceof RunLengthEncodedBlock)
                     .describedAs("single position inputs should not be RLE")
                     .isFalse();
@@ -193,7 +193,7 @@ public class TestMarkDistinctOperator
         for (Page page : result.getOutput()) {
             assertThat(page.getChannelCount()).isEqualTo(3);
             for (int i = 0; i < page.getPositionCount(); i++) {
-                assertThat(BOOLEAN.getBoolean(page.getBlock(2), i)).isTrue();
+                assertThat(BOOLEAN.getBoolean(page.getFieldBlock(2), i)).isTrue();
                 count++;
             }
         }

--- a/core/trino-main/src/test/java/io/trino/operator/TestMergeHashSort.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestMergeHashSort.java
@@ -63,7 +63,7 @@ public class TestMergeHashSort
         Page actualPage = mergedPage.getResult();
         assertThat(actualPage.getPositionCount()).isEqualTo(1);
         assertThat(actualPage.getChannelCount()).isEqualTo(1);
-        assertThat(BIGINT.getLong(actualPage.getBlock(0), 0)).isEqualTo(42);
+        assertThat(BIGINT.getLong(actualPage.getFieldBlock(0), 0)).isEqualTo(42);
 
         assertFinishes(mergedPage);
     }
@@ -86,7 +86,7 @@ public class TestMergeHashSort
         Page actualPage = mergedPage.getResult();
         assertThat(actualPage.getPositionCount()).isEqualTo(1);
         assertThat(actualPage.getChannelCount()).isEqualTo(1);
-        assertThat(BIGINT.getLong(actualPage.getBlock(0), 0)).isEqualTo(42);
+        assertThat(BIGINT.getLong(actualPage.getFieldBlock(0), 0)).isEqualTo(42);
 
         assertFinishes(mergedPage);
     }
@@ -112,10 +112,10 @@ public class TestMergeHashSort
         assertThat(mergedPages.process()).isTrue();
         Page resultPage = mergedPages.getResult();
         assertThat(resultPage.getPositionCount()).isEqualTo(4);
-        assertThat(BIGINT.getLong(resultPage.getBlock(0), 0)).isEqualTo(42);
-        assertThat(BIGINT.getLong(resultPage.getBlock(0), 1)).isEqualTo(42);
-        assertThat(BIGINT.getLong(resultPage.getBlock(0), 2)).isEqualTo(52);
-        assertThat(BIGINT.getLong(resultPage.getBlock(0), 3)).isEqualTo(60);
+        assertThat(BIGINT.getLong(resultPage.getFieldBlock(0), 0)).isEqualTo(42);
+        assertThat(BIGINT.getLong(resultPage.getFieldBlock(0), 1)).isEqualTo(42);
+        assertThat(BIGINT.getLong(resultPage.getFieldBlock(0), 2)).isEqualTo(52);
+        assertThat(BIGINT.getLong(resultPage.getFieldBlock(0), 3)).isEqualTo(60);
 
         assertFinishes(mergedPages);
     }

--- a/core/trino-main/src/test/java/io/trino/operator/TestPageUtils.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestPageUtils.java
@@ -43,7 +43,7 @@ public class TestPageUtils
 
         assertThat(sizeInBytes.get()).isEqualTo(first.getSizeInBytes() * 2);
 
-        page.getBlock(2).getLoadedBlock();
+        page.getFieldBlock(2).getLoadedBlock();
         assertThat(sizeInBytes.get()).isEqualTo(first.getSizeInBytes() * 3);
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/TestRowNumberOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestRowNumberOperator.java
@@ -167,7 +167,7 @@ public class TestRowNumberOperator
             for (Page page : result.getOutput()) {
                 assertThat(page.getChannelCount()).isEqualTo(3);
                 for (int i = 0; i < page.getPositionCount(); i++) {
-                    assertThat(BIGINT.getLong(page.getBlock(2), i)).isEqualTo(1);
+                    assertThat(BIGINT.getLong(page.getFieldBlock(2), i)).isEqualTo(1);
                     count++;
                 }
             }
@@ -377,7 +377,7 @@ public class TestRowNumberOperator
         for (Page page : pages) {
             int rowNumberChannel = page.getChannelCount() - 1;
             for (int i = 0; i < page.getPositionCount(); i++) {
-                BIGINT.writeLong(builder, BIGINT.getLong(page.getBlock(rowNumberChannel), i));
+                BIGINT.writeLong(builder, BIGINT.getLong(page.getFieldBlock(rowNumberChannel), i));
             }
         }
         return builder.build();
@@ -389,7 +389,7 @@ public class TestRowNumberOperator
                 .map(page -> {
                     Block[] blocks = new Block[page.getChannelCount() - 1];
                     for (int i = 0; i < page.getChannelCount() - 1; i++) {
-                        blocks[i] = page.getBlock(i);
+                        blocks[i] = page.getFieldBlock(i);
                     }
                     return new Page(page.getPositionCount(), blocks);
                 })

--- a/core/trino-main/src/test/java/io/trino/operator/TestRowNumberOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestRowNumberOperator.java
@@ -149,8 +149,8 @@ public class TestRowNumberOperator
             OperatorFactory operatorFactory = new RowNumberOperator.RowNumberOperatorFactory(
                     0,
                     new PlanNodeId("test"),
-                    ImmutableList.of(type),
-                    ImmutableList.of(0),
+                    ImmutableList.of(type, BIGINT),
+                    ImmutableList.of(0, 1),
                     ImmutableList.of(0),
                     ImmutableList.of(type),
                     Optional.empty(),

--- a/core/trino-main/src/test/java/io/trino/operator/TestRowReferencePageManager.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestRowReferencePageManager.java
@@ -308,7 +308,7 @@ public class TestRowReferencePageManager
     {
         Page page = pageManager.getPage(rowId);
         int position = pageManager.getPosition(rowId);
-        return BIGINT.getLong(page.getBlock(0), position);
+        return BIGINT.getLong(page.getFieldBlock(0), position);
     }
 
     private static Page createBigIntSingleBlockPage(long startInclusive, long endExclusive)

--- a/core/trino-main/src/test/java/io/trino/operator/TestScanFilterAndProjectOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestScanFilterAndProjectOperator.java
@@ -333,7 +333,7 @@ public class TestScanFilterAndProjectOperator
                 assertThat(page.getPositionCount()).isEqualTo(totalRows);
                 assertThat(page.getChannelCount()).isEqualTo(totalColumns);
                 for (int j = 0; j < totalColumns; j++) {
-                    assertThat(toValues(BIGINT, page.getBlock(j))).isEqualTo(toValues(BIGINT, input.getBlock(0)));
+                    assertThat(toValues(BIGINT, page.getFieldBlock(j))).isEqualTo(toValues(BIGINT, input.getFieldBlock(0)));
                 }
             }
             else {
@@ -401,7 +401,7 @@ public class TestScanFilterAndProjectOperator
         Page output = operator.getOutput();
         driverContext.getYieldSignal().reset();
         assertThat(output).isNotNull();
-        assertThat(toValues(BIGINT, output.getBlock(0))).isEqualTo(toValues(BIGINT, input.getBlock(0)));
+        assertThat(toValues(BIGINT, output.getFieldBlock(0))).isEqualTo(toValues(BIGINT, input.getFieldBlock(0)));
     }
 
     private static List<Page> toPages(Operator operator)

--- a/core/trino-main/src/test/java/io/trino/operator/TestScanFilterAndProjectOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestScanFilterAndProjectOperator.java
@@ -203,9 +203,9 @@ public class TestScanFilterAndProjectOperator
     @Test
     public void testPageSourceLazyLoad()
     {
-        Block inputBlock = BlockAssertions.createLongSequenceBlock(0, 100);
+        Block inputBlock = BlockAssertions.createLongSequenceBlock(0, 1);
         // If column 1 is loaded, test will fail
-        Page input = new Page(100, inputBlock, new LazyBlock(100, () -> {
+        Page input = new Page(1, inputBlock, new LazyBlock(1, () -> {
             throw new AssertionError("Lazy block should not be loaded");
         }));
         DriverContext driverContext = newDriverContext();

--- a/core/trino-main/src/test/java/io/trino/operator/TestTopNRankingOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestTopNRankingOperator.java
@@ -297,7 +297,7 @@ public class TestTopNRankingOperator
         for (Page page : result.getOutput()) {
             assertThat(page.getChannelCount()).isEqualTo(2);
             for (int i = 0; i < page.getPositionCount(); i++) {
-                assertThat(BIGINT.getLong(page.getBlock(1), i)).isEqualTo((byte) 1);
+                assertThat(BIGINT.getLong(page.getFieldBlock(1), i)).isEqualTo((byte) 1);
                 count++;
             }
         }

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/AggregationTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/AggregationTestUtils.java
@@ -84,7 +84,7 @@ public final class AggregationTestUtils
         for (int i = 1; i < page.getChannelCount(); i++) {
             assertThat(positions)
                     .describedAs("input blocks provided are not equal in position count")
-                    .isEqualTo(page.getBlock(i).getPositionCount());
+                    .isEqualTo(page.getFieldBlock(i).getPositionCount());
         }
         if (positions == 0) {
             assertAggregationInternal(function, equalAssertion, testDescription, expectedValue);
@@ -186,7 +186,7 @@ public final class AggregationTestUtils
         Page[] maskedPages = new Page[pages.length];
         for (int i = 0; i < pages.length; i++) {
             Page page = pages[i];
-            maskedPages[i] = page.appendColumn(RunLengthEncodedBlock.create(BooleanType.createBlockForSingleNonNullValue(maskValue), page.getPositionCount()));
+            maskedPages[i] = page.appendField(RunLengthEncodedBlock.create(BooleanType.createBlockForSingleNonNullValue(maskValue), page.getPositionCount()));
         }
         return maskedPages;
     }
@@ -201,7 +201,7 @@ public final class AggregationTestUtils
             for (int j = 0; j < page.getPositionCount(); j++) {
                 BOOLEAN.writeBoolean(blockBuilder, maskValue);
             }
-            maskedPages[i] = page.appendColumn(blockBuilder.build());
+            maskedPages[i] = page.appendField(blockBuilder.build());
         }
 
         return maskedPages;
@@ -420,7 +420,7 @@ public final class AggregationTestUtils
             else {
                 Block[] newBlocks = new Block[page.getChannelCount()];
                 for (int channel = 0; channel < page.getChannelCount(); channel++) {
-                    newBlocks[channel] = page.getBlock(page.getChannelCount() - channel - 1);
+                    newBlocks[channel] = page.getFieldBlock(page.getChannelCount() - channel - 1);
                 }
                 newPages[i] = new Page(page.getPositionCount(), newBlocks);
             }
@@ -438,7 +438,7 @@ public final class AggregationTestUtils
                 newBlocks[channel] = createAllNullBlock(page.getPositionCount());
             }
             for (int channel = 0; channel < page.getChannelCount(); channel++) {
-                newBlocks[channel + offset] = page.getBlock(channel);
+                newBlocks[channel + offset] = page.getFieldBlock(channel);
             }
             newPages[i] = new Page(page.getPositionCount(), newBlocks);
         }

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/BenchmarkAggregationMaskBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/BenchmarkAggregationMaskBuilder.java
@@ -258,13 +258,13 @@ public class BenchmarkAggregationMaskBuilder
             mask.reset(positionCount);
             mask.applyMaskBlock(optionalMaskBlock.orElse(null));
             if (first >= 0) {
-                mask.unselectNullPositions(arguments.getBlock(first));
+                mask.unselectNullPositions(arguments.getFieldBlock(first));
             }
             if (second >= 0) {
-                mask.unselectNullPositions(arguments.getBlock(second));
+                mask.unselectNullPositions(arguments.getFieldBlock(second));
             }
             if (third >= 0) {
-                mask.unselectNullPositions(arguments.getBlock(third));
+                mask.unselectNullPositions(arguments.getFieldBlock(third));
             }
             return mask;
         }
@@ -311,19 +311,37 @@ public class BenchmarkAggregationMaskBuilder
                 maskBlockMayHaveNull = false;
             }
 
-            Block nonNullArg0 = first < 0 ? null : arguments.getBlock(first);
+            Block nonNullArg0;
+            if (first < 0) {
+                nonNullArg0 = null;
+            }
+            else {
+                nonNullArg0 = arguments.getFieldBlock(first);
+            }
             if (isAlwaysNull(nonNullArg0)) {
                 return AggregationMask.createSelectNone(positionCount);
             }
             boolean nonNullArg0MayHaveNull = nonNullArg0 != null && nonNullArg0.mayHaveNull();
 
-            Block nonNullArg1 = third < 0 ? null : arguments.getBlock(second);
+            Block nonNullArg1;
+            if (third < 0) {
+                nonNullArg1 = null;
+            }
+            else {
+                nonNullArg1 = arguments.getFieldBlock(second);
+            }
             if (isAlwaysNull(nonNullArg1)) {
                 return AggregationMask.createSelectNone(positionCount);
             }
             boolean nonNullArg1MayHaveNull = nonNullArg1 != null && nonNullArg1.mayHaveNull();
 
-            Block nonNullArgN = third < 0 ? null : arguments.getBlock(third);
+            Block nonNullArgN;
+            if (third < 0) {
+                nonNullArgN = null;
+            }
+            else {
+                nonNullArgN = arguments.getFieldBlock(third);
+            }
             if (isAlwaysNull(nonNullArgN)) {
                 return AggregationMask.createSelectNone(positionCount);
             }

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/InterpretedAggregationMaskBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/InterpretedAggregationMaskBuilder.java
@@ -115,7 +115,7 @@ public class InterpretedAggregationMaskBuilder
 
         public void reset(Page arguments)
         {
-            block = arguments.getBlock(channel);
+            block = arguments.getFieldBlock(channel);
             mayHaveNull = block.mayHaveNull();
         }
 

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestMultimapAggAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestMultimapAggAggregation.java
@@ -229,7 +229,7 @@ public class TestMultimapAggAggregation
         Page page = pageBuilder.build();
 
         AggregationTestInput input = new AggregationTestInputBuilder(
-                new Block[] {page.getBlock(0), page.getBlock(1)},
+                new Block[] {page.getFieldBlock(0), page.getFieldBlock(1)},
                 aggregationFunction).build();
 
         AggregationTestOutput testOutput = new AggregationTestOutput(outputBuilder.build().asMap());

--- a/core/trino-main/src/test/java/io/trino/operator/exchange/TestLocalExchange.java
+++ b/core/trino-main/src/test/java/io/trino/operator/exchange/TestLocalExchange.java
@@ -1170,7 +1170,7 @@ public class TestLocalExchange
             public BucketFunction getBucketFunction(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle, List<Type> partitionChannelTypes, int bucketCount)
             {
                 return (page, position) -> {
-                    long rowValue = BIGINT.getLong(page.getBlock(0), position);
+                    long rowValue = BIGINT.getLong(page.getFieldBlock(0), position);
                     if (rowValue == 42) {
                         return 0;
                     }
@@ -1372,7 +1372,7 @@ public class TestLocalExchange
             public BucketFunction getBucketFunction(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle, List<Type> partitionChannelTypes, int bucketCount)
             {
                 return (page, position) -> {
-                    long rowValue = BIGINT.getLong(page.getBlock(0), position);
+                    long rowValue = BIGINT.getLong(page.getFieldBlock(0), position);
                     if (rowValue == 0) {
                         return 2;
                     }

--- a/core/trino-main/src/test/java/io/trino/operator/join/BenchmarkHashBuildAndJoinOperators.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/BenchmarkHashBuildAndJoinOperators.java
@@ -415,7 +415,7 @@ public class BenchmarkHashBuildAndJoinOperators
 
         for (int channel = 0; channel < types.size(); channel++) {
             Type type = types.get(channel);
-            type.appendTo(page.getBlock(channel), position, pageBuilder.getBlockBuilder(channel));
+            type.appendTo(page.getFieldBlock(channel), position, pageBuilder.getBlockBuilder(channel));
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/join/TestLookupJoinPageBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/TestLookupJoinPageBuilder.java
@@ -57,22 +57,22 @@ public class TestLookupJoinPageBuilder
 
         Page output = lookupJoinPageBuilder.build(probe);
         assertThat(output.getChannelCount()).isEqualTo(4);
-        assertThat(output.getBlock(0) instanceof DictionaryBlock).isTrue();
-        assertThat(output.getBlock(1) instanceof DictionaryBlock).isTrue();
+        assertThat(output.getFieldBlock(0) instanceof DictionaryBlock).isTrue();
+        assertThat(output.getFieldBlock(1) instanceof DictionaryBlock).isTrue();
         for (int i = 0; i < output.getPositionCount(); i++) {
-            assertThat(output.getBlock(0).isNull(i)).isFalse();
-            assertThat(output.getBlock(1).isNull(i)).isFalse();
-            assertThat(BIGINT.getLong(output.getBlock(0), i)).isEqualTo(i / 2);
-            assertThat(BIGINT.getLong(output.getBlock(1), i)).isEqualTo(i / 2);
+            assertThat(output.getFieldBlock(0).isNull(i)).isFalse();
+            assertThat(output.getFieldBlock(1).isNull(i)).isFalse();
+            assertThat(BIGINT.getLong(output.getFieldBlock(0), i)).isEqualTo(i / 2);
+            assertThat(BIGINT.getLong(output.getFieldBlock(1), i)).isEqualTo(i / 2);
             if (i % 2 == 0) {
-                assertThat(output.getBlock(2).isNull(i)).isFalse();
-                assertThat(output.getBlock(3).isNull(i)).isFalse();
-                assertThat(BIGINT.getLong(output.getBlock(2), i)).isEqualTo(i / 2);
-                assertThat(BIGINT.getLong(output.getBlock(3), i)).isEqualTo(i / 2);
+                assertThat(output.getFieldBlock(2).isNull(i)).isFalse();
+                assertThat(output.getFieldBlock(3).isNull(i)).isFalse();
+                assertThat(BIGINT.getLong(output.getFieldBlock(2), i)).isEqualTo(i / 2);
+                assertThat(BIGINT.getLong(output.getFieldBlock(3), i)).isEqualTo(i / 2);
             }
             else {
-                assertThat(output.getBlock(2).isNull(i)).isTrue();
-                assertThat(output.getBlock(3).isNull(i)).isTrue();
+                assertThat(output.getFieldBlock(2).isNull(i)).isTrue();
+                assertThat(output.getFieldBlock(3).isNull(i)).isTrue();
             }
         }
         assertThat(lookupJoinPageBuilder.toString().contains("positionCount=" + output.getPositionCount())).isTrue();
@@ -99,7 +99,7 @@ public class TestLookupJoinPageBuilder
         JoinProbe probe = joinProbeFactory.createJoinProbe(page);
         Page output = lookupJoinPageBuilder.build(probe);
         assertThat(output.getChannelCount()).isEqualTo(2);
-        assertThat(output.getBlock(0)).isInstanceOf(LongArrayBlock.class);
+        assertThat(output.getFieldBlock(0)).isInstanceOf(LongArrayBlock.class);
         assertThat(output.getPositionCount()).isEqualTo(0);
         lookupJoinPageBuilder.reset();
 
@@ -113,11 +113,11 @@ public class TestLookupJoinPageBuilder
         }
         output = lookupJoinPageBuilder.build(probe);
         assertThat(output.getChannelCount()).isEqualTo(2);
-        assertThat(output.getBlock(0)).isInstanceOf(DictionaryBlock.class);
+        assertThat(output.getFieldBlock(0)).isInstanceOf(DictionaryBlock.class);
         assertThat(output.getPositionCount()).isEqualTo(entries / 2);
         for (int i = 0; i < entries / 2; i++) {
-            assertThat(BIGINT.getLong(output.getBlock(0), i)).isEqualTo(i * 2L);
-            assertThat(BIGINT.getLong(output.getBlock(1), i)).isEqualTo(i * 2L);
+            assertThat(BIGINT.getLong(output.getFieldBlock(0), i)).isEqualTo(i * 2L);
+            assertThat(BIGINT.getLong(output.getFieldBlock(1), i)).isEqualTo(i * 2L);
         }
         lookupJoinPageBuilder.reset();
 
@@ -128,11 +128,11 @@ public class TestLookupJoinPageBuilder
         }
         output = lookupJoinPageBuilder.build(probe);
         assertThat(output.getChannelCount()).isEqualTo(2);
-        assertThat(output.getBlock(0)).isNotInstanceOf(DictionaryBlock.class);
+        assertThat(output.getFieldBlock(0)).isNotInstanceOf(DictionaryBlock.class);
         assertThat(output.getPositionCount()).isEqualTo(entries);
         for (int i = 0; i < entries; i++) {
-            assertThat(BIGINT.getLong(output.getBlock(0), i)).isEqualTo(i);
-            assertThat(BIGINT.getLong(output.getBlock(1), i)).isEqualTo(i);
+            assertThat(BIGINT.getLong(output.getFieldBlock(0), i)).isEqualTo(i);
+            assertThat(BIGINT.getLong(output.getFieldBlock(1), i)).isEqualTo(i);
         }
         lookupJoinPageBuilder.reset();
 
@@ -146,11 +146,11 @@ public class TestLookupJoinPageBuilder
         }
         output = lookupJoinPageBuilder.build(probe);
         assertThat(output.getChannelCount()).isEqualTo(2);
-        assertThat(output.getBlock(0)).isNotInstanceOf(DictionaryBlock.class);
+        assertThat(output.getFieldBlock(0)).isNotInstanceOf(DictionaryBlock.class);
         assertThat(output.getPositionCount()).isEqualTo(40);
         for (int i = 10; i < 50; i++) {
-            assertThat(BIGINT.getLong(output.getBlock(0), i - 10)).isEqualTo(i);
-            assertThat(BIGINT.getLong(output.getBlock(1), i - 10)).isEqualTo(i);
+            assertThat(BIGINT.getLong(output.getFieldBlock(0), i - 10)).isEqualTo(i);
+            assertThat(BIGINT.getLong(output.getFieldBlock(1), i - 10)).isEqualTo(i);
         }
     }
 
@@ -238,7 +238,7 @@ public class TestLookupJoinPageBuilder
         public void appendTo(long position, PageBuilder pageBuilder, int outputChannelOffset)
         {
             for (int i = 0; i < types.size(); i++) {
-                types.get(i).appendTo(page.getBlock(i), (int) position, pageBuilder.getBlockBuilder(i));
+                types.get(i).appendTo(page.getFieldBlock(i), (int) position, pageBuilder.getBlockBuilder(i));
             }
         }
 

--- a/core/trino-main/src/test/java/io/trino/operator/join/TestPositionLinks.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/TestPositionLinks.java
@@ -67,7 +67,7 @@ public class TestPositionLinks
     public void testSortedPositionLinks()
     {
         JoinFilterFunction filterFunction = (leftAddress, rightPosition, rightPage) ->
-                BIGINT.getLong(TEST_PAGE.getBlock(0), leftAddress) > 4;
+                BIGINT.getLong(TEST_PAGE.getFieldBlock(0), leftAddress) > 4;
 
         PositionLinks.FactoryBuilder factoryBuilder = buildSortedPositionLinks();
         PositionLinks positionLinks = factoryBuilder.build().create(ImmutableList.of(filterFunction));
@@ -98,7 +98,7 @@ public class TestPositionLinks
     public void testSortedPositionLinksAllMatch()
     {
         JoinFilterFunction filterFunction = (leftAddress, rightPosition, rightPage) ->
-                BIGINT.getLong(rightPage.getBlock(0), leftAddress) >= 0;
+                BIGINT.getLong(rightPage.getFieldBlock(0), leftAddress) >= 0;
 
         PositionLinks.FactoryBuilder factoryBuilder = buildSortedPositionLinks();
         PositionLinks positionLinks = factoryBuilder.build().create(ImmutableList.of(filterFunction));
@@ -133,9 +133,9 @@ public class TestPositionLinks
     @Test
     public void testSortedPositionLinksForRangePredicates()
     {
-        JoinFilterFunction filterFunctionOne = (leftAddress, rightPosition, rightPage) -> BIGINT.getLong(TEST_PAGE.getBlock(0), leftAddress) > 4;
+        JoinFilterFunction filterFunctionOne = (leftAddress, rightPosition, rightPage) -> BIGINT.getLong(TEST_PAGE.getFieldBlock(0), leftAddress) > 4;
 
-        JoinFilterFunction filterFunctionTwo = (leftAddress, rightPosition, rightPage) -> BIGINT.getLong(TEST_PAGE.getBlock(0), leftAddress) <= 11;
+        JoinFilterFunction filterFunctionTwo = (leftAddress, rightPosition, rightPage) -> BIGINT.getLong(TEST_PAGE.getFieldBlock(0), leftAddress) <= 11;
 
         PositionLinks.FactoryBuilder factoryBuilder = buildSortedPositionLinks();
         PositionLinks positionLinks = factoryBuilder.build().create(ImmutableList.of(filterFunctionOne, filterFunctionTwo));
@@ -164,9 +164,9 @@ public class TestPositionLinks
     @Test
     public void testSortedPositionLinksForRangePredicatesPrefixMatch()
     {
-        JoinFilterFunction filterFunctionOne = (leftAddress, rightPosition, rightPage) -> BIGINT.getLong(rightPage.getBlock(0), leftAddress) >= 0;
+        JoinFilterFunction filterFunctionOne = (leftAddress, rightPosition, rightPage) -> BIGINT.getLong(rightPage.getFieldBlock(0), leftAddress) >= 0;
 
-        JoinFilterFunction filterFunctionTwo = (leftAddress, rightPosition, rightPage) -> BIGINT.getLong(rightPage.getBlock(0), leftAddress) <= 11;
+        JoinFilterFunction filterFunctionTwo = (leftAddress, rightPosition, rightPage) -> BIGINT.getLong(rightPage.getFieldBlock(0), leftAddress) <= 11;
 
         PositionLinks.FactoryBuilder factoryBuilder = buildSortedPositionLinks();
         PositionLinks positionLinks = factoryBuilder.build().create(ImmutableList.of(filterFunctionOne, filterFunctionTwo));
@@ -199,9 +199,9 @@ public class TestPositionLinks
     @Test
     public void testSortedPositionLinksForRangePredicatesSuffixMatch()
     {
-        JoinFilterFunction filterFunctionOne = (leftAddress, rightPosition, rightPage) -> BIGINT.getLong(rightPage.getBlock(0), leftAddress) > 4;
+        JoinFilterFunction filterFunctionOne = (leftAddress, rightPosition, rightPage) -> BIGINT.getLong(rightPage.getFieldBlock(0), leftAddress) > 4;
 
-        JoinFilterFunction filterFunctionTwo = (leftAddress, rightPosition, rightPage) -> BIGINT.getLong(rightPage.getBlock(0), leftAddress) < 100;
+        JoinFilterFunction filterFunctionTwo = (leftAddress, rightPosition, rightPage) -> BIGINT.getLong(rightPage.getFieldBlock(0), leftAddress) < 100;
 
         PositionLinks.FactoryBuilder factoryBuilder = buildSortedPositionLinks();
         PositionLinks positionLinks = factoryBuilder.build().create(ImmutableList.of(filterFunctionOne, filterFunctionTwo));
@@ -233,7 +233,7 @@ public class TestPositionLinks
     public void testReverseSortedPositionLinks()
     {
         JoinFilterFunction filterFunction = (leftAddress, rightPosition, rightPage) ->
-                BIGINT.getLong(TEST_PAGE.getBlock(0), leftAddress) < 4;
+                BIGINT.getLong(TEST_PAGE.getFieldBlock(0), leftAddress) < 4;
 
         PositionLinks.FactoryBuilder factoryBuilder = buildSortedPositionLinks();
         PositionLinks positionLinks = factoryBuilder.build().create(ImmutableList.of(filterFunction));
@@ -251,7 +251,7 @@ public class TestPositionLinks
     public void testReverseSortedPositionLinksAllMatch()
     {
         JoinFilterFunction filterFunction = (leftAddress, rightPosition, rightPage) ->
-                BIGINT.getLong(rightPage.getBlock(0), leftAddress) < 13;
+                BIGINT.getLong(rightPage.getFieldBlock(0), leftAddress) < 13;
 
         PositionLinks.FactoryBuilder factoryBuilder = buildSortedPositionLinks();
         PositionLinks positionLinks = factoryBuilder.build().create(ImmutableList.of(filterFunction));
@@ -314,7 +314,7 @@ public class TestPositionLinks
         return new SimplePagesHashStrategy(
                 ImmutableList.of(BIGINT),
                 ImmutableList.of(),
-                ImmutableList.of(new ObjectArrayList<>(ImmutableList.of(TEST_PAGE.getBlock(0)))),
+                ImmutableList.of(new ObjectArrayList<>(ImmutableList.of(TEST_PAGE.getFieldBlock(0)))),
                 ImmutableList.of(),
                 OptionalInt.empty(),
                 Optional.of(0),

--- a/core/trino-main/src/test/java/io/trino/operator/join/unspilled/BenchmarkHashBuildAndJoinOperators.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/unspilled/BenchmarkHashBuildAndJoinOperators.java
@@ -415,7 +415,7 @@ public class BenchmarkHashBuildAndJoinOperators
 
         for (int channel = 0; channel < types.size(); channel++) {
             Type type = types.get(channel);
-            type.appendTo(page.getBlock(channel), position, pageBuilder.getBlockBuilder(channel));
+            type.appendTo(page.getFieldBlock(channel), position, pageBuilder.getBlockBuilder(channel));
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/join/unspilled/TestLookupJoinPageBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/unspilled/TestLookupJoinPageBuilder.java
@@ -58,22 +58,22 @@ public class TestLookupJoinPageBuilder
 
         Page output = lookupJoinPageBuilder.build(probe);
         assertThat(output.getChannelCount()).isEqualTo(4);
-        assertThat(output.getBlock(0)).isInstanceOf(DictionaryBlock.class);
-        assertThat(output.getBlock(1)).isInstanceOf(DictionaryBlock.class);
+        assertThat(output.getFieldBlock(0)).isInstanceOf(DictionaryBlock.class);
+        assertThat(output.getFieldBlock(1)).isInstanceOf(DictionaryBlock.class);
         for (int i = 0; i < output.getPositionCount(); i++) {
-            assertThat(output.getBlock(0).isNull(i)).isFalse();
-            assertThat(output.getBlock(1).isNull(i)).isFalse();
-            assertThat(BIGINT.getLong(output.getBlock(0), i)).isEqualTo(i / 2);
-            assertThat(BIGINT.getLong(output.getBlock(1), i)).isEqualTo(i / 2);
+            assertThat(output.getFieldBlock(0).isNull(i)).isFalse();
+            assertThat(output.getFieldBlock(1).isNull(i)).isFalse();
+            assertThat(BIGINT.getLong(output.getFieldBlock(0), i)).isEqualTo(i / 2);
+            assertThat(BIGINT.getLong(output.getFieldBlock(1), i)).isEqualTo(i / 2);
             if (i % 2 == 0) {
-                assertThat(output.getBlock(2).isNull(i)).isFalse();
-                assertThat(output.getBlock(3).isNull(i)).isFalse();
-                assertThat(BIGINT.getLong(output.getBlock(2), i)).isEqualTo(i / 2);
-                assertThat(BIGINT.getLong(output.getBlock(3), i)).isEqualTo(i / 2);
+                assertThat(output.getFieldBlock(2).isNull(i)).isFalse();
+                assertThat(output.getFieldBlock(3).isNull(i)).isFalse();
+                assertThat(BIGINT.getLong(output.getFieldBlock(2), i)).isEqualTo(i / 2);
+                assertThat(BIGINT.getLong(output.getFieldBlock(3), i)).isEqualTo(i / 2);
             }
             else {
-                assertThat(output.getBlock(2).isNull(i)).isTrue();
-                assertThat(output.getBlock(3).isNull(i)).isTrue();
+                assertThat(output.getFieldBlock(2).isNull(i)).isTrue();
+                assertThat(output.getFieldBlock(3).isNull(i)).isTrue();
             }
         }
         assertThat(lookupJoinPageBuilder.toString()).contains("positionCount=" + output.getPositionCount());
@@ -100,7 +100,7 @@ public class TestLookupJoinPageBuilder
         JoinProbe probe = joinProbeFactory.createJoinProbe(page, lookupSource);
         Page output = lookupJoinPageBuilder.build(probe);
         assertThat(output.getChannelCount()).isEqualTo(2);
-        assertThat(output.getBlock(0)).isInstanceOf(LongArrayBlock.class);
+        assertThat(output.getFieldBlock(0)).isInstanceOf(LongArrayBlock.class);
         assertThat(output.getPositionCount()).isEqualTo(0);
         lookupJoinPageBuilder.reset();
 
@@ -114,11 +114,11 @@ public class TestLookupJoinPageBuilder
         }
         output = lookupJoinPageBuilder.build(probe);
         assertThat(output.getChannelCount()).isEqualTo(2);
-        assertThat(output.getBlock(0)).isInstanceOf(DictionaryBlock.class);
+        assertThat(output.getFieldBlock(0)).isInstanceOf(DictionaryBlock.class);
         assertThat(output.getPositionCount()).isEqualTo(entries / 2);
         for (int i = 0; i < entries / 2; i++) {
-            assertThat(BIGINT.getLong(output.getBlock(0), i)).isEqualTo(i * 2L);
-            assertThat(BIGINT.getLong(output.getBlock(1), i)).isEqualTo(i * 2L);
+            assertThat(BIGINT.getLong(output.getFieldBlock(0), i)).isEqualTo(i * 2L);
+            assertThat(BIGINT.getLong(output.getFieldBlock(1), i)).isEqualTo(i * 2L);
         }
         lookupJoinPageBuilder.reset();
 
@@ -129,11 +129,11 @@ public class TestLookupJoinPageBuilder
         }
         output = lookupJoinPageBuilder.build(probe);
         assertThat(output.getChannelCount()).isEqualTo(2);
-        assertThat(output.getBlock(0)).isNotInstanceOf(DictionaryBlock.class);
+        assertThat(output.getFieldBlock(0)).isNotInstanceOf(DictionaryBlock.class);
         assertThat(output.getPositionCount()).isEqualTo(entries);
         for (int i = 0; i < entries; i++) {
-            assertThat(BIGINT.getLong(output.getBlock(0), i)).isEqualTo(i);
-            assertThat(BIGINT.getLong(output.getBlock(1), i)).isEqualTo(i);
+            assertThat(BIGINT.getLong(output.getFieldBlock(0), i)).isEqualTo(i);
+            assertThat(BIGINT.getLong(output.getFieldBlock(1), i)).isEqualTo(i);
         }
         lookupJoinPageBuilder.reset();
 
@@ -147,11 +147,11 @@ public class TestLookupJoinPageBuilder
         }
         output = lookupJoinPageBuilder.build(probe);
         assertThat(output.getChannelCount()).isEqualTo(2);
-        assertThat(output.getBlock(0)).isNotInstanceOf(DictionaryBlock.class);
+        assertThat(output.getFieldBlock(0)).isNotInstanceOf(DictionaryBlock.class);
         assertThat(output.getPositionCount()).isEqualTo(40);
         for (int i = 10; i < 50; i++) {
-            assertThat(BIGINT.getLong(output.getBlock(0), i - 10)).isEqualTo(i);
-            assertThat(BIGINT.getLong(output.getBlock(1), i - 10)).isEqualTo(i);
+            assertThat(BIGINT.getLong(output.getFieldBlock(0), i - 10)).isEqualTo(i);
+            assertThat(BIGINT.getLong(output.getFieldBlock(1), i - 10)).isEqualTo(i);
         }
     }
 
@@ -239,7 +239,7 @@ public class TestLookupJoinPageBuilder
         public void appendTo(long position, PageBuilder pageBuilder, int outputChannelOffset)
         {
             for (int i = 0; i < types.size(); i++) {
-                types.get(i).appendTo(page.getBlock(i), (int) position, pageBuilder.getBlockBuilder(i));
+                types.get(i).appendTo(page.getFieldBlock(i), (int) position, pageBuilder.getBlockBuilder(i));
             }
         }
 

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPagePartitioner.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPagePartitioner.java
@@ -637,7 +637,7 @@ public class TestPagePartitioner
         List<Object> result = new ArrayList<>();
 
         pages.forEach(page -> {
-            Block block = page.getBlock(channel);
+            Block block = page.getFieldBlock(channel);
             for (int i = 0; i < block.getPositionCount(); i++) {
                 if (block.isNull(i)) {
                     result.add(null);
@@ -984,7 +984,7 @@ public class TestPagePartitioner
         {
             long value = 0;
             for (int hashChannel : hashChannels) {
-                value += BIGINT.getLong(page.getBlock(hashChannel), position);
+                value += BIGINT.getLong(page.getFieldBlock(hashChannel), position);
             }
 
             return toIntExact(Math.abs(value) % partitionCount);

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppenderPageBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppenderPageBuilder.java
@@ -122,7 +122,7 @@ public class TestPositionsAppenderPageBuilder
         assertThat(result.getPositionCount())
                 .as("result positions should be below the 8192 maximum")
                 .isEqualTo(120);
-        assertThat(result.getBlock(0) instanceof RunLengthEncodedBlock)
+        assertThat(result.getFieldBlock(0) instanceof RunLengthEncodedBlock)
                 .as("result block is RLE encoded")
                 .isTrue();
     }
@@ -152,7 +152,7 @@ public class TestPositionsAppenderPageBuilder
         assertThat(flushedPage.isPresent())
                 .as("pageBuilder should force flush the dictionary")
                 .isTrue();
-        assertThat(flushedPage.get().getBlock(0) instanceof DictionaryBlock)
+        assertThat(flushedPage.get().getFieldBlock(0) instanceof DictionaryBlock)
                 .as("result should be dictionary encoded")
                 .isTrue();
     }
@@ -186,7 +186,7 @@ public class TestPositionsAppenderPageBuilder
                 .as("pageBuilder should have transitioned to direct mode").isEqualTo(valueBlock.getSizeInBytes());
 
         Page result = pageBuilder.build();
-        assertThat(result.getBlock(0) instanceof ValueBlock)
+        assertThat(result.getFieldBlock(0) instanceof ValueBlock)
                 .as("result should not be a dictionary block")
                 .isTrue();
     }

--- a/core/trino-main/src/test/java/io/trino/operator/project/TestDictionaryAwarePageFilter.java
+++ b/core/trino-main/src/test/java/io/trino/operator/project/TestDictionaryAwarePageFilter.java
@@ -276,7 +276,7 @@ public class TestDictionaryAwarePageFilter
         public SelectedPositions filter(ConnectorSession session, Page page)
         {
             assertThat(page.getChannelCount()).isEqualTo(1);
-            Block block = page.getBlock(0);
+            Block block = page.getFieldBlock(0);
 
             boolean sequential = true;
             IntArrayList selectedPositions = new IntArrayList();

--- a/core/trino-main/src/test/java/io/trino/operator/project/TestDictionaryAwarePageProjection.java
+++ b/core/trino-main/src/test/java/io/trino/operator/project/TestDictionaryAwarePageProjection.java
@@ -432,7 +432,7 @@ public class TestDictionaryAwarePageProjection
             public TestPageProjectionWork(DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
             {
                 this.yieldSignal = yieldSignal;
-                this.block = page.getBlock(0);
+                this.block = page.getFieldBlock(0);
                 this.selectedPositions = selectedPositions;
                 this.blockBuilder = BIGINT.createBlockBuilder(null, selectedPositions.size());
             }

--- a/core/trino-main/src/test/java/io/trino/operator/project/TestMergePages.java
+++ b/core/trino-main/src/test/java/io/trino/operator/project/TestMergePages.java
@@ -79,9 +79,9 @@ public class TestMergePages
     {
         Page page = createSequencePage(TYPES, 10);
 
-        LazyBlock channel1 = lazyWrapper(page.getBlock(0));
-        LazyBlock channel2 = lazyWrapper(page.getBlock(1));
-        LazyBlock channel3 = lazyWrapper(page.getBlock(2));
+        LazyBlock channel1 = lazyWrapper(page.getFieldBlock(0));
+        LazyBlock channel2 = lazyWrapper(page.getFieldBlock(1));
+        LazyBlock channel3 = lazyWrapper(page.getFieldBlock(2));
         page = new Page(channel1, channel2, channel3);
 
         WorkProcessor<Page> mergePages = mergePages(

--- a/core/trino-main/src/test/java/io/trino/operator/project/TestPageFieldsToInputParametersRewriter.java
+++ b/core/trino-main/src/test/java/io/trino/operator/project/TestPageFieldsToInputParametersRewriter.java
@@ -136,7 +136,7 @@ public class TestPageFieldsToInputParametersRewriter
         }
         Page page = result.getInputChannels().getInputChannels(new Page(blocks));
         for (int channel = 0; channel < columnCount; channel++) {
-            assertThat(page.getBlock(channel).isLoaded()).isEqualTo(eagerlyLoadedChannels.contains(channel));
+            assertThat(page.getFieldBlock(channel).isLoaded()).isEqualTo(eagerlyLoadedChannels.contains(channel));
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/project/TestPageProcessor.java
+++ b/core/trino-main/src/test/java/io/trino/operator/project/TestPageProcessor.java
@@ -316,7 +316,7 @@ public class TestPageProcessor
 
         // batch size will be reduced before the first page is produced until the first block is within the page size bounds
         int batchSize = MAX_BATCH_SIZE;
-        while (inputPage.getBlock(0).getRegionSizeInBytes(0, batchSize) > MAX_PAGE_SIZE_IN_BYTES) {
+        while (inputPage.getFieldBlock(0).getRegionSizeInBytes(0, batchSize) > MAX_PAGE_SIZE_IN_BYTES) {
             batchSize /= 2;
         }
 
@@ -655,7 +655,7 @@ public class TestPageProcessor
         @Override
         public Work<Block> project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
         {
-            return new CompletedWork<>(page.getBlock(0).getLoadedBlock());
+            return new CompletedWork<>(page.getFieldBlock(0).getLoadedBlock());
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestPageProcessorCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestPageProcessorCompiler.java
@@ -85,13 +85,13 @@ public class TestPageProcessorCompiler
                 .orElseThrow(() -> new AssertionError("page is not present"));
 
         assertThat(outputPage.getPositionCount()).isEqualTo(100);
-        assertThat(outputPage.getBlock(0) instanceof RunLengthEncodedBlock).isTrue();
-        assertThat(outputPage.getBlock(1) instanceof RunLengthEncodedBlock).isTrue();
+        assertThat(outputPage.getFieldBlock(0) instanceof RunLengthEncodedBlock).isTrue();
+        assertThat(outputPage.getFieldBlock(1) instanceof RunLengthEncodedBlock).isTrue();
 
-        RunLengthEncodedBlock rleBlock = (RunLengthEncodedBlock) outputPage.getBlock(0);
+        RunLengthEncodedBlock rleBlock = (RunLengthEncodedBlock) outputPage.getFieldBlock(0);
         assertThat(BIGINT.getLong(rleBlock.getValue(), 0)).isEqualTo(123L);
 
-        RunLengthEncodedBlock rleBlock1 = (RunLengthEncodedBlock) outputPage.getBlock(1);
+        RunLengthEncodedBlock rleBlock1 = (RunLengthEncodedBlock) outputPage.getFieldBlock(1);
         assertThat(VARCHAR.getSlice(rleBlock1.getValue(), 0)).isEqualTo(varcharValue);
     }
 
@@ -116,9 +116,9 @@ public class TestPageProcessorCompiler
                 .orElseThrow(() -> new AssertionError("page is not present"));
 
         assertThat(outputPage.getPositionCount()).isEqualTo(100);
-        assertThat(outputPage.getBlock(0) instanceof DictionaryBlock).isTrue();
+        assertThat(outputPage.getFieldBlock(0) instanceof DictionaryBlock).isTrue();
 
-        DictionaryBlock dictionaryBlock = (DictionaryBlock) outputPage.getBlock(0);
+        DictionaryBlock dictionaryBlock = (DictionaryBlock) outputPage.getFieldBlock(0);
         assertThat(dictionaryBlock.getDictionary().getPositionCount()).isEqualTo(10);
 
         // test filter caching
@@ -129,9 +129,9 @@ public class TestPageProcessorCompiler
                         newSimpleAggregatedMemoryContext().newLocalMemoryContext(PageProcessor.class.getSimpleName()),
                         page)).orElseThrow(() -> new AssertionError("page is not present"));
         assertThat(outputPage2.getPositionCount()).isEqualTo(100);
-        assertThat(outputPage2.getBlock(0) instanceof DictionaryBlock).isTrue();
+        assertThat(outputPage2.getFieldBlock(0) instanceof DictionaryBlock).isTrue();
 
-        DictionaryBlock dictionaryBlock2 = (DictionaryBlock) outputPage2.getBlock(0);
+        DictionaryBlock dictionaryBlock2 = (DictionaryBlock) outputPage2.getFieldBlock(0);
         // both output pages must have the same dictionary
         assertThat(dictionaryBlock2.getDictionary()).isEqualTo(dictionaryBlock.getDictionary());
     }
@@ -154,9 +154,9 @@ public class TestPageProcessorCompiler
                 .orElseThrow(() -> new AssertionError("page is not present"));
 
         assertThat(outputPage.getPositionCount()).isEqualTo(100);
-        assertThat(outputPage.getBlock(0) instanceof RunLengthEncodedBlock).isTrue();
+        assertThat(outputPage.getFieldBlock(0) instanceof RunLengthEncodedBlock).isTrue();
 
-        RunLengthEncodedBlock rle = (RunLengthEncodedBlock) outputPage.getBlock(0);
+        RunLengthEncodedBlock rle = (RunLengthEncodedBlock) outputPage.getFieldBlock(0);
         assertThat(BIGINT.getLong(rle.getValue(), 0)).isEqualTo(5L);
     }
 
@@ -175,9 +175,9 @@ public class TestPageProcessorCompiler
                 .orElseThrow(() -> new AssertionError("page is not present"));
 
         assertThat(outputPage.getPositionCount()).isEqualTo(100);
-        assertThat(outputPage.getBlock(0) instanceof DictionaryBlock).isTrue();
+        assertThat(outputPage.getFieldBlock(0) instanceof DictionaryBlock).isTrue();
 
-        DictionaryBlock dictionaryBlock = (DictionaryBlock) outputPage.getBlock(0);
+        DictionaryBlock dictionaryBlock = (DictionaryBlock) outputPage.getFieldBlock(0);
         assertThat(dictionaryBlock.getDictionary().getPositionCount()).isEqualTo(10);
     }
 
@@ -203,7 +203,7 @@ public class TestPageProcessorCompiler
                         newSimpleAggregatedMemoryContext().newLocalMemoryContext(PageProcessor.class.getSimpleName()),
                         page))
                 .orElseThrow(() -> new AssertionError("page is not present"));
-        assertThat(outputPage.getBlock(0) instanceof DictionaryBlock).isFalse();
+        assertThat(outputPage.getFieldBlock(0) instanceof DictionaryBlock).isFalse();
     }
 
     private static Block createDictionaryBlock(Slice[] expectedValues, int positionCount)

--- a/core/trino-main/src/test/java/io/trino/operator/unnest/TestingUnnesterUtil.java
+++ b/core/trino-main/src/test/java/io/trino/operator/unnest/TestingUnnesterUtil.java
@@ -270,7 +270,7 @@ public final class TestingUnnesterUtil
 
         for (int i = 0; i < unnestChannelCount; i++) {
             Type type = unnestTypes.get(i);
-            Block block = page.getBlock(replicatedChannelCount + i);
+            Block block = page.getFieldBlock(replicatedChannelCount + i);
             assertThat(type instanceof ArrayType || type instanceof MapType).isTrue();
 
             if (type instanceof ArrayType) {
@@ -324,12 +324,12 @@ public final class TestingUnnesterUtil
         int outputChannel = 0;
 
         for (int i = 0; i < replicatedTypes.size(); i++) {
-            outputBlocks[outputChannel++] = buildExpectedReplicatedBlock(page.getBlock(i), replicatedTypes.get(i), maxCardinalities, totalEntries);
+            outputBlocks[outputChannel++] = buildExpectedReplicatedBlock(page.getFieldBlock(i), replicatedTypes.get(i), maxCardinalities, totalEntries);
         }
 
         for (int i = 0; i < unnestTypes.size(); i++) {
             Type type = unnestTypes.get(i);
-            Block inputBlock = page.getBlock(replicatedTypes.size() + i);
+            Block inputBlock = page.getFieldBlock(replicatedTypes.size() + i);
 
             if (type instanceof ArrayType) {
                 Type elementType = ((ArrayType) type).getElementType();
@@ -406,7 +406,7 @@ public final class TestingUnnesterUtil
 
             for (int i = 0; i < types.size(); i++) {
                 BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(i);
-                Block block = page.getBlock(i);
+                Block block = page.getFieldBlock(i);
                 for (int position = 0; position < page.getPositionCount(); position++) {
                     if (block.isNull(position)) {
                         blockBuilder.appendNull();

--- a/core/trino-main/src/test/java/io/trino/spiller/TestGenericPartitioningSpiller.java
+++ b/core/trino-main/src/test/java/io/trino/spiller/TestGenericPartitioningSpiller.java
@@ -251,7 +251,7 @@ public class TestGenericPartitioningSpiller
         @Override
         public int getPartition(Page page, int position)
         {
-            long value = BIGINT.getLong(page.getBlock(valueChannel), position);
+            long value = BIGINT.getLong(page.getFieldBlock(valueChannel), position);
             if (value >= FOURTH_PARTITION_START) {
                 return 3;
             }
@@ -287,7 +287,7 @@ public class TestGenericPartitioningSpiller
         @Override
         public int getPartition(Page page, int position)
         {
-            long value = BIGINT.getLong(page.getBlock(valueChannel), position);
+            long value = BIGINT.getLong(page.getFieldBlock(valueChannel), position);
             return toIntExact(Math.abs(value) % partitionCount);
         }
     }

--- a/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkDynamicPageFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkDynamicPageFilter.java
@@ -115,7 +115,7 @@ public class BenchmarkDynamicPageFilter
             List<Page> filterValues = createSingleColumnData(valueWriter, type, 0, filterSize);
             ImmutableList.Builder<Object> valuesBuilder = ImmutableList.builder();
             for (Page page : filterValues) {
-                Block block = page.getBlock(0).getLoadedBlock();
+                Block block = page.getFieldBlock(0).getLoadedBlock();
                 for (int position = 0; position < block.getPositionCount(); position++) {
                     valuesBuilder.add(readNativeValue(type, block, position));
                 }

--- a/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkPageProcessor.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkPageProcessor.java
@@ -138,7 +138,7 @@ public class BenchmarkPageProcessor
     {
         public static int process(Page page, int start, int end, PageBuilder pageBuilder)
         {
-            Block discountBlock = page.getBlock(DISCOUNT);
+            Block discountBlock = page.getFieldBlock(DISCOUNT);
             int position = start;
             for (; position < end; position++) {
                 // where shipdate >= '1994-01-01'
@@ -146,8 +146,8 @@ public class BenchmarkPageProcessor
                 //    and discount >= 0.05
                 //    and discount <= 0.07
                 //    and quantity < 24;
-                if (filter(position, discountBlock, page.getBlock(SHIP_DATE), page.getBlock(QUANTITY))) {
-                    project(position, pageBuilder, page.getBlock(EXTENDED_PRICE), discountBlock);
+                if (filter(position, discountBlock, page.getFieldBlock(SHIP_DATE), page.getFieldBlock(QUANTITY))) {
+                    project(position, pageBuilder, page.getFieldBlock(EXTENDED_PRICE), discountBlock);
                 }
             }
 

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestColumnarFilters.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestColumnarFilters.java
@@ -933,7 +933,7 @@ public class TestColumnarFilters
         assertThat(types.size()).isEqualTo(actual.getChannelCount());
 
         for (int channel = 0; channel < types.size(); channel++) {
-            assertBlockEquals(types.get(channel), actual.getBlock(channel), expected.getBlock(channel));
+            assertBlockEquals(types.get(channel), actual.getFieldBlock(channel), expected.getFieldBlock(channel));
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestDictionaryAwareColumnarFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestDictionaryAwareColumnarFilter.java
@@ -261,7 +261,7 @@ public class TestDictionaryAwareColumnarFilter
         public int filterPositionsRange(ConnectorSession session, int[] outputPositions, int offset, int size, Page loadedPage)
         {
             assertThat(loadedPage.getChannelCount()).isEqualTo(1);
-            Block block = loadedPage.getBlock(0);
+            Block block = loadedPage.getFieldBlock(0);
 
             int outputPositionsCount = 0;
             for (int position = offset; position < offset + size; position++) {
@@ -287,7 +287,7 @@ public class TestDictionaryAwareColumnarFilter
         public int filterPositionsList(ConnectorSession session, int[] outputPositions, int[] activePositions, int offset, int size, Page loadedPage)
         {
             assertThat(loadedPage.getChannelCount()).isEqualTo(1);
-            Block block = loadedPage.getBlock(0);
+            Block block = loadedPage.getFieldBlock(0);
 
             int outputPositionsCount = 0;
             for (int index = offset; index < offset + size; index++) {

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestDynamicPageFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestDynamicPageFilter.java
@@ -360,7 +360,7 @@ public class TestDynamicPageFilter
 
         // EffectiveFilterProfiler should turn off row filtering
         assertThat(filterPage(inputPages.get(2), filterEvaluator).size()).isEqualTo(1024);
-        assertThat(inputPages.get(2).getBlock(0)).isInstanceOf(LazyBlock.class);
+        assertThat(inputPages.get(2).getFieldBlock(0)).isInstanceOf(LazyBlock.class);
     }
 
     @Test
@@ -395,7 +395,7 @@ public class TestDynamicPageFilter
 
         // EffectiveFilterProfiler should turn off row filtering only for the first column filter
         assertThat(filterPage(inputPages.get(2), filterEvaluator).size()).isEqualTo(1);
-        assertThat(inputPages.get(2).getBlock(0)).isInstanceOf(LazyBlock.class);
+        assertThat(inputPages.get(2).getFieldBlock(0)).isInstanceOf(LazyBlock.class);
     }
 
     @Test
@@ -416,7 +416,7 @@ public class TestDynamicPageFilter
 
         // EffectiveFilterProfiler should turn off row filtering only for the last column filter
         assertThat(filterPage(inputPages.get(3), filterEvaluator).size()).isEqualTo(900);
-        assertThat(inputPages.get(3).getBlock(1)).isInstanceOf(LazyBlock.class);
+        assertThat(inputPages.get(3).getFieldBlock(1)).isInstanceOf(LazyBlock.class);
     }
 
     @Test
@@ -434,9 +434,9 @@ public class TestDynamicPageFilter
                 ImmutableMap.of(columnA, 0, columnB, 1, columnC, 2));
         for (Page inputPage : inputPages) {
             assertThat(filterPage(inputPage, filterEvaluator).size()).isEqualTo(0);
-            assertThat(inputPage.getBlock(0)).isNotInstanceOf(LazyBlock.class);
-            assertThat(inputPage.getBlock(1)).isNotInstanceOf(LazyBlock.class);
-            assertThat(inputPage.getBlock(2)).isInstanceOf(LazyBlock.class);
+            assertThat(inputPage.getFieldBlock(0)).isNotInstanceOf(LazyBlock.class);
+            assertThat(inputPage.getFieldBlock(1)).isNotInstanceOf(LazyBlock.class);
+            assertThat(inputPage.getFieldBlock(2)).isInstanceOf(LazyBlock.class);
         }
     }
 
@@ -453,11 +453,11 @@ public class TestDynamicPageFilter
                 ImmutableMap.of(columnB, 1, columnD, 3));
         for (Page inputPage : inputPages) {
             assertThat(filterPage(inputPage, filterEvaluator).size()).isEqualTo(5);
-            assertThat(inputPage.getBlock(0)).isInstanceOf(LazyBlock.class);
-            assertThat(inputPage.getBlock(1)).isNotInstanceOf(LazyBlock.class);
-            assertThat(inputPage.getBlock(2)).isInstanceOf(LazyBlock.class);
-            assertThat(inputPage.getBlock(3)).isNotInstanceOf(LazyBlock.class);
-            assertThat(inputPage.getBlock(4)).isInstanceOf(LazyBlock.class);
+            assertThat(inputPage.getFieldBlock(0)).isInstanceOf(LazyBlock.class);
+            assertThat(inputPage.getFieldBlock(1)).isNotInstanceOf(LazyBlock.class);
+            assertThat(inputPage.getFieldBlock(2)).isInstanceOf(LazyBlock.class);
+            assertThat(inputPage.getFieldBlock(3)).isNotInstanceOf(LazyBlock.class);
+            assertThat(inputPage.getFieldBlock(4)).isInstanceOf(LazyBlock.class);
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestJoinCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestJoinCompiler.java
@@ -142,7 +142,7 @@ public class TestJoinCompiler
                 }
 
                 // verify output block matches
-                assertBlockEquals(VARCHAR, pageBuilder.build().getBlock(0), leftBlock);
+                assertBlockEquals(VARCHAR, pageBuilder.build().getFieldBlock(0), leftBlock);
             }
         }
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDeleteAndInsertMergeProcessor.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDeleteAndInsertMergeProcessor.java
@@ -77,10 +77,10 @@ public class TestDeleteAndInsertMergeProcessor
         assertThat(outputPage.getPositionCount()).isEqualTo(1);
 
         // The single operation is a delete
-        assertThat((int) TINYINT.getByte(outputPage.getBlock(3), 0)).isEqualTo(DELETE_OPERATION_NUMBER);
+        assertThat((int) TINYINT.getByte(outputPage.getFieldBlock(3), 0)).isEqualTo(DELETE_OPERATION_NUMBER);
 
         // Show that the row to be deleted is rowId 0, e.g. ('Dave', 11, 'Devon')
-        SqlRow rowIdRow = ((RowBlock) outputPage.getBlock(4)).getRow(0);
+        SqlRow rowIdRow = ((RowBlock) outputPage.getFieldBlock(4)).getRow(0);
         assertThat(BIGINT.getLong(rowIdRow.getRawFieldBlock(1), rowIdRow.getRawIndex())).isEqualTo(0);
     }
 
@@ -123,10 +123,10 @@ public class TestDeleteAndInsertMergeProcessor
 
         Page outputPage = processor.transformPage(inputPage);
         assertThat(outputPage.getPositionCount()).isEqualTo(8);
-        RowBlock rowIdBlock = (RowBlock) outputPage.getBlock(4);
+        RowBlock rowIdBlock = (RowBlock) outputPage.getFieldBlock(4);
         assertThat(rowIdBlock.getPositionCount()).isEqualTo(8);
         // Show that the first row has address "Arches"
-        assertThat(getString(outputPage.getBlock(2), 1)).isEqualTo("Arches/Arches");
+        assertThat(getString(outputPage.getFieldBlock(2), 1)).isEqualTo("Arches/Arches");
     }
 
     @Test
@@ -163,10 +163,10 @@ Page[positions=8 0:Dict[VarWidth["Aaron", "Dave", "Dave", "Ed", "Aaron", "Carol"
 
         Page outputPage = processor.transformPage(inputPage);
         assertThat(outputPage.getPositionCount()).isEqualTo(8);
-        RowBlock rowIdBlock = (RowBlock) outputPage.getBlock(4);
+        RowBlock rowIdBlock = (RowBlock) outputPage.getFieldBlock(4);
         assertThat(rowIdBlock.getPositionCount()).isEqualTo(8);
         // Show that the first row has address "Arches/Arches"
-        assertThat(getString(outputPage.getBlock(2), 1)).isEqualTo("Arches/Arches");
+        assertThat(getString(outputPage.getFieldBlock(2), 1)).isEqualTo("Arches/Arches");
     }
 
     private static Page makePageFromBlocks(int positionCount, Optional<boolean[]> rowIdNulls, Block[] rowIdBlocks, Block[] mergeCaseBlocks)

--- a/core/trino-main/src/test/java/io/trino/type/TypeTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/type/TypeTestUtils.java
@@ -54,8 +54,8 @@ public final class TypeTestUtils
 
         for (int channel : hashChannels) {
             hashTypes.add(types.get(channel));
-            hashBlocks[hashBlockIndex++] = page.getBlock(channel);
+            hashBlocks[hashBlockIndex++] = page.getFieldBlock(channel);
         }
-        return page.appendColumn(getHashBlock(hashTypes.build(), hashBlocks));
+        return page.appendField(getHashBlock(hashTypes.build(), hashBlocks));
     }
 }

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -285,6 +285,33 @@
                                     <code>java.method.removed</code>
                                     <old>method long io.trino.spi.block.RunLengthEncodedBlock::getLogicalSizeInBytes()</old>
                                 </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method io.trino.spi.Page io.trino.spi.Page::getColumns(int)</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method io.trino.spi.Page io.trino.spi.Page::getLoadedPage(int)</old>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityIncreased</code>
+                                    <old>method long io.trino.spi.Page::updateRetainedSize()</old>
+                                    <new>method long io.trino.spi.block.RowBlock::updateRetainedSize() @ io.trino.spi.Page</new>
+                                    <oldVisibility>private</oldVisibility>
+                                    <newVisibility>protected</newVisibility>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityIncreased</code>
+                                    <old>method void io.trino.spi.block.RowBlock::&lt;init&gt;(int, boolean[], io.trino.spi.block.Block[], int)</old>
+                                    <new>method void io.trino.spi.block.RowBlock::&lt;init&gt;(int, boolean[], io.trino.spi.block.Block[], int)</new>
+                                    <oldVisibility>private</oldVisibility>
+                                    <newVisibility>protected</newVisibility>
+                                </item>
+                                <item>
+                                    <code>java.method.returnTypeChangedCovariantly</code>
+                                    <old>method io.trino.spi.block.Block io.trino.spi.block.RowBlock::getLoadedBlock()</old>
+                                    <new>method io.trino.spi.block.RowBlock io.trino.spi.block.RowBlock::getLoadedBlock()</new>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/Page.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/Page.java
@@ -82,7 +82,7 @@ public final class Page
     }
 
     /**
-     * @Deprecated Use {@link #getFieldBlock(int)} instead
+     * @deprecated Use {@link #getFieldBlock(int)} instead
      */
     @Deprecated
     public Block getBlock(int channel)
@@ -91,7 +91,7 @@ public final class Page
     }
 
     /**
-     * @Deprecated Use {@link #appendField(Block)} instead
+     * @deprecated Use {@link #appendField(Block)} instead
      */
     @Deprecated
     public Page appendColumn(Block block)
@@ -147,24 +147,30 @@ public final class Page
     }
 
     /**
-     * @Deprecated Use {@link #getLoadedBlock()} instead
+     * @deprecated Use {@link #getLoadedBlock()} instead
      */
     @Deprecated
     public Page getLoadedPage()
     {
-        return (Page) getLoadedBlock();
+        return getLoadedBlock();
+    }
+
+    @Override
+    public Page getLoadedBlock()
+    {
+        return (Page) super.getLoadedBlock();
     }
 
     public Page getLoadedPage(int... columns)
     {
         loadFields(columns);
-        return (Page) getFields(columns);
+        return getFields(columns);
     }
 
     public Page getLoadedPage(int[] columns, int[] eagerlyLoadedColumns)
     {
         loadFields(eagerlyLoadedColumns);
-        return (Page) getFields(columns);
+        return getFields(columns);
     }
 
     @Override
@@ -189,12 +195,12 @@ public final class Page
     }
 
     /**
-     * @Deprecated Use {@link #getSingleValueBlock(int)} instead
+     * @deprecated Use {@link #getSingleValueBlock(int)} instead
      */
     @Deprecated
     public Page getSingleValuePage(int position)
     {
-        return (Page) super.getSingleValueBlock(position);
+        return getSingleValueBlock(position);
     }
 
     @Override
@@ -229,16 +235,22 @@ public final class Page
     }
 
     /**
-     * @Deprecated Use {@link #getFields(int...)} instead
+     * @deprecated Use {@link #getFields(int...)} instead
      */
     @Deprecated
     public Page getColumns(int... columns)
     {
-        return (Page) getFields(columns);
+        return getFields(columns);
+    }
+
+    @Override
+    public Page getFields(int... columns)
+    {
+        return (Page) super.getFields(columns);
     }
 
     /**
-     * @Deprecated Use {@link #prependField(Block)} instead
+     * @deprecated Use {@link #prependField(Block)} instead
      */
     @Deprecated
     public Page prependColumn(Block column)

--- a/core/trino-spi/src/main/java/io/trino/spi/PageBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/PageBuilder.java
@@ -181,7 +181,7 @@ public class PageBuilder
             }
         }
 
-        return Page.wrapBlocksWithoutCopy(declaredPositions, blocks);
+        return Page.createPageInternal(declaredPositions, blocks);
     }
 
     private static void checkArgument(boolean expression, String errorMessage)

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
@@ -237,6 +237,7 @@ public sealed class RowBlock
         for (Block fieldBlock : fieldBlocks) {
             retainedSizeInBytes += fieldBlock.getRetainedSizeInBytes();
         }
+        this.retainedSizeInBytes = retainedSizeInBytes;
         return retainedSizeInBytes;
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
@@ -198,10 +198,7 @@ public sealed class RowBlock
             return sizeInBytes;
         }
 
-        sizeInBytes = 0;
-        if (rowIsNull != null) {
-            sizeInBytes += Byte.BYTES * (long) positionCount;
-        }
+        sizeInBytes = rowIsNull == null ? 0 : Byte.BYTES * (long) positionCount;
 
         boolean hasUnloadedBlocks = false;
         for (Block fieldBlock : fieldBlocks) {
@@ -393,7 +390,7 @@ public sealed class RowBlock
     {
         checkValidRegion(positionCount, position, length);
 
-        long regionSizeInBytes = Byte.BYTES * (long) length;
+        long regionSizeInBytes = rowIsNull == null ? 0 : Byte.BYTES * (long) length;
         for (Block fieldBlock : fieldBlocks) {
             regionSizeInBytes += fieldBlock.getRegionSizeInBytes(position, length);
         }
@@ -415,7 +412,7 @@ public sealed class RowBlock
             return fixedSizePerRow * (long) selectedRowPositions;
         }
 
-        long sizeInBytes = Byte.BYTES * (long) selectedRowPositions;
+        long sizeInBytes = rowIsNull == null ? 0 : Byte.BYTES * (long) selectedRowPositions;
         for (Block fieldBlock : fieldBlocks) {
             sizeInBytes += fieldBlock.getPositionsSizeInBytes(positions, selectedRowPositions);
         }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/MergePage.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/MergePage.java
@@ -70,7 +70,7 @@ public final class MergePage
         if (positionCount <= 0) {
             throw new IllegalArgumentException("positionCount should be > 0, but is " + positionCount);
         }
-        Block operationBlock = inputPage.getBlock(inputChannelCount - 2);
+        Block operationBlock = inputPage.getFieldBlock(inputChannelCount - 2);
 
         int[] deletePositions = new int[positionCount];
         int[] insertPositions = new int[positionCount];
@@ -101,14 +101,14 @@ public final class MergePage
             }
             columns[dataColumnCount] = dataColumnCount + 1; // row ID channel
             deletePage = Optional.of(inputPage
-                    .getColumns(columns)
+                    .getFields(columns)
                     .getPositions(deletePositions, 0, deletePositionCount));
         }
 
         Optional<Page> insertPage = Optional.empty();
         if (insertPositionCount > 0) {
             insertPage = Optional.of(inputPage
-                    .getColumns(IntStream.range(0, dataColumnCount).toArray())
+                    .getFields(IntStream.range(0, dataColumnCount).toArray())
                     .getPositions(insertPositions, 0, insertPositionCount));
         }
 

--- a/core/trino-spi/src/main/java/module-info.java
+++ b/core/trino-spi/src/main/java/module-info.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module trino.spi {
+    requires transitive com.fasterxml.jackson.annotation;
+    requires transitive com.google.errorprone.annotations;
+    requires transitive io.opentelemetry.api;
+    requires transitive jakarta.annotation;
+    requires java.logging;
+    requires transitive slice;
+
+    exports io.trino.spi;
+    exports io.trino.spi.block;
+    exports io.trino.spi.catalog;
+    exports io.trino.spi.classloader;
+    exports io.trino.spi.connector;
+    exports io.trino.spi.eventlistener;
+    exports io.trino.spi.exchange;
+    exports io.trino.spi.expression;
+    exports io.trino.spi.function;
+    exports io.trino.spi.function.table;
+    exports io.trino.spi.memory;
+    exports io.trino.spi.metrics;
+    exports io.trino.spi.predicate;
+    exports io.trino.spi.resourcegroups;
+    exports io.trino.spi.security;
+    exports io.trino.spi.session;
+    exports io.trino.spi.statistics;
+    exports io.trino.spi.transaction;
+    exports io.trino.spi.type;
+}

--- a/core/trino-spi/src/test/java/io/trino/spi/TestPage.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/TestPage.java
@@ -102,19 +102,19 @@ public class TestPage
         page.compact();
 
         // dictionary blocks should all be compact
-        assertThat(((DictionaryBlock) page.getBlock(0)).isCompact()).isTrue();
-        assertThat(((DictionaryBlock) page.getBlock(1)).isCompact()).isTrue();
-        assertThat(((DictionaryBlock) page.getBlock(2)).isCompact()).isTrue();
-        assertThat(((DictionaryBlock) page.getBlock(0)).getDictionary().getPositionCount()).isEqualTo(commonDictionaryUsedPositions);
-        assertThat(((DictionaryBlock) page.getBlock(1)).getDictionary().getPositionCount()).isEqualTo(otherDictionaryUsedPositions);
-        assertThat(((DictionaryBlock) page.getBlock(2)).getDictionary().getPositionCount()).isEqualTo(commonDictionaryUsedPositions);
+        assertThat(((DictionaryBlock) page.getFieldBlock(0)).isCompact()).isTrue();
+        assertThat(((DictionaryBlock) page.getFieldBlock(1)).isCompact()).isTrue();
+        assertThat(((DictionaryBlock) page.getFieldBlock(2)).isCompact()).isTrue();
+        assertThat(((DictionaryBlock) page.getFieldBlock(0)).getDictionary().getPositionCount()).isEqualTo(commonDictionaryUsedPositions);
+        assertThat(((DictionaryBlock) page.getFieldBlock(1)).getDictionary().getPositionCount()).isEqualTo(otherDictionaryUsedPositions);
+        assertThat(((DictionaryBlock) page.getFieldBlock(2)).getDictionary().getPositionCount()).isEqualTo(commonDictionaryUsedPositions);
 
         // Blocks that had the same source id before compacting page should have the same source id after compacting page
-        assertThat(((DictionaryBlock) page.getBlock(0)).getDictionarySourceId())
-                .isNotEqualTo(((DictionaryBlock) page.getBlock(1)).getDictionarySourceId());
+        assertThat(((DictionaryBlock) page.getFieldBlock(0)).getDictionarySourceId())
+                .isNotEqualTo(((DictionaryBlock) page.getFieldBlock(1)).getDictionarySourceId());
 
-        assertThat(((DictionaryBlock) page.getBlock(0)).getDictionarySourceId())
-                .isEqualTo(((DictionaryBlock) page.getBlock(2)).getDictionarySourceId());
+        assertThat(((DictionaryBlock) page.getFieldBlock(0)).getDictionarySourceId())
+                .isEqualTo(((DictionaryBlock) page.getFieldBlock(2)).getDictionarySourceId());
     }
 
     @Test
@@ -130,7 +130,7 @@ public class TestPage
         Page page = new Page(block, block, block).getPositions(new int[] {0, 1, 1, 1, 2, 5, 5}, 1, 5);
         assertThat(page.getPositionCount()).isEqualTo(5);
         for (int i = 0; i < 3; i++) {
-            Block testBlock = page.getBlock(i);
+            Block testBlock = page.getFieldBlock(i);
             assertThat(BIGINT.getLong(testBlock, 0)).isEqualTo(1);
             assertThat(BIGINT.getLong(testBlock, 1)).isEqualTo(1);
             assertThat(BIGINT.getLong(testBlock, 2)).isEqualTo(1);
@@ -153,7 +153,7 @@ public class TestPage
         Page page = new Page(lazyBlock);
         long lazyPageRetainedSize = Page.INSTANCE_SIZE + sizeOf(new Block[] {block}) + lazyBlock.getRetainedSizeInBytes();
         assertThat(page.getRetainedSizeInBytes()).isEqualTo(lazyPageRetainedSize);
-        Page loadedPage = page.getLoadedPage();
+        Page loadedPage = page.getLoadedBlock();
         // Retained size of original page and loaded page both change to the fully loaded size
         long loadedPageRetainedSize = Page.INSTANCE_SIZE + sizeOf(new Block[] {block}) + block.getRetainedSizeInBytes();
         assertThat(page.getRetainedSizeInBytes()).isEqualTo(loadedPageRetainedSize);

--- a/core/trino-spi/src/test/java/io/trino/spi/TestPage.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/TestPage.java
@@ -54,7 +54,7 @@ public class TestPage
     {
         assertThatThrownBy(() -> new Page(0).getRegion(1, 1))
                 .isInstanceOf(IndexOutOfBoundsException.class)
-                .hasMessage("Invalid position 1 and length 1 in page with 0 positions");
+                .hasMessage("Invalid position 1 and length 1 in block with 0 positions");
     }
 
     @Test
@@ -154,10 +154,9 @@ public class TestPage
         long lazyPageRetainedSize = Page.INSTANCE_SIZE + sizeOf(new Block[] {block}) + lazyBlock.getRetainedSizeInBytes();
         assertThat(page.getRetainedSizeInBytes()).isEqualTo(lazyPageRetainedSize);
         Page loadedPage = page.getLoadedPage();
-        // Retained size of page remains the same
-        assertThat(page.getRetainedSizeInBytes()).isEqualTo(lazyPageRetainedSize);
+        // Retained size of original page and loaded page both change to the fully loaded size
         long loadedPageRetainedSize = Page.INSTANCE_SIZE + sizeOf(new Block[] {block}) + block.getRetainedSizeInBytes();
-        // Retained size of loaded page depends on the loaded block
+        assertThat(page.getRetainedSizeInBytes()).isEqualTo(loadedPageRetainedSize);
         assertThat(loadedPage.getRetainedSizeInBytes()).isEqualTo(loadedPageRetainedSize);
 
         lazyBlock = lazyWrapper(block);

--- a/core/trino-spi/src/test/java/io/trino/spi/block/TestLazyBlock.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/TestLazyBlock.java
@@ -104,7 +104,7 @@ public class TestLazyBlock
             return;
         }
         if (loadedBlock instanceof RowBlock rowBlock) {
-            long expectedSizeInBytes = loadedBlock.getPositionCount();
+            long expectedSizeInBytes = rowBlock.mayHaveNull() ? loadedBlock.getPositionCount() : 0;
             assertThat(loadedBlock.getSizeInBytes()).isEqualTo(expectedSizeInBytes);
 
             for (Block fieldBlock : rowBlock.getFieldBlocks()) {

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/avro/AvroPagePositionDataWriter.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/avro/AvroPagePositionDataWriter.java
@@ -565,7 +565,7 @@ public class AvroPagePositionDataWriter
         {
             verify(page.getChannelCount() == channelEncoders.length, "Page must have channels equal to provided type list");
             for (int channel = 0; channel < page.getChannelCount(); channel++) {
-                channelEncoders[channel].setBlock(page.getBlock(channel));
+                channelEncoders[channel].setBlock(page.getFieldBlock(channel));
             }
         }
 

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/csv/CsvSerializer.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/csv/CsvSerializer.java
@@ -73,7 +73,7 @@ public class CsvSerializer
             if (channel != 0) {
                 sliceOutput.write(separatorChar);
             }
-            Block block = page.getBlock(channel);
+            Block block = page.getFieldBlock(channel);
             if (!block.isNull(position)) {
                 // if quote is zero, quoting is disabled
                 if (quoteChar != '\0') {

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/json/JsonSerializer.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/json/JsonSerializer.java
@@ -90,7 +90,7 @@ public class JsonSerializer
         try (JsonGenerator generator = jsonFactory.createGenerator((OutputStream) sliceOutput)) {
             generator.writeStartObject();
             for (int field = 0; field < fieldWriters.length; field++) {
-                fieldWriters[field].writeField(generator, page.getBlock(field), position);
+                fieldWriters[field].writeField(generator, page.getFieldBlock(field), position);
             }
             generator.writeEndObject();
         }

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/openxjson/OpenXJsonSerializer.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/openxjson/OpenXJsonSerializer.java
@@ -119,7 +119,7 @@ public class OpenXJsonSerializer
             Column column = columns.get(columnIndex);
             String fieldName = column.name();
 
-            Block block = page.getBlock(columnIndex);
+            Block block = page.getFieldBlock(columnIndex);
             Object fieldValue = writeValue(column.type(), block, position);
             if (options.isExplicitNull() || fieldValue != null) {
                 jsonObject.put(fieldName, fieldValue);

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/simple/SimpleSerializer.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/simple/SimpleSerializer.java
@@ -74,7 +74,7 @@ public class SimpleSerializer
             if (channel > 0) {
                 sliceOutput.appendByte(separator);
             }
-            Block block = page.getBlock(channel);
+            Block block = page.getFieldBlock(channel);
             if (block.isNull(position)) {
                 sliceOutput.appendBytes(nullSequence);
             }

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/rcfile/RcFileWriteValidation.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/rcfile/RcFileWriteValidation.java
@@ -165,7 +165,7 @@ public class RcFileWriteValidation
             totalRowCount += page.getPositionCount();
             for (int channel = 0; channel < columnHashes.size(); channel++) {
                 ValidationHash validationHash = validationHashes.get(channel);
-                Block block = page.getBlock(channel);
+                Block block = page.getFieldBlock(channel);
                 XxHash64 xxHash64 = columnHashes.get(channel);
                 for (int position = 0; position < block.getPositionCount(); position++) {
                     long hash = validationHash.hash(block, position);

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/rcfile/RcFileWriter.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/rcfile/RcFileWriter.java
@@ -257,7 +257,7 @@ public class RcFileWriter
 
         bufferedSize = 0;
         for (int i = 0; i < page.getChannelCount(); i++) {
-            Block block = page.getBlock(i);
+            Block block = page.getFieldBlock(i);
             columnEncoders[i].writeBlock(block);
             bufferedSize += columnEncoders[i].getBufferedSize();
         }

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/FormatTestUtils.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/FormatTestUtils.java
@@ -467,7 +467,7 @@ public final class FormatTestUtils
     {
         List<Object> values = new ArrayList<>();
         for (int i = 0; i < columns.size(); i++) {
-            values.add(columns.get(i).type().getObjectValue(null, page.getBlock(i), position));
+            values.add(columns.get(i).type().getObjectValue(null, page.getFieldBlock(i), position));
         }
         return values;
     }

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/TestAvroBase.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/TestAvroBase.java
@@ -346,46 +346,46 @@ public abstract class TestAvroBase
     protected static void assertIsAllTypesPage(Page p)
     {
         // test boolean
-        assertThat(p.getBlock(0)).isInstanceOf(ByteArrayBlock.class);
-        assertThat(BooleanType.BOOLEAN.getBoolean(p.getBlock(0), 0)).isTrue();
+        assertThat(p.getFieldBlock(0)).isInstanceOf(ByteArrayBlock.class);
+        assertThat(BooleanType.BOOLEAN.getBoolean(p.getFieldBlock(0), 0)).isTrue();
         // test int
-        assertThat(p.getBlock(1)).isInstanceOf(IntArrayBlock.class);
-        assertThat(INTEGER.getInt(p.getBlock(1), 0)).isEqualTo(42);
+        assertThat(p.getFieldBlock(1)).isInstanceOf(IntArrayBlock.class);
+        assertThat(INTEGER.getInt(p.getFieldBlock(1), 0)).isEqualTo(42);
         // test long
-        assertThat(p.getBlock(2)).isInstanceOf(LongArrayBlock.class);
-        assertThat(BigintType.BIGINT.getLong(p.getBlock(2), 0)).isEqualTo(3400L);
+        assertThat(p.getFieldBlock(2)).isInstanceOf(LongArrayBlock.class);
+        assertThat(BigintType.BIGINT.getLong(p.getFieldBlock(2), 0)).isEqualTo(3400L);
         // test float
-        assertThat(p.getBlock(3)).isInstanceOf(IntArrayBlock.class);
-        assertThat(RealType.REAL.getFloat(p.getBlock(3), 0)).isCloseTo(3.14f, within(0.001f));
+        assertThat(p.getFieldBlock(3)).isInstanceOf(IntArrayBlock.class);
+        assertThat(RealType.REAL.getFloat(p.getFieldBlock(3), 0)).isCloseTo(3.14f, within(0.001f));
         // test double
-        assertThat(p.getBlock(4)).isInstanceOf(LongArrayBlock.class);
-        assertThat(DoubleType.DOUBLE.getDouble(p.getBlock(4), 0)).isCloseTo(9.81, within(0.001));
+        assertThat(p.getFieldBlock(4)).isInstanceOf(LongArrayBlock.class);
+        assertThat(DoubleType.DOUBLE.getDouble(p.getFieldBlock(4), 0)).isCloseTo(9.81, within(0.001));
         // test string
-        assertThat(p.getBlock(5)).isInstanceOf(VariableWidthBlock.class);
-        assertThat(VARCHAR.getObject(p.getBlock(5), 0)).isEqualTo(Slices.utf8Slice(A_STRING_VALUE));
+        assertThat(p.getFieldBlock(5)).isInstanceOf(VariableWidthBlock.class);
+        assertThat(VARCHAR.getObject(p.getFieldBlock(5), 0)).isEqualTo(Slices.utf8Slice(A_STRING_VALUE));
         // test bytes
-        assertThat(p.getBlock(6)).isInstanceOf(VariableWidthBlock.class);
-        assertThat(VarbinaryType.VARBINARY.getObject(p.getBlock(6), 0)).isEqualTo(Slices.wrappedHeapBuffer(A_BYTES_VALUE));
+        assertThat(p.getFieldBlock(6)).isInstanceOf(VariableWidthBlock.class);
+        assertThat(VarbinaryType.VARBINARY.getObject(p.getFieldBlock(6), 0)).isEqualTo(Slices.wrappedHeapBuffer(A_BYTES_VALUE));
         // test fixed
-        assertThat(p.getBlock(7)).isInstanceOf(VariableWidthBlock.class);
-        assertThat(VarbinaryType.VARBINARY.getObject(p.getBlock(7), 0)).isEqualTo(Slices.wrappedBuffer(A_FIXED_VALUE.bytes()));
+        assertThat(p.getFieldBlock(7)).isInstanceOf(VariableWidthBlock.class);
+        assertThat(VarbinaryType.VARBINARY.getObject(p.getFieldBlock(7), 0)).isEqualTo(Slices.wrappedBuffer(A_FIXED_VALUE.bytes()));
         //test array
-        assertThat(p.getBlock(8)).isInstanceOf(ArrayBlock.class);
-        assertThat(ARRAY_INTEGER.getObject(p.getBlock(8), 0)).isInstanceOf(IntArrayBlock.class);
-        assertBlockEquals(INTEGER, ARRAY_INTEGER.getObject(p.getBlock(8), 0), createIntsBlock(1, 2, 3, 4));
+        assertThat(p.getFieldBlock(8)).isInstanceOf(ArrayBlock.class);
+        assertThat(ARRAY_INTEGER.getObject(p.getFieldBlock(8), 0)).isInstanceOf(IntArrayBlock.class);
+        assertBlockEquals(INTEGER, ARRAY_INTEGER.getObject(p.getFieldBlock(8), 0), createIntsBlock(1, 2, 3, 4));
         // test map
-        assertThat(p.getBlock(9)).isInstanceOf(MapBlock.class);
-        assertThat(MAP_VARCHAR_INTEGER.getObjectValue(null, p.getBlock(9), 0)).isEqualTo(ImmutableMap.of("key1", 1, "key2", 2));
+        assertThat(p.getFieldBlock(9)).isInstanceOf(MapBlock.class);
+        assertThat(MAP_VARCHAR_INTEGER.getObjectValue(null, p.getFieldBlock(9), 0)).isEqualTo(ImmutableMap.of("key1", 1, "key2", 2));
         // test enum
-        assertThat(p.getBlock(10)).isInstanceOf(VariableWidthBlock.class);
-        assertThat(VARCHAR.getObject(p.getBlock(10), 0)).isEqualTo(Slices.utf8Slice("A"));
+        assertThat(p.getFieldBlock(10)).isInstanceOf(VariableWidthBlock.class);
+        assertThat(VARCHAR.getObject(p.getFieldBlock(10), 0)).isEqualTo(Slices.utf8Slice("A"));
         // test record
-        assertThat(p.getBlock(11)).isInstanceOf(RowBlock.class);
+        assertThat(p.getFieldBlock(11)).isInstanceOf(RowBlock.class);
         Block expected = createRowBlock(ImmutableList.of(INTEGER, DoubleType.DOUBLE, VARCHAR), new Object[] {5, 3.14159265358979, "Simple Record String Field"});
-        assertBlockEquals(RowType.anonymousRow(INTEGER, DoubleType.DOUBLE, VARCHAR), p.getBlock(11), expected);
+        assertBlockEquals(RowType.anonymousRow(INTEGER, DoubleType.DOUBLE, VARCHAR), p.getFieldBlock(11), expected);
         // test nullable union
-        assertThat(p.getBlock(12)).isInstanceOf(VariableWidthBlock.class);
-        assertThat(p.getBlock(12).isNull(0)).isTrue();
+        assertThat(p.getFieldBlock(12)).isInstanceOf(VariableWidthBlock.class);
+        assertThat(p.getFieldBlock(12).isNull(0)).isTrue();
     }
 
     protected TrinoInputFile createWrittenFileWithData(Schema schema, List<GenericRecord> records)

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/TestAvroPageDataReaderWithAvroNativeTypeManagement.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/TestAvroPageDataReaderWithAvroNativeTypeManagement.java
@@ -219,19 +219,19 @@ public class TestAvroPageDataReaderWithAvroNativeTypeManagement
                 Page p = avroFileReader.next();
                 for (int i = 0; i < p.getPositionCount(); i++) {
                     // millis timestamp const
-                    SqlTimestamp milliTimestamp = (SqlTimestamp) TimestampType.TIMESTAMP_MILLIS.getObjectValue(null, p.getBlock(0), i);
+                    SqlTimestamp milliTimestamp = (SqlTimestamp) TimestampType.TIMESTAMP_MILLIS.getObjectValue(null, p.getFieldBlock(0), i);
                     assertThat(milliTimestamp.getEpochMicros()).isEqualTo(testTime.getTime() * 1000);
 
                     // decimal bytes const
-                    SqlDecimal smallBytesDecimal = (SqlDecimal) SMALL_DECIMAL_TYPE.getObjectValue(null, p.getBlock(1), i);
+                    SqlDecimal smallBytesDecimal = (SqlDecimal) SMALL_DECIMAL_TYPE.getObjectValue(null, p.getFieldBlock(1), i);
                     assertThat(smallBytesDecimal.getUnscaledValue()).isEqualTo(new BigInteger(Longs.toByteArray(testTime.getTime())));
 
                     // time micros const
-                    SqlTime timeMicros = (SqlTime) TimeType.TIME_MICROS.getObjectValue(null, p.getBlock(2), i);
+                    SqlTime timeMicros = (SqlTime) TimeType.TIME_MICROS.getObjectValue(null, p.getFieldBlock(2), i);
                     assertThat(timeMicros.getPicos()).isEqualTo(39_600_000_000L * 1_000_000L);
 
                     //UUID const assert
-                    assertThat(id).isEqualTo(UuidType.UUID.getObjectValue(null, p.getBlock(3), i));
+                    assertThat(id).isEqualTo(UuidType.UUID.getObjectValue(null, p.getFieldBlock(3), i));
                 }
                 totalRecords += p.getPositionCount();
             }
@@ -269,16 +269,16 @@ public class TestAvroPageDataReaderWithAvroNativeTypeManagement
     {
         assertThat(p.getPositionCount()).isEqualTo(1);
         // Timestamps equal
-        SqlTimestamp milliTimestamp = (SqlTimestamp) TimestampType.TIMESTAMP_MILLIS.getObjectValue(null, p.getBlock(0), 0);
-        SqlTimestamp microTimestamp = (SqlTimestamp) TimestampType.TIMESTAMP_MICROS.getObjectValue(null, p.getBlock(1), 0);
+        SqlTimestamp milliTimestamp = (SqlTimestamp) TimestampType.TIMESTAMP_MILLIS.getObjectValue(null, p.getFieldBlock(0), 0);
+        SqlTimestamp microTimestamp = (SqlTimestamp) TimestampType.TIMESTAMP_MICROS.getObjectValue(null, p.getFieldBlock(1), 0);
         assertThat(milliTimestamp).isEqualTo(microTimestamp.roundTo(3));
         assertThat(microTimestamp.getEpochMicros()).isEqualTo(testTime.getTime() * 1000);
 
         // Decimals Equal
-        SqlDecimal smallBytesDecimal = (SqlDecimal) SMALL_DECIMAL_TYPE.getObjectValue(null, p.getBlock(2), 0);
-        SqlDecimal smallFixedDecimal = (SqlDecimal) SMALL_DECIMAL_TYPE.getObjectValue(null, p.getBlock(3), 0);
-        SqlDecimal largeBytesDecimal = (SqlDecimal) LARGE_DECIMAL_TYPE.getObjectValue(null, p.getBlock(4), 0);
-        SqlDecimal largeFixedDecimal = (SqlDecimal) LARGE_DECIMAL_TYPE.getObjectValue(null, p.getBlock(5), 0);
+        SqlDecimal smallBytesDecimal = (SqlDecimal) SMALL_DECIMAL_TYPE.getObjectValue(null, p.getFieldBlock(2), 0);
+        SqlDecimal smallFixedDecimal = (SqlDecimal) SMALL_DECIMAL_TYPE.getObjectValue(null, p.getFieldBlock(3), 0);
+        SqlDecimal largeBytesDecimal = (SqlDecimal) LARGE_DECIMAL_TYPE.getObjectValue(null, p.getFieldBlock(4), 0);
+        SqlDecimal largeFixedDecimal = (SqlDecimal) LARGE_DECIMAL_TYPE.getObjectValue(null, p.getFieldBlock(5), 0);
 
         assertThat(smallBytesDecimal).isEqualTo(smallFixedDecimal);
         assertThat(largeBytesDecimal).isEqualTo(largeFixedDecimal);
@@ -286,16 +286,16 @@ public class TestAvroPageDataReaderWithAvroNativeTypeManagement
         assertThat(smallBytesDecimal.getUnscaledValue()).isEqualTo(new BigInteger(Longs.toByteArray(78068160000000L)));
 
         // Get date
-        SqlDate date = (SqlDate) DateType.DATE.getObjectValue(null, p.getBlock(6), 0);
+        SqlDate date = (SqlDate) DateType.DATE.getObjectValue(null, p.getFieldBlock(6), 0);
         assertThat(date.getDays()).isEqualTo(9035);
 
         // Time equals
-        SqlTime timeMillis = (SqlTime) TimeType.TIME_MILLIS.getObjectValue(null, p.getBlock(7), 0);
-        SqlTime timeMicros = (SqlTime) TimeType.TIME_MICROS.getObjectValue(null, p.getBlock(8), 0);
+        SqlTime timeMillis = (SqlTime) TimeType.TIME_MILLIS.getObjectValue(null, p.getFieldBlock(7), 0);
+        SqlTime timeMicros = (SqlTime) TimeType.TIME_MICROS.getObjectValue(null, p.getFieldBlock(8), 0);
         assertThat(timeMillis).isEqualTo(timeMicros.roundTo(3));
         assertThat(timeMillis.getPicos()).isEqualTo(timeMicros.getPicos()).isEqualTo(39_600_000_000L * 1_000_000L);
 
         //UUID
-        assertThat(RANDOM_UUID.toString()).isEqualTo(UuidType.UUID.getObjectValue(null, p.getBlock(9), 0));
+        assertThat(RANDOM_UUID.toString()).isEqualTo(UuidType.UUID.getObjectValue(null, p.getFieldBlock(9), 0));
     }
 }

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/TestAvroPageDataReaderWithoutTypeManager.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/TestAvroPageDataReaderWithoutTypeManager.java
@@ -82,7 +82,7 @@ public class TestAvroPageDataReaderWithoutTypeManager
             while (avroFileReader.hasNext()) {
                 Page p = avroFileReader.next();
                 for (int pos = 0; pos < p.getPositionCount(); pos++) {
-                    assertThat(p.getBlock(0).isNull(pos)).isTrue();
+                    assertThat(p.getFieldBlock(0).isNull(pos)).isTrue();
                 }
                 totalRecords += p.getPositionCount();
             }
@@ -108,7 +108,7 @@ public class TestAvroPageDataReaderWithoutTypeManager
             int totalRecords = 0;
             while (avroFileReader.hasNext()) {
                 Page p = avroFileReader.next();
-                MapBlock mb = (MapBlock) p.getBlock(0);
+                MapBlock mb = (MapBlock) p.getFieldBlock(0);
                 MapBlock expected = (MapBlock) MAP_VARCHAR_VARCHAR.createBlockFromKeyValue(Optional.empty(),
                         new int[] {0, 1},
                         createStringsBlock("key1"),
@@ -116,7 +116,7 @@ public class TestAvroPageDataReaderWithoutTypeManager
                 mb = (MapBlock) mb.getRegion(0, 1);
                 assertBlockEquals(MAP_VARCHAR_VARCHAR, mb, expected);
 
-                ByteArrayBlock block = (ByteArrayBlock) p.getBlock(readerSchema.getFields().size() - 1);
+                ByteArrayBlock block = (ByteArrayBlock) p.getFieldBlock(readerSchema.getFields().size() - 1);
                 assertThat(block.getByte(0)).isGreaterThan((byte) 0);
                 totalRecords += p.getPositionCount();
             }
@@ -179,7 +179,7 @@ public class TestAvroPageDataReaderWithoutTypeManager
             while (avroFileReader.hasNext()) {
                 Page p = avroFileReader.next();
                 for (Map.Entry<Integer, Class<?>> channelClass : expectedBlockPerChannel.entrySet()) {
-                    assertThat(p.getBlock(channelClass.getKey())).isInstanceOf(channelClass.getValue());
+                    assertThat(p.getFieldBlock(channelClass.getKey())).isInstanceOf(channelClass.getValue());
                 }
                 totalRecords += p.getPositionCount();
             }
@@ -212,7 +212,7 @@ public class TestAvroPageDataReaderWithoutTypeManager
             int totalRecords = 0;
             while (avroFileReader.hasNext()) {
                 Page p = avroFileReader.next();
-                String actualSymbol = new String(((Slice) VARCHAR.getObject(p.getBlock(0), 0)).getBytes(), StandardCharsets.UTF_8);
+                String actualSymbol = new String(((Slice) VARCHAR.getObject(p.getFieldBlock(0), 0)).getBytes(), StandardCharsets.UTF_8);
                 assertThat(actualSymbol).isEqualTo(expected.get("myEnum").toString());
                 totalRecords += p.getPositionCount();
             }
@@ -225,7 +225,7 @@ public class TestAvroPageDataReaderWithoutTypeManager
             int totalRecords = 0;
             while (avroFileReader.hasNext()) {
                 Page p = avroFileReader.next();
-                String actualSymbol = new String(((Slice) VarcharType.VARCHAR.getObject(p.getBlock(0), 0)).getBytes(), StandardCharsets.UTF_8);
+                String actualSymbol = new String(((Slice) VarcharType.VARCHAR.getObject(p.getFieldBlock(0), 0)).getBytes(), StandardCharsets.UTF_8);
                 assertThat(actualSymbol).isEqualTo(expected.get("myEnum").toString());
                 totalRecords += p.getPositionCount();
             }

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/TestAvroPageDataWriterWithoutTypeManager.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/TestAvroPageDataWriterWithoutTypeManager.java
@@ -150,16 +150,16 @@ public class TestAvroPageDataWriterWithoutTypeManager
                 new BaseAvroTypeBlockHandler())) {
             assertThat(avroFileReader.hasNext()).isTrue();
             Page readPage = avroFileReader.next();
-            assertThat(INTEGER.getInt(readPage.getBlock(0), 0)).isEqualTo(2);
-            assertThat(INTEGER.getInt(readPage.getBlock(0), 1)).isEqualTo(2);
-            assertThat(VarcharType.VARCHAR.getSlice(readPage.getBlock(1), 0)).isEqualTo(Slices.utf8Slice("rleString"));
-            assertThat(VarcharType.VARCHAR.getSlice(readPage.getBlock(1), 1)).isEqualTo(Slices.utf8Slice("rleString"));
-            assertThat(VarcharType.VARCHAR.getSlice(readPage.getBlock(2), 0)).isEqualTo(Slices.utf8Slice("B"));
-            assertThat(VarcharType.VARCHAR.getSlice(readPage.getBlock(2), 1)).isEqualTo(Slices.utf8Slice("C"));
-            assertBlockEquals(simepleRecordType, readPage.getBlock(3).getSingleValueBlock(0), expectedRLERow);
-            assertBlockEquals(simepleRecordType, readPage.getBlock(3).getSingleValueBlock(1), expectedRLERow);
-            assertBlockEquals(simepleRecordType, readPage.getBlock(4).getSingleValueBlock(0), expectedDictionaryRow);
-            assertBlockEquals(simepleRecordType, readPage.getBlock(4).getSingleValueBlock(1), expectedDictionaryRow);
+            assertThat(INTEGER.getInt(readPage.getFieldBlock(0), 0)).isEqualTo(2);
+            assertThat(INTEGER.getInt(readPage.getFieldBlock(0), 1)).isEqualTo(2);
+            assertThat(VarcharType.VARCHAR.getSlice(readPage.getFieldBlock(1), 0)).isEqualTo(Slices.utf8Slice("rleString"));
+            assertThat(VarcharType.VARCHAR.getSlice(readPage.getFieldBlock(1), 1)).isEqualTo(Slices.utf8Slice("rleString"));
+            assertThat(VarcharType.VARCHAR.getSlice(readPage.getFieldBlock(2), 0)).isEqualTo(Slices.utf8Slice("B"));
+            assertThat(VarcharType.VARCHAR.getSlice(readPage.getFieldBlock(2), 1)).isEqualTo(Slices.utf8Slice("C"));
+            assertBlockEquals(simepleRecordType, readPage.getFieldBlock(3).getSingleValueBlock(0), expectedRLERow);
+            assertBlockEquals(simepleRecordType, readPage.getFieldBlock(3).getSingleValueBlock(1), expectedRLERow);
+            assertBlockEquals(simepleRecordType, readPage.getFieldBlock(4).getSingleValueBlock(0), expectedDictionaryRow);
+            assertBlockEquals(simepleRecordType, readPage.getFieldBlock(4).getSingleValueBlock(1), expectedDictionaryRow);
             assertThat(avroFileReader.hasNext()).isFalse();
         }
     }
@@ -214,11 +214,11 @@ public class TestAvroPageDataWriterWithoutTypeManager
                 new BaseAvroTypeBlockHandler())) {
             assertThat(avroFileReader.hasNext()).isTrue();
             Page readPage = avroFileReader.next();
-            assertThat(INTEGER.getInt(readPage.getBlock(0), 0)).isEqualTo(1);
-            assertThat(INTEGER.getInt(readPage.getBlock(1), 0)).isEqualTo(2);
-            assertThat(BIGINT.getLong(readPage.getBlock(2), 0)).isEqualTo(1);
-            assertThat(BIGINT.getLong(readPage.getBlock(3), 0)).isEqualTo(2);
-            assertThat(BIGINT.getLong(readPage.getBlock(4), 0)).isEqualTo(4);
+            assertThat(INTEGER.getInt(readPage.getFieldBlock(0), 0)).isEqualTo(1);
+            assertThat(INTEGER.getInt(readPage.getFieldBlock(1), 0)).isEqualTo(2);
+            assertThat(BIGINT.getLong(readPage.getFieldBlock(2), 0)).isEqualTo(1);
+            assertThat(BIGINT.getLong(readPage.getFieldBlock(3), 0)).isEqualTo(2);
+            assertThat(BIGINT.getLong(readPage.getFieldBlock(4), 0)).isEqualTo(4);
             assertThat(avroFileReader.hasNext()).isFalse();
         }
     }

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/TestHiveAvroTypeBlockHandler.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/TestHiveAvroTypeBlockHandler.java
@@ -120,45 +120,45 @@ public class TestHiveAvroTypeBlockHandler
                 assertThat(p.getPositionCount()).withFailMessage("Page Batch should be at least 3").isEqualTo(3);
                 //check first column
                 //check first column first row coerced struct
-                RowBlock readStraightUpStringsOnly = (RowBlock) p.getBlock(0).getSingleValueBlock(0);
+                RowBlock readStraightUpStringsOnly = (RowBlock) p.getFieldBlock(0).getSingleValueBlock(0);
                 assertThat(readStraightUpStringsOnly.getFieldBlocks().size()).isEqualTo(3); // tag, int and string block fields
                 assertThat(readStraightUpStringsOnly.getFieldBlocks().get(1).isNull(0)).isTrue(); // int field null
                 assertThat(VARCHAR.getObjectValue(null, readStraightUpStringsOnly.getFieldBlocks().get(2), 0)).isEqualTo("I am in column 0 field 1"); //string field expected value
                 // check first column second row coerced struct
-                RowBlock readStraightUpInts = (RowBlock) p.getBlock(0).getSingleValueBlock(1);
+                RowBlock readStraightUpInts = (RowBlock) p.getFieldBlock(0).getSingleValueBlock(1);
                 assertThat(readStraightUpInts.getFieldBlocks().size()).isEqualTo(3); // tag, int and string block fields
                 assertThat(readStraightUpInts.getFieldBlocks().get(2).isNull(0)).isTrue(); // string field null
                 assertThat(INTEGER.getObjectValue(null, readStraightUpInts.getFieldBlocks().get(1), 0)).isEqualTo(5);
 
                 //check first column third row is null
-                assertThat(p.getBlock(0).isNull(2)).isTrue();
+                assertThat(p.getFieldBlock(0).isNull(2)).isTrue();
                 //check second column
                 //check second column first row coerced struct
-                RowBlock readFromReverseStringsOnly = (RowBlock) p.getBlock(1).getSingleValueBlock(0);
+                RowBlock readFromReverseStringsOnly = (RowBlock) p.getFieldBlock(1).getSingleValueBlock(0);
                 assertThat(readFromReverseStringsOnly.getFieldBlocks().size()).isEqualTo(3); // tag, int and string block fields
                 assertThat(readFromReverseStringsOnly.getFieldBlocks().get(1).isNull(0)).isTrue(); // int field null
                 assertThat(VARCHAR.getObjectValue(null, readFromReverseStringsOnly.getFieldBlocks().get(2), 0)).isEqualTo("I am in column 1 field 1");
                 //check second column second row coerced struct
-                RowBlock readFromReverseUpInts = (RowBlock) p.getBlock(1).getSingleValueBlock(1);
+                RowBlock readFromReverseUpInts = (RowBlock) p.getFieldBlock(1).getSingleValueBlock(1);
                 assertThat(readFromReverseUpInts.getFieldBlocks().size()).isEqualTo(3); // tag, int and string block fields
                 assertThat(readFromReverseUpInts.getFieldBlocks().get(2).isNull(0)).isTrue(); // string field null
                 assertThat(INTEGER.getObjectValue(null, readFromReverseUpInts.getFieldBlocks().get(1), 0)).isEqualTo(21);
                 //check second column third row is null
-                assertThat(p.getBlock(1).isNull(2)).isTrue();
+                assertThat(p.getFieldBlock(1).isNull(2)).isTrue();
 
                 //check third column (default of 42 always)
                 //check third column first row coerced struct
-                RowBlock readFromDefaultStringsOnly = (RowBlock) p.getBlock(2).getSingleValueBlock(0);
+                RowBlock readFromDefaultStringsOnly = (RowBlock) p.getFieldBlock(2).getSingleValueBlock(0);
                 assertThat(readFromDefaultStringsOnly.getFieldBlocks().size()).isEqualTo(3); // tag, int and string block fields
                 assertThat(readFromDefaultStringsOnly.getFieldBlocks().get(2).isNull(0)).isTrue(); // string field null
                 assertThat(INTEGER.getObjectValue(null, readFromDefaultStringsOnly.getFieldBlocks().get(1), 0)).isEqualTo(42);
                 //check third column second row coerced struct
-                RowBlock readFromDefaultInts = (RowBlock) p.getBlock(2).getSingleValueBlock(1);
+                RowBlock readFromDefaultInts = (RowBlock) p.getFieldBlock(2).getSingleValueBlock(1);
                 assertThat(readFromDefaultInts.getFieldBlocks().size()).isEqualTo(3); // tag, int and string block fields
                 assertThat(readFromDefaultInts.getFieldBlocks().get(2).isNull(0)).isTrue(); // string field null
                 assertThat(INTEGER.getObjectValue(null, readFromDefaultInts.getFieldBlocks().get(1), 0)).isEqualTo(42);
                 //check third column third row coerced struct
-                RowBlock readFromDefaultNulls = (RowBlock) p.getBlock(2).getSingleValueBlock(2);
+                RowBlock readFromDefaultNulls = (RowBlock) p.getFieldBlock(2).getSingleValueBlock(2);
                 assertThat(readFromDefaultNulls.getFieldBlocks().size()).isEqualTo(3); // int and string block fields
                 assertThat(readFromDefaultNulls.getFieldBlocks().get(2).isNull(0)).isTrue(); // string field null
                 assertThat(INTEGER.getObjectValue(null, readFromDefaultNulls.getFieldBlocks().get(1), 0)).isEqualTo(42);

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/csv/TestCsvFormat.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/csv/TestCsvFormat.java
@@ -210,7 +210,7 @@ public class TestCsvFormat
         deserializer.deserialize(createLineBuffer(csvLine), pageBuilder);
         Page page = pageBuilder.build();
         return IntStream.range(0, deserializer.getTypes().size())
-                .mapToObj(page::getBlock)
+                .mapToObj(page::getFieldBlock)
                 .map(block -> block.isNull(0) ? null : VARCHAR.getSlice(block, 0).toStringUtf8())
                 .collect(Collectors.toCollection(ArrayList::new));
     }

--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcReader.java
@@ -426,7 +426,7 @@ public class OrcReader
                     })) {
                 for (Page page = orcRecordReader.nextPage(); page != null; page = orcRecordReader.nextPage()) {
                     // fully load the page
-                    page.getLoadedPage();
+                    page.getLoadedBlock();
                 }
             }
         }

--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcRecordReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcRecordReader.java
@@ -589,7 +589,7 @@ public class OrcRecordReader
     private void validateWritePageChecksum(Page page)
     {
         if (writeChecksumBuilder.isPresent()) {
-            page = page.getLoadedPage();
+            page = page.getLoadedBlock();
             writeChecksumBuilder.get().addPage(page);
             rowGroupStatisticsValidation.get().addPage(page);
             stripeStatisticsValidation.get().addPage(page);

--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcWriteValidation.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcWriteValidation.java
@@ -505,7 +505,7 @@ public class OrcWriteValidation
 
             for (int channel = 0; channel < columnHashes.size(); channel++) {
                 ValidationHash validationHash = validationHashes.get(channel);
-                Block block = page.getBlock(channel);
+                Block block = page.getFieldBlock(channel);
                 XxHash64 xxHash64 = columnHashes.get(channel);
                 for (int position = 0; position < block.getPositionCount(); position++) {
                     long hash = validationHash.hash(block, position);
@@ -553,7 +553,7 @@ public class OrcWriteValidation
         {
             rowCount += page.getPositionCount();
             for (int channel = 0; channel < columnStatisticsValidations.size(); channel++) {
-                columnStatisticsValidations.get(channel).addBlock(page.getBlock(channel));
+                columnStatisticsValidations.get(channel).addBlock(page.getFieldBlock(channel));
             }
         }
 

--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcWriter.java
@@ -255,7 +255,7 @@ public final class OrcWriter
 
         checkArgument(page.getChannelCount() == columnWriters.size());
         // page should already be loaded, but double check
-        page = page.getLoadedPage();
+        page = page.getLoadedBlock();
 
         if (validationBuilder != null) {
             validationBuilder.addPage(page);
@@ -292,7 +292,7 @@ public final class OrcWriter
         bufferedBytes = 0;
         for (int channel = 0; channel < chunk.getChannelCount(); channel++) {
             ColumnWriter writer = columnWriters.get(channel);
-            writer.writeBlock(chunk.getBlock(channel));
+            writer.writeBlock(chunk.getFieldBlock(channel));
             bufferedBytes += writer.getBufferedBytes();
         }
 

--- a/lib/trino-orc/src/test/java/io/trino/orc/BenchmarkColumnReaders.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/BenchmarkColumnReaders.java
@@ -329,7 +329,7 @@ public class BenchmarkColumnReaders
         List<Page> pages = new ArrayList<>();
         try (OrcRecordReader recordReader = data.createRecordReader()) {
             for (Page page = recordReader.nextPage(); page != null; page = recordReader.nextPage()) {
-                pages.add(page.getLoadedPage());
+                pages.add(page.getLoadedBlock());
             }
         }
         return pages;
@@ -376,7 +376,7 @@ public class BenchmarkColumnReaders
     {
         List<Block> blocks = new ArrayList<>();
         for (Page page = recordReader.nextPage(); page != null; page = recordReader.nextPage()) {
-            blocks.add(page.getBlock(0).getLoadedBlock());
+            blocks.add(page.getFieldBlock(0).getLoadedBlock());
         }
         return blocks;
     }

--- a/lib/trino-orc/src/test/java/io/trino/orc/BenchmarkOrcDecimalReader.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/BenchmarkOrcDecimalReader.java
@@ -72,7 +72,7 @@ public class BenchmarkOrcDecimalReader
         OrcRecordReader recordReader = data.createRecordReader();
         List<Block> blocks = new ArrayList<>();
         for (Page page = recordReader.nextPage(); page != null; page = recordReader.nextPage()) {
-            blocks.add(page.getBlock(0).getLoadedBlock());
+            blocks.add(page.getFieldBlock(0).getLoadedBlock());
         }
         return blocks;
     }

--- a/lib/trino-orc/src/test/java/io/trino/orc/OrcTester.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/OrcTester.java
@@ -507,7 +507,7 @@ public class OrcTester
                     isFirst = false;
                 }
                 else {
-                    Block block = page.getBlock(0);
+                    Block block = page.getFieldBlock(0);
 
                     List<Object> data = new ArrayList<>(block.getPositionCount());
                     for (int position = 0; position < block.getPositionCount(); position++) {

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestCachingOrcDataSource.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestCachingOrcDataSource.java
@@ -214,8 +214,8 @@ public class TestCachingOrcDataSource
             if (page == null) {
                 break;
             }
-            page = page.getLoadedPage();
-            Block block = page.getBlock(0);
+            page = page.getLoadedBlock();
+            Block block = page.getFieldBlock(0);
             positionCount += block.getPositionCount();
         }
         assertThat(positionCount).isEqualTo(POSITION_COUNT);

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestOrcLz4.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestOrcLz4.java
@@ -71,12 +71,12 @@ public class TestOrcLz4
                 if (page == null) {
                     break;
                 }
-                page = page.getLoadedPage();
+                page = page.getLoadedBlock();
                 rows += page.getPositionCount();
 
-                Block xBlock = page.getBlock(0);
-                Block yBlock = page.getBlock(1);
-                Block zBlock = page.getBlock(2);
+                Block xBlock = page.getFieldBlock(0);
+                Block yBlock = page.getFieldBlock(1);
+                Block zBlock = page.getFieldBlock(2);
 
                 for (int position = 0; position < page.getPositionCount(); position++) {
                     BIGINT.getLong(xBlock, position);

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestOrcReaderMemoryUsage.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestOrcReaderMemoryUsage.java
@@ -66,7 +66,7 @@ public class TestOrcReaderMemoryUsage
                 if (page == null) {
                     break;
                 }
-                page = page.getLoadedPage();
+                page = page.getLoadedBlock();
 
                 // We only verify the memory usage when the batchSize reaches MAX_BATCH_SIZE as batchSize may be
                 // increasing during the test, which will cause the StreamReader buffer sizes to increase too.
@@ -111,7 +111,7 @@ public class TestOrcReaderMemoryUsage
                 if (page == null) {
                     break;
                 }
-                page = page.getLoadedPage();
+                page = page.getLoadedBlock();
 
                 // We only verify the memory usage when the batchSize reaches MAX_BATCH_SIZE as batchSize may be
                 // increasing during the test, which will cause the StreamReader buffer sizes to increase too.
@@ -158,7 +158,7 @@ public class TestOrcReaderMemoryUsage
                 if (page == null) {
                     break;
                 }
-                page = page.getLoadedPage();
+                page = page.getLoadedBlock();
 
                 // We only verify the memory usage when the batchSize reaches MAX_BATCH_SIZE as batchSize may be
                 // increasing during the test, which will cause the StreamReader buffer sizes to increase too.

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestOrcReaderPositions.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestOrcReaderPositions.java
@@ -75,7 +75,7 @@ public class TestOrcReaderPositions
                 assertThat(reader.getFilePosition()).isEqualTo(reader.getReaderPosition());
 
                 for (int i = 0; i < 5; i++) {
-                    Page page = reader.nextPage().getLoadedPage();
+                    Page page = reader.nextPage().getLoadedBlock();
                     assertThat(page.getPositionCount()).isEqualTo(20);
                     assertThat(reader.getReaderPosition()).isEqualTo(i * 20L);
                     assertThat(reader.getFilePosition()).isEqualTo(reader.getReaderPosition());
@@ -113,14 +113,14 @@ public class TestOrcReaderPositions
                 assertThat(reader.getReaderPosition()).isEqualTo(0);
 
                 // second stripe
-                Page page = reader.nextPage().getLoadedPage();
+                Page page = reader.nextPage().getLoadedBlock();
                 assertThat(page.getPositionCount()).isEqualTo(20);
                 assertThat(reader.getReaderPosition()).isEqualTo(0);
                 assertThat(reader.getFilePosition()).isEqualTo(20);
                 assertCurrentBatch(page, 1);
 
                 // fourth stripe
-                page = reader.nextPage().getLoadedPage();
+                page = reader.nextPage().getLoadedBlock();
                 assertThat(page.getPositionCount()).isEqualTo(20);
                 assertThat(reader.getReaderPosition()).isEqualTo(20);
                 assertThat(reader.getFilePosition()).isEqualTo(60);
@@ -164,9 +164,9 @@ public class TestOrcReaderPositions
                     if (page == null) {
                         break;
                     }
-                    page = page.getLoadedPage();
+                    page = page.getLoadedBlock();
 
-                    Block block = page.getBlock(0);
+                    Block block = page.getFieldBlock(0);
                     for (int i = 0; i < block.getPositionCount(); i++) {
                         assertThat(BIGINT.getLong(block, i)).isEqualTo(position + i);
                     }
@@ -216,11 +216,11 @@ public class TestOrcReaderPositions
                     if (page == null) {
                         break;
                     }
-                    page = page.getLoadedPage();
+                    page = page.getLoadedBlock();
 
                     rowCountsInCurrentRowGroup += page.getPositionCount();
 
-                    Block block = page.getBlock(0);
+                    Block block = page.getFieldBlock(0);
                     if (MAX_BATCH_SIZE * (long) currentStringBytes <= READER_OPTIONS.getMaxBlockSize().toBytes()) {
                         // Either we are bounded by 1024 rows per batch, or it is the last batch in the row group
                         // For the first 3 row groups, the strings are of length 300, 600, and 900 respectively
@@ -272,10 +272,10 @@ public class TestOrcReaderPositions
                     if (page == null) {
                         break;
                     }
-                    page = page.getLoadedPage();
+                    page = page.getLoadedBlock();
                     rowCountsInCurrentRowGroup += page.getPositionCount();
 
-                    Block block = page.getBlock(0);
+                    Block block = page.getFieldBlock(0);
                     // 8 bytes per row; 1024 row at most given 1024 X 8B < 1MB
                     assertThat(block.getPositionCount() == MAX_BATCH_SIZE || rowCountsInCurrentRowGroup == rowsInRowGroup).isTrue();
 
@@ -336,7 +336,7 @@ public class TestOrcReaderPositions
                     if (page == null) {
                         break;
                     }
-                    page = page.getLoadedPage();
+                    page = page.getLoadedBlock();
 
                     assertThat(page.getPositionCount()).isEqualTo(expectedBatchSize);
                     assertThat(reader.getReaderPosition()).isEqualTo(totalReadRows);
@@ -369,7 +369,7 @@ public class TestOrcReaderPositions
 
     private static void assertCurrentBatch(Page page, int rowIndex, int batchSize)
     {
-        Block block = page.getBlock(0);
+        Block block = page.getFieldBlock(0);
         for (int i = 0; i < batchSize; i++) {
             assertThat(BIGINT.getLong(block, i)).isEqualTo((rowIndex + i) * 3L);
         }
@@ -377,7 +377,7 @@ public class TestOrcReaderPositions
 
     private static void assertCurrentBatch(Page page, int stripe)
     {
-        Block block = page.getBlock(0);
+        Block block = page.getFieldBlock(0);
         for (int i = 0; i < 20; i++) {
             assertThat(BIGINT.getLong(block, i)).isEqualTo(((stripe * 20L) + i) * 3);
         }

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestOrcWithoutRowGroupInfo.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestOrcWithoutRowGroupInfo.java
@@ -79,10 +79,10 @@ public class TestOrcWithoutRowGroupInfo
             if (page == null) {
                 break;
             }
-            page = page.getLoadedPage();
+            page = page.getLoadedBlock();
             rows += page.getPositionCount();
 
-            Block rowBlock = page.getBlock(5);
+            Block rowBlock = page.getFieldBlock(5);
 
             for (int position = 0; position < page.getPositionCount(); position++) {
                 SqlRow sqlRow = rowType.getObject(rowBlock, 0);

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestReadBloomFilter.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestReadBloomFilter.java
@@ -88,7 +88,7 @@ public class TestReadBloomFilter
 
             // without predicate a normal block will be created
             try (OrcRecordReader recordReader = createCustomOrcRecordReader(tempFile, OrcPredicate.TRUE, type, MAX_BATCH_SIZE)) {
-                assertThat(recordReader.nextPage().getLoadedPage().getPositionCount()).isEqualTo(MAX_BATCH_SIZE);
+                assertThat(recordReader.nextPage().getLoadedBlock().getPositionCount()).isEqualTo(MAX_BATCH_SIZE);
             }
 
             // predicate for specific value within the min/max range without bloom filter being enabled
@@ -97,7 +97,7 @@ public class TestReadBloomFilter
                     .build();
 
             try (OrcRecordReader recordReader = createCustomOrcRecordReader(tempFile, noBloomFilterPredicate, type, MAX_BATCH_SIZE)) {
-                assertThat(recordReader.nextPage().getLoadedPage().getPositionCount()).isEqualTo(MAX_BATCH_SIZE);
+                assertThat(recordReader.nextPage().getLoadedBlock().getPositionCount()).isEqualTo(MAX_BATCH_SIZE);
             }
 
             // predicate for specific value within the min/max range with bloom filter enabled, but a value not in the bloom filter
@@ -117,7 +117,7 @@ public class TestReadBloomFilter
                     .build();
 
             try (OrcRecordReader recordReader = createCustomOrcRecordReader(tempFile, matchBloomFilterPredicate, type, MAX_BATCH_SIZE)) {
-                assertThat(recordReader.nextPage().getLoadedPage().getPositionCount()).isEqualTo(MAX_BATCH_SIZE);
+                assertThat(recordReader.nextPage().getLoadedBlock().getPositionCount()).isEqualTo(MAX_BATCH_SIZE);
             }
         }
     }

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestStructColumnReader.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestStructColumnReader.java
@@ -272,7 +272,7 @@ public class TestStructColumnReader
                 OrcReader.INITIAL_BATCH_SIZE,
                 RuntimeException::new);
 
-        RowBlock block = (RowBlock) recordReader.nextPage().getLoadedPage().getBlock(0);
+        RowBlock block = (RowBlock) recordReader.nextPage().getLoadedBlock().getFieldBlock(0);
         recordReader.close();
         return block;
     }

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestTimestampTzMicros.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestTimestampTzMicros.java
@@ -53,7 +53,7 @@ public class TestTimestampTzMicros
                 newSimpleAggregatedMemoryContext(),
                 INITIAL_BATCH_SIZE,
                 RuntimeException::new)) {
-            assertThat(timestampTzType.getObject(reader.nextPage().getBlock(0), 0))
+            assertThat(timestampTzType.getObject(reader.nextPage().getFieldBlock(0), 0))
                     .isEqualTo(LongTimestampWithTimeZone.fromEpochMillisAndFraction(1654809982754L, 0, (short) 0));
         }
     }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetWriteValidation.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetWriteValidation.java
@@ -334,7 +334,7 @@ public class ParquetWriteValidation
 
             for (int channel = 0; channel < columnHashes.size(); channel++) {
                 ValidationHash validationHash = validationHashes.get(channel);
-                Block block = page.getBlock(channel);
+                Block block = page.getFieldBlock(channel);
                 XxHash64 xxHash64 = columnHashes.get(channel);
                 for (int position = 0; position < block.getPositionCount(); position++) {
                     long hash = validationHash.hash(block, position);
@@ -420,7 +420,7 @@ public class ParquetWriteValidation
 
             for (int channel = 0; channel < columnStatisticsValidations.size(); channel++) {
                 ColumnStatisticsValidation columnStatisticsValidation = columnStatisticsValidations.get(channel);
-                columnStatisticsValidation.addBlock(page.getBlock(channel));
+                columnStatisticsValidation.addBlock(page.getFieldBlock(channel));
             }
         }
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
@@ -589,7 +589,7 @@ public class ParquetReader
     private void validateWritePageChecksum(Page page)
     {
         if (writeChecksumBuilder.isPresent()) {
-            page = page.getLoadedPage();
+            page = page.getLoadedBlock();
             writeChecksumBuilder.get().addPage(page);
             rowGroupStatisticsValidation.orElseThrow().addPage(page);
         }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
@@ -175,7 +175,7 @@ public class ParquetWriter
         checkArgument(page.getChannelCount() == columnWriters.size());
 
         // page should already be loaded, but double check
-        page = page.getLoadedPage();
+        page = page.getLoadedBlock();
 
         Page validationPage = page;
         recordValidation(validation -> validation.addPage(validationPage));
@@ -200,7 +200,7 @@ public class ParquetWriter
         bufferedBytes = 0;
         for (int channel = 0; channel < page.getChannelCount(); channel++) {
             ColumnWriter writer = columnWriters.get(channel);
-            writer.writeBlock(new ColumnChunk(page.getBlock(channel)));
+            writer.writeBlock(new ColumnChunk(page.getFieldBlock(channel)));
             bufferedBytes += writer.getBufferedBytes();
         }
         rows += page.getPositionCount();
@@ -244,7 +244,7 @@ public class ParquetWriter
             try (ParquetReader parquetReader = createParquetReader(input, parquetMetadata, writeValidation)) {
                 for (Page page = parquetReader.nextPage(); page != null; page = parquetReader.nextPage()) {
                     // fully load the page
-                    page.getLoadedPage();
+                    page.getLoadedBlock();
                 }
             }
         }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestByteStreamSplitEncoding.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestByteStreamSplitEncoding.java
@@ -84,7 +84,7 @@ public class TestByteStreamSplitEncoding
             assertThat(page.getChannelCount()).isEqualTo(2);
             if (pageCount % 2 == 1) { // Skip loading every alternative page
                 for (int channel = 0; channel < page.getChannelCount(); channel++) {
-                    Block block = page.getBlock(channel).getLoadedBlock();
+                    Block block = page.getFieldBlock(channel).getLoadedBlock();
                     List<Double> expectedValues = expected.get(channel);
                     for (int postition = 0; postition < block.getPositionCount(); postition++) {
                         if (block instanceof IntArrayBlock) {

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestInt96Timestamp.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestInt96Timestamp.java
@@ -118,7 +118,7 @@ public class TestInt96Timestamp
         Page page = reader.nextPage();
         ImmutableList.Builder<LocalDateTime> builder = ImmutableList.builder();
         while (page != null) {
-            Fixed12Block block = (Fixed12Block) page.getBlock(0).getLoadedBlock();
+            Fixed12Block block = (Fixed12Block) page.getFieldBlock(0).getLoadedBlock();
             for (int i = 0; i < block.getPositionCount(); i++) {
                 builder.add(toLocalDateTime(block, i));
             }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReader.java
@@ -92,15 +92,15 @@ public class TestParquetReader
         ParquetReader reader = createParquetReader(dataSource, parquetMetadata, memoryContext, types, columnNames);
 
         Page page = reader.nextPage();
-        assertThat(page.getBlock(0)).isInstanceOf(LazyBlock.class);
+        assertThat(page.getFieldBlock(0)).isInstanceOf(LazyBlock.class);
         assertThat(memoryContext.getBytes()).isEqualTo(0);
-        page.getBlock(0).getLoadedBlock();
+        page.getFieldBlock(0).getLoadedBlock();
         // Memory usage due to reading data and decoding parquet page of 1st block
         long initialMemoryUsage = memoryContext.getBytes();
         assertThat(initialMemoryUsage).isGreaterThan(0);
 
         // Memory usage due to decoding parquet page of 2nd block
-        page.getBlock(1).getLoadedBlock();
+        page.getFieldBlock(1).getLoadedBlock();
         long currentMemoryUsage = memoryContext.getBytes();
         assertThat(currentMemoryUsage).isGreaterThan(initialMemoryUsage);
 
@@ -198,7 +198,7 @@ public class TestParquetReader
             Page page = reader.nextPage();
             Iterator<?> expected = expectedValues.iterator();
             while (page != null) {
-                Block block = page.getBlock(0);
+                Block block = page.getFieldBlock(0);
                 for (int i = 0; i < block.getPositionCount(); i++) {
                     assertThat(columnType.getObjectValue(session, block, i)).isEqualTo(expected.next());
                 }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestTimeMillis.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestTimeMillis.java
@@ -64,14 +64,14 @@ public class TestTimeMillis
         ParquetReader reader = createParquetReader(dataSource, parquetMetadata, newSimpleAggregatedMemoryContext(), types, columnNames);
 
         Page page = reader.nextPage();
-        Block block = page.getBlock(0).getLoadedBlock();
+        Block block = page.getFieldBlock(0).getLoadedBlock();
         assertThat(block.getPositionCount()).isEqualTo(1);
         // TIME '15:03:00'
         assertThat(timeType.getObjectValue(SESSION, block, 0))
                 .isEqualTo(SqlTime.newInstance(precision, 54180000000000000L));
 
         // TIME '23:59:59.999'
-        block = page.getBlock(1).getLoadedBlock();
+        block = page.getFieldBlock(1).getLoadedBlock();
         assertThat(block.getPositionCount()).isEqualTo(1);
         // Rounded up to 0 if precision < 3
         assertThat(timeType.getObjectValue(SESSION, block, 0))

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/MappedPageSource.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/MappedPageSource.java
@@ -59,7 +59,7 @@ public class MappedPageSource
         if (nextPage == null) {
             return null;
         }
-        return nextPage.getColumns(delegateFieldIndex);
+        return nextPage.getFields(delegateFieldIndex);
     }
 
     @Override

--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/io/AccumuloPageSink.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/io/AccumuloPageSink.java
@@ -233,7 +233,7 @@ public class AccumuloPageSink
                 Type type = columns.get(channel).type();
 
                 // Read the value from the page and append the field to the row
-                row.addField(TypeUtils.readNativeValue(type, page.getBlock(channel), position), type);
+                row.addField(TypeUtils.readNativeValue(type, page.getFieldBlock(channel), position), type);
             }
 
             try {

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPageSink.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPageSink.java
@@ -167,7 +167,7 @@ public class JdbcPageSink
     private void appendColumn(Page page, int position, int channel)
             throws SQLException
     {
-        Block block = page.getBlock(channel);
+        Block block = page.getFieldBlock(channel);
         int parameterIndex = channel + 1;
 
         WriteFunction writeFunction = columnWriters.get(channel);

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryPageSink.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryPageSink.java
@@ -94,7 +94,7 @@ public class BigQueryPageSink
             JSONObject row = new JSONObject();
             pageSinkIdColumnName.ifPresent(column -> row.put(column, pageSinkId.getId()));
             for (int channel = 0; channel < page.getChannelCount(); channel++) {
-                row.put(columnNames.get(channel), readNativeValue(columnTypes.get(channel), page.getBlock(channel), position));
+                row.put(columnNames.get(channel), readNativeValue(columnTypes.get(channel), page.getFieldBlock(channel), position));
             }
             batch.put(row);
         }

--- a/plugin/trino-blackhole/src/main/java/io/trino/plugin/blackhole/BlackHoleNodePartitioningProvider.java
+++ b/plugin/trino-blackhole/src/main/java/io/trino/plugin/blackhole/BlackHoleNodePartitioningProvider.java
@@ -57,7 +57,7 @@ public class BlackHoleNodePartitioningProvider
         return (page, position) -> {
             long hash = 13;
             for (int i = 0; i < partitionChannelTypes.size(); i++) {
-                Block block = page.getBlock(i);
+                Block block = page.getFieldBlock(i);
                 try {
                     long valueHash;
                     if (block.isNull(position)) {

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraPageSink.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraPageSink.java
@@ -149,7 +149,7 @@ public class CassandraPageSink
 
     private void appendColumn(List<Object> values, Page page, int position, int channel)
     {
-        Block block = page.getBlock(channel);
+        Block block = page.getFieldBlock(channel);
         Type type = columnTypes.get(channel);
         if (block.isNull(position)) {
             values.add(null);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/AbstractDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/AbstractDeltaLakePageSink.java
@@ -516,7 +516,7 @@ public abstract class AbstractDeltaLakePageSink
         Block[] blocks = new Block[dataColumnInputIndex.length];
         for (int i = 0; i < dataColumnInputIndex.length; i++) {
             int dataColumn = dataColumnInputIndex[i];
-            blocks[i] = page.getBlock(dataColumn);
+            blocks[i] = page.getFieldBlock(dataColumn);
         }
         return new Page(page.getPositionCount(), blocks);
     }
@@ -526,7 +526,7 @@ public abstract class AbstractDeltaLakePageSink
         Block[] blocks = new Block[columns.length];
         for (int i = 0; i < columns.length; i++) {
             int dataColumn = columns[i];
-            blocks[i] = page.getBlock(dataColumn);
+            blocks[i] = page.getFieldBlock(dataColumn);
         }
         return new Page(page.getPositionCount(), blocks);
     }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeBucketFunction.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeBucketFunction.java
@@ -50,7 +50,7 @@ public class DeltaLakeBucketFunction
     {
         long hash = 0;
         for (int channel = 0; channel < page.getChannelCount(); channel++) {
-            Block block = page.getBlock(channel);
+            Block block = page.getFieldBlock(channel);
             long valueHash = hashValue(hashCodeInvokers.get(channel), block, position);
             hash = (31 * hash) + valueHash;
         }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSource.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSource.java
@@ -192,10 +192,10 @@ public class DeltaLakePageSource
                     blocks[i] = RunLengthEncodedBlock.create(prefilledBlocks[i], batchSize);
                 }
                 else if (i == rowIdIndex) {
-                    blocks[i] = createRowIdBlock(dataPage.getBlock(delegateIndexes[i]));
+                    blocks[i] = createRowIdBlock(dataPage.getFieldBlock(delegateIndexes[i]));
                 }
                 else {
-                    blocks[i] = dataPage.getBlock(delegateIndexes[i]);
+                    blocks[i] = dataPage.getFieldBlock(delegateIndexes[i]);
                 }
             }
             return new Page(batchSize, blocks);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeUpdateBucketFunction.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeUpdateBucketFunction.java
@@ -35,7 +35,7 @@ public class DeltaLakeUpdateBucketFunction
     @Override
     public int getBucket(Page page, int position)
     {
-        Block block = page.getBlock(0);
+        Block block = page.getFieldBlock(0);
         SqlRow row = ((RowBlock) block.getUnderlyingValueBlock()).getRow(block.getUnderlyingValuePosition(position));
         Slice value = VARCHAR.getSlice(row.getRawFieldBlock(0), row.getRawIndex()); // file path field of row ID
         return (value.hashCode() & Integer.MAX_VALUE) % bucketCount;

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeWriter.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeWriter.java
@@ -136,7 +136,7 @@ public final class DeltaLakeWriter
         if (!coercers.isEmpty()) {
             Block[] translatedBlocks = new Block[originalPage.getChannelCount()];
             for (int index = 0; index < translatedBlocks.length; index++) {
-                Block originalBlock = originalPage.getBlock(index);
+                Block originalBlock = originalPage.getFieldBlock(index);
                 Function<Block, Block> coercer = coercers.get(index);
                 if (coercer != null) {
                     translatedBlocks[index] = new LazyBlock(

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/delete/PositionDeleteFilter.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/delete/PositionDeleteFilter.java
@@ -39,7 +39,7 @@ public final class PositionDeleteFilter
             int positionCount = page.getPositionCount();
             int[] retained = new int[positionCount];
             int retainedCount = 0;
-            Block block = page.getBlock(filePositionChannel);
+            Block block = page.getFieldBlock(filePositionChannel);
             for (int position = 0; position < positionCount; position++) {
                 long filePosition = BIGINT.getLong(block, position);
                 if (!deletedRows.contains(filePosition)) {

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/functions/tablechanges/TableChangesFunctionProcessor.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/functions/tablechanges/TableChangesFunctionProcessor.java
@@ -122,7 +122,7 @@ public class TableChangesFunctionProcessor
             int filePageColumns = page.getChannelCount();
             Block[] resultBlock = new Block[filePageColumns + NUMBER_OF_ADDITIONAL_COLUMNS_FOR_CDF_FILE];
             for (int i = 0; i < filePageColumns; i++) {
-                resultBlock[i] = page.getBlock(i);
+                resultBlock[i] = page.getFieldBlock(i);
             }
             resultBlock[filePageColumns] = RunLengthEncodedBlock.create(
                     currentVersionAsBlock, page.getPositionCount());
@@ -143,7 +143,7 @@ public class TableChangesFunctionProcessor
             int filePageColumns = page.getChannelCount();
             Block[] blocks = new Block[filePageColumns + NUMBER_OF_ADDITIONAL_COLUMNS_FOR_DATA_FILE];
             for (int i = 0; i < filePageColumns; i++) {
-                blocks[i] = page.getBlock(i);
+                blocks[i] = page.getFieldBlock(i);
             }
             blocks[filePageColumns] = RunLengthEncodedBlock.create(
                     nativeValueToBlock(VARCHAR, utf8Slice("insert")), page.getPositionCount());

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
@@ -836,12 +836,12 @@ public class CheckpointEntryIterator
                 DeltaLakeTransactionLogEntry entry;
                 if (extractor instanceof AddFileEntryExtractor) {
                     // Avoid unnecessary loading of the block in case there is a partition predicate mismatch for this add entry
-                    Block addBlock = page.getBlock(blockIndex);
-                    Block addPartitionValuesBlock = page.getBlock(blockIndex + 1);
+                    Block addBlock = page.getFieldBlock(blockIndex);
+                    Block addPartitionValuesBlock = page.getFieldBlock(blockIndex + 1);
                     entry = extractor.getEntry(session, pagePosition, addBlock, addPartitionValuesBlock.getLoadedBlock());
                 }
                 else {
-                    entry = extractor.getEntry(session, pagePosition, page.getBlock(blockIndex).getLoadedBlock());
+                    entry = extractor.getEntry(session, pagePosition, page.getFieldBlock(blockIndex).getLoadedBlock());
                 }
                 if (entry != null) {
                     nextEntries.add(entry);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/util/DeltaLakeWriteUtils.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/util/DeltaLakeWriteUtils.java
@@ -69,7 +69,7 @@ public final class DeltaLakeWriteUtils
     {
         ImmutableList.Builder<String> partitionValues = ImmutableList.builder();
         for (int field = 0; field < partitionColumns.getChannelCount(); field++) {
-            String value = toPartitionValue(partitionColumnTypes.get(field), partitionColumns.getBlock(field), position);
+            String value = toPartitionValue(partitionColumnTypes.get(field), partitionColumns.getFieldBlock(field), position);
             // TODO https://github.com/trinodb/trino/issues/18950 Remove or fix the following condition
             if (!CharMatcher.inRange((char) 0x20, (char) 0x7E).matchesAllOf(value)) {
                 String encoded = base16().withSeparator(" ", 2).encode(value.getBytes(UTF_8));

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeNodeLocalDynamicSplitPruning.java
@@ -167,8 +167,8 @@ public class TestDeltaLakeNodeLocalDynamicSplitPruning
                 Page page = nonEmptyPageSource.getNextPage();
                 assertThat(page).isNotNull();
                 assertThat(page.getPositionCount()).isEqualTo(1);
-                assertThat(INTEGER.getInt(page.getBlock(0), 0)).isEqualTo(keyColumnValue);
-                assertThat(VARCHAR.getSlice(page.getBlock(1), 0).toStringUtf8()).isEqualTo(dataColumnValue);
+                assertThat(INTEGER.getInt(page.getFieldBlock(0), 0)).isEqualTo(keyColumnValue);
+                assertThat(VARCHAR.getSlice(page.getFieldBlock(1), 0).toStringUtf8()).isEqualTo(dataColumnValue);
             }
         }
     }
@@ -293,9 +293,9 @@ public class TestDeltaLakeNodeLocalDynamicSplitPruning
                     Page page = nonEmptyPageSource.getNextPage();
                     assertThat(page).isNotNull();
                     assertThat(page.getPositionCount()).isEqualTo(1);
-                    assertThat(INTEGER.getInt(page.getBlock(0), 0)).isEqualTo(dateColumnValue);
-                    assertThat(VARCHAR.getSlice(page.getBlock(1), 0).toStringUtf8()).isEqualTo(receiptColumnValue);
-                    assertThat(((SqlDecimal) amountColumnType.getObjectValue(null, page.getBlock(2), 0)).toBigDecimal()).isEqualTo(amountColumnValue);
+                    assertThat(INTEGER.getInt(page.getFieldBlock(0), 0)).isEqualTo(dateColumnValue);
+                    assertThat(VARCHAR.getSlice(page.getFieldBlock(1), 0).toStringUtf8()).isEqualTo(receiptColumnValue);
+                    assertThat(((SqlDecimal) amountColumnType.getObjectValue(null, page.getFieldBlock(2), 0)).toBigDecimal()).isEqualTo(amountColumnValue);
                 }
             }
         }

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsPageSink.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsPageSink.java
@@ -53,7 +53,7 @@ public class SheetsPageSink
         for (int position = 0; position < page.getPositionCount(); position++) {
             List<Object> row = new ArrayList<>();
             for (int channel = 0; channel < page.getChannelCount(); channel++) {
-                row.add(getObjectValue(columns.get(channel).columnType(), page.getBlock(channel), position));
+                row.add(getObjectValue(columns.get(channel).columnType(), page.getFieldBlock(channel), position));
             }
             rows.add(row);
         }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSink.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSink.java
@@ -432,7 +432,7 @@ public class HivePageSink
         Block[] blocks = new Block[dataColumnInputIndex.length];
         for (int i = 0; i < dataColumnInputIndex.length; i++) {
             int dataColumn = dataColumnInputIndex[i];
-            blocks[i] = page.getBlock(dataColumn);
+            blocks[i] = page.getFieldBlock(dataColumn);
         }
         return new Page(page.getPositionCount(), blocks);
     }
@@ -457,7 +457,7 @@ public class HivePageSink
         Block[] blocks = new Block[columns.length];
         for (int i = 0; i < columns.length; i++) {
             int dataColumn = columns[i];
-            blocks[i] = page.getBlock(dataColumn);
+            blocks[i] = page.getFieldBlock(dataColumn);
         }
         return new Page(page.getPositionCount(), blocks);
     }
@@ -498,7 +498,7 @@ public class HivePageSink
             if (bucketBlock != null) {
                 Block[] blocks = new Block[partitionColumns.getChannelCount() + 1];
                 for (int i = 0; i < partitionColumns.getChannelCount(); i++) {
-                    blocks[i] = partitionColumns.getBlock(i);
+                    blocks[i] = partitionColumns.getFieldBlock(i);
                 }
                 blocks[blocks.length - 1] = bucketBlock;
                 partitionColumns = new Page(partitionColumns.getPositionCount(), blocks);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
@@ -197,7 +197,7 @@ public class HivePageSource
                         break;
                     case REGULAR:
                     case SYNTHESIZED:
-                        Block block = dataPage.getBlock(columnMapping.getIndex());
+                        Block block = dataPage.getFieldBlock(columnMapping.getIndex());
                         Optional<TypeCoercer<? extends Type, ? extends Type>> coercer = coercers.get(fieldId);
                         if (coercer.isPresent()) {
                             block = new LazyBlock(batchSize, new CoercionLazyBlockLoader(block, coercer.get()));
@@ -308,7 +308,7 @@ public class HivePageSource
         public Page filterPageToEligibleRowsOrDiscard(Page page)
         {
             IntArrayList ids = new IntArrayList(page.getPositionCount());
-            Page bucketColumnsPage = page.getColumns(bucketColumns);
+            Page bucketColumnsPage = page.getFields(bucketColumns);
             for (int position = 0; position < page.getPositionCount(); position++) {
                 int bucket = getHiveBucket(bucketingVersion, tableBucketCount, typeInfoList, bucketColumnsPage, position);
                 if ((bucket - bucketToKeep) % partitionBucketCount != 0) {
@@ -362,7 +362,7 @@ public class HivePageSource
 
         public void validate(Page page)
         {
-            Page bucketColumnsPage = page.getColumns(bucketColumnIndices);
+            Page bucketColumnsPage = page.getFields(bucketColumnIndices);
             for (int position = 0; position < page.getPositionCount(); position += VALIDATION_STRIDE) {
                 int bucket = getHiveBucket(bucketingVersion, bucketCount, bucketColumnTypes, bucketColumnsPage, position);
                 if (bucket != expectedBucket) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePartitionedBucketFunction.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePartitionedBucketFunction.java
@@ -70,7 +70,7 @@ public class HivePartitionedBucketFunction
         long partitionHash = 0;
         for (int i = 0; i < hashCodeInvokers.size(); i++) {
             try {
-                Block partitionColumn = page.getBlock(i + firstPartitionColumnIndex);
+                Block partitionColumn = page.getFieldBlock(i + firstPartitionColumnIndex);
                 partitionHash = (31 * partitionHash) + hashCodeNullSafe(hashCodeInvokers.get(i), partitionColumn, position);
             }
             catch (Throwable throwable) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveUpdateBucketFunction.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveUpdateBucketFunction.java
@@ -35,7 +35,7 @@ public class HiveUpdateBucketFunction
     @Override
     public int getBucket(Page page, int position)
     {
-        Block block = page.getBlock(0);
+        Block block = page.getFieldBlock(0);
         SqlRow bucketRow = ((RowBlock) block.getUnderlyingValueBlock()).getRow(block.getUnderlyingValuePosition(position));
         long value = INTEGER.getInt(bucketRow.getRawFieldBlock(BUCKET_CHANNEL), bucketRow.getRawIndex());
         return (int) (value & Integer.MAX_VALUE) % bucketCount;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/MergeFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/MergeFileWriter.java
@@ -134,7 +134,7 @@ public final class MergeFileWriter
 
         MergePage mergePage = createDeleteAndInsertPages(page, inputColumns.size());
         mergePage.getDeletionsPage().ifPresent(deletePage -> {
-            Block acidBlock = deletePage.getBlock(deletePage.getChannelCount() - 1);
+            Block acidBlock = deletePage.getFieldBlock(deletePage.getChannelCount() - 1);
             Page orcDeletePage = buildDeletePage(acidBlock, transaction.getWriteId());
             getOrCreateDeleteFileWriter().appendRows(orcDeletePage);
             deleteRowCount += deletePage.getPositionCount();
@@ -152,7 +152,7 @@ public final class MergeFileWriter
         int positionCount = insertPage.getPositionCount();
         List<Block> dataColumns = columns.stream()
                 .filter(column -> !column.isPartitionKey() && !column.isHidden())
-                .map(column -> insertPage.getBlock(column.getBaseHiveColumnIndex()))
+                .map(column -> insertPage.getFieldBlock(column.getBaseHiveColumnIndex()))
                 .collect(toImmutableList());
         Block mergedColumnsBlock = RowBlock.fromFieldBlocks(positionCount, dataColumns.toArray(new Block[] {}));
         Block currentTransactionBlock = RunLengthEncodedBlock.create(BIGINT, writeId, positionCount);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RcFileFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RcFileFileWriter.java
@@ -118,7 +118,7 @@ public final class RcFileFileWriter
                 blocks[i] = RunLengthEncodedBlock.create(nullBlocks.get(i), dataPage.getPositionCount());
             }
             else {
-                blocks[i] = dataPage.getBlock(inputColumnIndex);
+                blocks[i] = dataPage.getFieldBlock(inputColumnIndex);
             }
         }
         Page page = new Page(dataPage.getPositionCount(), blocks);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ReaderProjectionsAdapter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ReaderProjectionsAdapter.java
@@ -80,7 +80,7 @@ public class ReaderProjectionsAdapter
         for (int i = 0; i < outputToInputMapping.size(); i++) {
             ChannelMapping mapping = outputToInputMapping.get(i);
 
-            Block inputBlock = input.getBlock(mapping.getInputChannelIndex());
+            Block inputBlock = input.getFieldBlock(mapping.getInputChannelIndex());
             blocks[i] = createAdaptedLazyBlock(inputBlock, mapping.getDereferenceSequence());
         }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/avro/AvroHiveFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/avro/AvroHiveFileWriter.java
@@ -117,7 +117,7 @@ public final class AvroHiveFileWriter
         try {
             Block[] blocks = new Block[dataPage.getChannelCount() + typeCorrectNullBlocks.size()];
             for (int i = 0; i < dataPage.getChannelCount(); i++) {
-                blocks[i] = dataPage.getBlock(i);
+                blocks[i] = dataPage.getFieldBlock(i);
             }
             for (int i = 0; i < typeCorrectNullBlocks.size(); i++) {
                 blocks[i + dataPage.getChannelCount()] = RunLengthEncodedBlock.create(typeCorrectNullBlocks.get(i), dataPage.getPositionCount());

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/line/LineFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/line/LineFileWriter.java
@@ -86,7 +86,7 @@ public final class LineFileWriter
                 blocks[i] = RunLengthEncodedBlock.create(nullBlocks.get(i), dataPage.getPositionCount());
             }
             else {
-                blocks[i] = dataPage.getBlock(inputColumnIndex);
+                blocks[i] = dataPage.getFieldBlock(inputColumnIndex);
             }
         }
         Page page = new Page(dataPage.getPositionCount(), blocks);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcDeletedRows.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcDeletedRows.java
@@ -219,12 +219,12 @@ public class OrcDeletedRows
                 row = startRowId.getAsLong() + position;
             }
             else {
-                originalTransaction = BIGINT.getLong(sourcePage.getBlock(ORIGINAL_TRANSACTION_INDEX), position);
-                int encodedBucketValue = INTEGER.getInt(sourcePage.getBlock(BUCKET_ID_INDEX), position);
+                originalTransaction = BIGINT.getLong(sourcePage.getFieldBlock(ORIGINAL_TRANSACTION_INDEX), position);
+                int encodedBucketValue = INTEGER.getInt(sourcePage.getFieldBlock(BUCKET_ID_INDEX), position);
                 AcidBucketCodec bucketCodec = AcidBucketCodec.forBucket(encodedBucketValue);
                 bucket = bucketCodec.decodeWriterId(encodedBucketValue);
                 statementId = bucketCodec.decodeStatementId(encodedBucketValue);
-                row = BIGINT.getLong(sourcePage.getBlock(ROW_ID_INDEX), position);
+                row = BIGINT.getLong(sourcePage.getFieldBlock(ROW_ID_INDEX), position);
             }
             return new RowId(originalTransaction, bucket, statementId, row);
         }
@@ -330,12 +330,12 @@ public class OrcDeletedRows
                             }
 
                             while (currentPagePosition < currentPage.getPositionCount()) {
-                                long originalTransaction = BIGINT.getLong(currentPage.getBlock(ORIGINAL_TRANSACTION_INDEX), currentPagePosition);
-                                int encodedBucketValue = INTEGER.getInt(currentPage.getBlock(BUCKET_ID_INDEX), currentPagePosition);
+                                long originalTransaction = BIGINT.getLong(currentPage.getFieldBlock(ORIGINAL_TRANSACTION_INDEX), currentPagePosition);
+                                int encodedBucketValue = INTEGER.getInt(currentPage.getFieldBlock(BUCKET_ID_INDEX), currentPagePosition);
                                 AcidBucketCodec bucketCodec = AcidBucketCodec.forBucket(encodedBucketValue);
                                 int bucket = bucketCodec.decodeWriterId(encodedBucketValue);
                                 int statement = bucketCodec.decodeStatementId(encodedBucketValue);
-                                long row = BIGINT.getLong(currentPage.getBlock(ROW_ID_INDEX), currentPagePosition);
+                                long row = BIGINT.getLong(currentPage.getFieldBlock(ROW_ID_INDEX), currentPagePosition);
                                 RowId rowId = new RowId(originalTransaction, bucket, statement, row);
                                 deletedRowsBuilder.add(rowId);
                                 deletedRowsBuilderSize++;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcFileWriter.java
@@ -160,7 +160,7 @@ public final class OrcFileWriter
                 hasUnwrittenColumn = true;
             }
             else {
-                blocks[i] = dataPage.getBlock(inputColumnIndex);
+                blocks[i] = dataPage.getFieldBlock(inputColumnIndex);
             }
         }
         if (transaction.isInsert() && useAcidSchema) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSource.java
@@ -335,7 +335,7 @@ public class OrcPageSource
         @Override
         public Block block(Page sourcePage, MaskDeletedRowsFunction maskDeletedRowsFunction, long filePosition, OptionalLong startRowId)
         {
-            return new LazyBlock(maskDeletedRowsFunction.getPositionCount(), new MaskingBlockLoader(maskDeletedRowsFunction, sourcePage.getBlock(index)));
+            return new LazyBlock(maskDeletedRowsFunction.getPositionCount(), new MaskingBlockLoader(maskDeletedRowsFunction, sourcePage.getFieldBlock(index)));
         }
 
         @Override
@@ -416,9 +416,9 @@ public class OrcPageSource
             return maskDeletedRowsFunction.apply(fromFieldBlocks(
                     page.getPositionCount(),
                     new Block[] {
-                            page.getBlock(ORIGINAL_TRANSACTION_CHANNEL),
-                            page.getBlock(BUCKET_CHANNEL),
-                            page.getBlock(ROW_ID_CHANNEL)
+                            page.getFieldBlock(ORIGINAL_TRANSACTION_CHANNEL),
+                            page.getFieldBlock(BUCKET_CHANNEL),
+                            page.getFieldBlock(ROW_ID_CHANNEL)
                     }));
         }
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriter.java
@@ -131,7 +131,7 @@ public final class ParquetFileWriter
                 blocks[i] = RunLengthEncodedBlock.create(nullBlocks.get(i), dataPage.getPositionCount());
             }
             else {
-                blocks[i] = dataPage.getBlock(inputColumnIndex);
+                blocks[i] = dataPage.getFieldBlock(inputColumnIndex);
             }
         }
         Page page = new Page(dataPage.getPositionCount(), blocks);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSource.java
@@ -271,7 +271,7 @@ public class ParquetPageSource
         @Override
         public Block getBlock(Page sourcePage, long startRowId)
         {
-            return sourcePage.getBlock(sourceChannel);
+            return sourcePage.getFieldBlock(sourceChannel);
         }
 
         public int getSourceChannel()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV1.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV1.java
@@ -57,7 +57,7 @@ final class HiveBucketingV1
 
         int result = 0;
         for (int i = 0; i < types.size(); i++) {
-            int fieldHash = hash(types.get(i), page.getBlock(i), position);
+            int fieldHash = hash(types.get(i), page.getFieldBlock(i), position);
             result = result * 31 + fieldHash;
         }
         return result;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV2.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV2.java
@@ -59,7 +59,7 @@ final class HiveBucketingV2
 
         int result = 0;
         for (int i = 0; i < types.size(); i++) {
-            int fieldHash = hash(types.get(i), page.getBlock(i), position);
+            int fieldHash = hash(types.get(i), page.getFieldBlock(i), position);
             result = result * 31 + fieldHash;
         }
         return result;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
@@ -98,7 +98,7 @@ public final class HiveWriteUtils
     {
         ImmutableList.Builder<String> partitionValues = ImmutableList.builder();
         for (int field = 0; field < partitionColumns.getChannelCount(); field++) {
-            String value = toPartitionValue(partitionColumnTypes.get(field), partitionColumns.getBlock(field), position);
+            String value = toPartitionValue(partitionColumnTypes.get(field), partitionColumns.getFieldBlock(field), position);
             if (!CharMatcher.inRange((char) 0x20, (char) 0x7E).matchesAllOf(value)) {
                 String encoded = base16().withSeparator(" ", 2).encode(value.getBytes(UTF_8));
                 throw new TrinoException(HIVE_INVALID_PARTITION_VALUE, "Hive partition keys can only contain printable ASCII characters (0x20 - 0x7E). Invalid value: " + encoded);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/MergingPageIterator.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/MergingPageIterator.java
@@ -154,8 +154,8 @@ public class MergingPageIterator
                     int channel = sortFields.get(i);
                     MethodHandle orderingOperator = orderingOperators.get(i);
 
-                    Block block = page.getBlock(channel);
-                    Block otherBlock = other.page.getBlock(channel);
+                    Block block = page.getFieldBlock(channel);
+                    Block otherBlock = other.page.getFieldBlock(channel);
 
                     int result = (int) orderingOperator.invokeExact(block, position, otherBlock, other.position);
                     if (result != 0) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/SortBuffer.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/SortBuffer.java
@@ -94,7 +94,7 @@ public class SortBuffer
         pageBuilder.declarePosition();
         for (int i = 0; i < page.getChannelCount(); i++) {
             Type type = pageBuilder.getType(i);
-            Block block = page.getBlock(i);
+            Block block = page.getFieldBlock(i);
             BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(i);
             type.appendTo(block, position, blockBuilder);
         }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/TempFileReader.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/TempFileReader.java
@@ -73,7 +73,7 @@ public class TempFileReader
             }
 
             // eagerly load the page
-            return page.getLoadedPage();
+            return page.getLoadedBlock();
         }
         catch (IOException e) {
             throw handleException(e);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSink.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSink.java
@@ -254,7 +254,7 @@ public class TestHivePageSink
             while (!pageSource.isFinished()) {
                 Page nextPage = pageSource.getNextPage();
                 if (nextPage != null) {
-                    pages.add(nextPage.getLoadedPage());
+                    pages.add(nextPage.getLoadedBlock());
                 }
             }
         }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOrcPageSourceMemoryTracking.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOrcPageSourceMemoryTracking.java
@@ -207,7 +207,7 @@ public class TestOrcPageSourceMemoryTracking
             assertThat(pageSource.isFinished()).isFalse();
             Page page = pageSource.getNextPage();
             assertThat(page).isNotNull();
-            Block block = page.getBlock(1);
+            Block block = page.getFieldBlock(1);
 
             if (memoryUsage == -1) {
                 // Memory usage before lazy-loading the block
@@ -240,7 +240,7 @@ public class TestOrcPageSourceMemoryTracking
             assertThat(pageSource.isFinished()).isFalse();
             Page page = pageSource.getNextPage();
             assertThat(page).isNotNull();
-            Block block = page.getBlock(1);
+            Block block = page.getFieldBlock(1);
 
             if (memoryUsage == -1) {
                 // Memory usage before lazy-loading the block
@@ -273,7 +273,7 @@ public class TestOrcPageSourceMemoryTracking
             assertThat(pageSource.isFinished()).isFalse();
             Page page = pageSource.getNextPage();
             assertThat(page).isNotNull();
-            Block block = page.getBlock(1);
+            Block block = page.getFieldBlock(1);
 
             if (memoryUsage == -1) {
                 // Memory usage before lazy-loading the block
@@ -364,7 +364,7 @@ public class TestOrcPageSourceMemoryTracking
                     break;
                 }
                 assertThat(page).isNotNull();
-                page = page.getLoadedPage();
+                page = page.getLoadedBlock();
                 positionCount += page.getPositionCount();
                 // assert upper bound is tight
                 // ignore the first MAX_BATCH_SIZE rows given the sizes are set when loading the blocks

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestReaderProjectionsAdapter.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestReaderProjectionsAdapter.java
@@ -95,12 +95,12 @@ public class TestReaderProjectionsAdapter
                 column -> ((HiveColumnHandle) column).getType(),
                 HivePageSourceProvider::getProjection);
         Page inputPage = createPage(ImmutableList.of(inputBlockData), adapter.getInputTypes());
-        adapter.adaptPage(inputPage).getLoadedPage();
+        adapter.adaptPage(inputPage).getLoadedBlock();
 
         // Verify that only the block corresponding to subfield "col.f_row_0.f_bigint_0" should be completely loaded, others are not.
 
         // Assertion for "col"
-        Block lazyBlockLevel1 = inputPage.getBlock(0);
+        Block lazyBlockLevel1 = inputPage.getFieldBlock(0);
         assertThat(lazyBlockLevel1 instanceof LazyBlock).isTrue();
         assertThat(lazyBlockLevel1.isLoaded()).isFalse();
         RowBlock rowBlockLevel1 = (RowBlock) ((LazyBlock) lazyBlockLevel1).getBlock();
@@ -126,16 +126,16 @@ public class TestReaderProjectionsAdapter
         List<Type> inputTypes = adapter.getInputTypes();
 
         Page inputPage = createPage(inputPageData, inputTypes);
-        Page outputPage = adapter.adaptPage(inputPage).getLoadedPage();
+        Page outputPage = adapter.adaptPage(inputPage).getLoadedBlock();
 
         // Verify output block values
         for (int i = 0; i < columnMapping.size(); i++) {
             ReaderProjectionsAdapter.ChannelMapping mapping = columnMapping.get(i);
             int inputBlockIndex = mapping.getInputChannelIndex();
             verifyBlock(
-                    outputPage.getBlock(i),
+                    outputPage.getFieldBlock(i),
                     outputTypes.get(i),
-                    inputPage.getBlock(inputBlockIndex),
+                    inputPage.getFieldBlock(inputBlockIndex),
                     inputTypes.get(inputBlockIndex),
                     mapping.getDereferenceSequence());
         }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcDeletedRows.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcDeletedRows.java
@@ -69,7 +69,7 @@ public class TestOrcDeletedRows
 
         // page with deleted rows
         Page testPage = createTestPage(0, 10);
-        Block block = deletedRows.getMaskDeletedRowsFunction(testPage, OptionalLong.empty()).apply(testPage.getBlock(0));
+        Block block = deletedRows.getMaskDeletedRowsFunction(testPage, OptionalLong.empty()).apply(testPage.getFieldBlock(0));
         Set<Object> validRows = resultBuilder(SESSION, BIGINT)
                 .page(new Page(block))
                 .build()
@@ -80,7 +80,7 @@ public class TestOrcDeletedRows
 
         // page with no deleted rows
         testPage = createTestPage(10, 20);
-        block = deletedRows.getMaskDeletedRowsFunction(testPage, OptionalLong.empty()).apply(testPage.getBlock(1));
+        block = deletedRows.getMaskDeletedRowsFunction(testPage, OptionalLong.empty()).apply(testPage.getFieldBlock(1));
         assertThat(block.getPositionCount()).isEqualTo(10);
     }
 
@@ -98,7 +98,7 @@ public class TestOrcDeletedRows
 
         // page with deleted rows
         Page testPage = createTestPage(0, 8);
-        Block block = deletedRows.getMaskDeletedRowsFunction(testPage, OptionalLong.of(0L)).apply(testPage.getBlock(0));
+        Block block = deletedRows.getMaskDeletedRowsFunction(testPage, OptionalLong.of(0L)).apply(testPage.getFieldBlock(0));
         Set<Object> validRows = resultBuilder(SESSION, BIGINT)
                 .page(new Page(block))
                 .build()
@@ -109,7 +109,7 @@ public class TestOrcDeletedRows
 
         // page with no deleted rows
         testPage = createTestPage(5, 9);
-        block = deletedRows.getMaskDeletedRowsFunction(testPage, OptionalLong.empty()).apply(testPage.getBlock(1));
+        block = deletedRows.getMaskDeletedRowsFunction(testPage, OptionalLong.empty()).apply(testPage.getFieldBlock(1));
         assertThat(block.getPositionCount()).isEqualTo(4);
     }
 
@@ -123,7 +123,7 @@ public class TestOrcDeletedRows
 
         // page with deleted rows
         Page testPage = createTestPage(0, 10);
-        Block block = deletedRows.getMaskDeletedRowsFunction(testPage, OptionalLong.empty()).apply(testPage.getBlock(0));
+        Block block = deletedRows.getMaskDeletedRowsFunction(testPage, OptionalLong.empty()).apply(testPage.getFieldBlock(0));
         Set<Object> validRows = resultBuilder(SESSION, BIGINT)
                 .page(new Page(block))
                 .build()
@@ -134,7 +134,7 @@ public class TestOrcDeletedRows
 
         // page with no deleted rows
         testPage = createTestPage(10, 20);
-        block = deletedRows.getMaskDeletedRowsFunction(testPage, OptionalLong.empty()).apply(testPage.getBlock(1));
+        block = deletedRows.getMaskDeletedRowsFunction(testPage, OptionalLong.empty()).apply(testPage.getFieldBlock(1));
         assertThat(block.getPositionCount()).isEqualTo(10);
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcPageSourceFactory.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcPageSourceFactory.java
@@ -281,26 +281,26 @@ public class TestOrcPageSourceFactory
                 continue;
             }
 
-            page = page.getLoadedPage();
+            page = page.getLoadedBlock();
             for (int position = 0; position < page.getPositionCount(); position++) {
                 long nationKey = -42;
                 if (nationKeyColumn >= 0) {
-                    nationKey = BIGINT.getLong(page.getBlock(nationKeyColumn), position);
+                    nationKey = BIGINT.getLong(page.getFieldBlock(nationKeyColumn), position);
                 }
 
                 String name = "<not read>";
                 if (nameColumn >= 0) {
-                    name = VARCHAR.getSlice(page.getBlock(nameColumn), position).toStringUtf8();
+                    name = VARCHAR.getSlice(page.getFieldBlock(nameColumn), position).toStringUtf8();
                 }
 
                 long regionKey = -42;
                 if (regionKeyColumn >= 0) {
-                    regionKey = BIGINT.getLong(page.getBlock(regionKeyColumn), position);
+                    regionKey = BIGINT.getLong(page.getFieldBlock(regionKeyColumn), position);
                 }
 
                 String comment = "<not read>";
                 if (commentColumn >= 0) {
-                    comment = VARCHAR.getSlice(page.getBlock(commentColumn), position).toStringUtf8();
+                    comment = VARCHAR.getSlice(page.getFieldBlock(commentColumn), position).toStringUtf8();
                 }
 
                 rows.add(new Nation(position, nationKey, name, regionKey, comment));

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetTester.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetTester.java
@@ -509,7 +509,7 @@ class ParquetTester
                     assertThat(page.getPositionCount() == 1 || page.getSizeInBytes() <= max).isTrue());
 
             for (int field = 0; field < page.getChannelCount(); field++) {
-                Block block = page.getBlock(field);
+                Block block = page.getFieldBlock(field);
                 for (int i = 0; i < block.getPositionCount(); i++) {
                     assertThat(valuesByField[field].hasNext()).isTrue();
                     Object expected = valuesByField[field].next();

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestTimestamp.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestTimestamp.java
@@ -162,7 +162,7 @@ public class TestTimestamp
                     continue;
                 }
                 pageCount++;
-                Block block = page.getBlock(0);
+                Block block = page.getFieldBlock(0);
 
                 for (int i = 0; i < block.getPositionCount(); i++) {
                     assertThat(type.getObjectValue(session, block, i)).isEqualTo(expected.next());

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestMergingPageIterator.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestMergingPageIterator.java
@@ -81,13 +81,13 @@ public class TestMergingPageIterator
         while (iterator.hasNext()) {
             Page page = iterator.next();
             for (int i = 0; i < page.getPositionCount(); i++) {
-                if (page.getBlock(0).isNull(i)) {
-                    assertThat(page.getBlock(1).isNull(i)).isTrue();
+                if (page.getFieldBlock(0).isNull(i)) {
+                    assertThat(page.getFieldBlock(1).isNull(i)).isTrue();
                     values.add(null);
                 }
                 else {
-                    int x = INTEGER.getInt(page.getBlock(0), i);
-                    int y = INTEGER.getInt(page.getBlock(1), i);
+                    int x = INTEGER.getInt(page.getFieldBlock(0), i);
+                    int y = INTEGER.getInt(page.getFieldBlock(1), i);
                     assertThat(y).isEqualTo(x * 22);
                     values.add(x);
                 }

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiPageSource.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiPageSource.java
@@ -149,7 +149,7 @@ public class HudiPageSource
                     blocks[i] = RunLengthEncodedBlock.create(prefilledBlocks[i], positionCount);
                 }
                 else {
-                    blocks[i] = page.getBlock(delegateIndexes[i]);
+                    blocks[i] = page.getFieldBlock(delegateIndexes[i]);
                 }
             }
             return new Page(positionCount, blocks);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ConstantPopulatingPageSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ConstantPopulatingPageSource.java
@@ -83,7 +83,7 @@ public class ConstantPopulatingPageSource
                 blocks[targetChannel] = RunLengthEncodedBlock.create(constantValue, delegatePage.getPositionCount());
             }
             else {
-                blocks[targetChannel] = delegatePage.getBlock(targetChannelToSourceChannel[targetChannel]);
+                blocks[targetChannel] = delegatePage.getFieldBlock(targetChannelToSourceChannel[targetChannel]);
             }
         }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergAvroDataConversion.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergAvroDataConversion.java
@@ -116,7 +116,7 @@ public final class IcebergAvroDataConversion
                     .map(Types.NestedField::type)
                     .collect(toImmutableList());
             columnBlocks = IntStream.range(0, types.size())
-                    .mapToObj(page::getBlock)
+                    .mapToObj(page::getFieldBlock)
                     .collect(toImmutableList());
             positionCount = page.getPositionCount();
         }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergBucketFunction.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergBucketFunction.java
@@ -115,7 +115,7 @@ public class IcebergBucketFunction
 
         for (int i = 0; i < partitionColumns.size(); i++) {
             PartitionColumn partitionColumn = partitionColumns.get(i);
-            Block block = page.getBlock(partitionColumn.sourceChannel());
+            Block block = page.getFieldBlock(partitionColumn.sourceChannel());
             for (int index : partitionColumn.path()) {
                 block = getRowFieldsFromBlock(block).get(index);
             }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMergeSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMergeSink.java
@@ -99,7 +99,7 @@ public class IcebergMergeSink
         mergePage.getInsertionsPage().ifPresent(insertPageSink::appendPage);
 
         mergePage.getDeletionsPage().ifPresent(deletions -> {
-            List<Block> fields = RowBlock.getRowFieldsFromBlock(deletions.getBlock(deletions.getChannelCount() - 1));
+            List<Block> fields = RowBlock.getRowFieldsFromBlock(deletions.getFieldBlock(deletions.getChannelCount() - 1));
             Block fieldPathBlock = fields.get(0);
             Block rowPositionBlock = fields.get(1);
             Block partitionSpecIdBlock = fields.get(2);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergOrcFileWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergOrcFileWriter.java
@@ -138,7 +138,7 @@ public final class IcebergOrcFileWriter
                 blocks[i] = RunLengthEncodedBlock.create(nullBlocks.get(i), dataPage.getPositionCount());
             }
             else {
-                blocks[i] = dataPage.getBlock(inputColumnIndex);
+                blocks[i] = dataPage.getFieldBlock(inputColumnIndex);
             }
         }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
@@ -659,7 +659,8 @@ public class IcebergPageSink
         private static Block getPartitionBlock(PartitionColumn column, Page page)
         {
             List<Integer> sourceChannels = column.sourceChannels();
-            Block block = page.getBlock(sourceChannels.getFirst());
+            int channel = sourceChannels.getFirst();
+            Block block = page.getFieldBlock(channel);
             for (int i = 1; i < sourceChannels.size(); i++) {
                 block = getRowFieldsFromBlock(block).get(sourceChannels.get(i));
             }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSource.java
@@ -137,7 +137,7 @@ public class IcebergPageSource
             }
 
             dataPage = withRowIdBlock(dataPage);
-            dataPage = dataPage.getColumns(expectedColumnIndexes);
+            dataPage = dataPage.getFields(expectedColumnIndexes);
 
             return dataPage;
         }
@@ -163,7 +163,7 @@ public class IcebergPageSource
 
         Block[] rowIdFields = new Block[rowIdChildColumnIndexes.length];
         for (int childIndex = 0; childIndex < rowIdChildColumnIndexes.length; childIndex++) {
-            rowIdFields[childIndex] = page.getBlock(rowIdChildColumnIndexes[childIndex]);
+            rowIdFields[childIndex] = page.getFieldBlock(rowIdChildColumnIndexes[childIndex]);
         }
 
         Block[] fullPage = new Block[page.getChannelCount()];
@@ -173,7 +173,7 @@ public class IcebergPageSource
                 continue;
             }
 
-            fullPage[channel] = page.getBlock(channel);
+            fullPage[channel] = page.getFieldBlock(channel);
         }
 
         return new Page(page.getPositionCount(), fullPage);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUpdateBucketFunction.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUpdateBucketFunction.java
@@ -35,7 +35,7 @@ public class IcebergUpdateBucketFunction
     @Override
     public int getBucket(Page page, int position)
     {
-        Block block = page.getBlock(0);
+        Block block = page.getFieldBlock(0);
         SqlRow row = ((RowBlock) block.getUnderlyingValueBlock()).getRow(block.getUnderlyingValuePosition(position));
         Slice value = VARCHAR.getSlice(row.getRawFieldBlock(0), row.getRawIndex()); // file path field of row ID
         return (value.hashCode() & Integer.MAX_VALUE) % bucketCount;

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/LazyTrinoRow.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/LazyTrinoRow.java
@@ -68,7 +68,7 @@ final class LazyTrinoRow
             return value;
         }
 
-        value = getIcebergValue(page.getBlock(i), position, types[i]);
+        value = getIcebergValue(page.getFieldBlock(i), position, types[i]);
         values[i] = value;
         return value;
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/PositionDeleteFilter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/PositionDeleteFilter.java
@@ -43,7 +43,7 @@ public final class PositionDeleteFilter
     {
         int filePosChannel = rowPositionChannel(columns);
         return (page, position) -> {
-            long filePos = BIGINT.getLong(page.getBlock(filePosChannel), position);
+            long filePos = BIGINT.getLong(page.getFieldBlock(filePosChannel), position);
             return !deletedRows.contains(filePos);
         };
     }
@@ -71,8 +71,8 @@ public final class PositionDeleteFilter
                 continue;
             }
 
-            Block pathBlock = page.getBlock(0);
-            Block posBlock = page.getBlock(1);
+            Block pathBlock = page.getFieldBlock(0);
+            Block posBlock = page.getFieldBlock(1);
 
             for (int position = 0; position < page.getPositionCount(); position++) {
                 int result = comparator.compare(pathBlock, position);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/PositionDeleteWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/PositionDeleteWriter.java
@@ -132,6 +132,6 @@ public class PositionDeleteWriter
     {
         writer.appendRows(new Page(
                 RunLengthEncodedBlock.create(dataFilePathBlock, page.getPositionCount()),
-                page.getBlock(0)));
+                page.getFieldBlock(0)));
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/TrinoRow.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/TrinoRow.java
@@ -32,7 +32,7 @@ final class TrinoRow
         checkArgument(types.length == page.getChannelCount(), "mismatched types for page");
         values = new Object[types.length];
         for (int i = 0; i < values.length; i++) {
-            values[i] = getIcebergValue(page.getBlock(i), position, types[i]);
+            values[i] = getIcebergValue(page.getFieldBlock(i), position, types[i]);
         }
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessor.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessor.java
@@ -162,7 +162,7 @@ public class TableChangesFunctionProcessor
         for (int targetChannel = 0; targetChannel < delegateColumnMap.length; targetChannel++) {
             int delegateIndex = delegateColumnMap[targetChannel];
             if (delegateIndex != -1) {
-                blocks[targetChannel] = dataPage.getBlock(delegateIndex);
+                blocks[targetChannel] = dataPage.getFieldBlock(delegateIndex);
             }
         }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
@@ -193,8 +193,8 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                 Page page = nonEmptyPageSource.getNextPage();
                 assertThat(page).isNotNull();
                 assertThat(page.getPositionCount()).isEqualTo(1);
-                assertThat(INTEGER.getInt(page.getBlock(0), 0)).isEqualTo(keyColumnValue);
-                assertThat(VARCHAR.getSlice(page.getBlock(1), 0).toStringUtf8()).isEqualTo(dataColumnValue);
+                assertThat(INTEGER.getInt(page.getFieldBlock(0), 0)).isEqualTo(keyColumnValue);
+                assertThat(VARCHAR.getSlice(page.getFieldBlock(1), 0).toStringUtf8()).isEqualTo(dataColumnValue);
             }
 
             // Pruning due to IcebergSplit#fileStatisticsDomain
@@ -245,8 +245,8 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                 Page page = nonEmptyPageSource.getNextPage();
                 assertThat(page).isNotNull();
                 assertThat(page.getPositionCount()).isEqualTo(1);
-                assertThat(INTEGER.getInt(page.getBlock(0), 0)).isEqualTo(keyColumnValue);
-                assertThat(VARCHAR.getSlice(page.getBlock(1), 0).toStringUtf8()).isEqualTo(dataColumnValue);
+                assertThat(INTEGER.getInt(page.getFieldBlock(0), 0)).isEqualTo(keyColumnValue);
+                assertThat(VARCHAR.getSlice(page.getFieldBlock(1), 0).toStringUtf8()).isEqualTo(dataColumnValue);
             }
         }
     }
@@ -389,9 +389,9 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                     Page page = nonEmptyPageSource.getNextPage();
                     assertThat(page).isNotNull();
                     assertThat(page.getPositionCount()).isEqualTo(1);
-                    assertThat(INTEGER.getInt(page.getBlock(0), 0)).isEqualTo(dateColumnValue);
-                    assertThat(VARCHAR.getSlice(page.getBlock(1), 0).toStringUtf8()).isEqualTo(receiptColumnValue);
-                    assertThat(((SqlDecimal) amountColumnType.getObjectValue(null, page.getBlock(2), 0)).toBigDecimal()).isEqualTo(amountColumnValue);
+                    assertThat(INTEGER.getInt(page.getFieldBlock(0), 0)).isEqualTo(dateColumnValue);
+                    assertThat(VARCHAR.getSlice(page.getFieldBlock(1), 0).toStringUtf8()).isEqualTo(receiptColumnValue);
+                    assertThat(((SqlDecimal) amountColumnType.getObjectValue(null, page.getFieldBlock(2), 0)).toBigDecimal()).isEqualTo(amountColumnValue);
                 }
             }
         }
@@ -553,10 +553,10 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                     Page page = nonEmptyPageSource.getNextPage();
                     assertThat(page).isNotNull();
                     assertThat(page.getPositionCount()).isEqualTo(1);
-                    assertThat(INTEGER.getInt(page.getBlock(0), 0)).isEqualTo(2023L);
-                    assertThat(INTEGER.getInt(page.getBlock(1), 0)).isEqualTo(1L);
-                    assertThat(VARCHAR.getSlice(page.getBlock(2), 0).toStringUtf8()).isEqualTo(receiptColumnValue);
-                    assertThat(((SqlDecimal) amountColumnType.getObjectValue(null, page.getBlock(3), 0)).toBigDecimal()).isEqualTo(amountColumnValue);
+                    assertThat(INTEGER.getInt(page.getFieldBlock(0), 0)).isEqualTo(2023L);
+                    assertThat(INTEGER.getInt(page.getFieldBlock(1), 0)).isEqualTo(1L);
+                    assertThat(VARCHAR.getSlice(page.getFieldBlock(2), 0).toStringUtf8()).isEqualTo(receiptColumnValue);
+                    assertThat(((SqlDecimal) amountColumnType.getObjectValue(null, page.getFieldBlock(3), 0)).toBigDecimal()).isEqualTo(amountColumnValue);
                 }
             }
         }

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaPageSink.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaPageSink.java
@@ -116,10 +116,10 @@ public class KafkaPageSink
         for (int position = 0; position < page.getPositionCount(); position++) {
             for (int channel = 0; channel < page.getChannelCount(); channel++) {
                 if (columns.get(channel).isKeyCodec()) {
-                    keyEncoder.appendColumnValue(page.getBlock(channel), position);
+                    keyEncoder.appendColumnValue(page.getFieldBlock(channel), position);
                 }
                 else {
-                    messageEncoder.appendColumnValue(page.getBlock(channel), position);
+                    messageEncoder.appendColumnValue(page.getFieldBlock(channel), position);
                 }
             }
 

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduBucketFunction.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduBucketFunction.java
@@ -89,7 +89,7 @@ public class KuduBucketFunction
     private int calculateSchemaLevelBucketId(Page page, PartialRow partialRow, HashBucketSchema hashBucketSchema, int position)
     {
         for (int channel = 0; channel < page.getChannelCount(); channel++) {
-            Block block = page.getBlock(channel);
+            Block block = page.getFieldBlock(channel);
             Type type = this.bucketChannelTypes.get(channel);
             Integer bucketChannel = this.bucketChannels.get(channel);
             if (BOOLEAN.equals(type)) {

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduPageSink.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduPageSink.java
@@ -148,7 +148,7 @@ public class KuduPageSink
 
     private void appendColumn(PartialRow row, Page page, int position, int channel, int destChannel)
     {
-        Block block = page.getBlock(channel);
+        Block block = page.getFieldBlock(channel);
         Type type = columnTypes.get(destChannel);
         if (block.isNull(position)) {
             row.setNull(destChannel);
@@ -210,8 +210,8 @@ public class KuduPageSink
         // The last channel in the page is the rowId block, the next-to-last is the operation block
         int columnCount = originalColumnTypes.size();
         checkArgument(page.getChannelCount() == 2 + columnCount, "The page size should be 2 + columnCount (%s), but is %s", columnCount, page.getChannelCount());
-        Block operationBlock = page.getBlock(columnCount);
-        Block rowIds = page.getBlock(columnCount + 1);
+        Block operationBlock = page.getFieldBlock(columnCount);
+        Block rowIds = page.getFieldBlock(columnCount + 1);
 
         Schema schema = table.getSchema();
         try (KuduOperationApplier operationApplier = KuduOperationApplier.fromKuduClientSession(session)) {

--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryPageSourceProvider.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryPageSourceProvider.java
@@ -208,7 +208,7 @@ public final class MemoryPageSourceProvider
         for (Map.Entry<Integer, Domain> entry : domains.entrySet()) {
             int channel = entry.getKey();
             Domain domain = entry.getValue();
-            Object value = TypeUtils.readNativeValue(domain.getType(), page.getBlock(channel), position);
+            Object value = TypeUtils.readNativeValue(domain.getType(), page.getFieldBlock(channel), position);
             if (!domain.includesNullableValue(value)) {
                 return false;
             }

--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryPagesStore.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryPagesStore.java
@@ -121,9 +121,9 @@ public class MemoryPagesStore
                 Type type = columnTypes.get(j);
                 BlockBuilder builder = type.createBlockBuilder(null, page.getPositionCount());
                 IntStream.range(0, page.getPositionCount()).forEach(_ -> builder.appendNull());
-                page = page.appendColumn(builder.build());
+                page = page.appendField(builder.build());
             }
-            partitionedPages.add(page.getColumns(columnIndexes));
+            partitionedPages.add(page.getFields(columnIndexes));
         }
 
         return partitionedPages.build();

--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryPagesStore.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryPagesStore.java
@@ -173,15 +173,17 @@ public class TestMemoryPagesStore
     {
         BlockBuilder blockBuilder = BIGINT.createFixedSizeBlockBuilder(POSITIONS_PER_PAGE);
         BIGINT.writeLong(blockBuilder, 42L);
-        return new Page(0, blockBuilder.build());
+        return new Page(1, blockBuilder.build());
     }
 
     private static Page createOneMegaBytePage()
     {
         BlockBuilder blockBuilder = BIGINT.createFixedSizeBlockBuilder(POSITIONS_PER_PAGE);
+        int actualPositions = 0;
         while (blockBuilder.getRetainedSizeInBytes() < 1024 * 1024) {
             BIGINT.writeLong(blockBuilder, 42L);
+            actualPositions++;
         }
-        return new Page(0, blockBuilder.build());
+        return new Page(actualPositions, blockBuilder.build());
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSink.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSink.java
@@ -118,7 +118,7 @@ public class MongoPageSink
 
             for (int channel = 0; channel < page.getChannelCount(); channel++) {
                 MongoColumnHandle column = columns.get(channel);
-                doc.append(column.baseName(), getObjectValue(columns.get(channel).type(), page.getBlock(channel), position));
+                doc.append(column.baseName(), getObjectValue(columns.get(channel).type(), page.getFieldBlock(channel), position));
             }
             batch.add(doc);
         }

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMergeSink.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMergeSink.java
@@ -159,10 +159,10 @@ public class PhoenixMergeSink
     {
         checkArgument(page.getChannelCount() == 2 + columnCount, "The page size should be 2 + columnCount (%s), but is %s", columnCount, page.getChannelCount());
         int positionCount = page.getPositionCount();
-        Block operationBlock = page.getBlock(columnCount);
+        Block operationBlock = page.getFieldBlock(columnCount);
 
         int[] dataChannel = IntStream.range(0, columnCount).toArray();
-        Page dataPage = page.getColumns(dataChannel);
+        Page dataPage = page.getFields(dataChannel);
 
         int[] insertPositions = new int[positionCount];
         int insertPositionCount = 0;
@@ -194,7 +194,7 @@ public class PhoenixMergeSink
             insertSink.appendPage(dataPage.getPositions(insertPositions, 0, insertPositionCount));
         }
 
-        List<Block> rowIdFields = RowBlock.getRowFieldsFromBlock(page.getBlock(columnCount + 1));
+        List<Block> rowIdFields = RowBlock.getRowFieldsFromBlock(page.getFieldBlock(columnCount + 1));
         if (deletePositionCount > 0) {
             Block[] deleteBlocks = new Block[rowIdFields.size()];
             for (int field = 0; field < rowIdFields.size(); field++) {
@@ -206,7 +206,7 @@ public class PhoenixMergeSink
         if (updatePositionCount > 0) {
             Page updatePage = dataPage.getPositions(updatePositions, 0, updatePositionCount);
             if (hasRowKey) {
-                updatePage = updatePage.appendColumn(rowIdFields.get(0).getPositions(updatePositions, 0, updatePositionCount));
+                updatePage = updatePage.appendField(rowIdFields.get(0).getPositions(updatePositions, 0, updatePositionCount));
             }
 
             updateSink.appendPage(updatePage);

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixPageSource.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixPageSource.java
@@ -119,7 +119,7 @@ public class PhoenixPageSource
             requireNonNull(page, "page is null");
             Block[] mergeRowIdBlocks = new Block[mergeRowIdSourceChannels.size()];
             for (int i = 0; i < mergeRowIdBlocks.length; i++) {
-                mergeRowIdBlocks[i] = page.getBlock(mergeRowIdSourceChannels.get(i));
+                mergeRowIdBlocks[i] = page.getFieldBlock(mergeRowIdSourceChannels.get(i));
             }
             return fromFieldBlocks(page.getPositionCount(), mergeRowIdBlocks);
         }
@@ -136,7 +136,7 @@ public class PhoenixPageSource
         @Override
         public Block getBlock(Page sourcePage)
         {
-            return sourcePage.getBlock(sourceChannel);
+            return sourcePage.getFieldBlock(sourceChannel);
         }
     }
 }

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestBrokerQueries.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestBrokerQueries.java
@@ -118,12 +118,12 @@ public class TestBrokerQueries
         Page page = pageSource.getNextPage();
         assertThat(page.getChannelCount()).isEqualTo(columnHandles.size());
         assertThat(page.getPositionCount()).isEqualTo(RESPONSE.getResultTable().getRows().size());
-        Block block = page.getBlock(0);
+        Block block = page.getFieldBlock(0);
         String value = VARCHAR.getSlice(block, 0).toStringUtf8();
         assertThat(value).isEqualTo(getOnlyElement(RESPONSE.getResultTable().getRows())[0]);
-        block = page.getBlock(1);
+        block = page.getFieldBlock(1);
         assertThat(BIGINT.getLong(block, 0)).isEqualTo((long) getOnlyElement(RESPONSE.getResultTable().getRows())[1]);
-        block = page.getBlock(2);
+        block = page.getFieldBlock(2);
         value = VARCHAR.getSlice(block, 0).toStringUtf8();
         assertThat(value).isEqualTo(getOnlyElement(RESPONSE.getResultTable().getRows())[2]);
     }

--- a/plugin/trino-thrift-api/src/test/java/io/trino/plugin/thrift/api/TestReadWrite.java
+++ b/plugin/trino-thrift-api/src/test/java/io/trino/plugin/thrift/api/TestReadWrite.java
@@ -172,7 +172,7 @@ public class TestReadWrite
         assertThat(page).isNotNull();
         assertThat(page.getChannelCount()).isEqualTo(columns.size());
         for (int i = 0; i < columns.size(); i++) {
-            Block actual = page.getBlock(i);
+            Block actual = page.getFieldBlock(i);
             Block expected = inputBlocks.get(i);
             assertBlock(actual, expected, columns.get(i));
         }

--- a/plugin/trino-thrift-testing-server/src/main/java/io/trino/plugin/thrift/server/ThriftTpchService.java
+++ b/plugin/trino-thrift-testing-server/src/main/java/io/trino/plugin/thrift/server/ThriftTpchService.java
@@ -258,7 +258,7 @@ public class ThriftTpchService
         int numberOfColumns = columnTypes.size();
         List<TrinoThriftBlock> columnBlocks = new ArrayList<>(numberOfColumns);
         for (int i = 0; i < numberOfColumns; i++) {
-            columnBlocks.add(fromBlock(page.getBlock(i), columnTypes.get(i)));
+            columnBlocks.add(fromBlock(page.getFieldBlock(i), columnTypes.get(i)));
         }
         return new TrinoThriftPageResult(columnBlocks, page.getPositionCount(), nextToken);
     }

--- a/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/TestThriftIndexPageSource.java
+++ b/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/TestThriftIndexPageSource.java
@@ -120,7 +120,7 @@ public class TestThriftIndexPageSource
         assertThat((long) stats.getIndexPageSize().getAllTime().getTotal()).isEqualTo(pageSizeReceived);
         assertThat(page).isNotNull();
         assertThat(page.getPositionCount()).isEqualTo(1);
-        assertThat(INTEGER.getInt(page.getBlock(0), 0)).isEqualTo(20);
+        assertThat(INTEGER.getInt(page.getFieldBlock(0), 0)).isEqualTo(20);
         // not complete yet
         assertThat(pageSource.isFinished()).isFalse();
 
@@ -137,7 +137,7 @@ public class TestThriftIndexPageSource
         pageSizeReceived += page.getSizeInBytes();
         assertThat((long) stats.getIndexPageSize().getAllTime().getTotal()).isEqualTo(pageSizeReceived);
         assertThat(page.getPositionCount()).isEqualTo(1);
-        assertThat(INTEGER.getInt(page.getBlock(0), 0)).isEqualTo(10);
+        assertThat(INTEGER.getInt(page.getFieldBlock(0), 0)).isEqualTo(10);
         // still not complete
         assertThat(pageSource.isFinished()).isFalse();
 
@@ -148,7 +148,7 @@ public class TestThriftIndexPageSource
         pageSizeReceived += page.getSizeInBytes();
         assertThat((long) stats.getIndexPageSize().getAllTime().getTotal()).isEqualTo(pageSizeReceived);
         assertThat(page.getPositionCount()).isEqualTo(1);
-        assertThat(INTEGER.getInt(page.getBlock(0), 0)).isEqualTo(30);
+        assertThat(INTEGER.getInt(page.getFieldBlock(0), 0)).isEqualTo(30);
         // finished now
         assertThat(pageSource.isFinished()).isTrue();
 
@@ -206,7 +206,7 @@ public class TestThriftIndexPageSource
             blocked.get(1, SECONDS);
             Page page = pageSource.getNextPage();
             if (page != null) {
-                Block block = page.getBlock(0);
+                Block block = page.getFieldBlock(0);
                 for (int position = 0; position < block.getPositionCount(); position++) {
                     actual.add(INTEGER.getInt(block, position));
                 }

--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/LazyRecordPageSource.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/LazyRecordPageSource.java
@@ -137,7 +137,7 @@ class LazyRecordPageSource
     {
         Block[] lazyBlocks = new Block[page.getChannelCount()];
         for (int i = 0; i < page.getChannelCount(); ++i) {
-            Block block = page.getBlock(i);
+            Block block = page.getFieldBlock(i);
             lazyBlocks[i] = new LazyBlock(page.getPositionCount(), () -> block);
         }
 

--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchBucketFunction.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchBucketFunction.java
@@ -36,7 +36,7 @@ public class TpchBucketFunction
     @Override
     public int getBucket(Page page, int position)
     {
-        Block block = page.getBlock(0);
+        Block block = page.getFieldBlock(0);
         if (block.isNull(position)) {
             return 0;
         }

--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchTables.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchTables.java
@@ -63,7 +63,7 @@ public final class TpchTables
                     return computeNext();
                 }
 
-                return page.getLoadedPage();
+                return page.getLoadedBlock();
             }
         };
     }


### PR DESCRIPTION
## Description
This is the first step in replacing `Page` with `RowBlock` in Trino.  Now that RowBlock is not null-suppressed, the difference between `Page` and `RowBlock` are minimal.  The remaining main difference is the that `getPositions` method of a `Page` wraps each row in a dictionary, whereas `RowBlock` just wraps the entire `RowBlock` with a dictionary.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
## SPI
* Change `Page` to extend `RowBlock` . ({issue}`issuenumber`)
```
