### PR TITLE
Fix incorrect simplification of CASE with constant boolean results

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/SimplifyRedundantCase.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/SimplifyRedundantCase.java
@@ -13,6 +13,7 @@
  */
 package io.trino.sql.ir.optimizer.rule;
 
+import com.google.common.collect.ImmutableList;
 import io.trino.Session;
 import io.trino.metadata.Metadata;
 import io.trino.sql.PlannerContext;
@@ -25,6 +26,7 @@ import io.trino.sql.ir.WhenClause;
 import io.trino.sql.ir.optimizer.IrOptimizerRule;
 import io.trino.sql.planner.Symbol;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -65,21 +67,58 @@ public class SimplifyRedundantCase
             return Optional.empty();
         }
 
-        if (defaultValue.equals(FALSE)) {
-            List<Expression> operands = caseTerm.whenClauses().stream()
-                    .filter(clause -> clause.getResult().equals(TRUE))
-                    .map(WhenClause::getOperand)
-                    .toList();
+        return transformRecursive(0, caseTerm.whenClauses(), defaultValue);
+    }
 
-            return Optional.of(new Comparison(Comparison.Operator.IDENTICAL, IrUtils.or(operands), TRUE));
+    private Optional<Expression> transformRecursive(int start, List<WhenClause> clauses, Expression defaultExpression)
+    {
+        // An expression such as:
+        // CASE
+        //   WHEN a1 THEN false
+        //   WHEN a2 THEN false
+        //   WHEN a3 THEN true
+        //   WHEN a4 THEN false
+        //   WHEN a5 THEN true
+        //   WHEN a6 THEN false
+        //   ELSE true
+        // END
+        //
+        // can be transformed to:
+        //     (a1 ≢ true AND a2 ≢ true AND a3 ≡ true) OR
+        //     (a1 ≢ true AND a2 ≢ true AND a3 ≢ true AND a4 ≢ true AND a5 ≡ true) OR
+        //     (a1 ≢ true AND a2 ≢ true AND a3 ≢ true AND a4 ≢ true AND a5 ≢ true AND a6 ≢ true)
+        //
+        // which can be further simplified to:
+        //
+        //     a1 ≢ true AND a2 ≢ true AND (a3 ≡ true OR (a4 ≢ true AND (a5 ≡ true OR a6 ≢ true)))
+        //
+        // This method constructs the simplified expression recursively.
+
+        int end = start;
+        while (end < clauses.size() && clauses.get(end).getResult().equals(FALSE)) {
+            end++;
+        }
+
+        List<Expression> falseTerms = clauses.subList(start, end).stream()
+                .map(clause -> IrExpressions.not(metadata, new Comparison(Comparison.Operator.IDENTICAL, clause.getOperand(), TRUE)))
+                .toList();
+
+        if (end < clauses.size()) {
+            List<Expression> terms = new ArrayList<>();
+            terms.add(new Comparison(Comparison.Operator.IDENTICAL, clauses.get(end).getOperand(), TRUE));
+            transformRecursive(end + 1, clauses, defaultExpression).ifPresent(terms::add);
+
+            return Optional.of(IrUtils.and(
+                    ImmutableList.<Expression>builder()
+                            .addAll(falseTerms)
+                            .add(IrUtils.or(terms))
+                            .build()));
+        }
+        else if (defaultExpression.equals(TRUE)) {
+            return Optional.of(IrUtils.and(falseTerms));
         }
         else {
-            List<Expression> operands = caseTerm.whenClauses().stream()
-                    .filter(clause -> clause.getResult().equals(FALSE))
-                    .map(WhenClause::getOperand)
-                    .toList();
-
-            return Optional.of(IrExpressions.not(metadata, new Comparison(Comparison.Operator.IDENTICAL, IrUtils.or(operands), TRUE)));
+            return Optional.empty();
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/SimplifyRedundantCase.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/SimplifyRedundantCase.java
@@ -67,7 +67,8 @@ public class SimplifyRedundantCase
             return Optional.empty();
         }
 
-        return transformRecursive(0, caseTerm.whenClauses(), defaultValue);
+        return transformRecursive(0, caseTerm.whenClauses(), defaultValue)
+                .or(() -> Optional.<Expression>of(FALSE));
     }
 
     private Optional<Expression> transformRecursive(int start, List<WhenClause> clauses, Expression defaultExpression)

--- a/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestSimplifyRedundantCase.java
+++ b/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestSimplifyRedundantCase.java
@@ -74,9 +74,9 @@ public class TestSimplifyRedundantCase
 
         assertThat(optimize(
                 new Case(
-                        ImmutableList.of(new WhenClause(new Reference(BOOLEAN, "x"), TRUE)),
+                        ImmutableList.of(new WhenClause(new Reference(BOOLEAN, "x"), FALSE)),
                         FALSE)))
-                .isEqualTo(Optional.of(new Comparison(IDENTICAL, new Reference(BOOLEAN, "x"), TRUE)));
+                .isEqualTo(Optional.of(FALSE));
 
         assertThat(optimize(
                 new Case(

--- a/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestSimplifyRedundantCase.java
+++ b/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestSimplifyRedundantCase.java
@@ -66,6 +66,20 @@ public class TestSimplifyRedundantCase
 
         assertThat(optimize(
                 new Case(
+                        ImmutableList.of(new WhenClause(new Reference(BOOLEAN, "x"), TRUE)),
+                        TRUE)))
+                .isEqualTo(Optional.of(IrUtils.or(
+                        new Comparison(IDENTICAL, new Reference(BOOLEAN, "x"), TRUE),
+                        TRUE)));
+
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(new WhenClause(new Reference(BOOLEAN, "x"), TRUE)),
+                        FALSE)))
+                .isEqualTo(Optional.of(new Comparison(IDENTICAL, new Reference(BOOLEAN, "x"), TRUE)));
+
+        assertThat(optimize(
+                new Case(
                         ImmutableList.of(new WhenClause(new Comparison(EQUAL, new Reference(BIGINT, "x"), new Constant(BIGINT, 1L)), TRUE)),
                         FALSE)))
                 .isEqualTo(Optional.of(new Comparison(IDENTICAL, new Comparison(EQUAL, new Reference(BIGINT, "x"), new Constant(BIGINT, 1L)), TRUE)));
@@ -83,7 +97,12 @@ public class TestSimplifyRedundantCase
                                 new WhenClause(new Reference(BOOLEAN, "y"), FALSE),
                                 new WhenClause(new Reference(BOOLEAN, "z"), TRUE)),
                         FALSE)))
-                .isEqualTo(Optional.of(new Comparison(IDENTICAL, IrUtils.or(new Reference(BOOLEAN, "x"), new Reference(BOOLEAN, "z")), TRUE)));
+                .isEqualTo(Optional.of(
+                        IrUtils.or(
+                                new Comparison(IDENTICAL, new Reference(BOOLEAN, "x"), TRUE),
+                                IrUtils.and(
+                                        IrExpressions.not(PLANNER_CONTEXT.getMetadata(), new Comparison(IDENTICAL, new Reference(BOOLEAN, "y"), TRUE)),
+                                        new Comparison(IDENTICAL, new Reference(BOOLEAN, "z"), TRUE)))));
 
         assertThat(optimize(
                 new Case(
@@ -92,7 +111,54 @@ public class TestSimplifyRedundantCase
                                 new WhenClause(new Reference(BOOLEAN, "y"), FALSE),
                                 new WhenClause(new Reference(BOOLEAN, "z"), FALSE)),
                         TRUE)))
-                .isEqualTo(Optional.of(IrExpressions.not(PLANNER_CONTEXT.getMetadata(), new Comparison(IDENTICAL, IrUtils.or(new Reference(BOOLEAN, "y"), new Reference(BOOLEAN, "z")), TRUE))));
+                .isEqualTo(Optional.of(
+                        IrUtils.or(
+                                new Comparison(IDENTICAL, new Reference(BOOLEAN, "x"), TRUE),
+                                IrUtils.and(
+                                        IrExpressions.not(PLANNER_CONTEXT.getMetadata(), new Comparison(IDENTICAL, new Reference(BOOLEAN, "y"), TRUE)),
+                                        IrExpressions.not(PLANNER_CONTEXT.getMetadata(), new Comparison(IDENTICAL, new Reference(BOOLEAN, "z"), TRUE))))));
+
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(
+                                new WhenClause(new Reference(BOOLEAN, "a1"), TRUE),
+                                new WhenClause(new Reference(BOOLEAN, "a2"), FALSE),
+                                new WhenClause(new Reference(BOOLEAN, "a3"), FALSE),
+                                new WhenClause(new Reference(BOOLEAN, "a4"), TRUE)),
+                        TRUE)))
+                .isEqualTo(Optional.of(IrUtils.or(
+                        new Comparison(IDENTICAL, new Reference(BOOLEAN, "a1"), TRUE),
+                        IrUtils.and(
+                                IrExpressions.not(PLANNER_CONTEXT.getMetadata(), new Comparison(IDENTICAL, new Reference(BOOLEAN, "a2"), TRUE)),
+                                IrExpressions.not(PLANNER_CONTEXT.getMetadata(), new Comparison(IDENTICAL, new Reference(BOOLEAN, "a3"), TRUE)),
+                                IrUtils.or(
+                                        new Comparison(IDENTICAL, new Reference(BOOLEAN, "a4"), TRUE),
+                                        TRUE)))));
+
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(
+                                new WhenClause(new Reference(BOOLEAN, "a1"), FALSE),
+                                new WhenClause(new Reference(BOOLEAN, "a2"), FALSE),
+                                new WhenClause(new Reference(BOOLEAN, "a3"), TRUE),
+                                new WhenClause(new Reference(BOOLEAN, "a4"), FALSE)),
+                        TRUE)))
+                .isEqualTo(Optional.of(
+                        IrUtils.and(
+                                IrExpressions.not(PLANNER_CONTEXT.getMetadata(), new Comparison(IDENTICAL, new Reference(BOOLEAN, "a1"), TRUE)),
+                                IrExpressions.not(PLANNER_CONTEXT.getMetadata(), new Comparison(IDENTICAL, new Reference(BOOLEAN, "a2"), TRUE)),
+                                IrUtils.or(
+                                        new Comparison(IDENTICAL, new Reference(BOOLEAN, "a3"), TRUE),
+                                        IrExpressions.not(PLANNER_CONTEXT.getMetadata(), new Comparison(IDENTICAL, new Reference(BOOLEAN, "a4"), TRUE))))));
+
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(
+                                new WhenClause(new Reference(BOOLEAN, "a1"), TRUE),
+                                new WhenClause(new Reference(BOOLEAN, "a2"), FALSE),
+                                new WhenClause(new Reference(BOOLEAN, "a3"), FALSE)),
+                        FALSE)))
+                .isEqualTo(Optional.of(new Comparison(IDENTICAL, new Reference(BOOLEAN, "a1"), TRUE)));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestIssue23787.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestIssue23787.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestIssue23787
+{
+    @Test
+    public void test()
+    {
+        try (QueryAssertions assertions = new QueryAssertions()) {
+            assertThat(assertions.query(
+                    """
+                    WITH t(a, b) AS (
+                      VALUES
+                        (1, true)
+                    )
+                    SELECT
+                      CASE
+                        WHEN a = 1 OR b THEN 'a'
+                        WHEN a = 2 OR b THEN 'b'
+                        ELSE 'c'
+                      END = 'b'
+                    FROM t                    
+                    """))
+                    .matches("VALUES false");
+        }
+    }
+}


### PR DESCRIPTION
Expressions such as:
```
   CASE
      WHEN <e1> THEN <boolean>
      WHEN <e2> THEN <boolean>
      ...
      ELSE <boolean>
   END
```
were being incorrectly optimized. The terms in the rewritten boolean expression need to reflect the fact that all the preceding conditions should've evaluated to false in order for a given condition to evaluate to true. The optimization was ignoring them, which could result in incorrect results when the conditions are not exclusive.

For example:
```
   CASE
      WHEN a OR b THEN false
      WHEN a OR c THEN true
   END
```
Previously, it was being rewritten as:
```
   (a OR c) ≡ true
```
However, if `a` is true, then the first branch of the CASE should be evaluated and the expression should return false.

Fixes https://github.com/trinodb/trino/issues/23787

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix incorrect results for certain CASE expressions that return boolean results. ({issue}`23787`)
```
