### PR TITLE
Prefer information_schema schema prefixes at table prefixes overflow

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaMetadata.java
@@ -312,7 +312,10 @@ public class InformationSchemaMetadata
         if (tablePrefixes.size() > maxPrefetchedInformationSchemaPrefixes) {
             // in case of high number of prefixes it is better to populate all data and then filter
             // TODO this may cause re-running the above filtering upon next applyFilter
-            return defaultPrefixes(catalogName);
+            if (prefixes.size() > maxPrefetchedInformationSchemaPrefixes) {
+                return defaultPrefixes(catalogName);
+            }
+            return prefixes;
         }
         return tablePrefixes;
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestHiveMetastoreMetadataQueriesAccessOperations.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestHiveMetastoreMetadataQueriesAccessOperations.java
@@ -379,12 +379,13 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
     @Test
     public void testSelectColumnsWithLikeOverSchema()
     {
+        // schema_prefix <= MAX_PREFIXES_COUNT and table_prefix > MAX_PREFIXES_COUNT
         assertMetastoreInvocations(
                 "SELECT * FROM information_schema.columns WHERE table_schema LIKE 'test%'",
                 ImmutableMultiset.<MetastoreMethod>builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_TABLES, TEST_SCHEMAS_COUNT)
-                        .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
+                        .addCopies(GET_TABLES, TEST_SCHEMAS_COUNT - 1)
+                        .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT - TEST_TABLES_IN_SCHEMA_COUNT)
                         .build());
         assertMetastoreInvocations(
                 "SELECT * FROM system.jdbc.columns WHERE table_schem LIKE 'test%'",


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

https://github.com/trinodb/trino/commit/677b52d8b06f4fe983e41e2fcd1e470f79930a30 removed the following condition 
``` 
       if (prefixes.size() > MAX_PREFIXES_COUNT) {
            // in case of high number of prefixes it is better to populate all data and then filter
            prefixes = defaultPrefixes(catalogName);
        }
```
Before this, it uses schema prefixes when `prefixes <= MAX_PREFIXES_COUNT and tablePrefixes > MAX_PREFIXES_COUNT`

I'm not sure it was intentional, but using schema prefixes might be better than populating all data. 

We faced large memory consumption on coordinator at listing columns having a lot of schemas (more than 10K) and tables (more than 100 per schema).  A part of query looks like the following and it filters to tens of schemas out out 10K.
```
... from information_schema.columns where schema like '%test%'
```
but the final table-prefixes will be thousands as each schema has hundreds. In that case, Trino will try to load whole catalogs tables (more than 1M tables) at once. Increasing `optimizer.experimental-max-prefetched-information-schema-prefixes` to several thousands could be workaround but there's no reason not to use already filtered schema prefixes to save resources more.
 

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
