### PR TITLE
Serafin/mvn4.0.0 beta5

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+distributionUrl=https://repository.apache.org/content/repositories/maven-2228/org/apache/maven/apache-maven/4.0.0-beta-5/apache-maven-4.0.0-beta-5-bin.zip

--- a/pom.xml
+++ b/pom.xml
@@ -269,14 +269,6 @@
             </dependency>
 
             <dependency>
-                <groupId>io.grpc</groupId>
-                <artifactId>grpc-bom</artifactId>
-                <version>1.68.0</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
-            <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
                 <version>4.1.114.Final</version>


### PR DESCRIPTION
`./mvnw clean install -nsu -T 1C -DskipTests` fails with:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-install-plugin:3.1.3:install (default-install) on project trino-cli: 1 problem was  for io.trino:trino-cli:jar:463-SNAPSHOT
[ERROR]     - [FATAL] 'parent.relativePath' points at '../../../pom.xml' but no POM could be found, please verify your project structure @ line 3, column 3
```

Seems to be related to `shade-plugin` as removing it from `trino-cli` module makes the build for it successful.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
