### PR TITLE
Keep table location when updating Glue tables in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergTableOperations.java
@@ -131,7 +131,7 @@ public class GlueIcebergTableOperations
     {
         verify(version.isEmpty(), "commitNewTable called on a table which already exists");
         String newMetadataLocation = writeNewMetadata(metadata, 0);
-        TableInput tableInput = getTableInput(typeManager, tableName, owner, metadata, newMetadataLocation, ImmutableMap.of(), cacheTableMetadata);
+        TableInput tableInput = getTableInput(typeManager, tableName, owner, metadata, metadata.location(), newMetadataLocation, ImmutableMap.of(), cacheTableMetadata);
 
         CreateTableRequest createTableRequest = new CreateTableRequest()
                 .withDatabaseName(database)
@@ -160,12 +160,13 @@ public class GlueIcebergTableOperations
         commitTableUpdate(
                 getTable(database, tableName, false),
                 metadata,
-                (_, newMetadataLocation) ->
+                (table, newMetadataLocation) ->
                         getTableInput(
                                 typeManager,
                                 tableName,
                                 owner,
                                 metadata,
+                                table.getStorageDescriptor().getLocation(),
                                 newMetadataLocation,
                                 ImmutableMap.of(PREVIOUS_METADATA_LOCATION_PROP, currentMetadataLocation),
                                 cacheTableMetadata));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergUtil.java
@@ -69,6 +69,7 @@ public final class GlueIcebergUtil
             String tableName,
             Optional<String> owner,
             TableMetadata metadata,
+            String tableLocation,
             String newMetadataLocation,
             Map<String, String> parameters,
             boolean cacheTableMetadata)
@@ -78,18 +79,20 @@ public final class GlueIcebergUtil
         parameters.put(METADATA_LOCATION_PROP, newMetadataLocation);
         parameters.remove(TRINO_TABLE_METADATA_INFO_VALID_FOR); // no longer valid
 
+        StorageDescriptor storageDescriptor = new StorageDescriptor().withLocation(tableLocation);
+
         TableInput tableInput = new TableInput()
                 .withName(tableName)
                 .withOwner(owner.orElse(null))
                 // Iceberg does not distinguish managed and external tables, all tables are treated the same and marked as EXTERNAL
-                .withTableType(EXTERNAL_TABLE.name());
+                .withTableType(EXTERNAL_TABLE.name())
+                .withStorageDescriptor(storageDescriptor);
 
         if (cacheTableMetadata) {
             // Store table metadata sufficient to answer information_schema.columns and system.metadata.table_comments queries, which are often queried in bulk by e.g. BI tools
             Optional<List<Column>> glueColumns = glueColumns(typeManager, metadata);
 
-            glueColumns.ifPresent(columns -> tableInput.withStorageDescriptor(new StorageDescriptor()
-                    .withColumns(columns)));
+            glueColumns.ifPresent(columns -> tableInput.withStorageDescriptor(storageDescriptor.withColumns(columns)));
 
             String comment = metadata.properties().get(TABLE_COMMENT);
             if (comment != null) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -754,6 +754,7 @@ public class TrinoGlueCatalog
                 schemaTableName.getTableName(),
                 Optional.of(session.getUser()),
                 tableMetadata,
+                tableMetadata.location(),
                 tableMetadata.metadataFileLocation(),
                 ImmutableMap.of(),
                 cacheTableMetadata);
@@ -803,6 +804,7 @@ public class TrinoGlueCatalog
                     to.getTableName(),
                     Optional.ofNullable(table.getOwner()),
                     metadata,
+                    table.getStorageDescriptor().getLocation(),
                     metadataLocation,
                     tableParameters,
                     cacheTableMetadata);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogSkipArchive.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogSkipArchive.java
@@ -130,7 +130,7 @@ public class TestIcebergGlueCatalogSkipArchive
             FileIO io = new ForwardingFileIo(getFileSystemFactory(getDistributedQueryRunner()).create(SESSION));
             TableMetadata metadata = TableMetadataParser.read(io, io.newInputFile(metadataLocation));
             boolean cacheTableMetadata = new IcebergGlueCatalogConfig().isCacheTableMetadata();
-            TableInput tableInput = getTableInput(TESTING_TYPE_MANAGER, table.getName(), Optional.empty(), metadata, metadataLocation, tableParameters, cacheTableMetadata);
+            TableInput tableInput = getTableInput(TESTING_TYPE_MANAGER, table.getName(), Optional.empty(), metadata, metadata.location(), metadataLocation, tableParameters, cacheTableMetadata);
             glueClient.updateTable(new UpdateTableRequest().withDatabaseName(schemaName).withTableInput(tableInput));
             assertThat(getTableVersions(schemaName, table.getName())).hasSize(2);
 


### PR DESCRIPTION
## Description

This is AWS Athena behavior and resetting location may break Glue crawlers.  
We should keep the existing values as much as possible. 
Additionally, set a table location when creating new tables in Glue. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
