### PR TITLE
Rename `PartitionTable` to `PartitionsTable` in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/FilesTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/FilesTable.java
@@ -123,7 +123,7 @@ public class FilesTable
         this.icebergTable = requireNonNull(icebergTable, "icebergTable is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
 
-        List<PartitionField> partitionFields = PartitionTable.getAllPartitionFields(icebergTable);
+        List<PartitionField> partitionFields = PartitionsTable.getAllPartitionFields(icebergTable);
         partitionColumnType = getPartitionColumnType(partitionFields, icebergTable.schema(), typeManager);
         idToPrimitiveTypeMapping = IcebergUtil.primitiveFieldTypes(icebergTable.schema());
         primitiveFields = IcebergUtil.primitiveFields(icebergTable.schema()).stream()
@@ -194,7 +194,7 @@ public class FilesTable
                 columnNameToPosition,
                 typeManager,
                 partitionColumnType,
-                PartitionTable.getAllPartitionFields(icebergTable),
+                PartitionsTable.getAllPartitionFields(icebergTable),
                 idToPrimitiveTypeMapping);
         return planFilesIterable.cursor();
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -647,7 +647,7 @@ public class IcebergMetadata
             case HISTORY -> Optional.of(new HistoryTable(tableName, table));
             case METADATA_LOG_ENTRIES -> Optional.of(new MetadataLogEntriesTable(tableName, table));
             case SNAPSHOTS -> Optional.of(new SnapshotsTable(tableName, typeManager, table));
-            case PARTITIONS -> Optional.of(new PartitionTable(tableName, typeManager, table, getCurrentSnapshotId(table)));
+            case PARTITIONS -> Optional.of(new PartitionsTable(tableName, typeManager, table, getCurrentSnapshotId(table)));
             case MANIFESTS -> Optional.of(new ManifestsTable(tableName, table, getCurrentSnapshotId(table)));
             case FILES -> Optional.of(new FilesTable(tableName, typeManager, table, getCurrentSnapshotId(table)));
             case PROPERTIES -> Optional.of(new PropertiesTable(tableName, table));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionsTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionsTable.java
@@ -61,7 +61,7 @@ import static io.trino.spi.type.TypeUtils.writeNativeValue;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toSet;
 
-public class PartitionTable
+public class PartitionsTable
         implements SystemTable
 {
     private final TypeManager typeManager;
@@ -76,7 +76,7 @@ public class PartitionTable
     private final List<io.trino.spi.type.Type> resultTypes;
     private final ConnectorTableMetadata connectorTableMetadata;
 
-    public PartitionTable(SchemaTableName tableName, TypeManager typeManager, Table icebergTable, Optional<Long> snapshotId)
+    public PartitionsTable(SchemaTableName tableName, TypeManager typeManager, Table icebergTable, Optional<Long> snapshotId)
     {
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.icebergTable = requireNonNull(icebergTable, "icebergTable is null");


### PR DESCRIPTION
## Description

The metadata table name is `partitions`: https://trino.io/docs/current/connector/iceberg.html#partitions-table

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
