### PR TITLE
Specify default value for task.concurrency in docs for FTE mode

### DIFF
--- a/docs/src/main/sphinx/admin/properties-task.md
+++ b/docs/src/main/sphinx/admin/properties-task.md
@@ -4,7 +4,9 @@
 
 - **Type:** {ref}`prop-type-integer`
 - **Restrictions:** Must be a power of two
-- **Default value:** The number of physical CPUs of the node, with a minimum value of 2 and a maximum of 32
+- **Default value:** The number of physical CPUs of the node, with a minimum
+  value of 2 and a maximum of 32. Defaults to 8 in
+  [](/admin/fault-tolerant-execution) mode.
 - **Session property:** `task_concurrency`
 
 Default local concurrency for parallel operators, such as joins and aggregations.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
