### PR TITLE
Run testDeleteRowsConcurrently sequentially for better reliability

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
@@ -34,6 +34,8 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -124,6 +126,7 @@ public abstract class BaseIcebergConnectorSmokeTest
     // Repeat test with invocationCount for better test coverage, since the tested aspect is inherently non-deterministic.
     @RepeatedTest(4)
     @Timeout(120)
+    @Execution(ExecutionMode.SAME_THREAD)
     public void testDeleteRowsConcurrently()
             throws Exception
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Fixes: https://github.com/trinodb/trino/issues/21862

Currently test repetition runs in parallel which can cause query exceed 20s timeout, it's especially visible in case of Glue tests.

Analysis showed that most time is spend on:
1. Waiting for execution to be scheduled. For some queries time between beginMerge and finishMerge can vary from 3s to 16s.
2. Time of `glueClient.updateTable`, when executed in parallel and failing update throws `ConcurrentModificationException`, is about 10s

If query which consumed time on finishMerge also encounters ConcurrentModificationException, 20s is exceeded and test fails.

Running tests sequentially removes first problem and makes test more reliable.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
