### PR TITLE
Improve exception logging when serializing invalid pages

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/protocol/JsonArrayResultsIterator.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/JsonArrayResultsIterator.java
@@ -113,9 +113,9 @@ public class JsonArrayResultsIterator
         List<Object> row = new ArrayList<>(columns.size());
         for (OutputColumn outputColumn : columns) {
             Type type = outputColumn.type();
-            Block block = currentPage.getBlock(outputColumn.sourcePageChannel());
 
             try {
+                Block block = currentPage.getBlock(outputColumn.sourcePageChannel());
                 Object value = type.getObjectValue(session.toConnectorSession(), block, inPageIndex);
                 if (!supportsParametricDateTime) {
                     value = getLegacyValue(value, type);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

When a page has fewer channels than output columns, log the full stack trace, and avoid producing an empty response. This makes debugging page sources easier.

This is the stack trace produced with this change:
```
io.trino.testing.QueryFailedException: Could not serialize column '_col0' of type 'bigint' at position 1:1
	at io.trino.testing.AbstractTestingTrinoClient.execute(AbstractTestingTrinoClient.java:134)
	at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:565)
	at io.trino.testing.DistributedQueryRunner.execute(DistributedQueryRunner.java:548)
	at io.trino.testing.QueryRunner.execute(QueryRunner.java:82)
	at io.trino.plugin.redshift.RedshiftQueryRunner.verifyLoadedDataHasSameSchema(RedshiftQueryRunner.java:194)
	... 9 more
	Suppressed: java.lang.Exception: SQL: SELECT count(*) FROM redshift.test_schema.customer
		at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:572)
		... 12 more
Caused by: io.trino.spi.TrinoException: Could not serialize column '_col0' of type 'bigint' at position 1:1
	at io.trino.server.protocol.JsonArrayResultsIterator.propagateException(JsonArrayResultsIterator.java:209)
	at io.trino.server.protocol.JsonArrayResultsIterator.getRowValues(JsonArrayResultsIterator.java:126)
	at io.trino.server.protocol.JsonArrayResultsIterator.computeNext(JsonArrayResultsIterator.java:101)
	at io.trino.server.protocol.JsonArrayResultsIterator.computeNext(JsonArrayResultsIterator.java:53)
	at com.google.common.collect.AbstractIterator.tryToComputeNext(AbstractIterator.java:145)
	at com.google.common.collect.AbstractIterator.hasNext(AbstractIterator.java:140)
	at com.fasterxml.jackson.databind.ser.std.IterableSerializer.serializeContents(IterableSerializer.java:81)
	at com.fasterxml.jackson.databind.ser.std.IterableSerializer.serialize(IterableSerializer.java:72)
	at com.fasterxml.jackson.databind.ser.std.IterableSerializer.serialize(IterableSerializer.java:12)
	at com.fasterxml.jackson.databind.ser.std.StdDelegatingSerializer.serialize(StdDelegatingSerializer.java:167)
	at com.fasterxml.jackson.databind.SerializerProvider.defaultSerializeValue(SerializerProvider.java:1172)
	at io.trino.server.protocol.spooling.QueryDataJacksonModule$Serializer.serialize(QueryDataJacksonModule.java:68)
	at io.trino.server.protocol.spooling.QueryDataJacksonModule$Serializer.serialize(QueryDataJacksonModule.java:54)
	at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:732)
	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:770)
	at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:184)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._serialize(DefaultSerializerProvider.java:502)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:341)
	at com.fasterxml.jackson.databind.ObjectWriter$Prefetch.serialize(ObjectWriter.java:1583)
	at com.fasterxml.jackson.databind.ObjectWriter.writeValue(ObjectWriter.java:1061)
	at io.airlift.jaxrs.JsonMapper.write(JsonMapper.java:103)
	at io.airlift.jaxrs.AbstractJacksonMapper.writeTo(AbstractJacksonMapper.java:156)
	at io.airlift.jaxrs.JsonMapper.writeTo(JsonMapper.java:41)
	at org.glassfish.jersey.message.internal.WriterInterceptorExecutor$TerminalWriterInterceptor.invokeWriteTo(WriterInterceptorExecutor.java:242)
	at org.glassfish.jersey.message.internal.WriterInterceptorExecutor$TerminalWriterInterceptor.aroundWriteTo(WriterInterceptorExecutor.java:227)
	at org.glassfish.jersey.message.internal.WriterInterceptorExecutor.proceed(WriterInterceptorExecutor.java:139)
	at org.glassfish.jersey.server.internal.JsonWithPaddingInterceptor.aroundWriteTo(JsonWithPaddingInterceptor.java:85)
	at org.glassfish.jersey.message.internal.WriterInterceptorExecutor.proceed(WriterInterceptorExecutor.java:139)
	at io.trino.server.IoExceptionSuppressingWriterInterceptor.aroundWriteTo(IoExceptionSuppressingWriterInterceptor.java:37)
	at org.glassfish.jersey.message.internal.WriterInterceptorExecutor.proceed(WriterInterceptorExecutor.java:139)
	at org.glassfish.jersey.server.internal.MappableExceptionWrapperInterceptor.aroundWriteTo(MappableExceptionWrapperInterceptor.java:61)
	at org.glassfish.jersey.message.internal.WriterInterceptorExecutor.proceed(WriterInterceptorExecutor.java:139)
	at org.glassfish.jersey.message.internal.MessageBodyFactory.writeTo(MessageBodyFactory.java:1116)
	at org.glassfish.jersey.server.ServerRuntime$Responder.writeResponse(ServerRuntime.java:691)
	at org.glassfish.jersey.server.ServerRuntime$Responder.processResponse(ServerRuntime.java:398)
	at org.glassfish.jersey.server.ServerRuntime$Responder.process(ServerRuntime.java:388)
	at org.glassfish.jersey.server.ServerRuntime$AsyncResponder$3.run(ServerRuntime.java:926)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:248)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:244)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:292)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:274)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:244)
	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:266)
	at org.glassfish.jersey.server.ServerRuntime$AsyncResponder.resume(ServerRuntime.java:963)
	at org.glassfish.jersey.server.ServerRuntime$AsyncResponder.resume(ServerRuntime.java:914)
	at io.airlift.jaxrs.AsyncResponseHandler$1.onSuccess(AsyncResponseHandler.java:99)
	at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1137)
	at io.airlift.concurrent.BoundedExecutor.drainQueue(BoundedExecutor.java:79)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1575)
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
	at io.trino.spi.Page.getBlock(Page.java:126)
	at io.trino.server.protocol.JsonArrayResultsIterator.getRowValues(JsonArrayResultsIterator.java:118)
	... 49 more
```

Before, the only logged error is:
```
Could not write to output: JsonMappingException(Index 0 out of bounds for length 0 (through reference chain: io.trino.client.QueryResults["data"]))
```

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
