### PR TITLE
Pass in requestPayer for ListObjectsV2Request in listObjects method

### DIFF
--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystem.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystem.java
@@ -239,6 +239,7 @@ final class S3FileSystem
 
         ListObjectsV2Request request = ListObjectsV2Request.builder()
                 .overrideConfiguration(context::applyCredentialProviderOverride)
+                .requestPayer(requestPayer)
                 .bucket(s3Location.bucket())
                 .prefix(key)
                 .build();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Quick follow up on the previous merged commit https://github.com/trinodb/trino/pull/23906. Find this request is also missing the requesterPay header. Also just double checked all the rest of s3 requests in this module and this should be the only one left.


( X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
