### PR TITLE
Correct name for TPC-H and TPC-DS connectors

### DIFF
--- a/docs/src/main/sphinx/connector.md
+++ b/docs/src/main/sphinx/connector.md
@@ -43,8 +43,8 @@ Snowflake       <connector/snowflake>
 SQL Server      <connector/sqlserver>
 System          <connector/system>
 Thrift          <connector/thrift>
-TPCDS           <connector/tpcds>
-TPCH            <connector/tpch>
+TPC-DS           <connector/tpcds>
+TPC-H            <connector/tpch>
 Vertica         <connector/vertica>
 ```
 

--- a/docs/src/main/sphinx/connector/tpcds.md
+++ b/docs/src/main/sphinx/connector/tpcds.md
@@ -1,26 +1,26 @@
-# TPCDS connector
+# TPC-DS connector
 
-The TPCDS connector provides a set of schemas to support the
+The TPC-DS connector provides a set of schemas to support the
 [TPC Benchmark™ DS (TPC-DS)](http://www.tpc.org/tpcds/). TPC-DS is a database
 benchmark used to measure the performance of complex decision support databases.
 
 This connector can be used to test the capabilities and query
 syntax of Trino without configuring access to an external data
-source. When you query a TPCDS schema, the connector generates the
+source. When you query a TPC-DS schema, the connector generates the
 data on the fly using a deterministic algorithm.
 
 ## Configuration
 
-To configure the TPCDS connector, create a catalog properties file
+To configure the TPC-DS connector, create a catalog properties file
 `etc/catalog/example.properties` with the following contents:
 
 ```text
 connector.name=tpcds
 ```
 
-## TPCDS schemas
+## TPC-DS schemas
 
-The TPCDS connector supplies several schemas:
+The TPC-DS connector supplies several schemas:
 
 ```
 SHOW SCHEMAS FROM example;
@@ -44,9 +44,9 @@ SHOW SCHEMAS FROM example;
 ```
 
 Ignore the standard schema `information_schema`, which exists in every
-catalog, and is not directly provided by the TPCDS connector.
+catalog, and is not directly provided by the TPC-DS connector.
 
-Every TPCDS schema provides the same set of tables. Some tables are
+Every TPC-DS schema provides the same set of tables. Some tables are
 identical in all schemas. The *scale factor* of the tables in a particular
 schema is determined from the schema name. For example, the schema
 `sf1` corresponds to scale factor `1` and the schema `sf300`
@@ -59,7 +59,7 @@ testing.
 (tpcds-type-mapping)=
 ## Type mapping
 
-Trino supports all data types used within the TPCDS schemas so no mapping is
+Trino supports all data types used within the TPC-DS schemas so no mapping is
 required.
 
 (tpcds-sql-support)=

--- a/docs/src/main/sphinx/connector/tpch.md
+++ b/docs/src/main/sphinx/connector/tpch.md
@@ -1,17 +1,17 @@
-# TPCH connector
+# TPC-H connector
 
-The TPCH connector provides a set of schemas to support the
+The TPC-H connector provides a set of schemas to support the
 [TPC Benchmark™ H (TPC-H)](http://www.tpc.org/tpch/). TPC-H is a database
 benchmark used to measure the performance of highly-complex decision support databases.
 
 This connector can be used to test the capabilities and query
 syntax of Trino without configuring access to an external data
-source. When you query a TPCH schema, the connector generates the
+source. When you query a TPC-H schema, the connector generates the
 data on the fly using a deterministic algorithm.
 
 ## Configuration
 
-To configure the TPCH connector, create a catalog properties file
+To configure the TPC-H connector, create a catalog properties file
 `etc/catalog/example.properties` with the following contents:
 
 ```text
@@ -20,7 +20,7 @@ connector.name=tpch
 
 In the TPC-H specification, each column is assigned a prefix based on its
 corresponding table name, such as `l_` for the `lineitem` table. By default, the
-TPCH connector simplifies column names by excluding these prefixes with the
+TPC-H connector simplifies column names by excluding these prefixes with the
 default of `tpch.column-naming` to `SIMPLIFIED`. To use the long, standard
 column names, use the configuration in the catalog properties file:
 
@@ -28,9 +28,9 @@ column names, use the configuration in the catalog properties file:
 tpch.column-naming=STANDARD
 ```
 
-## TPCH schemas
+## TPC-H schemas
 
-The TPCH connector supplies several schemas:
+The TPC-H connector supplies several schemas:
 
 ```
 SHOW SCHEMAS FROM example;
@@ -53,13 +53,13 @@ SHOW SCHEMAS FROM example;
 ```
 
 Ignore the standard schema `information_schema`, which exists in every
-catalog, and is not directly provided by the TPCH connector.
+catalog, and is not directly provided by the TPC-H connector.
 
-Every TPCH schema provides the same set of tables. Some tables are
+Every TPC-H schema provides the same set of tables. Some tables are
 identical in all schemas. Other tables vary based on the *scale factor*,
 which is determined based on the schema name. For example, the schema
 `sf1` corresponds to scale factor `1` and the schema `sf300`
-corresponds to scale factor `300`. The TPCH connector provides an
+corresponds to scale factor `300`. The TPC-H connector provides an
 infinite number of schemas for any scale factor, not just the few common
 ones listed by `SHOW SCHEMAS`. The `tiny` schema is an alias for scale
 factor `0.01`, which is a very small data set useful for testing.
@@ -67,7 +67,7 @@ factor `0.01`, which is a very small data set useful for testing.
 (tpch-type-mapping)=
 ## Type mapping
 
-Trino supports all data types used within the TPCH schemas so no mapping
+Trino supports all data types used within the TPC-H schemas so no mapping
 is required.
 
 (tpch-sql-support)=

--- a/docs/src/main/sphinx/optimizer/pushdown.md
+++ b/docs/src/main/sphinx/optimizer/pushdown.md
@@ -68,7 +68,7 @@ You can check if pushdown for a specific query is performed by looking at the
 pushed down to the connector, the explain plan does **not** show that `Aggregate` operator.
 The explain plan only shows the operations that are performed by Trino.
 
-As an example, we loaded the TPCH data set into a PostgreSQL database and then
+As an example, we loaded the TPC-H data set into a PostgreSQL database and then
 queried it using the PostgreSQL connector:
 
 ```
@@ -199,7 +199,7 @@ EXPLAIN SELECT c.custkey, o.orderkey
 FROM orders o JOIN customer c ON c.custkey = o.custkey;
 ```
 
-The following plan results from the PostgreSQL connector querying TPCH
+The following plan results from the PostgreSQL connector querying TPC-H
 data in a PostgreSQL database. It does not show any `Join` operator as a
 result of the successful join push down.
 

--- a/docs/src/main/sphinx/overview/concepts.md
+++ b/docs/src/main/sphinx/overview/concepts.md
@@ -164,7 +164,7 @@ Trino contains [many built-in connectors](/connector):
   [Prometheus](/connector/prometheus), [SingleStore](/connector/singlestore),
   and [Snowflake](/connector/snowflake) connectors.
 * A number of other utility connectors such as the [JMX](/connector/jmx),
-  [System](/connector/system), and [TPCH](/connector/tpch) connectors.
+  [System](/connector/system), and [TPC-H](/connector/tpch) connectors.
 
 Every catalog uses a specific connector. If you examine a catalog configuration
 file, you see that each contains a mandatory property `connector.name` with the

--- a/docs/src/main/sphinx/release/release-0.148.md
+++ b/docs/src/main/sphinx/release/release-0.148.md
@@ -103,5 +103,5 @@ along with the server.
 
 ## Other connectors
 
-- Add support for `varchar(n)` to the Redis, TPCH, MongoDB, Local File
+- Add support for `varchar(n)` to the Redis, TPC-H, MongoDB, Local File
   and Example HTTP connectors.

--- a/docs/src/main/sphinx/release/release-0.183.md
+++ b/docs/src/main/sphinx/release/release-0.183.md
@@ -37,11 +37,11 @@
 - Improve error message for small ORC files that are completely corrupt or not actually ORC.
 - Add predicate pushdown for the hidden column `"$path"`.
 
-## TPCH
+## TPC-H
 
 - Add column statistics for schemas `tiny` and `sf1`.
 
-## TPCDS
+## TPC-DS
 
 - Add column statistics for schemas `tiny` and `sf1`.
 

--- a/docs/src/main/sphinx/release/release-0.184.md
+++ b/docs/src/main/sphinx/release/release-0.184.md
@@ -30,7 +30,7 @@
 - Reduce system memory usage when reading table columns containing string values
   from ORC or DWRF files. This can prevent high GC overhead or out-of-memory crashes.
 
-## TPCDS
+## TPC-DS
 
 - Fix display of table statistics when running `SHOW STATS FOR ...`.
 

--- a/docs/src/main/sphinx/release/release-0.60.md
+++ b/docs/src/main/sphinx/release/release-0.60.md
@@ -15,7 +15,7 @@ anymore.
 The {doc}`/client/cli` now supports `USE CATALOG` and
 `USE SCHEMA`.
 
-## TPCH connector
+## TPC-H connector
 
 We have added a new connector that will generate synthetic data following the
 TPC-H specification. This connector makes it easy to generate large datasets for


### PR DESCRIPTION
## Description

This makes the connector names more consistent with the actual name of the benchmarks.

## Additional context and related issues

Came up in https://github.com/trinodb/trino/pull/23987/files#r1823617713

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
