### PR TITLE
Fix insert to Clickhouse TimestampWithTimeZone

### DIFF
--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseTypeMapping.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseTypeMapping.java
@@ -1003,6 +1003,12 @@ public abstract class BaseClickHouseTypeMapping
             Session session = Session.builder(getSession())
                     .setTimeZoneKey(TimeZoneKey.getTimeZoneKey(sessionZone.getId()))
                     .build();
+            SqlDataTypeTest.create()
+                    .addRoundTrip("DateTime('Asia/Kathmandu')", "timestamp '2024-01-01 12:34:56'", TIMESTAMP_TZ_SECONDS, "TIMESTAMP '2024-01-01 05:19:56 +05:45'")
+                    .addRoundTrip("DateTime('Asia/Kathmandu')", "timestamp '2024-01-01 12:34:56 Asia/Kathmandu'", TIMESTAMP_TZ_SECONDS, "TIMESTAMP '2024-01-01 12:34:56 +05:45'")
+                    .addRoundTrip("DateTime('Asia/Kathmandu')", "timestamp '2024-01-01 12:34:56 +00:00'", TIMESTAMP_TZ_SECONDS, "TIMESTAMP '2024-01-01 18:19:56 +05:45'")
+                    .addRoundTrip("DateTime('Asia/Kathmandu')", "timestamp '2024-01-01 12:34:56 -01:00'", TIMESTAMP_TZ_SECONDS, "TIMESTAMP '2024-01-01 19:19:56 +05:45'")
+                    .execute(getQueryRunner(), session, clickhouseCreateAndTrinoInsert("tpch.test_timestamp_with_time_zone"));
 
             dateTimeWithTimeZoneTest(clickhouseDateTimeInputTypeFactory("datetime"))
                     .execute(getQueryRunner(), session, clickhouseCreateAndInsert("tpch.datetime_tz"));


### PR DESCRIPTION
The time zone is not stored in the rows of the table, but is stored in the column metadata.

From ClickHouse documentation
https://clickhouse.com/docs/en/sql-reference/data-types/datetime

The point in time is saved as a Unix timestamp, regardless of the time zone or daylight saving time. The time zone affects how the values of the DateTime type values are displayed in text format and how the values specified as strings are parsed (‘2020-01-01 05:00:01’).

Timezone agnostic Unix timestamp is stored in tables, and the timezone is used to transform it to text format or back during data import/export or to make calendar calculations on the values (example: toDate, toHour functions etc.). The time zone is not stored in the rows of the table (or in resultset), but is stored in the column metadata.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

- https://github.com/trinodb/trino/issues/7100
- https://github.com/trinodb/trino/issues/10537
- https://github.com/trinodb/trino/pull/15040

PRs:
- https://github.com/trinodb/trino/pull/23460
- https://github.com/trinodb/trino/pull/23785
- https://github.com/trinodb/trino/pull/23788
- https://github.com/trinodb/trino/pull/23789
- https://github.com/trinodb/trino/pull/23802

ClickHouse docs:
- https://clickhouse.com/docs/en/sql-reference/data-types/datetime
- https://clickhouse.com/docs/en/sql-reference/data-types/datetime64

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix insert for Clickhouse TimestampWithTimeZone. ({issue}`issuenumber`)
```
