### PR TITLE
Add BigQuery release notes entry for 464

### DIFF
--- a/docs/src/main/sphinx/release/release-464.md
+++ b/docs/src/main/sphinx/release/release-464.md
@@ -15,6 +15,11 @@
 
 * {{breaking}} Remove the Accumulo connector. ({issue}`23792`)  
 
+## BigQuery connector
+
+* Fix incorrect results when reading array columns and
+  `bigquery.arrow-serialization.enabled` is set to true. ({issue}`23982`)
+
 ## Delta Lake connector
 
 * Fix failure of S3 file listing of buckets that enforce [requester


### PR DESCRIPTION
## Description

Follow up to #23881 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
