### PR TITLE
Fix invisible prompt color on dark terminal background 

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/InputReader.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/InputReader.java
@@ -36,6 +36,7 @@ import static org.jline.reader.LineReader.Option.HISTORY_IGNORE_SPACE;
 import static org.jline.reader.LineReader.Option.HISTORY_TIMESTAMPED;
 import static org.jline.reader.LineReader.SECONDARY_PROMPT_PATTERN;
 import static org.jline.utils.AttributedStyle.BRIGHT;
+import static org.jline.utils.AttributedStyle.CYAN;
 import static org.jline.utils.AttributedStyle.DEFAULT;
 
 public class InputReader
@@ -93,6 +94,6 @@ public class InputReader
 
     private static String colored(String value)
     {
-        return new AttributedString(value, DEFAULT.foreground(BRIGHT)).toAnsi();
+        return new AttributedString(value, DEFAULT.foreground(CYAN | BRIGHT)).toAnsi();
     }
 }


### PR DESCRIPTION
## Description
This Pull Request modified the `InputReader`  class, it fixes #6190.  

Before:  Gray Prompt , it has Low Visibility on Dark Backgrounds, or maybe invisible on some dark themes.
![eda5b365eac88fa3676bd14b4338a86](https://github.com/user-attachments/assets/a53d04e3-c930-4a61-be60-1cd75211d54b)

Now: Bright Cyan Prompt, Improved Visibility, it can be seen clearly on both dark theme and bright theme.
![893d03707f2552cbcd3388cd880d82f](https://github.com/user-attachments/assets/309fe4f4-66db-425a-a177-076aaafbd9c2)

## Release notes
The prompt is now displayed in bright cyan, making it more readable on dark backgrounds.


