### PR TITLE
Prevent IllegalArgumentException if no pending node acquires

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/BinPackingNodeAllocatorService.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/BinPackingNodeAllocatorService.java
@@ -18,6 +18,7 @@ import com.google.common.base.Ticker;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
@@ -350,6 +351,10 @@ public class BinPackingNodeAllocatorService
         List<QueryPendingAcquires> iterators = pendingAcquires.entrySet().stream()
                 .map(entry -> new QueryPendingAcquires(entry.getKey(), entry.getValue().iterator()))
                 .collect(toCollection(ArrayList::new));
+
+        if (iterators.isEmpty()) {
+            return ImmutableList.<PendingAcquire>of().iterator();
+        }
 
         int startingIteratorIndex = 0;
         if (startingQueryId.isPresent()) {


### PR DESCRIPTION
We could get java.lang.IllegalArgumentException: bound must be positive when pendingAcquires was empty



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

