### PR TITLE
Add oauth2-server-uri support to Iceberg REST catalog

### DIFF
--- a/docs/src/main/sphinx/object-storage/metastores.md
+++ b/docs/src/main/sphinx/object-storage/metastores.md
@@ -494,6 +494,8 @@ following properties:
 * - `iceberg.rest-catalog.oauth2.scope`
   - Scope to be used when communicating with the REST Catalog. Applicable only
     when using `credential`.
+* - `iceberg.rest-catalog.oauth2.server-uri`
+  - The endpoint to retrieve access token from OAuth2 Server.
 * - `iceberg.rest-catalog.vended-credentials-enabled`
   - Use credentials provided by the REST backend for file system access.
     Defaults to `false`.

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/OAuth2SecurityConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/OAuth2SecurityConfig.java
@@ -18,6 +18,7 @@ import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.ConfigSecuritySensitive;
 import jakarta.validation.constraints.AssertTrue;
 
+import java.net.URI;
 import java.util.Optional;
 
 public class OAuth2SecurityConfig
@@ -25,6 +26,7 @@ public class OAuth2SecurityConfig
     private String credential;
     private String scope;
     private String token;
+    private URI serverUri;
 
     public Optional<String> getCredential()
     {
@@ -64,6 +66,19 @@ public class OAuth2SecurityConfig
     public OAuth2SecurityConfig setToken(String token)
     {
         this.token = token;
+        return this;
+    }
+
+    public Optional<URI> getServerUri()
+    {
+        return Optional.ofNullable(serverUri);
+    }
+
+    @Config("iceberg.rest-catalog.oauth2.server-uri")
+    @ConfigDescription("The endpoint to retrieve access token from OAuth2 Server")
+    public OAuth2SecurityConfig setServerUri(URI serverUri)
+    {
+        this.serverUri = serverUri;
         return this;
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/OAuth2SecurityProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/OAuth2SecurityProperties.java
@@ -40,6 +40,8 @@ public class OAuth2SecurityProperties
                 });
         securityConfig.getToken().ifPresent(
                 value -> propertiesBuilder.put(OAuth2Properties.TOKEN, value));
+        securityConfig.getServerUri().ifPresent(
+                value -> propertiesBuilder.put(OAuth2Properties.OAUTH2_SERVER_URI, value.toString()));
 
         this.securityProperties = propertiesBuilder.buildOrThrow();
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestOAuth2SecurityConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestOAuth2SecurityConfig.java
@@ -16,6 +16,7 @@ package io.trino.plugin.iceberg.catalog.rest;
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 
+import java.net.URI;
 import java.util.Map;
 
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
@@ -31,7 +32,8 @@ public class TestOAuth2SecurityConfig
         assertRecordedDefaults(recordDefaults(OAuth2SecurityConfig.class)
                 .setCredential(null)
                 .setToken(null)
-                .setScope(null));
+                .setScope(null)
+                .setServerUri(null));
     }
 
     @Test
@@ -41,12 +43,14 @@ public class TestOAuth2SecurityConfig
                 .put("iceberg.rest-catalog.oauth2.token", "token")
                 .put("iceberg.rest-catalog.oauth2.credential", "credential")
                 .put("iceberg.rest-catalog.oauth2.scope", "scope")
+                .put("iceberg.rest-catalog.oauth2.server-uri", "http://localhost:8080/realms/iceberg/protocol/openid-connect/token")
                 .buildOrThrow();
 
         OAuth2SecurityConfig expected = new OAuth2SecurityConfig()
                 .setCredential("credential")
                 .setToken("token")
-                .setScope("scope");
+                .setScope("scope")
+                .setServerUri(URI.create("http://localhost:8080/realms/iceberg/protocol/openid-connect/token"));
         assertThat(expected.credentialOrTokenPresent()).isTrue();
         assertThat(expected.scopePresentOnlyWithCredential()).isFalse();
         assertFullMapping(properties, expected);


### PR DESCRIPTION
## Description

This PR adds `iceberg.rest-catalog.oauth2.server-uri` property which serves the purpose of specifying the access token endpoint of IdP in Iceberg connector.

I'm setting it as a Draft as I'm not sure if more isn't required to implement this. I'm using this patch at my job and it works but we're also fairly new to Trino and Iceberg REST catalog

Fixes #23086 

## Release notes

```markdown
## Iceberg
* Allow configuring an OAuth2 server URI with the `iceberg.rest-catalog.oauth2.server-uri` config property. ({issue}`23086`)
```
