### PR TITLE
Ignore NotInTransactionException while obtaining stats

### DIFF
--- a/core/trino-main/src/main/java/io/trino/cost/CachingStatsProvider.java
+++ b/core/trino-main/src/main/java/io/trino/cost/CachingStatsProvider.java
@@ -97,7 +97,7 @@ public final class CachingStatsProvider
 
             if (isIgnoreStatsCalculatorFailures(session)) {
                 // log or fail for others, depending on the session setting
-                log.error(e, "Error occurred when computing stats for query %s", session.getQueryId());
+                log.warn(e, "Error occurred when computing stats for query %s", session.getQueryId());
                 return PlanNodeStatsEstimate.unknown();
             }
             throw e;


### PR DESCRIPTION
If query gets cancelled during planning transaction is removed from transaction manager and we start getting errors while trying to get table stats. Ignore such failures to avoid log pollution.
