### PR TITLE
Support JDBC validate connection

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/uri/ConnectionProperties.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/ConnectionProperties.java
@@ -115,6 +115,7 @@ final class ConnectionProperties
     public static final ConnectionProperty<String, LoggingLevel> HTTP_LOGGING_LEVEL = new HttpLoggingLevel();
     public static final ConnectionProperty<String, Map<String, String>> RESOURCE_ESTIMATES = new ResourceEstimates();
     public static final ConnectionProperty<String, List<String>> SQL_PATH = new SqlPath();
+    public static final ConnectionProperty<String, Boolean> VALIDATE_CONNECTION = new ValidateConnection();
 
     private static final Set<ConnectionProperty<?, ?>> ALL_PROPERTIES = ImmutableSet.<ConnectionProperty<?, ?>>builder()
             // Keep sorted
@@ -172,6 +173,7 @@ final class ConnectionProperties
             .add(TIMEZONE)
             .add(TRACE_TOKEN)
             .add(USER)
+            .add(VALIDATE_CONNECTION)
             .build();
 
     private static final Map<String, ConnectionProperty<?, ?>> KEY_LOOKUP = unmodifiableMap(ALL_PROPERTIES.stream()
@@ -587,6 +589,15 @@ final class ConnectionProperties
         public KerberosRemoteServiceName()
         {
             super(PropertyName.KERBEROS_REMOTE_SERVICE_NAME, NOT_REQUIRED, ALLOWED, STRING_CONVERTER);
+        }
+    }
+
+    private static class ValidateConnection
+            extends AbstractConnectionProperty<String, Boolean>
+    {
+        public ValidateConnection()
+        {
+            super(PropertyName.VALIDATE_CONNECTION, NOT_REQUIRED, ALLOWED, BOOLEAN_CONVERTER);
         }
     }
 

--- a/client/trino-client/src/main/java/io/trino/client/uri/PropertyName.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/PropertyName.java
@@ -75,7 +75,8 @@ public enum PropertyName
     TIMEOUT("timeout"),
     TIMEZONE("timezone"),
     TRACE_TOKEN("traceToken"),
-    USER("user");
+    USER("user"),
+    VALIDATE_CONNECTION("validateConnection");
 
     private final String key;
 

--- a/client/trino-client/src/main/java/io/trino/client/uri/TrinoUri.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/TrinoUri.java
@@ -98,6 +98,7 @@ import static io.trino.client.uri.ConnectionProperties.TIMEOUT;
 import static io.trino.client.uri.ConnectionProperties.TIMEZONE;
 import static io.trino.client.uri.ConnectionProperties.TRACE_TOKEN;
 import static io.trino.client.uri.ConnectionProperties.USER;
+import static io.trino.client.uri.ConnectionProperties.VALIDATE_CONNECTION;
 import static io.trino.client.uri.LoggingLevel.NONE;
 import static java.lang.String.CASE_INSENSITIVE_ORDER;
 import static java.lang.String.format;
@@ -459,6 +460,11 @@ public class TrinoUri
     public LoggingLevel getHttpLoggingLevel()
     {
         return resolveWithDefault(HTTP_LOGGING_LEVEL, NONE);
+    }
+
+    public boolean isValidateConnection()
+    {
+        return resolveWithDefault(VALIDATE_CONNECTION, false);
     }
 
     private Map<String, String> getResourceEstimates()
@@ -1045,6 +1051,11 @@ public class TrinoUri
         public Builder setPath(List<String> path)
         {
             return setProperty(SQL_PATH, requireNonNull(path, "path is null"));
+        }
+
+        public Builder setValidateConnection(boolean value)
+        {
+            return setProperty(VALIDATE_CONNECTION, value);
         }
 
         <V, T> Builder setProperty(ConnectionProperty<V, T> connectionProperty, T value)

--- a/client/trino-client/src/test/java/io/trino/client/uri/TestTrinoUri.java
+++ b/client/trino-client/src/test/java/io/trino/client/uri/TestTrinoUri.java
@@ -495,6 +495,17 @@ public class TestTrinoUri
         assertThat(secureUri.getHttpUri()).isEqualTo(URI.create("https://localhost:443"));
     }
 
+    @Test
+    public void testValidateConnection()
+    {
+        TrinoUri uri = createTrinoUri("trino://localhost:8080");
+        assertThat(uri.isValidateConnection()).isFalse();
+        uri = createTrinoUri("trino://localhost:8080?validateConnection=true");
+        assertThat(uri.isValidateConnection()).isTrue();
+        uri = createTrinoUri("trino://localhost:8080?validateConnection=false");
+        assertThat(uri.isValidateConnection()).isFalse();
+    }
+
     private static boolean isBuilderHelperMethod(String name)
     {
         if (name.equals("setSslVerificationNone")) {

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcConnection.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcConnection.java
@@ -23,6 +23,7 @@ import io.airlift.log.Logging;
 import io.trino.client.ClientSelectedRole;
 import io.trino.plugin.blackhole.BlackHolePlugin;
 import io.trino.plugin.hive.HivePlugin;
+import io.trino.server.security.PasswordAuthenticatorManager;
 import io.trino.server.testing.TestingTrinoServer;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableMetadata;
@@ -32,6 +33,8 @@ import io.trino.spi.connector.RecordCursor;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.security.AccessDeniedException;
+import io.trino.spi.security.BasicPrincipal;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
@@ -40,6 +43,12 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.parallel.Execution;
 
+import java.io.File;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.Key;
+import java.security.Principal;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -47,28 +56,39 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.io.Files.asCharSource;
+import static com.google.common.io.Resources.getResource;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.testing.Closeables.closeAll;
+import static io.jsonwebtoken.security.Keys.hmacShaKeyFor;
 import static io.trino.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
+import static io.trino.server.security.jwt.JwtUtil.newJwtBuilder;
 import static io.trino.spi.connector.SystemTable.Distribution.ALL_NODES;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.testing.assertions.Assert.assertEventually;
 import static java.lang.String.format;
+import static java.lang.System.currentTimeMillis;
+import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.sql.Types.VARCHAR;
+import static java.util.Base64.getMimeDecoder;
 import static java.util.UUID.randomUUID;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.assertj.core.api.Fail.fail;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
@@ -77,18 +97,47 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 @Execution(CONCURRENT)
 public class TestJdbcConnection
 {
+    private static final String TEST_USER = "admin";
+    private static final String TEST_PASSWORD = "password";
+
     private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed(getClass().getName()));
 
     private TestingTrinoServer server;
+    private Key defaultKey;
+    private String sslTrustStorePath;
 
     @BeforeAll
     public void setupServer()
             throws Exception
     {
         Logging.initialize();
+
+        Path passwordConfigDummy = Files.createTempFile("passwordConfigDummy", "");
+        passwordConfigDummy.toFile().deleteOnExit();
+
+        URL resource = getClass().getClassLoader().getResource("33.privateKey");
+        assertThat(resource)
+                .describedAs("key directory not found")
+                .isNotNull();
+        File keyDir = new File(resource.toURI()).getAbsoluteFile().getParentFile();
+
+        defaultKey = hmacShaKeyFor(getMimeDecoder().decode(asCharSource(new File(keyDir, "default-key.key"), US_ASCII).read().getBytes(US_ASCII)));
+        sslTrustStorePath = new File(getResource("localhost.truststore").toURI()).getPath();
+
         Module systemTables = binder -> newSetBinder(binder, SystemTable.class)
                 .addBinding().to(ExtraCredentialsSystemTable.class).in(Scopes.SINGLETON);
+
         server = TestingTrinoServer.builder()
+                .setProperties(ImmutableMap.<String, String>builder()
+                        .put("http-server.authentication.type", "PASSWORD,JWT")
+                        .put("password-authenticator.config-files", passwordConfigDummy.toString())
+                        .put("http-server.authentication.allow-insecure-over-http", "false")
+                        .put("http-server.process-forwarded", "true")
+                        .put("http-server.authentication.jwt.key-file", new File(keyDir, "${KID}.key").getPath())
+                        .put("http-server.https.enabled", "true")
+                        .put("http-server.https.keystore.path", new File(getResource("localhost.keystore").toURI()).getPath())
+                        .put("http-server.https.keystore.key", "changeit")
+                        .buildOrThrow())
                 .setAdditionalModule(systemTables)
                 .build();
         server.installPlugin(new HivePlugin());
@@ -98,6 +147,7 @@ public class TestJdbcConnection
                 .put("hive.security", "sql-standard")
                 .put("fs.hadoop.enabled", "true")
                 .buildOrThrow());
+        server.getInstance(com.google.inject.Key.get(PasswordAuthenticatorManager.class)).setAuthenticators(TestJdbcConnection::authenticate);
         server.installPlugin(new BlackHolePlugin());
         server.createCatalog("blackhole", "blackhole", ImmutableMap.of());
 
@@ -113,6 +163,14 @@ public class TestJdbcConnection
                     "CREATE TABLE blackhole.default.delay(dummy bigint) " +
                             "WITH (split_count = 1, pages_per_split = 1, rows_per_page = 1, page_processing_delay = '60s')");
         }
+    }
+
+    private static Principal authenticate(String user, String password)
+    {
+        if ((TEST_USER.equals(user) && TEST_PASSWORD.equals(password))) {
+            return new BasicPrincipal(user);
+        }
+        throw new AccessDeniedException("Invalid credentials");
     }
 
     @AfterAll
@@ -482,6 +540,96 @@ public class TestJdbcConnection
         testConcurrentCancellationOnConnectionClose(false);
     }
 
+    @Test
+    public void testConnectionValidation()
+            throws Exception
+    {
+        String validAccessToken = newJwtBuilder()
+                .subject("test")
+                .signWith(defaultKey)
+                .compact();
+
+        try (Connection conn = createConnectionUsingAccessToken(validAccessToken, "validateConnection=true")) {
+            assertThat(conn.isValid(10)).isTrue();
+        }
+
+        long delay = 50;
+        long expirationTime = 0;
+        long timeout = currentTimeMillis() + 60 * 1000;
+
+        Connection acquiredConnection = null;
+        while (currentTimeMillis() < timeout) {
+            expirationTime = currentTimeMillis() + delay;
+            String expiringAccessToken = newJwtBuilder()
+                    .subject("test")
+                    .expiration(new Date(expirationTime))
+                    .signWith(defaultKey)
+                    .compact();
+
+            try (Connection newConnection = createConnectionUsingAccessToken(expiringAccessToken, "validateConnection=true")) {
+                acquiredConnection = newConnection;
+                break;
+            }
+            catch (SQLException e) {
+                // Connection failure because the token is about to expire
+            }
+
+            delay *= 2;
+        }
+
+        assertThat(acquiredConnection).isNotNull();
+
+        try {
+            while (currentTimeMillis() < expirationTime) {
+                try {
+                    Thread.sleep(100);
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            assertThat(acquiredConnection.isValid(10)).isFalse();
+        }
+        finally {
+            acquiredConnection.close();
+        }
+
+        try (Connection conn = createConnectionUsingAccessToken(validAccessToken, "")) {
+            assertThat(conn.isValid(10)).isTrue();
+        }
+
+        // With an expired token, isValid returns true if validateConnection is not enabled
+        try (Connection conn = createConnectionUsingAccessToken(validAccessToken, "validateConnection=false");) {
+            assertThat(conn.isValid(10)).isTrue();
+        }
+    }
+
+    @Test
+    public void testValidateConnection()
+    {
+        // Invalid host
+        assertThatCode(() -> createConnectionUsingInvalidHost(""))
+                .doesNotThrowAnyException();
+
+        SQLException e = catchThrowableOfType(() -> createConnectionUsingInvalidHost("validateConnection=true"),
+                SQLException.class);
+        assertThat(e.getSQLState().equals("08001")).isTrue();
+
+        assertThatCode(() -> createConnectionUsingInvalidHost("validateConnection=false"))
+                .doesNotThrowAnyException();
+
+        // Invalid password
+        assertThatCode(() -> createConnectionUsingInvalidPassword(""))
+                .doesNotThrowAnyException();
+
+        e = catchThrowableOfType(() -> createConnectionUsingInvalidPassword("validateConnection=true"),
+                SQLException.class);
+        assertThat(e.getSQLState().equals("28000")).isTrue();
+
+        assertThatCode(() -> createConnectionUsingInvalidPassword("validateConnection=false"))
+                .doesNotThrowAnyException();
+    }
+
     private void testConcurrentCancellationOnConnectionClose(boolean autoCommit)
             throws Exception
     {
@@ -528,8 +676,52 @@ public class TestJdbcConnection
     private Connection createConnection(String extra)
             throws SQLException
     {
-        String url = format("jdbc:trino://%s/hive/default?%s", server.getAddress(), extra);
-        return DriverManager.getConnection(url, "admin", null);
+        String url = format("jdbc:trino://localhost:%s/hive/default?%s", server.getHttpsAddress().getPort(), extra);
+        Properties properties = new Properties();
+        properties.put("user", TEST_USER);
+        properties.put("password", TEST_PASSWORD);
+        properties.setProperty("SSL", "true");
+        properties.setProperty("SSLTrustStorePath", sslTrustStorePath);
+        properties.setProperty("SSLTrustStorePassword", "changeit");
+        return DriverManager.getConnection(url, properties);
+    }
+
+    private Connection createConnectionUsingInvalidHost(String extra)
+            throws SQLException
+    {
+        String url = format("jdbc:trino://invalidhost:%s/hive/default?%s", server.getHttpsAddress().getPort(), extra);
+        Properties properties = new Properties();
+        properties.put("user", TEST_USER);
+        properties.put("password", TEST_PASSWORD);
+        properties.setProperty("SSL", "true");
+        properties.setProperty("SSLTrustStorePath", sslTrustStorePath);
+        properties.setProperty("SSLTrustStorePassword", "changeit");
+        return DriverManager.getConnection(url, properties);
+    }
+
+    private Connection createConnectionUsingInvalidPassword(String extra)
+            throws SQLException
+    {
+        String url = format("jdbc:trino://localhost:%s/hive/default?%s", server.getHttpsAddress().getPort(), extra);
+        Properties properties = new Properties();
+        properties.put("user", TEST_USER);
+        properties.put("password", "invalid_" + TEST_PASSWORD);
+        properties.setProperty("SSL", "true");
+        properties.setProperty("SSLTrustStorePath", sslTrustStorePath);
+        properties.setProperty("SSLTrustStorePassword", "changeit");
+        return DriverManager.getConnection(url, properties);
+    }
+
+    private Connection createConnectionUsingAccessToken(String accessToken, String extra)
+            throws SQLException
+    {
+        String url = format("jdbc:trino://localhost:%s/hive/default?%s", server.getHttpsAddress().getPort(), extra);
+        Properties properties = new Properties();
+        properties.put("accessToken", accessToken);
+        properties.setProperty("SSL", "true");
+        properties.setProperty("SSLTrustStorePath", sslTrustStorePath);
+        properties.setProperty("SSLTrustStorePassword", "changeit");
+        return DriverManager.getConnection(url, properties);
     }
 
     private static Set<String> listTables(Connection connection)

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriver.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriver.java
@@ -870,6 +870,13 @@ public class TestTrinoDriver
                         .put("assumeLiteralUnderscoreInMetadataCallsForNonConformingClients", "true")
                         .buildOrThrow())))
                 .isNotNull();
+
+        assertThat(DriverManager.getConnection(jdbcUrl(),
+                toProperties(ImmutableMap.<String, String>builder()
+                        .put("user", "test")
+                        .put("validateConnection", "false")
+                        .buildOrThrow())))
+                .isNotNull();
     }
 
     @Test

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriverUri.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriverUri.java
@@ -479,6 +479,18 @@ public class TestTrinoDriverUri
         assertThat(secureUri.getHttpUri()).isEqualTo(URI.create("https://localhost:443"));
     }
 
+    @Test
+    public void testAValidateConnection()
+            throws SQLException
+    {
+        TrinoDriverUri uri = createDriverUri("jdbc:trino://localhost:8080");
+        assertThat(uri.isValidateConnection()).isFalse();
+        uri = createDriverUri("jdbc:trino://localhost:8080?validateConnection=true");
+        assertThat(uri.isValidateConnection()).isTrue();
+        uri = createDriverUri("jdbc:trino://localhost:8080?validateConnection=false");
+        assertThat(uri.isValidateConnection()).isFalse();
+    }
+
     private static void assertUriPortScheme(TrinoDriverUri parameters, int port, String scheme)
     {
         URI uri = parameters.getHttpUri();

--- a/core/trino-main/src/main/java/io/trino/dispatcher/QueuedStatementResource.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/QueuedStatementResource.java
@@ -54,6 +54,7 @@ import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HEAD;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -152,6 +153,14 @@ public class QueuedStatementResource
     public void stop()
     {
         queryManager.destroy();
+    }
+
+    @ResourceSecurity(AUTHENTICATED_USER)
+    @HEAD
+    @Produces(APPLICATION_JSON)
+    public Response validateConnection()
+    {
+        return Response.ok().build();
     }
 
     @ResourceSecurity(AUTHENTICATED_USER)

--- a/docs/src/main/sphinx/client/jdbc.md
+++ b/docs/src/main/sphinx/client/jdbc.md
@@ -269,7 +269,9 @@ may not be specified using both methods.
     Valid values are JSON with Zstandard compression, `json+zstd` (recommended),
     JSON with LZ4 compression `json+lz4`, and uncompressed JSON `json`. By
     default, the default encoding configured on the cluster is used.
-
+* - `validateConnection`
+  - Defaults to `false`. If set to `true`, connectivity and credentials are validated 
+    when the connection is created, and when `java.sql.Connection.isValid(int)` is called.
 :::
 
 (jdbc-spooling-protocol)=


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
- Support `HEAD /v1/statement`, this allows client to validate authentication without submitting a query.
- Add `validateConnection` property that allows validating connection when making a JDBC connection - #16504
- Fix JDBC `Connection.isValid(int)` - fix #22684



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix JDBC `Connection.isValid(int)` which does not validate connection and/or credentials. ({issue}`22684`)
* Add `validateConnection` JDBC property that allows validating connection when making a JDBC connection. ({issue}`16504`)
```
