### PR TITLE
WKBReader is not thread-safe. Remove static field

### DIFF
--- a/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/GeoFunctions.java
+++ b/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/GeoFunctions.java
@@ -177,8 +177,6 @@ public final class GeoFunctions
     private static final EnumSet<GeometryType> VALID_TYPES_FOR_ST_POINTS = EnumSet.of(
             LINE_STRING, POLYGON, POINT, MULTI_POINT, MULTI_LINE_STRING, MULTI_POLYGON, GEOMETRY_COLLECTION);
 
-    private static final WKBReader WKB_READER = new WKBReader();
-
     private GeoFunctions() {}
 
     @Description("Returns a Geometry type LineString object from Well-Known Text representation (WKT)")
@@ -1546,7 +1544,7 @@ public final class GeoFunctions
     {
         requireNonNull(input, "input is null");
         try {
-            return WKB_READER.read(input.getBytes());
+            return new WKBReader().read(input.getBytes());
         }
         catch (ParseException e) {
             throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "Invalid WKB", e);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

This is a follow up to PR #23894 
As discussed in the original PR the WKBReader is not thread-safe. This PR removes the static instance.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

PR #23894 

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

