### PR TITLE
Implement parallel jdbc driver

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
@@ -300,6 +300,9 @@ public class ClientOptions
     @Option(names = "--decimal-data-size", description = "Show data size and rate in base 10 rather than base 2")
     public boolean decimalDataSize;
 
+    @Option(names = "--prefetch-buffer-size", paramLabel = "<prefetch-buffer-size>", defaultValue = "64000", description = "Experimental spooled protocol prefetch buffer size, default: + " + DEFAULT_VALUE)
+    public String prefetchBufferSize;
+
     public enum OutputFormat
     {
         AUTO,
@@ -346,6 +349,7 @@ public class ClientOptions
                 .toClientSessionBuilder()
                 .source(uri.getSource().orElse(SOURCE_DEFAULT))
                 .encoding(encoding)
+                .prefetchBufferSize(prefetchBufferSize)
                 .build();
     }
 

--- a/client/trino-cli/src/test/java/io/trino/cli/TestClientOptions.java
+++ b/client/trino-cli/src/test/java/io/trino/cli/TestClientOptions.java
@@ -48,6 +48,15 @@ public class TestClientOptions
         assertThat(session.getServer().toString()).isEqualTo("http://localhost:8080");
         assertThat(session.getSource()).isEqualTo("trino-cli");
         assertThat(session.getTimeZone()).isEqualTo(ZoneId.systemDefault());
+        assertThat(session.getPrefetchBufferSize()).isEqualTo("64000000");
+    }
+
+    @Test
+    public void testPrefetchBufferSize()
+    {
+        Console console = createConsole("--prefetch-buffer-size=32000");
+        ClientSession session = console.clientOptions.toClientSession(console.clientOptions.getTrinoUri());
+        assertThat(session.getPrefetchBufferSize()).isEqualTo("32000");
     }
 
     @Test

--- a/client/trino-client/src/main/java/io/trino/client/ClientSession.java
+++ b/client/trino-client/src/main/java/io/trino/client/ClientSession.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -57,6 +58,9 @@ public class ClientSession
     private final Duration clientRequestTimeout;
     private final boolean compressionDisabled;
     private Optional<String> encoding;
+    private final String prefetchBufferSize;
+    private final ExecutorService decoderExecutorService;
+    private final ExecutorService segmentLoaderExecutorService;
 
     public static Builder builder()
     {
@@ -97,7 +101,10 @@ public class ClientSession
             String transactionId,
             Duration clientRequestTimeout,
             boolean compressionDisabled,
-            Optional<String> encoding)
+            Optional<String> encoding,
+            String prefetchBufferSize,
+            ExecutorService decoderExecutorService,
+            ExecutorService segmentLoaderExecutorService)
     {
         this.server = requireNonNull(server, "server is null");
         this.user = requireNonNull(user, "user is null");
@@ -121,6 +128,9 @@ public class ClientSession
         this.clientRequestTimeout = clientRequestTimeout;
         this.compressionDisabled = compressionDisabled;
         this.encoding = requireNonNull(encoding, "encoding is null");
+        this.prefetchBufferSize = requireNonNull(prefetchBufferSize, "prefetchBufferSize is null");
+        this.decoderExecutorService = requireNonNull(decoderExecutorService, "decoderExecutorService is null");
+        this.segmentLoaderExecutorService = requireNonNull(segmentLoaderExecutorService, "segmentLoaderExecutorService is null");
 
         for (String clientTag : clientTags) {
             checkArgument(!clientTag.contains(","), "client tag cannot contain ','");
@@ -269,6 +279,21 @@ public class ClientSession
         return encoding;
     }
 
+    public String getPrefetchBufferSize()
+    {
+        return prefetchBufferSize;
+    }
+
+    public ExecutorService getDecoderExecutorService()
+    {
+        return decoderExecutorService;
+    }
+
+    public ExecutorService getSegmentLoaderExecutorService()
+    {
+        return segmentLoaderExecutorService;
+    }
+
     @Override
     public String toString()
     {
@@ -292,6 +317,7 @@ public class ClientSession
                 .add("clientRequestTimeout", clientRequestTimeout)
                 .add("compressionDisabled", compressionDisabled)
                 .add("encoding", encoding)
+                .add("prefetchBufferSize", prefetchBufferSize)
                 .omitNullValues()
                 .toString();
     }
@@ -320,6 +346,9 @@ public class ClientSession
         private Duration clientRequestTimeout;
         private boolean compressionDisabled;
         private Optional<String> encoding = Optional.empty();
+        private String prefetchBufferSize;
+        private ExecutorService decoderExecutorService;
+        private ExecutorService segmentLoaderExecutorService;
 
         private Builder() {}
 
@@ -482,6 +511,24 @@ public class ClientSession
             return this;
         }
 
+        public Builder prefetchBufferSize(String prefetchBufferSize)
+        {
+            this.prefetchBufferSize = prefetchBufferSize;
+            return this;
+        }
+
+        public Builder decoderExecutorService(ExecutorService decoderExecutorService)
+        {
+            this.decoderExecutorService = decoderExecutorService;
+            return this;
+        }
+
+        public Builder segmentLoaderExecutorService(ExecutorService segmentLoaderExecutorService)
+        {
+            this.segmentLoaderExecutorService = segmentLoaderExecutorService;
+            return this;
+        }
+
         public ClientSession build()
         {
             return new ClientSession(
@@ -506,7 +553,10 @@ public class ClientSession
                     transactionId,
                     clientRequestTimeout,
                     compressionDisabled,
-                    encoding);
+                    encoding,
+                    prefetchBufferSize,
+                    decoderExecutorService,
+                    segmentLoaderExecutorService);
         }
     }
 }

--- a/client/trino-client/src/main/java/io/trino/client/StatementClientV1.java
+++ b/client/trino-client/src/main/java/io/trino/client/StatementClientV1.java
@@ -130,7 +130,11 @@ class StatementClientV1
                 .collect(toImmutableSet())));
         this.compressionDisabled = session.isCompressionDisabled();
 
-        this.resultRowsDecoder = new ResultRowsDecoder(new OkHttpSegmentLoader(requireNonNull(segmentHttpCallFactory, "segmentHttpCallFactory is null")));
+        this.resultRowsDecoder = new ResultRowsDecoder(
+                new OkHttpSegmentLoader(requireNonNull(segmentHttpCallFactory, "segmentHttpCallFactory is null")),
+                session.getPrefetchBufferSize(),
+                session.getDecoderExecutorService(),
+                session.getSegmentLoaderExecutorService());
 
         Request request = buildQueryRequest(session, query, session.getEncoding());
         // Pass empty as materializedJsonSizeLimit to always materialize the first response

--- a/client/trino-client/src/main/java/io/trino/client/spooling/DeferredIterable.java
+++ b/client/trino-client/src/main/java/io/trino/client/spooling/DeferredIterable.java
@@ -15,31 +15,244 @@ package io.trino.client.spooling;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.ListIterator;
+import java.util.NoSuchElementException;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 public class DeferredIterable
         implements Iterable<List<Object>>
 {
-    private final Future<Iterable<List<Object>>> future;
+    private final Future<Iterable<List<Object>>> futureIterable;
+    private final long size;
     private final Callable<Void> cleanUpAction;
 
-    public DeferredIterable(Future<Iterable<List<Object>>> future, Callable<Void> cleanUpAction)
+    public DeferredIterable(Future<Iterable<List<Object>>> futureIterable, long size, Callable<Void> cleanUpAction)
     {
-        this.future = future;
+        this.futureIterable = futureIterable;
+        this.size = size;
         this.cleanUpAction = cleanUpAction;
     }
 
     @Override
     public Iterator<List<Object>> iterator()
     {
-        try {
-            // blocks until the data has been downloaded and decoded
-            return new CleanupIterator(future.get().iterator(), cleanUpAction);
-        }
-        catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        return new CleanupIterator(new Iterator<List<Object>>()
+        {
+            private Iterator<List<Object>> actualIterator;
+            private int currentIndex;
+
+            private void initializeIterator()
+            {
+                if (actualIterator == null) {
+                    try {
+                        Iterable<List<Object>> iterable = futureIterable.get();
+                        actualIterator = iterable.iterator();
+                    }
+                    catch (InterruptedException | ExecutionException e) {
+                        throw new RuntimeException("Error while retrieving the future", e);
+                    }
+                }
+            }
+
+            @Override
+            public boolean hasNext()
+            {
+                return currentIndex < size;
+            }
+
+            @Override
+            public List<Object> next()
+            {
+                if (!hasNext()) {
+                    throw new NoSuchElementException("No more elements available");
+                }
+                currentIndex++;
+
+                // Return a lazy proxy for the actual list
+                return new LazyListProxy();
+            }
+
+            // Lazy proxy for List<Object>
+            class LazyListProxy
+                    implements List<Object>
+            {
+                private List<Object> actualList;
+
+                private void initializeList()
+                {
+                    if (actualList == null) {
+                        initializeIterator();
+                        if (!actualIterator.hasNext()) {
+                            throw new IllegalStateException("Underlying data has fewer elements than expected");
+                        }
+                        actualList = actualIterator.next();
+                    }
+                }
+
+                @Override
+                public int size()
+                {
+                    initializeList();
+                    return actualList.size();
+                }
+
+                @Override
+                public boolean isEmpty()
+                {
+                    initializeList();
+                    return actualList.isEmpty();
+                }
+
+                @Override
+                public boolean contains(Object o)
+                {
+                    initializeList();
+                    return actualList.contains(o);
+                }
+
+                @Override
+                public Iterator<Object> iterator()
+                {
+                    initializeList();
+                    return actualList.iterator();
+                }
+
+                @Override
+                public Object[] toArray()
+                {
+                    initializeList();
+                    return actualList.toArray();
+                }
+
+                @Override
+                public <T> T[] toArray(T[] a)
+                {
+                    initializeList();
+                    return actualList.toArray(a);
+                }
+
+                @Override
+                public boolean add(Object o)
+                {
+                    initializeList();
+                    return actualList.add(o);
+                }
+
+                @Override
+                public boolean remove(Object o)
+                {
+                    initializeList();
+                    return actualList.remove(o);
+                }
+
+                @Override
+                public boolean containsAll(java.util.Collection<?> c)
+                {
+                    initializeList();
+                    return actualList.containsAll(c);
+                }
+
+                @Override
+                public boolean addAll(java.util.Collection<? extends Object> c)
+                {
+                    initializeList();
+                    return actualList.addAll(c);
+                }
+
+                @Override
+                public boolean addAll(int index, java.util.Collection<? extends Object> c)
+                {
+                    initializeList();
+                    return actualList.addAll(index, c);
+                }
+
+                @Override
+                public boolean removeAll(java.util.Collection<?> c)
+                {
+                    initializeList();
+                    return actualList.removeAll(c);
+                }
+
+                @Override
+                public boolean retainAll(java.util.Collection<?> c)
+                {
+                    initializeList();
+                    return actualList.retainAll(c);
+                }
+
+                @Override
+                public void clear()
+                {
+                    initializeList();
+                    actualList.clear();
+                }
+
+                @Override
+                public Object get(int index)
+                {
+                    initializeList();
+                    return actualList.get(index);
+                }
+
+                @Override
+                public Object set(int index, Object element)
+                {
+                    initializeList();
+                    return actualList.set(index, element);
+                }
+
+                @Override
+                public void add(int index, Object element)
+                {
+                    initializeList();
+                    actualList.add(index, element);
+                }
+
+                @Override
+                public Object remove(int index)
+                {
+                    initializeList();
+                    return actualList.remove(index);
+                }
+
+                @Override
+                public int indexOf(Object o)
+                {
+                    initializeList();
+                    return actualList.indexOf(o);
+                }
+
+                @Override
+                public int lastIndexOf(Object o)
+                {
+                    initializeList();
+                    return actualList.lastIndexOf(o);
+                }
+
+                @Override
+                public ListIterator<Object> listIterator()
+                {
+                    initializeList();
+                    return actualList.listIterator();
+                }
+
+                @Override
+                public ListIterator<Object> listIterator(int index)
+                {
+                    initializeList();
+                    return actualList.listIterator(index);
+                }
+
+                @Override
+                public List<Object> subList(int fromIndex, int toIndex)
+                {
+                    initializeList();
+                    return actualList.subList(fromIndex, toIndex);
+                }
+            }
+        }, cleanUpAction);
     }
 
     private static class CleanupIterator

--- a/client/trino-client/src/main/java/io/trino/client/spooling/DeferredIterable.java
+++ b/client/trino-client/src/main/java/io/trino/client/spooling/DeferredIterable.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client.spooling;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+
+public class DeferredIterable
+        implements Iterable<List<Object>>
+{
+    private final Future<Iterable<List<Object>>> future;
+    private final Callable<Void> cleanUpAction;
+
+    public DeferredIterable(Future<Iterable<List<Object>>> future, Callable<Void> cleanUpAction)
+    {
+        this.future = future;
+        this.cleanUpAction = cleanUpAction;
+    }
+
+    @Override
+    public Iterator<List<Object>> iterator()
+    {
+        try {
+            // blocks until the data has been downloaded and decoded
+            return new CleanupIterator(future.get().iterator(), cleanUpAction);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static class CleanupIterator
+            implements Iterator<List<Object>>
+    {
+        private final Iterator<List<Object>> delegate;
+        private boolean isDone;
+        private final Callable<Void> cleanUpAction;
+
+        public CleanupIterator(Iterator<List<Object>> delegate, Callable<Void> cleanUpAction)
+        {
+            this.delegate = delegate;
+            this.cleanUpAction = cleanUpAction;
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            boolean hasNext = delegate.hasNext();
+            if (!hasNext) {
+                cleanup();
+            }
+            return hasNext;
+        }
+
+        @Override
+        public List<Object> next()
+        {
+            return delegate.next();
+        }
+
+        @Override
+        public void remove()
+        {
+            delegate.remove();
+        }
+
+        private void cleanup()
+        {
+            if (!isDone) {
+                isDone = true;
+                try {
+                    cleanUpAction.call();
+                }
+                catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/uri/ConnectionProperties.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/ConnectionProperties.java
@@ -110,6 +110,7 @@ final class ConnectionProperties
     public static final ConnectionProperty<String, ZoneId> TIMEZONE = new TimeZone();
     public static final ConnectionProperty<String, Boolean> EXPLICIT_PREPARE = new ExplicitPrepare();
     public static final ConnectionProperty<String, Boolean> ASSUME_NULL_CATALOG_MEANS_CURRENT_CATALOG = new AssumeNullCatalogMeansCurrentCatalog();
+    public static final ConnectionProperty<String, String> PREFETCH_BUFFER_SIZE = new PrefetchBufferSize();
     public static final ConnectionProperty<String, Locale> LOCALE = new UserLocale();
     public static final ConnectionProperty<String, Duration> TIMEOUT = new Timeout();
     public static final ConnectionProperty<String, LoggingLevel> HTTP_LOGGING_LEVEL = new HttpLoggingLevel();
@@ -148,6 +149,7 @@ final class ConnectionProperties
             .add(KERBEROS_REMOTE_SERVICE_NAME)
             .add(KERBEROS_SERVICE_PRINCIPAL_PATTERN)
             .add(KERBEROS_USE_CANONICAL_HOSTNAME)
+            .add(PREFETCH_BUFFER_SIZE)
             .add(LOCALE)
             .add(PASSWORD)
             .add(RESOURCE_ESTIMATES)
@@ -944,6 +946,15 @@ final class ConnectionProperties
         public AssumeNullCatalogMeansCurrentCatalog()
         {
             super(PropertyName.ASSUME_NULL_CATALOG_MEANS_CURRENT_CATALOG, NOT_REQUIRED, ALLOWED, BOOLEAN_CONVERTER);
+        }
+    }
+
+    private static class PrefetchBufferSize
+            extends AbstractConnectionProperty<String, String>
+    {
+        public PrefetchBufferSize()
+        {
+            super(PropertyName.PREFETCH_BUFFER_SIZE, NOT_REQUIRED, ALLOWED, STRING_CONVERTER);
         }
     }
 

--- a/client/trino-client/src/main/java/io/trino/client/uri/PropertyName.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/PropertyName.java
@@ -54,6 +54,7 @@ public enum PropertyName
     KERBEROS_USE_CANONICAL_HOSTNAME("KerberosUseCanonicalHostname"),
     LOCALE("locale"),
     PASSWORD("password"),
+    PREFETCH_BUFFER_SIZE("prefetchBufferSize"),
     SQL_PATH("path"),
     RESOURCE_ESTIMATES("resourceEstimates"),
     ROLES("roles"),

--- a/client/trino-client/src/main/java/io/trino/client/uri/TrinoUri.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/TrinoUri.java
@@ -74,6 +74,7 @@ import static io.trino.client.uri.ConnectionProperties.KERBEROS_SERVICE_PRINCIPA
 import static io.trino.client.uri.ConnectionProperties.KERBEROS_USE_CANONICAL_HOSTNAME;
 import static io.trino.client.uri.ConnectionProperties.LOCALE;
 import static io.trino.client.uri.ConnectionProperties.PASSWORD;
+import static io.trino.client.uri.ConnectionProperties.PREFETCH_BUFFER_SIZE;
 import static io.trino.client.uri.ConnectionProperties.RESOURCE_ESTIMATES;
 import static io.trino.client.uri.ConnectionProperties.ROLES;
 import static io.trino.client.uri.ConnectionProperties.SCHEMA;
@@ -415,6 +416,11 @@ public class TrinoUri
     public Optional<Boolean> getAssumeNullCatalogMeansCurrentCatalog()
     {
         return resolveOptional(ASSUME_NULL_CATALOG_MEANS_CURRENT_CATALOG);
+    }
+
+    public String getPrefetchBufferSize()
+    {
+        return resolveWithDefault(PREFETCH_BUFFER_SIZE, "64000000");
     }
 
     public boolean isCompressionDisabled()
@@ -820,6 +826,11 @@ public class TrinoUri
         public Builder setAssumeLiteralUnderscoreInMetadataCallsForNonConformingClients(boolean value)
         {
             return setProperty(ASSUME_LITERAL_UNDERSCORE_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS, value);
+        }
+
+        public Builder setPrefetchBufferSize(String prefetchBufferSize)
+        {
+            return setProperty(PREFETCH_BUFFER_SIZE, requireNonNull(prefetchBufferSize, "prefetchBufferSize is null"));
         }
 
         public Builder setSsl(Boolean ssl)

--- a/client/trino-jdbc/pom.xml
+++ b/client/trino-jdbc/pom.xml
@@ -279,7 +279,19 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-spooling-filesystem</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing-containers</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/NonRegisteringTrinoDriver.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/NonRegisteringTrinoDriver.java
@@ -35,7 +35,7 @@ import static io.trino.jdbc.DriverInfo.DRIVER_NAME;
 import static io.trino.jdbc.DriverInfo.DRIVER_VERSION;
 import static io.trino.jdbc.DriverInfo.DRIVER_VERSION_MAJOR;
 import static io.trino.jdbc.DriverInfo.DRIVER_VERSION_MINOR;
-import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.Executors.newFixedThreadPool;
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
 
 public class NonRegisteringTrinoDriver
@@ -53,8 +53,9 @@ public class NonRegisteringTrinoDriver
         this.pool = new ConnectionPool();
         this.decoder = newSingleThreadExecutor(
                 new ThreadFactoryBuilder().setNameFormat("Decoder-%s").setDaemon(true).build());
-        this.segmentLoader = newCachedThreadPool(
-            new ThreadFactoryBuilder().setNameFormat("Segment loader worker-%s").setDaemon(true).build());
+        this.segmentLoader = newFixedThreadPool(
+                5,
+                new ThreadFactoryBuilder().setNameFormat("Segment loader worker-%s").setDaemon(true).build());
     }
 
     @Override

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcResultSetWithEncoding.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcResultSetWithEncoding.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.jdbc;
+
+import io.airlift.log.Logging;
+import io.trino.plugin.memory.MemoryPlugin;
+import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.server.testing.TestingTrinoServer;
+import io.trino.spooling.filesystem.FileSystemSpoolingPlugin;
+import io.trino.testing.containers.Minio;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Map;
+import java.util.UUID;
+
+import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
+import static io.trino.testing.containers.Minio.MINIO_REGION;
+import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static io.trino.util.Ciphers.createRandomAesEncryptionKey;
+import static java.lang.String.format;
+import static java.util.Base64.getEncoder;
+
+/**
+ * An integration test for JDBC client interacting with Trino server.
+ */
+public abstract class TestJdbcResultSetWithEncoding
+        extends BaseTestJdbcResultSet
+{
+    private static final String BUCKET_NAME = "segments" + UUID.randomUUID();
+    private Minio minio;
+    private TestingTrinoServer server;
+
+    @BeforeClass
+    public void setupServer()
+            throws Exception
+    {
+        Logging.initialize();
+        server = createTestingServer();
+        server.installPlugin(new TpchPlugin());
+        server.createCatalog("tpch", "tpch");
+        server.installPlugin(new MemoryPlugin());
+        server.createCatalog("memory", "memory");
+
+        try (Connection connection = createConnection(); Statement statement = connection.createStatement()) {
+            statement.executeUpdate("CREATE SCHEMA memory.tiny");
+            statement.executeUpdate("CREATE TABLE memory.tiny.lineitem as SELECT * from tpch.tiny.lineitem");
+        }
+    }
+
+    protected TestingTrinoServer createTestingServer()
+    {
+        minio = Minio.builder().build();
+        minio.start();
+        minio.createBucket(BUCKET_NAME, true);
+
+        Map<String, String> filesystemProperties = new java.util.HashMap<>();
+        filesystemProperties.put("fs.s3.enabled", "true");
+        filesystemProperties.put("fs.location", "s3://" + BUCKET_NAME + "/segments");
+        filesystemProperties.put("fs.segment.encryption", "false");
+        filesystemProperties.put("s3.endpoint", minio.getMinioAddress());
+        filesystemProperties.put("s3.region", MINIO_REGION);
+        filesystemProperties.put("s3.aws-access-key", MINIO_ACCESS_KEY);
+        filesystemProperties.put("s3.aws-secret-key", MINIO_SECRET_KEY);
+        filesystemProperties.put("s3.path-style-access", "true");
+        TestingTrinoServer server = TestingTrinoServer.builder()
+                .addProperty("experimental.protocol.spooling.enabled", "true")
+                .addProperty("protocol.spooling.shared-secret-key", randomAES256Key())
+                .build();
+        server.installPlugin(new FileSystemSpoolingPlugin());
+        server.loadSpoolingManager("filesystem", filesystemProperties);
+        return server;
+    }
+
+    private static String randomAES256Key()
+    {
+        return getEncoder().encodeToString(createRandomAesEncryptionKey().getEncoded());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDownServer()
+            throws Exception
+    {
+        minio.close();
+        server.close();
+        server = null;
+    }
+
+    @Override
+    protected Connection createConnection()
+            throws SQLException
+    {
+        String url = format("jdbc:trino://%s?encoding=%s", server.getAddress(), getEncoding());
+        return DriverManager.getConnection(url, "test", null);
+    }
+
+    protected abstract String getEncoding();
+}

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcResultSetWithJsonEncoding.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcResultSetWithJsonEncoding.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.jdbc;
+
+public class TestJdbcResultSetWithJsonEncoding
+        extends TestJdbcResultSetWithEncoding
+{
+    @Override
+    protected String getEncoding()
+    {
+        return "json";
+    }
+}

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcResultSetWithJsonStdEncoding.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcResultSetWithJsonStdEncoding.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.jdbc;
+
+public class TestJdbcResultSetWithJsonStdEncoding
+        extends TestJdbcResultSetWithEncoding
+{
+    @Override
+    protected String getEncoding()
+    {
+        return "json+zstd";
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Make use of the spooled protocol to parallelise downloading spooled segments.
Performance related fixes based on 


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Instead of using a `BlockingArrayQueue` we use `LinkedConcurrentQueue` and block memory allocation based on segment size (this is not based on memory size but on the file size of the segment.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(*) Release notes are required, with the following suggested text:

```markdown
## Section
* Implement parallel JDBC driver. ({issue}`issuenumber`)
```
