### PR TITLE
Simplify toString of BigQuery table and column

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryColumnHandle.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryColumnHandle.java
@@ -83,4 +83,10 @@ public record BigQueryColumnHandle(
                 + estimatedSizeOf(subColumns, BigQueryColumnHandle::getRetainedSizeInBytes)
                 + estimatedSizeOf(description);
     }
+
+    @Override
+    public String toString()
+    {
+        return "%s:%s".formatted(getQualifiedName(), trinoType.getDisplayName());
+    }
 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryNamedRelationHandle.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryNamedRelationHandle.java
@@ -21,7 +21,6 @@ import io.trino.spi.connector.SchemaTableName;
 import java.util.Objects;
 import java.util.Optional;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 public class BigQueryNamedRelationHandle
@@ -105,11 +104,6 @@ public class BigQueryNamedRelationHandle
     @Override
     public String toString()
     {
-        return toStringHelper(this)
-                .add("remoteTableName", remoteTableName)
-                .add("schemaTableName", schemaTableName)
-                .add("type", type)
-                .add("comment", comment)
-                .toString();
+        return "%s:%s".formatted(remoteTableName, type);
     }
 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTableHandle.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTableHandle.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
 
 public record BigQueryTableHandle(
         BigQueryRelationHandle relationHandle,
@@ -71,6 +72,24 @@ public record BigQueryTableHandle(
     public boolean isQueryRelation()
     {
         return relationHandle instanceof BigQueryQueryRelationHandle;
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder builder = new StringBuilder();
+        builder.append(relationHandle);
+        if (constraint.isNone()) {
+            builder.append(" constraint=FALSE");
+        }
+        else if (!constraint.isAll()) {
+            builder.append(" constraint on ");
+            builder.append(constraint.getDomains().orElseThrow().keySet().stream()
+                    .map(columnHandle -> ((BigQueryColumnHandle) columnHandle).name())
+                    .collect(joining(", ", "[", "]")));
+        }
+        projectedColumns.ifPresent(columns -> builder.append(" columns=").append(columns));
+        return builder.toString();
     }
 
     public BigQueryNamedRelationHandle asPlainTable()

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
@@ -125,15 +125,6 @@ public abstract class BaseBigQueryConnectorTest
     }
 
     @Test
-    @Override // Override because the regexp is different from the base test
-    public void testPredicateReflectedInExplain()
-    {
-        assertExplain(
-                "EXPLAIN SELECT name FROM nation WHERE nationkey = 42",
-                "nationkey", "bigint", "42");
-    }
-
-    @Test
     public void testPredicatePushdown()
     {
         testPredicatePushdown("true", "true", true);


### PR DESCRIPTION
## Description

The current EXPLAIN with BigQuery connector is too verbose. 

Before:
```
 Trino version: testversion
 Fragment 0 [SOURCE]
     Output layout: [regionkey, name, comment]
     Output partitioning: SINGLE []
     Output[columnNames = [regionkey, name, comment]]
     │   Layout: [regionkey:bigint, name:varchar, comment:varchar]
     │   Estimates: {rows: ? (?), cpu: 0, memory: 0B, network: 0B}
     └─ TableScan[table = bigquery:BigQueryTableHandle[relationHandle=BigQueryNamedRelationHandle{remoteTableName=sep-bq-cicd.tpch.region, schemaTableName=tpch.region, type=TABLE, comment=Optional.empty}, constraint={BigQueryColumnHandle[name=regionkey, dereferenceNames=[], trinoType=bigint, bigqueryType=INT64, isPushdownSupported=true, mode=NULLABLE, subColumns=[], description=null, hidden=false]=[ SortedRangeSet[type=bigint, ranges=1, {[1]}] ]}, projectedColumns=Optional[[BigQueryColumnHandle[name=regionkey, dereferenceNames=[], trinoType=bigint, bigqueryType=INT64, isPushdownSupported=true, mode=NULLABLE, subColumns=[], description=null, hidden=false], BigQueryColumnHandle[name=name, dereferenceNames=[], trinoType=varchar, bigqueryType=STRING, isPushdownSupported=true, mode=NULLABLE, subColumns=[], description=null, hidden=false], BigQueryColumnHandle[name=comment, dereferenceNames=[], trinoType=varchar, bigqueryType=STRING, isPushdownSupported=true, mode=NULLABLE, subColumns=[], description=null, hidden=false]]]]]
            Layout: [regionkey:bigint, name:varchar, comment:varchar]
            Estimates: {rows: ? (?), cpu: ?, memory: 0B, network: 0B}
            name := BigQueryColumnHandle[name=name, dereferenceNames=[], trinoType=varchar, bigqueryType=STRING, isPushdownSupported=true, mode=NULLABLE, subColumns=[], description=null, hidden=false]
            regionkey := BigQueryColumnHandle[name=regionkey, dereferenceNames=[], trinoType=bigint, bigqueryType=INT64, isPushdownSupported=true, mode=NULLABLE, subColumns=[], description=null, hidden=false]
            comment := BigQueryColumnHandle[name=comment, dereferenceNames=[], trinoType=varchar, bigqueryType=STRING, isPushdownSupported=true, mode=NULLABLE, subColumns=[], description=null, hidden=false]
```

After:
```
 Trino version: testversion
 Fragment 0 [SOURCE]
     Output layout: [regionkey, name, comment]
     Output partitioning: SINGLE []
     Output[columnNames = [regionkey, name, comment]]
     │   Layout: [regionkey:bigint, name:varchar, comment:varchar]
     │   Estimates: {rows: ? (?), cpu: 0, memory: 0B, network: 0B}
     └─ TableScan[table = bigquery:sep-bq-cicd.tpch.region:TABLE constraint on [regionkey] columns=[regionkey:bigint, name:varchar, comment:varchar]]
            Layout: [regionkey:bigint, name:varchar, comment:varchar]
            Estimates: {rows: ? (?), cpu: ?, memory: 0B, network: 0B}
            name := name:varchar
            regionkey := regionkey:bigint
            comment := comment:varchar
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
