### PR TITLE
Reduce synchronization for metadata calls in SemiTransactionalHiveMetastore

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -238,9 +238,11 @@ public class SemiTransactionalHiveMetastore
         this.tableInvalidationCallback = requireNonNull(tableInvalidationCallback, "tableInvalidationCallback is null");
     }
 
-    public synchronized List<String> getAllDatabases()
+    public List<String> getAllDatabases()
     {
-        checkReadable();
+        synchronized (this) {
+            checkReadable();
+        }
         return delegate.getAllDatabases();
     }
 
@@ -259,11 +261,13 @@ public class SemiTransactionalHiveMetastore
         return delegate.getDatabase(databaseName);
     }
 
-    public synchronized List<TableInfo> getTables(String databaseName)
+    public List<TableInfo> getTables(String databaseName)
     {
-        checkReadable();
-        if (!tableActions.isEmpty()) {
-            throw new UnsupportedOperationException("Listing all tables after adding/dropping/altering tables/views in a transaction is not supported");
+        synchronized (this) {
+            checkReadable();
+            if (!tableActions.isEmpty()) {
+                throw new UnsupportedOperationException("Listing all tables after adding/dropping/altering tables/views in a transaction is not supported");
+            }
         }
         return delegate.getTables(databaseName);
     }


### PR DESCRIPTION
## Description
We don't need to hold lock on SemiTransactionalHiveMetastore object for remote calls which just read metadata. Listing views/tables/databases on metastore can be potentially slow. Holding lock blocks cleanupQuery, which prevents QueryTracker#enforceTimeLimits from failing queries which exceed time limit.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
