### PR TITLE
Increase allowed timeouts for BigQuery service

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryRpcConfig.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryRpcConfig.java
@@ -111,7 +111,7 @@ public class BigQueryRpcConfig
     }
 
     @Min(0)
-    @Max(16)
+    @Max(1024)
     public int getRetries()
     {
         return retries;
@@ -126,7 +126,7 @@ public class BigQueryRpcConfig
     }
 
     @MinDuration("0s")
-    @MaxDuration("1m")
+    @MaxDuration("30m")
     public Duration getTimeout()
     {
         return timeout;
@@ -141,7 +141,7 @@ public class BigQueryRpcConfig
     }
 
     @MinDuration("0s")
-    @MaxDuration("30s")
+    @MaxDuration("1m")
     public Duration getRetryDelay()
     {
         return retryDelay;


### PR DESCRIPTION
This should help to deal with Flakiness on CI with transient: 'Service is unavailable. Please retry.'

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
