### PR TITLE
Disallow window framing clause for certain window functions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -422,6 +422,7 @@ import static java.util.Objects.requireNonNull;
 class StatementAnalyzer
 {
     private static final Set<String> WINDOW_VALUE_FUNCTIONS = ImmutableSet.of("lead", "lag", "first_value", "last_value", "nth_value");
+    private static final Set<String> DISALLOWED_WINDOW_FRAME_FUNCTIONS = ImmutableSet.of("lead", "lag", "ntile", "rank", "dense_rank", "percent_rank", "cume_dist", "row_number");
 
     private final StatementAnalyzerFactory statementAnalyzerFactory;
     private final Analysis analysis;
@@ -4352,9 +4353,9 @@ class StatementAnalyzer
                     if (window.getOrderBy().isEmpty()) {
                         throw semanticException(MISSING_ORDER_BY, (Node) windowFunction.getWindow().orElseThrow(), "%s function requires an ORDER BY window clause", windowFunction.getName());
                     }
-                    if (window.getFrame().isPresent()) {
-                        throw semanticException(INVALID_WINDOW_FRAME, window.getFrame().get(), "Cannot specify window frame for %s function", windowFunction.getName());
-                    }
+                }
+                if (DISALLOWED_WINDOW_FRAME_FUNCTIONS.contains(name) && window.getFrame().isPresent()) {
+                    throw semanticException(INVALID_WINDOW_FRAME, window.getFrame().get(), "Cannot specify window frame for %s function", windowFunction.getName());
                 }
 
                 if (!WINDOW_VALUE_FUNCTIONS.contains(name) && windowFunction.getNullTreatment().isPresent()) {

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -1642,17 +1642,43 @@ public class TestAnalyzer
     }
 
     @Test
-    public void testWindowAttributesForLagLeadFunctions()
+    public void testWindowAttributes()
     {
         assertFails("SELECT lag(x, 2) OVER() FROM (VALUES 1, 2, 3, 4, 5) t(x) ")
                 .hasErrorCode(MISSING_ORDER_BY);
         assertFails("SELECT lag(x, 2) OVER(ORDER BY x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM (VALUES 1, 2, 3, 4, 5) t(x) ")
-                .hasErrorCode(INVALID_WINDOW_FRAME);
+                .hasErrorCode(INVALID_WINDOW_FRAME)
+                .hasMessage("line 1:34: Cannot specify window frame for lag function");
 
         assertFails("SELECT lead(x, 2) OVER() FROM (VALUES 1, 2, 3, 4, 5) t(x) ")
                 .hasErrorCode(MISSING_ORDER_BY);
         assertFails("SELECT lead(x, 2) OVER(ORDER BY x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM (VALUES 1, 2, 3, 4, 5) t(x) ")
-                .hasErrorCode(INVALID_WINDOW_FRAME);
+                .hasErrorCode(INVALID_WINDOW_FRAME)
+                .hasMessage("line 1:35: Cannot specify window frame for lead function");
+
+        assertFails("SELECT row_number() OVER(ORDER BY x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM (VALUES 1, 2, 3, 4, 5) t(x) ")
+                .hasErrorCode(INVALID_WINDOW_FRAME)
+                .hasMessage("line 1:37: Cannot specify window frame for row_number function");
+
+        assertFails("SELECT rank() OVER(ORDER BY x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM (VALUES 1, 2, 3, 4, 5) t(x) ")
+                .hasErrorCode(INVALID_WINDOW_FRAME)
+                .hasMessage("line 1:31: Cannot specify window frame for rank function");
+
+        assertFails("SELECT percent_rank() OVER(ORDER BY x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM (VALUES 1, 2, 3, 4, 5) t(x) ")
+                .hasErrorCode(INVALID_WINDOW_FRAME)
+                .hasMessage("line 1:39: Cannot specify window frame for percent_rank function");
+
+        assertFails("SELECT dense_rank() OVER(ORDER BY x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM (VALUES 1, 2, 3, 4, 5) t(x) ")
+                .hasErrorCode(INVALID_WINDOW_FRAME)
+                .hasMessage("line 1:37: Cannot specify window frame for dense_rank function");
+
+        assertFails("SELECT cume_dist() OVER(ORDER BY x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM (VALUES 1, 2, 3, 4, 5) t(x) ")
+                .hasErrorCode(INVALID_WINDOW_FRAME)
+                .hasMessage("line 1:36: Cannot specify window frame for cume_dist function");
+
+        assertFails("SELECT ntile(4) OVER(ORDER BY x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM (VALUES 1, 2, 3, 4, 5) t(x) ")
+                .hasErrorCode(INVALID_WINDOW_FRAME)
+                .hasMessage("line 1:33: Cannot specify window frame for ntile function");
     }
 
     @Test
@@ -1667,36 +1693,36 @@ public class TestAnalyzer
     @Test
     public void testWindowFrameTypeRows()
     {
-        assertFails("SELECT rank() OVER (ROWS UNBOUNDED FOLLOWING)")
+        assertFails("SELECT array_agg(x) OVER (ROWS UNBOUNDED FOLLOWING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT rank() OVER (ROWS 2 FOLLOWING)")
+        assertFails("SELECT array_agg(x) OVER (ROWS 2 FOLLOWING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT rank() OVER (ROWS BETWEEN UNBOUNDED FOLLOWING AND CURRENT ROW)")
+        assertFails("SELECT array_agg(x) OVER (ROWS BETWEEN UNBOUNDED FOLLOWING AND CURRENT ROW) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT rank() OVER (ROWS BETWEEN CURRENT ROW AND UNBOUNDED PRECEDING)")
+        assertFails("SELECT array_agg(x) OVER (ROWS BETWEEN CURRENT ROW AND UNBOUNDED PRECEDING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT rank() OVER (ROWS BETWEEN CURRENT ROW AND 5 PRECEDING)")
+        assertFails("SELECT array_agg(x) OVER (ROWS BETWEEN CURRENT ROW AND 5 PRECEDING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT rank() OVER (ROWS BETWEEN 2 FOLLOWING AND 5 PRECEDING)")
+        assertFails("SELECT array_agg(x) OVER (ROWS BETWEEN 2 FOLLOWING AND 5 PRECEDING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT rank() OVER (ROWS BETWEEN 2 FOLLOWING AND CURRENT ROW)")
+        assertFails("SELECT array_agg(x) OVER (ROWS BETWEEN 2 FOLLOWING AND CURRENT ROW) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
 
-        assertFails("SELECT rank() OVER (ROWS 5e-1 PRECEDING)")
+        assertFails("SELECT array_agg(x) OVER (ROWS 5e-1 PRECEDING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(TYPE_MISMATCH);
-        assertFails("SELECT rank() OVER (ROWS 'foo' PRECEDING)")
+        assertFails("SELECT array_agg(x) OVER (ROWS 'foo' PRECEDING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(TYPE_MISMATCH);
-        assertFails("SELECT rank() OVER (ROWS BETWEEN CURRENT ROW AND 5e-1 FOLLOWING)")
+        assertFails("SELECT array_agg(x) OVER (ROWS BETWEEN CURRENT ROW AND 5e-1 FOLLOWING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(TYPE_MISMATCH);
-        assertFails("SELECT rank() OVER (ROWS BETWEEN CURRENT ROW AND 'foo' FOLLOWING)")
+        assertFails("SELECT array_agg(x) OVER (ROWS BETWEEN CURRENT ROW AND 'foo' FOLLOWING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(TYPE_MISMATCH);
 
-        analyze("SELECT rank() OVER (ROWS BETWEEN SMALLINT '1' PRECEDING AND SMALLINT '2' FOLLOWING) FROM (VALUES 1) t(x)");
-        analyze("SELECT rank() OVER (ROWS BETWEEN TINYINT '1' PRECEDING AND TINYINT '2' FOLLOWING) FROM (VALUES 1) t(x)");
-        analyze("SELECT rank() OVER (ROWS BETWEEN INTEGER '1' PRECEDING AND INTEGER '2' FOLLOWING) FROM (VALUES 1) t(x)");
-        analyze("SELECT rank() OVER (ROWS BETWEEN BIGINT '1' PRECEDING AND BIGINT '2' FOLLOWING) FROM (VALUES 1) t(x)");
-        analyze("SELECT rank() OVER (ROWS BETWEEN DECIMAL '1' PRECEDING AND DECIMAL '2' FOLLOWING) FROM (VALUES 1) t(x)");
-        analyze("SELECT rank() OVER (ROWS BETWEEN CAST(1 AS decimal(38, 0)) PRECEDING AND CAST(2 AS decimal(38, 0)) FOLLOWING) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ROWS BETWEEN SMALLINT '1' PRECEDING AND SMALLINT '2' FOLLOWING) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ROWS BETWEEN TINYINT '1' PRECEDING AND TINYINT '2' FOLLOWING) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ROWS BETWEEN INTEGER '1' PRECEDING AND INTEGER '2' FOLLOWING) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ROWS BETWEEN BIGINT '1' PRECEDING AND BIGINT '2' FOLLOWING) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ROWS BETWEEN DECIMAL '1' PRECEDING AND DECIMAL '2' FOLLOWING) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ROWS BETWEEN CAST(1 AS decimal(38, 0)) PRECEDING AND CAST(2 AS decimal(38, 0)) FOLLOWING) FROM (VALUES 1) t(x)");
     }
 
     @Test
@@ -1782,46 +1808,46 @@ public class TestAnalyzer
     @Test
     public void testWindowFrameTypeGroups()
     {
-        assertFails("SELECT rank() OVER (ORDER BY x GROUPS UNBOUNDED FOLLOWING) FROM (VALUES 1) t(x)")
+        assertFails("SELECT array_agg(x) OVER (ORDER BY x GROUPS UNBOUNDED FOLLOWING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT rank() OVER (ORDER BY x GROUPS 2 FOLLOWING) FROM (VALUES 1) t(x)")
+        assertFails("SELECT array_agg(x) OVER (ORDER BY x GROUPS 2 FOLLOWING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN UNBOUNDED FOLLOWING AND CURRENT ROW) FROM (VALUES 1) t(x)")
+        assertFails("SELECT array_agg(x) OVER (ORDER BY x GROUPS BETWEEN UNBOUNDED FOLLOWING AND CURRENT ROW) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN CURRENT ROW AND UNBOUNDED PRECEDING) FROM (VALUES 1) t(x)")
+        assertFails("SELECT array_agg(x) OVER (ORDER BY x GROUPS BETWEEN CURRENT ROW AND UNBOUNDED PRECEDING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN CURRENT ROW AND 5 PRECEDING) FROM (VALUES 1) t(x)")
+        assertFails("SELECT array_agg(x) OVER (ORDER BY x GROUPS BETWEEN CURRENT ROW AND 5 PRECEDING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN 2 FOLLOWING AND 5 PRECEDING) FROM (VALUES 1) t(x)")
+        assertFails("SELECT array_agg(x) OVER (ORDER BY x GROUPS BETWEEN 2 FOLLOWING AND 5 PRECEDING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN 2 FOLLOWING AND CURRENT ROW) FROM (VALUES 1) t(x)")
+        assertFails("SELECT array_agg(x) OVER (ORDER BY x GROUPS BETWEEN 2 FOLLOWING AND CURRENT ROW) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
 
-        assertFails("SELECT rank() OVER (GROUPS 2 PRECEDING) FROM (VALUES 1) t(x)")
+        assertFails("SELECT array_agg(x) OVER (GROUPS 2 PRECEDING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(MISSING_ORDER_BY);
 
-        assertFails("SELECT rank() OVER (ORDER BY x GROUPS 5e-1 PRECEDING) FROM (VALUES 1) t(x)")
+        assertFails("SELECT array_agg(x) OVER (ORDER BY x GROUPS 5e-1 PRECEDING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(TYPE_MISMATCH);
-        assertFails("SELECT rank() OVER (ORDER BY x GROUPS 'foo' PRECEDING) FROM (VALUES 1) t(x)")
+        assertFails("SELECT array_agg(x) OVER (ORDER BY x GROUPS 'foo' PRECEDING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(TYPE_MISMATCH);
-        assertFails("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN CURRENT ROW AND 5e-1 FOLLOWING) FROM (VALUES 1) t(x)")
+        assertFails("SELECT array_agg(x) OVER (ORDER BY x GROUPS BETWEEN CURRENT ROW AND 5e-1 FOLLOWING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(TYPE_MISMATCH);
-        assertFails("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN CURRENT ROW AND 'foo' FOLLOWING) FROM (VALUES 1) t(x)")
+        assertFails("SELECT array_agg(x) OVER (ORDER BY x GROUPS BETWEEN CURRENT ROW AND 'foo' FOLLOWING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(TYPE_MISMATCH);
 
-        analyze("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN SMALLINT '1' PRECEDING AND SMALLINT '2' FOLLOWING) FROM (VALUES 1) t(x)");
-        analyze("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN TINYINT '1' PRECEDING AND TINYINT '2' FOLLOWING) FROM (VALUES 1) t(x)");
-        analyze("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN INTEGER '1' PRECEDING AND INTEGER '2' FOLLOWING) FROM (VALUES 1) t(x)");
-        analyze("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN BIGINT '1' PRECEDING AND BIGINT '2' FOLLOWING) FROM (VALUES 1) t(x)");
-        analyze("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN DECIMAL '1' PRECEDING AND DECIMAL '2' FOLLOWING) FROM (VALUES 1) t(x)");
-        analyze("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN CAST(1 AS decimal(38, 0)) PRECEDING AND CAST(2 AS decimal(38, 0)) FOLLOWING) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ORDER BY x GROUPS BETWEEN SMALLINT '1' PRECEDING AND SMALLINT '2' FOLLOWING) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ORDER BY x GROUPS BETWEEN TINYINT '1' PRECEDING AND TINYINT '2' FOLLOWING) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ORDER BY x GROUPS BETWEEN INTEGER '1' PRECEDING AND INTEGER '2' FOLLOWING) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ORDER BY x GROUPS BETWEEN BIGINT '1' PRECEDING AND BIGINT '2' FOLLOWING) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ORDER BY x GROUPS BETWEEN DECIMAL '1' PRECEDING AND DECIMAL '2' FOLLOWING) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ORDER BY x GROUPS BETWEEN CAST(1 AS decimal(38, 0)) PRECEDING AND CAST(2 AS decimal(38, 0)) FOLLOWING) FROM (VALUES 1) t(x)");
     }
 
     @Test
     public void testWindowFrameWithPatternRecognition()
     {
         // in-line window specification
-        analyze("SELECT rank() OVER (" +
+        analyze("SELECT array_agg(x) OVER (" +
                 "                           PARTITION BY x " +
                 "                           ORDER BY y " +
                 "                           MEASURES A.z AS last_z " +
@@ -1837,7 +1863,7 @@ public class TestAnalyzer
                 "           FROM (VALUES (1, 2, 3)) t(x, y, z)");
 
         // window clause
-        analyze("SELECT rank() OVER w FROM (VALUES (1, 2, 3)) t(x, y, z) " +
+        analyze("SELECT array_agg(x) OVER w FROM (VALUES (1, 2, 3)) t(x, y, z) " +
                 "                       WINDOW w AS (" +
                 "                           PARTITION BY x " +
                 "                           ORDER BY y " +
@@ -1856,7 +1882,7 @@ public class TestAnalyzer
     @Test
     public void testInvalidWindowFrameWithPatternRecognition()
     {
-        assertFails("SELECT rank() OVER (" +
+        assertFails("SELECT array_agg(x) OVER (" +
                 "                           PARTITION BY x " +
                 "                           ORDER BY y " +
                 "                           MEASURES A.z AS last_z " +
@@ -1868,9 +1894,9 @@ public class TestAnalyzer
                 "                         ) " +
                 "           FROM (VALUES (1, 2, 3)) t(x, y, z)")
                 .hasErrorCode(MISSING_VARIABLE_DEFINITIONS)
-                .hasMessage("line 1:128: Pattern recognition requires DEFINE clause");
+                .hasMessage("line 1:134: Pattern recognition requires DEFINE clause");
 
-        assertFails("SELECT rank() OVER (" +
+        assertFails("SELECT array_agg(x) OVER (" +
                 "                           PARTITION BY x " +
                 "                           ORDER BY y " +
                 "                           MEASURES A.z AS last_z " +
@@ -1885,9 +1911,9 @@ public class TestAnalyzer
                 "                         ) " +
                 "           FROM (VALUES (1, 2, 3)) t(x, y, z)")
                 .hasErrorCode(INVALID_WINDOW_FRAME)
-                .hasMessage("line 1:128: Pattern recognition requires ROWS frame type");
+                .hasMessage("line 1:134: Pattern recognition requires ROWS frame type");
 
-        assertFails("SELECT rank() OVER (" +
+        assertFails("SELECT array_agg(x) OVER (" +
                 "                           PARTITION BY x " +
                 "                           ORDER BY y " +
                 "                           MEASURES A.z AS last_z " +
@@ -1902,57 +1928,57 @@ public class TestAnalyzer
                 "                         ) " +
                 "           FROM (VALUES (1, 2, 3)) t(x, y, z)")
                 .hasErrorCode(INVALID_WINDOW_FRAME)
-                .hasMessage("line 1:128: Pattern recognition requires frame specified as BETWEEN CURRENT ROW AND ...");
+                .hasMessage("line 1:134: Pattern recognition requires frame specified as BETWEEN CURRENT ROW AND ...");
 
-        assertFails("SELECT rank() OVER ( " +
+        assertFails("SELECT array_agg(x) OVER ( " +
                 "                               MEASURES A.z AS last_z " +
                 "                               ROWS BETWEEN CURRENT ROW AND 5 FOLLOWING) " +
                 "           FROM (VALUES (1, 2, 3)) t(x, y, z)")
                 .hasErrorCode(MISSING_ROW_PATTERN)
-                .hasMessage("line 1:53: Row pattern measures require PATTERN clause");
+                .hasMessage("line 1:59: Row pattern measures require PATTERN clause");
 
-        assertFails("SELECT rank() OVER (" +
+        assertFails("SELECT array_agg(x) OVER (" +
                 "                               ROWS BETWEEN CURRENT ROW AND 5 FOLLOWING " +
                 "                               AFTER MATCH SKIP TO NEXT ROW) " +
                 "           FROM (VALUES (1, 2, 3)) t(x, y, z)")
                 .hasErrorCode(MISSING_ROW_PATTERN)
-                .hasMessage("line 1:136: AFTER MATCH SKIP clause requires PATTERN clause");
+                .hasMessage("line 1:142: AFTER MATCH SKIP clause requires PATTERN clause");
 
-        assertFails("SELECT rank() OVER (" +
+        assertFails("SELECT array_agg(x) OVER (" +
                 "                               ROWS BETWEEN CURRENT ROW AND 5 FOLLOWING " +
                 "                               SEEK) " +
                 "           FROM (VALUES (1, 2, 3)) t(x, y, z)")
                 .hasErrorCode(MISSING_ROW_PATTERN)
-                .hasMessage("line 1:124: SEEK modifier requires PATTERN clause");
+                .hasMessage("line 1:130: SEEK modifier requires PATTERN clause");
 
-        assertFails("SELECT rank() OVER (" +
+        assertFails("SELECT array_agg(x) OVER (" +
                 "                               ROWS BETWEEN CURRENT ROW AND 5 FOLLOWING " +
                 "                               SUBSET U = (A, B)) " +
                 "           FROM (VALUES (1, 2, 3)) t(x, y, z)")
                 .hasErrorCode(MISSING_ROW_PATTERN)
-                .hasMessage("line 1:131: Union variable definitions require PATTERN clause");
+                .hasMessage("line 1:137: Union variable definitions require PATTERN clause");
 
-        assertFails("SELECT rank() OVER (" +
+        assertFails("SELECT array_agg(x) OVER (" +
                 "                               ROWS BETWEEN CURRENT ROW AND 5 FOLLOWING " +
                 "                               DEFINE B AS false) " +
                 "           FROM (VALUES (1, 2, 3)) t(x, y, z)")
                 .hasErrorCode(MISSING_ROW_PATTERN)
-                .hasMessage("line 1:131: Primary pattern variable definitions require PATTERN clause");
+                .hasMessage("line 1:137: Primary pattern variable definitions require PATTERN clause");
     }
 
     @Test
     public void testSubsetClauseInWindow()
     {
-        assertFails("SELECT rank() OVER (" +
+        assertFails("SELECT array_agg(x) OVER (" +
                 "                               ROWS BETWEEN CURRENT ROW AND 5 FOLLOWING " +
                 "                               PATTERN (A B) " +
                 "                               SUBSET A = (C) " +
                 "                               DEFINE B AS false) " +
                 "           FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_LABEL)
-                .hasMessage("line 1:176: union pattern variable name: A is a duplicate of primary pattern variable name");
+                .hasMessage("line 1:182: union pattern variable name: A is a duplicate of primary pattern variable name");
 
-        assertFails("SELECT rank() OVER (" +
+        assertFails("SELECT array_agg(x) OVER (" +
                 "                               ROWS BETWEEN CURRENT ROW AND 5 FOLLOWING " +
                 "                               PATTERN (A B) " +
                 "                               SUBSET " +
@@ -1961,30 +1987,30 @@ public class TestAnalyzer
                 "                               DEFINE B AS false) " +
                 "           FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_LABEL)
-                .hasMessage("line 1:255: union pattern variable name: U is declared twice");
+                .hasMessage("line 1:261: union pattern variable name: U is declared twice");
 
-        assertFails("SELECT rank() OVER (" +
+        assertFails("SELECT array_agg(x) OVER (" +
                 "                               ROWS BETWEEN CURRENT ROW AND 5 FOLLOWING " +
                 "                               PATTERN (A B) " +
                 "                               SUBSET U = (A, C) " +
                 "                               DEFINE B AS false) " +
                 "           FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_LABEL)
-                .hasMessage("line 1:184: subset element: C is not a primary pattern variable");
+                .hasMessage("line 1:190: subset element: C is not a primary pattern variable");
     }
 
     @Test
     public void testDefineClauseInWindow()
     {
-        assertFails("SELECT rank() OVER (" +
+        assertFails("SELECT array_agg(x) OVER (" +
                 "                               ROWS BETWEEN CURRENT ROW AND 5 FOLLOWING " +
                 "                               PATTERN (A B) " +
                 "                               DEFINE C AS false) " +
                 "           FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_LABEL)
-                .hasMessage("line 1:176: defined variable: C is not a primary pattern variable");
+                .hasMessage("line 1:182: defined variable: C is not a primary pattern variable");
 
-        assertFails("SELECT rank() OVER (" +
+        assertFails("SELECT array_agg(x) OVER (" +
                 "                               ROWS BETWEEN CURRENT ROW AND 5 FOLLOWING " +
                 "                               PATTERN (A B) " +
                 "                               DEFINE " +
@@ -1992,56 +2018,56 @@ public class TestAnalyzer
                 "                                       A AS false) " +
                 "           FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_LABEL)
-                .hasMessage("line 1:265: pattern variable with name: A is defined twice");
+                .hasMessage("line 1:271: pattern variable with name: A is defined twice");
 
-        assertFails("SELECT rank() OVER (" +
+        assertFails("SELECT array_agg(x) OVER (" +
                 "                               ROWS BETWEEN CURRENT ROW AND 5 FOLLOWING " +
                 "                               PATTERN (A B) " +
                 "                               DEFINE A AS FINAL LAST(A.x) > 0) " +
                 "           FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_PROCESSING_MODE)
-                .hasMessage("line 1:181: FINAL semantics is not supported in DEFINE clause");
+                .hasMessage("line 1:187: FINAL semantics is not supported in DEFINE clause");
     }
 
     @Test
     public void testRangeQuantifiersInWindow()
     {
-        assertFails("SELECT rank() OVER (" +
+        assertFails("SELECT array_agg(x) OVER (" +
                 "                               ROWS BETWEEN CURRENT ROW AND 5 FOLLOWING " +
                 "                               PATTERN (A{,0}) " +
                 "                               DEFINE A AS false) " +
                 "           FROM (VALUES 1) t(x)")
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
-                .hasMessage("line 1:134: Pattern quantifier upper bound must be greater than or equal to 1");
+                .hasMessage("line 1:140: Pattern quantifier upper bound must be greater than or equal to 1");
 
-        assertFails("SELECT rank() OVER (" +
+        assertFails("SELECT array_agg(x) OVER (" +
                 "                               ROWS BETWEEN CURRENT ROW AND 5 FOLLOWING " +
                 "                               PATTERN (A{,3000000000}) " +
                 "                               DEFINE A AS false) " +
                 "           FROM (VALUES 1) t(x)")
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
-                .hasMessage("line 1:134: Pattern quantifier upper bound must not exceed 2147483647");
+                .hasMessage("line 1:140: Pattern quantifier upper bound must not exceed 2147483647");
 
-        assertFails("SELECT rank() OVER (" +
+        assertFails("SELECT array_agg(x) OVER (" +
                 "                               ROWS BETWEEN CURRENT ROW AND 5 FOLLOWING " +
                 "                               PATTERN (A{100,1}) " +
                 "                               DEFINE A AS false) " +
                 "           FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_RANGE)
-                .hasMessage("line 1:134: Pattern quantifier lower bound must not exceed upper bound");
+                .hasMessage("line 1:140: Pattern quantifier lower bound must not exceed upper bound");
     }
 
     @Test
     public void testAfterMatchSkipInWindow()
     {
-        analyze("SELECT rank() OVER (" +
+        analyze("SELECT array_agg(x) OVER (" +
                 "                               ROWS BETWEEN CURRENT ROW AND 5 FOLLOWING " +
                 "                               AFTER MATCH SKIP TO FIRST B " +
                 "                               PATTERN (A B) " +
                 "                               DEFINE A AS false) " +
                 "           FROM (VALUES 1) t(x)");
 
-        analyze("SELECT rank() OVER (" +
+        analyze("SELECT array_agg(x) OVER (" +
                 "                               ROWS BETWEEN CURRENT ROW AND 5 FOLLOWING " +
                 "                               AFTER MATCH SKIP TO FIRST U " +
                 "                               PATTERN (A B) " +
@@ -2049,27 +2075,27 @@ public class TestAnalyzer
                 "                               DEFINE A AS false) " +
                 "           FROM (VALUES 1) t(x)");
 
-        assertFails("SELECT rank() OVER (" +
+        assertFails("SELECT array_agg(x) OVER (" +
                 "                               ROWS BETWEEN CURRENT ROW AND 5 FOLLOWING " +
                 "                               AFTER MATCH SKIP TO FIRST C " +
                 "                               PATTERN (A B) " +
                 "                               DEFINE A AS false) " +
                 "           FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_LABEL)
-                .hasMessage("line 1:150: C is not a primary or union pattern variable");
+                .hasMessage("line 1:156: C is not a primary or union pattern variable");
     }
 
     @Test
     public void testPatternSearchModeInWindow()
     {
-        analyze("SELECT rank() OVER (" +
+        analyze("SELECT array_agg(x) OVER (" +
                 "                               ROWS BETWEEN CURRENT ROW AND 5 FOLLOWING " +
                 "                               INITIAL " +
                 "                               PATTERN (A B) " +
                 "                               DEFINE A AS false) " +
                 "           FROM (VALUES 1) t(x)");
 
-        analyze("SELECT rank() OVER (" +
+        analyze("SELECT array_agg(x) OVER (" +
                 "                               ROWS BETWEEN CURRENT ROW AND 5 FOLLOWING " +
                 "                               SEEK " +
                 "                               PATTERN (A B) " +
@@ -2080,27 +2106,27 @@ public class TestAnalyzer
     @Test
     public void testAnchorPatternInWindow()
     {
-        assertFails("SELECT rank() OVER (" +
+        assertFails("SELECT array_agg(x) OVER (" +
                 "                               ROWS BETWEEN CURRENT ROW AND 5 FOLLOWING " +
                 "                               PATTERN (^ A B) " +
                 "                               DEFINE B AS false) " +
                 "           FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_ROW_PATTERN)
-                .hasMessage("line 1:133: Anchor pattern syntax is not allowed in window");
+                .hasMessage("line 1:139: Anchor pattern syntax is not allowed in window");
 
-        assertFails("SELECT rank() OVER (" +
+        assertFails("SELECT array_agg(x) OVER (" +
                 "                               ROWS BETWEEN CURRENT ROW AND 5 FOLLOWING " +
                 "                               PATTERN (A B $) " +
                 "                               DEFINE B AS false) " +
                 "           FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_ROW_PATTERN)
-                .hasMessage("line 1:137: Anchor pattern syntax is not allowed in window");
+                .hasMessage("line 1:143: Anchor pattern syntax is not allowed in window");
     }
 
     @Test
     public void testMatchNumberFunctionInWindow()
     {
-        assertFails("SELECT rank() OVER ( " +
+        assertFails("SELECT array_agg(x) OVER ( " +
                 "                               MEASURES 1 + MATCH_NUMBER() AS m" +
                 "                               ROWS BETWEEN CURRENT ROW AND 5 FOLLOWING " +
                 "                               PATTERN (A B) " +
@@ -2108,9 +2134,9 @@ public class TestAnalyzer
                 "                              ) " +
                 "           FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_PATTERN_RECOGNITION_FUNCTION)
-                .hasMessage("line 1:66: MATCH_NUMBER function is not supported in window");
+                .hasMessage("line 1:72: MATCH_NUMBER function is not supported in window");
 
-        assertFails("SELECT rank() OVER ( " +
+        assertFails("SELECT array_agg(x) OVER ( " +
                 "                               MEASURES B.x AS m" +
                 "                               ROWS BETWEEN CURRENT ROW AND 5 FOLLOWING " +
                 "                               PATTERN (A B) " +
@@ -2118,14 +2144,14 @@ public class TestAnalyzer
                 "                              ) " +
                 "           FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_PATTERN_RECOGNITION_FUNCTION)
-                .hasMessage("line 1:230: MATCH_NUMBER function is not supported in window");
+                .hasMessage("line 1:236: MATCH_NUMBER function is not supported in window");
     }
 
     @Test
     public void testLabelNamesInWindow()
     {
         // SQL identifier semantics
-        analyze("SELECT rank() OVER ( " +
+        analyze("SELECT array_agg(x) OVER ( " +
                 "                               MEASURES " +
                 "                                       \"B\".x AS m1, " +
                 "                                       B.x AS m2 " +
@@ -2135,14 +2161,14 @@ public class TestAnalyzer
                 "                              ) " +
                 "           FROM (VALUES 1) t(x)");
 
-        assertFails("SELECT rank() OVER ( " +
+        assertFails("SELECT array_agg(x) OVER ( " +
                 "                               ROWS BETWEEN CURRENT ROW AND 5 FOLLOWING " +
                 "                               PATTERN (A B) " +
                 "                               DEFINE B AS \"b\".x > 0" +
                 "                              ) " +
                 "           FROM (VALUES 1) t(x)")
                 .hasErrorCode(COLUMN_NOT_FOUND)
-                .hasMessage("line 1:182: Column 'b.x' cannot be resolved");
+                .hasMessage("line 1:188: Column 'b.x' cannot be resolved");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -1648,6 +1648,11 @@ public class TestAnalyzer
                 .hasErrorCode(MISSING_ORDER_BY);
         assertFails("SELECT lag(x, 2) OVER(ORDER BY x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM (VALUES 1, 2, 3, 4, 5) t(x) ")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
+
+        assertFails("SELECT lead(x, 2) OVER() FROM (VALUES 1, 2, 3, 4, 5) t(x) ")
+                .hasErrorCode(MISSING_ORDER_BY);
+        assertFails("SELECT lead(x, 2) OVER(ORDER BY x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM (VALUES 1, 2, 3, 4, 5) t(x) ")
+                .hasErrorCode(INVALID_WINDOW_FRAME);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
@@ -2415,9 +2415,9 @@ public class TestLogicalPlanner
     @Test
     public void testPruneUnreferencedRowPatternWindowFunctions()
     {
-        // window function `row_number` is not referenced
+        // window function `last_value` is not referenced
         assertPlan("SELECT id, min FROM " +
-                        "       (SELECT id, min(value) OVER w min, row_number() OVER w " +
+                        "       (SELECT id, min(value) OVER w min, last_value(value) OVER w " +
                         "          FROM (VALUES (1, 90)) t(id, value) " +
                         "          WINDOW w AS ( " +
                         "                   ORDER BY id " +
@@ -2484,8 +2484,8 @@ public class TestLogicalPlanner
     public void testMergePatternRecognitionNodes()
     {
         // The pattern matching window `w` is referenced in three calls: row pattern measure calls: `val OVER w` and `label OVER w`,
-        // and window function call `row_number() OVER w`. They are all planned within a single PatternRecognitionNode.
-        assertPlan("SELECT id, val OVER w, label OVER w, row_number() OVER w " +
+        // and window function call `last_value(value) OVER w`. They are all planned within a single PatternRecognitionNode.
+        assertPlan("SELECT id, val OVER w, label OVER w, last_value(value) OVER w " +
                         "          FROM (VALUES (1, 90)) t(id, value) " +
                         "          WINDOW w AS ( " +
                         "                   ORDER BY id " +
@@ -2513,9 +2513,9 @@ public class TestLogicalPlanner
                                                         ImmutableMap.of("classy", new ClassifierValuePointer(
                                                                 new LogicalIndexPointer(ImmutableSet.of(), true, true, 0, 0))),
                                                         VARCHAR)
-                                                .addFunction("row_number", windowFunction(
-                                                        "row_number",
-                                                        ImmutableList.of(),
+                                                .addFunction("last_value", windowFunction(
+                                                        "last_value",
+                                                        ImmutableList.of("value"),
                                                         ROWS_FROM_CURRENT))
                                                 .rowsPerMatch(WINDOW)
                                                 .frame(ROWS_FROM_CURRENT)

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestRowPatternMatchingInWindow.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestRowPatternMatchingInWindow.java
@@ -1123,9 +1123,8 @@ public class TestRowPatternMatchingInWindow
     public void testWindowFunctions()
     {
         // multiple partitions, unordered input
-        // function row_number() ignores frame and numbers rows within partition
         // function array_agg() respects frame, which is reduced to the match (and empty in case of unmatched or skipped rows)
-        assertThat(assertions.query("SELECT part as partition, id AS row_id, val OVER w, label OVER w, row_number() OVER w, array_agg(value) OVER w " +
+        assertThat(assertions.query("SELECT part as partition, id AS row_id, val OVER w, label OVER w, array_agg(value) OVER w " +
                 "          FROM (VALUES " +
                 "                   (1, 'p1', 90), " +
                 "                   (2, 'p1', 80), " +
@@ -1152,18 +1151,18 @@ public class TestRowPatternMatchingInWindow
                 "                   DEFINE B AS B.value > NEXT (B.value) " +
                 "                )"))
                 .matches("VALUES " +
-                        "     ('p1', 1, 80, CAST('B' AS varchar), BIGINT '1', ARRAY[90, 80]), " +
-                        "     ('p1', 2, null, null, 2, null), " +
-                        "     ('p1', 3, null, null, 3, null), " +
-                        "     ('p1', 4, null, null, 4, null), " +
-                        "     ('p1', 5, 90,   'B',  5, ARRAY[90]), " +
-                        "     ('p1', 6, null, null, 6, null), " +
-                        "     ('p2', 1, null, null, 1, null), " +
-                        "     ('p2', 2, 20,   'B',  2, ARRAY[20]), " +
-                        "     ('p2', 3, null, null, 3, null), " +
-                        "     ('p3', 1, null, null, 1, null), " +
-                        "     ('p3', 2, null, null, 2, null), " +
-                        "     ('p3', 3, null, null, 3, null) ");
+                        "     ('p1', 1, 80, CAST('B' AS varchar), ARRAY[90, 80]), " +
+                        "     ('p1', 2, null, null, null), " +
+                        "     ('p1', 3, null, null, null), " +
+                        "     ('p1', 4, null, null, null), " +
+                        "     ('p1', 5, 90,   'B',  ARRAY[90]), " +
+                        "     ('p1', 6, null, null, null), " +
+                        "     ('p2', 1, null, null, null), " +
+                        "     ('p2', 2, 20,   'B',  ARRAY[20]), " +
+                        "     ('p2', 3, null, null, null), " +
+                        "     ('p3', 1, null, null, null), " +
+                        "     ('p3', 2, null, null, null), " +
+                        "     ('p3', 3, null, null, null) ");
 
         // with the option SEEK, pattern for the current row can be found starting from some following row within the base frame
         // e.g. for row 1, the match starts at row 2.

--- a/docs/src/main/sphinx/functions/window.md
+++ b/docs/src/main/sphinx/functions/window.md
@@ -45,12 +45,14 @@ Returns the cumulative distribution of a value in a group of values.
 The result is the number of rows preceding or peer with the row in the
 window ordering of the window partition divided by the total number of
 rows in the window partition. Thus, any tie values in the ordering will
-evaluate to the same distribution value.
+evaluate to the same distribution value. The window frame must not be 
+specified.
 :::
 
 :::{function} dense_rank() -> bigint
 Returns the rank of a value in a group of values. This is similar to
 {func}`rank`, except that tie values do not produce gaps in the sequence.
+The window frame must not be specified.
 :::
 
 :::{function} ntile(n) -> bigint
@@ -62,24 +64,29 @@ bucket, starting with the first bucket.
 
 For example, with `6` rows and `4` buckets, the bucket values would
 be as follows: `1` `1` `2` `2` `3` `4`
+
+For the {func}`ntile` function, the window frame must not be specified.
 :::
 
 :::{function} percent_rank() -> double
 Returns the percentage ranking of a value in group of values. The result
 is `(r - 1) / (n - 1)` where `r` is the {func}`rank` of the row and
-`n` is the total number of rows in the window partition.
+`n` is the total number of rows in the window partition. The window frame 
+must not be specified.
 :::
 
 :::{function} rank() -> bigint
 Returns the rank of a value in a group of values. The rank is one plus
 the number of rows preceding the row that are not peer with the row.
 Thus, tie values in the ordering will produce gaps in the sequence.
-The ranking is performed for each window partition.
+The ranking is performed for each window partition. The window frame must 
+not be specified.
 :::
 
 :::{function} row_number() -> bigint
 Returns a unique, sequential number for each row, starting with one,
-according to the ordering of rows within the window partition.
+according to the ordering of rows within the window partition. 
+The window frame must not be specified.
 :::
 
 ## Value functions


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Issue #23742 describes unexpected behavior of the `lag` function when used with a window framing clause. It turns out that the problem does not exist in the current version of Trino. This PR adds a test to confirm this. Additionally, it adds a check to verify that the window framing clause is not used with the `ntile`, `rank`, `dense_rank`, `percent_rank`, `cume_dist`, and `row_number` functions, which aligns with the SQL specification.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Fixes #23742

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Disallow the window framing clause for {func}`ntile`, {func}`rank`, {func}`dense_rank`, {func}`percent_rank`,  {func}`cume_dist`, and {func}`row_number`. ({issue}`23742`)
```
