### PR TITLE
Fix incorrect result when filtering partitions on Delta checkpoint

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
@@ -388,6 +388,7 @@ public class CheckpointEntryIterator
 
     private static HiveColumnHandle toPartitionValuesParsedField(HiveColumnHandle addColumn, DeltaLakeColumnHandle partitionColumn)
     {
+        checkArgument(partitionColumn.isBaseColumn(), "partitionColumn must be a base column: %s", partitionColumn);
         return new HiveColumnHandle(
                 addColumn.getBaseColumnName(),
                 addColumn.getBaseHiveColumnIndex(),
@@ -395,7 +396,7 @@ public class CheckpointEntryIterator
                 addColumn.getBaseType(),
                 Optional.of(new HiveColumnProjectionInfo(
                         ImmutableList.of(0, 0), // hiveColumnIndex; we provide fake value because we always find columns by name
-                        ImmutableList.of("partitionvalues_parsed", partitionColumn.columnName()),
+                        ImmutableList.of("partitionvalues_parsed", partitionColumn.basePhysicalColumnName()),
                         DeltaHiveTypeTranslator.toHiveType(partitionColumn.type()),
                         partitionColumn.type())),
                 HiveColumnHandle.ColumnType.REGULAR,

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -1665,6 +1665,29 @@ public class TestDeltaLakeConnectorTest
     }
 
     @Test
+    void testPartitionPredicateOnCheckpointWithColumnMappingMode()
+    {
+        testPartitionPredicateOnCheckpointWithColumnMappingMode(ColumnMappingMode.ID);
+        testPartitionPredicateOnCheckpointWithColumnMappingMode(ColumnMappingMode.NAME);
+        testPartitionPredicateOnCheckpointWithColumnMappingMode(ColumnMappingMode.NONE);
+    }
+
+    private void testPartitionPredicateOnCheckpointWithColumnMappingMode(ColumnMappingMode mode)
+    {
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "test_partition_checkpoint_with_column_mapping_mode",
+                "(x int, part int) WITH (column_mapping_mode='" + mode + "', checkpoint_interval = 3, partitioned_by = ARRAY['part'])")) {
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (1, 10)", 1);
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (2, 20)", 1);
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (3, 30)", 1);
+
+            assertThat(query("SELECT * FROM " + table.getName() + " WHERE part = 10"))
+                    .matches("VALUES (1, 10)");
+        }
+    }
+
+    @Test
     public void testSpecialCharacterColumnNamesWithColumnMappingMode()
     {
         testSpecialCharacterColumnNamesWithColumnMappingMode(ColumnMappingMode.ID);


### PR DESCRIPTION
## Description

`partitionvalues_parsed` holds physical column names `col-{uuid}`, not logical names. 

Fixes #24104

## Release notes

```markdown
## Delta Lake
* Fix some things. ({issue}`issuenumber`)
```
