### PR TITLE
Implement `toString()` method  in `MongoTableHandle` and `RemoteTableName` classes

### DIFF
--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/RemoteTableName.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/RemoteTableName.java
@@ -22,4 +22,10 @@ public record RemoteTableName(String databaseName, String collectionName)
         requireNonNull(databaseName, "databaseName is null");
         requireNonNull(collectionName, "collectionName is null");
     }
+
+    @Override
+    public String toString()
+    {
+        return "%s.%s".formatted(databaseName, collectionName);
+    }
 }


### PR DESCRIPTION
## Description

Implement `toString` in `MongoTableHandle` and `RemoteTableName` to improve EXPLAIN readability.

Before:
```
trino> EXPLAIN SELECT * FROM  mongodb.tpch.region WHERE name = 'X';
                                                                                                                                                                                  Query Plan
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Trino version: testversion
 Fragment 0 [SOURCE]
     Output layout: [regionkey, name, comment]
     Output partitioning: SINGLE []
     Output[columnNames = [regionkey, name, comment]]
     │   Layout: [regionkey:bigint, name:varchar(25), comment:varchar(152)]
     │   Estimates: {rows: ? (?), cpu: 0, memory: 0B, network: 0B}
     └─ TableScan[table = mongodb:MongoTableHandle[schemaTableName=tpch.region, remoteTableName=RemoteTableName[databaseName=tpch, collectionName=region], filter=Optional.empty, constraint={name:varchar(25)=[ SortedRangeSet[type=varchar(25), ranges=1, {[X]}] ]}, projectedColumns=[regionkey:bigint, name:varchar(25), comment:varchar(152)], limit=OptionalInt.empty]]
            Layout: [regionkey:bigint, name:varchar(25), comment:varchar(152)]
            Estimates: {rows: ? (?), cpu: ?, memory: 0B, network: 0B}
            comment := comment:varchar(152)
            regionkey := regionkey:bigint
            name := name:varchar(25)
```

After:
```
trino> EXPLAIN SELECT * FROM  mongodb.tpch.region WHERE name = 'X';
                                                              Query Plan
---------------------------------------------------------------------------------------------------------------------------------------
 Trino version: testversion
 Fragment 0 [SOURCE]
     Output layout: [regionkey, name, comment]
     Output partitioning: SINGLE []
     Output[columnNames = [regionkey, name, comment]]
     │   Layout: [regionkey:bigint, name:varchar(25), comment:varchar(152)]
     │   Estimates: {rows: ? (?), cpu: 0, memory: 0B, network: 0B}
     └─ TableScan[table = mongodb:tpch.region constraint on [name] columns=[regionkey:bigint, name:varchar(25), comment:varchar(152)]]
            Layout: [regionkey:bigint, name:varchar(25), comment:varchar(152)]
            Estimates: {rows: ? (?), cpu: ?, memory: 0B, network: 0B}
            comment := comment:varchar(152)
            name := name:varchar(25)
            regionkey := regionkey:bigint
```


## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
