### PR TITLE
List all properties docs on admin page

### DIFF
--- a/docs/src/main/sphinx/admin.md
+++ b/docs/src/main/sphinx/admin.md
@@ -8,7 +8,6 @@ admin/preview-web-interface
 admin/tuning
 admin/jmx
 admin/opentelemetry
-admin/properties
 admin/spill
 admin/resource-groups
 admin/session-property-managers
@@ -29,3 +28,33 @@ admin/event-listeners-kafka
 admin/event-listeners-mysql
 admin/event-listeners-openlineage
 ```
+
+## Properties reference
+
+Many aspects for running Trino are [configured with properties](config-properties).
+The following pages provide an overview and details for specific topics.
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+admin/properties
+```
+
+* [Properties reference overview](admin/properties)
+* [](admin/properties-general)
+* [](admin/properties-http-server)
+* [](admin/properties-resource-management)
+* [](admin/properties-query-management)
+* [](admin/properties-catalog)
+* [](admin/properties-sql-environment)
+* [](admin/properties-spilling)
+* [](admin/properties-exchange)
+* [](admin/properties-task)
+* [](admin/properties-write-partitioning)
+* [](admin/properties-writer-scaling)
+* [](admin/properties-node-scheduler)
+* [](admin/properties-optimizer)
+* [](admin/properties-logging)
+* [](admin/properties-web-interface)
+* [](admin/properties-regexp-function)
+* [](admin/properties-http-client)

--- a/docs/src/main/sphinx/admin.md
+++ b/docs/src/main/sphinx/admin.md
@@ -1,5 +1,8 @@
 # Administration
 
+The following documents cover a number of different aspect of configuring,
+running, and managing Trino clusters.
+
 ```{toctree}
 :maxdepth: 1
 
@@ -16,6 +19,10 @@ admin/dynamic-filtering
 admin/graceful-shutdown
 admin/fault-tolerant-execution
 ```
+
+Details about connecting [data sources](trino-concept-data-source) as
+[catalogs](trino-concept-catalog) are available in the [connector
+documentation](/connector).
 
 (admin-event-listeners)=
 ## Event listeners

--- a/docs/src/main/sphinx/connector.md
+++ b/docs/src/main/sphinx/connector.md
@@ -1,7 +1,9 @@
 # Connectors
 
-This section describes the connectors available in Trino to access data
-from different data sources.
+This section describes the connectors available in Trino to access data from
+different [data sources](trino-concept-data-source) by configuring
+[catalogs](trino-concept-catalog) with the connector-specific properties in
+[catalog properties files](catalog-properties).
 
 ```{toctree}
 :maxdepth: 1

--- a/docs/src/main/sphinx/installation/deployment.md
+++ b/docs/src/main/sphinx/installation/deployment.md
@@ -269,12 +269,15 @@ There are four levels: `DEBUG`, `INFO`, `WARN` and `ERROR`.
 (catalog-properties)=
 ### Catalog properties
 
-Trino accesses data via *connectors*, which are mounted in catalogs.
-The connector provides all of the schemas and tables inside of the catalog.
-For example, the Hive connector maps each Hive database to a schema.
-If the Hive connector is mounted as the `hive` catalog, and Hive
-contains a table `clicks` in database `web`, that table can be accessed
-in Trino as `hive.web.clicks`.
+Trino accesses data in a [data source](trino-concept-data-source) with a
+[connector](trino-concept-connector), which is configured in a
+[catalog](trino-concept-catalog). The connector provides all of the schemas and
+tables inside of the catalog.
+
+For example, the Hive connector maps each Hive database to a schema. If the Hive
+connector is configured in the `example` catalog, and Hive contains a table
+`clicks` in the database `web`, that table can be accessed in Trino as
+`example.web.clicks`.
 
 Catalogs are registered by creating a catalog properties file
 in the `etc/catalog` directory.
@@ -285,7 +288,7 @@ contents to mount the `jmx` connector as the `jmx` catalog:
 connector.name=jmx
 ```
 
-See {doc}`/connector` for more information about configuring connectors.
+See {doc}`/connector` for more information about configuring catalogs.
 
 (running-trino)=
 ## Running Trino


### PR DESCRIPTION
## Description

* see commit messages
* provides better visibility for the fact that there are a lot of pages with more details without messing up the left hand nav on properties
* improve linkage to concepts page and content about data sources, catalogs, and connectors

## Additional context and related issues

na

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
