### PR TITLE
Add redirect for removed connectors

### DIFF
--- a/docs/src/main/sphinx/connector.md
+++ b/docs/src/main/sphinx/connector.md
@@ -46,3 +46,9 @@ Thrift          <connector/thrift>
 TPCDS           <connector/tpcds>
 TPCH            <connector/tpch>
 ```
+
+```{toctree}
+:hidden:
+
+connector/removed
+```

--- a/docs/src/main/sphinx/connector/removed.md
+++ b/docs/src/main/sphinx/connector/removed.md
@@ -1,0 +1,5 @@
+# 404 - Connector removed
+
+The connector you are trying to learn more about has been removed in a prior
+Trino release. Refer to the [list of connectors](/connector) and [release
+notes](/release) for details.

--- a/docs/src/main/sphinx/redirects.txt
+++ b/docs/src/main/sphinx/redirects.txt
@@ -6,3 +6,5 @@ connector/hive-cos.md object-storage/legacy-cos.md
 connector/hive-gcs-tutorial.md object-storage/legacy-gcs.md
 connector/hive-s3.md object-storage/legacy-s3.md
 connector/hive-security.md object-storage/file-system-hdfs.md
+connector/atop.md connector/removed.md
+connector/localfile.md connector/removed.md


### PR DESCRIPTION
## Description

atop and localfile connectors were recently removed. Users that look for the docs from an old link are now redirected to a dedicated page for removed connectors.

raptor connector was also removed but there were never docs.

The page can also be used for future removals.

## Additional context and related issues

#23550 
#23588 
#23551 

Going forward also

#23923 
#23791 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
