### PR TITLE
Make Faker deterministic

### DIFF
--- a/docs/src/main/sphinx/connector/faker.md
+++ b/docs/src/main/sphinx/connector/faker.md
@@ -284,7 +284,4 @@ CREATE TABLE generator.default.customer (
 
 ## Limitations
 
-- Generated data is not deterministic. There is no way to specify a seed for
-  the random generator. The same query reading from catalogs using this
-  connector, executed multiple times, returns different results each time.
 - It is not possible to choose the locale used by the Datafaker's generators.

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerSplit.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerSplit.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
-public record FakerSplit(List<HostAddress> addresses, long limit)
+public record FakerSplit(List<HostAddress> addresses, long splitNumber, long limit)
         implements ConnectorSplit
 {
     public FakerSplit

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerSplitManager.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerSplitManager.java
@@ -70,11 +70,11 @@ public class FakerSplitManager
         ImmutableList.Builder<ConnectorSplit> splits = ImmutableList.builder();
         for (long i = 0; i < splitCount - 1; i++) {
             HostAddress address = addresses.get((int) (i % addresses.size()));
-            splits.add(new FakerSplit(ImmutableList.of(address), MAX_ROWS_PER_SPLIT));
+            splits.add(new FakerSplit(ImmutableList.of(address), i, MAX_ROWS_PER_SPLIT));
         }
         HostAddress address = addresses.get((int) ((splitCount - 1) % addresses.size()));
         long limit = fakerTable.limit() % MAX_ROWS_PER_SPLIT;
-        splits.add(new FakerSplit(ImmutableList.of(address), limit == 0 ? MAX_ROWS_PER_SPLIT : limit));
+        splits.add(new FakerSplit(ImmutableList.of(address), splitCount - 1, limit == 0 ? MAX_ROWS_PER_SPLIT : limit));
         return new FixedSplitSource(splits.build());
     }
 }

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerSplitManager.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerSplitManager.java
@@ -73,7 +73,8 @@ public class FakerSplitManager
             splits.add(new FakerSplit(ImmutableList.of(address), MAX_ROWS_PER_SPLIT));
         }
         HostAddress address = addresses.get((int) ((splitCount - 1) % addresses.size()));
-        splits.add(new FakerSplit(ImmutableList.of(address), fakerTable.limit() % MAX_ROWS_PER_SPLIT));
+        long limit = fakerTable.limit() % MAX_ROWS_PER_SPLIT;
+        splits.add(new FakerSplit(ImmutableList.of(address), limit == 0 ? MAX_ROWS_PER_SPLIT : limit));
         return new FixedSplitSource(splits.build());
     }
 }

--- a/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerQueries.java
+++ b/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerQueries.java
@@ -18,6 +18,8 @@ import io.trino.testing.QueryRunner;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 
+import static io.trino.plugin.faker.FakerSplitManager.MAX_ROWS_PER_SPLIT;
+
 final class TestFakerQueries
         extends AbstractTestQueryFramework
 {
@@ -191,6 +193,9 @@ final class TestFakerQueries
         @Language("SQL")
         String testQuery = "SELECT count(rnd_bigint) FROM (SELECT rnd_bigint FROM single_column LIMIT 5) a";
         assertQuery(testQuery, "VALUES (5)");
+
+        testQuery = "SELECT count(rnd_bigint) FROM (SELECT rnd_bigint FROM single_column LIMIT %d) a".formatted(2*MAX_ROWS_PER_SPLIT);
+        assertQuery(testQuery, "VALUES (%d)".formatted(2*MAX_ROWS_PER_SPLIT));
 
         testQuery = "SELECT count(distinct rnd_bigint) FROM single_column LIMIT 5";
         assertQuery(testQuery, "VALUES (1000)");

--- a/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerQueries.java
+++ b/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerQueries.java
@@ -186,19 +186,39 @@ final class TestFakerQueries
     @Test
     void testSelectLimit()
     {
-        @Language("SQL")
-        String tableQuery = "CREATE TABLE faker.default.single_column (rnd_bigint bigint NOT NULL)";
-        assertUpdate(tableQuery);
+        assertUpdate("CREATE TABLE faker.default.single_column (rnd_bigint bigint NOT NULL)");
 
-        @Language("SQL")
-        String testQuery = "SELECT count(rnd_bigint) FROM (SELECT rnd_bigint FROM single_column LIMIT 5) a";
-        assertQuery(testQuery, "VALUES (5)");
+        assertQuery("SELECT count(rnd_bigint) FROM (SELECT rnd_bigint FROM single_column LIMIT 5) a",
+                "VALUES (5)");
 
-        testQuery = "SELECT count(rnd_bigint) FROM (SELECT rnd_bigint FROM single_column LIMIT %d) a".formatted(2*MAX_ROWS_PER_SPLIT);
-        assertQuery(testQuery, "VALUES (%d)".formatted(2*MAX_ROWS_PER_SPLIT));
+        assertQuery("""
+                    SELECT count(rnd_bigint)
+                    FROM (SELECT rnd_bigint FROM single_column LIMIT %d) a""".formatted(2 * MAX_ROWS_PER_SPLIT),
+                "VALUES (%d)".formatted(2 * MAX_ROWS_PER_SPLIT));
 
-        testQuery = "SELECT count(distinct rnd_bigint) FROM single_column LIMIT 5";
-        assertQuery(testQuery, "VALUES (1000)");
+        assertQuery("SELECT count(distinct rnd_bigint) FROM single_column LIMIT 5",
+                "VALUES (1000)");
+
+        assertQuery("""
+                    SELECT count(rnd_bigint)
+                    FROM (SELECT rnd_bigint FROM single_column LIMIT %d) a""".formatted(MAX_ROWS_PER_SPLIT),
+                "VALUES (%d)".formatted(MAX_ROWS_PER_SPLIT));
+
+        // generating data should be deterministic
+        String testQuery = """
+                           SELECT to_hex(checksum(rnd_bigint))
+                           FROM (SELECT rnd_bigint FROM single_column LIMIT %d) a""".formatted(3 * MAX_ROWS_PER_SPLIT);
+        assertQuery(testQuery, "VALUES ('1FB3289AC3A44EEA')");
+        assertQuery(testQuery, "VALUES ('1FB3289AC3A44EEA')");
+        assertQuery(testQuery, "VALUES ('1FB3289AC3A44EEA')");
+
+        // there should be no overlap between data generated from different splits
+        assertQuery("""
+                    SELECT count(1)
+                    FROM (SELECT rnd_bigint FROM single_column LIMIT %d) a
+                    JOIN (SELECT rnd_bigint FROM single_column LIMIT %d) b ON a.rnd_bigint = b.rnd_bigint""".formatted(2 * MAX_ROWS_PER_SPLIT, 5 * MAX_ROWS_PER_SPLIT),
+                "VALUES (%d)".formatted(2 * MAX_ROWS_PER_SPLIT));
+
         assertUpdate("DROP TABLE faker.default.single_column");
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Use a jumpable random generator and make sure to jump it a different number of times for every split.

Ref: https://docs.oracle.com/en/java/javase/23/core/choosing-prng-algorithm.html

## Release notes

```markdown
## Faker
* Make generated data deterministic. ({issue}`24008`)
```
