### PR TITLE
First try to solve the issue #23069

### DIFF
--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchColumnHandle.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchColumnHandle.java
@@ -37,4 +37,9 @@ public record ElasticsearchColumnHandle(
     {
         return name() + "::" + type();
     }
+
+    public ElasticsearchColumnHandle withName(String newName)
+    {
+        return new ElasticsearchColumnHandle(newName, type, decoderDescriptor, supportsPredicates);
+    }
 }

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchQueryBuilder.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchQueryBuilder.java
@@ -27,6 +27,9 @@ import org.elasticsearch.index.query.QueryStringQueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.query.RegexpQueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.index.query.NestedQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.ScoreMode;
 
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -168,5 +171,20 @@ public final class ElasticsearchQueryBuilder
                     .format(ISO_DATE_TIME);
         }
         throw new IllegalArgumentException("Unhandled type: " + type);
+    }
+
+    private static void buildTermQuery(String columnName, Object value, QueryBuilder queryBuilder)
+    {
+        String[] parts = columnName.split("\\.");
+        if (parts.length > 1) {
+            NestedQueryBuilder nestedQuery = QueryBuilders.nestedQuery(
+                    String.join(".", Arrays.copyOfRange(parts, 0, parts.length - 1)),
+                    QueryBuilders.termQuery(columnName, value),
+                    ScoreMode.None);
+            queryBuilder.must(nestedQuery);
+        }
+        else {
+            queryBuilder.must(QueryBuilders.termQuery(columnName, value));
+        }
     }
 }


### PR DESCRIPTION
## Description
Add dereference pushdown support in Elasticsearch. Learn more about dereference pushdown at https://trino.io/docs/current/optimizer/pushdown.html#dereference-pushdown

## Additional context and related issues
This issue primarily aligns with issue #22646, which also focuses on enhancing Elasticsearch's capability by adding dereference pushdown support. Similar optimizations are introduced here to improve query performance when accessing nested fields.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
## Elasticsearch
* Improve performance of queries that reference nested fields from Elasticsearch documents. ({issue}`23069`)
```
