### PR TITLE
Refactor merge to support partial update

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -13,6 +13,7 @@
  */
 package io.trino.metadata;
 
+import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.slice.Slice;
 import io.trino.Session;
@@ -452,8 +453,10 @@ public interface Metadata
 
     /**
      * Begin merge query
+     *
+     * @param updateCaseColumnHandles The merge update case number to the assignment target columns mapping
      */
-    MergeHandle beginMerge(Session session, TableHandle tableHandle);
+    MergeHandle beginMerge(Session session, TableHandle tableHandle, Multimap<Integer, ColumnHandle> updateCaseColumnHandles);
 
     /**
      * Finish merge query

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -17,6 +17,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
 import com.google.common.collect.Streams;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -1352,11 +1353,15 @@ public final class MetadataManager
     }
 
     @Override
-    public MergeHandle beginMerge(Session session, TableHandle tableHandle)
+    public MergeHandle beginMerge(Session session, TableHandle tableHandle, Multimap<Integer, ColumnHandle> updateCaseColumns)
     {
         CatalogHandle catalogHandle = tableHandle.catalogHandle();
         ConnectorMetadata metadata = getMetadataForWrite(session, catalogHandle);
-        ConnectorMergeTableHandle newHandle = metadata.beginMerge(session.toConnectorSession(catalogHandle), tableHandle.connectorHandle(), getRetryPolicy(session).getRetryMode());
+        ConnectorMergeTableHandle newHandle = metadata.beginMerge(
+                session.toConnectorSession(catalogHandle),
+                tableHandle.connectorHandle(),
+                updateCaseColumns.asMap(),
+                getRetryPolicy(session).getRetryMode());
         return new MergeHandle(tableHandle.withConnectorHandle(newHandle.getTableHandle()), newHandle);
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/ChangeOnlyUpdatedColumnsMergeProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ChangeOnlyUpdatedColumnsMergeProcessor.java
@@ -67,12 +67,14 @@ public class ChangeOnlyUpdatedColumnsMergeProcessor
 
         Block mergeRow = inputPage.getBlock(mergeRowChannel).getLoadedBlock();
         List<Block> fields = getRowFieldsFromBlock(mergeRow);
-        List<Block> builder = new ArrayList<>(dataColumnChannels.size() + 3);
+        List<Block> builder = new ArrayList<>(dataColumnChannels.size() + 4);
         for (int channel : dataColumnChannels) {
             builder.add(fields.get(channel));
         }
         Block operationChannelBlock = fields.get(fields.size() - 2);
         builder.add(operationChannelBlock);
+        Block caseNumberChannelBlock = fields.get(fields.size() - 1);
+        builder.add(caseNumberChannelBlock);
         builder.add(inputPage.getBlock(rowIdChannel));
         builder.add(RunLengthEncodedBlock.create(INSERT_FROM_UPDATE_BLOCK, positionCount));
 

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -1842,6 +1842,8 @@ public class Analysis
         private final List<ColumnHandle> dataColumnHandles;
         private final List<ColumnHandle> redistributionColumnHandles;
         private final List<List<ColumnHandle>> mergeCaseColumnHandles;
+        // Case number map to columns
+        private final Multimap<Integer, ColumnHandle> updateCaseColumnHandles;
         private final Set<ColumnHandle> nonNullableColumnHandles;
         private final Map<ColumnHandle, Integer> columnHandleFieldNumbers;
         private final RowType mergeRowType;
@@ -1857,6 +1859,7 @@ public class Analysis
                 List<ColumnHandle> dataColumnHandles,
                 List<ColumnHandle> redistributionColumnHandles,
                 List<List<ColumnHandle>> mergeCaseColumnHandles,
+                Multimap<Integer, ColumnHandle> updateCaseColumnHandles,
                 Set<ColumnHandle> nonNullableColumnHandles,
                 Map<ColumnHandle, Integer> columnHandleFieldNumbers,
                 RowType mergeRowType,
@@ -1871,6 +1874,7 @@ public class Analysis
             this.dataColumnHandles = requireNonNull(dataColumnHandles, "dataColumnHandles is null");
             this.redistributionColumnHandles = requireNonNull(redistributionColumnHandles, "redistributionColumnHandles is null");
             this.mergeCaseColumnHandles = requireNonNull(mergeCaseColumnHandles, "mergeCaseColumnHandles is null");
+            this.updateCaseColumnHandles = requireNonNull(updateCaseColumnHandles, "updateCaseColumnHandles is null");
             this.nonNullableColumnHandles = requireNonNull(nonNullableColumnHandles, "nonNullableColumnHandles is null");
             this.columnHandleFieldNumbers = requireNonNull(columnHandleFieldNumbers, "columnHandleFieldNumbers is null");
             this.mergeRowType = requireNonNull(mergeRowType, "mergeRowType is null");
@@ -1904,6 +1908,11 @@ public class Analysis
         public List<List<ColumnHandle>> getMergeCaseColumnHandles()
         {
             return mergeCaseColumnHandles;
+        }
+
+        public Multimap<Integer, ColumnHandle> getUpdateCaseColumnHandles()
+        {
+            return updateCaseColumnHandles;
         }
 
         public Set<ColumnHandle> getNonNullableColumnHandles()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
@@ -553,6 +553,8 @@ class QueryPlanner
         List<Symbol> columnSymbols = columnSymbolsBuilder.build();
         Symbol operationSymbol = symbolAllocator.newSymbol("operation", TINYINT);
         assignmentsBuilder.put(operationSymbol, new Constant(TINYINT, (long) DELETE_OPERATION_NUMBER));
+        Symbol caseNumberSymbol = symbolAllocator.newSymbol("case_number", INTEGER);
+        assignmentsBuilder.put(caseNumberSymbol, new Constant(INTEGER, 0L));
         Symbol projectedRowIdSymbol = symbolAllocator.newSymbol(rowIdSymbol.name(), rowIdType);
         assignmentsBuilder.put(projectedRowIdSymbol, rowIdSymbol.toSymbolReference());
         assignmentsBuilder.put(symbolAllocator.newSymbol("insert_from_update", TINYINT), new Constant(TINYINT, 0L));
@@ -575,7 +577,8 @@ class QueryPlanner
                         Optional.empty(),
                         tableMetadata.table(),
                         paradigmAndTypes,
-                        findSourceTableHandles(projectNode)),
+                        findSourceTableHandles(projectNode),
+                        ImmutableListMultimap.of()),
                 projectNode.getOutputSymbols(),
                 partitioningScheme,
                 outputs);
@@ -943,7 +946,8 @@ class QueryPlanner
                 Optional.empty(),
                 metadata.getTableName(session, handle).getSchemaTableName(),
                 mergeParadigmAndTypes,
-                findSourceTableHandles(planNode));
+                findSourceTableHandles(planNode),
+                mergeAnalysis.getUpdateCaseColumnHandles());
 
         ImmutableList.Builder<Symbol> columnSymbolsBuilder = ImmutableList.builder();
         for (ColumnHandle columnHandle : mergeAnalysis.getDataColumnHandles()) {
@@ -958,11 +962,13 @@ class QueryPlanner
         }
 
         Symbol operationSymbol = symbolAllocator.newSymbol("operation", TINYINT);
+        Symbol caseNumberSymbol = symbolAllocator.newSymbol("case_number", INTEGER);
         Symbol insertFromUpdateSymbol = symbolAllocator.newSymbol("insert_from_update", TINYINT);
 
         List<Symbol> projectedSymbols = ImmutableList.<Symbol>builder()
                 .addAll(columnSymbols)
                 .add(operationSymbol)
+                .add(caseNumberSymbol)
                 .add(rowIdSymbol)
                 .add(insertFromUpdateSymbol)
                 .build();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/BeginTableWrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/BeginTableWrite.java
@@ -212,7 +212,8 @@ public class BeginTableWrite
                         mergeTarget.getMergeHandle(),
                         mergeTarget.getSchemaTableName(),
                         mergeTarget.getMergeParadigmAndTypes(),
-                        findSourceTableHandles(node));
+                        findSourceTableHandles(node),
+                        mergeTarget.getUpdateCaseColumnHandles());
             }
 
             if (node instanceof ExchangeNode || node instanceof UnionNode) {
@@ -247,13 +248,14 @@ public class BeginTableWrite
                         findSourceTableHandles(planNode));
             }
             if (target instanceof MergeTarget merge) {
-                MergeHandle mergeHandle = metadata.beginMerge(session, merge.getHandle());
+                MergeHandle mergeHandle = metadata.beginMerge(session, merge.getHandle(), merge.getUpdateCaseColumnHandles());
                 return new MergeTarget(
                         mergeHandle.tableHandle(),
                         Optional.of(mergeHandle),
                         merge.getSchemaTableName(),
                         merge.getMergeParadigmAndTypes(),
-                        findSourceTableHandles(planNode));
+                        findSourceTableHandles(planNode),
+                        merge.getUpdateCaseColumnHandles());
             }
             if (target instanceof TableWriterNode.RefreshMaterializedViewReference refreshMV) {
                 return new TableWriterNode.RefreshMaterializedViewTarget(

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableWriterNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableWriterNode.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Multimap;
 import com.google.errorprone.annotations.Immutable;
 import io.trino.Session;
 import io.trino.metadata.InsertTableHandle;
@@ -731,6 +732,7 @@ public class TableWriterNode
         private final SchemaTableName schemaTableName;
         private final MergeParadigmAndTypes mergeParadigmAndTypes;
         private final List<TableHandle> sourceTableHandles;
+        private final Multimap<Integer, ColumnHandle> updateCaseColumnHandles;
 
         @JsonCreator
         public MergeTarget(
@@ -738,13 +740,15 @@ public class TableWriterNode
                 @JsonProperty("mergeHandle") Optional<MergeHandle> mergeHandle,
                 @JsonProperty("schemaTableName") SchemaTableName schemaTableName,
                 @JsonProperty("mergeParadigmAndTypes") MergeParadigmAndTypes mergeParadigmAndTypes,
-                @JsonProperty("sourceTableHandles") List<TableHandle> sourceTableHandles)
+                @JsonProperty("sourceTableHandles") List<TableHandle> sourceTableHandles,
+                @JsonProperty("updateCaseColumnHandles") Multimap<Integer, ColumnHandle> updateCaseColumnHandles)
         {
             this.handle = requireNonNull(handle, "handle is null");
             this.mergeHandle = requireNonNull(mergeHandle, "mergeHandle is null");
             this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
             this.mergeParadigmAndTypes = requireNonNull(mergeParadigmAndTypes, "mergeElements is null");
             this.sourceTableHandles = ImmutableList.copyOf(requireNonNull(sourceTableHandles, "sourceTableHandles is null"));
+            this.updateCaseColumnHandles = requireNonNull(updateCaseColumnHandles, "updateCaseColumnHandles is null");
         }
 
         @JsonProperty
@@ -799,6 +803,12 @@ public class TableWriterNode
         public List<TableHandle> getSourceTableHandles()
         {
             return sourceTableHandles;
+        }
+
+        @JsonProperty
+        public Multimap<Integer, ColumnHandle> getUpdateCaseColumnHandles()
+        {
+            return updateCaseColumnHandles;
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
@@ -771,6 +771,15 @@ public class TracingConnectorMetadata
     }
 
     @Override
+    public ConnectorMergeTableHandle beginMerge(ConnectorSession session, ConnectorTableHandle tableHandle, Map<Integer, Collection<ColumnHandle>> updateCaseColumns, RetryMode retryMode)
+    {
+        Span span = startSpan("beginMerge", tableHandle);
+        try (var _ = scopedSpan(span)) {
+            return delegate.beginMerge(session, tableHandle, updateCaseColumns, retryMode);
+        }
+    }
+
+    @Override
     public void finishMerge(ConnectorSession session, ConnectorMergeTableHandle tableHandle, List<ConnectorTableHandle> sourceTableHandles, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         Span span = startSpan("finishMerge", tableHandle.getTableHandle());

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
@@ -14,6 +14,7 @@
 package io.trino.tracing;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.inject.Inject;
 import io.airlift.slice.Slice;
@@ -822,11 +823,11 @@ public class TracingMetadata
     }
 
     @Override
-    public MergeHandle beginMerge(Session session, TableHandle tableHandle)
+    public MergeHandle beginMerge(Session session, TableHandle tableHandle, Multimap<Integer, ColumnHandle> updateCaseColumns)
     {
         Span span = startSpan("beginMerge", tableHandle);
         try (var _ = scopedSpan(span)) {
-            return delegate.beginMerge(session, tableHandle);
+            return delegate.beginMerge(session, tableHandle, updateCaseColumns);
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -17,6 +17,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.slice.Slice;
 import io.trino.Session;
@@ -549,7 +550,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public MergeHandle beginMerge(Session session, TableHandle tableHandle)
+    public MergeHandle beginMerge(Session session, TableHandle tableHandle, Multimap<Integer, ColumnHandle> updateCaseColumnHandles)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDeleteAndInsertMergeProcessor.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDeleteAndInsertMergeProcessor.java
@@ -80,7 +80,7 @@ public class TestDeleteAndInsertMergeProcessor
         assertThat((int) TINYINT.getByte(outputPage.getBlock(3), 0)).isEqualTo(DELETE_OPERATION_NUMBER);
 
         // Show that the row to be deleted is rowId 0, e.g. ('Dave', 11, 'Devon')
-        SqlRow rowIdRow = ((RowBlock) outputPage.getBlock(4)).getRow(0);
+        SqlRow rowIdRow = ((RowBlock) outputPage.getBlock(5)).getRow(0);
         assertThat(BIGINT.getLong(rowIdRow.getRawFieldBlock(1), rowIdRow.getRawIndex())).isEqualTo(0);
     }
 
@@ -123,7 +123,7 @@ public class TestDeleteAndInsertMergeProcessor
 
         Page outputPage = processor.transformPage(inputPage);
         assertThat(outputPage.getPositionCount()).isEqualTo(8);
-        RowBlock rowIdBlock = (RowBlock) outputPage.getBlock(4);
+        RowBlock rowIdBlock = (RowBlock) outputPage.getBlock(5);
         assertThat(rowIdBlock.getPositionCount()).isEqualTo(8);
         // Show that the first row has address "Arches"
         assertThat(getString(outputPage.getBlock(2), 1)).isEqualTo("Arches/Arches");
@@ -163,7 +163,7 @@ Page[positions=8 0:Dict[VarWidth["Aaron", "Dave", "Dave", "Ed", "Aaron", "Carol"
 
         Page outputPage = processor.transformPage(inputPage);
         assertThat(outputPage.getPositionCount()).isEqualTo(8);
-        RowBlock rowIdBlock = (RowBlock) outputPage.getBlock(4);
+        RowBlock rowIdBlock = (RowBlock) outputPage.getBlock(5);
         assertThat(rowIdBlock.getPositionCount()).isEqualTo(8);
         // Show that the first row has address "Arches/Arches"
         assertThat(getString(outputPage.getBlock(2), 1)).isEqualTo("Arches/Arches");

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -15,6 +15,7 @@ package io.trino.sql.planner.iterative.rule.test;
 
 import com.google.common.base.Functions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ListMultimap;
@@ -787,7 +788,8 @@ public class PlanBuilder
                 Optional.empty(),
                 schemaTableName,
                 mergeParadigmAndTypes,
-                List.of());
+                List.of(),
+                ImmutableListMultimap.of());
     }
 
     public ExchangeNode gatheringExchange(ExchangeNode.Scope scope, PlanNode child)

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -878,10 +878,22 @@ public interface ConnectorMetadata
     /**
      * Do whatever is necessary to start an MERGE query, returning the {@link ConnectorMergeTableHandle}
      * instance that will be passed to the PageSink, and to the {@link #finishMerge} method.
+     *
+     * @deprecated {Use {@link #beginMerge(ConnectorSession, ConnectorTableHandle, Map, RetryMode)}}
      */
+    @Deprecated
     default ConnectorMergeTableHandle beginMerge(ConnectorSession session, ConnectorTableHandle tableHandle, RetryMode retryMode)
     {
         throw new TrinoException(NOT_SUPPORTED, MODIFYING_ROWS_MESSAGE);
+    }
+
+    /**
+     * Do whatever is necessary to start an MERGE query, returning the {@link ConnectorMergeTableHandle}
+     * instance that will be passed to the PageSink, and to the {@link #finishMerge} method.
+     */
+    default ConnectorMergeTableHandle beginMerge(ConnectorSession session, ConnectorTableHandle tableHandle, Map<Integer, Collection<ColumnHandle>> updateCaseColumns, RetryMode retryMode)
+    {
+        return beginMerge(session, tableHandle, retryMode);
     }
 
     /**

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/MergePage.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/MergePage.java
@@ -62,15 +62,15 @@ public final class MergePage
     {
         // see page description in ConnectorMergeSink
         int inputChannelCount = inputPage.getChannelCount();
-        if (inputChannelCount != dataColumnCount + 2) {
-            throw new IllegalArgumentException(format("inputPage channelCount (%s) == dataColumns size (%s) + 2", inputChannelCount, dataColumnCount));
+        if (inputChannelCount != dataColumnCount + 3) {
+            throw new IllegalArgumentException(format("inputPage channelCount (%s) == dataColumns size (%s) + 3", inputChannelCount, dataColumnCount));
         }
 
         int positionCount = inputPage.getPositionCount();
         if (positionCount <= 0) {
             throw new IllegalArgumentException("positionCount should be > 0, but is " + positionCount);
         }
-        Block operationBlock = inputPage.getBlock(inputChannelCount - 2);
+        Block operationBlock = inputPage.getBlock(dataColumnCount);
 
         int[] deletePositions = new int[positionCount];
         int[] insertPositions = new int[positionCount];
@@ -99,7 +99,7 @@ public final class MergePage
             for (int i = 0; i < dataColumnCount; i++) {
                 columns[i] = i;
             }
-            columns[dataColumnCount] = dataColumnCount + 1; // row ID channel
+            columns[dataColumnCount] = dataColumnCount + 2; // row ID channel
             deletePage = Optional.of(inputPage
                     .getColumns(columns)
                     .getPositions(deletePositions, 0, deletePositionCount));

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -1215,6 +1215,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public ConnectorMergeTableHandle beginMerge(ConnectorSession session, ConnectorTableHandle tableHandle, Map<Integer, Collection<ColumnHandle>> updateCaseColumns, RetryMode retryMode)
+    {
+        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
+            return delegate.beginMerge(session, tableHandle, updateCaseColumns, retryMode);
+        }
+    }
+
+    @Override
     public void finishMerge(ConnectorSession session, ConnectorMergeTableHandle mergeTableHandle, List<ConnectorTableHandle> sourceTableHandles, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
@@ -818,10 +818,10 @@ public class BigQueryMetadata
     }
 
     @Override
-    public ConnectorMergeTableHandle beginMerge(ConnectorSession session, ConnectorTableHandle tableHandle, RetryMode retryMode)
+    public ConnectorMergeTableHandle beginMerge(ConnectorSession session, ConnectorTableHandle tableHandle, Map<Integer, Collection<ColumnHandle>> updateCaseColumns, RetryMode retryMode)
     {
         // TODO Fix BaseBigQueryFailureRecoveryTest when implementing this method
-        return ConnectorMetadata.super.beginMerge(session, tableHandle, retryMode);
+        return ConnectorMetadata.super.beginMerge(session, tableHandle, updateCaseColumns, retryMode);
     }
 
     @Override

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraMetadata.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraMetadata.java
@@ -471,7 +471,7 @@ public class CassandraMetadata
     }
 
     @Override
-    public ConnectorMergeTableHandle beginMerge(ConnectorSession session, ConnectorTableHandle tableHandle, RetryMode retryMode)
+    public ConnectorMergeTableHandle beginMerge(ConnectorSession session, ConnectorTableHandle tableHandle, Map<Integer, Collection<ColumnHandle>> updateCaseColumns, RetryMode retryMode)
     {
         throw new TrinoException(NOT_SUPPORTED, "Delete without primary key or partition key is not supported");
     }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
@@ -190,7 +190,7 @@ public class DeltaLakeMergeSink
             dataColumnsIndices[i] = i;
             dataAndRowIdColumnsIndices[i] = i;
         }
-        dataAndRowIdColumnsIndices[tableColumnCount] = tableColumnCount + 1; // row ID channel
+        dataAndRowIdColumnsIndices[tableColumnCount] = tableColumnCount + 2; // row ID channel
     }
 
     @Override
@@ -252,15 +252,15 @@ public class DeltaLakeMergeSink
     private DeltaLakeMergePage createPages(Page inputPage, int dataColumnCount)
     {
         int inputChannelCount = inputPage.getChannelCount();
-        if (inputChannelCount != dataColumnCount + 2) {
-            throw new IllegalArgumentException(format("inputPage channelCount (%s) == dataColumns size (%s) + 2", inputChannelCount, dataColumnCount));
+        if (inputChannelCount != dataColumnCount + 3) {
+            throw new IllegalArgumentException(format("inputPage channelCount (%s) == dataColumns size (%s) + 3", inputChannelCount, dataColumnCount));
         }
 
         int positionCount = inputPage.getPositionCount();
         if (positionCount <= 0) {
             throw new IllegalArgumentException("positionCount should be > 0, but is " + positionCount);
         }
-        Block operationBlock = inputPage.getBlock(inputChannelCount - 2);
+        Block operationBlock = inputPage.getBlock(inputChannelCount - 3);
         int[] deletePositions = new int[positionCount];
         int[] insertPositions = new int[positionCount];
         int[] updateInsertPositions = new int[positionCount];

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduMetadata.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduMetadata.java
@@ -431,7 +431,7 @@ public class KuduMetadata
     }
 
     @Override
-    public ConnectorMergeTableHandle beginMerge(ConnectorSession session, ConnectorTableHandle tableHandle, RetryMode retryMode)
+    public ConnectorMergeTableHandle beginMerge(ConnectorSession session, ConnectorTableHandle tableHandle, Map<Integer, Collection<ColumnHandle>> updateCaseColumns, RetryMode retryMode)
     {
         KuduTableHandle kuduTableHandle = (KuduTableHandle) tableHandle;
         KuduTable table = kuduTableHandle.getTable(clientSession);

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduPageSink.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduPageSink.java
@@ -207,11 +207,11 @@ public class KuduPageSink
     @Override
     public void storeMergedRows(Page page)
     {
-        // The last channel in the page is the rowId block, the next-to-last is the operation block
+        // The last channel in the page is the rowId block, the next-to-last is the case number block, then the next is operation block
         int columnCount = originalColumnTypes.size();
-        checkArgument(page.getChannelCount() == 2 + columnCount, "The page size should be 2 + columnCount (%s), but is %s", columnCount, page.getChannelCount());
+        checkArgument(page.getChannelCount() == 3 + columnCount, "The page size should be 3 + columnCount (%s), but is %s", columnCount, page.getChannelCount());
         Block operationBlock = page.getBlock(columnCount);
-        Block rowIds = page.getBlock(columnCount + 1);
+        Block rowIds = page.getBlock(columnCount + 2);
 
         Schema schema = table.getSchema();
         try (KuduOperationApplier operationApplier = KuduOperationApplier.fromKuduClientSession(session)) {

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMergeSink.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMergeSink.java
@@ -13,7 +13,9 @@
  */
 package io.trino.plugin.phoenix5;
 
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
 import io.trino.plugin.jdbc.JdbcClient;
 import io.trino.plugin.jdbc.JdbcOutputTableHandle;
@@ -32,19 +34,27 @@ import io.trino.spi.connector.ConnectorPageSinkId;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
+import org.apache.phoenix.util.SchemaUtil;
 
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static io.trino.plugin.phoenix5.PhoenixClient.ROWKEY;
 import static io.trino.plugin.phoenix5.PhoenixClient.ROWKEY_COLUMN_HANDLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.apache.phoenix.util.SchemaUtil.getEscapedArgument;
@@ -56,8 +66,10 @@ public class PhoenixMergeSink
     private final int columnCount;
 
     private final ConnectorPageSink insertSink;
-    private final ConnectorPageSink updateSink;
+    private final Map<Integer, Supplier<ConnectorPageSink>> updateSinkSuppliers;
     private final ConnectorPageSink deleteSink;
+
+    private final Map<Integer, Set<Integer>> updateCaseChannels;
 
     public PhoenixMergeSink(
             ConnectorSession session,
@@ -73,7 +85,6 @@ public class PhoenixMergeSink
         this.columnCount = phoenixOutputTableHandle.getColumnNames().size();
 
         this.insertSink = new JdbcPageSink(session, phoenixOutputTableHandle, phoenixClient, pageSinkId, remoteQueryModifier, JdbcClient::buildInsertSql);
-        this.updateSink = createUpdateSink(session, phoenixOutputTableHandle, phoenixClient, pageSinkId, remoteQueryModifier);
 
         ImmutableList.Builder<String> mergeRowIdFieldNamesBuilder = ImmutableList.builder();
         ImmutableList.Builder<Type> mergeRowIdFieldTypesBuilder = ImmutableList.builder();
@@ -84,6 +95,31 @@ public class PhoenixMergeSink
             mergeRowIdFieldTypesBuilder.add(field.getType());
         }
         List<String> mergeRowIdFieldNames = mergeRowIdFieldNamesBuilder.build();
+        List<String> dataColumnNames = phoenixOutputTableHandle.getColumnNames().stream()
+                .map(SchemaUtil::getEscapedArgument)
+                .collect(toImmutableList());
+        Set<Integer> mergeRowIdChannels = mergeRowIdFieldNames.stream()
+                .map(dataColumnNames::indexOf)
+                .collect(toImmutableSet());
+
+        Map<Integer, Set<Integer>> updateCaseChannels = new HashMap<>();
+        for (Map.Entry<Integer, Set<Integer>> entry : phoenixMergeTableHandle.updateCaseColumns().entrySet()) {
+            updateCaseChannels.put(entry.getKey(), entry.getValue());
+            if (!hasRowKey) {
+                checkArgument(!mergeRowIdChannels.isEmpty() && !mergeRowIdChannels.contains(-1), "No primary keys found");
+                updateCaseChannels.get(entry.getKey()).addAll(mergeRowIdChannels);
+            }
+        }
+        this.updateCaseChannels = ImmutableMap.copyOf(updateCaseChannels);
+
+        ImmutableMap.Builder<Integer, Supplier<ConnectorPageSink>> updateSinksBuilder = ImmutableMap.builder();
+        for (Map.Entry<Integer, Set<Integer>> entry : this.updateCaseChannels.entrySet()) {
+            int caseNumber = entry.getKey();
+            Supplier<ConnectorPageSink> updateSupplier = Suppliers.memoize(() -> createUpdateSink(session, phoenixOutputTableHandle, phoenixClient, pageSinkId, remoteQueryModifier, entry.getValue()));
+            updateSinksBuilder.put(caseNumber, updateSupplier);
+        }
+        this.updateSinkSuppliers = updateSinksBuilder.buildOrThrow();
+
         this.deleteSink = createDeleteSink(session, mergeRowIdFieldTypesBuilder.build(), phoenixClient, phoenixMergeTableHandle, mergeRowIdFieldNames, pageSinkId, remoteQueryModifier, queryBuilder);
     }
 
@@ -92,12 +128,17 @@ public class PhoenixMergeSink
             PhoenixOutputTableHandle phoenixOutputTableHandle,
             PhoenixClient phoenixClient,
             ConnectorPageSinkId pageSinkId,
-            RemoteQueryModifier remoteQueryModifier)
+            RemoteQueryModifier remoteQueryModifier,
+            Set<Integer> updateChannels)
     {
         ImmutableList.Builder<String> columnNamesBuilder = ImmutableList.builder();
         ImmutableList.Builder<Type> columnTypesBuilder = ImmutableList.builder();
-        columnNamesBuilder.addAll(phoenixOutputTableHandle.getColumnNames());
-        columnTypesBuilder.addAll(phoenixOutputTableHandle.getColumnTypes());
+        for (int channel = 0; channel < phoenixOutputTableHandle.getColumnNames().size(); channel++) {
+            if (updateChannels.contains(channel)) {
+                columnNamesBuilder.add(phoenixOutputTableHandle.getColumnNames().get(channel));
+                columnTypesBuilder.add(phoenixOutputTableHandle.getColumnTypes().get(channel));
+            }
+        }
         if (phoenixOutputTableHandle.rowkeyColumn().isPresent()) {
             columnNamesBuilder.add(ROWKEY);
             columnTypesBuilder.add(ROWKEY_COLUMN_HANDLE.getColumnType());
@@ -168,8 +209,10 @@ public class PhoenixMergeSink
         int insertPositionCount = 0;
         int[] deletePositions = new int[positionCount];
         int deletePositionCount = 0;
-        int[] updatePositions = new int[positionCount];
-        int updatePositionCount = 0;
+
+        Block updateCaseBlock = page.getBlock(columnCount + 1);
+        Map<Integer, int[]> updatePositions = new HashMap<>();
+        Map<Integer, Integer> updatePositionCounts = new HashMap<>();
 
         for (int position = 0; position < positionCount; position++) {
             int operation = TINYINT.getByte(operationBlock, position);
@@ -183,8 +226,10 @@ public class PhoenixMergeSink
                     deletePositionCount++;
                 }
                 case UPDATE_OPERATION_NUMBER -> {
-                    updatePositions[updatePositionCount] = position;
-                    updatePositionCount++;
+                    int caseNumber = INTEGER.getInt(updateCaseBlock, position);
+                    int updatePositionCount = updatePositionCounts.getOrDefault(caseNumber, 0);
+                    updatePositions.computeIfAbsent(caseNumber, _ -> new int[positionCount])[updatePositionCount] = position;
+                    updatePositionCounts.put(caseNumber, updatePositionCount + 1);
                 }
                 default -> throw new IllegalStateException("Unexpected value: " + operation);
             }
@@ -203,13 +248,21 @@ public class PhoenixMergeSink
             deleteSink.appendPage(new Page(deletePositionCount, deleteBlocks));
         }
 
-        if (updatePositionCount > 0) {
-            Page updatePage = dataPage.getPositions(updatePositions, 0, updatePositionCount);
-            if (hasRowKey) {
-                updatePage = updatePage.appendColumn(rowIdFields.get(0).getPositions(updatePositions, 0, updatePositionCount));
-            }
+        for (Map.Entry<Integer, Integer> entry : updatePositionCounts.entrySet()) {
+            int caseNumber = entry.getKey();
+            int updatePositionCount = entry.getValue();
+            if (updatePositionCount > 0) {
+                checkArgument(updatePositions.containsKey(caseNumber), "Unexpected case number %s", caseNumber);
 
-            updateSink.appendPage(updatePage);
+                Page updatePage = dataPage
+                        .getColumns(updateCaseChannels.get(caseNumber).stream().mapToInt(Integer::intValue).sorted().toArray())
+                        .getPositions(updatePositions.get(caseNumber), 0, updatePositionCount);
+                if (hasRowKey) {
+                    updatePage = updatePage.appendColumn(rowIdFields.get(0).getPositions(updatePositions.get(caseNumber), 0, updatePositionCount));
+                }
+
+                updateSinkSuppliers.get(caseNumber).get().appendPage(updatePage);
+            }
         }
     }
 
@@ -218,7 +271,7 @@ public class PhoenixMergeSink
     {
         insertSink.finish();
         deleteSink.finish();
-        updateSink.finish();
+        updateSinkSuppliers.values().stream().map(Supplier::get).forEach(ConnectorPageSink::finish);
         return completedFuture(ImmutableList.of());
     }
 
@@ -227,6 +280,6 @@ public class PhoenixMergeSink
     {
         insertSink.abort();
         deleteSink.abort();
-        updateSink.abort();
+        updateSinkSuppliers.values().stream().map(Supplier::get).forEach(ConnectorPageSink::abort);
     }
 }

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMergeSink.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMergeSink.java
@@ -157,7 +157,7 @@ public class PhoenixMergeSink
     @Override
     public void storeMergedRows(Page page)
     {
-        checkArgument(page.getChannelCount() == 2 + columnCount, "The page size should be 2 + columnCount (%s), but is %s", columnCount, page.getChannelCount());
+        checkArgument(page.getChannelCount() == 3 + columnCount, "The page size should be 3 + columnCount (%s), but is %s", columnCount, page.getChannelCount());
         int positionCount = page.getPositionCount();
         Block operationBlock = page.getBlock(columnCount);
 
@@ -194,7 +194,7 @@ public class PhoenixMergeSink
             insertSink.appendPage(dataPage.getPositions(insertPositions, 0, insertPositionCount));
         }
 
-        List<Block> rowIdFields = RowBlock.getRowFieldsFromBlock(page.getBlock(columnCount + 1));
+        List<Block> rowIdFields = RowBlock.getRowFieldsFromBlock(page.getBlock(columnCount + 2));
         if (deletePositionCount > 0) {
             Block[] deleteBlocks = new Block[rowIdFields.size()];
             for (int field = 0; field < rowIdFields.size(); field++) {

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMergeTableHandle.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMergeTableHandle.java
@@ -21,13 +21,17 @@ import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorMergeTableHandle;
 import io.trino.spi.predicate.TupleDomain;
 
+import java.util.Map;
+import java.util.Set;
+
 import static java.util.Objects.requireNonNull;
 
 public record PhoenixMergeTableHandle(
         JdbcTableHandle tableHandle,
         PhoenixOutputTableHandle phoenixOutputTableHandle,
         JdbcColumnHandle mergeRowIdColumnHandle,
-        TupleDomain<ColumnHandle> primaryKeysDomain)
+        TupleDomain<ColumnHandle> primaryKeysDomain,
+        Map<Integer, Set<Integer>> updateCaseColumns)
         implements ConnectorMergeTableHandle
 {
     @JsonCreator
@@ -35,12 +39,14 @@ public record PhoenixMergeTableHandle(
             @JsonProperty("tableHandle") JdbcTableHandle tableHandle,
             @JsonProperty("phoenixOutputTableHandle") PhoenixOutputTableHandle phoenixOutputTableHandle,
             @JsonProperty("mergeRowIdColumnHandle") JdbcColumnHandle mergeRowIdColumnHandle,
-            @JsonProperty("primaryKeysDomain") TupleDomain<ColumnHandle> primaryKeysDomain)
+            @JsonProperty("primaryKeysDomain") TupleDomain<ColumnHandle> primaryKeysDomain,
+            @JsonProperty("updateCaseColumns") Map<Integer, Set<Integer>> updateCaseColumns)
     {
         this.tableHandle = requireNonNull(tableHandle, "tableHandle is null");
         this.phoenixOutputTableHandle = requireNonNull(phoenixOutputTableHandle, "phoenixOutputTableHandle is null");
         this.mergeRowIdColumnHandle = requireNonNull(mergeRowIdColumnHandle, "mergeRowIdColumnHandle is null");
         this.primaryKeysDomain = requireNonNull(primaryKeysDomain, "primaryKeysDomain is null");
+        this.updateCaseColumns = requireNonNull(updateCaseColumns, "updateCaseColumns is null");
     }
 
     @JsonProperty
@@ -69,5 +75,12 @@ public record PhoenixMergeTableHandle(
     public TupleDomain<ColumnHandle> primaryKeysDomain()
     {
         return primaryKeysDomain;
+    }
+
+    @Override
+    @JsonProperty
+    public Map<Integer, Set<Integer>> updateCaseColumns()
+    {
+        return updateCaseColumns;
     }
 }

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
@@ -66,6 +66,7 @@ import java.util.Set;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.plugin.jdbc.JdbcMetadata.getColumns;
 import static io.trino.plugin.phoenix5.MetadataUtil.getEscapedTableName;
 import static io.trino.plugin.phoenix5.MetadataUtil.toTrinoSchemaName;
@@ -350,11 +351,23 @@ public class PhoenixMetadata
             primaryKeysDomainBuilder.put(columnHandle, dummy);
         }
 
+        ImmutableMap.Builder<Integer, Set<Integer>> updateColumnChannelsBuilder = ImmutableMap.builder();
+        for (Map.Entry<Integer, Collection<ColumnHandle>> entry : updateColumnHandles.entrySet()) {
+            int caseNumber = entry.getKey();
+            Set<Integer> updateColumnChannels = entry.getValue().stream()
+                    .map(JdbcColumnHandle.class::cast)
+                    .peek(column -> checkArgument(columns.contains(column), "update column %s not found in the target table", column))
+                    .map(columns::indexOf)
+                    .collect(toImmutableSet());
+            updateColumnChannelsBuilder.put(caseNumber, updateColumnChannels);
+        }
+
         return new PhoenixMergeTableHandle(
                 phoenixClient.updatedScanColumnTable(session, handle, handle.getColumns(), mergeRowIdColumnHandle),
                 phoenixOutputTableHandle,
                 mergeRowIdColumnHandle,
-                TupleDomain.withColumnDomains(primaryKeysDomainBuilder.buildOrThrow()));
+                TupleDomain.withColumnDomains(primaryKeysDomainBuilder.buildOrThrow()),
+                updateColumnChannelsBuilder.buildOrThrow());
     }
 
     @Override

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
@@ -330,7 +330,7 @@ public class PhoenixMetadata
     }
 
     @Override
-    public ConnectorMergeTableHandle beginMerge(ConnectorSession session, ConnectorTableHandle tableHandle, RetryMode retryMode)
+    public ConnectorMergeTableHandle beginMerge(ConnectorSession session, ConnectorTableHandle tableHandle, Map<Integer, Collection<ColumnHandle>> updateColumnHandles, RetryMode retryMode)
     {
         JdbcTableHandle handle = (JdbcTableHandle) tableHandle;
         checkArgument(handle.isNamedRelation(), "Merge target must be named relation table");

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestingPhoenixServer.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestingPhoenixServer.java
@@ -20,7 +20,9 @@ import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.MiniHBaseCluster;
 import org.apache.hadoop.hbase.StartMiniClusterOption;
+import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.zookeeper.MiniZooKeeperCluster;
+import org.apache.phoenix.query.HBaseFactoryProvider;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -86,6 +88,12 @@ public final class TestingPhoenixServer
         catch (Exception e) {
             throw new RuntimeException("Can't start phoenix server.", e);
         }
+    }
+
+    public Connection getConnection()
+            throws IOException
+    {
+        return HBaseFactoryProvider.getHConnectionFactory().createConnection(this.conf);
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Currently the `update` implementation of MERGE update updates the whole row, this pr is going to update the engine merge impl to support partial update.
The main idea is to keep the `merge case_number` of the `UpdateCase` in the output of the `MergeProcessNode`,(this value already kept in the `merge_row` symbol that in the sourceNode of the `MergeProcessNode`, so only needs to project it), and then in the `MergeWriterNode`, the `updateSink` can perform the update according to the update case.

The partial update also needs to know the mapping of the case number with the relevant columns, thus the `ConnectorMetadata#beginMerge` is refactored to hold the info.

Here use the Phoenix connector as a example to show how it works.
<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Prerequisites for https://github.com/trinodb/trino/pull/23034

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
() Release notes are required, with the following suggested text:

```markdown
## Section
* Support partial update in engine.
* Support partial update in Phoenix.
```
