### PR TITLE
Fix change data feed with delete vectors

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
@@ -62,6 +62,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
@@ -356,10 +357,25 @@ public class DeltaLakeMergeSink
 
     private Slice writeMergeResult(Slice path, FileDeletion deletion)
     {
+        RoaringBitmapArray rowsDeletedByDelete = deletion.rowsDeletedByDelete();
+        RoaringBitmapArray rowsDeletedByUpdate = deletion.rowsDeletedByUpdate();
         RoaringBitmapArray deletedRows = loadDeletionVector(Location.of(path.toStringUtf8()));
-        deletedRows.or(deletion.rowsDeletedByDelete());
-        deletedRows.or(deletion.rowsDeletedByUpdate());
+        deletedRows.or(rowsDeletedByDelete);
+        deletedRows.or(rowsDeletedByUpdate);
 
+        if (cdfEnabled) {
+            try (ConnectorPageSource connectorPageSource = createParquetPageSource(Location.of(path.toStringUtf8())).get()) {
+                readConnectorPageSource(
+                        connectorPageSource,
+                        rowsDeletedByDelete,
+                        rowsDeletedByUpdate,
+                        deletion,
+                        _ -> {});
+            }
+            catch (IOException e) {
+                throw new TrinoException(DELTA_LAKE_FILESYSTEM_ERROR, "Error reading Parquet file: " + path, e);
+            }
+        }
         TrinoInputFile inputFile = fileSystem.newInputFile(Location.of(path.toStringUtf8()));
         try (ParquetDataSource dataSource = new TrinoParquetDataSource(inputFile, parquetReaderOptions, fileFormatDataSourceStats)) {
             ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
@@ -523,47 +539,16 @@ public class DeltaLakeMergeSink
         RoaringBitmapArray rowsDeletedByDelete = deletion.rowsDeletedByDelete();
         RoaringBitmapArray rowsDeletedByUpdate = deletion.rowsDeletedByUpdate();
         try (ConnectorPageSource connectorPageSource = createParquetPageSource(path).get()) {
-            long filePosition = 0;
-            while (!connectorPageSource.isFinished()) {
-                Page page = connectorPageSource.getNextPage();
-                if (page == null) {
-                    continue;
-                }
-
-                int positionCount = page.getPositionCount();
-                int[] retained = new int[positionCount];
-                int[] deletedByDelete = new int[(int) rowsDeletedByDelete.cardinality()];
-                int[] deletedByUpdate = new int[(int) rowsDeletedByUpdate.cardinality()];
-                int retainedCount = 0;
-                int deletedByUpdateCount = 0;
-                int deletedByDeleteCount = 0;
-                for (int position = 0; position < positionCount; position++) {
-                    if (rowsDeletedByDelete.contains(filePosition)) {
-                        deletedByDelete[deletedByDeleteCount] = position;
-                        deletedByDeleteCount++;
-                    }
-                    else if (rowsDeletedByUpdate.contains(filePosition)) {
-                        deletedByUpdate[deletedByUpdateCount] = position;
-                        deletedByUpdateCount++;
-                    }
-                    else {
-                        retained[retainedCount] = position;
-                        retainedCount++;
-                    }
-                    filePosition++;
-                }
-
-                storeCdfEntries(page, deletedByDelete, deletedByDeleteCount, deletion, DELETE_CDF_LABEL);
-                storeCdfEntries(page, deletedByUpdate, deletedByUpdateCount, deletion, UPDATE_PREIMAGE_CDF_LABEL);
-
-                if (retainedCount != positionCount) {
-                    page = page.getPositions(retained, 0, retainedCount);
-                }
-
-                if (page.getPositionCount() > 0) {
-                    fileWriter.appendRows(page);
-                }
-            }
+            readConnectorPageSource(
+                    connectorPageSource,
+                    rowsDeletedByDelete,
+                    rowsDeletedByUpdate,
+                    deletion,
+                    page -> {
+                        if (page.getPositionCount() > 0) {
+                            fileWriter.appendRows(page);
+                        }
+                    });
             if (fileWriter.getRowCount() == 0) {
                 fileWriter.rollback();
                 return Optional.empty();
@@ -583,6 +568,54 @@ public class DeltaLakeMergeSink
         }
 
         return Optional.of(fileWriter.getDataFileInfo());
+    }
+
+    private void readConnectorPageSource(
+            ConnectorPageSource connectorPageSource,
+            RoaringBitmapArray rowsDeletedByDelete,
+            RoaringBitmapArray rowsDeletedByUpdate,
+            FileDeletion deletion,
+            Consumer<Page> pageConsumer)
+    {
+        long filePosition = 0;
+        while (!connectorPageSource.isFinished()) {
+            Page page = connectorPageSource.getNextPage();
+            if (page == null) {
+                continue;
+            }
+
+            int positionCount = page.getPositionCount();
+            int[] retained = new int[positionCount];
+            int[] deletedByDelete = new int[(int) rowsDeletedByDelete.cardinality()];
+            int[] deletedByUpdate = new int[(int) rowsDeletedByUpdate.cardinality()];
+            int retainedCount = 0;
+            int deletedByUpdateCount = 0;
+            int deletedByDeleteCount = 0;
+            for (int position = 0; position < positionCount; position++) {
+                if (rowsDeletedByDelete.contains(filePosition)) {
+                    deletedByDelete[deletedByDeleteCount] = position;
+                    deletedByDeleteCount++;
+                }
+                else if (rowsDeletedByUpdate.contains(filePosition)) {
+                    deletedByUpdate[deletedByUpdateCount] = position;
+                    deletedByUpdateCount++;
+                }
+                else {
+                    retained[retainedCount] = position;
+                    retainedCount++;
+                }
+                filePosition++;
+            }
+
+            storeCdfEntries(page, deletedByDelete, deletedByDeleteCount, deletion, DELETE_CDF_LABEL);
+            storeCdfEntries(page, deletedByUpdate, deletedByUpdateCount, deletion, UPDATE_PREIMAGE_CDF_LABEL);
+
+            if (retainedCount != positionCount) {
+                page = page.getPositions(retained, 0, retainedCount);
+            }
+
+            pageConsumer.accept(page);
+        }
     }
 
     private void storeCdfEntries(Page page, int[] deleted, int deletedCount, FileDeletion deletion, String operation)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -2852,12 +2852,6 @@ public class DeltaLakeMetadata
         }
         checkUnsupportedUniversalFormat(handle.getMetadataEntry());
         checkUnsupportedWriterFeatures(handle.getProtocolEntry());
-
-        boolean changeDataFeedEnabled = changeDataFeedEnabled(handle.getMetadataEntry(), handle.getProtocolEntry()).orElse(false);
-        boolean deletionVectorEnabled = isDeletionVectorEnabled(handle.getMetadataEntry(), handle.getProtocolEntry());
-        if (changeDataFeedEnabled && deletionVectorEnabled) {
-            throw new TrinoException(NOT_SUPPORTED, "Writing to tables with both change data feed and deletion vectors enabled is not supported");
-        }
     }
 
     public static void checkUnsupportedUniversalFormat(MetadataEntry metadataEntry)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Fixes https://github.com/trinodb/trino/issues/23620


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
When deletion vectors were enabled code that is supposed to create `update_preimage` was not executed. 


## Release notes

```markdown
## Delta Lake
* Add support for writing change data feed when deletion vector is enabeld. ({(https://github.com/trinodb/trino/issues/23620)}`23620`)
```
