### PR TITLE
Use drop and create to replace a function on Hive Metastore

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
@@ -762,7 +762,11 @@ public class ThriftHiveMetastoreClient
     public void alterFunction(Function function)
             throws TException
     {
-        client.alterFunction(prependCatalogToDbName(catalogName, function.getDbName()), function.getFunctionName(), function);
+        // Hive 3 does not actually replace the content of the function
+        // https://github.com/apache/hive/blob/rel/release-3.1.2/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java#L9310
+        // Fall back to use drop & create for doing the replace function operation
+        dropFunction(function.getDbName(), function.getFunctionName());
+        createFunction(function);
     }
 
     @Override

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHive3OnDataLake.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHive3OnDataLake.java
@@ -1987,9 +1987,12 @@ public class TestHive3OnDataLake
         String name = "test_" + randomNameSuffix();
         String name2 = "test_" + randomNameSuffix();
 
-        assertUpdate("CREATE FUNCTION " + name + "(x integer) RETURNS bigint COMMENT 't42' RETURN x * 42");
+        assertUpdate("CREATE FUNCTION " + name + "(x integer) RETURNS bigint RETURN x * 10");
+        assertQuery("SELECT " + name + "(99)", "SELECT 990");
 
+        assertUpdate("CREATE OR REPLACE FUNCTION " + name + "(x integer) RETURNS bigint COMMENT 't42' RETURN x * 42");
         assertQuery("SELECT " + name + "(99)", "SELECT 4158");
+
         assertQueryFails("SELECT " + name + "(2.9)", ".*Unexpected parameters.*");
 
         assertUpdate("CREATE FUNCTION " + name + "(x double) RETURNS double COMMENT 't88' RETURN x * 8.8");


### PR DESCRIPTION
Hive 3 does not actually replace the content of the function

https://github.com/apache/hive/blob/rel/release-3.1.2/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java#L9310

Fall-back to using two operations: drop function followed create function for effectively handling the replace operation for the function when working with Hive Metastore.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Hive
* Use drop & create function when replacing an existing function backed by Hive Metastore  ({issue}`issuenumber`)
```
