### PR TITLE
Add Trino 463 release notes

### DIFF
--- a/docs/src/main/sphinx/release.md
+++ b/docs/src/main/sphinx/release.md
@@ -6,6 +6,7 @@
 ```{toctree}
 :maxdepth: 1
 
+release/release-463
 release/release-462
 release/release-461
 release/release-460

--- a/docs/src/main/sphinx/release/release-463.md
+++ b/docs/src/main/sphinx/release/release-463.md
@@ -1,0 +1,36 @@
+# Release 463 (23 Oct 2024)
+
+## General
+
+* Enable HTTP/2 for internal communication by default. The previous behavior can
+  be restored by setting `internal-communication.http2.enabled` to `false`. ({issue}`21793`)
+* Add {func}`timezone` functions to extract the timezone identifier from from a
+  `timestamp(p) with time zone` or `time(p) with time zone`. ({issue}`20893`)
+* Include table functions with `SHOW FUNCTIONS` output. ({issue}`12550`)
+* Print peak memory usage in `EXPLAIN ANALYZE` output. ({issue}`23874`)
+* Disallow the window framing clause for {func}`ntile`, {func}`rank`,
+  {func}`dense_rank`, {func}`percent_rank`,  {func}`cume_dist`, and
+  {func}`row_number`. ({issue}`23742`)
+
+## ClickHouse connector
+
+* Improve performance for queries with `IS NULL` expressions. ({issue}`23459`)
+
+## Delta Lake connector
+
+* Add support for writing change data feed when [deletion vector](https://docs.delta.io/latest/delta-deletion-vectors.html) 
+  is enabled. ({issue}`23620`)
+
+## Iceberg connector
+
+* Add support for nested namespaces with the REST catalog. ({issue}`22916`)
+* Add support for configuring the maximum number of rows per row-group in the
+  ORC writer with the `orc_writer_max_row_group_rows` catalog session property. ({issue}`23722`)
+* Clean up position delete files when `OPTIMIZE` is run on a subset of the
+  table's partitions. ({issue}`23801`)
+* Rename `iceberg.add_files-procedure.enabled` catalog configuration property to
+  `iceberg.add-files-procedure.enabled`. ({issue}`23873`)
+
+## SingleStore connector
+
+* Fix incorrect column length of `varchar` type in SingleStore version 8. ({issue}`23780`)


### PR DESCRIPTION
## Description

Assemble the release notes for the upcoming Trino 463 release.

## Additional context and related issues

See https://github.com/trinodb/trino/pulls?q=is%3Apr+is%3Aclosed+milestone%3A463

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

## Verification for each pull request

Format: PR/issue number, ✅ / ❌ rn ✅ / ❌ docs
✅ rn - release note added and verified, or assessed to be not necessary, set to ❌ rn before completion
✅ docs - need for docs assessed and merged, or assessed to be not necessary, set to ❌ docs before completion

## 16 Oct 2024

* #23811 ✅ rn ✅ docs
* #23809 ✅ rn ✅ docs

## 17 Oct 2024

* #23564 ✅ rn ✅ docs, see #23821
* #23741 ✅ rn ✅ docs
* #23816 ✅ rn ✅ docs
* #23459 ✅ rn ✅ docs
* #23801 ✅ rn ✅ docs
* #23821 ✅ rn ✅ docs
* #23744 ✅ rn ✅ docs

## 18 Oct 2024

* #23825 ✅ rn ✅ docs
* #23806 ✅ rn ✅ docs
* #23393 ✅ rn ✅ docs
* #23777 ✅ rn ✅ docs
* #21000 ✅ rn ✅ docs
* #15337 ✅ rn ✅ docs

## 19 Oct 2024

* #23840 ✅ rn ✅ docs
* #23814 ✅ rn ✅ docs

## 20 Oct 2024

* #23453 ✅ rn ✅ docs
* #23830 ✅ rn ✅ docs
* #23834 ✅ rn ✅ docs
* #23841 ✅ rn ✅ docs

## 21 Oct 2024

* #23848 ✅ rn ✅ docs
* #23856 ✅ rn ✅ docs
* #23831 ✅ rn ✅ docs

## 22 Oct 2024

* #23850 ✅ rn ✅ docs
* #23861 ✅ rn ✅ docs
* #23827 ✅ rn ✅ docs
* #23858 ✅ rn ✅ docs
* #23863 ✅ rn ✅ docs
* #23865 ✅ rn ✅ docs
* #23723 ✅ rn ✅ docs
* #23868 ✅ rn ✅ docs
* #23857 ✅ rn ✅ docs

## 23 Oct 2024

* #23844 ✅ rn ✅ docs
* #23873 ✅ rn ✅ docs
* #23872 ✅ rn ✅ docs
* #23874 ✅ rn ✅ docs
* #23797 ✅ rn ✅ docs
* #23684 ✅ rn ✅ docs
