### PR TITLE
Add StartedQueries stat to InternalResourceGroup for tracking query start rate

### DIFF
--- a/core/trino-main/src/test/java/io/trino/execution/resourcegroups/TestResourceGroups.java
+++ b/core/trino-main/src/test/java/io/trino/execution/resourcegroups/TestResourceGroups.java
@@ -1302,17 +1302,20 @@ public class TestResourceGroups
                 // No op to allow the test fine-grained control about when to trigger the next query.
             }
         };
-        var rootA = root.getOrCreateSubGroup("a");
-        var rootA1 = rootA.getOrCreateSubGroup("1");
-        var rootB = root.getOrCreateSubGroup("b");
+        InternalResourceGroup rootA = root.getOrCreateSubGroup("a");
+        InternalResourceGroup rootA1 = rootA.getOrCreateSubGroup("1");
+        InternalResourceGroup rootB = root.getOrCreateSubGroup("b");
 
-        var allGroups = List.of(root, rootB, rootA, rootA1);
+        List<InternalResourceGroup> allGroups = List.of(root, rootB, rootA, rootA1);
         allGroups.forEach(group -> {
             group.setHardConcurrencyLimit(2);
             group.setMaxQueuedQueries(100);
         });
 
-        var queries = Stream.generate(() -> new MockManagedQueryExecutionBuilder().build()).limit(4).toArray(MockManagedQueryExecution[]::new);
+        MockManagedQueryExecution[] queries = Stream
+                .generate(() -> new MockManagedQueryExecutionBuilder().build())
+                .limit(4)
+                .toArray(MockManagedQueryExecution[]::new);
 
         rootB.run(queries[0]);
         // no values yet since there is no previous start time to compare against


### PR DESCRIPTION
## Description
Add a new `StartedQueries` stat to `InternalResourceGroup` to track the rate of queries being started/submitted to a resource group. After #22957 we have nearly all of the useful operational stats that you would want to know about a resource group (like CPU / memory, queued/running queries at any given time, etc.), but one thing that is missing is an understanding of the rate at which queries are being submitted into this resource group.

## Additional context and related issues
Currently we have a metric `TimeBetweenStartsSec` but it doesn't meet the needs described here:
1. It only tracks time between starts, not the count of queries
2. It doesn't count the first start after newly becoming eligible ([refer to this discussion](https://github.com/prestodb/presto/pull/10007#discussion_r171422808)), limiting its utility for tracking the query submission/start rate.
3. It currently appears to be broken in two ways; first, it only updates for non-leaf groups ([refer to this Slack discussion](https://trinodb.slack.com/archives/C07ABNN828M/p1729522974595069?thread_ts=1729270838.519639&cid=C07ABNN828M)); second, it is a `CounterStat`, but is trying to measure timing information, so it really should be a `TimeStat`. Currently it is putting timing information (count of seconds) into a `CounterStat` which doesn't really produce meaningful data.

Point (3) is fixable and I have a WIP to address it (https://github.com/xkrogen/trino/commit/c2d474deccc456b25ea124a5877b49455c246413), but after working on it I have become convinced that even if fixed, it is confusing and not useful. I am more inclined to just remove it and entirely replace it with this new metric. Will be happy to do that as a follow-on to this PR if others agree, or if there is consensus that `TimeBetweenStartsSec` indeed adds significant value and it's worth fixing the issues described in (3), I can finish up my WIP changes.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# General
* Expose query start count/rate metrics for resource groups. ({issue}`23984`)
```
