### PR TITLE
Improve performance when listing columns in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -406,7 +406,7 @@ public class IcebergMetadata
     private final Optional<HiveMetastoreFactory> metastoreFactory;
     private final boolean addFilesProcedureEnabled;
     private final Predicate<String> allowedExtraProperties;
-    private final ExecutorService executor;
+    private final ExecutorService icebergScanExecutor;
 
     private final Map<IcebergTableHandle, AtomicReference<TableStatistics>> tableStatisticsCache = new ConcurrentHashMap<>();
 
@@ -423,7 +423,7 @@ public class IcebergMetadata
             Optional<HiveMetastoreFactory> metastoreFactory,
             boolean addFilesProcedureEnabled,
             Predicate<String> allowedExtraProperties,
-            ExecutorService executor)
+            ExecutorService icebergScanExecutor)
     {
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.trinoCatalogHandle = requireNonNull(trinoCatalogHandle, "trinoCatalogHandle is null");
@@ -434,7 +434,7 @@ public class IcebergMetadata
         this.metastoreFactory = requireNonNull(metastoreFactory, "metastoreFactory is null");
         this.addFilesProcedureEnabled = addFilesProcedureEnabled;
         this.allowedExtraProperties = requireNonNull(allowedExtraProperties, "allowedExtraProperties is null");
-        this.executor = requireNonNull(executor, "executor is null");
+        this.icebergScanExecutor = requireNonNull(icebergScanExecutor, "icebergScanExecutor is null");
     }
 
     @Override
@@ -694,15 +694,15 @@ public class IcebergMetadata
         return switch (tableType) {
             case DATA, MATERIALIZED_VIEW_STORAGE -> throw new VerifyException("Unexpected table type: " + tableType); // Handled above.
             case HISTORY -> Optional.of(new HistoryTable(tableName, table));
-            case METADATA_LOG_ENTRIES -> Optional.of(new MetadataLogEntriesTable(tableName, table, executor));
-            case SNAPSHOTS -> Optional.of(new SnapshotsTable(tableName, typeManager, table, executor));
-            case PARTITIONS -> Optional.of(new PartitionsTable(tableName, typeManager, table, getCurrentSnapshotId(table), executor));
-            case ALL_MANIFESTS -> Optional.of(new AllManifestsTable(tableName, table, executor));
+            case METADATA_LOG_ENTRIES -> Optional.of(new MetadataLogEntriesTable(tableName, table, icebergScanExecutor));
+            case SNAPSHOTS -> Optional.of(new SnapshotsTable(tableName, typeManager, table, icebergScanExecutor));
+            case PARTITIONS -> Optional.of(new PartitionsTable(tableName, typeManager, table, getCurrentSnapshotId(table), icebergScanExecutor));
+            case ALL_MANIFESTS -> Optional.of(new AllManifestsTable(tableName, table, icebergScanExecutor));
             case MANIFESTS -> Optional.of(new ManifestsTable(tableName, table, getCurrentSnapshotId(table)));
-            case FILES -> Optional.of(new FilesTable(tableName, typeManager, table, getCurrentSnapshotId(table), executor));
-            case ENTRIES -> Optional.of(new EntriesTable(typeManager, tableName, table, executor));
+            case FILES -> Optional.of(new FilesTable(tableName, typeManager, table, getCurrentSnapshotId(table), icebergScanExecutor));
+            case ENTRIES -> Optional.of(new EntriesTable(typeManager, tableName, table, icebergScanExecutor));
             case PROPERTIES -> Optional.of(new PropertiesTable(tableName, table));
-            case REFS -> Optional.of(new RefsTable(tableName, table, executor));
+            case REFS -> Optional.of(new RefsTable(tableName, table, icebergScanExecutor));
         };
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadataFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadataFactory.java
@@ -41,7 +41,7 @@ public class IcebergMetadataFactory
     private final Optional<HiveMetastoreFactory> metastoreFactory;
     private final boolean addFilesProcedureEnabled;
     private final Predicate<String> allowedExtraProperties;
-    private final ExecutorService executor;
+    private final ExecutorService icebergScanExecutor;
 
     @Inject
     public IcebergMetadataFactory(
@@ -52,7 +52,7 @@ public class IcebergMetadataFactory
             IcebergFileSystemFactory fileSystemFactory,
             TableStatisticsWriter tableStatisticsWriter,
             @RawHiveMetastoreFactory Optional<HiveMetastoreFactory> metastoreFactory,
-            @ForIcebergScanPlanning ExecutorService executor,
+            @ForIcebergScanPlanning ExecutorService icebergScanExecutor,
             IcebergConfig config)
     {
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
@@ -62,7 +62,7 @@ public class IcebergMetadataFactory
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.tableStatisticsWriter = requireNonNull(tableStatisticsWriter, "tableStatisticsWriter is null");
         this.metastoreFactory = requireNonNull(metastoreFactory, "metastoreFactory is null");
-        this.executor = requireNonNull(executor, "executor is null");
+        this.icebergScanExecutor = requireNonNull(icebergScanExecutor, "icebergScanExecutor is null");
         this.addFilesProcedureEnabled = config.isAddFilesProcedureEnabled();
         if (config.getAllowedExtraProperties().equals(ImmutableList.of("*"))) {
             this.allowedExtraProperties = _ -> true;
@@ -84,6 +84,6 @@ public class IcebergMetadataFactory
                 metastoreFactory,
                 addFilesProcedureEnabled,
                 allowedExtraProperties,
-                executor);
+                icebergScanExecutor);
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/BaseTrinoCatalogTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/BaseTrinoCatalogTest.java
@@ -48,6 +48,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static io.trino.metastore.TableInfo.ExtendedRelationType.TABLE;
@@ -122,7 +123,8 @@ public abstract class BaseTrinoCatalogTest
                     Optional.empty(),
                     false,
                     _ -> false,
-                    newDirectExecutorService());
+                    newDirectExecutorService(),
+                    directExecutor());
             assertThat(icebergMetadata.schemaExists(SESSION, namespace)).as("icebergMetadata.schemaExists(namespace)")
                     .isFalse();
             assertThat(icebergMetadata.schemaExists(SESSION, schema)).as("icebergMetadata.schemaExists(schema)")

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestTrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestTrinoGlueCatalog.java
@@ -141,7 +141,8 @@ public class TestTrinoGlueCatalog
                     Optional.empty(),
                     false,
                     _ -> false,
-                    newDirectExecutorService());
+                    newDirectExecutorService(),
+                    directExecutor());
             assertThat(icebergMetadata.schemaExists(SESSION, databaseName)).as("icebergMetadata.schemaExists(databaseName)")
                     .isFalse();
             assertThat(icebergMetadata.schemaExists(SESSION, trinoSchemaName)).as("icebergMetadata.schemaExists(trinoSchemaName)")

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestTrinoNessieCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestTrinoNessieCatalog.java
@@ -46,6 +46,7 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
@@ -191,7 +192,8 @@ public class TestTrinoNessieCatalog
                     Optional.empty(),
                     false,
                     _ -> false,
-                    newDirectExecutorService());
+                    newDirectExecutorService(),
+                    directExecutor());
             assertThat(icebergMetadata.schemaExists(SESSION, namespace)).as("icebergMetadata.schemaExists(namespace)")
                     .isTrue();
             assertThat(icebergMetadata.schemaExists(SESSION, schema)).as("icebergMetadata.schemaExists(schema)")

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
@@ -45,6 +45,7 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static io.trino.metastore.TableInfo.ExtendedRelationType.OTHER_VIEW;
@@ -129,7 +130,8 @@ public class TestTrinoRestCatalog
                     Optional.empty(),
                     false,
                     _ -> false,
-                    newDirectExecutorService());
+                    newDirectExecutorService(),
+                    directExecutor());
             assertThat(icebergMetadata.schemaExists(SESSION, namespace)).as("icebergMetadata.schemaExists(namespace)")
                     .isTrue();
             assertThat(icebergMetadata.schemaExists(SESSION, schema)).as("icebergMetadata.schemaExists(schema)")

--- a/plugin/trino-iceberg/src/test/java/org/apache/iceberg/snowflake/TestTrinoSnowflakeCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/org/apache/iceberg/snowflake/TestTrinoSnowflakeCatalog.java
@@ -58,6 +58,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static io.trino.plugin.iceberg.catalog.snowflake.TestIcebergSnowflakeCatalogConnectorSmokeTest.S3_ACCESS_KEY;
@@ -225,7 +226,8 @@ public class TestTrinoSnowflakeCatalog
                 Optional.empty(),
                 false,
                 _ -> false,
-                newDirectExecutorService());
+                newDirectExecutorService(),
+                directExecutor());
         assertThat(icebergMetadata.schemaExists(SESSION, namespace)).as("icebergMetadata.schemaExists(namespace)")
                 .isTrue();
         assertThat(icebergMetadata.schemaExists(SESSION, schema)).as("icebergMetadata.schemaExists(schema)")


### PR DESCRIPTION
# Improve Performance for Retrieving Tables Metadata from Iceberg Catalog

## Overview

This PR addresses a performance issue encountered when querying column metadata from the Iceberg catalog in Trino (Issue #[23468](https://github.com/trinodb/trino/issues/23468)). The primary concern is that requests to retrieve table metadata are executed sequentially for each table, which significantly impacts query performance when dealing with a large number of tables.

## Description

The issue manifests when executing the following query on the Iceberg catalog:

```sql
SELECT * FROM iceberg.information_schema.columns;
```

In environments with a large number of tables, the query’s response time increases considerably due to the sequential execution of catalog requests.

### Changes Made

To improve the performance, this PR introduces parallelism in the metadata retrieval process. The old code executed catalog requests sequentially for each table, which resulted in longer execution times. The updated code utilizes `CompletableFuture` to handle requests asynchronously, thereby reducing the overall execution time.

The updated implementation leverages `CompletableFuture` to process tables concurrently, significantly reducing the latency in retrieving column metadata.

## Additional Context and Related Issues

Fixes #23468

### Test Setup & Observations:
 I checked the code changes and get faster query in over x4 faster then without the proposed change
- Trino Version: 463 and trino with the code in master branch with the proposed change lets called it trino 464-SNAPSHOT
- Nessie Version: 0.94.4 (In memory)
- REST Catalog based on JDBC (e.g., Tabular REST Catalog)
- Testing environment: Docker Compose with MinIO for Iceberg storage and Jaeger for tracing.
- Hardware: Intel Core i9 processor, 32GB RAM

### Performance Comparison

As you can see in this table we get around 70% reduce in time for retrieving the columns

| **Number of Tables** | **Trino Version** | **Catalog Setup** | **Query Execution Time (s)** | **Performance Increase (%)** |
|-----------------------|-------------------|-------------------|-------------------------------|------------------------------|
| **10**                | Trino 463         | REST              | 0.691                         |                              |
|                       |                   | Nessie            | 1.07                          |                              |
|                       | Trino 464-SNAPSHOT         | REST              | 0.677                         |  2.02%    |
|                       |                   | Nessie            | 0.982                         | 8.23%       |
|-----------------------|-------------------|-------------------|-------------------------------|------------------------------|
| **100**               | Trino 463         | REST              | 1.24                          |                              |
|                       |                   | Nessie            | 1.89                          |                              |
|                       | Trino 464-SNAPSHOT         | REST              | 0.772                         | 37.90%      |
|                       |                   | Nessie            | 1.29                          | 31.59%       |
|-----------------------|-------------------|-------------------|-------------------------------|------------------------------|
| **1,000**             | Trino 463         | REST              | 3.06                          |                              |
|                       |                   | Nessie            | 6.55                          |                              |
|                       | Trino 464-SNAPSHOT         | REST              | 1.17                          | 61.59%      |
|                       |                   | Nessie            | 2.42                          | 63.01%      |
|-----------------------|-------------------|-------------------|-------------------------------|------------------------------|
| **10,000**            | Trino 463         | REST              | 11.38                         |                              |
|                       |                   | Nessie            | 29.59                         |                              |
|                       | Trino 464-SNAPSHOT         | REST              | 3.41                          | 70.04%    |
|                       |                   | Nessie            | 7.70                          | 73.00%     |
|-----------------------|-------------------|-------------------|-------------------------------|------------------------------|
| **100,000**             | Trino 463         | REST              | 105                           |                              |
|                       |                   | Nessie            | 255                           |                              |
|                       | Trino 464-SNAPSHOT         | REST              | 16.96                         | 83.86%        |
|                       |                   | Nessie            | 34.72                         | 86.38%        |

- Each table in this  comparison has 10 columns
- I ran each test several times, and the results were largely consistent.

## Release Notes

```md
## Iceberg
* Improve performance when listing columns. 
```