### PR TITLE
Add iceberg.jdbc-catalog.retryable-status-codes configuration property

### DIFF
--- a/docs/src/main/sphinx/object-storage/metastores.md
+++ b/docs/src/main/sphinx/object-storage/metastores.md
@@ -563,6 +563,14 @@ directory.
 * - `iceberg.jdbc-catalog.schema-version`
   - JDBC catalog schema version.
     Valid values are `V0` or `V1`. Defaults to `V1`.
+* - `iceberg.jdbc-catalog.retryable-status-codes`
+  - On connection error to JDBC metastore, retry if
+    it is one of these JDBC status codes.
+    Valid value is a comma-separated list of status codes.
+    Note: JDBC catalog always retries the following status
+    codes: `08000,08003,08006,08007,40001`. Specify only
+    additional codes (such as `57000,57P03,57P04` if using
+    PostgreSQL driver) here.
 :::
 
 :::{warning}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/IcebergJdbcCatalogConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/IcebergJdbcCatalogConfig.java
@@ -35,6 +35,7 @@ public class IcebergJdbcCatalogConfig
     private String catalogName;
     private String defaultWarehouseDir;
     private SchemaVersion schemaVersion = SchemaVersion.V1;
+    private String retryableStatusCodes;
 
     @NotNull
     public String getDriverClass()
@@ -132,6 +133,20 @@ public class IcebergJdbcCatalogConfig
     public IcebergJdbcCatalogConfig setSchemaVersion(SchemaVersion schemaVersion)
     {
         this.schemaVersion = schemaVersion;
+        return this;
+    }
+
+    @NotNull
+    public Optional<String> getRetryableStatusCodes()
+    {
+        return Optional.ofNullable(retryableStatusCodes);
+    }
+
+    @Config("iceberg.jdbc-catalog.retryable-status-codes")
+    @ConfigDescription("On connection error to JDBC metastore, retry if it is one of these JDBC status codes")
+    public IcebergJdbcCatalogConfig setRetryableStatusCodes(String retryableStatusCodes)
+    {
+        this.retryableStatusCodes = retryableStatusCodes;
         return this;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalogFactory.java
@@ -74,6 +74,7 @@ public class TrinoJdbcCatalogFactory
         properties.put(PROPERTY_PREFIX + "schema-version", jdbcConfig.getSchemaVersion().toString());
         jdbcConfig.getConnectionUser().ifPresent(user -> properties.put(PROPERTY_PREFIX + "user", user));
         jdbcConfig.getConnectionPassword().ifPresent(password -> properties.put(PROPERTY_PREFIX + "password", password));
+        jdbcConfig.getRetryableStatusCodes().ifPresent(codes -> properties.put("retryable_status_codes", codes));
         this.catalogProperties = properties.buildOrThrow();
 
         this.clientPool = new JdbcClientPool(jdbcConfig.getConnectionUrl(), catalogProperties);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogConfig.java
@@ -35,6 +35,7 @@ public class TestIcebergJdbcCatalogConfig
                 .setConnectionPassword(null)
                 .setCatalogName(null)
                 .setDefaultWarehouseDir(null)
+                .setRetryableStatusCodes(null)
                 .setSchemaVersion(SchemaVersion.V1));
     }
 
@@ -48,6 +49,7 @@ public class TestIcebergJdbcCatalogConfig
                 .put("iceberg.jdbc-catalog.connection-password", "bar")
                 .put("iceberg.jdbc-catalog.catalog-name", "test")
                 .put("iceberg.jdbc-catalog.default-warehouse-dir", "s3://bucket")
+                .put("iceberg.jdbc-catalog.retryable-status-codes", "57P01,57P05")
                 .put("iceberg.jdbc-catalog.schema-version", "V0")
                 .buildOrThrow();
 
@@ -58,6 +60,7 @@ public class TestIcebergJdbcCatalogConfig
                 .setConnectionPassword("bar")
                 .setCatalogName("test")
                 .setDefaultWarehouseDir("s3://bucket")
+                .setRetryableStatusCodes("57P01,57P05")
                 .setSchemaVersion(SchemaVersion.V0);
 
         assertFullMapping(properties, expected);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogConnectorSmokeTest.java
@@ -109,6 +109,7 @@ public class TestIcebergJdbcCatalogConnectorSmokeTest
                                 .put("iceberg.register-table-procedure.enabled", "true")
                                 .put("iceberg.writer-sort-buffer-size", "1MB")
                                 .put("iceberg.jdbc-catalog.default-warehouse-dir", warehouseLocation.getAbsolutePath())
+                                .put("iceberg.jdbc-catalog.retryable-status-codes", "57P01,57P05")
                                 .buildOrThrow())
                 .setInitialTables(REQUIRED_TPCH_TABLES)
                 .build();


### PR DESCRIPTION
Allows retrying additional, JDBC driver and database specific errors
such as Postgres status codes `57000,57P03,57P04` if using Postgres.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->Add iceberg.jdbc-catalog.retryable-status-codes configuration property.
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Iceberg JDBC catalog uses internal connection pool which supports retrying transient
connection errors which improves Iceberg catalog resilience.

By default, only a limited set of status codes is supported: https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/jdbc/JdbcClientPool.java#L50

These codes are database-agnostic and do not include database-specific transient errors.

To configure additional status codes, Iceberg JDBC Catalog supports `retryable_status_codes` configuration
property: https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/jdbc/JdbcClientPool.java#L73

This PR adds this property to the Trino Iceberg catalog properties so it can be configured.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Partially fixes #23095.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Add `iceberg.jdbc-catalog.retryable-status-codes` configuration property in JDBC catalog
 to allow configuring retryable status codes on JDBC connection errors.  ({issue}`23095`)
```
