### PR TITLE
Add support for PostGIS

### DIFF
--- a/docs/src/main/sphinx/connector/postgresql.md
+++ b/docs/src/main/sphinx/connector/postgresql.md
@@ -213,6 +213,9 @@ this table:
 * - `ARRAY`
   - Disabled, `ARRAY`, or `JSON`
   - See [](postgresql-array-type-handling) for more information.
+* - `GEOMETRY`, `GEOMETRY(GEOMETRY TYPE, SRID)`
+  - `GEOMETRY`
+  -
 :::
 
 No other types are supported.
@@ -281,6 +284,9 @@ this table:
 * - `ARRAY`
   - `ARRAY`
   - See [](postgresql-array-type-handling) for more information.
+* - `GEOMETRY`
+  - `GEOMETRY`
+  -
 ::::
 
 No other types are supported.

--- a/plugin/trino-postgresql/pom.xml
+++ b/plugin/trino-postgresql/pom.xml
@@ -41,6 +41,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-geospatial</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-matching</artifactId>
         </dependency>
 
@@ -144,6 +149,12 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>tracing</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/PostgreSqlQueryRunner.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/PostgreSqlQueryRunner.java
@@ -16,6 +16,7 @@ package io.trino.plugin.postgresql;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.airlift.log.Logger;
+import io.trino.plugin.geospatial.GeoPlugin;
 import io.trino.plugin.jmx.JmxPlugin;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
@@ -25,8 +26,8 @@ import io.trino.tpch.TpchTable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
-import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.trino.plugin.postgresql.TestingPostgreSqlServer.DEFAULT_IMAGE_NAME;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
@@ -54,6 +55,7 @@ public final class PostgreSqlQueryRunner
     {
         private final Map<String, String> connectorProperties = new HashMap<>();
         private List<TpchTable<?>> initialTables = ImmutableList.of();
+        private Consumer<QueryRunner> additionalSetup = _ -> {};
 
         private Builder()
         {
@@ -61,6 +63,14 @@ public final class PostgreSqlQueryRunner
                     .setCatalog("postgresql")
                     .setSchema(TPCH_SCHEMA)
                     .build());
+        }
+
+        @Override
+        @CanIgnoreReturnValue
+        public Builder setAdditionalSetup(Consumer<QueryRunner> additionalSetup)
+        {
+            this.additionalSetup = requireNonNull(additionalSetup, "additionalSetup is null");
+            return this;
         }
 
         @CanIgnoreReturnValue
@@ -81,22 +91,20 @@ public final class PostgreSqlQueryRunner
         public DistributedQueryRunner build()
                 throws Exception
         {
-            DistributedQueryRunner queryRunner = super.build();
-            try {
-                queryRunner.installPlugin(new TpchPlugin());
-                queryRunner.createCatalog("tpch", "tpch");
+            super.setAdditionalSetup(runner -> {
+                runner.installPlugin(new GeoPlugin()); // GeoPlugin needs to be installed early.
 
-                queryRunner.installPlugin(new PostgreSqlPlugin());
-                queryRunner.createCatalog("postgresql", "postgresql", connectorProperties);
+                additionalSetup.accept(runner);
 
-                copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, initialTables);
+                runner.installPlugin(new TpchPlugin());
+                runner.createCatalog("tpch", "tpch");
 
-                return queryRunner;
-            }
-            catch (Throwable e) {
-                closeAllSuppress(e, queryRunner);
-                throw e;
-            }
+                runner.installPlugin(new PostgreSqlPlugin());
+                runner.createCatalog("postgresql", "postgresql", connectorProperties);
+
+                copyTpchTables(runner, "tpch", TINY_SCHEMA_NAME, initialTables);
+            });
+            return super.build();
         }
     }
 

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlClient.java
@@ -70,7 +70,6 @@ import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.sql.ir.IrExpressions.not;
-import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -113,7 +112,7 @@ public class TestPostgreSqlClient
             new JdbcStatisticsConfig(),
             session -> { throw new UnsupportedOperationException(); },
             new DefaultQueryBuilder(RemoteQueryModifier.NONE),
-            TESTING_TYPE_MANAGER,
+            new TestingPostgreSqlConnectorContext().getTypeManager(),
             new DefaultIdentifierMapping(),
             RemoteQueryModifier.NONE);
 

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlGeometryType.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlGeometryType.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.postgresql;
+
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.sql.TestTable;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.utility.DockerImageName;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestPostgreSqlGeometryType
+        extends AbstractTestQueryFramework
+{
+    private TestingPostgreSqlServer postgreSqlServer;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        postgreSqlServer = closeAfterClass(new TestingPostgreSqlServer(
+                DockerImageName.parse("postgis/postgis:17-3.4-alpine").asCompatibleSubstituteFor("postgres"),
+                false));
+        return PostgreSqlQueryRunner.builder(postgreSqlServer).build();
+    }
+
+    @Test
+    void testGeometryRead()
+    {
+        try (TestTable table = new TestTable(postgreSqlServer::execute, "test_geometry_read", "(geom geometry)")) {
+            postgreSqlServer.execute("INSERT INTO " + table.getName() + " VALUES (ST_Point(1, 1))");
+            assertThat(query("SELECT * FROM " + table.getName()))
+                    .matches("VALUES ST_Point(1, 1)");
+        }
+    }
+
+    @Test
+    void testGeometryReadWithSrid()
+    {
+        try (TestTable table = new TestTable(postgreSqlServer::execute, "test_geometry_read", "(geom geometry(point, 4326))")) {
+            postgreSqlServer.execute("INSERT INTO " + table.getName() + " VALUES (ST_SetSRID(ST_Point(1, 1), 4326))");
+            assertThat(query("SELECT * FROM " + table.getName()))
+                    .matches("VALUES ST_Point(1, 1)");
+        }
+    }
+
+    @Test
+    void testGeometryWrite()
+    {
+        try (TestTable table = new TestTable(postgreSqlServer::execute, "test_geometry_write", "(geom geometry)")) {
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (ST_Point(1, 1))", 1);
+            assertThat(query("SELECT * FROM " + table.getName()))
+                    .matches("VALUES ST_Point(1, 1)");
+        }
+    }
+
+    @Test
+    void testGeometryNullRead()
+    {
+        try (TestTable table = new TestTable(postgreSqlServer::execute, "test_geometry_null_read", "(id int, geom geometry)")) {
+            postgreSqlServer.execute("INSERT INTO " + table.getName() + " VALUES (1, NULL), (2, ST_Point(1, 1))");
+            assertThat(query("SELECT geom FROM " + table.getName()))
+                    .matches("VALUES CAST(NULL AS Geometry), ST_Point(1,1)");
+            assertThat(query("SELECT id FROM " + table.getName() + " WHERE geom IS NULL"))
+                    .matches("VALUES 1");
+            assertThat(query("SELECT id FROM " + table.getName() + " WHERE geom IS NOT NULL"))
+                    .matches("VALUES 2");
+        }
+    }
+
+    @Test
+    void testGeometryNullWrite()
+    {
+        try (TestTable table = new TestTable(postgreSqlServer::execute, "test_geometry_null_write", "(id int, geom geometry)")) {
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (1, NULL), (2, ST_Point(1, 1))", 2);
+            assertThat(query("SELECT id FROM " + table.getName() + " WHERE geom IS NULL"))
+                    .matches("VALUES 1");
+            assertThat(query("SELECT id FROM " + table.getName() + " WHERE geom IS NOT NULL"))
+                    .matches("VALUES 2");
+        }
+    }
+}

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlPlugin.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlPlugin.java
@@ -16,7 +16,6 @@ package io.trino.plugin.postgresql;
 import com.google.common.collect.ImmutableMap;
 import io.trino.spi.Plugin;
 import io.trino.spi.connector.ConnectorFactory;
-import io.trino.testing.TestingConnectorContext;
 import org.junit.jupiter.api.Test;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
@@ -33,6 +32,6 @@ public class TestPostgreSqlPlugin
                 ImmutableMap.of(
                         "connection-url", "jdbc:postgresql:test",
                         "bootstrap.quiet", "true"),
-                new TestingConnectorContext()).shutdown();
+                new TestingPostgreSqlConnectorContext()).shutdown();
     }
 }

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestingPostgreSqlConnectorContext.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestingPostgreSqlConnectorContext.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.postgresql;
+
+import io.airlift.tracing.Tracing;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Tracer;
+import io.trino.FeaturesConfig;
+import io.trino.connector.ConnectorAwareNodeManager;
+import io.trino.metadata.InMemoryNodeManager;
+import io.trino.metadata.TypeRegistry;
+import io.trino.operator.FlatHashStrategyCompiler;
+import io.trino.operator.GroupByHashPageIndexerFactory;
+import io.trino.operator.PagesIndex;
+import io.trino.operator.PagesIndexPageSorter;
+import io.trino.plugin.geospatial.GeometryType;
+import io.trino.spi.NodeManager;
+import io.trino.spi.PageIndexerFactory;
+import io.trino.spi.PageSorter;
+import io.trino.spi.VersionEmbedder;
+import io.trino.spi.connector.CatalogHandle;
+import io.trino.spi.connector.ConnectorContext;
+import io.trino.spi.connector.MetadataProvider;
+import io.trino.spi.type.TypeManager;
+import io.trino.spi.type.TypeOperators;
+import io.trino.type.InternalTypeManager;
+import io.trino.util.EmbedVersion;
+
+import static io.trino.spi.connector.MetadataProvider.NOOP_METADATA_PROVIDER;
+import static io.trino.testing.TestingHandles.TEST_CATALOG_HANDLE;
+
+public class TestingPostgreSqlConnectorContext
+        implements ConnectorContext
+{
+    private final NodeManager nodeManager;
+    private final VersionEmbedder versionEmbedder = new EmbedVersion("testversion");
+    private final PageSorter pageSorter = new PagesIndexPageSorter(new PagesIndex.TestingFactory(false));
+    private final PageIndexerFactory pageIndexerFactory;
+    private final TypeManager typeManager;
+
+    public TestingPostgreSqlConnectorContext()
+    {
+        pageIndexerFactory = new GroupByHashPageIndexerFactory(new FlatHashStrategyCompiler(new TypeOperators()));
+        nodeManager = new ConnectorAwareNodeManager(new InMemoryNodeManager(), "testenv", TEST_CATALOG_HANDLE, true);
+        TypeRegistry typeRegistry = new TypeRegistry(new TypeOperators(), new FeaturesConfig());
+        typeRegistry.addType(GeometryType.GEOMETRY);
+        typeManager = new InternalTypeManager(typeRegistry);
+    }
+
+    @Override
+    public CatalogHandle getCatalogHandle()
+    {
+        return TEST_CATALOG_HANDLE;
+    }
+
+    @Override
+    public OpenTelemetry getOpenTelemetry()
+    {
+        return OpenTelemetry.noop();
+    }
+
+    @Override
+    public Tracer getTracer()
+    {
+        return Tracing.noopTracer();
+    }
+
+    @Override
+    public NodeManager getNodeManager()
+    {
+        return nodeManager;
+    }
+
+    @Override
+    public VersionEmbedder getVersionEmbedder()
+    {
+        return versionEmbedder;
+    }
+
+    @Override
+    public TypeManager getTypeManager()
+    {
+        return typeManager;
+    }
+
+    @Override
+    public MetadataProvider getMetadataProvider()
+    {
+        return NOOP_METADATA_PROVIDER;
+    }
+
+    @Override
+    public PageSorter getPageSorter()
+    {
+        return pageSorter;
+    }
+
+    @Override
+    public PageIndexerFactory getPageIndexerFactory()
+    {
+        return pageIndexerFactory;
+    }
+}

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestingPostgreSqlServer.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestingPostgreSqlServer.java
@@ -20,6 +20,7 @@ import io.trino.plugin.jdbc.RemoteLogTracingEvent;
 import org.intellij.lang.annotations.Language;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.containers.output.OutputFrame;
+import org.testcontainers.utility.DockerImageName;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -82,6 +83,11 @@ public class TestingPostgreSqlServer
     }
 
     public TestingPostgreSqlServer(String dockerImageName, boolean shouldExposeFixedPorts)
+    {
+        this(DockerImageName.parse(dockerImageName), shouldExposeFixedPorts);
+    }
+
+    public TestingPostgreSqlServer(DockerImageName dockerImageName, boolean shouldExposeFixedPorts)
     {
         dockerContainer = new PostgreSQLContainer<>(dockerImageName)
                 .withStartupAttempts(3)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Add support for geometry type mapping in the PostgreSQL connector.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Issue: #5580
There is an old, inactive PR at #9951 

My take is slightly different when it comes to reading PostGIS geometries. The previous attempt rewrote the query and wrapped geometry columns in ST_GeomAsWKB to convert them to a Well Known Binary format. I'm using the native format which is hex encoded EWKB.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

```md
## PostgreSQL connector 
* Add support for `geometry` type. ({issue}`5580`)
```
