### PR TITLE
Cleanup UnnestNode filter removal

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/EffectivePredicateExtractor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/EffectivePredicateExtractor.java
@@ -301,7 +301,10 @@ public class EffectivePredicateExtractor
         @Override
         public Expression visitUnnest(UnnestNode node, Void context)
         {
-            return TRUE;
+            return switch (node.getJoinType()) {
+                case INNER, LEFT -> pullExpressionThroughSymbols(node.getSource().accept(this, context), node.getOutputSymbols());
+                case RIGHT, FULL -> TRUE;
+            };
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneUnnestColumns.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneUnnestColumns.java
@@ -13,7 +13,6 @@
  */
 package io.trino.sql.planner.iterative.rule;
 
-import com.google.common.collect.ImmutableSet;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.UnnestNode;
@@ -67,16 +66,12 @@ public class PruneUnnestColumns
     @Override
     protected Optional<PlanNode> pushDownProjectOff(Context context, UnnestNode unnestNode, Set<Symbol> referencedOutputs)
     {
-        ImmutableSet.Builder<Symbol> referencedAndFilterSymbolsBuilder = ImmutableSet.<Symbol>builder()
-                .addAll(referencedOutputs);
-        Set<Symbol> referencedAndFilterSymbols = referencedAndFilterSymbolsBuilder.build();
-
         List<Symbol> prunedReplicateSymbols = unnestNode.getReplicateSymbols().stream()
-                .filter(referencedAndFilterSymbols::contains)
+                .filter(referencedOutputs::contains)
                 .collect(toImmutableList());
 
         Optional<Symbol> prunedOrdinalitySymbol = unnestNode.getOrdinalitySymbol()
-                .filter(referencedAndFilterSymbols::contains);
+                .filter(referencedOutputs::contains);
 
         if (prunedReplicateSymbols.size() == unnestNode.getReplicateSymbols().size() && prunedOrdinalitySymbol.equals(unnestNode.getOrdinalitySymbol())) {
             return Optional.empty();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferenceThroughUnnest.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferenceThroughUnnest.java
@@ -74,12 +74,8 @@ public class PushDownDereferenceThroughUnnest
     {
         UnnestNode unnestNode = captures.get(CHILD);
 
-        // Extract dereferences from project node's assignments and unnest node's filter
-        ImmutableList.Builder<Expression> expressionsBuilder = ImmutableList.builder();
-        expressionsBuilder.addAll(projectNode.getAssignments().getExpressions());
-
-        // Extract dereferences for pushdown
-        Set<FieldReference> dereferences = extractRowSubscripts(expressionsBuilder.build(), false);
+        // Extract dereferences for pushdown from project node's assignments
+        Set<FieldReference> dereferences = extractRowSubscripts(projectNode.getAssignments().getExpressions(), false);
 
         // Only retain dereferences on replicate symbols
         dereferences = dereferences.stream()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/GraphvizPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/GraphvizPrinter.java
@@ -76,6 +76,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Maps.immutableEnumMap;
 import static io.trino.sql.ir.Booleans.TRUE;
 import static io.trino.sql.planner.plan.ExchangeNode.Type.REPARTITION;
+import static io.trino.sql.planner.plan.JoinType.INNER;
 import static io.trino.sql.planner.planprinter.PlanPrinter.formatAggregation;
 import static java.lang.String.format;
 
@@ -408,11 +409,17 @@ public final class GraphvizPrinter
         public Void visitUnnest(UnnestNode node, Void context)
         {
             StringBuilder label = new StringBuilder();
-            if (!node.getReplicateSymbols().isEmpty()) {
-                label.append("CrossJoin Unnest");
+            if (node.getJoinType() == INNER) {
+                if (node.getReplicateSymbols().isEmpty()) {
+                    label.append("Unnest");
+                }
+                else {
+                    label.append("CrossJoin Unnest");
+                }
             }
             else {
-                label.append("Unnest");
+                label.append(node.getJoinType().getJoinLabel())
+                        .append(" Unnest on true");
             }
 
             List<Symbol> unnestInputs = node.getMappings().stream()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
@@ -1383,11 +1383,17 @@ public class PlanPrinter
         public Void visitUnnest(UnnestNode node, Context context)
         {
             String name;
+
             if (node.getJoinType() == INNER) {
-                name = "CrossJoin Unnest";
+                if (node.getReplicateSymbols().isEmpty()) {
+                    name = "Unnest";
+                }
+                else {
+                    name = "CrossJoin Unnest";
+                }
             }
             else {
-                name = node.getJoinType().getJoinLabel() + " Unnest";
+                name = node.getJoinType().getJoinLabel() + " Unnest on true";
             }
 
             List<Symbol> unnestInputs = node.getMappings().stream()


### PR DESCRIPTION
Related change: https://github.com/trinodb/trino/pull/20994/commits/bdbdc8f8ddb21c9e06a89f6e6666267d0e409f1b 

Includes:
- logical change: extracting source predicate for relevant join types in `EffectivePredicateExtractor`
- fixes to `GraphvizPrinter` and `PlanPrinter` regarding UnnestNode's join type
- code and comment cleanup

By removing filter from `UnnestNode`, we lost distinction between Unnest being in the context of a join or standalone. Given the way Unnest is planned, it is not incorrect. However, this information sometimes cannot be restored in plan printers.

No docs or release notes needed.