### PR TITLE
Use renamed column name in $partition table in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTransforms.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTransforms.java
@@ -28,6 +28,7 @@ import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 import jakarta.annotation.Nullable;
 import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.transforms.Transform;
 import org.joda.time.DateTimeField;
 import org.joda.time.chrono.ISOChronology;
 
@@ -158,6 +159,41 @@ public final class PartitionTransforms
         }
 
         throw new UnsupportedOperationException("Unsupported partition transform: " + field);
+    }
+
+    public static String partitionNameTransform(Transform<?, ?> transform, String columnName)
+    {
+        String transformString = transform.toString();
+        switch (transformString) {
+            case "identity" -> {
+                return columnName;
+            }
+            case "void" -> {
+                return columnName + "_null";
+            }
+            case "year" -> {
+                return columnName + "_year";
+            }
+            case "month" -> {
+                return columnName + "_month";
+            }
+            case "day" -> {
+                return columnName + "_day";
+            }
+            case "hour" -> {
+                return columnName + "_hour";
+            }
+        }
+
+        Matcher matcher = BUCKET_PATTERN.matcher(transformString);
+        if (matcher.matches()) {
+            return columnName + "_bucket";
+        }
+        matcher = TRUNCATE_PATTERN.matcher(transformString);
+        if (matcher.matches()) {
+            return columnName + "_trunc";
+        }
+        throw new UnsupportedOperationException("Unsupported partition transform: " + transform);
     }
 
     private static ColumnTransform identity(Type type)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Trino use the `field.name()` as partition name when building Iceberg `$partition` table. 
After a partition column rename, the `$partition` table returns old partition column name that no longer exists.

Fix the logic to use updated partition column name to keep it consistent with new schema.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
