### PR TITLE
JSON predicate pushdown for Pinot

### DIFF
--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotConfig.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotConfig.java
@@ -62,6 +62,7 @@ public class PinotConfig
     private int maxRowsForBrokerQueries = 50_000;
     private boolean aggregationPushdownEnabled = true;
     private boolean countDistinctPushdownEnabled = true;
+    private boolean jsonPredicatePushdownEnabled;
     private boolean proxyEnabled;
     private DataSize targetSegmentPageSize = DataSize.of(1, MEGABYTE);
 
@@ -219,11 +220,24 @@ public class PinotConfig
         return countDistinctPushdownEnabled;
     }
 
+    public boolean isJsonPredicatePushdownEnabled()
+    {
+        return jsonPredicatePushdownEnabled;
+    }
+
     @Config("pinot.count-distinct-pushdown.enabled")
     @ConfigDescription("Controls whether distinct count is pushed down to Pinot. Distinct count pushdown can cause Pinot to do a full scan. Aggregation pushdown must also be enabled in addition to this parameter otherwise no pushdowns will be enabled.")
     public PinotConfig setCountDistinctPushdownEnabled(boolean countDistinctPushdownEnabled)
     {
         this.countDistinctPushdownEnabled = countDistinctPushdownEnabled;
+        return this;
+    }
+
+    @Config("pinot.json-predicate-pushdown.enabled")
+    @ConfigDescription("Controls whether JSON predicates are pushed down to Pinot. A JSON predicate is converted to a Pinot JSON_MATCH function call which generates an error when a JSON index is missing.")
+    public PinotConfig setJsonPredicatePushdownEnabled(boolean jsonPredicatePushdownEnabled)
+    {
+        this.jsonPredicatePushdownEnabled = jsonPredicatePushdownEnabled;
         return this;
     }
 

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotPageSourceProvider.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotPageSourceProvider.java
@@ -88,7 +88,7 @@ public class PinotPageSourceProvider
                 if (pinotTableHandle.query().isPresent()) {
                     DynamicTable dynamicTable = pinotTableHandle.query().get();
                     pinotQueryInfo = new PinotQueryInfo(dynamicTable.tableName(),
-                            extractPql(dynamicTable, pinotTableHandle.constraint()),
+                            extractPql(dynamicTable, pinotTableHandle.constraint(), pinotTableHandle.constraintPql()),
                             dynamicTable.groupingColumns().size());
                 }
                 else {

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotSessionProperties.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotSessionProperties.java
@@ -37,6 +37,7 @@ public class PinotSessionProperties
     private static final String SEGMENTS_PER_SPLIT = "segments_per_split";
     private static final String AGGREGATION_PUSHDOWN_ENABLED = "aggregation_pushdown_enabled";
     private static final String COUNT_DISTINCT_PUSHDOWN_ENABLED = "count_distinct_pushdown_enabled";
+    private static final String JSON_PREDICATE_PUSHDOWN_ENABLED = "json_predicate_pushdown_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -84,6 +85,11 @@ public class PinotSessionProperties
                         COUNT_DISTINCT_PUSHDOWN_ENABLED,
                         "Enable count distinct pushdown",
                         pinotConfig.isCountDistinctPushdownEnabled(),
+                        false),
+                booleanProperty(
+                        JSON_PREDICATE_PUSHDOWN_ENABLED,
+                        "Enable json predicate pushdown",
+                        pinotConfig.isJsonPredicatePushdownEnabled(),
                         false));
     }
 
@@ -128,6 +134,11 @@ public class PinotSessionProperties
         // This should never fail as this method would never be called unless aggregation pushdown is enabled
         verify(isAggregationPushdownEnabled(session), "%s must be enabled when %s is enabled", AGGREGATION_PUSHDOWN_ENABLED, COUNT_DISTINCT_PUSHDOWN_ENABLED);
         return session.getProperty(COUNT_DISTINCT_PUSHDOWN_ENABLED, Boolean.class);
+    }
+
+    public static boolean isJsonPredicatePushdownEnabled(ConnectorSession session)
+    {
+        return session.getProperty(JSON_PREDICATE_PUSHDOWN_ENABLED, Boolean.class);
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotTableHandle.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotTableHandle.java
@@ -30,7 +30,8 @@ public record PinotTableHandle(
         boolean enableNullHandling,
         TupleDomain<ColumnHandle> constraint,
         OptionalLong limit,
-        Optional<DynamicTable> query)
+        Optional<DynamicTable> query,
+        Optional<String> constraintPql)
         implements ConnectorTableHandle
 {
     public PinotTableHandle
@@ -40,6 +41,7 @@ public record PinotTableHandle(
         requireNonNull(constraint, "constraint is null");
         requireNonNull(limit, "limit is null");
         requireNonNull(query, "query is null");
+        requireNonNull(constraintPql, "constraintPql is null");
     }
 
     @Override

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/predicate/PinotEqualityPredicate.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/predicate/PinotEqualityPredicate.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.pinot.query.predicate;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.expression.Variable;
+import io.trino.spi.type.VarcharType;
+
+import java.util.List;
+
+import static java.lang.String.format;
+
+public class PinotEqualityPredicate
+        implements PinotPredicate
+{
+    private static final FunctionName EQUALS = new FunctionName("$equal");
+    private static final FunctionName NOT_EQUALS = new FunctionName("$not_equal");
+    private final String columnName;
+    private final String value;
+    private final String operator;
+    private final boolean valueIsString;
+
+    public PinotEqualityPredicate(Call call)
+    {
+        operator = EQUALS.equals(call.getFunctionName()) ? "=" : "!=";
+        List<ConnectorExpression> arguments = call.getArguments();
+        columnName = ((Variable) arguments.get(0)).getName();
+        Constant constant = (Constant) arguments.get(1);
+        if (constant.getType() instanceof VarcharType) {
+            valueIsString = true;
+            value = ((Slice) constant.getValue()).toStringUtf8();
+        }
+        else {
+            valueIsString = false;
+            value = constant.getValue().toString();
+        }
+    }
+
+    @Override
+    public String toPql()
+    {
+        String quote = valueIsString ? "'" : "";
+        return format("%s %s %s%s%s",
+                columnName, operator, quote, value, quote);
+    }
+
+    public static boolean supportsCall(Call call)
+    {
+        if (!EQUALS.equals(call.getFunctionName()) && !NOT_EQUALS.equals(call.getFunctionName())) {
+            return false;
+        }
+
+        List<ConnectorExpression> arguments = call.getArguments();
+        if (!(arguments.get(0) instanceof Variable && arguments.get(1) instanceof Constant)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/predicate/PinotJsonArrayContainsEqualsPredicate.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/predicate/PinotJsonArrayContainsEqualsPredicate.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.pinot.query.predicate;
+
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.type.BooleanType;
+
+import java.util.List;
+
+public class PinotJsonArrayContainsEqualsPredicate
+        implements PinotPredicate
+{
+    private static final FunctionName EQUALS = new FunctionName("$equal");
+    private static final FunctionName NOT_EQUALS = new FunctionName("$not_equal");
+    private String pql;
+
+    public PinotJsonArrayContainsEqualsPredicate(Call call)
+    {
+        List<ConnectorExpression> arguments = call.getArguments();
+        boolean negate = false;
+
+        boolean booleanValue = (boolean) ((Constant) arguments.get(1)).getValue();
+        if (EQUALS.equals(call.getFunctionName()) && !booleanValue) {
+            negate = true;
+        }
+        else if (NOT_EQUALS.equals(call.getFunctionName()) && booleanValue) {
+            negate = true;
+        }
+
+        pql = new PinotJsonArrayContainsPredicate((Call) arguments.getFirst()).toPql();
+        if (negate) {
+            pql = "NOT(" + pql + ")";
+        }
+    }
+
+    @Override
+    public String toPql()
+    {
+        return pql;
+    }
+
+    public static boolean supportsCall(Call call)
+    {
+        if (!EQUALS.equals(call.getFunctionName()) && !NOT_EQUALS.equals(call.getFunctionName())) {
+            return false;
+        }
+
+        List<ConnectorExpression> arguments = call.getArguments();
+
+        if (!PinotJsonArrayContainsPredicate.supportsCall((Call) arguments.getFirst())) {
+            return false;
+        }
+
+        return arguments.get(1) instanceof Constant && arguments.get(1).getType() instanceof BooleanType;
+    }
+}

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/predicate/PinotJsonArrayContainsPredicate.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/predicate/PinotJsonArrayContainsPredicate.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.pinot.query.predicate;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.expression.Variable;
+import io.trino.spi.type.VarcharType;
+
+import java.util.List;
+
+public class PinotJsonArrayContainsPredicate
+        implements PinotPredicate
+{
+    public static final FunctionName JSON_ARRAY_CONTAINS = new FunctionName("json_array_contains");
+    private final String columnName;
+    private final String jsonPath;
+    private final String value;
+    private final boolean valueIsString;
+
+    public PinotJsonArrayContainsPredicate(Call call)
+    {
+        List<ConnectorExpression> jsonArrayContainsCallArgs = call.getArguments();
+        Call jsonExtractCall = (Call) jsonArrayContainsCallArgs.get(0);
+        List<ConnectorExpression> args = jsonExtractCall.getArguments();
+        columnName = ((Variable) args.get(0)).getName();
+        jsonPath = ((Slice) ((Constant) args.get(1)).getValue()).toStringUtf8();
+
+        Constant constant = (Constant) jsonArrayContainsCallArgs.get(1);
+        if (constant.getType() instanceof VarcharType) {
+            valueIsString = true;
+            value = ((Slice) constant.getValue()).toStringUtf8();
+        }
+        else {
+            valueIsString = false;
+            value = constant.getValue().toString();
+        }
+    }
+
+    @Override
+    public String toPql()
+    {
+        String quote = valueIsString ? "''" : "";
+        return String.format("JSON_MATCH(%s, '\"%s[*]\" = %s%s%s')",
+                columnName, jsonPath, quote, value, quote);
+    }
+
+    public static boolean supportsCall(Call call)
+    {
+        if (!JSON_ARRAY_CONTAINS.equals(call.getFunctionName())) {
+            return false;
+        }
+
+        List<ConnectorExpression> arguments = call.getArguments();
+
+        if (arguments.size() != 2) {
+            return false;
+        }
+
+        if (!(arguments.get(0) instanceof Call || arguments.get(1) instanceof Constant)) {
+            return false;
+        }
+
+        return PinotPredicate.isSupportedCall((Call) arguments.get(0), "json_extract");
+    }
+}

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/predicate/PinotJsonContainsEqualsPredicate.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/predicate/PinotJsonContainsEqualsPredicate.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.pinot.query.predicate;
+
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.type.BooleanType;
+
+import java.util.List;
+
+public class PinotJsonContainsEqualsPredicate
+        implements PinotPredicate
+{
+    private static final FunctionName EQUALS = new FunctionName("$equal");
+    private static final FunctionName NOT_EQUALS = new FunctionName("$not_equal");
+    private final String pql;
+
+    public PinotJsonContainsEqualsPredicate(Call call)
+    {
+        List<ConnectorExpression> arguments = call.getArguments();
+        String operator = "IN (";
+
+        boolean booleanValue = (boolean) ((Constant) arguments.get(1)).getValue();
+        if (EQUALS.equals(call.getFunctionName()) && !booleanValue) {
+            operator = "NOT IN (";
+        }
+        else if (NOT_EQUALS.equals(call.getFunctionName()) && booleanValue) {
+            operator = "NOT IN (";
+        }
+
+        pql = new PinotJsonContainsPredicate((Call) arguments.getFirst())
+                .toPql()
+                .replace("IN (", operator);
+    }
+
+    @Override
+    public String toPql()
+    {
+        return pql;
+    }
+
+    public static boolean supportsCall(Call call)
+    {
+        if (!EQUALS.equals(call.getFunctionName()) && !NOT_EQUALS.equals(call.getFunctionName())) {
+            return false;
+        }
+
+        List<ConnectorExpression> arguments = call.getArguments();
+
+        if (!PinotJsonContainsPredicate.supportsCall((Call) arguments.getFirst())) {
+            return false;
+        }
+
+        return arguments.get(1) instanceof Constant && arguments.get(1).getType() instanceof BooleanType;
+    }
+}

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/predicate/PinotJsonContainsPredicate.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/predicate/PinotJsonContainsPredicate.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.pinot.query.predicate;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.block.IntArrayBlock;
+import io.trino.spi.block.VariableWidthBlock;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.expression.Variable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PinotJsonContainsPredicate
+        implements PinotPredicate
+{
+    private static final FunctionName CONTAINS = new FunctionName("contains");
+    private static final FunctionName CAST = new FunctionName("$cast");
+    private final String columnName;
+    private final String jsonPath;
+    private final List<String> values;
+    private final boolean valuesContainsStrings;
+
+    public PinotJsonContainsPredicate(Call call)
+    {
+        List<ConnectorExpression> containsCallArgs = call.getArguments();
+        Constant arrayArg = (Constant) containsCallArgs.getFirst();
+        values = new ArrayList<>();
+        if (arrayArg.getValue() instanceof VariableWidthBlock stringArray) {
+            valuesContainsStrings = true;
+            for (int index = 0; index < stringArray.getPositionCount(); index++) {
+                values.add(stringArray.getSlice(index).toStringUtf8());
+            }
+        }
+        else if (arrayArg.getValue() instanceof IntArrayBlock intArray) {
+            valuesContainsStrings = false;
+            for (int index = 0; index < intArray.getPositionCount(); index++) {
+                values.add(String.valueOf(intArray.getInt(index)));
+            }
+        }
+        else {
+            throw new IllegalArgumentException("Unsupported array argument type: " + arrayArg.getValue());
+        }
+
+        Call innerCall = (Call) containsCallArgs.get(1);
+        Call jsonExtractScalarCall = innerCall;
+        if (CAST.equals(innerCall.getFunctionName())) {
+            jsonExtractScalarCall = (Call) innerCall.getArguments().getFirst();
+        }
+
+        List<ConnectorExpression> args = jsonExtractScalarCall.getArguments();
+        columnName = ((Variable) args.get(0)).getName();
+        jsonPath = ((Slice) ((Constant) args.get(1)).getValue()).toStringUtf8();
+    }
+
+    @Override
+    public String toPql()
+    {
+        String escape = valuesContainsStrings ? "''" : "";
+        String values = String.join(String.format("%s,%s", escape, escape), this.values);
+        return String.format("JSON_MATCH(%s, '\"%s\" IN (%s%s%s)')",
+                columnName, jsonPath, escape, values, escape);
+    }
+
+    public static boolean supportsCall(Call call)
+    {
+        if (!CONTAINS.equals(call.getFunctionName())) {
+            return false;
+        }
+
+        List<ConnectorExpression> arguments = call.getArguments();
+        ConnectorExpression arrayArg = arguments.get(0);
+        if (!(arrayArg instanceof Constant) || !(arguments.get(1) instanceof Call innerCall)) {
+            return false;
+        }
+
+        Constant constant = (Constant) arrayArg;
+        if (!(constant.getValue() instanceof VariableWidthBlock || constant.getValue() instanceof IntArrayBlock)) {
+            return false;
+        }
+
+        if (CAST.equals(innerCall.getFunctionName())) {
+            List<ConnectorExpression> castArguments = innerCall.getArguments();
+            if (!(castArguments.getFirst() instanceof Call jsonExtracatScalarCall)) {
+                return false;
+            }
+            return PinotPredicate.isSupportedCall(jsonExtracatScalarCall, "json_extract_scalar");
+        }
+        return PinotPredicate.isSupportedCall(innerCall, "json_extract_scalar");
+    }
+}

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/predicate/PinotJsonExtractScalarIsNullPredicate.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/predicate/PinotJsonExtractScalarIsNullPredicate.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.pinot.query.predicate;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.expression.Variable;
+
+import java.util.List;
+
+public class PinotJsonExtractScalarIsNullPredicate
+        implements PinotPredicate
+{
+    private static final FunctionName IS_NULL = new FunctionName("$is_null");
+    private final String columnName;
+    private final String jsonPath;
+
+    public PinotJsonExtractScalarIsNullPredicate(Call call)
+    {
+        List<ConnectorExpression> arguments = call.getArguments();
+        Call innerCall = (Call) arguments.getFirst();
+        List<ConnectorExpression> innerArgs = innerCall.getArguments();
+        columnName = ((Variable) innerArgs.getFirst()).getName();
+        jsonPath = ((Slice) ((Constant) innerArgs.get(1)).getValue()).toStringUtf8();
+    }
+
+    @Override
+    public String toPql()
+    {
+        return String.format("JSON_MATCH(%s, '\"%s\" IS NULL')",
+                columnName, jsonPath);
+    }
+
+    public static boolean supportsCall(Call call)
+    {
+        if (!IS_NULL.equals(call.getFunctionName())) {
+            return false;
+        }
+
+        List<ConnectorExpression> arguments = call.getArguments();
+        if (!(arguments.getFirst() instanceof Call innerCall)) {
+            return false;
+        }
+
+        if (!PinotPredicate.isSupportedCall(innerCall, "json_extract_scalar")) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/predicate/PinotNotJsonArrayContainsPredicate.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/predicate/PinotNotJsonArrayContainsPredicate.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.pinot.query.predicate;
+
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.FunctionName;
+
+import java.util.List;
+
+public class PinotNotJsonArrayContainsPredicate
+        implements PinotPredicate
+{
+    private static final FunctionName NOT = new FunctionName("$not");
+    private final String pql;
+
+    public PinotNotJsonArrayContainsPredicate(Call call)
+    {
+        List<ConnectorExpression> arguments = call.getArguments();
+        pql = "NOT(" + new PinotJsonArrayContainsPredicate((Call) arguments.getFirst()).toPql() + ")";
+    }
+
+    @Override
+    public String toPql()
+    {
+        return pql;
+    }
+
+    public static boolean supportsCall(Call call)
+    {
+        if (!NOT.equals(call.getFunctionName())) {
+            return false;
+        }
+
+        List<ConnectorExpression> arguments = call.getArguments();
+
+        return PinotJsonArrayContainsPredicate.supportsCall((Call) arguments.getFirst());
+    }
+}

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/predicate/PinotNotJsonContainsPredicate.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/predicate/PinotNotJsonContainsPredicate.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.pinot.query.predicate;
+
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.FunctionName;
+
+import java.util.List;
+
+public class PinotNotJsonContainsPredicate
+        implements PinotPredicate
+{
+    private static final FunctionName NOT = new FunctionName("$not");
+    private final String pql;
+
+    public PinotNotJsonContainsPredicate(Call call)
+    {
+        List<ConnectorExpression> arguments = call.getArguments();
+        pql = new PinotJsonContainsPredicate((Call) arguments.getFirst())
+                .toPql()
+                .replace("IN (", "NOT IN (");
+    }
+
+    @Override
+    public String toPql()
+    {
+        return pql;
+    }
+
+    public static boolean supportsCall(Call call)
+    {
+        if (!NOT.equals(call.getFunctionName())) {
+            return false;
+        }
+
+        List<ConnectorExpression> arguments = call.getArguments();
+
+        return PinotJsonContainsPredicate.supportsCall((Call) arguments.getFirst());
+    }
+}

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/predicate/PinotPredicate.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/predicate/PinotPredicate.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.pinot.query.predicate;
+
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.expression.Variable;
+
+import java.util.List;
+
+public interface PinotPredicate
+{
+    static boolean supportsCall(Call call)
+    {
+        return false;
+    }
+
+    static boolean isSupportedCall(Call call, String functionName)
+    {
+        if (!new FunctionName(functionName).equals(call.getFunctionName())) {
+            return false;
+        }
+
+        List<ConnectorExpression> arguments = call.getArguments();
+        if (arguments.size() != 2) {
+            return false;
+        }
+
+        if (!(arguments.get(0) instanceof Variable) || !(arguments.get(1) instanceof Constant)) {
+            return false;
+        }
+
+        // TODO: resolve dependency issues to allow usage of io.trino.type.JsonType
+        // return arguments.get(0).getType() instanceof JsonType;
+
+        return true;
+    }
+
+    String toPql();
+}

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/PinotTpchTables.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/PinotTpchTables.java
@@ -128,11 +128,14 @@ public final class PinotTpchTables
                 .name("clerk").type().stringType().noDefault()
                 .name("shippriority").type().intType().noDefault()
                 .name("comment").type().stringType().noDefault()
+                .name("json").type().stringType().noDefault()
                 .name("updated_at").type().longType().noDefault()
                 .endRecord();
         ImmutableList.Builder<ProducerRecord<String, GenericRecord>> ordersRowsBuilder = ImmutableList.builder();
         MaterializedResult ordersRows = queryRunner.execute("SELECT * FROM tpch.tiny.orders");
         for (MaterializedRow row : ordersRows.getMaterializedRows()) {
+            String json = """
+                    { "orderstatus": "%s", "shippriority": %s, "stringArray": ["%s"], "intArray": [%s]}""".formatted(row.getField(2), row.getField(7), row.getField(2), row.getField(7));
             ordersRowsBuilder.add(new ProducerRecord<>(ordersTableName, "key" + row.getField(0), new GenericRecordBuilder(ordersSchema)
                     .set("orderkey", row.getField(0))
                     .set("custkey", row.getField(1))
@@ -143,6 +146,7 @@ public final class PinotTpchTables
                     .set("clerk", row.getField(6))
                     .set("shippriority", row.getField(7))
                     .set("comment", row.getField(8))
+                    .set("json", json)
                     .set("updated_at", INITIAL_UPDATED_AT.plusMillis(1000).toEpochMilli())
                     .build()));
         }

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotConfig.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotConfig.java
@@ -48,6 +48,7 @@ public class TestPinotConfig
                         .setMaxRowsForBrokerQueries(50_000)
                         .setAggregationPushdownEnabled(true)
                         .setCountDistinctPushdownEnabled(true)
+                        .setJsonPredicatePushdownEnabled(false)
                         .setProxyEnabled(false)
                         .setTargetSegmentPageSize(DataSize.of(1, MEGABYTE)));
     }
@@ -68,6 +69,7 @@ public class TestPinotConfig
                 .put("pinot.max-rows-for-broker-queries", "5000")
                 .put("pinot.aggregation-pushdown.enabled", "false")
                 .put("pinot.count-distinct-pushdown.enabled", "false")
+                .put("pinot.json-predicate-pushdown.enabled", "true")
                 .put("pinot.proxy.enabled", "true")
                 .put("pinot.target-segment-page-size", "2MB")
                 .buildOrThrow();
@@ -85,6 +87,7 @@ public class TestPinotConfig
                 .setMaxRowsForBrokerQueries(5000)
                 .setAggregationPushdownEnabled(false)
                 .setCountDistinctPushdownEnabled(false)
+                .setJsonPredicatePushdownEnabled(true)
                 .setProxyEnabled(true)
                 .setTargetSegmentPageSize(DataSize.of(2, MEGABYTE));
 

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotConnectorTest.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotConnectorTest.java
@@ -79,6 +79,7 @@ public class TestPinotConnectorTest
                 .row("clerk", "varchar", "", "") // String columns are reported only as varchar
                 .row("comment", "varchar", "", "")
                 .row("custkey", "bigint", "", "") // Long columns are reported as bigint
+                .row("json", "json", "", "")
                 .row("orderdate", "date", "", "")
                 .row("orderkey", "bigint", "", "")
                 .row("orderpriority", "varchar", "", "")
@@ -109,6 +110,7 @@ public class TestPinotConnectorTest
                VALUES
                    ('orders', 'orderkey'),
                    ('orders', 'custkey'),
+                   ('orders', 'json'),
                    ('orders', 'orderstatus'),
                    ('orders', 'totalprice'),
                    ('orders', 'orderdate'),
@@ -131,6 +133,7 @@ public class TestPinotConnectorTest
                            clerk varchar,
                            comment varchar,
                            custkey bigint,
+                           json json,
                            orderdate date,
                            orderkey bigint,
                            orderpriority varchar,

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotMetadata.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotMetadata.java
@@ -15,8 +15,15 @@ package io.trino.plugin.pinot;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import io.trino.spi.block.IntArrayBlockBuilder;
+import io.trino.spi.block.VariableWidthBlockBuilder;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.expression.Variable;
 import io.trino.spi.type.TestingTypeManager;
 import org.junit.jupiter.api.Test;
 
@@ -24,8 +31,13 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 
+import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.plugin.pinot.MetadataUtil.TEST_TABLE;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestPinotMetadata
 {
@@ -62,5 +74,198 @@ public class TestPinotMetadata
                 Optional.empty(),
                 Optional.empty());
         assertThat(withUppercaseTable.tableName()).isEqualTo("airlineStats");
+    }
+
+    @Test
+    public void testBuildConstraintSQLThrowsUnsupportedOperationException()
+    {
+        assertThatThrownBy(() ->
+                PinotMetadata.buildConstraintPql(
+                        new Call(BOOLEAN, new FunctionName("unsupported"), List.of()), null))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    public void testBuildConstraintPqlEqualsNotEqualsPredicate()
+    {
+        assertPQLEquals(getCall("$equal", "string"), "string = 'string'");
+        assertPQLEquals(getCall("$equal", "int"), "int = 1");
+        assertPQLEquals(getCall("$not_equal", "string"), "string != 'string'");
+        assertPQLEquals(getCall("$not_equal", "int"), "int != 1");
+    }
+
+    @Test
+    public void testBuildConstraintPqlJsonExtractIsNullPredicate()
+    {
+        assertPQLEquals(getCall("$is_null", "json_extract_scalar"),
+                "JSON_MATCH(json, '\"$.selector\" IS NULL')");
+    }
+
+    @Test
+    public void testBuildConstraintPqlJsonContainsPredicate()
+    {
+        assertPQLEquals(getCall("contains", "string_array"),
+                "JSON_MATCH(json, '\"$.selector\" IN (''a'',''b'',''c'')')");
+        assertPQLEquals(getCall("contains", "int_array"),
+                "JSON_MATCH(json, '\"$.selector\" IN (1)')");
+    }
+
+    @Test
+    public void testBuildConstraintPqlPinotJsonArrayContainsPredicate()
+    {
+        assertPQLEquals(getCall("json_array_contains", "array_contains_string"),
+                "JSON_MATCH(json, '\"$.selector[*]\" = ''string''')");
+        assertPQLEquals(getCall("json_array_contains", "array_contains_int"),
+                "JSON_MATCH(json, '\"$.selector[*]\" = 1')");
+    }
+
+    @Test
+    public void testBuildConstraintPqlPinotJsonArrayContainsEqualsPredicate()
+    {
+        // equals false case
+        assertPQLEquals(new Call(BOOLEAN, new FunctionName("$equal"), List.of(
+                        getCall("json_array_contains", "array_contains_string"),
+                        new Constant(false, BOOLEAN))),
+                "NOT(JSON_MATCH(json, '\"$.selector[*]\" = ''string'''))");
+
+        // equals true case
+        assertPQLEquals(new Call(BOOLEAN, new FunctionName("$equal"), List.of(
+                        getCall("json_array_contains", "array_contains_string"),
+                        new Constant(true, BOOLEAN))),
+                "JSON_MATCH(json, '\"$.selector[*]\" = ''string''')");
+
+        // not equals true case
+        assertPQLEquals(new Call(BOOLEAN, new FunctionName("$not_equal"), List.of(
+                        getCall("json_array_contains", "array_contains_string"),
+                        new Constant(true, BOOLEAN))),
+                "NOT(JSON_MATCH(json, '\"$.selector[*]\" = ''string'''))");
+
+        // not equals false case
+        assertPQLEquals(new Call(BOOLEAN, new FunctionName("$not_equal"), List.of(
+                        getCall("json_array_contains", "array_contains_string"),
+                        new Constant(false, BOOLEAN))),
+                "JSON_MATCH(json, '\"$.selector[*]\" = ''string''')");
+    }
+
+    @Test
+    public void testBuildConstraintPqlPinotNotJsonArrayContainsPredicate()
+    {
+        assertPQLEquals(new Call(BOOLEAN, new FunctionName("$not"), List.of(
+                        getCall("json_array_contains", "array_contains_string"))),
+                "NOT(JSON_MATCH(json, '\"$.selector[*]\" = ''string'''))");
+    }
+
+    @Test
+    public void testBuildConstraintPqlPinotJsonContainsEqualsPredicate()
+    {
+        // equals false case
+        Call containsCall = getCall("contains", "string_array");
+        assertPQLEquals(new Call(BOOLEAN, new FunctionName("$equal"), List.of(
+                containsCall,
+                new Constant(false, BOOLEAN))),
+                "JSON_MATCH(json, '\"$.selector\" NOT IN (''a'',''b'',''c'')')");
+
+        // equals true case
+        assertPQLEquals(new Call(BOOLEAN, new FunctionName("$equal"), List.of(
+                        containsCall,
+                        new Constant(true, BOOLEAN))),
+                "JSON_MATCH(json, '\"$.selector\" IN (''a'',''b'',''c'')')");
+
+        // not equals true case
+        assertPQLEquals(new Call(BOOLEAN, new FunctionName("$not_equal"), List.of(
+                        containsCall,
+                        new Constant(true, BOOLEAN))),
+                "JSON_MATCH(json, '\"$.selector\" NOT IN (''a'',''b'',''c'')')");
+
+        // not equals false case
+        assertPQLEquals(new Call(BOOLEAN, new FunctionName("$not_equal"), List.of(
+                        containsCall,
+                        new Constant(false, BOOLEAN))),
+                "JSON_MATCH(json, '\"$.selector\" IN (''a'',''b'',''c'')')");
+    }
+
+    @Test
+    public void testBuildConstraintPqlPinotNotJsonContainsPredicate()
+    {
+        assertPQLEquals(new Call(BOOLEAN, new FunctionName("$not"), List.of(
+                getCall("contains", "string_array"))),
+                "JSON_MATCH(json, '\"$.selector\" NOT IN (''a'',''b'',''c'')')");
+    }
+
+    @Test
+    public void testBuildConstraintPQLANDedPredicates()
+    {
+        assertPQLEquals(new Call(BOOLEAN, new FunctionName("$and"), List.of(
+                        getCall("$equal", "string"),
+                        getCall("$is_null", "json_extract_scalar"))),
+                "(string = 'string' AND JSON_MATCH(json, '\"$.selector\" IS NULL'))");
+    }
+
+    @Test
+    public void testBuildConstraintPQLORedPredicates()
+    {
+        assertPQLEquals(new Call(BOOLEAN, new FunctionName("$or"), List.of(
+                        getCall("$equal", "string"),
+                        getCall("$is_null", "json_extract_scalar"))),
+                "(string = 'string' OR JSON_MATCH(json, '\"$.selector\" IS NULL'))");
+    }
+
+    @Test
+    public void testBuildConstraintPQLNOTedExpression()
+    {
+        assertPQLEquals(new Call(BOOLEAN, new FunctionName("$not"), List.of(
+                new Call(BOOLEAN, new FunctionName("$or"), List.of(
+                        getCall("$equal", "string"),
+                        getCall("$is_null", "json_extract_scalar"))))),
+                "NOT((string = 'string' OR JSON_MATCH(json, '\"$.selector\" IS NULL')))");
+    }
+
+    private static Call getCall(String functionName, String argType)
+    {
+        List<ConnectorExpression> arguments = switch (argType) {
+            case "string" -> List.of(
+                    new Variable("string", VARCHAR),
+                    new Constant(utf8Slice("string"), VARCHAR));
+            case "int" -> List.of(
+                    new Variable("int", VARCHAR),
+                    new Constant(1, INTEGER));
+            case "json_extract", "json_extract_scalar" -> List.of(
+                    new Call(BOOLEAN, new FunctionName(argType), List.of(
+                            new Variable("json", VARCHAR),
+                            new Constant(utf8Slice("$.selector"), VARCHAR))));
+            case "string_array" -> List.of(
+                    new Constant(new VariableWidthBlockBuilder(null, 0, 0)
+                            .writeEntry(utf8Slice("a"))
+                            .writeEntry(utf8Slice("b"))
+                            .writeEntry(utf8Slice("c"))
+                            .buildValueBlock(), VARCHAR),
+                    new Call(BOOLEAN, new FunctionName("json_extract_scalar"), List.of(
+                            new Variable("json", VARCHAR),
+                            new Constant(utf8Slice("$.selector"), VARCHAR))));
+            case "int_array" -> List.of(
+                    new Constant(new IntArrayBlockBuilder(null, 0)
+                            .writeInt(1)
+                            .build(), INTEGER),
+                    getCall("$cast", "json_extract_scalar"));
+            case "array_contains_string" -> List.of(
+                    new Call(BOOLEAN, new FunctionName("json_extract"), List.of(
+                            new Variable("json", VARCHAR),
+                            new Constant(utf8Slice("$.selector"), VARCHAR))),
+                    new Constant(utf8Slice("string"), VARCHAR));
+            case "array_contains_int" -> List.of(
+                    new Call(BOOLEAN, new FunctionName("json_extract"), List.of(
+                            new Variable("json", VARCHAR),
+                            new Constant(utf8Slice("$.selector"), VARCHAR))),
+                    new Constant(1, INTEGER));
+            default -> List.of();
+        };
+        return new Call(BOOLEAN, new FunctionName(functionName), arguments);
+    }
+
+    private static void assertPQLEquals(Call call, String pql)
+    {
+        StringBuilder pqlBuilder = new StringBuilder();
+        PinotMetadata.buildConstraintPql(call, pqlBuilder);
+        assertThat(pqlBuilder.toString()).isEqualTo(pql);
     }
 }

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotSplitManager.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotSplitManager.java
@@ -53,7 +53,7 @@ public class TestPinotSplitManager
         SchemaTableName schemaTableName = new SchemaTableName("default", format("SELECT %s, %s FROM %s LIMIT %d", "AirlineID", "OriginStateName", "airlineStats", 100));
         DynamicTable dynamicTable = buildFromPql(pinotMetadata, schemaTableName, mockClusterInfoFetcher, TESTING_TYPE_CONVERTER);
 
-        PinotTableHandle pinotTableHandle = new PinotTableHandle("default", dynamicTable.tableName(), false, TupleDomain.all(), OptionalLong.empty(), Optional.of(dynamicTable));
+        PinotTableHandle pinotTableHandle = new PinotTableHandle("default", dynamicTable.tableName(), false, TupleDomain.all(), OptionalLong.empty(), Optional.of(dynamicTable), Optional.empty());
         List<PinotSplit> splits = getSplitsHelper(pinotTableHandle, 1, false);
         assertSplits(splits, 1, BROKER);
     }

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotTableHandle.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotTableHandle.java
@@ -55,6 +55,6 @@ public class TestPinotTableHandle
 
     public static PinotTableHandle newTableHandle(String schemaName, String tableName)
     {
-        return new PinotTableHandle(schemaName, tableName, false, TupleDomain.all(), OptionalLong.empty(), Optional.empty());
+        return new PinotTableHandle(schemaName, tableName, false, TupleDomain.all(), OptionalLong.empty(), Optional.empty(), Optional.empty());
     }
 }

--- a/plugin/trino-pinot/src/test/resources/orders_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/orders_realtimeSpec.json
@@ -21,6 +21,7 @@
         "noDictionaryColumns": [],
         "aggregateMetrics": "false",
         "nullHandlingEnabled": "true",
+        "jsonIndexColumns": ["json"],
         "streamConfigs": {
             "streamType": "kafka",
             "stream.kafka.consumer.type": "lowLevel",

--- a/plugin/trino-pinot/src/test/resources/orders_schema.json
+++ b/plugin/trino-pinot/src/test/resources/orders_schema.json
@@ -32,6 +32,10 @@
         {
             "name": "comment",
             "dataType": "STRING"
+        },
+        {
+            "name": "json",
+            "dataType": "JSON"
         }
     ],
     "dateTimeFieldSpecs": [

--- a/plugin/trino-pinot/src/test/resources/realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/realtimeSpec.json
@@ -20,6 +20,7 @@
     "invertedIndexColumns": ["vendor","city"],
     "noDictionaryColumns": [],
     "aggregateMetrics": "false",
+    "jsonIndexColumns": ["json"],
     "streamConfigs": {
       "streamType": "kafka",
       "stream.kafka.consumer.type": "LowLevel",

--- a/plugin/trino-pinot/src/test/resources/schema.json
+++ b/plugin/trino-pinot/src/test/resources/schema.json
@@ -34,6 +34,11 @@
       "name": "long_numbers",
       "dataType": "LONG",
       "singleValueField": false
+    },
+    {
+      "name": "json",
+      "dataType": "JSON",
+      "singleValueField": true
     }
   ],
   "metricFieldSpecs": [


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
These changes allow the Trino-Pinot connector to perform predicate pushdowns for a combination of JSON functions.

For example, the following Trino function calls:
```
where
    contains(ARRAY['O'], json_extract_scalar(json, '$.orderstatus')) 
    AND (
      json_array_contains(json_extract(json, '$.stringArray'), 'O') 
      OR json_array_contains(json_extract(json, '$.stringArray'), 'F') 
    ) 
    AND (
        json_extract_scalar(json, '$.dne') IS NULL 
        OR json_array_contains(json_extract(json, '$.stringArray'), 'X') = false
        OR json_array_contains(json_extract(json, '$.intArray'), 0)
    );
```

Are translated to the following Pinot function calls:
```
where (
    JSON_MATCH(json, '"$.orderstatus" in (''O'')') 
    AND (
        JSON_MATCH(json, '"$.stringArray[*]" = ''O''') 
        OR JSON_MATCH(json, '"$.stringArray[*]" = ''F''')
    ) 
    AND (
        JSON_MATCH(json, '"$.dne" IS NULL') 
        OR NOT(JSON_MATCH(json, '"$.stringArray[*]" = ''X'''))
        OR JSON_MATCH(json, '"$.intArray[*]" = 0')
    )
)
```

The new session property (`pinot.json_predicate_pushdown_enabled`) defaults to false because `JSON_MATCH` can fail when a JSON index hasn't been configured in Pinot.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
`PinotMetadata.applyFilter` calls `buildConstraintPQL` which recursively walks through the call tree and returns the converted SQL if the entire call tree is supported.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes
TODO

( ) This is not user-visible or is docs only, and no release notes are required.
(X) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

