### PR TITLE
Allow hive table owner to change ownership

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControl.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControl.java
@@ -317,7 +317,7 @@ public class SqlStandardAccessControl
     @Override
     public void checkCanSetTableAuthorization(ConnectorSecurityContext context, SchemaTableName tableName, TrinoPrincipal principal)
     {
-        if (!isAdmin(context)) {
+        if (!isTableOwner(context, tableName)) {
             denySetTableAuthorization(tableName.toString(), principal);
         }
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -945,11 +945,7 @@ public abstract class BaseHiveConnectorTest
                 "ALTER TABLE test_table_authorization.foo SET AUTHORIZATION alice",
                 "Cannot set authorization for table test_table_authorization.foo to USER alice");
         assertUpdate(admin, "ALTER TABLE test_table_authorization.foo SET AUTHORIZATION alice");
-        // only admin can change the owner
-        assertAccessDenied(
-                alice,
-                "ALTER TABLE test_table_authorization.foo SET AUTHORIZATION alice",
-                "Cannot set authorization for table test_table_authorization.foo to USER alice");
+        assertUpdate(alice, "ALTER TABLE test_table_authorization.foo SET AUTHORIZATION alice");
         // alice as new owner can now drop table
         assertUpdate(alice, "DROP TABLE test_table_authorization.foo");
 
@@ -982,11 +978,10 @@ public abstract class BaseHiveConnectorTest
                 "DROP TABLE test_table_authorization_role.foo",
                 "Cannot drop table test_table_authorization_role.foo");
         assertUpdate(admin, "ALTER TABLE test_table_authorization_role.foo SET AUTHORIZATION alice");
-        // Only admin can change the owner
-        assertAccessDenied(
+        assertQueryFails(
                 alice,
                 "ALTER TABLE test_table_authorization_role.foo SET AUTHORIZATION ROLE admin",
-                "Cannot set authorization for table test_table_authorization_role.foo to ROLE admin");
+                "Setting table owner type as a role is not supported");
         // new owner can drop table
         assertUpdate(alice, "DROP TABLE test_table_authorization_role.foo");
         assertUpdate(admin, "DROP SCHEMA test_table_authorization_role");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Hive sql-standard security mode restricts the possibility to change ownership to `admin` users only, making the [authorization rules ](https://trino.io/docs/current/security/file-system-access-control.html#authorization-rules) almost useless.

With this PR, Hive table owners will be able to transfer the ownership to other users, similar to community databases like Postgres.

For views, only admin users will be able to transfer ownership, as by letting owners to do it, a security breach will happen while they might transfer the ownership to users that able to select sensitive masked columns (or more filtered rows) and expose themself to data that they are not allowed to query.

Actually the option for transferring ownership to other users can be achieved by letting the new owner a grant to show view code and recreate the view and become the new owner.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## hive-connector
* Allow table owner to change ownership with sql-standard security mode. ({issue}`23842`)
```
