### PR TITLE
Change Block and Page to load lazy blocks in place 

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/join/LookupJoinPageBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/LookupJoinPageBuilder.java
@@ -111,7 +111,7 @@ public class LookupJoinPageBuilder
         if (!isSequentialProbeIndices || outputPositions == 0) {
             int[] probeIndices = probeIndexBuilder.toIntArray();
             for (int i = 0; i < probeOutputChannels.length; i++) {
-                blocks[i] = unwrapLoadedBlock(probePage.getBlock(probeOutputChannels[i]).getPositions(probeIndices, 0, outputPositions));
+                blocks[i] = probePage.getBlock(probeOutputChannels[i]).getPositions(probeIndices, 0, outputPositions).getLoadedBlock();
             }
         }
         else {
@@ -127,7 +127,7 @@ public class LookupJoinPageBuilder
                     // only a subregion of the block should be output
                     block = block.getRegion(startRegion, outputPositions);
                 }
-                blocks[i] = unwrapLoadedBlock(block);
+                blocks[i] = block.getLoadedBlock();
             }
         }
 
@@ -146,13 +146,6 @@ public class LookupJoinPageBuilder
                 .add("estimatedSize", estimatedProbeBlockBytes + buildPageBuilder.getSizeInBytes())
                 .add("positionCount", buildPageBuilder.getPositionCount())
                 .toString();
-    }
-
-    private static Block unwrapLoadedBlock(Block filteredProbeBlock)
-    {
-        // Lazy blocks (e.g. used in filter condition) could be loaded during filter evaluation.
-        // Unwrap them to reduce overhead of further processing.
-        return filteredProbeBlock.isLoaded() ? filteredProbeBlock.getLoadedBlock() : filteredProbeBlock;
     }
 
     private void appendProbeIndex(JoinProbe probe)

--- a/core/trino-main/src/main/java/io/trino/operator/join/unspilled/LookupJoinPageBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/unspilled/LookupJoinPageBuilder.java
@@ -131,7 +131,7 @@ public class LookupJoinPageBuilder
         if (!isSequentialProbeIndices || outputPositions == 0) {
             int[] probeIndices = probeIndexBuilder.toIntArray();
             for (int i = 0; i < probeOutputChannels.length; i++) {
-                blocks[i] = unwrapLoadedBlock(probePage.getBlock(probeOutputChannels[i]).getPositions(probeIndices, 0, outputPositions));
+                blocks[i] = probePage.getBlock(probeOutputChannels[i]).getPositions(probeIndices, 0, outputPositions).getLoadedBlock();
             }
         }
         else {
@@ -147,7 +147,7 @@ public class LookupJoinPageBuilder
                     // only a subregion of the block should be output
                     block = block.getRegion(startRegion, outputPositions);
                 }
-                blocks[i] = unwrapLoadedBlock(block);
+                blocks[i] = block.getLoadedBlock();
             }
         }
 
@@ -192,13 +192,6 @@ public class LookupJoinPageBuilder
                 .add("estimatedSize", estimatedProbeBlockBytes + buildPageBuilder.getSizeInBytes())
                 .add("positionCount", buildPageBuilder.getPositionCount())
                 .toString();
-    }
-
-    private static Block unwrapLoadedBlock(Block filteredProbeBlock)
-    {
-        // Lazy blocks (e.g. used in filter condition) could be loaded during filter evaluation.
-        // Unwrap them to reduce overhead of further processing.
-        return filteredProbeBlock.isLoaded() ? filteredProbeBlock.getLoadedBlock() : filteredProbeBlock;
     }
 
     private void appendProbeIndex(JoinProbe probe)

--- a/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
@@ -263,15 +263,11 @@ public class PageProcessor
             retainedSizeInBytes = Page.getInstanceSizeInBytes(page.getChannelCount());
             ReferenceCountMap referenceCountMap = new ReferenceCountMap();
             for (int channel = 0; channel < page.getChannelCount(); channel++) {
-                Block block = page.getBlock(channel);
-                // TODO: block might be partially loaded
-                if (block.isLoaded()) {
-                    block.retainedBytesForEachPart((object, size) -> {
-                        if (referenceCountMap.incrementAndGet(object) == 1) {
-                            retainedSizeInBytes += size;
-                        }
-                    });
-                }
+                page.getBlock(channel).retainedBytesForEachPart((object, size) -> {
+                    if (referenceCountMap.incrementAndGet(object) == 1) {
+                        retainedSizeInBytes += size;
+                    }
+                });
             }
             for (Block previouslyComputedResult : previouslyComputedResults) {
                 if (previouslyComputedResult != null) {

--- a/core/trino-main/src/test/java/io/trino/block/TestMapBlock.java
+++ b/core/trino-main/src/test/java/io/trino/block/TestMapBlock.java
@@ -81,10 +81,11 @@ public class TestMapBlock
         assertThat(mapBlock.getPositionCount()).isEqualTo(2);
         assertThat(mapBlock.getKeyBlock()).isInstanceOf(LazyBlock.class);
         assertThat(mapBlock.getValueBlock().isLoaded()).isTrue();
-        MapBlock loadedMap = (MapBlock) mapBlock.getLoadedBlock();
+        MapBlock loadedMap = mapBlock.getLoadedBlock();
         assertThat(loadedMap.getPositionCount()).isEqualTo(2);
         assertThat(loadedMap.getKeyBlock().isLoaded()).isTrue();
         assertThat(loadedMap.getValueBlock().isLoaded()).isTrue();
+        assertThat(loadedMap).isSameAs(mapBlock);
     }
 
     @Test

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -342,6 +342,26 @@
                                     <old>method io.trino.spi.block.BlockBuilder io.trino.spi.type.UuidType::createBlockBuilder(io.trino.spi.block.BlockBuilderStatus, int, int)</old>
                                     <new>method io.trino.spi.block.BlockBuilder io.trino.spi.type.Type::createBlockBuilder(io.trino.spi.block.BlockBuilderStatus, int, int) @ io.trino.spi.type.UuidType</new>
                                 </item>
+                                <item>
+                                    <code>java.method.returnTypeChangedCovariantly</code>
+                                    <old>method io.trino.spi.block.Block io.trino.spi.block.DictionaryBlock::getLoadedBlock()</old>
+                                    <new>method io.trino.spi.block.DictionaryBlock io.trino.spi.block.DictionaryBlock::getLoadedBlock()</new>
+                                </item>
+                                <item>
+                                    <code>java.method.returnTypeChangedCovariantly</code>
+                                    <old>method io.trino.spi.block.Block io.trino.spi.block.MapBlock::getLoadedBlock()</old>
+                                    <new>method io.trino.spi.block.MapBlock io.trino.spi.block.MapBlock::getLoadedBlock()</new>
+                                </item>
+                                <item>
+                                    <code>java.method.returnTypeChangedCovariantly</code>
+                                    <old>method io.trino.spi.block.Block io.trino.spi.block.RowBlock::getLoadedBlock()</old>
+                                    <new>method io.trino.spi.block.RowBlock io.trino.spi.block.RowBlock::getLoadedBlock()</new>
+                                </item>
+                                <item>
+                                    <code>java.method.returnTypeChangedCovariantly</code>
+                                    <old>method io.trino.spi.block.Block io.trino.spi.block.RunLengthEncodedBlock::getLoadedBlock()</old>
+                                    <new>method io.trino.spi.block.RunLengthEncodedBlock io.trino.spi.block.RunLengthEncodedBlock::getLoadedBlock()</new>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlock.java
@@ -42,7 +42,7 @@ public final class ArrayBlock
     private final int arrayOffset;
     private final int positionCount;
     private final boolean[] valueIsNull;
-    private final Block values;
+    private Block values;
     private final int[] offsets;
 
     private volatile long sizeInBytes;
@@ -219,17 +219,13 @@ public final class ArrayBlock
     @Override
     public ArrayBlock getLoadedBlock()
     {
-        Block loadedValuesBlock = values.getLoadedBlock();
-
-        if (loadedValuesBlock == values) {
-            return this;
+        if (values instanceof LazyBlock) {
+            values = values.getLoadedBlock();
         }
-        return createArrayBlockInternal(
-                arrayOffset,
-                positionCount,
-                valueIsNull,
-                offsets,
-                loadedValuesBlock);
+        else {
+            values.getLoadedBlock();
+        }
+        return this;
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Block.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Block.java
@@ -171,10 +171,9 @@ public sealed interface Block
     }
 
     /**
-     * Returns a fully loaded block that assures all data is in memory.
-     * Neither the returned block nor any nested block will be a {@link LazyBlock}.
-     * The same block will be returned if neither the current block nor any
-     * nested blocks are {@link LazyBlock},
+     * Returns a fully loaded block without any {@link LazyBlock} instances.
+     * Blocks are updated in-place, and the same block is returned, unless the
+     * current block is a {@link LazyBlock} in which case a different block is returned.
      * <p>
      * This allows streaming data sources to skip sections that are not
      * accessed in a query.

--- a/core/trino-spi/src/main/java/io/trino/spi/block/BlockUtil.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/BlockUtil.java
@@ -248,27 +248,6 @@ final class BlockUtil
         return true;
     }
 
-    /**
-     * Returns the input blocks array if all blocks are already loaded, otherwise returns a new blocks array with all blocks loaded
-     */
-    static Block[] ensureBlocksAreLoaded(Block[] blocks)
-    {
-        for (int i = 0; i < blocks.length; i++) {
-            Block loaded = blocks[i].getLoadedBlock();
-            if (loaded != blocks[i]) {
-                // Transition to new block creation mode after the first newly loaded block is encountered
-                Block[] loadedBlocks = blocks.clone();
-                loadedBlocks[i++] = loaded;
-                for (; i < blocks.length; i++) {
-                    loadedBlocks[i] = blocks[i].getLoadedBlock();
-                }
-                return loadedBlocks;
-            }
-        }
-        // No newly loaded blocks
-        return blocks;
-    }
-
     static boolean[] copyIsNullAndAppendNull(@Nullable boolean[] isNull, int offsetBase, int positionCount)
     {
         int desiredLength = offsetBase + positionCount + 1;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
@@ -37,7 +37,7 @@ public final class DictionaryBlock
     private static final int NULL_NOT_FOUND = -1;
 
     private final int positionCount;
-    private final ValueBlock dictionary;
+    private ValueBlock dictionary;
     private final int idsOffset;
     private final int[] ids;
     private final long retainedSizeInBytes;
@@ -464,14 +464,11 @@ public final class DictionaryBlock
     }
 
     @Override
-    public Block getLoadedBlock()
+    public DictionaryBlock getLoadedBlock()
     {
-        Block loadedDictionary = dictionary.getLoadedBlock();
-
-        if (loadedDictionary == dictionary) {
-            return this;
-        }
-        return createInternal(idsOffset, getPositionCount(), loadedDictionary, ids, randomDictionaryId());
+        // dictionary cannot be a {@link LazyBlock}, but it can be a block that contains {@link LazyBlock}s
+        dictionary.getLoadedBlock();
+        return this;
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LazyBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LazyBlock.java
@@ -109,7 +109,10 @@ public final class LazyBlock
     @Override
     public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
-        getBlock().retainedBytesForEachPart(consumer);
+        Block block = lazyData.getBlockIfLoaded();
+        if (block != null) {
+            block.retainedBytesForEachPart(consumer);
+        }
         consumer.accept(this, INSTANCE_SIZE);
     }
 
@@ -289,6 +292,12 @@ public final class LazyBlock
             }
 
             load(true);
+            return block;
+        }
+
+        @Nullable
+        public Block getBlockIfLoaded()
+        {
             return block;
         }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LazyBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LazyBlock.java
@@ -319,6 +319,9 @@ public final class LazyBlock
             }
 
             block = requireNonNull(loader.load(), "loader returned null");
+            if (block instanceof LazyBlock) {
+                throw new IllegalStateException("LazyBlock returned by loader");
+            }
             if (block.getPositionCount() != positionsCount) {
                 throw new IllegalStateException(format("Loaded block positions count (%s) doesn't match lazy block positions count (%s)", block.getPositionCount(), positionsCount));
             }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/MapBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/MapBlock.java
@@ -52,8 +52,8 @@ public final class MapBlock
     @Nullable
     private final boolean[] mapIsNull;
     private final int[] offsets;
-    private final Block keyBlock;
-    private final Block valueBlock;
+    private Block keyBlock;
+    private Block valueBlock;
     private final MapHashTables hashTables;
 
     private final long baseSizeInBytes;
@@ -290,22 +290,21 @@ public final class MapBlock
     }
 
     @Override
-    public Block getLoadedBlock()
+    public MapBlock getLoadedBlock()
     {
-        Block loadedKeyBlock = keyBlock.getLoadedBlock();
-        Block loadedValueBlock = valueBlock.getLoadedBlock();
-        if (loadedKeyBlock == keyBlock && loadedValueBlock == valueBlock) {
-            return this;
+        if (keyBlock instanceof LazyBlock) {
+            keyBlock = keyBlock.getLoadedBlock();
         }
-        return createMapBlockInternal(
-                getMapType(),
-                startOffset,
-                positionCount,
-                Optional.ofNullable(mapIsNull),
-                offsets,
-                loadedKeyBlock,
-                loadedValueBlock,
-                hashTables);
+        else {
+            keyBlock.getLoadedBlock();
+        }
+        if (valueBlock instanceof LazyBlock) {
+            valueBlock = valueBlock.getLoadedBlock();
+        }
+        else {
+            valueBlock.getLoadedBlock();
+        }
+        return this;
     }
 
     void ensureHashTableLoaded()

--- a/core/trino-spi/src/main/java/io/trino/spi/block/MapBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/MapBlock.java
@@ -292,13 +292,9 @@ public final class MapBlock
     @Override
     public Block getLoadedBlock()
     {
-        if (keyBlock != keyBlock.getLoadedBlock()) {
-            // keyBlock has to be loaded since MapBlock constructs hash table eagerly.
-            throw new IllegalStateException();
-        }
-
+        Block loadedKeyBlock = keyBlock.getLoadedBlock();
         Block loadedValueBlock = valueBlock.getLoadedBlock();
-        if (loadedValueBlock == valueBlock) {
+        if (loadedKeyBlock == keyBlock && loadedValueBlock == valueBlock) {
             return this;
         }
         return createMapBlockInternal(
@@ -307,7 +303,7 @@ public final class MapBlock
                 positionCount,
                 Optional.ofNullable(mapIsNull),
                 offsets,
-                keyBlock,
+                loadedKeyBlock,
                 loadedValueBlock,
                 hashTables);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
@@ -239,14 +239,11 @@ public final class RunLengthEncodedBlock
     }
 
     @Override
-    public Block getLoadedBlock()
+    public RunLengthEncodedBlock getLoadedBlock()
     {
-        Block loadedValueBlock = value.getLoadedBlock();
-
-        if (loadedValueBlock == value) {
-            return this;
-        }
-        return create(loadedValueBlock, positionCount);
+        // dictionary cannot be a {@link LazyBlock}, but it can be a block that contains {@link LazyBlock}s
+        value.getLoadedBlock();
+        return this;
     }
 
     @Override

--- a/core/trino-spi/src/test/java/io/trino/spi/TestPage.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/TestPage.java
@@ -153,17 +153,16 @@ public class TestPage
         Page page = new Page(lazyBlock);
         long lazyPageRetainedSize = Page.INSTANCE_SIZE + sizeOf(new Block[] {block}) + lazyBlock.getRetainedSizeInBytes();
         assertThat(page.getRetainedSizeInBytes()).isEqualTo(lazyPageRetainedSize);
-        Page loadedPage = page.getLoadedPage();
-        // Retained size of page remains the same
-        assertThat(page.getRetainedSizeInBytes()).isEqualTo(lazyPageRetainedSize);
+        // load the page and assert instance is the same
+        assertThat(page).isSameAs(page.getLoadedPage());
         long loadedPageRetainedSize = Page.INSTANCE_SIZE + sizeOf(new Block[] {block}) + block.getRetainedSizeInBytes();
         // Retained size of loaded page depends on the loaded block
-        assertThat(loadedPage.getRetainedSizeInBytes()).isEqualTo(loadedPageRetainedSize);
+        assertThat(page.getRetainedSizeInBytes()).isEqualTo(loadedPageRetainedSize);
 
         lazyBlock = lazyWrapper(block);
         page = new Page(lazyBlock);
         assertThat(page.getRetainedSizeInBytes()).isEqualTo(lazyPageRetainedSize);
-        loadedPage = page.getLoadedPage(new int[] {0}, new int[] {0});
+        Page loadedPage = page.getLoadedPage(new int[] {0}, new int[] {0});
         // Retained size of page is updated based on loaded block
         assertThat(page.getRetainedSizeInBytes()).isEqualTo(loadedPageRetainedSize);
         assertThat(loadedPage.getRetainedSizeInBytes()).isEqualTo(loadedPageRetainedSize);


### PR DESCRIPTION
## Description
When a block or page is loaded a new instance is created in most cases, but this isn't necessary and the nested block array or block field can be updated directly. This is done without any synchronization on the array or field because the update is a benign race on an object reference, which can be safely updated without tearing.

This behavior exists already existed in one of the Page load methods and is being extended to all block containers. The block documentation has been updated to state the current block instance is returned in all cases, except for a `LazyBlock`.

Additionally, this PR removes the eager loading of all blocks in `Page.getSizeInBytes`

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
