### PR TITLE
Update docs for internal communication

### DIFF
--- a/docs/src/main/sphinx/admin/properties-http-server.md
+++ b/docs/src/main/sphinx/admin/properties-http-server.md
@@ -181,7 +181,7 @@ cluster share and use to authenticate within the cluster. See
 - **Default value:** `true`
 
 Enable use of the HTTP/2 protocol for internal communication for enhanced
-scalability compared to HTTP/1.1. Only turn this feature off, if you encounter
+scalability compared to HTTP/1.1. Only turn this feature off if you encounter
 issues with HTTP/2 usage within the cluster in your deployment.
 
 ### `internal-communication.https.required`

--- a/docs/src/main/sphinx/admin/properties-http-server.md
+++ b/docs/src/main/sphinx/admin/properties-http-server.md
@@ -159,3 +159,34 @@ Configuration properties for the `PASSWORD` authentication types
 ### `http-server.log.*`
 
 Configuration properties for [](/admin/properties-logging).
+
+(props-internal-communication)
+## Internal communication
+
+The following properties are used for configuring the [internal
+communication](/security/internal-communication) between all
+[nodes](trino-concept-node) of a Trino cluster.
+
+### `internal-communication.shared-secret`
+
+- **Type:** [](prop-type-string)
+
+The string to use as secret that only the coordinators and workers in a specific
+cluster share and use to authenticate within the cluster. See
+[](internal-secret) for details.
+
+### `internal-communication.http2.enabled`
+
+- **Type:** [](prop-type-boolean)
+- **Default value:** `true`
+
+Enable use of the HTTP/2 protocol for internal communication for enhanced
+scalability compared to HTTP/1.1. Only turn this feature off, if you encounter
+issues with HTTP/2 usage within the cluster in your deployment.
+
+### `internal-communication.https.required`
+
+- **Type:** [](prop-type-boolean)
+- **Default value:** `false`
+
+Enable the use of [SSL/TLS for all internal communication](internal-tls).

--- a/docs/src/main/sphinx/security/internal-communication.md
+++ b/docs/src/main/sphinx/security/internal-communication.md
@@ -4,15 +4,16 @@ The Trino cluster can be configured to use secured communication with internal
 authentication of the nodes in the cluster, and to optionally use added security
 with {ref}`TLS <glossTLS>`.
 
+(internal-secret)=
 ## Configure shared secret
 
-Configure a shared secret to authenticate all communication between nodes of the
-cluster. Use this configuration under the following conditions:
+You must configure a shared secret to authenticate all communication between
+nodes of the cluster in the following scenarios:
 
-- When opting to configure [internal TLS encryption](internal-tls)
-  between nodes of the cluster
-- When using any {doc}`external authentication <authentication-types>` method
-  between clients and the coordinator
+- When using [any authentication](authentication-types) between clients and the
+  coordinator.
+- When using [internal TLS encryption](internal-tls) between all nodes of the
+  cluster.
 
 Set the shared secret to the same value in {ref}`config.properties
 <config-properties>` on all nodes of the cluster:
@@ -121,6 +122,12 @@ to be transferred between the nodes (for example, distributed joins, aggregation
 window functions, which require repartitioning), the performance impact can be
 considerable. The slowdown may vary from 10% to even 100%+, depending on the network
 traffic and the CPU utilization.
+
+:::{note}
+By default, internal communication with SSL/TLS enabled uses HTTP/2 for
+increased scalability. You can turn off this feature with
+`internal-communication.http2.enabled=false`.
+:::
 
 (internal-performance)=
 ### Advanced performance tuning

--- a/docs/src/main/sphinx/security/internal-communication.md
+++ b/docs/src/main/sphinx/security/internal-communication.md
@@ -99,16 +99,6 @@ configuration identical on all cluster nodes.
 Certificates are automatically created and used to ensure all communication
 inside the cluster is secured with TLS.
 
-:::{warning}
-Older versions of Trino required you to manually manage all the certificates
-on the nodes. If you upgrade from this setup, you must remove the following
-configuration properties:
-
-- `internal-communication.https.keystore.path`
-- `internal-communication.https.truststore.path`
-- `node.internal-address-source`
-:::
-
 ### Performance with SSL/TLS enabled
 
 Enabling encryption impacts performance. The performance degradation can vary


### PR DESCRIPTION
## Description

See title, adding since we are switching to HTTP/2 by default now and need to docs for switching back if desired.

After discussion with @electrum we decided to go ahead with the second commit and remove the info about manual config for internal TLS.

## Additional context and related issues

Related to #21793 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
