### PR TITLE
Add a function for testing Faker expressions

### DIFF
--- a/docs/src/main/sphinx/connector/faker.md
+++ b/docs/src/main/sphinx/connector/faker.md
@@ -126,6 +126,13 @@ See the Datafaker's documentation for more information about
 [the expression](https://www.datafaker.net/documentation/expressions/) syntax
 and [available providers](https://www.datafaker.net/documentation/providers/).
 
+To test a generator expression, without having to recreate the table, use the
+`random_string` function from the `default` schema:
+
+```sql
+SELECT default.random_string('#{Name.first_name}')
+```
+
 ### Non-character types
 
 Faker supports the following non-character types:

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerConnector.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerConnector.java
@@ -25,11 +25,13 @@ import io.trino.spi.connector.ConnectorPageSourceProvider;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.function.FunctionProvider;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.transaction.IsolationLevel;
 import jakarta.inject.Inject;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import static io.trino.spi.StandardErrorCode.INVALID_COLUMN_PROPERTY;
@@ -48,18 +50,21 @@ public class FakerConnector
     private final FakerSplitManager splitManager;
     private final FakerPageSourceProvider pageSourceProvider;
     private final FakerPageSinkProvider pageSinkProvider;
+    private final FakerFunctionProvider functionProvider;
 
     @Inject
     public FakerConnector(
             FakerMetadata metadata,
             FakerSplitManager splitManager,
             FakerPageSourceProvider pageSourceProvider,
-            FakerPageSinkProvider pageSinkProvider)
+            FakerPageSinkProvider pageSinkProvider,
+            FakerFunctionProvider functionProvider)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
         this.pageSinkProvider = requireNonNull(pageSinkProvider, "pageSinkProvider is null");
+        this.functionProvider = requireNonNull(functionProvider, "functionPovider is null");
     }
 
     @Override
@@ -164,5 +169,11 @@ public class FakerConnector
         if (!expression) {
             throw new TrinoException(errorCode, errorMessage);
         }
+    }
+
+    @Override
+    public Optional<FunctionProvider> getFunctionProvider()
+    {
+        return Optional.of(functionProvider);
     }
 }

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerFunctionProvider.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerFunctionProvider.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.faker;
+
+import com.google.inject.Inject;
+import io.trino.metadata.SqlScalarFunction;
+import io.trino.operator.scalar.annotations.ScalarFromAnnotationsParser;
+import io.trino.spi.function.BoundSignature;
+import io.trino.spi.function.FunctionDependencies;
+import io.trino.spi.function.FunctionId;
+import io.trino.spi.function.FunctionMetadata;
+import io.trino.spi.function.FunctionProvider;
+import io.trino.spi.function.InvocationConvention;
+import io.trino.spi.function.ScalarFunctionImplementation;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class FakerFunctionProvider
+        implements FunctionProvider
+{
+    private final List<SqlScalarFunction> functions;
+
+    @Inject
+    public FakerFunctionProvider()
+    {
+        functions = ScalarFromAnnotationsParser.parseFunctionDefinitions(FakerFunctions.class);
+    }
+
+    @Override
+    public ScalarFunctionImplementation getScalarFunctionImplementation(
+            FunctionId functionId,
+            BoundSignature boundSignature,
+            FunctionDependencies functionDependencies,
+            InvocationConvention invocationConvention)
+    {
+        return functions.stream()
+                .filter(function -> function.getFunctionMetadata().getFunctionId().equals(functionId))
+                .map(function -> function.specialize(boundSignature, functionDependencies))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown function " + functionId))
+                .getScalarFunctionImplementation(invocationConvention);
+    }
+
+    public List<FunctionMetadata> functionsMetadata()
+    {
+        return functions.stream()
+                .map(SqlScalarFunction::getFunctionMetadata)
+                .collect(toImmutableList());
+    }
+}

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerFunctions.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerFunctions.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.faker;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.function.Description;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlType;
+import net.datafaker.Faker;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.spi.type.StandardTypes.VARCHAR;
+
+public final class FakerFunctions
+{
+    private final Faker faker;
+
+    public FakerFunctions()
+    {
+        faker = new Faker();
+    }
+
+    @ScalarFunction(deterministic = false)
+    @Description("Generate a random string based on the Faker expression")
+    @SqlType(VARCHAR)
+    public Slice randomString(@SqlType(VARCHAR) Slice fakerExpression)
+    {
+        return utf8Slice(faker.expression(fakerExpression.toStringUtf8()));
+    }
+}

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerModule.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerModule.java
@@ -48,6 +48,7 @@ public class FakerModule
         binder.bind(FakerSplitManager.class).in(Scopes.SINGLETON);
         binder.bind(FakerPageSourceProvider.class).in(Scopes.SINGLETON);
         binder.bind(FakerPageSinkProvider.class).in(Scopes.SINGLETON);
+        binder.bind(FakerFunctionProvider.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(FakerConfig.class);
     }
 }

--- a/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerQueries.java
+++ b/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerQueries.java
@@ -246,6 +246,14 @@ final class TestFakerQueries
     }
 
     @Test
+    void testSelectFunctions()
+    {
+        @Language("SQL")
+        String testQuery = "SELECT faker.default.random_string('#{options.option ''a'', ''b''}') IN ('a', 'b')";
+        assertQuery(testQuery, "VALUES (true)");
+    }
+
+    @Test
     void testSelectRange()
     {
         @Language("SQL")


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Add a `random_string` function in the Faker connector that makes it easier to test generator expressions, before using it in column properties.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
