### PR TITLE
Synchronize AutoCloseableCloser

### DIFF
--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/util/TestAutoCloseableCloser.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/util/TestAutoCloseableCloser.java
@@ -31,6 +31,18 @@ public class TestAutoCloseableCloser
     }
 
     @Test
+    public void testRegisterAfterClose()
+            throws Exception
+    {
+        AutoCloseableCloser closer = AutoCloseableCloser.create();
+        closer.close();
+        assertThatThrownBy(() -> closer.register(failingCloseable(new Exception("Expected failure"))))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Already closed")
+                .hasSuppressedException(new Exception("Expected failure"));
+    }
+
+    @Test
     public void testAllClosed()
     {
         assertAllClosed(succeedingCloseable(), succeedingCloseable());


### PR DESCRIPTION
## Description
Synchronizes access to the internal structure of AutoCloseableCloser, which previously allowed racey access to the underlying Deque of registered entries.

This was mostly an issue in test methods that could run concurrently with one another.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
