### PR TITLE
Correctly categorize filesystem error in Iceberg connector

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -165,6 +165,7 @@ import org.apache.iceberg.UpdateStatistics;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Term;
@@ -2965,9 +2966,16 @@ public class IcebergMetadata
             Table icebergTable = catalog.loadTable(session, table.getSchemaTableName());
 
             Set<Integer> partitionSpecIds = table.getSnapshotId().map(
-                            snapshot -> icebergTable.snapshot(snapshot).allManifests(icebergTable.io()).stream()
-                                    .map(ManifestFile::partitionSpecId)
-                                    .collect(toImmutableSet()))
+                            snapshot -> {
+                                try {
+                                    return icebergTable.snapshot(snapshot).allManifests(icebergTable.io()).stream()
+                                            .map(ManifestFile::partitionSpecId)
+                                            .collect(toImmutableSet());
+                                }
+                                catch (NotFoundException | UncheckedIOException e) {
+                                    throw new TrinoException(ICEBERG_INVALID_METADATA, "Error accessing manifest file for table %s".formatted(icebergTable.name()), e);
+                                }
+                            })
                     // No snapshot, so no data. This case doesn't matter.
                     .orElseGet(() -> ImmutableSet.copyOf(icebergTable.specs().keySet()));
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Below is the stack trace for failure

```java
"message": "Failed to open input stream for file: s3://<bucket>/<path>/metadata/snap-xxxxxxx.avro",
"stack": [
"io.trino.plugin.iceberg.fileio.ForwardingInputFile.newStream(ForwardingInputFile.java:55)",
"org.apache.iceberg.avro.AvroIterable.newFileReader(AvroIterable.java:102)",
"org.apache.iceberg.avro.AvroIterable.iterator(AvroIterable.java:77)",
"org.apache.iceberg.avro.AvroIterable.iterator(AvroIterable.java:37)",
"org.apache.iceberg.relocated.com.google.common.collect.Iterables.addAll(Iterables.java:333)",
"org.apache.iceberg.relocated.com.google.common.collect.Lists.newLinkedList(Lists.java:242)",
"org.apache.iceberg.ManifestLists.read(ManifestLists.java:45)",
"org.apache.iceberg.BaseSnapshot.cacheManifests(BaseSnapshot.java:146)",
"org.apache.iceberg.BaseSnapshot.allManifests(BaseSnapshot.java:164)",
"io.trino.plugin.iceberg.IcebergMetadata.lambda$applyFilter$80(IcebergMetadata.java:3000)",
"java.base/java.util.Optional.map(Optional.java:260)",
"io.trino.plugin.iceberg.IcebergMetadata.applyFilter(IcebergMetadata.java:2999)",
"io.trino.plugin.objectstore.TracingObjectStoreConnectorMetadata.applyFilter(TracingObjectStoreConnectorMetadata.java:1201)",
"io.trino.plugin.objectstore.ObjectStoreMetadata.applyFilter(ObjectStoreMetadata.java:1465)",
```

Explanation on chain of calls and how `NotFoundException` and `UncheckedIOException` were chosen in the catch clause.

https://github.com/trinodb/trino/blob/20d025ea8fb24b72bc17d93ef73d7131c1ec1dea/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java#L2968

calls

https://github.com/apache/iceberg/blob/0a705b0637db484730eb4eece69ae6c4d52fd9da/core/src/main/java/org/apache/iceberg/BaseSnapshot.java#L164

calls

https://github.com/apache/iceberg/blob/0a705b0637db484730eb4eece69ae6c4d52fd9da/core/src/main/java/org/apache/iceberg/BaseSnapshot.java#L146

calls 
https://github.com/apache/iceberg/blob/0a705b0637db484730eb4eece69ae6c4d52fd9da/core/src/main/java/org/apache/iceberg/ManifestLists.java#L43 which returns `AvroIterable`

`AvroIterable` has 
https://github.com/apache/iceberg/blob/0a705b0637db484730eb4eece69ae6c4d52fd9da/core/src/main/java/org/apache/iceberg/avro/AvroIterable.java#L102 which calls `file.newStream()`, `file.getLength()`

If `file` is of `ForwardingInputFile` type then, `ForwardingInputFile#getLength` and `ForwardingInputFile#newStream` may throw `NotFoundException` and/or `UncheckedIOException`


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
