### PR TITLE
Add Trino 464 release notes

### DIFF
--- a/docs/src/main/sphinx/release.md
+++ b/docs/src/main/sphinx/release.md
@@ -6,6 +6,7 @@
 ```{toctree}
 :maxdepth: 1
 
+release/release-464
 release/release-463
 release/release-462
 release/release-461

--- a/docs/src/main/sphinx/release/release-464.md
+++ b/docs/src/main/sphinx/release/release-464.md
@@ -1,0 +1,50 @@
+# Release 464 (30 Oct 2024)
+
+## General
+
+* {{breaking}} Require JDK 23 to run Trino. ({issue}`21316`)
+* Add the [](/connector/faker) for easy generation of data. ({issue}`23691`)
+* Add the [](/connector/vertica). ({issue}`23948`)
+* Rename the
+  `fault-tolerant-execution-eager-speculative-tasks-node_memory-overcommit`
+  configuration property to
+  `fault-tolerant-execution-eager-speculative-tasks-node-memory-overcommit`.
+  ({issue}`23876`)  
+
+## Accumulo connector
+
+* {{breaking}} Remove the Accumulo connector. ({issue}`23792`)  
+
+## Delta Lake connector
+
+* Fix failure of S3 file listing of buckets that enforce [requester
+  pays](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RequesterPaysBuckets.html).
+  ({issue}`23906`)
+
+## Hive connector
+
+* Use the `hive.metastore.partition-batch-size.max` catalog configuration
+  property value in the `sync_partition_metadata` procedure. Change the default
+  batch size from 1000 to 100. ({issue}`23895`)
+* Fix failure of S3 file listing of buckets that enforce [requester
+  pays](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RequesterPaysBuckets.html).
+  ({issue}`23906`)
+
+## Hudi connector
+
+* Fix failure of S3 file listing of buckets that enforce [requester
+  pays](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RequesterPaysBuckets.html).
+  ({issue}`23906`)
+
+## Iceberg connector
+
+* Improve performance of `OPTIMIZE` on large partitioned tables. ({issue}`10785`)
+* Rename the `iceberg.expire_snapshots.min-retention` configuration property to
+  `iceberg.expire-snapshots.min-retention`. ({issue}`23876`)
+* Rename the `iceberg.remove_orphan_files.min-retention` configuration property
+  to `iceberg.remove-orphan-files.min-retention`. ({issue}`23876`)
+* Fix failure of S3 file listing of buckets that enforce [requester
+  pays](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RequesterPaysBuckets.html).
+  ({issue}`23906`)
+* Fix incorrect column constraints when using the `migrate` procedure on tables
+  that contain `NULL` values. ({issue}`23928`)


### PR DESCRIPTION
## Description

Assemble the release notes for the upcoming Trino 464 release.

## Additional context and related issues

See https://github.com/trinodb/trino/pulls?q=is%3Apr+is%3Aclosed+milestone%3A464

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

## Verification for each pull request

Format: PR/issue number, ✅ / ❌ rn ✅ / ❌ docs
✅ rn - release note added and verified, or assessed to be not necessary, set to ❌ rn before completion
✅ docs - need for docs assessed and merged, or assessed to be not necessary, set to ❌ docs before completion

## 23 Oct 2024

* #23783 ✅ rn ✅ docs
* #23876 ✅ rn ✅ docs
* #23870 ✅ rn ✅ docs
* #23883 ✅ rn ✅ docs
* #23887 ✅ rn ✅ docs

## 24 Oct 2024

* #23878 ✅ rn ✅ docs
* #23892 ✅ rn ✅ docs
* #23890 ✅ rn ✅ docs
* #23691 ✅ rn ✅ docs, update in #23901 
* #23762 ✅ rn ✅ docs
* #23903 ✅ rn ✅ docs
* #23895 ✅ rn ✅ docs
* #23912 ✅ rn ✅ docs
* #23908 ✅ rn ✅ docs

## 25 Oct 2024

* #23914 ✅ rn ✅ docs
* #23916 ✅ rn ✅ docs
* #23906 ✅ rn ✅ docs
* #23864 ✅ rn ✅ docs
* #23667 ✅ rn ✅ docs
* #23902 ✅ rn ✅ docs
* #23919 ✅ rn ✅ docs
* #23925 ✅ rn ✅ docs
* #23918 ✅ rn ✅ docs

## 26 Oct 2024

* #23928 ✅ rn ✅ docs

## 27 Oct 2024

* #23934 ✅ rn ✅ docs

## 28 Oct 2024

* #23939 ✅ rn ✅ docs
* #23942 ✅ rn ✅ docs
* #23920 ✅ rn ✅ docs
* #23926 ✅ rn ✅ docs
* #23951 ✅ rn ✅ docs 

## 29 Oct 2024

* #23949 ✅ rn ✅ docs 
* #23884 ✅ rn ✅ docs 
* #23946 ✅ rn ✅ docs 
* #23952 ✅ rn ✅ docs 
* #23328 ✅ rn ✅ docs 
* #23953 ✅ rn ✅ docs 
* #23791 ✅ rn ✅ docs 
* #23954 ✅ rn ✅ docs
* #23959 ✅ rn ✅ docs
* #23938 ✅ rn ✅ docs
* #23948 ✅ rn ✅ docs, see https://github.com/trinodb/trino/pull/23967
* #23965 ✅ rn ✅ docs 

## 30 Oct 2024

* #23977 ✅ rn ✅ docs 
* #23976 ✅ rn ✅ docs 
* #23979 ✅ rn ✅ docs 
* #23901 ✅ rn ✅ docs 
* #23980 ✅ rn ✅ docs 
* #23967 ✅ rn ✅ docs 