### PR TITLE
Support ORDER BY in window functions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedWindowAccumulator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedWindowAccumulator.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.operator.PagesIndex;
+import io.trino.operator.window.PagesWindowIndex;
+import io.trino.spi.PageBuilder;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.ValueBlock;
+import io.trino.spi.connector.SortOrder;
+import io.trino.spi.function.WindowAccumulator;
+import io.trino.spi.function.WindowIndex;
+import io.trino.spi.type.Type;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class OrderedWindowAccumulator
+        implements WindowAccumulator
+{
+    private final PagesIndex.Factory pagesIndexFactory;
+    private final PagesIndex pagesIndex;
+    private final List<Type> argumentTypes;
+    private final List<Integer> argumentChannels;
+    private final List<Integer> sortKeysArguments;
+    private final List<SortOrder> sortOrders;
+
+    private WindowAccumulator delegate;
+    private final WindowAccumulator initialDelegate;
+
+    private PageBuilder pageBuilder;
+    private boolean pagesIndexSorted;
+
+    public OrderedWindowAccumulator(
+            PagesIndex.Factory pagesIndexFactory,
+            WindowAccumulator delegate,
+            List<Type> argumentTypes,
+            List<Integer> argumentChannels,
+            List<Integer> sortKeysArguments,
+            List<SortOrder> sortOrders)
+    {
+        this(pagesIndexFactory, pagesIndexFactory.newPagesIndex(argumentTypes, 10_000), delegate, argumentTypes, argumentChannels, sortKeysArguments, sortOrders);
+    }
+
+    private OrderedWindowAccumulator(
+            PagesIndex.Factory pagesIndexFactory,
+            PagesIndex pagesIndex,
+            WindowAccumulator delegate,
+            List<Type> argumentTypes,
+            List<Integer> argumentChannels,
+            List<Integer> sortKeysArguments,
+            List<SortOrder> sortOrders)
+    {
+        this.pagesIndexFactory = requireNonNull(pagesIndexFactory, "pagesIndexFactory is null");
+        this.pagesIndex = requireNonNull(pagesIndex, "pagesIndex is null");
+
+        requireNonNull(argumentTypes, "argumentTypes is null");
+        requireNonNull(argumentChannels, "argumentChannels is null");
+        checkArgument(argumentTypes.size() == argumentChannels.size(), "argumentTypes and argumentChannels must have the same size");
+        this.argumentTypes = ImmutableList.copyOf(argumentTypes);
+        this.argumentChannels = ImmutableList.copyOf(argumentChannels);
+        requireNonNull(sortOrders, "sortOrders is null");
+        requireNonNull(sortKeysArguments, "sortChannels is null");
+        checkArgument(sortOrders.size() == sortKeysArguments.size(), "sortOrders and sortChannels must have the same size");
+        sortKeysArguments.forEach(argument -> {
+            checkArgument(
+                    argument < argumentChannels.size(),
+                    "invalid argument %s referenced; total number of arguments is %s", argument, argumentChannels.size());
+        });
+        this.sortOrders = ImmutableList.copyOf(sortOrders);
+        this.sortKeysArguments = ImmutableList.copyOf(sortKeysArguments);
+
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        this.initialDelegate = delegate.copy();
+
+        this.pageBuilder = new PageBuilder(argumentTypes);
+    }
+
+    @Override
+    public long getEstimatedSize()
+    {
+        return delegate.getEstimatedSize() + initialDelegate.getEstimatedSize() + pagesIndex.getEstimatedSize().toBytes() + pageBuilder.getRetainedSizeInBytes();
+    }
+
+    @Override
+    public WindowAccumulator copy()
+    {
+        PagesIndex pagesIndexCopy = pagesIndexFactory.newPagesIndex(argumentTypes, pagesIndex.getPositionCount());
+        pagesIndex.getPages().forEachRemaining(pagesIndexCopy::addPage);
+        return new OrderedWindowAccumulator(pagesIndexFactory, pagesIndexCopy, delegate.copy(), argumentTypes, argumentChannels, sortKeysArguments, sortOrders);
+    }
+
+    @Override
+    public void addInput(WindowIndex index, int startPosition, int endPosition)
+    {
+        if (pagesIndexSorted) {
+            pagesIndexSorted = false;
+            // operate on delegate as of start
+            // nicer would be to add reset() method to WindowAccumulator but it requires reset method in each AccumulatorState class
+            delegate = initialDelegate.copy();
+        }
+        // index is remapped so just go from 0 to argumentChannels.size()
+        for (int position = startPosition; position <= endPosition; position++) {
+            if (pageBuilder.isFull()) {
+                indexCurrentPage();
+            }
+            for (int channel = 0; channel < argumentChannels.size(); channel++) {
+                ValueBlock value = index.getSingleValueBlock(channel, position).getSingleValueBlock(0);
+                pageBuilder.getBlockBuilder(channel).append(value, 0);
+            }
+            pageBuilder.declarePosition();
+        }
+    }
+
+    private void indexCurrentPage()
+    {
+        pagesIndex.addPage(pageBuilder.build());
+        pageBuilder.reset();
+    }
+
+    @Override
+    public void output(BlockBuilder blockBuilder)
+    {
+        if (!pagesIndexSorted) {
+            if (!pageBuilder.isEmpty()) {
+                indexCurrentPage();
+            }
+            int positionCount = pagesIndex.getPositionCount();
+            if (positionCount == 0) {
+                delegate.output(blockBuilder);
+                return;
+            }
+            pagesIndex.sort(sortKeysArguments, sortOrders);
+            WindowIndex sortedWindowIndex = new PagesWindowIndex(pagesIndex, 0, positionCount);
+            delegate.addInput(sortedWindowIndex, 0, positionCount - 1);
+            pagesIndexSorted = true;
+        }
+        checkState(pageBuilder.isEmpty());
+
+        delegate.output(blockBuilder);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/window/AggregateWindowFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/AggregateWindowFunction.java
@@ -24,7 +24,7 @@ import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 
-class AggregateWindowFunction
+public class AggregateWindowFunction
         implements WindowFunction
 {
     private final Supplier<WindowAccumulator> accumulatorFactory;

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionTreeUtils.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionTreeUtils.java
@@ -85,9 +85,10 @@ public final class ExpressionTreeUtils
 
     private static boolean isAggregation(FunctionCall functionCall, Session session, FunctionResolver functionResolver, AccessControl accessControl)
     {
-        return ((functionResolver.isAggregationFunction(session, functionCall.getName(), accessControl) || functionCall.getFilter().isPresent())
-                && functionCall.getWindow().isEmpty())
-                || functionCall.getOrderBy().isPresent();
+        return (functionResolver.isAggregationFunction(session, functionCall.getName(), accessControl)
+                || functionCall.getFilter().isPresent()
+                || functionCall.getOrderBy().isPresent())
+                && functionCall.getWindow().isEmpty();
     }
 
     private static boolean isWindow(FunctionCall functionCall, Session session, FunctionResolver functionResolver, AccessControl accessControl)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -103,6 +103,7 @@ import io.trino.operator.aggregation.AccumulatorFactory;
 import io.trino.operator.aggregation.AggregatorFactory;
 import io.trino.operator.aggregation.DistinctAccumulatorFactory;
 import io.trino.operator.aggregation.OrderedAccumulatorFactory;
+import io.trino.operator.aggregation.OrderedWindowAccumulator;
 import io.trino.operator.aggregation.partial.PartialAggregationController;
 import io.trino.operator.exchange.LocalExchange;
 import io.trino.operator.exchange.LocalExchangeSinkOperator.LocalExchangeSinkOperatorFactory;
@@ -134,6 +135,7 @@ import io.trino.operator.project.CursorProcessor;
 import io.trino.operator.project.PageProcessor;
 import io.trino.operator.project.PageProjection;
 import io.trino.operator.unnest.UnnestOperator;
+import io.trino.operator.window.AggregateWindowFunction;
 import io.trino.operator.window.AggregationWindowFunctionSupplier;
 import io.trino.operator.window.FrameInfo;
 import io.trino.operator.window.PartitionerSupplier;
@@ -171,6 +173,7 @@ import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.CatalogSchemaFunctionName;
 import io.trino.spi.function.FunctionId;
 import io.trino.spi.function.FunctionKind;
+import io.trino.spi.function.WindowFunction;
 import io.trino.spi.function.WindowFunctionSupplier;
 import io.trino.spi.function.table.TableFunctionProcessorProvider;
 import io.trino.spi.predicate.Domain;
@@ -1145,15 +1148,15 @@ public class LocalExecutionPlanner
 
                 WindowNode.Function function = entry.getValue();
                 ResolvedFunction resolvedFunction = function.getResolvedFunction();
-                ImmutableList.Builder<Integer> arguments = ImmutableList.builder();
+                ArrayList<Integer> argumentChannels = new ArrayList<>();
                 for (Expression argument : function.getArguments()) {
                     if (!(argument instanceof Lambda)) {
                         Symbol argumentSymbol = Symbol.from(argument);
-                        arguments.add(source.getLayout().get(argumentSymbol));
+                        argumentChannels.add(source.getLayout().get(argumentSymbol));
                     }
                 }
                 Symbol symbol = entry.getKey();
-                WindowFunctionSupplier windowFunctionSupplier = getWindowFunctionImplementation(resolvedFunction);
+
                 Type type = resolvedFunction.signature().getReturnType();
 
                 List<Lambda> lambdas = function.getArguments().stream()
@@ -1165,8 +1168,39 @@ public class LocalExecutionPlanner
                         .map(FunctionType.class::cast)
                         .collect(toImmutableList());
 
+                WindowFunctionSupplier windowFunctionSupplier;
+                if (function.getOrderingScheme().isPresent()) {
+                    OrderingScheme orderingScheme = function.getOrderingScheme().orElseThrow();
+                    List<Symbol> sortKeys = orderingScheme.orderBy();
+                    List<SortOrder> sortOrders = sortKeys.stream()
+                            .map(orderingScheme::ordering)
+                            .collect(toImmutableList());
+
+                    ImmutableList.Builder<Integer> sortKeysArguments = ImmutableList.builder();
+                    sortKeys.forEach(orderingArgumentSymbol -> {
+                        argumentChannels.add(source.getLayout().get(orderingArgumentSymbol));
+                        sortKeysArguments.add(argumentChannels.size() - 1); // last added argument
+                    });
+
+                    List<Type> argumentTypes = argumentChannels.stream()
+                            .map(channel -> source.getTypes().get(channel))
+                            .collect(toImmutableList());
+
+                    windowFunctionSupplier = getOrderedWindowFunctionImplementation(
+                            resolvedFunction,
+                            argumentTypes,
+                            argumentChannels,
+                            sortKeysArguments.build(),
+                            sortOrders);
+                }
+                else {
+                    windowFunctionSupplier = getWindowFunctionImplementation(resolvedFunction);
+                }
+
                 List<Supplier<Object>> lambdaProviders = makeLambdaProviders(lambdas, windowFunctionSupplier.getLambdaInterfaces(), functionTypes);
-                windowFunctionsBuilder.add(window(windowFunctionSupplier, type, frameInfo, function.isIgnoreNulls(), lambdaProviders, arguments.build()));
+                WindowFunctionDefinition windowFunction = window(windowFunctionSupplier, type, frameInfo, function.isIgnoreNulls(), lambdaProviders, ImmutableList.copyOf(argumentChannels));
+
+                windowFunctionsBuilder.add(windowFunction);
                 windowFunctionOutputSymbolsBuilder.add(symbol);
             }
 
@@ -1210,15 +1244,58 @@ public class LocalExecutionPlanner
         private WindowFunctionSupplier getWindowFunctionImplementation(ResolvedFunction resolvedFunction)
         {
             if (resolvedFunction.functionKind() == FunctionKind.AGGREGATE) {
-                return uncheckedCacheGet(aggregationWindowFunctionSupplierCache, new FunctionKey(resolvedFunction.functionId(), resolvedFunction.signature()), () -> {
-                    AggregationImplementation aggregationImplementation = plannerContext.getFunctionManager().getAggregationImplementation(resolvedFunction);
-                    return new AggregationWindowFunctionSupplier(
-                            resolvedFunction.signature(),
-                            aggregationImplementation,
-                            resolvedFunction.functionNullability());
-                });
+                return getAggregationWindowFunctionSupplier(resolvedFunction);
             }
             return plannerContext.getFunctionManager().getWindowFunctionSupplier(resolvedFunction);
+        }
+
+        private AggregationWindowFunctionSupplier getAggregationWindowFunctionSupplier(ResolvedFunction resolvedFunction)
+        {
+            checkArgument(
+                    resolvedFunction.functionKind() == FunctionKind.AGGREGATE,
+                    "Expected %s to be AGGREGATE function, but got %s",
+                    resolvedFunction.functionId(),
+                    resolvedFunction.functionKind());
+            return uncheckedCacheGet(aggregationWindowFunctionSupplierCache, new FunctionKey(resolvedFunction.functionId(), resolvedFunction.signature()), () -> {
+                AggregationImplementation aggregationImplementation = plannerContext.getFunctionManager().getAggregationImplementation(resolvedFunction);
+                return new AggregationWindowFunctionSupplier(
+                        resolvedFunction.signature(),
+                        aggregationImplementation,
+                        resolvedFunction.functionNullability());
+            });
+        }
+
+        private WindowFunctionSupplier getOrderedWindowFunctionImplementation(
+                ResolvedFunction resolvedFunction,
+                List<Type> argumentTypes,
+                List<Integer> argumentChannels,
+                List<Integer> sortKeysArguments,
+                List<SortOrder> sortOrders)
+        {
+            AggregationWindowFunctionSupplier aggregationWindowFunctionSupplier = getAggregationWindowFunctionSupplier(resolvedFunction);
+            return new WindowFunctionSupplier() {
+                @Override
+                public WindowFunction createWindowFunction(boolean ignoreNulls, List<Supplier<Object>> lambdaProviders)
+                {
+                    AggregationImplementation aggregationImplementation = plannerContext.getFunctionManager().getAggregationImplementation(resolvedFunction);
+                    boolean hasRemoveInput = aggregationImplementation.getWindowAccumulator().isPresent();
+                    return new AggregateWindowFunction(
+                            () -> new OrderedWindowAccumulator(
+                                    pagesIndexFactory,
+                                    aggregationWindowFunctionSupplier.createWindowAccumulator(lambdaProviders),
+                                    argumentTypes,
+                                    argumentChannels,
+                                    sortKeysArguments,
+                                    sortOrders),
+                            hasRemoveInput);
+                }
+
+                @Override
+                public List<Class<?>> getLambdaInterfaces()
+                {
+                    return aggregationWindowFunctionSupplier.getLambdaInterfaces();
+                }
+            };
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -111,6 +111,7 @@ import io.trino.sql.planner.iterative.rule.PruneMarkDistinctColumns;
 import io.trino.sql.planner.iterative.rule.PruneMergeSourceColumns;
 import io.trino.sql.planner.iterative.rule.PruneOffsetColumns;
 import io.trino.sql.planner.iterative.rule.PruneOrderByInAggregation;
+import io.trino.sql.planner.iterative.rule.PruneOrderByInWindowAggregation;
 import io.trino.sql.planner.iterative.rule.PruneOutputSourceColumns;
 import io.trino.sql.planner.iterative.rule.PrunePattenRecognitionColumns;
 import io.trino.sql.planner.iterative.rule.PrunePatternRecognitionSourceColumns;
@@ -460,6 +461,7 @@ public class PlanOptimizers
                                         new MergeLimitWithDistinct(),
                                         new PruneCountAggregationOverScalar(metadata),
                                         new PruneOrderByInAggregation(metadata),
+                                        new PruneOrderByInWindowAggregation(metadata),
                                         new RewriteSpatialPartitioningAggregation(plannerContext),
                                         new SimplifyCountOverConstant(plannerContext),
                                         new PreAggregateCaseAggregations(plannerContext),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/SymbolsExtractor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/SymbolsExtractor.java
@@ -110,6 +110,7 @@ public final class SymbolsExtractor
         for (Expression argument : function.getArguments()) {
             builder.addAll(extractAll(argument));
         }
+        function.getOrderingScheme().ifPresent(orderBy -> builder.addAll(orderBy.orderBy()));
         function.getFrame().getEndValue().ifPresent(builder::add);
         function.getFrame().getSortKeyCoercedForFrameEndComparison().ifPresent(builder::add);
         function.getFrame().getStartValue().ifPresent(builder::add);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DecorrelateUnnest.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DecorrelateUnnest.java
@@ -464,6 +464,7 @@ public class DecorrelateUnnest
             WindowNode.Function rowNumberFunction = new WindowNode.Function(
                     metadata.resolveBuiltinFunction("row_number", ImmutableList.of()),
                     ImmutableList.of(),
+                    Optional.empty(),
                     DEFAULT_FRAME,
                     false);
             WindowNode windowNode = new WindowNode(

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ImplementLimitWithTies.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ImplementLimitWithTies.java
@@ -123,6 +123,7 @@ public class ImplementLimitWithTies
         WindowNode.Function rankFunction = new WindowNode.Function(
                 metadata.resolveBuiltinFunction("rank", ImmutableList.of()),
                 ImmutableList.of(),
+                Optional.empty(),
                 DEFAULT_FRAME,
                 false);
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ImplementTableFunctionSource.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ImplementTableFunctionSource.java
@@ -317,8 +317,8 @@ public class ImplementTableFunctionSource
                 source,
                 specification,
                 ImmutableMap.of(
-                        rowNumber, new WindowNode.Function(rowNumberFunction, ImmutableList.of(), FULL_FRAME, false),
-                        partitionSize, new WindowNode.Function(countFunction, ImmutableList.of(), FULL_FRAME, false)),
+                        rowNumber, new WindowNode.Function(rowNumberFunction, ImmutableList.of(), Optional.empty(), FULL_FRAME, false),
+                        partitionSize, new WindowNode.Function(countFunction, ImmutableList.of(), Optional.empty(), FULL_FRAME, false)),
                 Optional.empty(),
                 ImmutableSet.of(),
                 0);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneOrderByInWindowAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneOrderByInWindowAggregation.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.metadata.Metadata;
+import io.trino.spi.function.FunctionKind;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.plan.WindowNode;
+import io.trino.sql.planner.plan.WindowNode.Function;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.sql.planner.plan.Patterns.window;
+import static java.util.Objects.requireNonNull;
+
+public class PruneOrderByInWindowAggregation
+        implements Rule<WindowNode>
+{
+    private static final Pattern<WindowNode> PATTERN = window();
+    private final Metadata metadata;
+
+    public PruneOrderByInWindowAggregation(Metadata metadata)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
+    @Override
+    public Pattern<WindowNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(WindowNode node, Captures captures, Context context)
+    {
+        boolean anyRewritten = false;
+        ImmutableMap.Builder<Symbol, Function> rewritten = ImmutableMap.builder();
+        for (Map.Entry<Symbol, Function> entry : node.getWindowFunctions().entrySet()) {
+            Function function = entry.getValue();
+            // getAggregateFunctionImplementation can be expensive, so check it last.
+            if (function.getOrderingScheme().isPresent() &&
+                    function.getResolvedFunction().functionKind() == FunctionKind.AGGREGATE &&
+                    !metadata.getAggregationFunctionMetadata(context.getSession(), function.getResolvedFunction()).isOrderSensitive()) {
+                function = new Function(
+                        function.getResolvedFunction(),
+                        function.getArguments(),
+                        Optional.empty(), // prune
+                        function.getFrame(),
+                        function.isIgnoreNulls());
+                anyRewritten = true;
+            }
+            rewritten.put(entry.getKey(), function);
+        }
+
+        if (!anyRewritten) {
+            return Result.empty();
+        }
+        return Result.ofPlanNode(new WindowNode(
+                node.getId(),
+                node.getSource(),
+                node.getSpecification(),
+                rewritten.buildOrThrow(),
+                node.getHashSymbol(),
+                node.getPrePartitionedInputs(),
+                node.getPreSortedOrderPrefix()));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneWindowColumns.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneWindowColumns.java
@@ -59,6 +59,7 @@ public class PruneWindowColumns
         windowNode.getHashSymbol().ifPresent(referencedInputs::add);
 
         for (WindowNode.Function windowFunction : referencedFunctions.values()) {
+            windowFunction.getOrderingScheme().ifPresent(orderingScheme -> referencedInputs.addAll(orderingScheme.orderBy()));
             referencedInputs.addAll(SymbolsExtractor.extractUnique(windowFunction));
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferencesThroughWindow.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferencesThroughWindow.java
@@ -96,6 +96,7 @@ public class PushDownDereferencesThroughWindow
                     // Exclude partitionBy, orderBy and synthesized symbols
                     return !specification.partitionBy().contains(symbol) &&
                             !specification.orderingScheme().map(OrderingScheme::orderBy).orElse(ImmutableList.of()).contains(symbol) &&
+                            !windowNode.getWindowFunctions().values().stream().anyMatch(function -> function.getOrderingScheme().map(scheme -> scheme.orderBy().contains(symbol)).orElse(false)) &&
                             !windowNode.getCreatedSymbols().contains(symbol);
                 })
                 .collect(toImmutableSet());
@@ -138,6 +139,7 @@ public class PushDownDereferencesThroughWindow
                                                             oldFunction.getArguments().stream()
                                                                     .map(expression -> replaceExpression(expression, mappings))
                                                                     .collect(toImmutableList()),
+                                                            oldFunction.getOrderingScheme(),
                                                             oldFunction.getFrame(),
                                                             oldFunction.isIgnoreNulls());
                                                 })),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SetOperationNodeTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SetOperationNodeTranslator.java
@@ -194,6 +194,7 @@ public class SetOperationNodeTranslator
             functions.put(output, new WindowNode.Function(
                     countFunction,
                     ImmutableList.of(markers.get(i).toSymbolReference()),
+                    Optional.empty(),
                     defaultFrame,
                     false));
         }
@@ -201,6 +202,7 @@ public class SetOperationNodeTranslator
         functions.put(rowNumberSymbol, new WindowNode.Function(
                 rowNumberFunction,
                 ImmutableList.of(),
+                Optional.empty(),
                 defaultFrame,
                 false));
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SymbolMapper.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SymbolMapper.java
@@ -69,6 +69,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -248,8 +249,9 @@ public class SymbolMapper
                     .map(this::map)
                     .collect(toImmutableList());
             WindowNode.Frame newFrame = map(function.getFrame());
+            Optional<OrderingScheme> newOrderingScheme = function.getOrderingScheme().map(this::map);
 
-            newFunctions.put(map(symbol), new WindowNode.Function(function.getResolvedFunction(), newArguments, newFrame, function.isIgnoreNulls()));
+            newFunctions.put(map(symbol), new WindowNode.Function(function.getResolvedFunction(), newArguments, newOrderingScheme, newFrame, function.isIgnoreNulls()));
         });
 
         SpecificationWithPreSortedPrefix newSpecification = mapAndDistinct(node.getSpecification(), node.getPreSortedOrderPrefix());
@@ -307,8 +309,9 @@ public class SymbolMapper
                     .map(this::map)
                     .collect(toImmutableList());
             WindowNode.Frame newFrame = map(function.getFrame());
+            verify(function.getOrderingScheme().isEmpty());
 
-            newFunctions.put(map(symbol), new WindowNode.Function(function.getResolvedFunction(), newArguments, newFrame, function.isIgnoreNulls()));
+            newFunctions.put(map(symbol), new WindowNode.Function(function.getResolvedFunction(), newArguments, Optional.empty(), newFrame, function.isIgnoreNulls()));
         });
 
         ImmutableMap.Builder<Symbol, Measure> newMeasures = ImmutableMap.builder();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/WindowNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/WindowNode.java
@@ -290,6 +290,7 @@ public class WindowNode
     {
         private final ResolvedFunction resolvedFunction;
         private final List<Expression> arguments;
+        private final Optional<OrderingScheme> orderingScheme;
         private final Frame frame;
         private final boolean ignoreNulls;
 
@@ -297,11 +298,13 @@ public class WindowNode
         public Function(
                 @JsonProperty("resolvedFunction") ResolvedFunction resolvedFunction,
                 @JsonProperty("arguments") List<Expression> arguments,
+                @JsonProperty("orderingScheme") Optional<OrderingScheme> orderingScheme,
                 @JsonProperty("frame") Frame frame,
                 @JsonProperty("ignoreNulls") boolean ignoreNulls)
         {
             this.resolvedFunction = requireNonNull(resolvedFunction, "resolvedFunction is null");
             this.arguments = requireNonNull(arguments, "arguments is null");
+            this.orderingScheme = requireNonNull(orderingScheme, "orderingScheme is null");
             this.frame = requireNonNull(frame, "frame is null");
             this.ignoreNulls = ignoreNulls;
         }
@@ -319,6 +322,12 @@ public class WindowNode
         }
 
         @JsonProperty
+        public Optional<OrderingScheme> getOrderingScheme()
+        {
+            return orderingScheme;
+        }
+
+        @JsonProperty
         public Frame getFrame()
         {
             return frame;
@@ -333,7 +342,7 @@ public class WindowNode
         @Override
         public int hashCode()
         {
-            return Objects.hash(resolvedFunction, arguments, frame, ignoreNulls);
+            return Objects.hash(resolvedFunction, arguments, orderingScheme, frame, ignoreNulls);
         }
 
         @Override
@@ -348,6 +357,7 @@ public class WindowNode
             Function other = (Function) obj;
             return Objects.equals(this.resolvedFunction, other.resolvedFunction) &&
                     Objects.equals(this.arguments, other.arguments) &&
+                    Objects.equals(this.orderingScheme, other.orderingScheme) &&
                     Objects.equals(this.frame, other.frame) &&
                     this.ignoreNulls == other.ignoreNulls;
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
@@ -2071,7 +2071,7 @@ public class PlanPrinter
 
         private String formatOrderingScheme(OrderingScheme orderingScheme)
         {
-            return formatCollection(orderingScheme.orderBy(), input -> anonymizer.anonymize(input) + " " + orderingScheme.ordering(input));
+            return PlanPrinter.formatOrderingScheme(anonymizer, orderingScheme);
         }
 
         @SafeVarargs
@@ -2177,6 +2177,11 @@ public class PlanPrinter
         }
     }
 
+    private static String formatOrderingScheme(Anonymizer anonymizer, OrderingScheme orderingScheme)
+    {
+        return formatCollection(orderingScheme.orderBy(), input -> anonymizer.anonymize(input) + " " + orderingScheme.ordering(input));
+    }
+
     private static <T> String formatCollection(Collection<T> collection, Function<T, String> formatter)
     {
         return collection.stream()
@@ -2201,9 +2206,9 @@ public class PlanPrinter
         builder.append(formatFunctionName(aggregation.getResolvedFunction()))
                 .append('(').append(arguments);
 
-        aggregation.getOrderingScheme().ifPresent(orderingScheme -> builder.append(' ').append(orderingScheme.orderBy().stream()
-                .map(input -> anonymizer.anonymize(input) + " " + orderingScheme.ordering(input))
-                .collect(joining(", "))));
+        aggregation.getOrderingScheme()
+                .map(orderingScheme -> formatOrderingScheme(anonymizer, orderingScheme))
+                .ifPresent(ordering -> builder.append(' ').append(ordering));
 
         builder.append(')');
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
@@ -913,10 +913,11 @@ public class PlanPrinter
                 String frameInfo = formatFrame(function.getFrame());
 
                 nodeOutput.appendDetails(
-                        "%s := %s(%s) %s",
+                        "%s := %s(%s%s) %s",
                         anonymizer.anonymize(entry.getKey()),
                         formatFunctionName(function.getResolvedFunction()),
                         Joiner.on(", ").join(anonymizeExpressions(function.getArguments())),
+                        function.getOrderingScheme().map(this::formatOrderingScheme).orElse(""),
                         frameInfo);
             }
             return processChildren(node, new Context(context.isInitialPlan()));

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestTypeValidator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestTypeValidator.java
@@ -143,7 +143,7 @@ public class TestTypeValidator
                 Optional.empty(),
                 Optional.empty());
 
-        WindowNode.Function function = new WindowNode.Function(resolvedFunction, ImmutableList.of(columnC.toSymbolReference()), frame, false);
+        WindowNode.Function function = new WindowNode.Function(resolvedFunction, ImmutableList.of(columnC.toSymbolReference()), Optional.empty(), frame, false);
 
         DataOrganizationSpecification specification = new DataOrganizationSpecification(ImmutableList.of(), Optional.empty());
 
@@ -238,7 +238,7 @@ public class TestTypeValidator
                 Optional.empty(),
                 Optional.empty());
 
-        WindowNode.Function function = new WindowNode.Function(resolvedFunction, ImmutableList.of(columnA.toSymbolReference()), frame, false);
+        WindowNode.Function function = new WindowNode.Function(resolvedFunction, ImmutableList.of(columnA.toSymbolReference()), Optional.empty(), frame, false);
 
         DataOrganizationSpecification specification = new DataOrganizationSpecification(ImmutableList.of(), Optional.empty());
 
@@ -271,7 +271,7 @@ public class TestTypeValidator
                 Optional.empty(),
                 Optional.empty());
 
-        WindowNode.Function function = new WindowNode.Function(resolvedFunction, ImmutableList.of(columnC.toSymbolReference()), frame, false);
+        WindowNode.Function function = new WindowNode.Function(resolvedFunction, ImmutableList.of(columnC.toSymbolReference()), Optional.empty(), frame, false);
 
         DataOrganizationSpecification specification = new DataOrganizationSpecification(ImmutableList.of(), Optional.empty());
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/AggregationFunction.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/AggregationFunction.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 public record AggregationFunction(
         String name,
         Optional<Symbol> filter,
-        Optional<OrderingScheme> orderBy,
+        Optional<OrderingScheme> orderingScheme,
         boolean distinct,
         List<Expression> arguments)
 {

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/AggregationFunctionMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/AggregationFunctionMatcher.java
@@ -61,7 +61,7 @@ public class AggregationFunctionMatcher
     {
         return Objects.equals(expectedCall.name(), aggregation.getResolvedFunction().signature().getName().getFunctionName()) &&
                 Objects.equals(expectedCall.filter(), aggregation.getFilter()) &&
-                Objects.equals(expectedCall.orderBy(), aggregation.getOrderingScheme()) &&
+                Objects.equals(expectedCall.orderingScheme(), aggregation.getOrderingScheme()) &&
                 expectedCall.distinct() == aggregation.isDistinct() &&
                 Objects.equals(expectedCall.arguments(), aggregation.getArguments());
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/AggregationFunctionProvider.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/AggregationFunctionProvider.java
@@ -63,7 +63,7 @@ final class AggregationFunctionProvider
     {
         List<Expression> symbolReferences = toSymbolReferences(args, aliases);
 
-        Optional<OrderingScheme> orderByClause = Optional.empty();
+        Optional<OrderingScheme> orderingScheme = Optional.empty();
         if (!orderBy.isEmpty()) {
             ImmutableList.Builder<Symbol> fields = ImmutableList.builder();
             ImmutableMap.Builder<Symbol, SortOrder> orders = ImmutableMap.builder();
@@ -74,9 +74,9 @@ final class AggregationFunctionProvider
                 fields.add(symbol);
                 orders.put(symbol, ordering.getSortOrder());
             }
-            orderByClause = Optional.of(new OrderingScheme(fields.build(), orders.buildOrThrow()));
+            orderingScheme = Optional.of(new OrderingScheme(fields.build(), orders.buildOrThrow()));
         }
 
-        return new AggregationFunction(name, filter.map(symbol -> symbol.toSymbol(aliases)), orderByClause, distinct, symbolReferences);
+        return new AggregationFunction(name, filter.map(symbol -> symbol.toSymbol(aliases)), orderingScheme, distinct, symbolReferences);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/AggregationFunctionProvider.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/AggregationFunctionProvider.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.spi.connector.SortOrder;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.Reference;
 import io.trino.sql.planner.OrderingScheme;
 import io.trino.sql.planner.Symbol;
 
@@ -25,7 +26,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static io.trino.sql.planner.assertions.PlanMatchPattern.toSymbolReferences;
-import static io.trino.type.UnknownType.UNKNOWN;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -69,7 +69,8 @@ final class AggregationFunctionProvider
             ImmutableMap.Builder<Symbol, SortOrder> orders = ImmutableMap.builder();
 
             for (PlanMatchPattern.Ordering ordering : this.orderBy) {
-                Symbol symbol = new Symbol(UNKNOWN, aliases.get(ordering.getField()).name());
+                Reference reference = aliases.get(ordering.getField());
+                Symbol symbol = new Symbol(reference.type(), reference.name());
                 fields.add(symbol);
                 orders.put(symbol, ordering.getSortOrder());
             }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
@@ -1105,7 +1105,12 @@ public final class PlanMatchPattern
 
     public static ExpectedValueProvider<WindowFunction> windowFunction(String name, List<String> args, WindowNode.Frame frame)
     {
-        return new WindowFunctionProvider(name, frame, toSymbolAliases(args));
+        return windowFunction(name, args, frame, ImmutableList.of());
+    }
+
+    public static ExpectedValueProvider<WindowFunction> windowFunction(String name, List<String> args, WindowNode.Frame frame, List<PlanMatchPattern.Ordering> orderBy)
+    {
+        return new WindowFunctionProvider(name, frame, toSymbolAliases(args), orderBy);
     }
 
     public static List<Expression> toSymbolReferences(List<PlanTestSymbol> aliases, SymbolAliases symbolAliases)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/TableFunctionMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/TableFunctionMatcher.java
@@ -235,9 +235,9 @@ public class TableFunctionMatcher
     public record DescriptorArgumentValue(Optional<Descriptor> descriptor)
             implements ArgumentValue
     {
-        public DescriptorArgumentValue(Optional<Descriptor> descriptor)
+        public DescriptorArgumentValue
         {
-            this.descriptor = requireNonNull(descriptor, "descriptor is null");
+            requireNonNull(descriptor, "descriptor is null");
         }
 
         public static DescriptorArgumentValue descriptorArgument(Descriptor descriptor)
@@ -264,20 +264,10 @@ public class TableFunctionMatcher
             Set<String> passThroughSymbols)
             implements ArgumentValue
     {
-        public TableArgumentValue(
-                int sourceIndex,
-                boolean rowSemantics,
-                boolean pruneWhenEmpty,
-                boolean passThroughColumns,
-                Optional<ExpectedValueProvider<DataOrganizationSpecification>> specification,
-                Set<String> passThroughSymbols)
+        public TableArgumentValue
         {
-            this.sourceIndex = sourceIndex;
-            this.rowSemantics = rowSemantics;
-            this.pruneWhenEmpty = pruneWhenEmpty;
-            this.passThroughColumns = passThroughColumns;
-            this.specification = requireNonNull(specification, "specification is null");
-            this.passThroughSymbols = ImmutableSet.copyOf(passThroughSymbols);
+            requireNonNull(specification, "specification is null");
+            passThroughSymbols = ImmutableSet.copyOf(passThroughSymbols);
         }
 
         public static class Builder

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/WindowFunction.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/WindowFunction.java
@@ -15,21 +15,25 @@ package io.trino.sql.planner.assertions;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.planner.OrderingScheme;
 import io.trino.sql.planner.plan.WindowNode;
 
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
 public record WindowFunction(
         String name,
         WindowNode.Frame frame,
-        List<Expression> arguments)
+        List<Expression> arguments,
+        Optional<OrderingScheme> orderingScheme)
 {
-    public WindowFunction(String name, WindowNode.Frame frame, List<Expression> arguments)
+    public WindowFunction
     {
-        this.name = requireNonNull(name, "name is null");
-        this.frame = requireNonNull(frame, "frame is null");
-        this.arguments = ImmutableList.copyOf(arguments);
+        requireNonNull(name, "name is null");
+        requireNonNull(frame, "frame is null");
+        arguments = ImmutableList.copyOf(arguments);
+        requireNonNull(orderingScheme, "orderingScheme is null");
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/WindowFunctionMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/WindowFunctionMatcher.java
@@ -22,6 +22,7 @@ import io.trino.sql.planner.plan.WindowNode;
 import io.trino.sql.planner.plan.WindowNode.Function;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -70,6 +71,7 @@ public class WindowFunctionMatcher
     {
         return expectedCall.name().equals(windowFunction.getResolvedFunction().signature().getName().getFunctionName()) &&
                 WindowFrameMatcher.matches(expectedCall.frame(), windowFunction.getFrame(), aliases) &&
+                Objects.equals(expectedCall.orderingScheme(), windowFunction.getOrderingScheme()) &&
                 expectedCall.arguments().equals(windowFunction.getArguments());
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestMergeAdjacentWindows.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestMergeAdjacentWindows.java
@@ -224,6 +224,7 @@ public class TestMergeAdjacentWindows
                 Arrays.stream(symbols)
                         .map(Symbol::toSymbolReference)
                         .collect(Collectors.toList()),
+                Optional.empty(),
                 DEFAULT_FRAME,
                 false);
     }
@@ -235,6 +236,7 @@ public class TestMergeAdjacentWindows
                 Arrays.stream(symbols)
                         .map(name -> new Reference(DOUBLE, name))
                         .collect(Collectors.toList()),
+                Optional.empty(),
                 DEFAULT_FRAME,
                 false);
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestMergePatternRecognitionNodes.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestMergePatternRecognitionNodes.java
@@ -166,7 +166,7 @@ public class TestMergePatternRecognitionNodes
                         .pattern(new IrLabel("X"))
                         .addVariableDefinition(new IrLabel("X"), TRUE)
                         .source(p.patternRecognition(childBuilder -> childBuilder
-                                .addWindowFunction(p.symbol("function"), new WindowNode.Function(lag, ImmutableList.of(p.symbol("a").toSymbolReference()), DEFAULT_FRAME, false))
+                                .addWindowFunction(p.symbol("function"), new WindowNode.Function(lag, ImmutableList.of(p.symbol("a").toSymbolReference()), Optional.empty(), DEFAULT_FRAME, false))
                                 .rowsPerMatch(WINDOW)
                                 .frame(new WindowNode.Frame(ROWS, CURRENT_ROW, Optional.empty(), Optional.empty(), UNBOUNDED_FOLLOWING, Optional.empty(), Optional.empty()))
                                 .pattern(new IrLabel("X"))
@@ -177,13 +177,13 @@ public class TestMergePatternRecognitionNodes
         // parent node's window function depends on child node's window function output
         tester().assertThat(new MergePatternRecognitionNodesWithoutProject())
                 .on(p -> p.patternRecognition(parentBuilder -> parentBuilder
-                        .addWindowFunction(p.symbol("dependent"), new WindowNode.Function(lag, ImmutableList.of(p.symbol("function").toSymbolReference()), DEFAULT_FRAME, false))
+                        .addWindowFunction(p.symbol("dependent"), new WindowNode.Function(lag, ImmutableList.of(p.symbol("function").toSymbolReference()), Optional.empty(), DEFAULT_FRAME, false))
                         .rowsPerMatch(WINDOW)
                         .frame(new WindowNode.Frame(ROWS, CURRENT_ROW, Optional.empty(), Optional.empty(), UNBOUNDED_FOLLOWING, Optional.empty(), Optional.empty()))
                         .pattern(new IrLabel("X"))
                         .addVariableDefinition(new IrLabel("X"), TRUE)
                         .source(p.patternRecognition(childBuilder -> childBuilder
-                                .addWindowFunction(p.symbol("function"), new WindowNode.Function(lag, ImmutableList.of(p.symbol("a").toSymbolReference()), DEFAULT_FRAME, false))
+                                .addWindowFunction(p.symbol("function"), new WindowNode.Function(lag, ImmutableList.of(p.symbol("a").toSymbolReference()), Optional.empty(), DEFAULT_FRAME, false))
                                 .rowsPerMatch(WINDOW)
                                 .frame(new WindowNode.Frame(ROWS, CURRENT_ROW, Optional.empty(), Optional.empty(), UNBOUNDED_FOLLOWING, Optional.empty(), Optional.empty()))
                                 .pattern(new IrLabel("X"))
@@ -194,7 +194,7 @@ public class TestMergePatternRecognitionNodes
         // parent node's window function depends on child node's measure output
         tester().assertThat(new MergePatternRecognitionNodesWithoutProject())
                 .on(p -> p.patternRecognition(parentBuilder -> parentBuilder
-                        .addWindowFunction(p.symbol("dependent"), new WindowNode.Function(lag, ImmutableList.of(p.symbol("measure").toSymbolReference()), DEFAULT_FRAME, false))
+                        .addWindowFunction(p.symbol("dependent"), new WindowNode.Function(lag, ImmutableList.of(p.symbol("measure").toSymbolReference()), Optional.empty(), DEFAULT_FRAME, false))
                         .rowsPerMatch(WINDOW)
                         .frame(new WindowNode.Frame(ROWS, CURRENT_ROW, Optional.empty(), Optional.empty(), UNBOUNDED_FOLLOWING, Optional.empty(), Optional.empty()))
                         .pattern(new IrLabel("X"))
@@ -306,7 +306,7 @@ public class TestMergePatternRecognitionNodes
                                 ImmutableMap.of("pointer", new ScalarValuePointer(
                                         new LogicalIndexPointer(ImmutableSet.of(new IrLabel("X")), true, true, 0, 0),
                                         new Symbol(BIGINT, "b"))))
-                        .addWindowFunction(p.symbol("parent_function"), new WindowNode.Function(lag, ImmutableList.of(p.symbol("a").toSymbolReference()), DEFAULT_FRAME, false))
+                        .addWindowFunction(p.symbol("parent_function"), new WindowNode.Function(lag, ImmutableList.of(p.symbol("a").toSymbolReference()), Optional.empty(), DEFAULT_FRAME, false))
                         .rowsPerMatch(WINDOW)
                         .frame(new WindowNode.Frame(ROWS, CURRENT_ROW, Optional.empty(), Optional.empty(), UNBOUNDED_FOLLOWING, Optional.empty(), Optional.empty()))
                         .skipTo(LAST, ImmutableSet.of(new IrLabel("X")))
@@ -324,7 +324,7 @@ public class TestMergePatternRecognitionNodes
                                             ImmutableMap.of("pointer", new ScalarValuePointer(
                                                     new LogicalIndexPointer(ImmutableSet.of(new IrLabel("X")), false, true, 0, 0),
                                                     new Symbol(BIGINT, "a"))))
-                                    .addWindowFunction(p.symbol("child_function"), new WindowNode.Function(lag, ImmutableList.of(p.symbol("b").toSymbolReference()), DEFAULT_FRAME, false))
+                                    .addWindowFunction(p.symbol("child_function"), new WindowNode.Function(lag, ImmutableList.of(p.symbol("b").toSymbolReference()), Optional.empty(), DEFAULT_FRAME, false))
                                     .rowsPerMatch(WINDOW)
                                     .frame(new WindowNode.Frame(ROWS, CURRENT_ROW, Optional.empty(), Optional.empty(), UNBOUNDED_FOLLOWING, Optional.empty(), Optional.empty()))
                                     .skipTo(LAST, ImmutableSet.of(new IrLabel("X")))

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneOrderByInAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneOrderByInAggregation.java
@@ -38,7 +38,6 @@ import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
 import static io.trino.sql.planner.plan.AggregationNode.Step.SINGLE;
 import static io.trino.sql.tree.SortItem.NullOrdering.LAST;
 import static io.trino.sql.tree.SortItem.Ordering.ASCENDING;
-import static io.trino.type.UnknownType.UNKNOWN;
 
 public class TestPruneOrderByInAggregation
         extends BaseRuleTest
@@ -81,16 +80,16 @@ public class TestPruneOrderByInAggregation
                         "avg",
                         ImmutableList.of(new Reference(BIGINT, "input")),
                         new OrderingScheme(
-                                ImmutableList.of(new Symbol(UNKNOWN, "input")),
-                                ImmutableMap.of(new Symbol(UNKNOWN, "input"), SortOrder.ASC_NULLS_LAST))),
+                                ImmutableList.of(new Symbol(BIGINT, "input")),
+                                ImmutableMap.of(new Symbol(BIGINT, "input"), SortOrder.ASC_NULLS_LAST))),
                         ImmutableList.of(BIGINT),
                         mask)
                 .addAggregation(arrayAgg, PlanBuilder.aggregation(
                         "array_agg",
                         ImmutableList.of(new Reference(BIGINT, "input")),
                         new OrderingScheme(
-                                ImmutableList.of(new Symbol(UNKNOWN, "input")),
-                                ImmutableMap.of(new Symbol(UNKNOWN, "input"), SortOrder.ASC_NULLS_LAST))),
+                                ImmutableList.of(new Symbol(BIGINT, "input")),
+                                ImmutableMap.of(new Symbol(BIGINT, "input"), SortOrder.ASC_NULLS_LAST))),
                         ImmutableList.of(BIGINT),
                         mask)
                 .hashSymbol(keyHash)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneOrderByInWindowAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneOrderByInWindowAggregation.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.metadata.Metadata;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.spi.connector.SortOrder;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.planner.OrderingScheme;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
+import io.trino.sql.planner.plan.WindowNode;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.metadata.TestMetadataManager.createTestMetadataManager;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.sort;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.specification;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.window;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.windowFunction;
+import static io.trino.sql.planner.plan.WindowNode.Frame.DEFAULT_FRAME;
+import static io.trino.sql.tree.SortItem.NullOrdering.LAST;
+import static io.trino.sql.tree.SortItem.Ordering.ASCENDING;
+
+public class TestPruneOrderByInWindowAggregation
+        extends BaseRuleTest
+{
+    private static final Metadata METADATA = createTestMetadataManager();
+
+    @Test
+    public void testBasics()
+    {
+        tester().assertThat(new PruneOrderByInWindowAggregation(METADATA))
+                .on(planBuilder -> {
+                    Symbol avg = planBuilder.symbol("avg");
+                    Symbol arrayAgg = planBuilder.symbol("araray_agg");
+                    Symbol input = planBuilder.symbol("input");
+                    Symbol key = planBuilder.symbol("key");
+                    Symbol keyHash = planBuilder.symbol("keyHash");
+                    Symbol mask = planBuilder.symbol("mask");
+                    List<Symbol> sourceSymbols = ImmutableList.of(input, key, keyHash, mask);
+
+                    ResolvedFunction avgFunction = METADATA.resolveBuiltinFunction("avg", fromTypes(BIGINT));
+                    ResolvedFunction arrayAggFunction = METADATA.resolveBuiltinFunction("array_agg", fromTypes(BIGINT));
+
+                    return planBuilder.window(
+                            new DataOrganizationSpecification(ImmutableList.of(planBuilder.symbol("key", BIGINT)), Optional.empty()),
+                            ImmutableMap.of(
+                                    avg, new WindowNode.Function(avgFunction,
+                                            ImmutableList.of(new Reference(BIGINT, "input")),
+                                            Optional.of(new OrderingScheme(
+                                                    ImmutableList.of(new Symbol(BIGINT, "input")),
+                                                    ImmutableMap.of(new Symbol(BIGINT, "input"), SortOrder.ASC_NULLS_LAST))),
+                                            DEFAULT_FRAME,
+                                            false),
+                                    arrayAgg, new WindowNode.Function(arrayAggFunction,
+                                            ImmutableList.of(new Reference(BIGINT, "input")),
+                                            Optional.of(new OrderingScheme(
+                                                    ImmutableList.of(new Symbol(BIGINT, "input")),
+                                                    ImmutableMap.of(new Symbol(BIGINT, "input"), SortOrder.ASC_NULLS_LAST))),
+                                            DEFAULT_FRAME,
+                                            false)),
+                            planBuilder.values(sourceSymbols, ImmutableList.of()));
+                })
+                .matches(
+                        window(
+                                windowMatcherBuilder -> windowMatcherBuilder
+                                        .specification(specification(
+                                                ImmutableList.of("key"),
+                                                ImmutableList.of(),
+                                                ImmutableMap.of()))
+                                        .addFunction(
+                                                "avg",
+                                                windowFunction("avg", ImmutableList.of("input"), DEFAULT_FRAME))
+                                        .addFunction(
+                                                "array_agg",
+                                                windowFunction("array_agg", ImmutableList.of("input"), DEFAULT_FRAME, ImmutableList.of(sort("input", ASCENDING, LAST)))),
+                                values("input", "key", "keyHash", "mask")));
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPrunePattenRecognitionColumns.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPrunePattenRecognitionColumns.java
@@ -103,7 +103,7 @@ public class TestPrunePattenRecognitionColumns
                 .on(p -> p.project(
                         Assignments.identity(p.symbol("b")),
                         p.patternRecognition(builder -> builder
-                                .addWindowFunction(p.symbol("rank"), new WindowNode.Function(rank, ImmutableList.of(), DEFAULT_FRAME, false))
+                                .addWindowFunction(p.symbol("rank"), new WindowNode.Function(rank, ImmutableList.of(), Optional.empty(), DEFAULT_FRAME, false))
                                 .addMeasure(
                                         p.symbol("measure"),
                                         new Reference(BIGINT, "pointer"),
@@ -132,7 +132,7 @@ public class TestPrunePattenRecognitionColumns
                 .on(p -> p.project(
                         Assignments.identity(p.symbol("measure", BIGINT)),
                         p.patternRecognition(builder -> builder
-                                .addWindowFunction(p.symbol("lag", BIGINT), new WindowNode.Function(lag, ImmutableList.of(p.symbol("b", BIGINT).toSymbolReference()), DEFAULT_FRAME, false))
+                                .addWindowFunction(p.symbol("lag", BIGINT), new WindowNode.Function(lag, ImmutableList.of(p.symbol("b", BIGINT).toSymbolReference()), Optional.empty(), DEFAULT_FRAME, false))
                                 .addMeasure(
                                         p.symbol("measure", BIGINT),
                                         new Reference(BIGINT, "pointer"),
@@ -191,7 +191,7 @@ public class TestPrunePattenRecognitionColumns
                 .on(p -> p.project(
                         Assignments.identity(p.symbol("lag")),
                         p.patternRecognition(builder -> builder
-                                .addWindowFunction(p.symbol("lag"), new WindowNode.Function(lag, ImmutableList.of(p.symbol("b").toSymbolReference()), frame, false))
+                                .addWindowFunction(p.symbol("lag"), new WindowNode.Function(lag, ImmutableList.of(p.symbol("b").toSymbolReference()), Optional.empty(), frame, false))
                                 .addMeasure(
                                         p.symbol("measure"),
                                         new Reference(BIGINT, "pointer"),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneWindowColumns.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneWindowColumns.java
@@ -20,7 +20,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import io.trino.metadata.ResolvedFunction;
 import io.trino.metadata.TestingFunctionResolution;
-import io.trino.spi.connector.SortOrder;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.planner.OrderingScheme;
 import io.trino.sql.planner.Symbol;
@@ -33,15 +32,18 @@ import io.trino.sql.planner.plan.WindowNode;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 
 import static com.google.common.base.Predicates.alwaysTrue;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.spi.connector.SortOrder.ASC_NULLS_FIRST;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.sort;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.strictProject;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.window;
@@ -49,6 +51,8 @@ import static io.trino.sql.planner.assertions.PlanMatchPattern.windowFunction;
 import static io.trino.sql.planner.plan.FrameBoundType.CURRENT_ROW;
 import static io.trino.sql.planner.plan.FrameBoundType.UNBOUNDED_PRECEDING;
 import static io.trino.sql.planner.plan.WindowFrameType.RANGE;
+import static io.trino.sql.tree.SortItem.NullOrdering.FIRST;
+import static io.trino.sql.tree.SortItem.Ordering.ASCENDING;
 import static io.trino.type.UnknownType.UNKNOWN;
 
 public class TestPruneWindowColumns
@@ -57,7 +61,7 @@ public class TestPruneWindowColumns
     private static final ResolvedFunction MIN_FUNCTION = new TestingFunctionResolution().resolveFunction("min", fromTypes(BIGINT));
 
     private static final List<String> inputSymbolNameList =
-            ImmutableList.of("orderKey", "partitionKey", "hash", "startValue1", "startValue2", "endValue1", "endValue2", "input1", "input2", "unused");
+            ImmutableList.of("orderKey", "partitionKey", "hash", "startValue1", "startValue2", "endValue1", "endValue2", "input1", "input2", "aggOrderInput1", "aggOrderInput2", "unused");
     private static final Set<String> inputSymbolNameSet = ImmutableSet.copyOf(inputSymbolNameList);
 
     private static final WindowNode.Frame FRAME1 = new WindowNode.Frame(
@@ -106,13 +110,13 @@ public class TestPruneWindowColumns
                                                 .specification(
                                                         ImmutableList.of("partitionKey"),
                                                         ImmutableList.of("orderKey"),
-                                                        ImmutableMap.of("orderKey", SortOrder.ASC_NULLS_FIRST))
+                                                        ImmutableMap.of("orderKey", ASC_NULLS_FIRST))
                                                 .preSortedOrderPrefix(0)
-                                                .addFunction("output2", windowFunction("min", ImmutableList.of("input2"), FRAME2))
+                                                .addFunction("output2", windowFunction("min", ImmutableList.of("input2"), FRAME2, List.of(sort("aggOrderInput2", ASCENDING, FIRST))))
                                                 .hashSymbol("hash"),
                                         strictProject(
                                                 Maps.asMap(
-                                                        Sets.difference(inputSymbolNameSet, ImmutableSet.of("input1", "startValue1", "endValue1")),
+                                                        Sets.difference(inputSymbolNameSet, ImmutableSet.of("input1", "startValue1", "endValue1", "aggOrderInput1")),
                                                         symbol -> expression(new Reference(BIGINT, symbol))),
                                                 values(inputSymbolNameList)))));
     }
@@ -158,10 +162,10 @@ public class TestPruneWindowColumns
                                                 .specification(
                                                         ImmutableList.of("partitionKey"),
                                                         ImmutableList.of("orderKey"),
-                                                        ImmutableMap.of("orderKey", SortOrder.ASC_NULLS_FIRST))
+                                                        ImmutableMap.of("orderKey", ASC_NULLS_FIRST))
                                                 .preSortedOrderPrefix(0)
-                                                .addFunction("output1", windowFunction("min", ImmutableList.of("input1"), FRAME1))
-                                                .addFunction("output2", windowFunction("min", ImmutableList.of("input2"), FRAME2))
+                                                .addFunction("output1", windowFunction("min", ImmutableList.of("input1"), FRAME1, List.of(sort("aggOrderInput1", ASCENDING, FIRST))))
+                                                .addFunction("output2", windowFunction("min", ImmutableList.of("input2"), FRAME2, List.of(sort("aggOrderInput2", ASCENDING, FIRST))))
                                                 .hashSymbol("hash"),
                                         strictProject(
                                                 Maps.asMap(
@@ -184,10 +188,13 @@ public class TestPruneWindowColumns
         Symbol endValue2 = p.symbol("endValue2");
         Symbol input1 = p.symbol("input1");
         Symbol input2 = p.symbol("input2");
+        Symbol aggOrderInput1 = p.symbol("aggOrderInput1");
+        Symbol aggOrderInput2 = p.symbol("aggOrderInput2");
         Symbol unused = p.symbol("unused");
         Symbol output1 = p.symbol("output1");
         Symbol output2 = p.symbol("output2");
-        List<Symbol> inputs = ImmutableList.of(orderKey, partitionKey, hash, startValue1, startValue2, endValue1, endValue2, input1, input2, unused);
+
+        List<Symbol> inputs = ImmutableList.of(orderKey, partitionKey, hash, startValue1, startValue2, endValue1, endValue2, input1, input2, aggOrderInput1, aggOrderInput2, unused);
         List<Symbol> outputs = ImmutableList.<Symbol>builder().addAll(inputs).add(output1, output2).build();
 
         return p.project(
@@ -200,12 +207,13 @@ public class TestPruneWindowColumns
                                 ImmutableList.of(partitionKey),
                                 Optional.of(new OrderingScheme(
                                         ImmutableList.of(orderKey),
-                                        ImmutableMap.of(orderKey, SortOrder.ASC_NULLS_FIRST)))),
+                                        ImmutableMap.of(orderKey, ASC_NULLS_FIRST)))),
                         ImmutableMap.of(
                                 output1,
                                 new WindowNode.Function(
                                         MIN_FUNCTION,
                                         ImmutableList.of(input1.toSymbolReference()),
+                                        Optional.of(new OrderingScheme(List.of(aggOrderInput1), Map.of(aggOrderInput1, ASC_NULLS_FIRST))),
                                         new WindowNode.Frame(
                                                 RANGE,
                                                 UNBOUNDED_PRECEDING,
@@ -219,6 +227,7 @@ public class TestPruneWindowColumns
                                 new WindowNode.Function(
                                         MIN_FUNCTION,
                                         ImmutableList.of(input2.toSymbolReference()),
+                                        Optional.of(new OrderingScheme(List.of(aggOrderInput2), Map.of(aggOrderInput2, ASC_NULLS_FIRST))),
                                         new WindowNode.Frame(
                                                 RANGE,
                                                 UNBOUNDED_PRECEDING,

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushDownDereferencesRules.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushDownDereferencesRules.java
@@ -626,6 +626,7 @@ public class TestPushDownDereferencesRules
                                                 new WindowNode.Function(
                                                         createTestMetadataManager().resolveBuiltinFunction("min", fromTypes(ROW_TYPE)),
                                                         ImmutableList.of(p.symbol("msg3", ROW_TYPE).toSymbolReference()),
+                                                        Optional.empty(),
                                                         new WindowNode.Frame(
                                                                 RANGE,
                                                                 UNBOUNDED_PRECEDING,

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushPredicateThroughProjectIntoWindow.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushPredicateThroughProjectIntoWindow.java
@@ -297,6 +297,7 @@ public class TestPushPredicateThroughProjectIntoWindow
         return new Function(
                 tester().getMetadata().resolveBuiltinFunction("row_number", fromTypes()),
                 ImmutableList.of(),
+                Optional.empty(),
                 DEFAULT_FRAME,
                 false);
     }
@@ -306,6 +307,7 @@ public class TestPushPredicateThroughProjectIntoWindow
         return new Function(
                 tester().getMetadata().resolveBuiltinFunction("rank", fromTypes()),
                 ImmutableList.of(),
+                Optional.empty(),
                 DEFAULT_FRAME,
                 false);
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushdownFilterIntoWindow.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushdownFilterIntoWindow.java
@@ -171,6 +171,7 @@ public class TestPushdownFilterIntoWindow
         return new WindowNode.Function(
                 resolvedFunction,
                 ImmutableList.of(symbol.toSymbolReference()),
+                Optional.empty(),
                 DEFAULT_FRAME,
                 false);
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushdownLimitIntoWindow.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushdownLimitIntoWindow.java
@@ -201,6 +201,7 @@ public class TestPushdownLimitIntoWindow
         return new WindowNode.Function(
                 resolvedFunction,
                 ImmutableList.of(symbol.toSymbolReference()),
+                Optional.empty(),
                 DEFAULT_FRAME,
                 false);
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestReplaceWindowWithRowNumber.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestReplaceWindowWithRowNumber.java
@@ -115,6 +115,7 @@ public class TestReplaceWindowWithRowNumber
         return new WindowNode.Function(
                 resolvedFunction,
                 ImmutableList.of(),
+                Optional.empty(),
                 DEFAULT_FRAME,
                 false);
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSwapAdjacentWindowsBySpecifications.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSwapAdjacentWindowsBySpecifications.java
@@ -61,7 +61,7 @@ public class TestSwapAdjacentWindowsBySpecifications
                                 ImmutableList.of(p.symbol("a")),
                                 Optional.empty()),
                         ImmutableMap.of(p.symbol("avg_1"),
-                                new WindowNode.Function(resolvedFunction, ImmutableList.of(), DEFAULT_FRAME, false)),
+                                new WindowNode.Function(resolvedFunction, ImmutableList.of(), Optional.empty(), DEFAULT_FRAME, false)),
                         p.values(p.symbol("a"))))
                 .doesNotFire();
     }
@@ -81,12 +81,12 @@ public class TestSwapAdjacentWindowsBySpecifications
                                         ImmutableList.of(p.symbol("a")),
                                         Optional.empty()),
                                 ImmutableMap.of(p.symbol("avg_1", DOUBLE),
-                                        new WindowNode.Function(resolvedFunction, ImmutableList.of(new Reference(BIGINT, "a")), DEFAULT_FRAME, false)),
+                                        new WindowNode.Function(resolvedFunction, ImmutableList.of(new Reference(BIGINT, "a")), Optional.empty(), DEFAULT_FRAME, false)),
                                 p.window(new DataOrganizationSpecification(
                                                 ImmutableList.of(p.symbol("a"), p.symbol("b")),
                                                 Optional.empty()),
                                         ImmutableMap.of(p.symbol("avg_2", DOUBLE),
-                                                new WindowNode.Function(resolvedFunction, ImmutableList.of(new Reference(BIGINT, "b")), DEFAULT_FRAME, false)),
+                                                new WindowNode.Function(resolvedFunction, ImmutableList.of(new Reference(BIGINT, "b")), Optional.empty(), DEFAULT_FRAME, false)),
                                         p.values(p.symbol("a"), p.symbol("b")))))
                 .matches(
                         window(windowMatcherBuilder -> windowMatcherBuilder
@@ -107,12 +107,12 @@ public class TestSwapAdjacentWindowsBySpecifications
                                         ImmutableList.of(p.symbol("a", BIGINT)),
                                         Optional.empty()),
                                 ImmutableMap.of(p.symbol("avg_1", DOUBLE),
-                                        new WindowNode.Function(resolvedFunction, ImmutableList.of(new Reference(DOUBLE, "avg_2")), DEFAULT_FRAME, false)),
+                                        new WindowNode.Function(resolvedFunction, ImmutableList.of(new Reference(DOUBLE, "avg_2")), Optional.empty(), DEFAULT_FRAME, false)),
                                 p.window(new DataOrganizationSpecification(
                                                 ImmutableList.of(p.symbol("a", BIGINT), p.symbol("b", BIGINT)),
                                                 Optional.empty()),
                                         ImmutableMap.of(p.symbol("avg_2", DOUBLE),
-                                                new WindowNode.Function(resolvedFunction, ImmutableList.of(new Reference(BIGINT, "a")), DEFAULT_FRAME, false)),
+                                                new WindowNode.Function(resolvedFunction, ImmutableList.of(new Reference(BIGINT, "a")), Optional.empty(), DEFAULT_FRAME, false)),
                                         p.values(p.symbol("a", BIGINT), p.symbol("b", BIGINT)))))
                 .doesNotFire();
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -268,14 +268,14 @@ public class PlanBuilder
         return new EnforceSingleRowNode(idAllocator.getNextId(), source);
     }
 
-    public SortNode sort(List<Symbol> orderBy, PlanNode source)
+    public SortNode sort(List<Symbol> orderBySymbols, PlanNode source)
     {
         return new SortNode(
                 idAllocator.getNextId(),
                 source,
                 new OrderingScheme(
-                        orderBy,
-                        Maps.toMap(orderBy, Functions.constant(SortOrder.ASC_NULLS_FIRST))),
+                        orderBySymbols,
+                        Maps.toMap(orderBySymbols, Functions.constant(SortOrder.ASC_NULLS_FIRST))),
                 false);
     }
 
@@ -317,25 +317,25 @@ public class PlanBuilder
                 preSortedInputs);
     }
 
-    public TopNNode topN(long count, List<Symbol> orderBy, PlanNode source)
+    public TopNNode topN(long count, List<Symbol> orderBySymbols, PlanNode source)
     {
-        return topN(count, orderBy, TopNNode.Step.SINGLE, source);
+        return topN(count, orderBySymbols, TopNNode.Step.SINGLE, source);
     }
 
-    public TopNNode topN(long count, List<Symbol> orderBy, TopNNode.Step step, PlanNode source)
+    public TopNNode topN(long count, List<Symbol> orderBySymbols, TopNNode.Step step, PlanNode source)
     {
-        return topN(count, orderBy, step, SortOrder.ASC_NULLS_FIRST, source);
+        return topN(count, orderBySymbols, step, SortOrder.ASC_NULLS_FIRST, source);
     }
 
-    public TopNNode topN(long count, List<Symbol> orderBy, TopNNode.Step step, SortOrder sortOrder, PlanNode source)
+    public TopNNode topN(long count, List<Symbol> orderBySymbols, TopNNode.Step step, SortOrder sortOrder, PlanNode source)
     {
         return new TopNNode(
                 idAllocator.getNextId(),
                 source,
                 count,
                 new OrderingScheme(
-                        orderBy,
-                        Maps.toMap(orderBy, Functions.constant(sortOrder))),
+                        orderBySymbols,
+                        Maps.toMap(orderBySymbols, Functions.constant(sortOrder))),
                 step);
     }
 
@@ -447,7 +447,7 @@ public class PlanBuilder
                     aggregation.arguments(),
                     aggregation.distinct(),
                     aggregation.filter(),
-                    aggregation.orderBy(),
+                    aggregation.orderingScheme(),
                     mask));
         }
 
@@ -1312,7 +1312,7 @@ public class PlanBuilder
                 aggregation.arguments(),
                 aggregation.distinct(),
                 aggregation.filter(),
-                aggregation.orderBy(),
+                aggregation.orderingScheme(),
                 Optional.empty());
     }
 
@@ -1452,9 +1452,9 @@ public class PlanBuilder
         return new AggregationFunction(name, Optional.of(filter), Optional.empty(), false, arguments);
     }
 
-    public static AggregationFunction aggregation(String name, List<Expression> arguments, OrderingScheme orderBy)
+    public static AggregationFunction aggregation(String name, List<Expression> arguments, OrderingScheme orderingScheme)
     {
-        return new AggregationFunction(name, Optional.empty(), Optional.of(orderBy), false, arguments);
+        return new AggregationFunction(name, Optional.empty(), Optional.of(orderingScheme), false, arguments);
     }
 
     public Collection<Symbol> getSymbols()

--- a/core/trino-main/src/test/java/io/trino/sql/planner/plan/TestPatternRecognitionNodeSerialization.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/plan/TestPatternRecognitionNodeSerialization.java
@@ -208,6 +208,7 @@ public class TestPatternRecognitionNodeSerialization
                         new Function(
                                 rankFunction,
                                 ImmutableList.of(),
+                                Optional.empty(),
                                 new Frame(ROWS, CURRENT_ROW, Optional.empty(), Optional.empty(), UNBOUNDED_FOLLOWING, Optional.empty(), Optional.empty()),
                                 false)),
                 ImmutableMap.of(

--- a/core/trino-main/src/test/java/io/trino/sql/planner/plan/TestWindowNode.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/plan/TestWindowNode.java
@@ -93,7 +93,7 @@ public class TestWindowNode
                 Optional.of(new OrderingScheme(
                         ImmutableList.of(columnB),
                         ImmutableMap.of(columnB, SortOrder.ASC_NULLS_FIRST))));
-        Map<Symbol, WindowNode.Function> functions = ImmutableMap.of(windowSymbol, new WindowNode.Function(resolvedFunction, ImmutableList.of(columnC.toSymbolReference()), frame, false));
+        Map<Symbol, WindowNode.Function> functions = ImmutableMap.of(windowSymbol, new WindowNode.Function(resolvedFunction, ImmutableList.of(columnC.toSymbolReference()), Optional.empty(), frame, false));
         Optional<Symbol> hashSymbol = Optional.of(columnB);
         Set<Symbol> prePartitionedInputs = ImmutableSet.of(columnA);
         WindowNode windowNode = new WindowNode(

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestWindow.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestWindow.java
@@ -72,4 +72,209 @@ public class TestWindow
                 """))
                 .matches("VALUES (BIGINT '1', BIGINT '1', 1, 1, BIGINT '1', BIGINT '1', 1, 1, BIGINT '1', BIGINT '1', 1, 1, BIGINT '1', BIGINT '1', 1, 1, BIGINT '1', BIGINT '1', 1, 1, BIGINT '1', BIGINT '1', 1, 1)");
     }
+
+    @Test
+    public void testWindowWithOrderBy()
+    {
+        // window and aggregate ordering on different columns
+        assertThat(assertions.query(
+                """
+                SELECT a, ARRAY_AGG(c ORDER BY c) OVER w
+                FROM (
+                    VALUES (1, 1, 1), (1, 2, 2), (1, 3, 3), (1, 4, 4), (1, 4, 7) , (1, 5, 5),
+                           (2, 1, 1), (2, 2, 3), (2, 3, 2), (2, 4, 1)) AS t(a, b, c)
+                WINDOW w AS (PARTITION BY a ORDER BY b)
+                """))
+                .matches(
+                        """
+                        VALUES
+                            (1, ARRAY[1]),
+                            (1, ARRAY[1, 2]),
+                            (1, ARRAY[1, 2, 3]),
+                            (1, ARRAY[1, 2, 3, 4, 7]),
+                            (1, ARRAY[1, 2, 3, 4, 7]),
+                            (1, ARRAY[1, 2, 3, 4, 5, 7]),
+                            (2, ARRAY[1]),
+                            (2, ARRAY[1, 3]),
+                            (2, ARRAY[1, 2, 3]),
+                            (2, ARRAY[1, 1, 2, 3])
+                        """);
+
+        // window and aggregate ordering on different columns (different ordering)
+        assertThat(assertions.query(
+                """
+                SELECT a, ARRAY_AGG(c ORDER BY c DESC) OVER w
+                FROM (
+                    VALUES (1, 1, 1), (1, 2, 2), (1, 3, 3), (1, 4, 4), (1, 4, 7), (1, 5, 5),
+                           (2, 1, 1), (2, 2, 3), (2, 3, 2), (2, 4, 1)) AS t(a, b, c)
+                WINDOW w AS (PARTITION BY a ORDER BY b)
+                """))
+                .matches(
+                        """
+                        VALUES
+                            (1, ARRAY[1]),
+                            (1, ARRAY[2, 1]),
+                            (1, ARRAY[3, 2, 1]),
+                            (1, ARRAY[7, 4, 3, 2, 1]),
+                            (1, ARRAY[7, 4, 3, 2, 1]),
+                            (1, ARRAY[7, 5, 4, 3, 2, 1]),
+                            (2, ARRAY[1]),
+                            (2, ARRAY[3, 1]),
+                            (2, ARRAY[3, 2, 1]),
+                            (2, ARRAY[3, 2, 1, 1])
+                        """);
+
+        // aggregate ordering on column not in output
+        assertThat(assertions.query(
+                """
+                SELECT a, ARRAY_AGG(c ORDER BY d) OVER w
+                FROM (
+                    VALUES (1, 1, 1, 5), (1, 2, 2, 4), (1, 3, 3, 1), (1, 4, 4, 2), (1, 4, 7, 6) , (1, 5, 5, 3),
+                           (2, 1, 1, 4), (2, 2, 3, 3), (2, 3, 2, 2), (2, 4, 1, 1)) AS t(a, b, c, d)
+                WINDOW w AS (PARTITION BY a ORDER BY b)
+                """))
+                .matches(
+                        """
+                        VALUES
+                            (1, ARRAY[1]),
+                            (1, ARRAY[2, 1]),
+                            (1, ARRAY[3, 2, 1]),
+                            (1, ARRAY[3, 4, 2, 1, 7]),
+                            (1, ARRAY[3, 4, 2, 1, 7]),
+                            (1, ARRAY[3, 4, 5, 2, 1, 7]),
+                            (2, ARRAY[1]),
+                            (2, ARRAY[3, 1]),
+                            (2, ARRAY[2, 3, 1]),
+                            (2, ARRAY[1, 2, 3, 1])
+                        """);
+
+        // window and aggregate ordering on the same column
+        assertThat(assertions.query(
+                """
+                SELECT a, ARRAY_AGG(c ORDER BY b) OVER w
+                FROM (
+                    VALUES (1, 1, 1), (1, 2, 2), (1, 3, 3), (1, 4, 4) , (1, 5, 5),
+                           (2, 1, 1), (2, 2, 3), (2, 3, 2), (2, 4, 1)) AS t(a, b, c)
+                WINDOW w AS (PARTITION BY a ORDER BY b)
+                """))
+                .matches(
+                        """
+                        VALUES
+                            (1, ARRAY[1]),
+                            (1, ARRAY[1, 2]),
+                            (1, ARRAY[1, 2, 3]),
+                            (1, ARRAY[1, 2, 3, 4]),
+                            (1, ARRAY[1, 2, 3, 4, 5]),
+                            (2, ARRAY[1]),
+                            (2, ARRAY[1, 3]),
+                            (2, ARRAY[1, 3, 2]),
+                            (2, ARRAY[1, 3, 2, 1])
+                        """);
+
+        // window and aggregate ordering on same column (different sort order)
+        assertThat(assertions.query(
+                """
+                SELECT a, ARRAY_AGG(c ORDER BY b DESC) OVER w
+                FROM (
+                    VALUES (1, 1, 1), (1, 2, 2), (1, 3, 3), (1, 4, 4), (1, 5, 5),
+                           (2, 1, 1), (2, 2, 3), (2, 3, 2), (2, 4, 1)) AS t(a, b, c)
+                WINDOW w AS (PARTITION BY a ORDER BY b)
+                """))
+                .matches(
+                        """
+                        VALUES
+                            (1, ARRAY[1]),
+                            (1, ARRAY[2, 1]),
+                            (1, ARRAY[3, 2, 1]),
+                            (1, ARRAY[4, 3, 2, 1]),
+                            (1, ARRAY[5, 4, 3, 2, 1]),
+                            (2, ARRAY[1]),
+                            (2, ARRAY[3, 1]),
+                            (2, ARRAY[2, 3, 1]),
+                            (2, ARRAY[1, 2, 3, 1])
+                        """);
+
+        // aggregate ordering on two columns (tiebreaker ASC)
+        assertThat(assertions.query(
+                """
+                SELECT a, ARRAY_AGG(c ORDER BY d, c) OVER w
+                FROM (
+                    VALUES (1, 1, 1, 5), (1, 2, 2, 4), (1, 3, 3, 4), (1, 4, 4, 5), (1, 4, 7, 1) , (1, 5, 5, 2)) AS t(a, b, c, d)
+                WINDOW w AS (PARTITION BY a ORDER BY b)
+                """))
+                .matches(
+                        """
+                        VALUES
+                            (1, ARRAY[1]),
+                            (1, ARRAY[2, 1]),
+                            (1, ARRAY[2, 3, 1]),
+                            (1, ARRAY[7, 2, 3, 1, 4]),
+                            (1, ARRAY[7, 2, 3, 1, 4]),
+                            (1, ARRAY[7, 5, 2, 3, 1, 4])
+                        """);
+
+        // aggregate ordering on two columns (tiebreaker DESC)
+        assertThat(assertions.query(
+                """
+                SELECT a, ARRAY_AGG(c ORDER BY d, c DESC) OVER w
+                FROM (
+                    VALUES (1, 1, 1, 5), (1, 2, 2, 4), (1, 3, 3, 4), (1, 4, 4, 5), (1, 4, 7, 1) , (1, 5, 5, 2)) AS t(a, b, c, d)
+                WINDOW w AS (PARTITION BY a ORDER BY b)
+                """))
+                .matches(
+                        """
+                        VALUES
+                            (1, ARRAY[1]),
+                            (1, ARRAY[2, 1]),
+                            (1, ARRAY[3, 2, 1]),
+                            (1, ARRAY[7, 3, 2, 4, 1]),
+                            (1, ARRAY[7, 3, 2, 4, 1]),
+                            (1, ARRAY[7, 5, 3, 2, 4, 1])
+                        """);
+
+        // multiple aggregate functions
+        assertThat(assertions.query(
+                """
+                SELECT a,
+                       ARRAY_AGG(c ORDER BY c) OVER w,
+                       ARRAY_AGG(c ORDER BY c DESC) OVER w,
+                       ARRAY_AGG(c ORDER BY d) OVER w
+                FROM (
+                    VALUES (1, 1, 1, 5), (1, 2, 2, 4), (1, 3, 3, 1), (1, 4, 4, 2), (1, 4, 7, 6) , (1, 5, 5, 3),
+                           (2, 1, 1, 4), (2, 2, 3, 3), (2, 3, 2, 2), (2, 4, 1, 1)) AS t(a, b, c, d)
+                WINDOW w AS (PARTITION BY a ORDER BY b)
+                """))
+                .matches(
+                        """
+                        VALUES
+                            (1, ARRAY[1], ARRAY[1], ARRAY[1]),
+                            (1, ARRAY[1, 2], ARRAY[2, 1], ARRAY[2, 1]),
+                            (1, ARRAY[1, 2, 3], ARRAY[3, 2, 1], ARRAY[3, 2, 1]),
+                            (1, ARRAY[1, 2, 3, 4, 7], ARRAY[7, 4, 3, 2, 1], ARRAY[3, 4, 2, 1, 7]),
+                            (1, ARRAY[1, 2, 3, 4, 7], ARRAY[7, 4, 3, 2, 1], ARRAY[3, 4, 2, 1, 7]),
+                            (1, ARRAY[1, 2, 3, 4, 5, 7], ARRAY[7, 5, 4, 3, 2, 1], ARRAY[3, 4, 5, 2, 1, 7]),
+                            (2, ARRAY[1], ARRAY[1], ARRAY[1]),
+                            (2, ARRAY[1, 3], ARRAY[3, 1], ARRAY[3, 1]),
+                            (2, ARRAY[1, 2, 3], ARRAY[3, 2, 1], ARRAY[2, 3, 1]),
+                            (2, ARRAY[1, 1, 2, 3], ARRAY[3, 2, 1, 1], ARRAY[1, 2, 3, 1])
+                        """);
+
+        // test empty frames
+        assertThat(assertions.query(
+                """
+                SELECT a, ARRAY_AGG(c ORDER BY b DESC) OVER w
+                FROM (
+                    VALUES (1, 1, 1), (1, 2, 2), (1, 3, 3), (1, 4, 4), (1, 5, 5)) t(a, b, c)
+                WINDOW w AS (PARTITION BY a ORDER BY b GROUPS BETWEEN 1 FOLLOWING AND 2 FOLLOWING)
+                """))
+                .matches(
+                        """
+                        VALUES
+                            (1, ARRAY[3, 2]),
+                            (1, ARRAY[4, 3]),
+                            (1, ARRAY[5, 4]),
+                            (1, ARRAY[5]),
+                            (1, NULL)
+                        """);
+    }
 }

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/trino-product-tests/conf/environment/multinode-kafka-sasl-plaintext/jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/trino-product-tests/conf/environment/multinode-kafka-sasl-plaintext/jvm.config
@@ -17,5 +17,5 @@
 # Allow loading dynamic agent used by JOL
 -XX:+EnableDynamicAgentLoading
 -XX:+UnlockDiagnosticVMOptions
-# https://bugs.openjdk.org/browse/JDK-8327134a
+# https://bugs.openjdk.org/browse/JDK-8327134
 -Djava.security.manager=allow


### PR DESCRIPTION
Add basic support for `ORDER BY` in aggregate functions used in WINDOW context.
Lightly speaking, not a very performant implementation.

TODO:
 * [x] - test coverage 

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Add support for ORDER BY clause in aggregate functions used in window context. ({issue}`issuenumber`)
```
