### PR TITLE
Allow configuring locale in the Faker connector

### DIFF
--- a/docs/src/main/sphinx/connector/faker.md
+++ b/docs/src/main/sphinx/connector/faker.md
@@ -21,6 +21,7 @@ For example, to generate data in the `generator` catalog, create the file
 connector.name=faker
 faker.null-probability=0.1
 faker.default-limit=1000
+faker.locale=pl-PL
 ```
 
 Create tables in the `default` schema, or create different schemas first. Tables
@@ -46,6 +47,9 @@ The following table details all general configuration properties:
     that allows them. Defaults to `0.5`.
 * - `faker.default-limit`
   - Default number of rows in a table. Defaults to `1000`.
+* - `faker.locale`
+  - Default locale for generating character based data, specified as a IETF BCP
+    47 language tag string. Defaults to `en`.
 :::
 
 The following table details all supported schema properties. If they're not

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerConfig.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerConfig.java
@@ -19,10 +19,13 @@ import io.airlift.configuration.ConfigDescription;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
+import java.util.Locale;
+
 public class FakerConfig
 {
     private double nullProbability = 0.5;
     private long defaultLimit = 1000L;
+    private Locale locale = Locale.ENGLISH;
 
     @Max(1)
     @Min(0)
@@ -50,6 +53,19 @@ public class FakerConfig
     public FakerConfig setDefaultLimit(long value)
     {
         this.defaultLimit = value;
+        return this;
+    }
+
+    public Locale getLocale()
+    {
+        return locale;
+    }
+
+    @Config("faker.locale")
+    @ConfigDescription("Default locale for generating character based data, specified as a IETF BCP 47 language tag string")
+    public FakerConfig setLocale(String value)
+    {
+        this.locale = new Locale.Builder().setLanguageTag(value).build();
         return this;
     }
 }

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerPageSourceProvider.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerPageSourceProvider.java
@@ -25,6 +25,7 @@ import jakarta.inject.Inject;
 import net.datafaker.Faker;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Random;
 import java.util.random.RandomGeneratorFactory;
 
@@ -34,19 +35,21 @@ import static java.util.random.RandomGenerator.JumpableGenerator;
 public class FakerPageSourceProvider
         implements ConnectorPageSourceProvider
 {
+    private final Locale locale;
     private final JumpableGenerator jumpableRandom;
     private final Faker faker;
 
     @Inject
-    public FakerPageSourceProvider()
+    public FakerPageSourceProvider(FakerConfig config)
     {
+        locale = config.getLocale();
         // Every split should generate data in a sequence that does not overlap with other splits.
         // To make data generation deterministic, use a generator with the same seed,
         // but advance its state by a different offset for every split.
         // A jumpable random generator's state can be advanced forward by a big distance in a single call.
         // Xoroshiro128PlusPlus state has a period of 2^128, and a jump distance of 2^64.
         jumpableRandom = (JumpableGenerator) RandomGeneratorFactory.of("Xoroshiro128PlusPlus").create(1);
-        faker = new Faker(Random.from(jumpableRandom.copy()));
+        faker = new Faker(locale, Random.from(jumpableRandom.copy()));
     }
 
     @Override
@@ -66,7 +69,7 @@ public class FakerPageSourceProvider
         FakerTableHandle fakerTable = (FakerTableHandle) table;
         FakerSplit fakerSplit = (FakerSplit) split;
         Random random = random(fakerSplit.splitNumber());
-        return new FakerPageSource(new Faker(random), random, handles, fakerTable.constraint(), fakerSplit.rowsOffset(), fakerSplit.rowsCount());
+        return new FakerPageSource(new Faker(locale, random), random, handles, fakerTable.constraint(), fakerSplit.rowsOffset(), fakerSplit.rowsCount());
     }
 
     private Random random(long index)

--- a/plugin/trino-faker/src/test/java/io/trino/plugin/faker/FakerQueryRunner.java
+++ b/plugin/trino-faker/src/test/java/io/trino/plugin/faker/FakerQueryRunner.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.faker;
 
+import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Level;
 import io.airlift.log.Logger;
 import io.airlift.log.Logging;
@@ -39,12 +40,20 @@ public class FakerQueryRunner
     public static class Builder
             extends DistributedQueryRunner.Builder<Builder>
     {
+        private Map<String, String> properties = ImmutableMap.of();
+
         protected Builder()
         {
             super(testSessionBuilder()
                     .setCatalog(CATALOG)
                     .setSchema("default")
                     .build());
+        }
+
+        public Builder setFakerProperties(Map<String, String> properties)
+        {
+            this.properties = ImmutableMap.copyOf(properties);
+            return this;
         }
 
         @Override
@@ -56,7 +65,7 @@ public class FakerQueryRunner
 
             try {
                 queryRunner.installPlugin(new FakerPlugin());
-                queryRunner.createCatalog(CATALOG, "faker");
+                queryRunner.createCatalog(CATALOG, "faker", properties);
 
                 return queryRunner;
             }

--- a/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerConfig.java
+++ b/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerConfig.java
@@ -29,7 +29,8 @@ final class TestFakerConfig
     {
         assertRecordedDefaults(recordDefaults(FakerConfig.class)
                 .setNullProbability(0.5)
-                .setDefaultLimit(1000L));
+                .setDefaultLimit(1000L)
+                .setLocale("en"));
     }
 
     @Test
@@ -38,11 +39,13 @@ final class TestFakerConfig
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("faker.null-probability", "1.0")
                 .put("faker.default-limit", "10")
+                .put("faker.locale", "pl-PL")
                 .buildOrThrow();
 
         FakerConfig expected = new FakerConfig()
                 .setNullProbability(1.0)
-                .setDefaultLimit(10L);
+                .setDefaultLimit(10L)
+                .setLocale("pl-PL");
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerQueries.java
+++ b/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerQueries.java
@@ -214,31 +214,31 @@ final class TestFakerQueries
                     "VALUES (5)");
 
             assertQuery("""
-                            SELECT count(rnd_bigint)
-                            FROM (SELECT rnd_bigint FROM %s LIMIT %d) a""".formatted(table.getName(), 2 * MAX_ROWS_PER_SPLIT),
+                        SELECT count(rnd_bigint)
+                        FROM (SELECT rnd_bigint FROM %s LIMIT %d) a""".formatted(table.getName(), 2 * MAX_ROWS_PER_SPLIT),
                     "VALUES (%d)".formatted(2 * MAX_ROWS_PER_SPLIT));
 
             assertQuery("SELECT count(distinct rnd_bigint) FROM %s LIMIT 5".formatted(table.getName()),
                     "VALUES (1000)");
 
             assertQuery("""
-                            SELECT count(rnd_bigint)
-                            FROM (SELECT rnd_bigint FROM %s LIMIT %d) a""".formatted(table.getName(), MAX_ROWS_PER_SPLIT),
+                        SELECT count(rnd_bigint)
+                        FROM (SELECT rnd_bigint FROM %s LIMIT %d) a""".formatted(table.getName(), MAX_ROWS_PER_SPLIT),
                     "VALUES (%d)".formatted(MAX_ROWS_PER_SPLIT));
 
             // generating data should be deterministic
             String testQuery = """
-                    SELECT to_hex(checksum(rnd_bigint))
-                    FROM (SELECT rnd_bigint FROM %s LIMIT %d) a""".formatted(table.getName(), 3 * MAX_ROWS_PER_SPLIT);
+                               SELECT to_hex(checksum(rnd_bigint))
+                               FROM (SELECT rnd_bigint FROM %s LIMIT %d) a""".formatted(table.getName(), 3 * MAX_ROWS_PER_SPLIT);
             assertQuery(testQuery, "VALUES ('1FB3289AC3A44EEA')");
             assertQuery(testQuery, "VALUES ('1FB3289AC3A44EEA')");
             assertQuery(testQuery, "VALUES ('1FB3289AC3A44EEA')");
 
             // there should be no overlap between data generated from different splits
             assertQuery("""
-                            SELECT count(1)
-                            FROM (SELECT rnd_bigint FROM %s LIMIT %d) a
-                            JOIN (SELECT rnd_bigint FROM %s LIMIT %d) b ON a.rnd_bigint = b.rnd_bigint""".formatted(table.getName(), 2 * MAX_ROWS_PER_SPLIT, table.getName(), 5 * MAX_ROWS_PER_SPLIT),
+                        SELECT count(1)
+                        FROM (SELECT rnd_bigint FROM %s LIMIT %d) a
+                        JOIN (SELECT rnd_bigint FROM %s LIMIT %d) b ON a.rnd_bigint = b.rnd_bigint""".formatted(table.getName(), 2 * MAX_ROWS_PER_SPLIT, table.getName(), 5 * MAX_ROWS_PER_SPLIT),
                     "VALUES (%d)".formatted(2 * MAX_ROWS_PER_SPLIT));
         }
     }
@@ -262,12 +262,13 @@ final class TestFakerQueries
     @Test
     void testSelectGenerator()
     {
-        try (TestTable table = new TestTable(getQueryRunner()::execute, "generators", """
-            (
-                name VARCHAR NOT NULL WITH (generator = '#{Name.first_name} #{Name.last_name}'),
-                age_years INTEGER NOT NULL
-            )
-            """)) {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "generators",
+                """
+                (
+                    name VARCHAR NOT NULL WITH (generator = '#{Name.first_name} #{Name.last_name}'),
+                    age_years INTEGER NOT NULL
+                )
+                """)) {
             assertQuery("SELECT count(name) FILTER (WHERE LENGTH(name) - LENGTH(REPLACE(name, ' ', '')) = 1) FROM " + table.getName(), "VALUES (1000)");
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Allow configuring locale in the Faker connector.

## Release notes

```markdown
## Faker
* Allow configuring locale via the `aker.locale` config property. ({issue}`24152`)
```
