### PR TITLE
Handle edge cases when converting double from JSON to Trino types

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeParquetStatisticsUtils.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeParquetStatisticsUtils.java
@@ -18,6 +18,8 @@ import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
 import io.trino.parquet.metadata.ColumnChunkMetadata;
 import io.trino.plugin.base.type.DecodedTimestamp;
+import io.trino.plugin.deltalake.transactionlog.statistics.DeltaLakeJsonFileStatistics;
+import io.trino.plugin.deltalake.transactionlog.statistics.DeltaLakeParquetFileStatistics;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.SqlRow;
 import io.trino.spi.type.ArrayType;
@@ -492,5 +494,14 @@ public final class DeltaLakeParquetStatisticsUtils
 
         LOG.debug("Accumulating Parquet statistics with Trino type: %s and Parquet statistics of type: %s is not supported", type, statistics);
         return Optional.empty();
+    }
+
+    public static DeltaLakeJsonFileStatistics convertParquetToJsonStatistics(Map<String, Type> columnTypeMapping, DeltaLakeParquetFileStatistics parquetFileStatistics)
+    {
+        return new DeltaLakeJsonFileStatistics(
+                parquetFileStatistics.getNumRecords(),
+                parquetFileStatistics.getMinValues().map(values -> toJsonValues(columnTypeMapping, values)),
+                parquetFileStatistics.getMaxValues().map(values -> toJsonValues(columnTypeMapping, values)),
+                parquetFileStatistics.getNullCount().map(nullCounts -> toNullCounts(columnTypeMapping, nullCounts)));
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeParquetStatisticsUtils.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeParquetStatisticsUtils.java
@@ -130,11 +130,36 @@ public final class DeltaLakeParquetStatisticsUtils
             return (long) floatToRawIntBits((float) (double) jsonValue);
         }
         if (type == DOUBLE) {
+            if (jsonValue instanceof String stringValue) {
+                switch (stringValue) {
+                    case "Infinity" -> {
+                        return Double.POSITIVE_INFINITY;
+                    }
+                    case "-Infinity" -> {
+                        return Double.NEGATIVE_INFINITY;
+                    }
+                    case "NaN" -> {
+                        return Double.NaN;
+                    }
+                    default -> throw new IllegalArgumentException("Unexpected value for double type: " + jsonValue);
+                }
+            }
+
             //noinspection RedundantCast
             return (double) jsonValue;
         }
         if (type instanceof DecimalType decimalType) {
-            BigDecimal decimal = new BigDecimal((String) jsonValue);
+            BigDecimal decimal;
+
+            if (jsonValue instanceof Double doubleValue) {
+                decimal = BigDecimal.valueOf(doubleValue);
+            }
+            else if (jsonValue instanceof Long longValue) {
+                decimal = BigDecimal.valueOf(longValue);
+            }
+            else {
+                decimal = new BigDecimal((String) jsonValue);
+            }
 
             if (decimalType.isShort()) {
                 return Decimals.encodeShortScaledValue(decimal, decimalType.getScale());
@@ -151,14 +176,19 @@ public final class DeltaLakeParquetStatisticsUtils
             return Instant.parse((String) jsonValue).toEpochMilli() * MICROSECONDS_PER_MILLISECOND;
         }
         if (type == TIMESTAMP_MICROS) {
-            Instant instant = Instant.parse((String) jsonValue);
+            String stringValue = (String) jsonValue;
+            // TIMESTAMP_MICROS stats may or may not have timezone information. We accept both for maximum compatibility, assuming UTC
+            if (!stringValue.endsWith("Z")) {
+                stringValue += "Z";
+            }
+            Instant instant = Instant.parse(stringValue);
             return (instant.getEpochSecond() * MICROSECONDS_PER_SECOND) + (instant.getNano() / NANOSECONDS_PER_MICROSECOND);
         }
         if (type instanceof RowType rowType) {
             Map<?, ?> values = (Map<?, ?>) jsonValue;
             List<Type> fieldTypes = rowType.getFieldTypes();
             return buildRowValue(rowType, fields -> {
-                for (int i = 0; i < values.size(); ++i) {
+                for (int i = 0; i < fieldTypes.size(); ++i) {
                     Type fieldType = fieldTypes.get(i);
                     String fieldName = rowType.getFields().get(i).getName().orElseThrow(() -> new IllegalArgumentException("Field name must exist"));
                     Object fieldValue = jsonValueToTrinoValue(fieldType, values.remove(fieldName));

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriter.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriter.java
@@ -59,9 +59,8 @@ import static com.google.common.base.Predicates.alwaysTrue;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.deltalake.transactionlog.DeltaLakeParquetStatisticsUtils.convertParquetToJsonStatistics;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeParquetStatisticsUtils.jsonValueToTrinoValue;
-import static io.trino.plugin.deltalake.transactionlog.DeltaLakeParquetStatisticsUtils.toJsonValues;
-import static io.trino.plugin.deltalake.transactionlog.DeltaLakeParquetStatisticsUtils.toNullCounts;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.extractPartitionColumns;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.extractSchema;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.isDeletionVectorEnabled;
@@ -347,11 +346,7 @@ public class CheckpointWriter
             DeltaLakeFileStatistics statistics = addFileEntry.getStats().get();
             if (statistics instanceof DeltaLakeParquetFileStatistics parquetFileStatistics) {
                 Map<String, Type> columnTypeMapping = getColumnTypeMapping(metadataEntry, protocolEntry);
-                DeltaLakeJsonFileStatistics jsonFileStatistics = new DeltaLakeJsonFileStatistics(
-                        parquetFileStatistics.getNumRecords(),
-                        parquetFileStatistics.getMinValues().map(values -> toJsonValues(columnTypeMapping, values)),
-                        parquetFileStatistics.getMaxValues().map(values -> toJsonValues(columnTypeMapping, values)),
-                        parquetFileStatistics.getNullCount().map(nullCounts -> toNullCounts(columnTypeMapping, nullCounts)));
+                DeltaLakeJsonFileStatistics jsonFileStatistics = convertParquetToJsonStatistics(columnTypeMapping, parquetFileStatistics);
                 statsJson = getStatsString(jsonFileStatistics).orElse(null);
             }
             else {

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointWriter.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointWriter.java
@@ -24,6 +24,7 @@ import io.trino.filesystem.TrinoOutputFile;
 import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
 import io.trino.parquet.ParquetReaderOptions;
 import io.trino.plugin.base.metrics.FileFormatDataSourceStats;
+import io.trino.plugin.deltalake.DeltaLakeColumnMetadata;
 import io.trino.plugin.deltalake.DeltaLakeConfig;
 import io.trino.plugin.deltalake.transactionlog.AddFileEntry;
 import io.trino.plugin.deltalake.transactionlog.DeltaLakeTransactionLogEntry;
@@ -38,14 +39,18 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.SqlRow;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.BigintType;
+import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Int128;
 import io.trino.spi.type.IntegerType;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
 import io.trino.util.DateTimeUtils;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Iterator;
 import java.util.List;
@@ -54,10 +59,13 @@ import java.util.Optional;
 
 import static com.google.common.base.Predicates.alwaysTrue;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.plugin.deltalake.DeltaTestingConnectorSession.SESSION;
+import static io.trino.plugin.deltalake.transactionlog.DeltaLakeParquetStatisticsUtils.convertParquetToJsonStatistics;
+import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.extractSchema;
 import static io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointEntryIterator.EntryType.ADD;
 import static io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointEntryIterator.EntryType.METADATA;
 import static io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointEntryIterator.EntryType.PROTOCOL;
@@ -72,6 +80,7 @@ import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MICROSECOND;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static io.trino.util.DateTimeUtils.parseDate;
+import static java.math.RoundingMode.HALF_UP;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -93,26 +102,35 @@ public class TestCheckpointWriter
                         ImmutableMap.of(
                                 "formatOptionX", "blah",
                                 "fomatOptionY", "plah")),
-                "{\"type\":\"struct\",\"fields\":" +
-                        "[{\"name\":\"part_key\",\"type\":\"double\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"ts\",\"type\":\"timestamp\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"ts_ntz\",\"type\":\"timestamp_ntz\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"str\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"dec_short\",\"type\":\"decimal(5,1)\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"dec_long\",\"type\":\"decimal(25,3)\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"l\",\"type\":\"long\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"in\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"sh\",\"type\":\"short\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"byt\",\"type\":\"byte\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"fl\",\"type\":\"float\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"dou\",\"type\":\"double\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"bool\",\"type\":\"boolean\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"bin\",\"type\":\"binary\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"dat\",\"type\":\"date\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"arr\",\"type\":{\"type\":\"array\",\"elementType\":\"integer\",\"containsNull\":true},\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"m\",\"type\":{\"type\":\"map\",\"keyType\":\"integer\",\"valueType\":\"string\",\"valueContainsNull\":true},\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"row\",\"type\":{\"type\":\"struct\",\"fields\":[{\"name\":\"s1\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"s2\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}]},\"nullable\":true,\"metadata\":{}}]}",
+                """
+                        {
+                          "type": "struct",
+                          "fields": [
+                            {"name": "part_key", "type": "double", "nullable": true, "metadata": {}},
+                            {"name": "ts", "type": "timestamp", "nullable": true, "metadata": {}},
+                            {"name": "ts_ntz", "type": "timestamp_ntz", "nullable": true, "metadata": {}},
+                            {"name": "str", "type": "string", "nullable": true, "metadata": {}},
+                            {"name": "dec_short", "type": "decimal(5,1)", "nullable": true, "metadata": {}},
+                            {"name": "dec_long", "type": "decimal(25,3)", "nullable": true, "metadata": {}},
+                            {"name": "l", "type": "long", "nullable": true, "metadata": {}},
+                            {"name": "in", "type": "integer", "nullable": true, "metadata": {}},
+                            {"name": "sh", "type": "short", "nullable": true, "metadata": {}},
+                            {"name": "byt", "type": "byte", "nullable": true, "metadata": {}},
+                            {"name": "fl", "type": "float", "nullable": true, "metadata": {}},
+                            {"name": "dou", "type": "double", "nullable": true, "metadata": {}},
+                            {"name": "bool", "type": "boolean", "nullable": true, "metadata": {}},
+                            {"name": "bin", "type": "binary", "nullable": true, "metadata": {}},
+                            {"name": "dat", "type": "date", "nullable": true, "metadata": {}},
+                            {"name": "arr", "type": {"type": "array", "elementType": "integer", "containsNull": true}, "nullable": true, "metadata": {}},
+                            {"name": "m", "type": {"type": "map", "keyType": "integer", "valueType": "string", "valueContainsNull": true}, "nullable": true, "metadata": {}},
+                            {"name": "row", "type": {
+                                "type": "struct",
+                                "fields": [
+                                  {"name": "s1", "type": "integer", "nullable": true, "metadata": {}},
+                                  {"name": "s2", "type": "string", "nullable": true, "metadata": {}}
+                                ]}, "nullable": true, "metadata": {}}
+                          ]
+                        }""",
                 ImmutableList.of("part_key"),
                 ImmutableMap.of(
                         "delta.checkpoint.writeStatsAsStruct", "false",
@@ -127,54 +145,67 @@ public class TestCheckpointWriter
                 1000,
                 1001,
                 true,
-                Optional.of("{" +
-                        "\"numRecords\":20," +
-                        "\"minValues\":{" +
-                        "\"ts\":\"2960-10-31T01:00:00.000Z\"," +
-                        "\"ts_ntz\":\"2020-01-01T01:02:03.123\"," +
-                        "\"str\":\"a\"," +
-                        "\"dec_short\":10.1," +
-                        "\"dec_long\":111111111111.123," +
-                        "\"l\":1000000000," +
-                        "\"in\":100000," +
-                        "\"sh\":100," +
-                        "\"byt\":10," +
-                        "\"fl\":0.100," +
-                        "\"dou\":0.101," +
-                        "\"dat\":\"2000-01-01\"," +
-                        "\"row\":{\"s1\":1,\"s2\":\"a\"}" +
-                        "}," +
-                        "\"maxValues\":{" +
-                        "\"ts\":\"2960-10-31T02:00:00.000Z\"," +
-                        "\"ts_ntz\":\"3000-01-01T01:02:03.123\"," +
-                        "\"str\":\"z\"," +
-                        "\"dec_short\":20.1," +
-                        "\"dec_long\":222222222222.123," +
-                        "\"l\":2000000000," +
-                        "\"in\":200000," +
-                        "\"sh\":200," +
-                        "\"byt\":20," +
-                        "\"fl\":0.200," +
-                        "\"dou\":0.202," +
-                        "\"dat\":\"3000-01-01\"," +
-                        "\"row\":{\"s1\":1,\"s2\":\"a\"}" +
-                        "}," +
-                        "\"nullCount\":{" +
-                        "\"ts\":1," +
-                        "\"str\":2," +
-                        "\"dec_short\":3," +
-                        "\"dec_long\":4," +
-                        "\"l\":5," +
-                        "\"in\":6," +
-                        "\"sh\":7," +
-                        "\"byt\":8," +
-                        "\"fl\":9," +
-                        "\"dou\":10," +
-                        "\"bool\":11," +
-                        "\"bin\":12," +
-                        "\"dat\":13," +
-                        "\"arr\":0,\"m\":14," +
-                        "\"row\":{\"s1\":0,\"s2\":15}}}"),
+                Optional.of("""
+                        {
+                          "numRecords": 20,
+                          "minValues": {
+                            "ts": "2960-10-31T01:00:00.000Z",
+                            "ts_ntz": "2020-01-01T01:02:03.123",
+                            "str": "a",
+                            "dec_short": 10.1,
+                            "dec_long": 111111111111.123,
+                            "l": 1000000000,
+                            "in": 100000,
+                            "sh": 100,
+                            "byt": 10,
+                            "fl": 0.100,
+                            "dou": 0.101,
+                            "dat": "2000-01-01",
+                            "row": {
+                              "s1": 1,
+                              "s2": "a"
+                            }
+                          },
+                          "maxValues": {
+                            "ts": "2960-10-31T02:00:00.000Z",
+                            "ts_ntz": "3000-01-01T01:02:03.123",
+                            "str": "z",
+                            "dec_short": 20.1,
+                            "dec_long": 222222222222.123,
+                            "l": 2000000000,
+                            "in": 200000,
+                            "sh": 200,
+                            "byt": 20,
+                            "fl": 0.200,
+                            "dou": 0.202,
+                            "dat": "3000-01-01",
+                            "row": {
+                              "s1": 1,
+                              "s2": "a"
+                            }
+                          },
+                          "nullCount": {
+                            "ts": 1,
+                            "str": 2,
+                            "dec_short": 3,
+                            "dec_long": 4,
+                            "l": 5,
+                            "in": 6,
+                            "sh": 7,
+                            "byt": 8,
+                            "fl": 9,
+                            "dou": 10,
+                            "bool": 11,
+                            "bin": 12,
+                            "dat": 13,
+                            "arr": 0,
+                            "m": 14,
+                            "row": {
+                              "s1": 0,
+                              "s2": 15
+                            }
+                          }
+                        }"""),
                 Optional.empty(),
                 ImmutableMap.of(
                         "someTag", "someValue",
@@ -204,12 +235,16 @@ public class TestCheckpointWriter
         targetFile.delete(); // file must not exist when writer is called
         writer.write(entries, createOutputFile(targetPath));
 
+        ImmutableMap<String, Type> columnTypeMapping = extractSchema(metadataEntry, protocolEntry, typeManager).stream()
+                .collect(toImmutableMap(DeltaLakeColumnMetadata::physicalName, DeltaLakeColumnMetadata::physicalColumnType));
+
         CheckpointEntries readEntries = readCheckpoint(targetPath, metadataEntry, protocolEntry, true);
         assertThat(readEntries.transactionEntries()).isEqualTo(entries.transactionEntries());
         assertThat(readEntries.removeFileEntries()).isEqualTo(entries.removeFileEntries());
         assertThat(readEntries.metadataEntry()).isEqualTo(entries.metadataEntry());
         assertThat(readEntries.protocolEntry()).isEqualTo(entries.protocolEntry());
-        assertThat(readEntries.addFileEntries().stream().map(this::makeComparable).collect(toImmutableSet())).isEqualTo(entries.addFileEntries().stream().map(this::makeComparable).collect(toImmutableSet()));
+        assertThat(readEntries.addFileEntries().stream().map((x) -> makeComparable(columnTypeMapping, x)).collect(toImmutableSet()))
+                .isEqualTo(entries.addFileEntries().stream().map((x) -> makeComparable(columnTypeMapping, x)).collect(toImmutableSet()));
     }
 
     @Test
@@ -225,26 +260,35 @@ public class TestCheckpointWriter
                         ImmutableMap.of(
                                 "formatOptionX", "blah",
                                 "fomatOptionY", "plah")),
-                "{\"type\":\"struct\",\"fields\":" +
-                        "[{\"name\":\"part_key\",\"type\":\"double\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"ts\",\"type\":\"timestamp\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"ts_ntz\",\"type\":\"timestamp_ntz\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"str\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"dec_short\",\"type\":\"decimal(5,1)\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"dec_long\",\"type\":\"decimal(25,3)\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"l\",\"type\":\"long\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"in\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"sh\",\"type\":\"short\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"byt\",\"type\":\"byte\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"fl\",\"type\":\"float\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"dou\",\"type\":\"double\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"bool\",\"type\":\"boolean\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"bin\",\"type\":\"binary\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"dat\",\"type\":\"date\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"arr\",\"type\":{\"type\":\"array\",\"elementType\":\"integer\",\"containsNull\":true},\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"m\",\"type\":{\"type\":\"map\",\"keyType\":\"integer\",\"valueType\":\"string\",\"valueContainsNull\":true},\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"row\",\"type\":{\"type\":\"struct\",\"fields\":[{\"name\":\"s1\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"s2\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}]},\"nullable\":true,\"metadata\":{}}]}",
+                """
+                        {
+                          "type": "struct",
+                          "fields": [
+                            {"name": "part_key", "type": "double", "nullable": true, "metadata": {}},
+                            {"name": "ts", "type": "timestamp", "nullable": true, "metadata": {}},
+                            {"name": "ts_ntz", "type": "timestamp_ntz", "nullable": true, "metadata": {}},
+                            {"name": "str", "type": "string", "nullable": true, "metadata": {}},
+                            {"name": "dec_short", "type": "decimal(5,1)", "nullable": true, "metadata": {}},
+                            {"name": "dec_long", "type": "decimal(25,3)", "nullable": true, "metadata": {}},
+                            {"name": "l", "type": "long", "nullable": true, "metadata": {}},
+                            {"name": "in", "type": "integer", "nullable": true, "metadata": {}},
+                            {"name": "sh", "type": "short", "nullable": true, "metadata": {}},
+                            {"name": "byt", "type": "byte", "nullable": true, "metadata": {}},
+                            {"name": "fl", "type": "float", "nullable": true, "metadata": {}},
+                            {"name": "dou", "type": "double", "nullable": true, "metadata": {}},
+                            {"name": "bool", "type": "boolean", "nullable": true, "metadata": {}},
+                            {"name": "bin", "type": "binary", "nullable": true, "metadata": {}},
+                            {"name": "dat", "type": "date", "nullable": true, "metadata": {}},
+                            {"name": "arr", "type": {"type": "array", "elementType": "integer", "containsNull": true}, "nullable": true, "metadata": {}},
+                            {"name": "m", "type": {"type": "map", "keyType": "integer", "valueType": "string", "valueContainsNull": true}, "nullable": true, "metadata": {}},
+                            {"name": "row", "type": {
+                                "type": "struct",
+                                "fields": [
+                                  {"name": "s1", "type": "integer", "nullable": true, "metadata": {}},
+                                  {"name": "s2", "type": "string", "nullable": true, "metadata": {}}
+                                ]}, "nullable": true, "metadata": {}}
+                          ]
+                        }""",
                 ImmutableList.of("part_key"),
                 ImmutableMap.of(
                         "configOption1", "blah",
@@ -346,12 +390,161 @@ public class TestCheckpointWriter
         targetFile.delete(); // file must not exist when writer is called
         writer.write(entries, createOutputFile(targetPath));
 
+        ImmutableMap<String, Type> columnTypeMapping = extractSchema(metadataEntry, protocolEntry, typeManager).stream()
+                .collect(toImmutableMap(DeltaLakeColumnMetadata::physicalName, DeltaLakeColumnMetadata::physicalColumnType));
+
         CheckpointEntries readEntries = readCheckpoint(targetPath, metadataEntry, protocolEntry, true);
         assertThat(readEntries.transactionEntries()).isEqualTo(entries.transactionEntries());
         assertThat(readEntries.removeFileEntries()).isEqualTo(entries.removeFileEntries());
         assertThat(readEntries.metadataEntry()).isEqualTo(entries.metadataEntry());
         assertThat(readEntries.protocolEntry()).isEqualTo(entries.protocolEntry());
-        assertThat(readEntries.addFileEntries().stream().map(this::makeComparable).collect(toImmutableSet())).isEqualTo(entries.addFileEntries().stream().map(this::makeComparable).collect(toImmutableSet()));
+        assertThat(readEntries.addFileEntries().stream().map((x) -> makeComparable(columnTypeMapping, x)).collect(toImmutableSet()))
+                .isEqualTo(entries.addFileEntries().stream().map((x) -> makeComparable(columnTypeMapping, x)).collect(toImmutableSet()));
+    }
+
+    @Test
+    void testCheckpointWriteJsonReadParquet()
+            throws IOException
+    {
+        MetadataEntry metadataEntry = new MetadataEntry(
+                "metadataId",
+                "metadataName",
+                "metadataDescription",
+                new MetadataEntry.Format(
+                        "metadataFormatProvider",
+                        ImmutableMap.of(
+                                "formatOptionX", "blah",
+                                "fomatOptionY", "plah")),
+                """
+                        {
+                          "type": "struct",
+                          "fields": [
+                            {"name": "part_key", "type": "double", "nullable": true, "metadata": {}},
+                            {"name": "ts", "type": "timestamp", "nullable": true, "metadata": {}},
+                            {"name": "ts_ntz", "type": "timestamp_ntz", "nullable": true, "metadata": {}},
+                            {"name": "str", "type": "string", "nullable": true, "metadata": {}},
+                            {"name": "dec_short", "type": "decimal(5,1)", "nullable": true, "metadata": {}},
+                            {"name": "dec_long", "type": "decimal(25,3)", "nullable": true, "metadata": {}},
+                            {"name": "l", "type": "long", "nullable": true, "metadata": {}},
+                            {"name": "in", "type": "integer", "nullable": true, "metadata": {}},
+                            {"name": "sh", "type": "short", "nullable": true, "metadata": {}},
+                            {"name": "byt", "type": "byte", "nullable": true, "metadata": {}},
+                            {"name": "fl", "type": "float", "nullable": true, "metadata": {}},
+                            {"name": "dou", "type": "double", "nullable": true, "metadata": {}},
+                            {"name": "bool", "type": "boolean", "nullable": true, "metadata": {}},
+                            {"name": "bin", "type": "binary", "nullable": true, "metadata": {}},
+                            {"name": "dat", "type": "date", "nullable": true, "metadata": {}},
+                            {"name": "arr", "type": {"type": "array", "elementType": "integer", "containsNull": true}, "nullable": true, "metadata": {}},
+                            {"name": "m", "type": {"type": "map", "keyType": "integer", "valueType": "string", "valueContainsNull": true}, "nullable": true, "metadata": {}},
+                            {"name": "row", "type": {
+                                "type": "struct",
+                                "fields": [
+                                  {"name": "s1", "type": "integer", "nullable": true, "metadata": {}},
+                                  {"name": "s2", "type": "string", "nullable": true, "metadata": {}}
+                                ]}, "nullable": true, "metadata": {}}
+                          ]
+                        }""",
+                ImmutableList.of("part_key"),
+                ImmutableMap.of(
+                        "configOption1", "blah",
+                        "configOption2", "plah"),
+                1000);
+        ProtocolEntry protocolEntry = new ProtocolEntry(10, 20, Optional.empty(), Optional.empty());
+        TransactionEntry transactionEntry = new TransactionEntry("appId", 1, 1001);
+        AddFileEntry addFileEntryJsonStats = new AddFileEntry(
+                "addFilePathJson",
+                ImmutableMap.of("part_key", "7.0"),
+                1000,
+                1001,
+                true,
+                Optional.of("""
+                        {
+                          "numRecords": 20,
+                          "minValues": {
+                            "ts": "2960-10-31T01:00:00.001Z",
+                            "ts_ntz": "2020-01-01T01:02:03.123",
+                            "str": "a",
+                            "dec_short": 10.1,
+                            "dec_long": 111111111111.123,
+                            "l": 1000000000,
+                            "in": 100000,
+                            "sh": 100,
+                            "byt": 10,
+                            "fl": 0.100,
+                            "dou": "-Infinity",
+                            "dat": "2000-01-01"
+                          },
+                          "maxValues": {
+                            "ts": "2960-10-31T02:00:00.002Z",
+                            "ts_ntz": "3000-01-01T01:02:03.123",
+                            "str": "z",
+                            "dec_short": 20.1,
+                            "dec_long": 222222222222.123,
+                            "l": 2000000000,
+                            "in": 200000,
+                            "sh": 200,
+                            "byt": 20,
+                            "fl": 0.200,
+                            "dou": 0.202,
+                            "dat": "3000-01-01"
+                          },
+                          "nullCount": {
+                            "ts": 1,
+                            "str": 2,
+                            "dec_short": 3,
+                            "dec_long": 4,
+                            "l": 5,
+                            "in": 6,
+                            "sh": 7,
+                            "byt": 8,
+                            "fl": 9,
+                            "dou": 10,
+                            "bool": 11,
+                            "bin": 12,
+                            "dat": 13,
+                            "arr": 0,
+                            "m": 14
+                          }
+                        }"""),
+                Optional.empty(),
+                ImmutableMap.of(
+                        "someTag", "someValue",
+                        "otherTag", "otherValue"),
+                Optional.empty());
+
+        RemoveFileEntry removeFileEntry = new RemoveFileEntry(
+                "removeFilePath",
+                ImmutableMap.of("part_key", "7.0"),
+                1000,
+                true,
+                Optional.empty());
+
+        CheckpointEntries entries = new CheckpointEntries(
+                metadataEntry,
+                protocolEntry,
+                ImmutableSet.of(transactionEntry),
+                ImmutableSet.of(addFileEntryJsonStats),
+                ImmutableSet.of(removeFileEntry));
+
+        CheckpointWriter writer = new CheckpointWriter(typeManager, checkpointSchemaManager, "test");
+
+        File targetFile = File.createTempFile("testCheckpointWriteJsonReadParquet-", ".checkpoint.parquet");
+        targetFile.deleteOnExit();
+
+        String targetPath = "file://" + targetFile.getAbsolutePath();
+        targetFile.delete(); // file must not exist when writer is called
+        writer.write(entries, createOutputFile(targetPath));
+
+        ImmutableMap<String, Type> columnTypeMapping = extractSchema(metadataEntry, protocolEntry, typeManager).stream()
+                .collect(toImmutableMap(DeltaLakeColumnMetadata::physicalName, DeltaLakeColumnMetadata::physicalColumnType));
+
+        CheckpointEntries readEntries = readCheckpoint(targetPath, metadataEntry, protocolEntry, true);
+        assertThat(readEntries.transactionEntries()).isEqualTo(entries.transactionEntries());
+        assertThat(readEntries.removeFileEntries()).isEqualTo(entries.removeFileEntries());
+        assertThat(readEntries.metadataEntry()).isEqualTo(entries.metadataEntry());
+        assertThat(readEntries.protocolEntry()).isEqualTo(entries.protocolEntry());
+        assertThat(readEntries.addFileEntries().stream().map((x) -> makeComparable(columnTypeMapping, x)).collect(toImmutableSet()))
+                .isEqualTo(entries.addFileEntries().stream().map((x) -> makeComparable(columnTypeMapping, x)).collect(toImmutableSet()));
     }
 
     private static long convertToTimestamp(String value)
@@ -374,10 +567,14 @@ public class TestCheckpointWriter
                         ImmutableMap.of(
                                 "formatOptionX", "blah",
                                 "fomatOptionY", "plah")),
-                "{\"type\":\"struct\",\"fields\":" +
-                        "[{\"name\":\"part_key\",\"type\":\"double\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"row\",\"type\":{\"type\":\"struct\",\"fields\":[{\"name\":\"s1\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}," +
-                        "{\"name\":\"s2\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}]},\"nullable\":true,\"metadata\":{}}]}",
+                """
+                {
+                  "type":"struct",
+                  "fields":[
+                    {"name":"part_key","type":"double","nullable":true,"metadata":{}},
+                    {"name":"row","type":{"type":"struct","fields":[{"name":"s1","type":"integer","nullable":true,"metadata":{}},{"name":"s2","type":"string","nullable":true,"metadata":{}}]},"nullable":true,"metadata":{}}
+                  ]
+                }""",
                 ImmutableList.of("part_key"),
                 ImmutableMap.of(),
                 1000);
@@ -431,7 +628,7 @@ public class TestCheckpointWriter
         assertThat(fileStatistics.getNullCount().get()).isEmpty();
     }
 
-    private AddFileEntry makeComparable(AddFileEntry original)
+    private AddFileEntry makeComparable(Map<String, Type> columnTypeMapping, AddFileEntry original)
     {
         return new AddFileEntry(
                 original.getPath(),
@@ -440,27 +637,37 @@ public class TestCheckpointWriter
                 original.getModificationTime(),
                 original.isDataChange(),
                 original.getStatsString(),
-                makeComparable(original.getStats()),
+                makeComparable(columnTypeMapping, original.getStats()),
                 original.getTags(),
                 original.getDeletionVector());
     }
 
-    private Optional<DeltaLakeParquetFileStatistics> makeComparable(Optional<? extends DeltaLakeFileStatistics> original)
+    private Optional<DeltaLakeParquetFileStatistics> makeComparable(Map<String, Type> columnTypeMapping, Optional<? extends DeltaLakeFileStatistics> original)
     {
-        if (original.isEmpty() || original.get() instanceof DeltaLakeJsonFileStatistics) {
+        if (original.isEmpty()) {
             return Optional.empty();
         }
 
-        DeltaLakeParquetFileStatistics originalStatistics = (DeltaLakeParquetFileStatistics) original.get();
+        DeltaLakeJsonFileStatistics stats;
+        if (original.get() instanceof DeltaLakeJsonFileStatistics jsonStats) {
+            stats = jsonStats;
+        }
+        else if (original.get() instanceof DeltaLakeParquetFileStatistics parquetStats) {
+            stats = convertParquetToJsonStatistics(columnTypeMapping, parquetStats);
+        }
+        else {
+            throw new RuntimeException("Unsupported subclass of DeltaLakeFileStatistics");
+        }
+
         return Optional.of(
                 new DeltaLakeParquetFileStatistics(
-                        originalStatistics.getNumRecords(),
-                        makeComparableStatistics(originalStatistics.getMinValues()),
-                        makeComparableStatistics(originalStatistics.getMaxValues()),
-                        makeComparableStatistics(originalStatistics.getNullCount())));
+                        stats.getNumRecords(),
+                        makeComparableStatistics(columnTypeMapping, stats.getMinValues()),
+                        makeComparableStatistics(columnTypeMapping, stats.getMaxValues()),
+                        makeComparableStatistics(columnTypeMapping, stats.getNullCount())));
     }
 
-    private Optional<Map<String, Object>> makeComparableStatistics(Optional<Map<String, Object>> original)
+    private Optional<Map<String, Object>> makeComparableStatistics(Map<String, Type> columnTypeMapping, Optional<Map<String, Object>> original)
     {
         if (original.isEmpty()) {
             return Optional.empty();
@@ -470,6 +677,7 @@ public class TestCheckpointWriter
         ImmutableMap.Builder<String, Object> comparableStats = ImmutableMap.builder();
         for (String key : stats.keySet()) {
             Object statsValue = stats.get(key);
+            Type type = columnTypeMapping.get(key);
             if (statsValue instanceof SqlRow sqlRow) {
                 // todo: this validation is just broken. The only way to compare values is to use types.
                 // see https://github.com/trinodb/trino/issues/19557
@@ -481,8 +689,21 @@ public class TestCheckpointWriter
             else if (statsValue instanceof Slice slice) {
                 comparableStats.put(key, slice.toStringUtf8());
             }
+            else if (type instanceof TimestampType && statsValue instanceof String stringValue) {
+                // Coerce ntz timestamps to tz as we support reading both
+                if (!stringValue.endsWith("Z")) {
+                    stringValue += "Z";
+                }
+                comparableStats.put(key, stringValue);
+            }
+            else if (type instanceof DecimalType decimalType && statsValue instanceof Double doubleValue) {
+                // Convert Decimals to a String representation for comparison
+                comparableStats.put(key, BigDecimal.valueOf(doubleValue)
+                        .setScale(decimalType.getScale(), HALF_UP)
+                        .toPlainString());
+            }
             else {
-                comparableStats.put(key, statsValue);
+                comparableStats.put(key, statsValue.toString());
             }
         }
 


### PR DESCRIPTION
## Description

Currently, we are unable to optimise tables when they contain infinity/NaN values in fields of type "DOUBLE" because the conversion fails when we try to cast a string containing "Infinity", "-Infinity" or "NaN" into a double.

Instead, we try to check if the JSON value contains a string, and convert it appropriately.

## Additional context and related issues

Fixes #24029 
Fixes https://github.com/trinodb/trino/issues/28532

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Delta Lake
* Fix silent failure to write checkpoint files for tables containing double values Infinity or NaN. ({issue}`24029`)
```
