### PR TITLE
Allow disabling client segment acknowledgment

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/spooling/Segment.java
+++ b/client/trino-client/src/main/java/io/trino/client/spooling/Segment.java
@@ -87,7 +87,7 @@ public abstract class Segment
         return new InlineSegment(data, attributes);
     }
 
-    public static Segment spooled(URI retrieveUri, URI ackUri, DataAttributes attributes, Map<String, List<String>> headers)
+    public static Segment spooled(URI retrieveUri, Optional<URI> ackUri, DataAttributes attributes, Map<String, List<String>> headers)
     {
         return new SpooledSegment(retrieveUri, ackUri, attributes, headers);
     }

--- a/client/trino-client/src/main/java/io/trino/client/spooling/SegmentLoader.java
+++ b/client/trino-client/src/main/java/io/trino/client/spooling/SegmentLoader.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -55,7 +56,7 @@ public class SegmentLoader
         return loadFromURI(segment.getDataUri(), segment.getAckUri(), segment.getHeaders());
     }
 
-    public InputStream loadFromURI(URI segmentUri, URI ackUri, Map<String, List<String>> headers)
+    public InputStream loadFromURI(URI segmentUri, Optional<URI> ackUri, Map<String, List<String>> headers)
             throws IOException
     {
         Headers requestHeaders = toHeaders(headers);
@@ -99,7 +100,7 @@ public class SegmentLoader
         });
     }
 
-    private InputStream delegatingInputStream(Response response, InputStream delegate, URI ackUri, Headers headers)
+    private InputStream delegatingInputStream(Response response, InputStream delegate, Optional<URI> ackUri, Headers headers)
     {
         return new FilterInputStream(delegate)
         {
@@ -108,7 +109,7 @@ public class SegmentLoader
                     throws IOException
             {
                 try (Response ignored = response; InputStream ignored2 = delegate) {
-                    acknowledge(ackUri, headers);
+                    ackUri.ifPresent(uri -> acknowledge(uri, headers));
                 }
             }
         };

--- a/client/trino-client/src/main/java/io/trino/client/spooling/SpooledSegment.java
+++ b/client/trino-client/src/main/java/io/trino/client/spooling/SpooledSegment.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.lang.String.format;
@@ -30,20 +31,20 @@ public final class SpooledSegment
         extends Segment
 {
     private final URI dataUri;
+    private final Optional<URI> ackUri;
     private final Map<String, List<String>> headers;
-    private final URI ackUri;
 
     @JsonCreator
     public SpooledSegment(
             @JsonProperty("uri") URI dataUri,
-            @JsonProperty("ackUri") URI ackUri,
+            @JsonProperty("ackUri") Optional<URI> ackUri,
             @JsonProperty("metadata") Map<String, Object> metadata,
             @JsonProperty("headers") Map<String, List<String>> headers)
     {
         this(dataUri, ackUri, new DataAttributes(metadata), headers);
     }
 
-    SpooledSegment(URI dataUri, URI ackUri, DataAttributes metadata, Map<String, List<String>> headers)
+    SpooledSegment(URI dataUri, Optional<URI> ackUri, DataAttributes metadata, Map<String, List<String>> headers)
     {
         super(metadata);
         this.dataUri = requireNonNull(dataUri, "dataUri is null");
@@ -58,7 +59,7 @@ public final class SpooledSegment
     }
 
     @JsonProperty("ackUri")
-    public URI getAckUri()
+    public Optional<URI> getAckUri()
     {
         return ackUri;
     }
@@ -73,6 +74,6 @@ public final class SpooledSegment
     @Override
     public String toString()
     {
-        return format("SpooledSegment{offset=%d, rows=%d, size=%d, headers=%s}", getOffset(), getRowsCount(), getSegmentSize(), headers.keySet());
+        return format("SpooledSegment{offset=%d, rows=%d, size=%d, headers=%s, ack=%b}", getOffset(), getRowsCount(), getSegmentSize(), headers.keySet(), ackUri.isPresent());
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/OutputSpoolingOperatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OutputSpoolingOperatorFactory.java
@@ -135,6 +135,7 @@ public class OutputSpoolingOperatorFactory
             implements Operator
     {
         private final OutputSpoolingController controller;
+        private final boolean explicitAck;
 
         enum State
         {
@@ -165,6 +166,7 @@ public class OutputSpoolingOperatorFactory
                     spoolingConfig.getMaximumSegmentSize().toBytes(),
                     spoolingConfig.getInitialSegmentSize().toBytes(),
                     spoolingConfig.getMaximumSegmentSize().toBytes());
+            this.explicitAck = spoolingConfig.isExplicitAck();
             this.userMemoryContext = operatorContext.newLocalUserMemoryContext(OutputSpoolingOperator.class.getSimpleName());
             this.queryDataEncoder = requireNonNull(queryDataEncoder, "queryDataEncoder is null");
             this.spoolingManager = requireNonNull(spoolingManager, "spoolingManager is null");
@@ -278,7 +280,7 @@ public class OutputSpoolingOperatorFactory
                 controller.recordEncoded(attributes.get(SEGMENT_SIZE, Integer.class));
 
                 // This page is small (hundreds of bytes) so there is no point in tracking its memory usage
-                return emptySingleRowPage(SpooledBlock.forLocation(spoolingManager.location(segmentHandle), attributes).serialize());
+                return emptySingleRowPage(SpooledBlock.forLocation(spoolingManager.location(segmentHandle), attributes, explicitAck).serialize());
             }
             catch (IOException e) {
                 throw new UncheckedIOException(e);

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/CoordinatorSegmentResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/CoordinatorSegmentResource.java
@@ -53,12 +53,14 @@ public class CoordinatorSegmentResource
     private final SpoolingManager spoolingManager;
     private final SegmentRetrievalMode retrievalMode;
     private final InternalNodeManager nodeManager;
+    private final boolean explicitAck;
 
     @Inject
     public CoordinatorSegmentResource(SpoolingManager spoolingManager, SpoolingConfig config, InternalNodeManager nodeManager)
     {
         this.spoolingManager = requireNonNull(spoolingManager, "spoolingManager is null");
         this.retrievalMode = requireNonNull(config, "config is null").getRetrievalMode();
+        this.explicitAck = config.isExplicitAck();
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
     }
 
@@ -97,6 +99,12 @@ public class CoordinatorSegmentResource
     public Response acknowledge(@PathParam("identifier") String identifier, @Context HttpHeaders headers)
             throws IOException
     {
+        if (!explicitAck) {
+            return Response.status(Response.Status.NOT_ACCEPTABLE)
+                    .entity("Explicit segment acknowledgment is disabled")
+                    .build();
+        }
+
         try {
             spoolingManager.acknowledge(handle(identifier, headers));
             return Response.ok().build();

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/SpooledQueryDataProducer.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/SpooledQueryDataProducer.java
@@ -29,6 +29,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import static io.trino.client.spooling.DataAttribute.ROWS_COUNT;
@@ -76,8 +77,9 @@ public class SpooledQueryDataProducer
                             .set(ROW_OFFSET, currentOffset)
                             .build();
                     builder.withSegment(spooled(
-                            metadata.directUri().orElseGet(() -> buildSegmentDownloadURI(uriBuilder, metadata.identifier())),
-                            buildSegmentAckURI(uriBuilder, metadata.identifier()),
+                            metadata.directUri()
+                                    .orElseGet(() -> buildSegmentDownloadURI(uriBuilder, metadata.identifier())),
+                            metadata.explicitAck() ? Optional.of(buildSegmentAckURI(uriBuilder, metadata.identifier())) : Optional.empty(),
                             attributes,
                             metadata.headers()));
                     currentOffset += attributes.get(ROWS_COUNT, Long.class);

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/SpoolingConfig.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/SpoolingConfig.java
@@ -38,6 +38,7 @@ public class SpoolingConfig
     private Optional<Duration> storageRedirectTtl = Optional.empty();
 
     private boolean allowInlining = true;
+    private boolean explicitAck = true;
     private long maximumInlinedRows = 1000;
     private DataSize maximumInlinedSize = DataSize.of(128, KILOBYTE);
     private DataSize initialSegmentSize = DataSize.of(8, MEGABYTE);
@@ -120,6 +121,19 @@ public class SpoolingConfig
     public SpoolingConfig setAllowInlining(boolean allowInlining)
     {
         this.allowInlining = allowInlining;
+        return this;
+    }
+
+    public boolean isExplicitAck()
+    {
+        return explicitAck;
+    }
+
+    @ConfigDescription("Allow client to acknowledge segment retrieval and its eager removal")
+    @Config("protocol.spooling.explicit-ack.enabled")
+    public SpoolingConfig setExplicitAck(boolean explicitAck)
+    {
+        this.explicitAck = explicitAck;
         return this;
     }
 

--- a/core/trino-main/src/test/java/io/trino/server/protocol/TestQueryDataSerialization.java
+++ b/core/trino-main/src/test/java/io/trino/server/protocol/TestQueryDataSerialization.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.Set;
 
@@ -138,11 +139,11 @@ public class TestQueryDataSerialization
                         inlined("super".getBytes(UTF_8), dataAttributes(0, 100, 5)),
                         spooled(
                                 URI.create("http://localhost:8080/v1/download/20160128_214710_00012_rk68b/segments/1"),
-                                URI.create("http://localhost:8080/v1/ack/20160128_214710_00012_rk68b/segments/1"),
+                                Optional.of(URI.create("http://localhost:8080/v1/ack/20160128_214710_00012_rk68b/segments/1")),
                                 dataAttributes(100, 100, 1024), Map.of("x-amz-server-side-encryption", List.of("AES256"))),
                         spooled(
                                 URI.create("http://localhost:8080/v1/download/20160128_214710_00012_rk68b/segments/2"),
-                                URI.create("http://localhost:8080/v1/ack/20160128_214710_00012_rk68b/segments/2"),
+                                Optional.empty(),
                                 dataAttributes(200, 100, 1024), Map.of("x-amz-server-side-encryption", List.of("AES256")))))
                 .withAttributes(DataAttributes.builder()
                         .set(SCHEMA, "serializedSchema")
@@ -179,7 +180,6 @@ public class TestQueryDataSerialization
                     {
                       "type": "spooled",
                       "uri": "http://localhost:8080/v1/download/20160128_214710_00012_rk68b/segments/2",
-                      "ackUri": "http://localhost:8080/v1/ack/20160128_214710_00012_rk68b/segments/2",
                       "metadata": {
                         "rowOffset": 200,
                         "rowsCount": 100,
@@ -199,9 +199,15 @@ public class TestQueryDataSerialization
 
         EncodedQueryData spooledQueryData = new EncodedQueryData("json+zstd", ImmutableMap.of("decryption_key", "secret"), ImmutableList.of(spooled(
                 URI.create("http://coordinator:8080/v1/segments/uuid"),
-                URI.create("http://coordinator:8080/v1/segments/uuid"),
+                Optional.of(URI.create("http://coordinator:8080/v1/segments/uuid")),
                 dataAttributes(10, 2, 1256), headers())));
-        assertThat(spooledQueryData.toString()).isEqualTo("EncodedQueryData{encoding=json+zstd, segments=[SpooledSegment{offset=10, rows=2, size=1256, headers=[x-amz-server-side-encryption]}], metadata=[decryption_key]}");
+        assertThat(spooledQueryData.toString()).isEqualTo("EncodedQueryData{encoding=json+zstd, segments=[SpooledSegment{offset=10, rows=2, size=1256, headers=[x-amz-server-side-encryption], ack=true}], metadata=[decryption_key]}");
+
+        EncodedQueryData spooledQueryDataWithoutAck = new EncodedQueryData("json+zstd", ImmutableMap.of("decryption_key", "secret"), ImmutableList.of(spooled(
+                URI.create("http://coordinator:8080/v1/segments/uuid"),
+                Optional.empty(),
+                dataAttributes(10, 2, 1256), headers())));
+        assertThat(spooledQueryDataWithoutAck.toString()).isEqualTo("EncodedQueryData{encoding=json+zstd, segments=[SpooledSegment{offset=10, rows=2, size=1256, headers=[x-amz-server-side-encryption], ack=false}], metadata=[decryption_key]}");
     }
 
     private void testRoundTrip(QueryData queryData, String expectedDataRepresentation)

--- a/core/trino-main/src/test/java/io/trino/server/protocol/spooling/TestSpooledBlock.java
+++ b/core/trino-main/src/test/java/io/trino/server/protocol/spooling/TestSpooledBlock.java
@@ -55,7 +55,7 @@ class TestSpooledBlock
 
     public void verifySerializationRoundTrip(Slice identifier, Optional<URI> directUri, Map<String, List<String>> headers)
     {
-        SpooledBlock metadata = new SpooledBlock(identifier, directUri, headers, createDataAttributes(10, 1200));
+        SpooledBlock metadata = new SpooledBlock(identifier, directUri, headers, createDataAttributes(10, 1200), true);
         Page page = new Page(metadata.serialize());
         SpooledBlock retrieved = SpooledBlock.deserialize(page);
         assertThat(metadata).isEqualTo(retrieved);
@@ -63,7 +63,7 @@ class TestSpooledBlock
 
     private void verifySerializationRoundTripWithNonEmptyPage(Slice identifier, Optional<URI> directUri, Map<String, List<String>> headers)
     {
-        SpooledBlock metadata = new SpooledBlock(identifier, directUri, headers, createDataAttributes(10, 1100));
+        SpooledBlock metadata = new SpooledBlock(identifier, directUri, headers, createDataAttributes(10, 1100), false);
         Page page = new Page(blockWithPositions(1, true), metadata.serialize());
         SpooledBlock retrieved = SpooledBlock.deserialize(page);
         assertThat(metadata).isEqualTo(retrieved);
@@ -71,7 +71,7 @@ class TestSpooledBlock
 
     private void verifyThrowsErrorOnNonNullPositions(Slice identifier, Optional<URI> directUri, Map<String, List<String>> headers)
     {
-        SpooledBlock metadata = new SpooledBlock(identifier, directUri, headers, createDataAttributes(20, 1200));
+        SpooledBlock metadata = new SpooledBlock(identifier, directUri, headers, createDataAttributes(20, 1200), true);
 
         assertThatThrownBy(() -> SpooledBlock.deserialize(new Page(blockWithPositions(1, false), metadata.serialize())))
                 .hasMessage("Spooling metadata block must have all but last channels null");
@@ -79,7 +79,7 @@ class TestSpooledBlock
 
     private void verifyThrowsErrorOnMultiplePositions(Slice identifier, Optional<URI> directUri, Map<String, List<String>> headers)
     {
-        SpooledBlock metadata = new SpooledBlock(identifier, directUri, headers, createDataAttributes(30, 1300));
+        SpooledBlock metadata = new SpooledBlock(identifier, directUri, headers, createDataAttributes(30, 1300), false);
         RowBlockBuilder rowBlockBuilder = SPOOLING_METADATA_TYPE.createBlockBuilder(null, 2);
         metadata.serialize(rowBlockBuilder);
         metadata.serialize(rowBlockBuilder);

--- a/core/trino-main/src/test/java/io/trino/server/protocol/spooling/TestSpoolingConfig.java
+++ b/core/trino-main/src/test/java/io/trino/server/protocol/spooling/TestSpoolingConfig.java
@@ -44,7 +44,8 @@ class TestSpoolingConfig
                 .setMaximumSegmentSize(DataSize.of(16, MEGABYTE))
                 .setMaximumInlinedRows(1000)
                 .setMaximumInlinedSize(DataSize.of(128, KILOBYTE))
-                .setAllowInlining(true));
+                .setAllowInlining(true)
+                .setExplicitAck(true));
     }
 
     @Test
@@ -57,6 +58,7 @@ class TestSpoolingConfig
                 .put("protocol.spooling.retrieval-mode", "coordinator_storage_redirect")
                 .put("protocol.spooling.coordinator-storage-redirect-ttl", "60s")
                 .put("protocol.spooling.inlining.enabled", "false")
+                .put("protocol.spooling.explicit-ack.enabled", "false")
                 .put("protocol.spooling.initial-segment-size", "1kB")
                 .put("protocol.spooling.maximum-segment-size", "8kB")
                 .put("protocol.spooling.inlining.max-rows", "1024")
@@ -71,7 +73,8 @@ class TestSpoolingConfig
                 .setMaximumSegmentSize(DataSize.of(8, KILOBYTE))
                 .setMaximumInlinedRows(1024)
                 .setMaximumInlinedSize(DataSize.of(1, MEGABYTE))
-                .setAllowInlining(false);
+                .setAllowInlining(false)
+                .setExplicitAck(false);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
This allows for storage-wide expiration policies to be implemented
that doesn't require explicit API call to remove an expired segment.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
