### PR TITLE
Add link to js client in docs

### DIFF
--- a/docs/src/main/sphinx/client.md
+++ b/docs/src/main/sphinx/client.md
@@ -20,6 +20,7 @@ client/jdbc
 The Trino project maintains the following other client libraries:
 
 * [trino-go-client](https://github.com/trinodb/trino-go-client)
+* [trino-js-client](https://github.com/trinodb/trino-js-client)
 * [trino-python-client](https://github.com/trinodb/trino-python-client)
 
 In addition, other communities and vendors provide [numerous other client


### PR DESCRIPTION
## Description

see title, there is no release of the client yet but very soon and code is already maintained in that repo so we should link to it now.

## Additional context and related issues

na

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
