### PR TITLE
Add type-cast operator `::` (WIP)

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -585,6 +585,7 @@ primaryExpression
     | CASE operand=expression whenClause+ (ELSE elseExpression=expression)? END           #simpleCase
     | CASE whenClause+ (ELSE elseExpression=expression)? END                              #searchedCase
     | CAST '(' expression AS type ')'                                                     #cast
+    | primaryExpression DOUBLE_COLON type                                                 #typeCast
     | TRY_CAST '(' expression AS type ')'                                                 #cast
     | ARRAY '[' (expression (',' expression)*)? ']'                                       #arrayConstructor
     | value=primaryExpression '[' index=valueExpression ']'                               #subscript
@@ -1323,6 +1324,7 @@ PERCENT: '%';
 CONCAT: '||';
 QUESTION_MARK: '?';
 SEMICOLON: ';';
+DOUBLE_COLON: '::';
 
 STRING
     : '\'' ( ~'\'' | '\'\'' )* '\''

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -2174,6 +2174,12 @@ class AstBuilder
     }
 
     @Override
+    public Node visitTypeCast(SqlBaseParser.TypeCastContext context)
+    {
+        return new Cast(getLocation(context), (Expression) visit(context.primaryExpression()), (DataType) visit(context.type()), false);
+    }
+
+    @Override
     public Node visitBetween(SqlBaseParser.BetweenContext context)
     {
         Expression expression = new BetweenPredicate(

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -1602,6 +1602,24 @@ public class TestSqlParser
                                                         field(location(1, 30), "COL0", simpleType(location(1, 35), "INTEGER")),
                                                         field(location(1, 44), "COL1", simpleType(location(1, 49), "INTEGER")))),
                                         identifier("col0")))));
+
+        assertStatement("SELECT '11' || 22::VARCHAR",
+                simpleQuery(
+                        selectList(
+                                new FunctionCall(
+                                        QualifiedName.of("concat"),
+                                        ImmutableList.of(
+                                                new StringLiteral("11"),
+                                                new Cast(new LongLiteral("22"), simpleType(location(1, 20), "VARCHAR")))))));
+
+        assertStatement("SELECT col.f1.f2::VARCHAR",
+                simpleQuery(
+                        selectList(
+                                new Cast(
+                                        new DereferenceExpression(
+                                                new DereferenceExpression(identifier("col"), identifier("f1")),
+                                                identifier("f2")),
+                                        simpleType(location(1, 19), "VARCHAR")))));
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
@@ -33,7 +33,7 @@ public class TestSqlParserErrorHandling
     {
         return Stream.of(
                 Arguments.of("", "line 1:1: mismatched input '<EOF>'. Expecting: <expression>"),
-                Arguments.of("1 + 1 x", "line 1:7: mismatched input 'x'. Expecting: '%', '*', '+', '-', '.', '/', 'AND', 'AT', 'OR', '[', '||', <EOF>, <predicate>"));
+                Arguments.of("1 + 1 x", "line 1:7: mismatched input 'x'. Expecting: '%', '*', '+', '-', '.', '/', '::', 'AND', 'AT', 'OR', '[', '||', <EOF>, <predicate>"));
     }
 
     private static Stream<Arguments> statements()
@@ -67,7 +67,7 @@ public class TestSqlParserErrorHandling
                 Arguments.of("select 1x from dual",
                         "line 1:8: identifiers must not start with a digit; surround the identifier with double quotes"),
                 Arguments.of("select fuu from dual order by fuu order by fuu",
-                        "line 1:35: mismatched input 'order'. Expecting: '%', '*', '+', ',', '-', '.', '/', 'AND', 'ASC', 'AT', 'DESC', 'FETCH', 'LIMIT', 'NULLS', 'OFFSET', 'OR', '[', '||', <EOF>, <predicate>"),
+                        "line 1:35: mismatched input 'order'. Expecting: '%', '*', '+', ',', '-', '.', '/', '::', 'AND', 'ASC', 'AT', 'DESC', 'FETCH', 'LIMIT', 'NULLS', 'OFFSET', 'OR', '[', '||', <EOF>, <predicate>"),
                 Arguments.of("select fuu from dual limit 10 order by fuu",
                         "line 1:31: mismatched input 'order'. Expecting: <EOF>"),
                 Arguments.of("select CAST(12223222232535343423232435343 AS BIGINT)",
@@ -99,7 +99,7 @@ public class TestSqlParserErrorHandling
                 Arguments.of("SELECT x() over (ROWS select) FROM t",
                         "line 1:23: mismatched input 'select'. Expecting: ')', 'BETWEEN', 'CURRENT', 'GROUPS', 'MEASURES', 'ORDER', 'PARTITION', 'RANGE', 'ROWS', 'UNBOUNDED', <expression>"),
                 Arguments.of("SELECT X() OVER (ROWS UNBOUNDED) FROM T",
-                        "line 1:32: mismatched input ')'. Expecting: '%', '(', '*', '+', '-', '->', '.', '/', 'AND', 'AT', 'FOLLOWING', 'OR', 'OVER', 'PRECEDING', '[', '||', <predicate>, <string>"),
+                        "line 1:32: mismatched input ')'. Expecting: '%', '(', '*', '+', '-', '->', '.', '/', '::', 'AND', 'AT', 'FOLLOWING', 'OR', 'OVER', 'PRECEDING', '[', '||', <predicate>, <string>"),
                 Arguments.of("SELECT a FROM x ORDER BY (SELECT b FROM t WHERE ",
                         "line 1:49: mismatched input '<EOF>'. Expecting: <expression>"),
                 Arguments.of("SELECT a FROM a AS x TABLESAMPLE x ",
@@ -134,7 +134,7 @@ public class TestSqlParserErrorHandling
                 Arguments.of("SELECT a FROM \"\".s.t",
                         "line 1:15: Zero-length delimited identifier not allowed"),
                 Arguments.of("WITH t AS (SELECT 1 SELECT t.* FROM t",
-                        "line 1:21: mismatched input 'SELECT'. Expecting: '%', ')', '*', '+', ',', '-', '.', '/', 'AND', 'AS', 'AT', 'EXCEPT', 'FETCH', 'FROM', " +
+                        "line 1:21: mismatched input 'SELECT'. Expecting: '%', ')', '*', '+', ',', '-', '.', '/', '::', 'AND', 'AS', 'AT', 'EXCEPT', 'FETCH', 'FROM', " +
                                 "'GROUP', 'HAVING', 'INTERSECT', 'LIMIT', 'OFFSET', 'OR', 'ORDER', 'UNION', 'WHERE', 'WINDOW', '[', '||', " +
                                 "<identifier>, <predicate>"),
                 Arguments.of("SHOW CATALOGS LIKE '%$_%' ESCAPE",
@@ -160,9 +160,9 @@ public class TestSqlParserErrorHandling
                 Arguments.of("SELECT * FROM t FOR VERSION AS OF TIMESTAMP WHERE",
                         "line 1:50: mismatched input '<EOF>'. Expecting: <expression>"),
                 Arguments.of("SELECT ROW(DATE '2022-10-10', DOUBLE 12.0)",
-                        "line 1:38: mismatched input '12.0'. Expecting: '%', '(', ')', '*', '+', ',', '-', '->', '.', '/', 'AND', 'AT', 'OR', 'ORDER', 'OVER', 'PRECISION', '[', '||', <predicate>, <string>"),
+                        "line 1:38: mismatched input '12.0'. Expecting: '%', '(', ')', '*', '+', ',', '-', '->', '.', '/', '::', 'AND', 'AT', 'OR', 'ORDER', 'OVER', 'PRECISION', '[', '||', <predicate>, <string>"),
                 Arguments.of("VALUES(DATE 2)",
-                        "line 1:13: mismatched input '2'. Expecting: '%', '(', ')', '*', '+', ',', '-', '->', '.', '/', 'AND', 'AT', 'OR', 'OVER', '[', '||', <predicate>, <string>"),
+                        "line 1:13: mismatched input '2'. Expecting: '%', '(', ')', '*', '+', ',', '-', '->', '.', '/', '::', 'AND', 'AT', 'OR', 'OVER', '[', '||', <predicate>, <string>"),
                 Arguments.of("SELECT count(DISTINCT *) FROM (VALUES 1)",
                         "line 1:23: mismatched input '*'. Expecting: <expression>"));
     }
@@ -182,7 +182,7 @@ public class TestSqlParserErrorHandling
                         "1 * 2 * 3 * 4 * 5 * 6 * 7 * 8 * 9 * " +
                         "1 * 2 * 3 * 4 * 5 * 6 * 7 * 8 * 9 * " +
                         "1 * 2 * 3 * 4 * 5 * 6 * 7 * 8 * 9",
-                "line 1:375: mismatched input '<EOF>'. Expecting: '%', '*', '+', '-', '.', '/', 'AND', 'AT', 'OR', 'THEN', '[', '||', <predicate>");
+                "line 1:375: mismatched input '<EOF>'. Expecting: '%', '*', '+', '-', '.', '/', '::', 'AND', 'AT', 'OR', 'THEN', '[', '||', <predicate>");
     }
 
     @Test
@@ -212,7 +212,7 @@ public class TestSqlParserErrorHandling
                         "OR (f()\n" +
                         "OR (f()\n" +
                         "GROUP BY id",
-                "line 24:1: mismatched input 'GROUP'. Expecting: '%', ')', '*', '+', ',', '-', '.', '/', 'AND', 'AT', 'FILTER', 'IGNORE', 'OR', 'OVER', 'RESPECT', '[', '||', <predicate>");
+                "line 24:1: mismatched input 'GROUP'. Expecting: '%', ')', '*', '+', ',', '-', '.', '/', '::', 'AND', 'AT', 'FILTER', 'IGNORE', 'OR', 'OVER', 'RESPECT', '[', '||', <predicate>");
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## Description
Add type-cast operator `::`


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Add support for x::type cast operator as an alternative syntax for CAST(x AS type).


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: