### PR TITLE
Enable errorprone PatternMatchingInstanceof

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2880,6 +2880,7 @@
                                     -Xep:OptionalNotPresent:ERROR \
                                     -Xep:OrphanedFormatString:ERROR \
                                     -Xep:Overrides:ERROR \
+                                    -Xep:PatternMatchingInstanceof:ERROR \
                                     <!-- flags List fields even if initialized with ImmutableList -->
                                     -Xep:PreferredInterfaceType:OFF \
                                     -Xep:PrimitiveArrayPassedToVarargsMethod:ERROR \


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
