### PR TITLE
Move nested namespace support in REST catalog behind a config

### DIFF
--- a/docs/src/main/sphinx/object-storage/metastores.md
+++ b/docs/src/main/sphinx/object-storage/metastores.md
@@ -500,6 +500,9 @@ following properties:
 * - `iceberg.rest-catalog.vended-credentials-enabled`
   - Use credentials provided by the REST backend for file system access.
     Defaults to `false`.
+* - `iceberg.rest-catalog.nested-namespace-enabled`
+  - Support querying objects under nested namespace.
+    Defaults to `false`.
   :::
 
 The following example shows a minimal catalog configuration using an Iceberg

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogConfig.java
@@ -39,6 +39,7 @@ public class IcebergRestCatalogConfig
     private Optional<String> prefix = Optional.empty();
     private Optional<String> warehouse = Optional.empty();
     private Namespace parentNamespace = Namespace.of();
+    private boolean nestedNamespaceEnabled;
     private Security security = Security.NONE;
     private SessionType sessionType = SessionType.NONE;
     private boolean vendedCredentialsEnabled;
@@ -95,6 +96,19 @@ public class IcebergRestCatalogConfig
     public IcebergRestCatalogConfig setParentNamespace(String parentNamespace)
     {
         this.parentNamespace = parentNamespace == null ? Namespace.empty() : Namespace.of(parentNamespace);
+        return this;
+    }
+
+    public boolean isNestedNamespaceEnabled()
+    {
+        return nestedNamespaceEnabled;
+    }
+
+    @Config("iceberg.rest-catalog.nested-namespace-enabled")
+    @ConfigDescription("Support querying objects under nested namespace")
+    public IcebergRestCatalogConfig setNestedNamespaceEnabled(boolean nestedNamespaceEnabled)
+    {
+        this.nestedNamespaceEnabled = nestedNamespaceEnabled;
         return this;
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
@@ -51,6 +51,7 @@ public class TrinoIcebergRestCatalogFactory
     private final Optional<String> prefix;
     private final Optional<String> warehouse;
     private final Namespace parentNamespace;
+    private final boolean nestedNamespaceEnabled;
     private final SessionType sessionType;
     private final boolean vendedCredentialsEnabled;
     private final SecurityProperties securityProperties;
@@ -78,6 +79,7 @@ public class TrinoIcebergRestCatalogFactory
         this.prefix = restConfig.getPrefix();
         this.warehouse = restConfig.getWarehouse();
         this.parentNamespace = restConfig.getParentNamespace();
+        this.nestedNamespaceEnabled = restConfig.isNestedNamespaceEnabled();
         this.sessionType = restConfig.getSessionType();
         this.vendedCredentialsEnabled = restConfig.isVendedCredentialsEnabled();
         this.securityProperties = requireNonNull(securityProperties, "securityProperties is null");
@@ -126,6 +128,7 @@ public class TrinoIcebergRestCatalogFactory
                 sessionType,
                 credentials,
                 parentNamespace,
+                nestedNamespaceEnabled,
                 trinoVersion,
                 typeManager,
                 uniqueTableLocation);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogConfig.java
@@ -32,6 +32,7 @@ public class TestIcebergRestCatalogConfig
                 .setPrefix(null)
                 .setWarehouse(null)
                 .setParentNamespace(null)
+                .setNestedNamespaceEnabled(false)
                 .setSessionType(IcebergRestCatalogConfig.SessionType.NONE)
                 .setSecurity(IcebergRestCatalogConfig.Security.NONE)
                 .setVendedCredentialsEnabled(false));
@@ -45,6 +46,7 @@ public class TestIcebergRestCatalogConfig
                 .put("iceberg.rest-catalog.prefix", "dev")
                 .put("iceberg.rest-catalog.warehouse", "test_warehouse_identifier")
                 .put("iceberg.rest-catalog.parent-namespace", "main")
+                .put("iceberg.rest-catalog.nested-namespace-enabled", "true")
                 .put("iceberg.rest-catalog.security", "OAUTH2")
                 .put("iceberg.rest-catalog.session", "USER")
                 .put("iceberg.rest-catalog.vended-credentials-enabled", "true")
@@ -55,6 +57,7 @@ public class TestIcebergRestCatalogConfig
                 .setPrefix("dev")
                 .setWarehouse("test_warehouse_identifier")
                 .setParentNamespace("main")
+                .setNestedNamespaceEnabled(true)
                 .setSessionType(IcebergRestCatalogConfig.SessionType.USER)
                 .setSecurity(IcebergRestCatalogConfig.Security.OAUTH2)
                 .setVendedCredentialsEnabled(true);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
@@ -86,6 +86,7 @@ public class TestTrinoRestCatalog
                 NONE,
                 ImmutableMap.of(),
                 Namespace.empty(),
+                false,
                 "test",
                 new TestingTypeManager(),
                 useUniqueTableLocations);


### PR DESCRIPTION
## Description

Closes https://github.com/trinodb/trino/issues/23961

## Release notes

```markdown
## Iceberg
* Allow configuring whether reading nested namespaces. This is controlled by the new `iceberg.rest-catalog.nested-namespace-enabled` 
  catalog configuration property and defaults to `false`. ({issue}`24016`)
```
