### PR TITLE
Rename Ssl to Tls in MongoDB connector

### DIFF
--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientModule.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientModule.java
@@ -59,7 +59,7 @@ public class MongoClientModule
         install(conditionalModule(
                 MongoClientConfig.class,
                 MongoClientConfig::getTlsEnabled,
-                new MongoSslModule()));
+                new MongoTlsModule()));
 
         install(conditionalModule(
                 MongoClientConfig.class,

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoTlsConfig.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoTlsConfig.java
@@ -20,7 +20,7 @@ import io.airlift.configuration.validation.FileExists;
 import java.io.File;
 import java.util.Optional;
 
-public class MongoSslConfig
+public class MongoTlsConfig
 {
     private File keystorePath;
     private String keystorePassword;
@@ -33,7 +33,7 @@ public class MongoSslConfig
     }
 
     @Config("mongodb.tls.keystore-path")
-    public MongoSslConfig setKeystorePath(File keystorePath)
+    public MongoTlsConfig setKeystorePath(File keystorePath)
     {
         this.keystorePath = keystorePath;
         return this;
@@ -46,7 +46,7 @@ public class MongoSslConfig
 
     @Config("mongodb.tls.keystore-password")
     @ConfigSecuritySensitive
-    public MongoSslConfig setKeystorePassword(String keystorePassword)
+    public MongoTlsConfig setKeystorePassword(String keystorePassword)
     {
         this.keystorePassword = keystorePassword;
         return this;
@@ -58,7 +58,7 @@ public class MongoSslConfig
     }
 
     @Config("mongodb.tls.truststore-path")
-    public MongoSslConfig setTruststorePath(File truststorePath)
+    public MongoTlsConfig setTruststorePath(File truststorePath)
     {
         this.truststorePath = truststorePath;
         return this;
@@ -71,7 +71,7 @@ public class MongoSslConfig
 
     @Config("mongodb.tls.truststore-password")
     @ConfigSecuritySensitive
-    public MongoSslConfig setTruststorePassword(String truststorePassword)
+    public MongoTlsConfig setTruststorePassword(String truststorePassword)
     {
         this.truststorePassword = truststorePassword;
         return this;

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoTlsModule.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoTlsModule.java
@@ -30,18 +30,18 @@ import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.trino.plugin.base.ssl.SslUtils.createSSLContext;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 
-public class MongoSslModule
+public class MongoTlsModule
         implements Module
 {
     @Override
     public void configure(Binder binder)
     {
-        configBinder(binder).bindConfig(MongoSslConfig.class);
+        configBinder(binder).bindConfig(MongoTlsConfig.class);
     }
 
     @ProvidesIntoSet
     @Singleton
-    public MongoClientSettingConfigurator sslSpecificConfigurator(MongoSslConfig config)
+    public MongoClientSettingConfigurator sslSpecificConfigurator(MongoTlsConfig config)
     {
         return options -> options.applyToSslSettings(
                 builder -> {

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoTlsConfig.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoTlsConfig.java
@@ -24,12 +24,12 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertFullMappin
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 
-public class TestMongoSslConfig
+public class TestMongoTlsConfig
 {
     @Test
     public void testDefaults()
     {
-        assertRecordedDefaults(recordDefaults(MongoSslConfig.class)
+        assertRecordedDefaults(recordDefaults(MongoTlsConfig.class)
                 .setKeystorePath(null)
                 .setKeystorePassword(null)
                 .setTruststorePath(null)
@@ -50,7 +50,7 @@ public class TestMongoSslConfig
                 .put("mongodb.tls.truststore-password", "truststore-password")
                 .buildOrThrow();
 
-        MongoSslConfig expected = new MongoSslConfig()
+        MongoTlsConfig expected = new MongoTlsConfig()
                 .setKeystorePath(keystoreFile.toFile())
                 .setKeystorePassword("keystore-password")
                 .setTruststorePath(truststoreFile.toFile())


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
