### PR TITLE
Cleanup SPI Java module dependencies 

### DIFF
--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -295,6 +295,10 @@
                                     <code>java.method.addedToInterface</code>
                                     <new>method void io.trino.spi.resourcegroups.ResourceGroup::setDisabled(boolean)</new>
                                 </item>
+                                <item>
+                                    <code>java.class.removed</code>
+                                    <old>class io.trino.spi.connector.ConnectorMetadata.Helper</old>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/module-info.java
+++ b/core/trino-spi/src/main/java/module-info.java
@@ -12,10 +12,10 @@
  * limitations under the License.
  */
 module trino.spi {
-    requires transitive com.fasterxml.jackson.annotation;
-    requires transitive com.google.errorprone.annotations;
+    requires com.fasterxml.jackson.annotation;
+    requires com.google.errorprone.annotations;
     requires transitive io.opentelemetry.api;
-    requires transitive jakarta.annotation;
+    requires jakarta.annotation;
     requires java.logging;
     requires transitive slice;
 

--- a/core/trino-spi/src/main/java/module-info.java
+++ b/core/trino-spi/src/main/java/module-info.java
@@ -16,7 +16,6 @@ module trino.spi {
     requires com.google.errorprone.annotations;
     requires transitive io.opentelemetry.api;
     requires jakarta.annotation;
-    requires java.logging;
     requires transitive slice;
 
     exports io.trino.spi;


### PR DESCRIPTION
## Description
The annotation libraries do not need to be transitive dependencies, and the logging usage isn't needed at all.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
