### PR TITLE
stream function/type to process array elements one by one

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
@@ -167,6 +167,7 @@ import io.trino.operator.scalar.SequenceFunction;
 import io.trino.operator.scalar.SessionFunctions;
 import io.trino.operator.scalar.SplitToMapFunction;
 import io.trino.operator.scalar.SplitToMultimapFunction;
+import io.trino.operator.scalar.StreamFunction;
 import io.trino.operator.scalar.StringFunctions;
 import io.trino.operator.scalar.TDigestFunctions;
 import io.trino.operator.scalar.TryFunction;
@@ -518,6 +519,7 @@ public final class SystemFunctionBundle
                 .scalar(ConcatWsFunction.ConcatArrayWs.class)
                 .scalar(DynamicFilters.Function.class)
                 .scalar(DynamicFilters.NullableFunction.class)
+                .scalar(StreamFunction.class)
                 .functions(ZIP_WITH_FUNCTION, MAP_ZIP_WITH_FUNCTION)
                 .functions(ZIP_FUNCTIONS)
                 .scalars(ArrayJoin.class)

--- a/core/trino-main/src/main/java/io/trino/metadata/TypeRegistry.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/TypeRegistry.java
@@ -100,6 +100,7 @@ import static io.trino.type.JsonType.JSON;
 import static io.trino.type.LikePatternType.LIKE_PATTERN;
 import static io.trino.type.MapParametricType.MAP;
 import static io.trino.type.RowParametricType.ROW;
+import static io.trino.type.StreamParametricType.STREAM;
 import static io.trino.type.TDigestType.TDIGEST;
 import static io.trino.type.UnknownType.UNKNOWN;
 import static io.trino.type.setdigest.SetDigestType.SET_DIGEST;
@@ -162,6 +163,7 @@ public final class TypeRegistry
         addParametricType(MAP);
         addParametricType(FUNCTION);
         addParametricType(QDIGEST);
+        addParametricType(STREAM);
         addParametricType(TIMESTAMP);
         addParametricType(TIMESTAMP_WITH_TIME_ZONE);
         addParametricType(TIME);

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/DefaultApproximateCountDistinctAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/DefaultApproximateCountDistinctAggregation.java
@@ -28,6 +28,7 @@ import io.trino.spi.function.OutputFunction;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.function.TypeParameter;
 import io.trino.spi.type.StandardTypes;
+import io.trino.spi.type.Type;
 
 import java.lang.invoke.MethodHandle;
 
@@ -82,6 +83,7 @@ public final class DefaultApproximateCountDistinctAggregation
     @InputFunction
     @TypeParameter("T")
     public static void input(
+            @TypeParameter("T") Type type,
             @OperatorDependency(
                     operator = XX_HASH_64,
                     argumentTypes = "T",
@@ -90,7 +92,7 @@ public final class DefaultApproximateCountDistinctAggregation
             @AggregationState HyperLogLogState state,
             @SqlType("T") Object value)
     {
-        ApproximateCountDistinctAggregation.input(methodHandle, state, value, DEFAULT_STANDARD_ERROR);
+        ApproximateCountDistinctAggregation.input(type, methodHandle, state, value, DEFAULT_STANDARD_ERROR);
     }
 
     @CombineFunction

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/MinAggregationFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/MinAggregationFunction.java
@@ -29,6 +29,8 @@ import io.trino.spi.function.OperatorType;
 import io.trino.spi.function.OutputFunction;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.function.TypeParameter;
+import io.trino.spi.type.Type;
+import io.trino.type.StreamType;
 
 import java.lang.invoke.MethodHandle;
 
@@ -45,6 +47,7 @@ public final class MinAggregationFunction
     @InputFunction
     @TypeParameter("T")
     public static void input(
+            @TypeParameter("T") Type type,
             @OperatorDependency(
                     operator = OperatorType.COMPARISON_UNORDERED_LAST,
                     argumentTypes = {"T", "T"},
@@ -55,8 +58,17 @@ public final class MinAggregationFunction
             @BlockIndex int position)
             throws Throwable
     {
-        if (state.isNull() || ((long) compare.invokeExact(block, position, state)) < 0) {
-            state.set(block, position);
+        if (type instanceof StreamType streamType) {
+            for (ValueBlock sub : streamType.arrayIterable(block, position)) {
+                if (state.isNull() || ((long) compare.invokeExact(sub, 0, state)) < 0) {
+                    state.set(sub, 0);
+                }
+            }
+        }
+        else {
+            if (state.isNull() || ((long) compare.invokeExact(block, position, state)) < 0) {
+                state.set(block, position);
+            }
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/StreamFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/StreamFunction.java
@@ -11,21 +11,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.operator.window;
+package io.trino.operator.scalar;
 
-import io.trino.annotation.UsedByGeneratedCode;
 import io.trino.spi.block.Block;
-import io.trino.spi.function.WindowIndex;
-import io.trino.spi.type.Type;
+import io.trino.spi.function.Description;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.function.TypeParameter;
 
-public interface InternalWindowIndex
-        extends WindowIndex
+@ScalarFunction("stream")
+@Description("Return stream of array")
+public final class StreamFunction
 {
-    @UsedByGeneratedCode
-    Block getRawBlock(int channel, int position);
+    @TypeParameter("E")
+    public StreamFunction()
+    {
+    }
 
-    @UsedByGeneratedCode
-    int getRawBlockPosition(int position);
-
-    Type getType(int channel);
+    @TypeParameter("E")
+    @SqlType("stream(E)")
+    public Block stream(@SqlType("E") Block block)
+    {
+        return block;
+    }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/window/MappedWindowIndex.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/MappedWindowIndex.java
@@ -18,6 +18,7 @@ import io.airlift.slice.Slice;
 import io.trino.annotation.UsedByGeneratedCode;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.type.Type;
 
 import java.util.List;
 
@@ -105,6 +106,12 @@ public class MappedWindowIndex
     public int getRawBlockPosition(int position)
     {
         return delegate.getRawBlockPosition(position);
+    }
+
+    @Override
+    public Type getType(int channel)
+    {
+        return delegate.getType(toDelegateChannel(channel));
     }
 
     private int toDelegateChannel(int channel)

--- a/core/trino-main/src/main/java/io/trino/operator/window/PagesWindowIndex.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/PagesWindowIndex.java
@@ -17,6 +17,7 @@ import io.airlift.slice.Slice;
 import io.trino.operator.PagesIndex;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.type.Type;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -121,5 +122,11 @@ public class PagesWindowIndex
         return toStringHelper(this)
                 .add("size", size)
                 .toString();
+    }
+
+    @Override
+    public Type getType(int channel)
+    {
+        return pagesIndex.getType(channel);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/window/pattern/ProjectingPagesWindowIndex.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/pattern/ProjectingPagesWindowIndex.java
@@ -277,4 +277,10 @@ public class ProjectingPagesWindowIndex
                 .add("projected channels", projectedTypes.size())
                 .toString();
     }
+
+    @Override
+    public Type getType(int channel)
+    {
+        return pagesIndex.getType(channel);
+    }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -152,6 +152,7 @@ import io.trino.sql.tree.WindowFrame;
 import io.trino.sql.tree.WindowOperation;
 import io.trino.type.FunctionType;
 import io.trino.type.JsonPath2016Type;
+import io.trino.type.StreamType;
 import io.trino.type.TypeCoercion;
 import io.trino.type.UnknownType;
 import jakarta.annotation.Nullable;
@@ -1422,6 +1423,9 @@ public class ExpressionAnalyzer
             }
 
             Type type = signature.getReturnType();
+            if (isAggregation && type instanceof StreamType streamType) {
+                type = streamType.getArrayType();
+            }
             return setExpressionType(node, type);
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -271,6 +271,7 @@ import io.trino.sql.tree.WindowSpecification;
 import io.trino.sql.tree.With;
 import io.trino.sql.tree.WithQuery;
 import io.trino.transaction.TransactionManager;
+import io.trino.type.StreamType;
 import io.trino.type.TypeCoercion;
 
 import java.math.RoundingMode;
@@ -4865,6 +4866,9 @@ class StatementAnalyzer
                         "DISTINCT can only be applied to comparable types (actual: %s): %s",
                         type,
                         expression);
+            }
+            if (type instanceof StreamType) {
+                throw semanticException(TYPE_MISMATCH, node.getSelect(), "Stream type is not allowed in output");
             }
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -275,6 +275,7 @@ import io.trino.sql.relational.RowExpression;
 import io.trino.sql.relational.SqlToRowExpressionTranslator;
 import io.trino.type.BlockTypeOperators;
 import io.trino.type.FunctionType;
+import io.trino.type.StreamType;
 import org.objectweb.asm.MethodTooLargeException;
 
 import java.util.AbstractMap.SimpleEntry;
@@ -3916,6 +3917,9 @@ public class LocalExecutionPlanner
                     .collect(toImmutableList());
             Type intermediateType = (intermediateTypes.size() == 1) ? getOnlyElement(intermediateTypes) : RowType.anonymous(intermediateTypes);
             Type finalType = resolvedFunction.signature().getReturnType();
+            if (finalType instanceof StreamType streamType) {
+                finalType = streamType.getArrayType();
+            }
 
             OptionalInt maskChannel = aggregation.getMask().stream()
                     .mapToInt(value -> source.getLayout().get(value))

--- a/core/trino-main/src/main/java/io/trino/sql/planner/sanity/TypeValidator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/sanity/TypeValidator.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ListMultimap;
 import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.spi.function.BoundSignature;
+import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.sql.PlannerContext;
@@ -31,6 +32,7 @@ import io.trino.sql.planner.plan.ProjectNode;
 import io.trino.sql.planner.plan.UnionNode;
 import io.trino.sql.planner.plan.WindowNode;
 import io.trino.type.FunctionType;
+import io.trino.type.StreamType;
 import io.trino.type.UnknownType;
 
 import java.util.List;
@@ -176,6 +178,9 @@ public final class TypeValidator
                         .toList();
 
                 checkArgument(expectedFieldType.equals(actualFieldTypes), "type of symbol '%s' is expected to be %s, but the actual type is %s", symbol.name(), expected, actual);
+            }
+            else if (actual instanceof StreamType streamType && expected instanceof ArrayType arrayType) {
+                checkArgument(arrayType.equals(streamType.getArrayType()), "type of symbol '%s' is expected to be %s, but the actual type is %s", symbol.name(), expected, actual);
             }
             else if (!(actual instanceof UnknownType)) { // UNKNOWN should be considered as a wildcard type, which matches all the other types
                 checkArgument(expected.equals(actual), "type of symbol '%s' is expected to be %s, but the actual type is %s", symbol.name(), expected, actual);

--- a/core/trino-main/src/main/java/io/trino/type/StreamParametricType.java
+++ b/core/trino-main/src/main/java/io/trino/type/StreamParametricType.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.type;
+
+import io.trino.spi.type.ParameterKind;
+import io.trino.spi.type.ParametricType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeManager;
+import io.trino.spi.type.TypeParameter;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public final class StreamParametricType
+        implements ParametricType
+{
+    public static final StreamParametricType STREAM = new StreamParametricType();
+
+    private StreamParametricType()
+    {
+    }
+
+    @Override
+    public String getName()
+    {
+        return "STREAM";
+    }
+
+    @Override
+    public Type createType(TypeManager typeManager, List<TypeParameter> parameters)
+    {
+        checkArgument(parameters.size() == 1, "Array type expects exactly one type as a parameter, got %s", parameters);
+        checkArgument(
+                parameters.getFirst().getKind() == ParameterKind.TYPE,
+                "Array expects type as a parameter, got %s",
+                parameters);
+        return new StreamType(parameters.getFirst().getType());
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/type/StreamType.java
+++ b/core/trino-main/src/main/java/io/trino/type/StreamType.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.type;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Streams;
+import io.trino.spi.block.ArrayBlock;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.BlockBuilderStatus;
+import io.trino.spi.block.DictionaryBlock;
+import io.trino.spi.block.IntArrayBlock;
+import io.trino.spi.block.LongArrayBlock;
+import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.spi.block.ValueBlock;
+import io.trino.spi.block.VariableWidthBlock;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.type.AbstractType;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeOperatorDeclaration;
+import io.trino.spi.type.TypeOperators;
+import io.trino.spi.type.TypeSignature;
+import io.trino.spi.type.TypeSignatureParameter;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.util.Collections.singletonList;
+
+public class StreamType
+        extends AbstractType
+{
+    public static final StreamType STREAM_INTEGER = new StreamType(new ArrayType(INTEGER));
+    public static final StreamType STREAM_BIGINT = new StreamType(new ArrayType(BIGINT));
+    public static final StreamType STREAM_VARCHAR = new StreamType(new ArrayType(VARCHAR));
+
+    private static final String STREAM = "stream";
+    private volatile TypeOperatorDeclaration operatorDeclaration;
+
+    private final Type elementType;
+    private final ArrayType arrayType;
+
+    public StreamType(Type elementType)
+    {
+        super(new TypeSignature(STREAM, TypeSignatureParameter.typeParameter(elementType.getTypeSignature())), Block.class, ArrayBlock.class);
+        checkArgument(elementType instanceof ArrayType || elementType instanceof StreamType, "elementType must be an array type or a stream type");
+        this.elementType = elementType;
+        this.arrayType = underlyingArrayType(elementType);
+    }
+
+    private static ArrayType underlyingArrayType(Type type)
+    {
+        Type arrayType = type;
+        while (arrayType instanceof StreamType streamType) {
+            arrayType = streamType.elementType;
+        }
+        return (ArrayType) arrayType;
+    }
+
+    public ArrayType getArrayType()
+    {
+        return arrayType;
+    }
+
+    @Override
+    public List<Type> getTypeParameters()
+    {
+        return singletonList(elementType);
+    }
+
+    @Override
+    public String getDisplayName()
+    {
+        return STREAM + "(" + elementType.getDisplayName() + ")";
+    }
+
+    @Override
+    public TypeOperatorDeclaration getTypeOperatorDeclaration(TypeOperators typeOperators)
+    {
+        if (operatorDeclaration == null) {
+            operatorDeclaration = arrayType.getTypeOperatorDeclaration(typeOperators);
+        }
+        return operatorDeclaration;
+    }
+
+    @Override
+    public Object getObjectValue(ConnectorSession session, Block block, int position)
+    {
+        return arrayType.getObjectValue(session, block, position);
+    }
+
+    @Override
+    public Object getObject(Block block, int position)
+    {
+        return arrayType.getObject(block, position);
+    }
+
+    @Override
+    public void writeObject(BlockBuilder blockBuilder, Object value)
+    {
+        arrayType.writeObject(blockBuilder, value);
+    }
+
+    @Override
+    public void appendTo(Block block, int position, BlockBuilder blockBuilder)
+    {
+        arrayType.appendTo(block, position, blockBuilder);
+    }
+
+    @Override
+    public int getFlatFixedSize()
+    {
+        return 8;
+    }
+
+    @Override
+    public boolean isFlatVariableWidth()
+    {
+        return true;
+    }
+
+    @Override
+    public int getFlatVariableWidthSize(Block block, int position)
+    {
+        return arrayType.getFlatVariableWidthSize(block, position);
+    }
+
+    @Override
+    public int relocateFlatVariableWidthOffsets(byte[] fixedSizeSlice, int fixedSizeOffset, byte[] variableSizeSlice, int variableSizeOffset)
+    {
+        return arrayType.relocateFlatVariableWidthOffsets(fixedSizeSlice, fixedSizeOffset, variableSizeSlice, variableSizeOffset);
+    }
+
+    @Override
+    public boolean isComparable()
+    {
+        return elementType.isComparable();
+    }
+
+    @Override
+    public boolean isOrderable()
+    {
+        return elementType.isOrderable();
+    }
+
+    @Override
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
+    {
+        return arrayType.createBlockBuilder(blockBuilderStatus, expectedEntries, expectedBytesPerEntry);
+    }
+
+    @Override
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        return createBlockBuilder(blockBuilderStatus, expectedEntries, 100);
+    }
+
+    public Iterable<Object> valueIterable(Block block)
+    {
+        ValueBlock valueBlock = getValueBlock(block, 0);
+        return () -> IntStream.range(0, valueBlock.getPositionCount()).boxed()
+                .map(i -> getValueObject(valueBlock, i))
+                .iterator();
+    }
+
+    private static Object getValueObject(ValueBlock valueBlock, int position)
+    {
+        if (valueBlock instanceof IntArrayBlock intArrayBlock) {
+            return (long) intArrayBlock.getInt(position);
+        }
+        if (valueBlock instanceof LongArrayBlock longArrayBlock) {
+            return longArrayBlock.getLong(position);
+        }
+        if (valueBlock instanceof VariableWidthBlock variableWidthBlock) {
+            return variableWidthBlock.getSlice(position);
+        }
+        throw new UnsupportedOperationException("unsupported block type: " + valueBlock.getClass().getName());
+    }
+
+    private static ValueBlock getValueBlock(Block block, int position)
+    {
+        if (block instanceof ArrayBlock arrayBlock) {
+            return arrayBlock.getUnderlyingValueBlock().getArray(arrayBlock.getUnderlyingValuePosition(position)).getUnderlyingValueBlock();
+        }
+        if (block instanceof ValueBlock valueBlock) {
+            return valueBlock.getUnderlyingValueBlock();
+        }
+        if (block instanceof RunLengthEncodedBlock rleBlock) {
+            return rleBlock.getValue();
+        }
+        if (block instanceof DictionaryBlock dictionaryBlock) {
+            return dictionaryBlock.getDictionary();
+        }
+
+        throw new UnsupportedOperationException("unsupported block type: " + block.getClass().getName());
+    }
+
+    private Iterable<ValueBlock> streamValueBlocks(ValueBlock streamBlock, int position)
+    {
+        ValueBlock block = streamBlock.getSingleValueBlock(position);
+        if (elementType instanceof StreamType subStreamType) {
+            return subStreamType.arrayIterable(getValueBlock(block, position), 0);
+        }
+        return ImmutableList.of(block);
+    }
+
+    public Iterable<ValueBlock> blockValueIterable(Block block, int position)
+    {
+        ValueBlock streamBlock = getValueBlock(block, position);
+
+        return () -> IntStream.range(0, streamBlock.getPositionCount())
+                .boxed()
+                .flatMap(i -> Streams.stream(streamValueBlocks(streamBlock, i)))
+                .iterator();
+    }
+
+    public Iterable<ValueBlock> arrayIterable(Block block, int position)
+    {
+        return Iterables.transform(blockValueIterable(block, position),
+                b -> ArrayBlock.fromElementBlock(1, Optional.of(new boolean[] {false}), new int[] {0, 1}, b));
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestAccumulatorCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestAccumulatorCompiler.java
@@ -35,6 +35,7 @@ import io.trino.spi.function.WindowAccumulator;
 import io.trino.spi.type.LongTimestamp;
 import io.trino.spi.type.RealType;
 import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.Type;
 import io.trino.sql.gen.IsolatedClass;
 import org.junit.jupiter.api.Test;
 
@@ -220,6 +221,12 @@ public class TestAccumulatorCompiler
         public int getRawBlockPosition(int position)
         {
             return 0;
+        }
+
+        @Override
+        public Type getType(int channel)
+        {
+            return BIGINT;
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Proposing a new syntax to aggregate array elements in a stream way.
Currently, the array is processed as one value unless using CROSS JOIN UNNEST to process array elements individually.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Usage could be
```
sum(stream(arr))
max(stream(arr))
approx_distinct(stream(arr))
or nested array: max(stream(stream(arr2)))
```

https://github.com/trinodb/trino/issues/22445 


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`22445`)
```
