### PR TITLE
Fix incorrect partitionValues_parsed with id & name column mapping in Delta Lake

### DIFF
--- a/lib/trino-parquet/src/test/java/io/trino/parquet/ParquetTestUtils.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/ParquetTestUtils.java
@@ -53,6 +53,7 @@ import java.util.Random;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.parquet.ParquetTypeUtils.constructField;
 import static io.trino.parquet.ParquetTypeUtils.getColumnIO;
 import static io.trino.parquet.ParquetTypeUtils.getDescriptors;
@@ -101,6 +102,16 @@ public class ParquetTestUtils
                 "test-version",
                 Optional.of(DateTimeZone.getDefault()),
                 Optional.empty());
+    }
+
+    public static ParquetReader createParquetReader(
+            ParquetDataSource input,
+            ParquetMetadata parquetMetadata,
+            List<Type> types,
+            List<String> columnNames)
+            throws IOException
+    {
+        return createParquetReader(input, parquetMetadata, new ParquetReaderOptions(), newSimpleAggregatedMemoryContext(), types, columnNames, TupleDomain.all());
     }
 
     public static ParquetReader createParquetReader(

--- a/plugin/trino-delta-lake/pom.xml
+++ b/plugin/trino-delta-lake/pom.xml
@@ -398,6 +398,13 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-parquet</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-parser</artifactId>
             <scope>test</scope>
         </dependency>

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -254,6 +254,7 @@ import static io.trino.plugin.deltalake.metastore.HiveMetastoreBackedDeltaLakeMe
 import static io.trino.plugin.deltalake.procedure.DeltaLakeTableProcedureId.OPTIMIZE;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.APPEND_ONLY_CONFIGURATION_KEY;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.CHANGE_DATA_FEED_FEATURE_NAME;
+import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.COLUMN_MAPPING_FEATURE_NAME;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.COLUMN_MAPPING_PHYSICAL_NAME_CONFIGURATION_KEY;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.ColumnMappingMode.ID;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.ColumnMappingMode.NAME;
@@ -2917,6 +2918,8 @@ public class DeltaLakeMetadata
         if (columnMappingMode == ID || columnMappingMode == NAME) {
             readerVersion = max(readerVersion, COLUMN_MAPPING_MODE_SUPPORTED_READER_VERSION);
             writerVersion = max(writerVersion, COLUMN_MAPPING_MODE_SUPPORTED_WRITER_VERSION);
+            readerFeatures.add(COLUMN_MAPPING_FEATURE_NAME);
+            writerFeatures.add(COLUMN_MAPPING_FEATURE_NAME);
         }
         if (containsTimestampType) {
             readerVersion = max(readerVersion, TIMESTAMP_NTZ_SUPPORTED_READER_VERSION);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeSchemaSupport.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeSchemaSupport.java
@@ -110,7 +110,7 @@ public final class DeltaLakeSchemaSupport
     private static final String APPEND_ONLY_FEATURE_NAME = "appendOnly";
     public static final String CHANGE_DATA_FEED_FEATURE_NAME = "changeDataFeed";
     private static final String CHECK_CONSTRAINTS_FEATURE_NAME = "checkConstraints";
-    private static final String COLUMN_MAPPING_FEATURE_NAME = "columnMapping";
+    public static final String COLUMN_MAPPING_FEATURE_NAME = "columnMapping";
     public static final String DELETION_VECTORS_FEATURE_NAME = "deletionVectors";
     private static final String ICEBERG_COMPATIBILITY_V1_FEATURE_NAME = "icebergCompatV1";
     private static final String ICEBERG_COMPATIBILITY_V2_FEATURE_NAME = "icebergCompatV2";

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointSchemaManager.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointSchemaManager.java
@@ -183,7 +183,7 @@ public class CheckpointSchemaManager
             List<DeltaLakeColumnHandle> partitionColumns = extractPartitionColumns(metadataEntry, protocolEntry, typeManager);
             if (!partitionColumns.isEmpty()) {
                 List<RowType.Field> partitionValuesParsed = partitionColumns.stream()
-                        .map(column -> RowType.field(column.columnName(), typeManager.getType(getTypeSignature(DeltaHiveTypeTranslator.toHiveType(column.type())))))
+                        .map(column -> RowType.field(column.basePhysicalColumnName(), typeManager.getType(getTypeSignature(DeltaHiveTypeTranslator.toHiveType(column.type())))))
                         .collect(toImmutableList());
                 addFields.add(RowType.field("partitionValues_parsed", RowType.from(partitionValuesParsed)));
             }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriter.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriter.java
@@ -161,7 +161,7 @@ public class CheckpointWriter
         }
         List<DeltaLakeColumnHandle> partitionColumns = extractPartitionColumns(entries.metadataEntry(), entries.protocolEntry(), typeManager);
         List<RowType.Field> partitionValuesParsedFieldTypes = partitionColumns.stream()
-                .map(column -> RowType.field(column.columnName(), column.type()))
+                .map(column -> RowType.field(column.basePhysicalColumnName(), column.type()))
                 .collect(toImmutableList());
         for (AddFileEntry addFileEntry : entries.addFileEntries()) {
             writeAddFileEntry(pageBuilder, addEntryType, addFileEntry, entries.metadataEntry(), entries.protocolEntry(), partitionColumns, partitionValuesParsedFieldTypes, writeStatsAsJson, writeStatsAsStruct);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -1517,6 +1517,35 @@ public class TestDeltaLakeConnectorTest
     }
 
     @Test
+    void testCreateTableWithColumnMappingModeAndTimestampNtz()
+    {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_column_mapping", "(x int) WITH (column_mapping_mode = 'NAME')")) {
+            assertThat(query("SELECT * FROM \"" + table.getName() + "$properties\""))
+                    .skippingTypesCheck()
+                    .matches("VALUES " +
+                            "('delta.enableDeletionVectors', 'false')," +
+                            "('delta.columnMapping.mode', 'name')," +
+                            "('delta.columnMapping.maxColumnId', '1')," +
+                            "('delta.minReaderVersion', '2')," +
+                            "('delta.minWriterVersion', '5')");
+        }
+
+        // timestamp type requires reader version 3 and writer version 7
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_column_mapping", "(x timestamp) WITH (column_mapping_mode = 'NAME')")) {
+            assertThat(query("SELECT * FROM \"" + table.getName() + "$properties\""))
+                    .skippingTypesCheck()
+                    .matches("VALUES " +
+                            "('delta.enableDeletionVectors', 'false')," +
+                            "('delta.columnMapping.mode', 'name')," +
+                            "('delta.columnMapping.maxColumnId', '1')," +
+                            "('delta.minReaderVersion', '3')," +
+                            "('delta.minWriterVersion', '7')," +
+                            "('delta.feature.columnMapping', 'supported')," +
+                            "('delta.feature.timestampNtz', 'supported')");
+        }
+    }
+
+    @Test
     public void testDropAndAddColumnShowStatsForColumnMappingMode()
     {
         testDropAndAddColumnShowStatsForColumnMappingMode(ColumnMappingMode.ID);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -384,6 +384,7 @@ public class TestDeltaLakeConnectorTest
     @Test
     public void testCreateTableWithUnsupportedPartitionType()
     {
+        // Update TestDeltaLakeBasic.testPartitionValuesParsedCheckpoint() when the connector supports these types as partition columns
         String tableName = "test_create_table_unsupported_partition_types_" + randomNameSuffix();
         assertQueryFails(
                 "CREATE TABLE " + tableName + "(a INT, part ARRAY(INT)) WITH (partitioned_by = ARRAY['part'])",
@@ -394,6 +395,19 @@ public class TestDeltaLakeConnectorTest
         assertQueryFails(
                 "CREATE TABLE " + tableName + "(a INT, part ROW(field INT)) WITH (partitioned_by = ARRAY['part'])",
                 "Using array, map or row type on partitioned columns is unsupported");
+    }
+
+    @Test
+    public void testInsertIntoUnsupportedVarbinaryPartitionType()
+    {
+        // TODO https://github.com/trinodb/trino/issues/24155 Cannot insert varbinary values into partitioned columns
+        // Update TestDeltaLakeBasic.testPartitionValuesParsedCheckpoint() when fixing this issue
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "test_varbinary_partition",
+                "(x int, part varbinary) WITH (partitioned_by = ARRAY['part'])")) {
+            assertQueryFails("INSERT INTO " + table.getName() + " VALUES (1, X'01')", "Unsupported type for partition: varbinary");
+        }
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -1311,6 +1311,13 @@
                 <groupId>io.trino</groupId>
                 <artifactId>trino-parquet</artifactId>
                 <version>${project.version}</version>
+                <type>test-jar</type>
+            </dependency>
+
+            <dependency>
+                <groupId>io.trino</groupId>
+                <artifactId>trino-parquet</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Description

We should write physical column names in `partitionValues_parsed` field on checkpoint files. 

Fixes #24121

## Release notes

```markdown
## Delta Lake
* Fix some things. ({issue}`issuenumber`)
```
