### PR TITLE
use input column count when returning without projection adaptation

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/avro/AvroPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/avro/AvroPageSourceFactory.java
@@ -156,7 +156,7 @@ public class AvroPageSourceFactory
             // will error if UUID is same name as base column for underlying storage table but should never
             // return false data. If file data has f+uuid column in schema then resolution of read null from not null will fail.
             SchemaBuilder.FieldAssembler<Schema> nullSchema = SchemaBuilder.record("null_only").fields();
-            for (int i = 0; i < Math.max(projectedReaderColumns.size(), 1); i++) {
+            for (int i = 0; i < Math.max(columns.size(), 1); i++) {
                 String notAColumnName = null;
                 while (Objects.isNull(notAColumnName) || Objects.nonNull(tableSchema.getField(notAColumnName))) {
                     notAColumnName = "f" + UUID.randomUUID().toString().replace('-', '_');


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Without projection adaption, the count of columns returned should equal the columns given, happens only for an edge case where:
- All return fields come from a nested type
- that nested type is not a part of the table schema for the partition 


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
