### PR TITLE
Fix categerization of partitioning handles for writer stage

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenTaskSourceFactory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenTaskSourceFactory.java
@@ -227,8 +227,7 @@ public class EventDrivenTaskSourceFactory
                     standardSplitSizeInBytes,
                     maxArbitraryDistributionTaskSplitCount);
         }
-        if (partitioning.equals(FIXED_HASH_DISTRIBUTION) || partitioning.getCatalogHandle().isPresent() ||
-                (partitioning.getConnectorHandle() instanceof MergePartitioningHandle)) {
+        if (partitioning.equals(FIXED_HASH_DISTRIBUTION)) {
             return HashDistributionSplitAssigner.create(
                     partitioning.getCatalogHandle(),
                     partitionedSources,
@@ -240,7 +239,9 @@ public class EventDrivenTaskSourceFactory
                     toIntExact(round(getFaultTolerantExecutionHashDistributionComputeTasksToNodesMinRatio(session) * nodeManager.getAllNodes().getActiveNodes().size())),
                     Integer.MAX_VALUE); // compute tasks are bounded by the number of partitions anyways
         }
-        if (partitioning.equals(SCALED_WRITER_HASH_DISTRIBUTION)) {
+        if (partitioning.equals(SCALED_WRITER_HASH_DISTRIBUTION)
+                || partitioning.getCatalogHandle().isPresent()
+                || (partitioning.getConnectorHandle() instanceof MergePartitioningHandle)) {
             return HashDistributionSplitAssigner.create(
                     partitioning.getCatalogHandle(),
                     partitionedSources,


### PR DESCRIPTION
We use different configuration of HashSplitAssigner based on partitining handle used by source stage. We want to determine if we are in write stage or not. The logic was wrong.
