### PR TITLE
Add 463 release notes entries

### DIFF
--- a/docs/src/main/sphinx/release/release-463.md
+++ b/docs/src/main/sphinx/release/release-463.md
@@ -4,6 +4,7 @@
 
 * Enable HTTP/2 for internal communication by default. The previous behavior can
   be restored by setting `internal-communication.http2.enabled` to `false`. ({issue}`21793`)
+* Support connecting over HTTP/2 for client drivers and client applications. ({issue}`21793`)
 * Add {func}`timezone` functions to extract the timezone identifier from from a
   `timestamp(p) with time zone` or `time(p) with time zone`. ({issue}`20893`)
 * Include table functions with `SHOW FUNCTIONS` output. ({issue}`12550`)
@@ -11,6 +12,14 @@
 * Disallow the window framing clause for {func}`ntile`, {func}`rank`,
   {func}`dense_rank`, {func}`percent_rank`,  {func}`cume_dist`, and
   {func}`row_number`. ({issue}`23742`)
+
+## JDBC driver
+
+* Support connecting over HTTP/2. ({issue}`21793`)
+
+## CLI
+
+* Support connecting over HTTP/2. ({issue}`21793`)
 
 ## ClickHouse connector
 


### PR DESCRIPTION
## Description

While HTTP/2 was supported before, now it is used by default with CLI as well as the JDBC driver.

As discussed with @wendigo and @martint in maintainer call .. do we need an entry in general since I think it might be enabled for all clients ... 

## Additional context and related issues

#23810 

One of the commits of https://github.com/trinodb/trino/pull/23857

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
