### PR TITLE
Use statistics in Faker CTAS

### DIFF
--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/ColumnInfo.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/ColumnInfo.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.faker;
 
 import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.type.Type;
 
 import java.util.Optional;
 
@@ -33,6 +34,11 @@ public record ColumnInfo(FakerColumnHandle handle, ColumnMetadata metadata)
     public String name()
     {
         return metadata.getName();
+    }
+
+    public Type type()
+    {
+        return metadata.getType();
     }
 
     @Override

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerConfig.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerConfig.java
@@ -23,6 +23,7 @@ public class FakerConfig
 {
     private double nullProbability = 0.5;
     private long defaultLimit = 1000L;
+    private double sequenceMinDistinctValuesRatio = 0.98;
     private long maxDictionarySize = 1000L;
 
     @Max(1)
@@ -51,6 +52,24 @@ public class FakerConfig
     public FakerConfig setDefaultLimit(long value)
     {
         this.defaultLimit = value;
+        return this;
+    }
+
+    @Max(2)
+    @Min(0)
+    public double getSequenceMinDistinctValuesRatio()
+    {
+        return sequenceMinDistinctValuesRatio;
+    }
+
+    @Config("faker.sequence-min-distinct-values-ratio")
+    @ConfigDescription(
+            """
+            Minimum ratio of distinct values of a column to total number of rows in a table to treat the columns as a sequence
+            when creating a table using existing data. Set to a value greater than 1 to disable using sequences""")
+    public FakerConfig setSequenceMinDistinctValuesRatio(double value)
+    {
+        this.sequenceMinDistinctValuesRatio = value;
         return this;
     }
 

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerConfig.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerConfig.java
@@ -23,6 +23,7 @@ public class FakerConfig
 {
     private double nullProbability = 0.5;
     private long defaultLimit = 1000L;
+    private long maxDictionarySize = 1000L;
 
     @Max(1)
     @Min(0)
@@ -50,6 +51,23 @@ public class FakerConfig
     public FakerConfig setDefaultLimit(long value)
     {
         this.defaultLimit = value;
+        return this;
+    }
+
+    @Min(0)
+    public long getMaxDictionarySize()
+    {
+        return maxDictionarySize;
+    }
+
+    @Config("faker.max-dictionary-size")
+    @ConfigDescription(
+            """
+            Maximum size of randomly generated dictionaries to pick values from, used for columns with low number of approximate distinct values
+            observed during table creation using existing data. Set to zero to disable using dictionaries""")
+    public FakerConfig setMaxDictionarySize(long value)
+    {
+        this.maxDictionarySize = value;
         return this;
     }
 }

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerConnector.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerConnector.java
@@ -119,6 +119,17 @@ public class FakerConnector
                         null,
                         defaultLimit -> checkProperty(1 <= defaultLimit, INVALID_SCHEMA_PROPERTY, "default_limit value must be equal or greater than 1"),
                         false),
+                doubleProperty(
+                        SchemaInfo.SEQUENCE_MIN_DISTINCT_VALUES_RATIO,
+                        """
+                                Minimum ratio of distinct values of a column to total number of rows in a table to treat the columns as a sequence
+                                when creating a table in this schema using existing data. Set to a value greater than 1 to disable using sequences""",
+                        null,
+                        sequenceMinDistinctValuesRatio -> checkProperty(
+                                0 <= sequenceMinDistinctValuesRatio && sequenceMinDistinctValuesRatio <= 2,
+                                INVALID_SCHEMA_PROPERTY,
+                                SchemaInfo.SEQUENCE_MIN_DISTINCT_VALUES_RATIO + " value must be between 0 and 2, inclusive"),
+                        false),
                 longProperty(
                         SchemaInfo.MAX_DICTIONARY_SIZE,
                         """
@@ -144,6 +155,17 @@ public class FakerConnector
                         "Default limit of rows returned from this table if not specified in the query",
                         null,
                         defaultLimit -> checkProperty(1 <= defaultLimit, INVALID_TABLE_PROPERTY, "default_limit value must be equal or greater than 1"),
+                        false),
+                doubleProperty(
+                        TableInfo.SEQUENCE_MIN_DISTINCT_VALUES_RATIO,
+                        """
+                                Minimum ratio of distinct values of a column to total number of rows in a table to treat the columns as a sequence
+                                when creating a table using existing data. Set to a value greater than 1 to disable using sequences""",
+                        null,
+                        sequenceMinDistinctValuesRatio -> checkProperty(
+                                0 <= sequenceMinDistinctValuesRatio && sequenceMinDistinctValuesRatio <= 2,
+                                INVALID_TABLE_PROPERTY,
+                                TableInfo.SEQUENCE_MIN_DISTINCT_VALUES_RATIO + " value must be between 0 and 2, inclusive"),
                         false),
                 longProperty(
                         TableInfo.MAX_DICTIONARY_SIZE,

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerConnector.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerConnector.java
@@ -118,6 +118,14 @@ public class FakerConnector
                         "Default limit of rows returned from any table in this schema, if not specified in the query",
                         null,
                         defaultLimit -> checkProperty(1 <= defaultLimit, INVALID_SCHEMA_PROPERTY, "default_limit value must be equal or greater than 1"),
+                        false),
+                longProperty(
+                        SchemaInfo.MAX_DICTIONARY_SIZE,
+                        """
+                                Maximum size of randomly generated dictionaries to pick values from, used for columns with low number of approximate distinct values
+                                observed during table created in this schema using existing data. Set to zero to disable using dictionaries""",
+                        null,
+                        maxDictionarySize -> checkProperty(0 <= maxDictionarySize, INVALID_SCHEMA_PROPERTY, "max_dictionary_size value must be equal or greater than 0"),
                         false));
     }
 
@@ -136,6 +144,14 @@ public class FakerConnector
                         "Default limit of rows returned from this table if not specified in the query",
                         null,
                         defaultLimit -> checkProperty(1 <= defaultLimit, INVALID_TABLE_PROPERTY, "default_limit value must be equal or greater than 1"),
+                        false),
+                longProperty(
+                        TableInfo.MAX_DICTIONARY_SIZE,
+                        """
+                                Maximum size of randomly generated dictionaries to pick values from, used for columns with low number of approximate distinct values
+                                observed during table creation using existing data. Set to zero to disable using dictionaries""",
+                        null,
+                        maxDictionarySize -> checkProperty(0 <= maxDictionarySize, INVALID_TABLE_PROPERTY, "max_dictionary_size value must be equal or greater than 0"),
                         false));
     }
 

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerConnectorFactory.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerConnectorFactory.java
@@ -51,7 +51,8 @@ public class FakerConnectorFactory
         Bootstrap app = new Bootstrap(
                 new FakerModule(
                         context.getNodeManager(),
-                        context.getTypeManager()));
+                        context.getTypeManager(),
+                        catalogName));
 
         Injector injector = app
                 .doNotInitializeLogging()

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerModule.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerModule.java
@@ -18,6 +18,7 @@ import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
 import io.trino.spi.NodeManager;
+import io.trino.spi.catalog.CatalogName;
 import io.trino.spi.type.TypeManager;
 import jakarta.inject.Inject;
 
@@ -29,12 +30,14 @@ public class FakerModule
 {
     private final NodeManager nodeManager;
     private final TypeManager typeManager;
+    private final String catalogName;
 
     @Inject
-    public FakerModule(NodeManager nodeManager, TypeManager typeManager)
+    public FakerModule(NodeManager nodeManager, TypeManager typeManager, String catalogName)
     {
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.catalogName = requireNonNull(catalogName, "catalogName is null");
     }
 
     @Override
@@ -50,5 +53,7 @@ public class FakerModule
         binder.bind(FakerPageSinkProvider.class).in(Scopes.SINGLETON);
         binder.bind(FakerFunctionProvider.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(FakerConfig.class);
+
+        binder.bind(CatalogName.class).toInstance(new CatalogName(catalogName));
     }
 }

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerPageSinkProvider.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerPageSinkProvider.java
@@ -51,7 +51,7 @@ public class FakerPageSinkProvider
         @Override
         public CompletableFuture<?> appendPage(Page page)
         {
-            throw new UnsupportedOperationException("The faker connector does not support writes");
+            return NOT_BLOCKED;
         }
 
         @Override
@@ -63,7 +63,6 @@ public class FakerPageSinkProvider
         @Override
         public void abort()
         {
-            throw new UnsupportedOperationException("The faker connector does not support writes");
         }
     }
 }

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/LiteralFormatter.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/LiteralFormatter.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.faker;
+
+import com.google.common.net.InetAddresses;
+import com.google.common.primitives.Shorts;
+import com.google.common.primitives.SignedBytes;
+import io.airlift.slice.Slice;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Int128;
+import io.trino.spi.type.LongTimeWithTimeZone;
+import io.trino.spi.type.LongTimestamp;
+import io.trino.spi.type.LongTimestampWithTimeZone;
+import io.trino.spi.type.SqlTime;
+import io.trino.spi.type.SqlTimeWithTimeZone;
+import io.trino.spi.type.SqlTimestamp;
+import io.trino.spi.type.SqlTimestampWithTimeZone;
+import io.trino.spi.type.SqlVarbinary;
+import io.trino.spi.type.TimeType;
+import io.trino.spi.type.TimeWithTimeZoneType;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.TimestampWithTimeZoneType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.UuidType;
+import io.trino.spi.type.VarbinaryType;
+import io.trino.spi.type.VarcharType;
+import io.trino.type.IntervalDayTimeType;
+import io.trino.type.IntervalYearMonthType;
+import io.trino.type.IpAddressType;
+import io.trino.type.SqlIntervalDayTime;
+import io.trino.type.SqlIntervalYearMonth;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.MathContext;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.LocalDate;
+
+import static com.google.common.base.Verify.verify;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
+import static io.trino.spi.type.DateTimeEncoding.unpackOffsetMinutes;
+import static io.trino.spi.type.DateTimeEncoding.unpackTimeNanos;
+import static io.trino.spi.type.DateTimeEncoding.unpackZoneKey;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimeZoneKey.getTimeZoneKey;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.UuidType.trinoUuidToJavaUuid;
+import static java.lang.Float.intBitsToFloat;
+import static java.lang.Math.toIntExact;
+
+public final class LiteralFormatter
+{
+    private LiteralFormatter() {}
+
+    public static String formatLiteral(Type type, Object value)
+    {
+        Class<?> javaType = type.getJavaType();
+        if (javaType == boolean.class) {
+            boolean typedValue = (boolean) value;
+            return Boolean.toString(typedValue);
+        }
+
+        if (javaType == double.class) {
+            double typedValue = (double) value;
+            return formatStringLiteral("DOUBLE", Double.toString(typedValue));
+        }
+
+        if (javaType == long.class) {
+            long typedValue = (long) value;
+
+            if (type == TINYINT) {
+                return formatStringLiteral("TINYINT", Byte.toString(SignedBytes.checkedCast(typedValue)));
+            }
+
+            if (type == REAL) {
+                return formatStringLiteral("REAL", Float.toString(intBitsToFloat(toIntExact(typedValue))));
+            }
+
+            if (type == DATE) {
+                return formatStringLiteral("DATE", LocalDate.ofEpochDay(typedValue).toString());
+            }
+
+            if (type == BIGINT) {
+                return formatStringLiteral("BIGINT", Long.toString(typedValue));
+            }
+
+            if (type == INTEGER) {
+                return formatStringLiteral("INTEGER", Integer.toString(toIntExact(typedValue)));
+            }
+
+            if (type instanceof DecimalType decimalType) {
+                BigInteger unscaledValue = BigInteger.valueOf(typedValue);
+                BigDecimal bigDecimal = new BigDecimal(unscaledValue, decimalType.getScale(), new MathContext(decimalType.getPrecision()));
+                return formatStringLiteral("DECIMAL", bigDecimal.toString());
+            }
+
+            if (type == SMALLINT) {
+                return formatStringLiteral(
+                        "SMALLINT",
+                        Short.toString(Shorts.checkedCast(typedValue)));
+            }
+
+            if (type instanceof TimeType timeType) {
+                return formatStringLiteral(
+                        "TIME",
+                        SqlTime.newInstance(timeType.getPrecision(), typedValue).toString());
+            }
+
+            if (type instanceof TimestampType timestampType) {
+                if (timestampType.isShort()) {
+                    return formatStringLiteral(
+                            "TIMESTAMP",
+                            SqlTimestamp.newInstance(timestampType.getPrecision(), typedValue, 0).toString());
+                }
+            }
+
+            if (type instanceof TimeWithTimeZoneType timeWithTimeZoneType) {
+                verify(timeWithTimeZoneType.isShort(), "Short TimeWithTimeZoneType was expected");
+                return formatStringLiteral("TIME", SqlTimeWithTimeZone.newInstance(
+                        timeWithTimeZoneType.getPrecision(),
+                        unpackTimeNanos(typedValue) * PICOSECONDS_PER_NANOSECOND,
+                        unpackOffsetMinutes(typedValue)).toString());
+            }
+
+            if (type instanceof TimestampWithTimeZoneType timestampWithTimeZoneType) {
+                verify(timestampWithTimeZoneType.isShort(), "Short TimestampWithTimezone was expected");
+                return formatStringLiteral(
+                        "TIMESTAMP",
+                        SqlTimestampWithTimeZone.newInstance(
+                                timestampWithTimeZoneType.getPrecision(),
+                                unpackMillisUtc(typedValue),
+                                0,
+                                unpackZoneKey(typedValue)).toString());
+            }
+
+            if (type instanceof IntervalDayTimeType) {
+                return "INTERVAL " + escapeStringLiteral(new SqlIntervalDayTime(typedValue).toString()) + " DAY TO SECOND";
+            }
+
+            if (type instanceof IntervalYearMonthType) {
+                return "INTERVAL " + escapeStringLiteral(new SqlIntervalYearMonth((int) typedValue).toString()) + " YEAR TO MONTH";
+            }
+        }
+
+        if (javaType == Slice.class) {
+            Slice typedValue = (Slice) value;
+            switch (type) {
+                case VarcharType _, CharType _ -> {
+                    return escapeStringLiteral(typedValue.toStringUtf8());
+                }
+                case VarbinaryType _ -> {
+                    return "x" + escapeStringLiteral(new SqlVarbinary(typedValue.getBytes()).toString());
+                }
+                case IpAddressType _ -> {
+                    try {
+                        return formatStringLiteral("IPADDRESS", InetAddresses.toAddrString(InetAddress.getByAddress(typedValue.getBytes())));
+                    }
+                    catch (UnknownHostException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+                case UuidType _ -> {
+                    return formatStringLiteral("UUID", trinoUuidToJavaUuid(typedValue).toString());
+                }
+                default -> throw new UnsupportedOperationException("Unsupported type " + type + " backed by java " + javaType);
+            }
+        }
+
+        if (javaType == Int128.class) {
+            if (type instanceof DecimalType decimalType) {
+                Int128 typedValue = (Int128) value;
+
+                BigInteger unscaledValue = typedValue.toBigInteger();
+                BigDecimal bigDecimal = new BigDecimal(unscaledValue, decimalType.getScale(), new MathContext(decimalType.getPrecision()));
+                return formatStringLiteral("DECIMAL", bigDecimal.toPlainString());
+            }
+        }
+
+        switch (type) {
+            case TimeWithTimeZoneType timeWithTimeZoneType when javaType == LongTimeWithTimeZone.class -> {
+                LongTimeWithTimeZone typedValue = (LongTimeWithTimeZone) value;
+                return formatStringLiteral("TIME",
+                        SqlTimeWithTimeZone.newInstance(
+                                timeWithTimeZoneType.getPrecision(),
+                                typedValue.getPicoseconds(),
+                                typedValue.getOffsetMinutes()).toString());
+            }
+            case TimestampType timestampType when javaType == LongTimestamp.class -> {
+                LongTimestamp typedValue = (LongTimestamp) value;
+
+                return formatStringLiteral(
+                        "TIMESTAMP",
+                        SqlTimestamp.newInstance(
+                                timestampType.getPrecision(),
+                                typedValue.getEpochMicros(),
+                                typedValue.getPicosOfMicro()).toString());
+            }
+            case TimestampWithTimeZoneType timestampWithTimeZoneType when javaType == LongTimestampWithTimeZone.class -> {
+                LongTimestampWithTimeZone typedValue = (LongTimestampWithTimeZone) value;
+                return formatStringLiteral(
+                        "TIMESTAMP",
+                        SqlTimestampWithTimeZone.newInstance(
+                                timestampWithTimeZoneType.getPrecision(),
+                                typedValue.getEpochMillis(),
+                                typedValue.getPicosOfMilli(),
+                                getTimeZoneKey(typedValue.getTimeZoneKey())).toString());
+            }
+            default -> throw new UnsupportedOperationException("Unsupported type " + type + " backed by java " + javaType);
+        }
+    }
+
+    private static String formatStringLiteral(String typeName, String value)
+    {
+        return typeName + " " + escapeStringLiteral(value);
+    }
+
+    private static String escapeStringLiteral(String value)
+    {
+        return "'" + value.replace("'", "''") + "'";
+    }
+}

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/SchemaInfo.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/SchemaInfo.java
@@ -23,6 +23,7 @@ public record SchemaInfo(String name, Map<String, Object> properties)
 {
     public static final String NULL_PROBABILITY_PROPERTY = "null_probability";
     public static final String DEFAULT_LIMIT_PROPERTY = "default_limit";
+    public static final String SEQUENCE_MIN_DISTINCT_VALUES_RATIO = "sequence_min_distinct_values_ratio";
     public static final String MAX_DICTIONARY_SIZE = "max_dictionary_size";
 
     public SchemaInfo

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/SchemaInfo.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/SchemaInfo.java
@@ -23,6 +23,7 @@ public record SchemaInfo(String name, Map<String, Object> properties)
 {
     public static final String NULL_PROBABILITY_PROPERTY = "null_probability";
     public static final String DEFAULT_LIMIT_PROPERTY = "default_limit";
+    public static final String MAX_DICTIONARY_SIZE = "max_dictionary_size";
 
     public SchemaInfo
     {

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/TableInfo.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/TableInfo.java
@@ -27,6 +27,7 @@ public record TableInfo(List<ColumnInfo> columns, Map<String, Object> properties
 {
     public static final String NULL_PROBABILITY_PROPERTY = "null_probability";
     public static final String DEFAULT_LIMIT_PROPERTY = "default_limit";
+    public static final String SEQUENCE_MIN_DISTINCT_VALUES_RATIO = "sequence_min_distinct_values_ratio";
     public static final String MAX_DICTIONARY_SIZE = "max_dictionary_size";
 
     public TableInfo

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/TableInfo.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/TableInfo.java
@@ -27,6 +27,7 @@ public record TableInfo(List<ColumnInfo> columns, Map<String, Object> properties
 {
     public static final String NULL_PROBABILITY_PROPERTY = "null_probability";
     public static final String DEFAULT_LIMIT_PROPERTY = "default_limit";
+    public static final String MAX_DICTIONARY_SIZE = "max_dictionary_size";
 
     public TableInfo
     {

--- a/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerConfig.java
+++ b/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerConfig.java
@@ -29,7 +29,8 @@ final class TestFakerConfig
     {
         assertRecordedDefaults(recordDefaults(FakerConfig.class)
                 .setNullProbability(0.5)
-                .setDefaultLimit(1000L));
+                .setDefaultLimit(1000L)
+                .setMaxDictionarySize(1000L));
     }
 
     @Test
@@ -38,11 +39,13 @@ final class TestFakerConfig
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("faker.null-probability", "1.0")
                 .put("faker.default-limit", "10")
+                .put("faker.max-dictionary-size", "0")
                 .buildOrThrow();
 
         FakerConfig expected = new FakerConfig()
                 .setNullProbability(1.0)
-                .setDefaultLimit(10L);
+                .setDefaultLimit(10L)
+                .setMaxDictionarySize(0L);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerConfig.java
+++ b/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerConfig.java
@@ -30,6 +30,7 @@ final class TestFakerConfig
         assertRecordedDefaults(recordDefaults(FakerConfig.class)
                 .setNullProbability(0.5)
                 .setDefaultLimit(1000L)
+                .setSequenceMinDistinctValuesRatio(0.98)
                 .setMaxDictionarySize(1000L));
     }
 
@@ -39,12 +40,14 @@ final class TestFakerConfig
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("faker.null-probability", "1.0")
                 .put("faker.default-limit", "10")
+                .put("faker.sequence-min-distinct-values-ratio", "2")
                 .put("faker.max-dictionary-size", "0")
                 .buildOrThrow();
 
         FakerConfig expected = new FakerConfig()
                 .setNullProbability(1.0)
                 .setDefaultLimit(10L)
+                .setSequenceMinDistinctValuesRatio(2.0)
                 .setMaxDictionarySize(0L);
 
         assertFullMapping(properties, expected);

--- a/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerMetadata.java
+++ b/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerMetadata.java
@@ -1,0 +1,346 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.faker;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorOutputTableHandle;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.ConnectorViewDefinition;
+import io.trino.spi.connector.ConnectorViewDefinition.ViewColumn;
+import io.trino.spi.connector.SaveMode;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.security.TrinoPrincipal;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.spi.StandardErrorCode.SCHEMA_NOT_FOUND;
+import static io.trino.spi.StandardErrorCode.TABLE_ALREADY_EXISTS;
+import static io.trino.spi.connector.RetryMode.NO_RETRIES;
+import static io.trino.spi.security.PrincipalType.USER;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.testing.QueryAssertions.assertEqualsIgnoreOrder;
+import static io.trino.testing.TestingConnectorSession.SESSION;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Fail.fail;
+
+public class TestFakerMetadata
+{
+    @Test
+    public void tableIsCreatedAfterCommits()
+    {
+        FakerMetadata metadata = createMetadata();
+        assertNoTables(metadata);
+
+        SchemaTableName schemaTableName = new SchemaTableName("default", "temp_table");
+
+        ConnectorOutputTableHandle table = metadata.beginCreateTable(
+                SESSION,
+                new ConnectorTableMetadata(schemaTableName, ImmutableList.of(), ImmutableMap.of()),
+                Optional.empty(),
+                NO_RETRIES,
+                false);
+
+        metadata.finishCreateTable(SESSION, table, ImmutableList.of(), ImmutableList.of());
+
+        List<SchemaTableName> tables = metadata.listTables(SESSION, Optional.empty());
+        assertThat(tables.size())
+                .describedAs("Expected only one table")
+                .isEqualTo(1);
+        assertThat(tables.get(0).getTableName())
+                .describedAs("Expected table with name 'temp_table'")
+                .isEqualTo("temp_table");
+    }
+
+    @Test
+    public void tableAlreadyExists()
+    {
+        FakerMetadata metadata = createMetadata();
+        assertNoTables(metadata);
+
+        SchemaTableName test1Table = new SchemaTableName("default", "test1");
+        SchemaTableName test2Table = new SchemaTableName("default", "test2");
+        metadata.createTable(SESSION, new ConnectorTableMetadata(test1Table, ImmutableList.of()), SaveMode.FAIL);
+
+        assertTrinoExceptionThrownBy(() -> metadata.createTable(SESSION, new ConnectorTableMetadata(test1Table, ImmutableList.of()), SaveMode.FAIL))
+                .hasErrorCode(TABLE_ALREADY_EXISTS)
+                .hasMessage("Table 'default.test1' already exists");
+
+        ConnectorTableHandle test1TableHandle = metadata.getTableHandle(SESSION, test1Table, Optional.empty(), Optional.empty());
+        metadata.createTable(SESSION, new ConnectorTableMetadata(test2Table, ImmutableList.of()), SaveMode.FAIL);
+
+        assertTrinoExceptionThrownBy(() -> metadata.renameTable(SESSION, test1TableHandle, test2Table))
+                .hasErrorCode(TABLE_ALREADY_EXISTS)
+                .hasMessage("Table 'default.test2' already exists");
+    }
+
+    @Test
+    public void testReadTableBeforeCreationCompleted()
+    {
+        FakerMetadata metadata = createMetadata();
+        assertNoTables(metadata);
+
+        SchemaTableName tableName = new SchemaTableName("default", "temp_table");
+
+        ConnectorOutputTableHandle table = metadata.beginCreateTable(
+                SESSION,
+                new ConnectorTableMetadata(tableName, ImmutableList.of(), ImmutableMap.of()),
+                Optional.empty(),
+                NO_RETRIES,
+                false);
+
+        List<SchemaTableName> tableNames = metadata.listTables(SESSION, Optional.empty());
+        assertThat(tableNames.size())
+                .describedAs("Expected exactly one table")
+                .isEqualTo(1);
+
+        metadata.finishCreateTable(SESSION, table, ImmutableList.of(), ImmutableList.of());
+    }
+
+    @Test
+    public void testCreateSchema()
+    {
+        FakerMetadata metadata = createMetadata();
+        assertThat(metadata.listSchemaNames(SESSION)).isEqualTo(ImmutableList.of("default"));
+        metadata.createSchema(SESSION, "test", ImmutableMap.of(), new TrinoPrincipal(USER, SESSION.getUser()));
+        assertThat(metadata.listSchemaNames(SESSION)).isEqualTo(ImmutableList.of("default", "test"));
+        assertThat(metadata.listTables(SESSION, Optional.of("test"))).isEqualTo(ImmutableList.of());
+
+        SchemaTableName tableName = new SchemaTableName("test", "first_table");
+        metadata.createTable(
+                SESSION,
+                new ConnectorTableMetadata(
+                        tableName,
+                        ImmutableList.of(),
+                        ImmutableMap.of()),
+                SaveMode.FAIL);
+
+        assertThat(metadata.listTables(SESSION, Optional.empty())).isEqualTo(ImmutableList.of(tableName));
+        assertThat(metadata.listTables(SESSION, Optional.of("test"))).isEqualTo(ImmutableList.of(tableName));
+        assertThat(metadata.listTables(SESSION, Optional.of("default"))).isEqualTo(ImmutableList.of());
+    }
+
+    @Test
+    public void testCreateViewWithoutReplace()
+    {
+        SchemaTableName test = new SchemaTableName("test", "test_view");
+        FakerMetadata metadata = createMetadata();
+        metadata.createSchema(SESSION, "test", ImmutableMap.of(), new TrinoPrincipal(USER, SESSION.getUser()));
+        try {
+            metadata.createView(SESSION, test, testingViewDefinition("test"), ImmutableMap.of(), false);
+        }
+        catch (Exception e) {
+            fail("should have succeeded");
+        }
+        assertThatThrownBy(() -> metadata.createView(SESSION, test, testingViewDefinition("test"), ImmutableMap.of(), false))
+                .isInstanceOf(TrinoException.class)
+                .hasMessageMatching("View '%s' already exists".formatted(test));
+    }
+
+    @Test
+    public void testCreateViewWithReplace()
+    {
+        SchemaTableName test = new SchemaTableName("test", "test_view");
+
+        FakerMetadata metadata = createMetadata();
+        metadata.createSchema(SESSION, "test", ImmutableMap.of(), new TrinoPrincipal(USER, SESSION.getUser()));
+        metadata.createView(SESSION, test, testingViewDefinition("aaa"), ImmutableMap.of(), true);
+        metadata.createView(SESSION, test, testingViewDefinition("bbb"), ImmutableMap.of(), true);
+
+        assertThat(metadata.getView(SESSION, test))
+                .map(ConnectorViewDefinition::getOriginalSql)
+                .hasValue("bbb");
+    }
+
+    @Test
+    public void testCreatedViewShouldBeListedAsTable()
+    {
+        String schemaName = "test";
+        SchemaTableName viewName = new SchemaTableName(schemaName, "test_view");
+
+        FakerMetadata metadata = createMetadata();
+        metadata.createSchema(SESSION, schemaName, ImmutableMap.of(), new TrinoPrincipal(USER, SESSION.getUser()));
+        metadata.createView(SESSION, viewName, testingViewDefinition("aaa"), ImmutableMap.of(), true);
+
+        assertThat(metadata.listTables(SESSION, Optional.of(schemaName)))
+                .contains(viewName);
+    }
+
+    @Test
+    public void testViews()
+    {
+        FakerMetadata metadata = createMetadata();
+        SchemaTableName test1 = new SchemaTableName("test", "test_view1");
+        SchemaTableName test2 = new SchemaTableName("test", "test_view2");
+        SchemaTableName test3 = new SchemaTableName("test", "test_view3");
+
+        // create schema
+        metadata.createSchema(SESSION, "test", ImmutableMap.of(), new TrinoPrincipal(USER, SESSION.getUser()));
+
+        // create views
+        metadata.createView(SESSION, test1, testingViewDefinition("test1"), ImmutableMap.of(), false);
+        metadata.createView(SESSION, test2, testingViewDefinition("test2"), ImmutableMap.of(), false);
+
+        // verify listing
+        List<SchemaTableName> list = metadata.listViews(SESSION, Optional.of("test"));
+        assertEqualsIgnoreOrder(list, ImmutableList.of(test1, test2));
+
+        // verify getting data
+        Map<SchemaTableName, ConnectorViewDefinition> views = metadata.getViews(SESSION, Optional.of("test"));
+        assertThat(views.keySet()).isEqualTo(ImmutableSet.of(test1, test2));
+        assertThat(views.get(test1).getOriginalSql()).isEqualTo("test1");
+        assertThat(views.get(test2).getOriginalSql()).isEqualTo("test2");
+
+        // all schemas
+        assertThat(metadata.getViews(SESSION, Optional.empty()))
+                .containsOnlyKeys(test1, test2);
+
+        // exact match on one schema and table
+        assertThat(metadata.getView(SESSION, new SchemaTableName("test", "test_view1")))
+                .map(ConnectorViewDefinition::getOriginalSql)
+                .contains("test1");
+
+        // non-existent table
+        assertThat(metadata.getView(SESSION, new SchemaTableName("test", "nonexistenttable")))
+                .isEmpty();
+
+        // non-existent schema
+        assertThat(metadata.getViews(SESSION, Optional.of("nonexistentschema")))
+                .isEmpty();
+
+        // drop first view
+        metadata.dropView(SESSION, test1);
+
+        assertThat(metadata.getViews(SESSION, Optional.of("test")))
+                .containsOnlyKeys(test2);
+
+        // rename second view
+        metadata.renameView(SESSION, test2, test3);
+
+        assertThat(metadata.getViews(SESSION, Optional.of("test")))
+                .containsOnlyKeys(test3);
+
+        // drop second view
+        metadata.dropView(SESSION, test3);
+
+        assertThat(metadata.getViews(SESSION, Optional.of("test")))
+                .isEmpty();
+
+        // verify listing everything
+        assertThat(metadata.getViews(SESSION, Optional.empty()))
+                .isEmpty();
+    }
+
+    @Test
+    public void testCreateTableAndViewInNotExistSchema()
+    {
+        FakerMetadata metadata = createMetadata();
+        assertThat(metadata.listSchemaNames(SESSION)).isEqualTo(ImmutableList.of("default"));
+
+        SchemaTableName table1 = new SchemaTableName("test1", "test_schema_table1");
+        assertTrinoExceptionThrownBy(() -> metadata.beginCreateTable(
+                SESSION,
+                new ConnectorTableMetadata(table1, ImmutableList.of(), ImmutableMap.of()),
+                Optional.empty(),
+                NO_RETRIES,
+                false))
+                .hasErrorCode(SCHEMA_NOT_FOUND)
+                .hasMessage("Schema 'test1' does not exist");
+
+        SchemaTableName view2 = new SchemaTableName("test2", "test_schema_view2");
+        assertTrinoExceptionThrownBy(() -> metadata.createView(SESSION, view2, testingViewDefinition("aaa"), ImmutableMap.of(), false))
+                .hasErrorCode(SCHEMA_NOT_FOUND)
+                .hasMessage("Schema 'test2' does not exist");
+
+        SchemaTableName view3 = new SchemaTableName("test3", "test_schema_view3");
+        assertTrinoExceptionThrownBy(() -> metadata.createView(SESSION, view3, testingViewDefinition("bbb"), ImmutableMap.of(), true))
+                .hasErrorCode(SCHEMA_NOT_FOUND)
+                .hasMessage("Schema 'test3' does not exist");
+
+        assertThat(metadata.listSchemaNames(SESSION)).isEqualTo(ImmutableList.of("default"));
+    }
+
+    @Test
+    public void testRenameTable()
+    {
+        SchemaTableName tableName = new SchemaTableName("test_schema", "test_table_to_be_renamed");
+        FakerMetadata metadata = createMetadata();
+        metadata.createSchema(SESSION, "test_schema", ImmutableMap.of(), new TrinoPrincipal(USER, SESSION.getUser()));
+        ConnectorOutputTableHandle table = metadata.beginCreateTable(
+                SESSION,
+                new ConnectorTableMetadata(tableName, ImmutableList.of(), ImmutableMap.of()),
+                Optional.empty(),
+                NO_RETRIES,
+                false);
+        metadata.finishCreateTable(SESSION, table, ImmutableList.of(), ImmutableList.of());
+
+        // rename table to schema which does not exist
+        SchemaTableName invalidSchemaTableName = new SchemaTableName("test_schema_not_exist", "test_table_renamed");
+        ConnectorTableHandle tableHandle = metadata.getTableHandle(SESSION, tableName, Optional.empty(), Optional.empty());
+        assertThat(tableHandle).isNotNull();
+        assertTrinoExceptionThrownBy(() -> metadata.renameTable(SESSION, tableHandle, invalidSchemaTableName))
+                .isInstanceOf(TrinoException.class)
+                .hasErrorCode(SCHEMA_NOT_FOUND)
+                .hasMessage("Schema 'test_schema_not_exist' does not exist");
+
+        // rename table to same schema
+        ConnectorTableHandle originalTableHandle = metadata.getTableHandle(SESSION, tableName, Optional.empty(), Optional.empty());
+        assertThat(originalTableHandle).isNotNull();
+        SchemaTableName sameSchemaTableName = new SchemaTableName("test_schema", "test_renamed");
+        metadata.renameTable(SESSION, originalTableHandle, sameSchemaTableName);
+        assertThat(metadata.listTables(SESSION, Optional.of("test_schema"))).isEqualTo(ImmutableList.of(sameSchemaTableName));
+
+        // rename table to different schema
+        metadata.createSchema(SESSION, "test_different_schema", ImmutableMap.of(), new TrinoPrincipal(USER, SESSION.getUser()));
+        ConnectorTableHandle renamedTableHandle = metadata.getTableHandle(SESSION, sameSchemaTableName, Optional.empty(), Optional.empty());
+        assertThat(renamedTableHandle).isNotNull();
+        SchemaTableName differentSchemaTableName = new SchemaTableName("test_different_schema", "test_renamed");
+        metadata.renameTable(SESSION, renamedTableHandle, differentSchemaTableName);
+        assertThat(metadata.listTables(SESSION, Optional.of("test_schema"))).isEqualTo(ImmutableList.of());
+        assertThat(metadata.listTables(SESSION, Optional.of("test_different_schema"))).isEqualTo(ImmutableList.of(differentSchemaTableName));
+    }
+
+    private static void assertNoTables(FakerMetadata metadata)
+    {
+        assertThat(metadata.listTables(SESSION, Optional.empty()))
+                .describedAs("No table was expected")
+                .isEqualTo(ImmutableList.of());
+    }
+
+    private static ConnectorViewDefinition testingViewDefinition(String sql)
+    {
+        return new ConnectorViewDefinition(
+                sql,
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableList.of(new ViewColumn("test", BIGINT.getTypeId(), Optional.empty())),
+                Optional.empty(),
+                Optional.empty(),
+                true,
+                ImmutableList.of());
+    }
+
+    private static FakerMetadata createMetadata()
+    {
+        return new FakerMetadata(new FakerConfig(), new FakerFunctionProvider());
+    }
+}

--- a/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerMetadata.java
+++ b/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerMetadata.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.spi.TrinoException;
+import io.trino.spi.catalog.CatalogName;
 import io.trino.spi.connector.ConnectorOutputTableHandle;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTableMetadata;
@@ -341,6 +342,6 @@ public class TestFakerMetadata
 
     private static FakerMetadata createMetadata()
     {
-        return new FakerMetadata(new FakerConfig(), new FakerFunctionProvider());
+        return new FakerMetadata(new FakerConfig(), new FakerFunctionProvider(), new CatalogName("test"));
     }
 }

--- a/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerQueries.java
+++ b/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerQueries.java
@@ -824,7 +824,7 @@ final class TestFakerQueries
     @Test
     void testCreateTableAsSelect()
     {
-        assertUpdate("CREATE TABLE faker.default.limited_range WITH (null_probability = 0, default_limit = 50) AS " +
+        assertUpdate("CREATE TABLE faker.default.limited_range WITH (null_probability = 0, default_limit = 50, max_dictionary_size = 0) AS " +
                 "SELECT * FROM (VALUES -1, 3, 5) t(id)", 3);
 
         assertQuery("SELECT count(id) FROM (SELECT id FROM limited_range) a",
@@ -882,7 +882,7 @@ final class TestFakerQueries
 
         tableQuery =
                 """
-                CREATE TABLE faker.default.limited_range WITH (null_probability = 0, default_limit = 1000) AS
+                CREATE TABLE faker.default.limited_range WITH (null_probability = 0, default_limit = 1000, max_dictionary_size = 0) AS
                 SELECT
                   "$row_id" as seq_bigint,
                   rnd_bigint,

--- a/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerQueries.java
+++ b/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerQueries.java
@@ -820,4 +820,221 @@ final class TestFakerQueries
 
         assertUpdate("DROP TABLE faker.default.all_types_in");
     }
+
+    @Test
+    void testCreateTableAsSelect()
+    {
+        assertUpdate("CREATE TABLE faker.default.limited_range WITH (null_probability = 0, default_limit = 50) AS " +
+                "SELECT * FROM (VALUES -1, 3, 5) t(id)", 3);
+
+        assertQuery("SELECT count(id) FROM (SELECT id FROM limited_range) a",
+                "VALUES (50)");
+        assertQuery("SELECT count(id), min(id), max(id) FROM (SELECT id FROM faker.default.limited_range_view) a",
+                "VALUES (50, -1, 5)");
+
+        assertUpdate("DROP TABLE faker.default.limited_range");
+
+        @Language("SQL")
+        String tableQuery =
+                """
+                CREATE TABLE faker.default.ctas_all_types_range (
+                seq_bigint bigint NOT NULL,
+                rnd_bigint bigint NOT NULL,
+                rnd_integer integer NOT NULL,
+                rnd_smallint smallint NOT NULL,
+                rnd_tinyint tinyint NOT NULL,
+                rnd_boolean boolean NOT NULL,
+                rnd_date date NOT NULL,
+                rnd_decimal1 decimal NOT NULL,
+                rnd_decimal2 decimal(18,5) NOT NULL,
+                rnd_decimal3 decimal(38,0) NOT NULL,
+                rnd_decimal4 decimal(38,38) NOT NULL,
+                rnd_decimal5 decimal(5,2) NOT NULL,
+                rnd_real real NOT NULL,
+                rnd_double double NOT NULL,
+                rnd_interval_day_time interval day to second NOT NULL,
+                rnd_interval_year interval year to month NOT NULL,
+                rnd_timestamp timestamp NOT NULL,
+                rnd_timestamp0 timestamp(0) NOT NULL,
+                rnd_timestamp6 timestamp(6) NOT NULL,
+                rnd_timestamp9 timestamp(9) NOT NULL,
+                rnd_timestamptz timestamp with time zone NOT NULL,
+                rnd_timestamptz0 timestamp(0) with time zone NOT NULL,
+                rnd_timestamptz6 timestamp(6) with time zone NOT NULL,
+                rnd_timestamptz9 timestamp(9) with time zone NOT NULL,
+                rnd_time time NOT NULL,
+                rnd_time0 time(0) NOT NULL,
+                rnd_time6 time(6) NOT NULL,
+                rnd_time9 time(9) NOT NULL,
+                rnd_timetz time with time zone NOT NULL,
+                rnd_timetz0 time(0) with time zone NOT NULL,
+                rnd_timetz6 time(6) with time zone NOT NULL,
+                rnd_timetz9 time(9) with time zone NOT NULL,
+                rnd_timetz12 time(12) with time zone NOT NULL,
+                rnd_varbinary varbinary NOT NULL,
+                rnd_varchar varchar NOT NULL,
+                rnd_nvarchar varchar(1000) NOT NULL,
+                rnd_char char NOT NULL,
+                rnd_nchar char(1000) NOT NULL,
+                rnd_ipaddress ipaddress NOT NULL,
+                rnd_uuid uuid NOT NULL)""";
+        assertUpdate(tableQuery);
+
+        tableQuery =
+                """
+                CREATE TABLE faker.default.limited_range WITH (null_probability = 0, default_limit = 1000) AS
+                SELECT
+                  "$row_id" as seq_bigint,
+                  rnd_bigint,
+                  rnd_integer,
+                  rnd_smallint,
+                  rnd_tinyint,
+                  rnd_date,
+                  rnd_decimal1,
+                  rnd_decimal2,
+                  rnd_decimal3,
+                  rnd_decimal4,
+                  rnd_decimal5,
+                  rnd_real,
+                  rnd_double,
+                  rnd_interval_day_time,
+                  rnd_interval_year,
+                  rnd_timestamp,
+                  rnd_timestamp0,
+                  rnd_timestamp6,
+                  rnd_timestamp9,
+                  rnd_timestamptz,
+                  rnd_timestamptz0,
+                  rnd_timestamptz6,
+                  rnd_timestamptz9,
+                  rnd_time,
+                  rnd_time0,
+                  rnd_time6,
+                  rnd_time9,
+                  rnd_timetz,
+                  rnd_timetz0,
+                  rnd_timetz6,
+                  rnd_timetz9
+                FROM ctas_all_types_range
+                WHERE 1=1
+                AND rnd_bigint BETWEEN 0 AND 1
+                AND rnd_integer BETWEEN 0 AND 1
+                AND rnd_smallint BETWEEN 0 AND 1
+                AND rnd_tinyint BETWEEN 0 AND 1
+                AND rnd_date BETWEEN DATE '2022-03-01' AND DATE '2022-03-02'
+                AND rnd_decimal1 BETWEEN 0 AND 1
+                AND rnd_decimal2 BETWEEN 0.00000 AND 0.00001
+                AND rnd_decimal3 BETWEEN 0 AND 1
+                AND rnd_decimal4 BETWEEN DECIMAL '0.00000000000000000000000000000000000000' AND  DECIMAL '0.00000000000000000000000000000000000001'
+                AND rnd_decimal5 BETWEEN 0.00 AND 0.01
+                AND rnd_real BETWEEN REAL '0.0' AND REAL '1.4E-45'
+                AND rnd_double BETWEEN DOUBLE '0.0' AND DOUBLE '4.9E-324'
+                AND rnd_interval_day_time BETWEEN INTERVAL '0.000' SECOND AND INTERVAL '0.001' SECOND
+                AND rnd_interval_year BETWEEN INTERVAL '0' MONTH AND INTERVAL '1' MONTH
+                AND rnd_timestamp BETWEEN TIMESTAMP '2022-03-21 00:00:00.000' AND  TIMESTAMP '2022-03-21 00:00:00.001'
+                AND rnd_timestamp0 BETWEEN TIMESTAMP '2022-03-21 00:00:00' AND  TIMESTAMP '2022-03-21 00:00:01'
+                AND rnd_timestamp6 BETWEEN TIMESTAMP '2022-03-21 00:00:00.000000' AND  TIMESTAMP '2022-03-21 00:00:00.000001'
+                AND rnd_timestamp9 BETWEEN TIMESTAMP '2022-03-21 00:00:00.000000000' AND  TIMESTAMP '2022-03-21 00:00:00.000000001'
+                AND rnd_timestamptz BETWEEN TIMESTAMP '2022-03-21 00:00:00.000 +01:00' AND  TIMESTAMP '2022-03-21 00:00:00.001 +01:00'
+                AND rnd_timestamptz0 BETWEEN TIMESTAMP '2022-03-21 00:00:00 +01:00' AND  TIMESTAMP '2022-03-21 00:00:01 +01:00'
+                AND rnd_timestamptz6 BETWEEN TIMESTAMP '2022-03-21 00:00:00.000000 +01:00' AND  TIMESTAMP '2022-03-21 00:00:00.000001 +01:00'
+                AND rnd_timestamptz9 BETWEEN TIMESTAMP '2022-03-21 00:00:00.000000000 +01:00' AND  TIMESTAMP '2022-03-21 00:00:00.000000001 +01:00'
+                AND rnd_time BETWEEN TIME '01:02:03.456' AND  TIME '01:02:03.457'
+                AND rnd_time0 BETWEEN TIME '01:02:03' AND  TIME '01:02:04'
+                AND rnd_time6 BETWEEN TIME '01:02:03.000456' AND  TIME '01:02:03.000457'
+                AND rnd_time9 BETWEEN TIME '01:02:03.000000456' AND  TIME '01:02:03.000000457'
+                AND rnd_timetz BETWEEN TIME '01:02:03.456 +01:00' AND  TIME '01:02:03.457 +01:00'
+                AND rnd_timetz0 BETWEEN TIME '01:02:03 +01:00' AND  TIME '01:02:04 +01:00'
+                AND rnd_timetz6 BETWEEN TIME '01:02:03.000456 +01:00' AND  TIME '01:02:03.000457 +01:00'
+                AND rnd_timetz9 BETWEEN TIME '01:02:03.000000456 +01:00' AND  TIME '01:02:03.000000457 +01:00'""";
+        assertUpdate(tableQuery, 1000);
+
+        @Language("SQL")
+        String testQuery;
+
+        testQuery =
+                """
+                SELECT
+                count(distinct seq_bigint),
+                count(distinct rnd_bigint),
+                count(distinct rnd_integer),
+                count(distinct rnd_smallint),
+                count(distinct rnd_tinyint),
+                count(distinct rnd_date),
+                count(distinct rnd_decimal1),
+                count(distinct rnd_decimal2),
+                count(distinct rnd_decimal3),
+                count(distinct rnd_decimal4),
+                count(distinct rnd_decimal5),
+                count(distinct rnd_real),
+                count(distinct rnd_double),
+                count(distinct rnd_interval_day_time),
+                count(distinct rnd_interval_year),
+                count(distinct rnd_timestamp),
+                count(distinct rnd_timestamp0),
+                count(distinct rnd_timestamp6),
+                count(distinct rnd_timestamp9),
+                count(distinct rnd_timestamptz),
+                count(distinct rnd_timestamptz0),
+                count(distinct rnd_timestamptz6),
+                count(distinct rnd_timestamptz9),
+                count(distinct rnd_time),
+                count(distinct rnd_time0),
+                count(distinct rnd_time6),
+                count(distinct rnd_time9),
+                count(distinct rnd_timetz),
+                count(distinct rnd_timetz0),
+                count(distinct rnd_timetz6),
+                count(distinct rnd_timetz9)
+                FROM limited_range_view
+                """;
+        assertQuery(testQuery,
+                """
+                VALUES (
+                -- sequential integers
+                1000,
+                -- random integers
+                2,
+                2,
+                2,
+                2,
+                -- date
+                2,
+                -- decimal
+                2,
+                2,
+                2,
+                2,
+                2,
+                -- real, double
+                2,
+                2,
+                -- intervals
+                2,
+                2,
+                -- timestamps
+                2,
+                2,
+                2,
+                2,
+                -- timestamps with time zone
+                2,
+                2,
+                2,
+                2,
+                -- time
+                2,
+                2,
+                2,
+                2,
+                -- time with time zone
+                2,
+                2,
+                2,
+                2)
+                """);
+
+        assertUpdate("DROP TABLE faker.default.ctas_all_types_range");
+        assertUpdate("DROP TABLE faker.default.limited_range");
+    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Use statistics when using `CREATE TABLE AS SELECT` in the Faker connector to:
* set the `default_limit` table property to the estimated number of rows from the source table
* create a view to read from the table with range predicates, based on the statistics
* detect high-cardinality `BIGINT` columns and use sequences for them
* detect low-cardinality columns and generate dictionaries to select values from

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Faker
* Use statistics when using `CREATE TABLE AS SELECT` in the Faker connector. ({issue}`issuenumber`)
```
