### PR TITLE
Add spec_id, partition, sort_order_id, readable_metrics columns to Iceberg $files table

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -1241,6 +1241,13 @@ The output of the query has the following columns:
 * - `file_format`
   - `VARCHAR`
   - The format of the data file.
+* - `spec_id`
+  - `INTEGER`
+  - Spec ID used to track the file containing a row.
+* - `partition`
+  - `ROW(...)`
+  - A row that contains the mapping of the partition column names to the
+    partition column values.
 * - `record_count`
   - `BIGINT`
   - The number of entries contained in the data file.
@@ -1280,6 +1287,12 @@ The output of the query has the following columns:
 * - `equality_ids`
   - `array(INTEGER)`
   - The set of field IDs used for equality comparison in equality delete files.
+* - `sort_order_id`
+  - `INTEGER`
+  - ID representing sort order for this file.
+* - `readable_metrics`
+  - `JSON`
+  - File metrics in human-readable form.
 :::
 
 ##### `$refs` table

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPartitionColumn.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPartitionColumn.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.type.RowType;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public record IcebergPartitionColumn(RowType rowType, List<Integer> fieldIds)
+{
+    public IcebergPartitionColumn
+    {
+        requireNonNull(rowType, "rowType is null");
+        fieldIds = ImmutableList.copyOf(requireNonNull(fieldIds, "fieldIds is null"));
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTable.java
@@ -134,7 +134,7 @@ public class PartitionTable
         return connectorTableMetadata;
     }
 
-    private static List<PartitionField> getAllPartitionFields(Table icebergTable)
+    static List<PartitionField> getAllPartitionFields(Table icebergTable)
     {
         Set<Integer> existingColumnsIds = TypeUtil.indexById(icebergTable.schema().asStruct()).keySet();
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/DataFileRecord.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/DataFileRecord.java
@@ -37,19 +37,19 @@ public class DataFileRecord
     @SuppressWarnings("unchecked")
     public static DataFileRecord toDataFileRecord(MaterializedRow row)
     {
-        assertThat(row.getFieldCount()).isEqualTo(14);
+        assertThat(row.getFieldCount()).isEqualTo(17);
         return new DataFileRecord(
                 (int) row.getField(0),
                 (String) row.getField(1),
                 (String) row.getField(2),
-                (long) row.getField(3),
                 (long) row.getField(4),
-                row.getField(5) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(5)) : null,
+                (long) row.getField(5),
                 row.getField(6) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(6)) : null,
                 row.getField(7) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(7)) : null,
                 row.getField(8) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(8)) : null,
-                row.getField(9) != null ? ImmutableMap.copyOf((Map<Integer, String>) row.getField(9)) : null,
-                row.getField(10) != null ? ImmutableMap.copyOf((Map<Integer, String>) row.getField(10)) : null);
+                row.getField(9) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(9)) : null,
+                row.getField(10) != null ? ImmutableMap.copyOf((Map<Integer, String>) row.getField(10)) : null,
+                row.getField(11) != null ? ImmutableMap.copyOf((Map<Integer, String>) row.getField(11)) : null);
     }
 
     private DataFileRecord(


### PR DESCRIPTION
## Description

Relates to #24101

Add 4 missing columns Spark supports: https://iceberg.apache.org/docs/latest/spark-queries/#files
* spec_id: INTEGER
* partition: ROW(...)
* sort_order_id: INTEGER
* readable_metrics: JSON

## Release notes

```markdown
## Iceberg
* Add `spec_id`, `partition`, `sort_order_id`, `readable_metrics` columns to `$files` metadata table. ({issue}`24102`)
```
