### PR TITLE
Correct docs about key format

### DIFF
--- a/docs/src/main/sphinx/connector/elasticsearch.md
+++ b/docs/src/main/sphinx/connector/elasticsearch.md
@@ -138,7 +138,7 @@ clusters with TLS enabled.
 
 If your cluster has globally-trusted certificates, you should only need to
 enable TLS. If you require custom configuration for certificates, the connector
-supports key stores and trust stores in PEM or Java Key Store (JKS) format.
+supports key stores and trust stores in P12 (PKCS) or Java Key Store (JKS) format.
 
 The available configuration values are listed in the following table:
 
@@ -151,10 +151,10 @@ The available configuration values are listed in the following table:
 * - `elasticsearch.tls.enabled`
   - Enables TLS security.
 * - `elasticsearch.tls.keystore-path`
-  - The path to the [PEM](/security/inspect-pem) or [JKS](/security/inspect-jks)
+  - The path to the P12 (PKCS) or [JKS](/security/inspect-jks)
     key store.
 * - `elasticsearch.tls.truststore-path`
-  - The path to [PEM](/security/inspect-pem) or [JKS](/security/inspect-jks)
+  - The path to P12 (PKCS) or [JKS](/security/inspect-jks)
     trust store.
 * - `elasticsearch.tls.keystore-password`
   - The key password for the key store specified by

--- a/docs/src/main/sphinx/connector/opensearch.md
+++ b/docs/src/main/sphinx/connector/opensearch.md
@@ -141,7 +141,7 @@ clusters with TLS enabled.
 
 If your cluster uses globally-trusted certificates, you only need to
 enable TLS. If you require custom configuration for certificates, the connector
-supports key stores and trust stores in PEM or Java Key Store (JKS) format.
+supports key stores and trust stores in P12 (PKCS) or Java Key Store (JKS) format.
 
 The available configuration values are listed in the following table:
 
@@ -154,10 +154,10 @@ The available configuration values are listed in the following table:
 * - `opensearch.tls.enabled`
   - Enable TLS security. Defaults to `false`.
 * - `opensearch.tls.keystore-path`
-  - The path to the [PEM](/security/inspect-pem) or [JKS](/security/inspect-jks)
+  - The path to the P12 (PKCS) or [JKS](/security/inspect-jks)
     key store.
 * - `opensearch.tls.truststore-path`
-  - The path to [PEM](/security/inspect-pem) or [JKS](/security/inspect-jks)
+  - The path to P12 (PKCS) or [JKS](/security/inspect-jks)
     trust store.
 * - `opensearch.tls.keystore-password`
   - The password for the key store specified by


### PR DESCRIPTION
## Description

For TLS to OpenSearch and Elastisearch only P12 (PKCS) is supported. Not PEM as for the TLS setup.

## Additional context and related issues

See discussion in https://github.com/trinodb/trino/issues/23402

Fyi @ilsaloving
 
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
