### PR TITLE
Fix iceberg migrate to use nullable columns

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrateProcedure.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrateProcedure.java
@@ -286,7 +286,7 @@ public class MigrateProcedure
         for (Column column : columns) {
             int index = icebergColumns.size();
             org.apache.iceberg.types.Type type = toIcebergType(typeManager.getType(getTypeSignature(column.getType(), MILLISECONDS)), nextFieldId, storageFormat);
-            Types.NestedField field = Types.NestedField.of(index, false, column.getName(), type, column.getComment().orElse(null));
+            Types.NestedField field = Types.NestedField.optional(index, column.getName(), type, column.getComment().orElse(null));
             icebergColumns.add(field);
         }
 


### PR DESCRIPTION
## Description
Previous logic was setting all columns as non-nullable which is not valid when the data contains nulls

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Fix migrate for tables which contain NULLs. ({issue}`23928`)
```
