### PR TITLE
Replace "fail() + catch" pattern in HiveType testing

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestHiveTypeTranslator.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestHiveTypeTranslator.java
@@ -44,7 +44,7 @@ import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Fail.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestHiveTypeTranslator
 {
@@ -83,19 +83,12 @@ public class TestHiveTypeTranslator
 
     private static void assertInvalidTypeTranslation(Type type, ErrorCode errorCode, String message)
     {
-        try {
-            toHiveType(type);
-            fail("expected exception");
-        }
-        catch (TrinoException e) {
-            try {
-                assertThat(e.getErrorCode()).isEqualTo(errorCode);
-                assertThat(e).hasMessageContaining(message);
-            }
-            catch (Throwable failure) {
-                failure.addSuppressed(e);
-                throw failure;
-            }
-        }
+        assertThatThrownBy(() -> toHiveType(type))
+                .isInstanceOf(TrinoException.class)
+                .satisfies(e -> {
+                    TrinoException trinoException = (TrinoException) e;
+                    assertThat(trinoException.getErrorCode()).isEqualTo(errorCode);
+                    assertThat(trinoException).hasMessageContaining(message);
+                });
     }
 }


### PR DESCRIPTION
## Description
"fail() + catch" pattern in testing replaced with `assertThatThrownBy()` to improve readability. Functionality is identical, second `try-catch` block is unchanged so `addSuppressed()` still executes on a non-`TrinoException` exceptions.

## Additional context and related issues
Partially fixes readability issues raised in #6553

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: