### PR TITLE
Fix table stats docs for Vertica

### DIFF
--- a/docs/src/main/sphinx/connector/vertica.md
+++ b/docs/src/main/sphinx/connector/vertica.md
@@ -221,10 +221,8 @@ The connector supports pushdown for a number of operations:
 
 ### Table statistics
 
-You can use [](/sql/analyze) statements in Trino to populate the table
-statistics in Vertica. The [cost-based
-optimizer](/optimizer/cost-based-optimizations) then uses these statistics to
-improve query performance.
+The [cost-based optimizer](/optimizer/cost-based-optimizations) can use table
+statistics from the Vertica database to improve query performance.
 
 Support for table statistics is disabled by default. You can enable it with the
 catalog property `statistics.enabled` set to `true`. In addition, the


### PR DESCRIPTION
## Description

According to @ebyhr the connector does not support `analyze` .. so I think that means it doesnt support stats either.. but this is kinda a guess.

Updated now to only remove the analyze stuff

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Follow up to https://github.com/trinodb/trino/pull/23967#discussion_r1823511249


## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
