### PR TITLE
Support reading geometries in EWKB format.

### DIFF
--- a/docs/src/main/sphinx/functions/geospatial.md
+++ b/docs/src/main/sphinx/functions/geospatial.md
@@ -61,7 +61,7 @@ Returns a geometry type object from WKT representation.
 :::
 
 :::{function} ST_GeomFromBinary(varbinary) -> Geometry
-Returns a geometry type object from WKB representation.
+Returns a geometry type object from WKB or EWKB representation.
 :::
 
 :::{function} geometry_from_hadoop_shape(varbinary) -> Geometry

--- a/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/GeoFunctions.java
+++ b/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/GeoFunctions.java
@@ -62,6 +62,8 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;
 import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKBReader;
 import org.locationtech.jts.linearref.LengthIndexedLine;
 import org.locationtech.jts.operation.distance.DistanceOp;
 
@@ -174,6 +176,8 @@ public final class GeoFunctions
 
     private static final EnumSet<GeometryType> VALID_TYPES_FOR_ST_POINTS = EnumSet.of(
             LINE_STRING, POLYGON, POINT, MULTI_POINT, MULTI_LINE_STRING, MULTI_POLYGON, GEOMETRY_COLLECTION);
+
+    private static final WKBReader WKB_READER = new WKBReader();
 
     private GeoFunctions() {}
 
@@ -1538,18 +1542,15 @@ public final class GeoFunctions
         return geometry;
     }
 
-    private static OGCGeometry geomFromBinary(Slice input)
+    private static Geometry geomFromBinary(Slice input)
     {
         requireNonNull(input, "input is null");
-        OGCGeometry geometry;
         try {
-            geometry = OGCGeometry.fromBinary(input.toByteBuffer().slice());
+            return WKB_READER.read(input.getBytes());
         }
-        catch (IllegalArgumentException | IndexOutOfBoundsException e) {
+        catch (ParseException e) {
             throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "Invalid WKB", e);
         }
-        geometry.setSpatialReference(null);
-        return geometry;
     }
 
     private static ByteBuffer getShapeByteBuffer(Slice input)

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestGeoFunctions.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestGeoFunctions.java
@@ -2159,6 +2159,12 @@ public class TestGeoFunctions
         assertGeomFromBinary("MULTIPOLYGON (((1 1, 3 1, 3 3, 1 3, 1 1)), ((2 4, 6 4, 6 6, 2 6, 2 4)))");
         assertGeomFromBinary("GEOMETRYCOLLECTION (POINT (1 2), LINESTRING (0 0, 1 2, 3 4), POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)))");
 
+        // The EWKB representation of "SRID=4326;POINT (1 1)".
+        assertThat(assertions.expression("ST_AsText(ST_GeomFromBinary(wkb))")
+                .binding("wkb", "x'0101000020E6100000000000000000F03F000000000000F03F'"))
+                .hasType(VARCHAR)
+                .isEqualTo("POINT (1 1)");
+
         // array of geometries
         assertThat(assertions.expression("transform(a, wkb -> ST_AsText(ST_GeomFromBinary(wkb)))")
                 .binding("a", "ARRAY[ST_AsBinary(ST_Point(1, 2)), ST_AsBinary(ST_Point(3, 4))]"))


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Add support for parsing EKWB format in ST_GeomFromBinary

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

EWKB is a popular extension to WKB. 
Closes #23824

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text: Add support for EWKB in ST_GeomFromBinary

