### PR TITLE
Add `coordinatorId` to `/v1/info`

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/ServerInfo.java
+++ b/client/trino-client/src/main/java/io/trino/client/ServerInfo.java
@@ -34,6 +34,7 @@ public class ServerInfo
 
     // optional to maintain compatibility with older servers
     private final Optional<Duration> uptime;
+    private final Optional<String> coordinatorId;
 
     @JsonCreator
     public ServerInfo(
@@ -41,13 +42,15 @@ public class ServerInfo
             @JsonProperty("environment") String environment,
             @JsonProperty("coordinator") boolean coordinator,
             @JsonProperty("starting") boolean starting,
-            @JsonProperty("uptime") Optional<Duration> uptime)
+            @JsonProperty("uptime") Optional<Duration> uptime,
+            @JsonProperty("coordinatorId") Optional<String> coordinatorId)
     {
         this.nodeVersion = requireNonNull(nodeVersion, "nodeVersion is null");
         this.environment = requireNonNull(environment, "environment is null");
         this.coordinator = coordinator;
         this.starting = starting;
         this.uptime = requireNonNull(uptime, "uptime is null");
+        this.coordinatorId = requireNonNull(coordinatorId, "coordinatorId is null");
     }
 
     @JsonProperty
@@ -80,6 +83,12 @@ public class ServerInfo
         return uptime;
     }
 
+    @JsonProperty
+    public Optional<String> getCoordinatorId()
+    {
+        return coordinatorId;
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -109,6 +118,7 @@ public class ServerInfo
                 .add("environment", environment)
                 .add("coordinator", coordinator)
                 .add("uptime", uptime.orElse(null))
+                .add("coordinatorId", coordinatorId.orElse(null))
                 .omitNullValues()
                 .toString();
     }

--- a/client/trino-client/src/test/java/io/trino/client/TestServerInfo.java
+++ b/client/trino-client/src/test/java/io/trino/client/TestServerInfo.java
@@ -31,14 +31,15 @@ public class TestServerInfo
     @Test
     public void testJsonRoundTrip()
     {
-        assertJsonRoundTrip(new ServerInfo(UNKNOWN, "test", true, false, Optional.of(new Duration(2, MINUTES))));
-        assertJsonRoundTrip(new ServerInfo(UNKNOWN, "test", true, false, Optional.empty()));
+        assertJsonRoundTrip(new ServerInfo(UNKNOWN, "test", true, false, Optional.of(new Duration(2, MINUTES)), Optional.of("3sruz")));
+        assertJsonRoundTrip(new ServerInfo(UNKNOWN, "test", true, false, Optional.of(new Duration(2, MINUTES)), Optional.empty()));
+        assertJsonRoundTrip(new ServerInfo(UNKNOWN, "test", true, false, Optional.empty(), Optional.empty()));
     }
 
     @Test
     public void testBackwardsCompatible()
     {
-        ServerInfo newServerInfo = new ServerInfo(UNKNOWN, "test", true, false, Optional.empty());
+        ServerInfo newServerInfo = new ServerInfo(UNKNOWN, "test", true, false, Optional.empty(), Optional.empty());
         ServerInfo legacyServerInfo = SERVER_INFO_CODEC.fromJson("{\"nodeVersion\":{\"version\":\"<unknown>\"},\"environment\":\"test\",\"coordinator\":true}");
         assertThat(newServerInfo).isEqualTo(legacyServerInfo);
     }

--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -19,6 +19,7 @@ import com.google.inject.Key;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
+import com.google.inject.multibindings.OptionalBinder;
 import com.google.inject.multibindings.ProvidesIntoSet;
 import io.airlift.concurrent.BoundedExecutor;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
@@ -44,6 +45,7 @@ import io.trino.execution.LocationFactory;
 import io.trino.execution.MemoryRevokingScheduler;
 import io.trino.execution.NoOpFailureInjector;
 import io.trino.execution.NodeTaskMap;
+import io.trino.execution.QueryIdGenerator;
 import io.trino.execution.QueryManagerConfig;
 import io.trino.execution.SqlTaskManager;
 import io.trino.execution.TableExecuteContextManager;
@@ -442,6 +444,7 @@ public class ServerMainModule
 
         // server info resource
         jaxrsBinder(binder).bind(ServerInfoResource.class);
+        OptionalBinder.newOptionalBinder(binder, QueryIdGenerator.class);
 
         // node status resource
         jaxrsBinder(binder).bind(StatusResource.class);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Add `coordinatorId` to `/v1/info`.

### Motivation
Trino Gateway works as a proxy between client and coordinator. After the initial query submission, subsequent requests for the same query must be routed to the same coordinator. Currently, gateway [store the queryId](https://github.com/trinodb/trino-gateway/blob/fd418e62656e0251094beb406145e965c39c0d0b/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingManager.java#L54C9-L54C28) after the initial response from coordinator for later routing purposes.

If the queryId doesn't exist in the store (which happens when there are multiple gateway instances being deployed without sticky session), gateway will [query every coordinator]( https://github.com/trinodb/trino-gateway/blob/fd418e62656e0251094beb406145e965c39c0d0b/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingManager.java#L151-L162) to find the correct destination.

By adding `coordinatorId` to `/v1/info`, the above routing logic can be simplified to:
* During health check, get and store the `coordinatorId` in gateway.
* Extract `coordinatorId` from `queryId` and route it accordingly.

### Other concerns
`coordinatorId` is just a random string being generated during server startup. The only usage so far is for generating `queryId`. I don't think there are security concerns with exposing it in the public API.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
From coordinator:
```
$ curl localhost:8080/v1/info | jq
{
  "nodeVersion": {
    "version": "dev"
  },
  "environment": "test",
  "coordinator": true,
  "starting": true,
  "uptime": "13.03s",
  "coordinatorId": "mv3x6"
}
```

From worker:
```
$ curl localhost:8080/v1/info | jq
{
  "nodeVersion": {
    "version": "dev"
  },
  "environment": "test",
  "coordinator": false,
  "starting": true,
  "uptime": "16.89s"
}
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Add `coordinatorId` to `/v1/info`. ({issue}`issuenumber`)
```
