### PR TITLE
Improve HiveViewReader to show column comments

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
@@ -43,8 +43,10 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -244,11 +246,17 @@ public final class ViewReaderUtil
                 RelToTrinoConverter relToTrino = new RelToTrinoConverter(metastoreClient);
                 String trinoSql = relToTrino.convert(rel);
                 RelDataType rowType = rel.getRowType();
+                Map<String, String> columnComments = table.getDataColumns().stream()
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toMap(Column::getName,
+                                column -> column.getComment().orElse(""),
+                                (existing, replacement) -> existing));
+
                 List<ViewColumn> columns = rowType.getFieldList().stream()
                         .map(field -> new ViewColumn(
                                 field.getName(),
                                 typeManager.fromSqlType(getTypeString(field.getType(), hiveViewsTimestampPrecision)).getTypeId(),
-                                Optional.empty()))
+                                Optional.ofNullable(columnComments.get(field.getName()))))
                         .collect(toImmutableList());
                 return new ConnectorViewDefinition(
                         trinoSql,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

hive view in experimental mode, the column comment cannot be queried like `describe table` or `show columns from table`.
So, In the HiveViewReader, add the column's comment to the ViewColumn object

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
- In legacy mode, you can check the column's comment. However, it cannot be confirmed in experimental mode.
- https://github.com/trinodb/trino/issues/23845


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(X) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

