### PR TITLE
Faker: Override generator expression in select statement

### DIFF
--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerPageSource.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerPageSource.java
@@ -230,6 +230,10 @@ class FakerPageSource
     {
         if (domain.isSingleValue()) {
             ObjectWriter singleValueWriter = objectWriter(handle.type());
+            if (domain.getType() instanceof VarcharType) {
+                String valueAsString = ((Slice) domain.getSingleValue()).toStringUtf8();
+                return (blockBuilder) -> VARCHAR.writeSlice(blockBuilder, Slices.utf8Slice(faker.expression(valueAsString)));
+            }
             return (blockBuilder) -> singleValueWriter.accept(blockBuilder, domain.getSingleValue());
         }
         if (domain.getValues().isDiscreteSet()) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Faker: Add a possibility to override the generator expression in the `select statement`.  It is possible to do something like this:
```
SELECT name FROM person WHERE name='#{Name.first_name}' limit 1
```

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
