### PR TITLE
Add `@ConfigSecuritySensitive` to mysql-event-listener.db.url

### DIFF
--- a/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/MysqlEventListenerConfig.java
+++ b/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/MysqlEventListenerConfig.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.eventlistener.mysql;
 
 import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigSecuritySensitive;
 import jakarta.validation.constraints.NotNull;
 
 public class MysqlEventListenerConfig
@@ -26,6 +27,7 @@ public class MysqlEventListenerConfig
         return url;
     }
 
+    @ConfigSecuritySensitive
     @Config("mysql-event-listener.db.url")
     public MysqlEventListenerConfig setUrl(String url)
     {

--- a/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/MysqlEventListenerConfig.java
+++ b/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/MysqlEventListenerConfig.java
@@ -13,9 +13,13 @@
  */
 package io.trino.plugin.eventlistener.mysql;
 
+import com.mysql.cj.jdbc.Driver;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigSecuritySensitive;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
+
+import java.sql.SQLException;
 
 public class MysqlEventListenerConfig
 {
@@ -33,5 +37,16 @@ public class MysqlEventListenerConfig
     {
         this.url = url;
         return this;
+    }
+
+    @AssertTrue(message = "Invalid JDBC URL for MySQL event listener")
+    public boolean isValidUrl()
+    {
+        try {
+            return new Driver().acceptsURL(getUrl());
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/plugin/trino-mysql-event-listener/src/test/java/io/trino/plugin/eventlistener/mysql/TestMysqlEventListenerConfig.java
+++ b/plugin/trino-mysql-event-listener/src/test/java/io/trino/plugin/eventlistener/mysql/TestMysqlEventListenerConfig.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static org.assertj.core.api.Assertions.assertThat;
 
 final class TestMysqlEventListenerConfig
 {
@@ -34,11 +35,26 @@ final class TestMysqlEventListenerConfig
     void testExplicitPropertyMappings()
     {
         Map<String, String> properties = Map.of(
-                "mysql-event-listener.db.url", "abc");
+                "mysql-event-listener.db.url", "jdbc:mysql://example.net:3306");
 
         MysqlEventListenerConfig expected = new MysqlEventListenerConfig()
-                .setUrl("abc");
+                .setUrl("jdbc:mysql://example.net:3306");
 
         assertFullMapping(properties, expected);
+    }
+
+    @Test
+    void testIsValidUrl()
+    {
+        assertThat(isValidUrl("jdbc:mysql://example.net:3306")).isTrue();
+        assertThat(isValidUrl("jdbc:mysql://example.net:3306/")).isTrue();
+        assertThat(isValidUrl("jdbc:postgresql://example.net:3306/somedatabase")).isFalse();
+    }
+
+    private static boolean isValidUrl(String url)
+    {
+        return new MysqlEventListenerConfig()
+                .setUrl(url)
+                .isValidUrl();
     }
 }


### PR DESCRIPTION
## Description

Add `@ConfigSecuritySensitive` to `mysql-event-listener.db.url` config property.
The value contains password in most cases. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
