### PR TITLE
Skip unsupported timestamp type when reading views in BigQuery

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
@@ -565,10 +565,10 @@ public class BigQueryClient
 
         TableInfo tableInfo = getTable(tableHandle.asPlainTable().getRemoteTableName().toTableId())
                 .orElseThrow(() -> new TableNotFoundException(tableHandle.asPlainTable().getSchemaTableName()));
-        return buildColumnHandles(tableInfo);
+        return buildColumnHandles(tableInfo, tableHandle.relationHandle().isUseStorageApi());
     }
 
-    public List<BigQueryColumnHandle> buildColumnHandles(TableInfo tableInfo)
+    public List<BigQueryColumnHandle> buildColumnHandles(TableInfo tableInfo, boolean useStorageApi)
     {
         Schema schema = tableInfo.getDefinition().getSchema();
         if (schema == null) {
@@ -577,8 +577,8 @@ public class BigQueryClient
         }
         return schema.getFields()
                 .stream()
-                .filter(typeManager::isSupportedType)
-                .map(typeManager::toColumnHandle)
+                .filter(field -> typeManager.isSupportedType(field, useStorageApi))
+                .map(field -> typeManager.toColumnHandle(field, useStorageApi))
                 .collect(toImmutableList());
     }
 

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryNamedRelationHandle.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryNamedRelationHandle.java
@@ -31,6 +31,7 @@ public class BigQueryNamedRelationHandle
     private final String type;
     private final Optional<BigQueryPartitionType> partitionType;
     private final Optional<String> comment;
+    private final boolean useStorageApi;
 
     @JsonCreator
     public BigQueryNamedRelationHandle(
@@ -38,13 +39,15 @@ public class BigQueryNamedRelationHandle
             @JsonProperty("remoteTableName") RemoteTableName remoteTableName,
             @JsonProperty("type") String type,
             @JsonProperty("partitionType") Optional<BigQueryPartitionType> partitionType,
-            @JsonProperty("comment") Optional<String> comment)
+            @JsonProperty("comment") Optional<String> comment,
+            @JsonProperty("useStorageApi") boolean useStorageApi)
     {
         this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
         this.remoteTableName = requireNonNull(remoteTableName, "remoteTableName is null");
         this.type = requireNonNull(type, "type is null");
         this.partitionType = requireNonNull(partitionType, "partitionType is null");
         this.comment = requireNonNull(comment, "comment is null");
+        this.useStorageApi = useStorageApi;
     }
 
     @JsonProperty
@@ -75,6 +78,13 @@ public class BigQueryNamedRelationHandle
     public Optional<String> getComment()
     {
         return comment;
+    }
+
+    @JsonProperty
+    @Override
+    public boolean isUseStorageApi()
+    {
+        return useStorageApi;
     }
 
     @Override

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryQueryPageSource.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryQueryPageSource.java
@@ -197,7 +197,7 @@ public class BigQueryQueryPageSource
 
     private void appendTo(Type type, FieldValue value, BlockBuilder output)
     {
-        // TODO (https://github.com/trinodb/trino/issues/12346) Add support for bignumeric and timestamp with time zone types
+        // TODO (https://github.com/trinodb/trino/issues/12346) Add support for timestamp with time zone type
         if (value == null || value.isNull()) {
             output.appendNull();
             return;

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryQueryRelationHandle.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryQueryRelationHandle.java
@@ -49,6 +49,7 @@ public class BigQueryQueryRelationHandle
     }
 
     @JsonProperty
+    @Override
     public boolean isUseStorageApi()
     {
         return useStorageApi;

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryRelationHandle.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryRelationHandle.java
@@ -25,6 +25,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 })
 public abstract class BigQueryRelationHandle
 {
+    public abstract boolean isUseStorageApi();
+
     @Override
     public abstract String toString();
 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ptf/Query.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ptf/Query.java
@@ -122,11 +122,11 @@ public class Query
 
             ImmutableList.Builder<BigQueryColumnHandle> columnsBuilder = ImmutableList.builderWithExpectedSize(schema.getFields().size());
             for (com.google.cloud.bigquery.Field field : schema.getFields()) {
-                if (!typeManager.isSupportedType(field)) {
+                if (!typeManager.isSupportedType(field, useStorageApi)) {
                     // TODO: Skip unsupported type instead of throwing an exception
                     throw new TrinoException(NOT_SUPPORTED, "Unsupported type: " + field.getType());
                 }
-                columnsBuilder.add(typeManager.toColumnHandle(field));
+                columnsBuilder.add(typeManager.toColumnHandle(field, useStorageApi));
             }
 
             Descriptor returnedType = new Descriptor(columnsBuilder.build().stream()


### PR DESCRIPTION
## Description

Fix query failure when reading views having timestamp type in BigQuery connector.
Relates to https://github.com/trinodb/trino/issues/12346

## Release notes

```md
## BigQuery
* Fix failure when reading views which have `timestamp` columns. ({issue}`24004`)
```
