### PR TITLE
Enhance DevelopmentPluginsProvider to handle plugin directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,16 @@ IntelliJ, using `$MODULE_DIR$` accomplishes this automatically.
 If `VM options` doesn't exist in the dialog, you need to select `Modify options`
 and enable `Add VM options`.
 
+To adjust which plugins are enabled for the development server, adjust the value of
+`plugin.bundles` in `config.properties`. Each entry in this list must represent a plugin
+specified by one of the following options:
+* A path to a `pom.xml` or `*.pom` file describing a Maven project that produces a plugin.
+* Maven coordinates, in the form `<groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>`. The plugin will be loaded via Maven and therefore must be available in your local repository or a remote repository.
+* A path to a plugin directory containing JAR files. See [Deploying a custom plugin](https://trino.io/docs/current/develop/spi-overview.html#deploying-a-custom-plugin) for more details.
+
+If you want to use a plugin in a catalog, you must add a corresponding
+`<catalog_name>.properties` file to `testing/trino-server-dev/etc/catalog`.
+
 ### Running the CLI
 
 Start the CLI to connect to the server and run SQL queries:


### PR DESCRIPTION
## Description
This is an alternative approach to solve the same use case described in #23100.

This PR makes it possible to use the local `DevelopmentServer` with plugin directories, which have the same setup as a typical production plugin directory. This makes it easier to test the same setup you may have in a real production setup, but in your local development environment. This gives you the most apples-to-apples experience, and allows for easier integration of plugins developed on non-Maven builds. Some additional documentation is added to the `README` to describe the various ways to configure plugins in `plugin.bundles`.

## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: