### PR TITLE
Parallelize tables retrieval from multiple catalogs

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/system/MaterializedViewSystemTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/MaterializedViewSystemTable.java
@@ -25,6 +25,7 @@ import io.trino.security.AccessControl;
 import io.trino.spi.connector.CatalogSchemaTableName;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.InMemoryRecordSet;
@@ -102,7 +103,8 @@ public class MaterializedViewSystemTable
             ConnectorTransactionHandle transactionHandle,
             ConnectorSession connectorSession,
             TupleDomain<Integer> constraint,
-            Set<Integer> requiredColumns)
+            Set<Integer> requiredColumns,
+            ConnectorSplit split)
     {
         Session session = ((FullConnectorSession) connectorSession).getSession();
         Set<String> requiredColumnNames = requiredColumns.stream()

--- a/core/trino-main/src/main/java/io/trino/connector/system/SystemPageSourceProvider.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/SystemPageSourceProvider.java
@@ -115,12 +115,19 @@ public class SystemPageSourceProvider
                             systemTable,
                             session,
                             newConstraint,
-                            requiredColumns.build()),
+                            requiredColumns.build(),
+                            systemSplit),
                     userToSystemFieldIndex.build()));
         }
     }
 
-    private static RecordSet toRecordSet(ConnectorTransactionHandle sourceTransaction, SystemTable table, ConnectorSession session, TupleDomain<Integer> constraint, Set<Integer> requiredColumns)
+    private static RecordSet toRecordSet(
+            ConnectorTransactionHandle sourceTransaction,
+            SystemTable table,
+            ConnectorSession session,
+            TupleDomain<Integer> constraint,
+            Set<Integer> requiredColumns,
+            ConnectorSplit split)
     {
         return new RecordSet()
         {
@@ -137,7 +144,7 @@ public class SystemPageSourceProvider
             @Override
             public RecordCursor cursor()
             {
-                return table.cursor(sourceTransaction, session, constraint, requiredColumns);
+                return table.cursor(sourceTransaction, session, constraint, requiredColumns, split);
             }
         };
     }

--- a/core/trino-main/src/main/java/io/trino/connector/system/SystemSplitManager.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/SystemSplitManager.java
@@ -33,6 +33,7 @@ import io.trino.spi.connector.SystemTable.Distribution;
 import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.predicate.TupleDomain;
 
+import java.util.Optional;
 import java.util.Set;
 
 import static io.trino.metadata.NodeState.ACTIVE;
@@ -68,10 +69,15 @@ public class SystemSplitManager
                 // table might disappear in the meantime
                 .orElseThrow(() -> new TableNotFoundException(table.schemaTableName()));
 
+        Optional<ConnectorSplitSource> connectorSplitSource = systemTable.splitSource(session, tableConstraint);
+        if (connectorSplitSource.isPresent()) {
+            return connectorSplitSource.get();
+        }
+
         Distribution tableDistributionMode = systemTable.getDistribution();
         if (tableDistributionMode == SINGLE_COORDINATOR) {
             HostAddress address = nodeManager.getCurrentNode().getHostAndPort();
-            ConnectorSplit split = new SystemSplit(address, tableConstraint);
+            ConnectorSplit split = new SystemSplit(address, tableConstraint, Optional.empty());
             return new FixedSplitSource(ImmutableList.of(split));
         }
 
@@ -85,7 +91,7 @@ public class SystemSplitManager
         }
         Set<InternalNode> nodeSet = nodes.build();
         for (InternalNode node : nodeSet) {
-            splits.add(new SystemSplit(node.getHostAndPort(), tableConstraint));
+            splits.add(new SystemSplit(node.getHostAndPort(), tableConstraint, Optional.empty()));
         }
         return new FixedSplitSource(splits.build());
     }

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/TableJdbcTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/TableJdbcTable.java
@@ -17,12 +17,20 @@ import com.google.inject.Inject;
 import io.airlift.slice.Slices;
 import io.trino.FullConnectorSession;
 import io.trino.Session;
+import io.trino.connector.system.SystemColumnHandle;
+import io.trino.connector.system.SystemSplit;
+import io.trino.metadata.InternalNodeManager;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedTablePrefix;
 import io.trino.security.AccessControl;
+import io.trino.spi.HostAddress;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.connector.ConnectorSplitSource;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.FixedSplitSource;
 import io.trino.spi.connector.InMemoryRecordSet;
 import io.trino.spi.connector.InMemoryRecordSet.Builder;
 import io.trino.spi.connector.RecordCursor;
@@ -31,14 +39,18 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.connector.system.jdbc.FilterUtil.isImpossibleObjectName;
 import static io.trino.connector.system.jdbc.FilterUtil.tablePrefix;
 import static io.trino.connector.system.jdbc.FilterUtil.tryGetSingleVarcharValue;
 import static io.trino.metadata.MetadataListing.getRelationTypes;
 import static io.trino.metadata.MetadataListing.listCatalogNames;
 import static io.trino.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
+import static io.trino.spi.connector.FixedSplitSource.emptySplitSource;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.util.Objects.requireNonNull;
 
@@ -60,14 +72,18 @@ public class TableJdbcTable
             .column("ref_generation", VARCHAR)
             .build();
 
+    private static final ColumnHandle CATALOG_COLUMN = new SystemColumnHandle("table_cat");
+
     private final Metadata metadata;
     private final AccessControl accessControl;
+    private final InternalNodeManager nodeManager;
 
     @Inject
-    public TableJdbcTable(Metadata metadata, AccessControl accessControl)
+    public TableJdbcTable(Metadata metadata, AccessControl accessControl, InternalNodeManager nodeManager)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
+        this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
     }
 
     @Override
@@ -77,17 +93,22 @@ public class TableJdbcTable
     }
 
     @Override
-    public RecordCursor cursor(ConnectorTransactionHandle transactionHandle, ConnectorSession connectorSession, TupleDomain<Integer> constraint)
+    public RecordCursor cursor(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession connectorSession,
+            TupleDomain<Integer> constraint,
+            Set<Integer> requiredColumns,
+            ConnectorSplit split)
     {
         Builder table = InMemoryRecordSet.builder(METADATA);
         Session session = ((FullConnectorSession) connectorSession).getSession();
+        SystemSplit systemSplit = (SystemSplit) split;
 
-        Domain catalogDomain = constraint.getDomain(0, VARCHAR);
         Domain schemaDomain = constraint.getDomain(1, VARCHAR);
         Domain tableDomain = constraint.getDomain(2, VARCHAR);
         Domain typeDomain = constraint.getDomain(3, VARCHAR);
 
-        if (isImpossibleObjectName(catalogDomain) || isImpossibleObjectName(schemaDomain) || isImpossibleObjectName(tableDomain)) {
+        if (isImpossibleObjectName(schemaDomain) || isImpossibleObjectName(tableDomain)) {
             return table.build().cursor();
         }
 
@@ -100,17 +121,33 @@ public class TableJdbcTable
             return table.build().cursor();
         }
 
-        for (String catalog : listCatalogNames(session, metadata, accessControl, catalogDomain)) {
-            QualifiedTablePrefix prefix = tablePrefix(catalog, schemaFilter, tableFilter);
+        String catalog = systemSplit.getCatalogName().orElseThrow();
+        QualifiedTablePrefix prefix = tablePrefix(catalog, schemaFilter, tableFilter);
 
-            getRelationTypes(session, metadata, accessControl, prefix).forEach((name, type) -> {
-                boolean isView = type == RelationType.VIEW;
-                if ((includeTables && !isView) || (includeViews && isView)) {
-                    table.addRow(tableRow(catalog, name, isView ? "VIEW" : "TABLE"));
-                }
-            });
-        }
+        getRelationTypes(session, metadata, accessControl, prefix).forEach((name, type) -> {
+            boolean isView = type == RelationType.VIEW;
+            if ((includeTables && !isView) || (includeViews && isView)) {
+                table.addRow(tableRow(catalog, name, isView ? "VIEW" : "TABLE"));
+            }
+        });
         return table.build().cursor();
+    }
+
+    @Override
+    public Optional<ConnectorSplitSource> splitSource(ConnectorSession connectorSession, TupleDomain<ColumnHandle> constraint)
+    {
+        Domain catalogDomain = constraint.getDomain(CATALOG_COLUMN, VARCHAR);
+        if (isImpossibleObjectName(catalogDomain)) {
+            return Optional.of(emptySplitSource());
+        }
+
+        Session session = ((FullConnectorSession) connectorSession).getSession();
+        // This is an implementation of SINGLE_COORDINATOR distribution for this table.
+        HostAddress address = nodeManager.getCurrentNode().getHostAndPort();
+        List<SystemSplit> splits = listCatalogNames(session, metadata, accessControl, catalogDomain).stream()
+                .map(catalog -> new SystemSplit(address, constraint, Optional.of(catalog)))
+                .collect(toImmutableList());
+        return Optional.of(new FixedSplitSource(splits));
     }
 
     private static Object[] tableRow(String catalog, SchemaTableName name, String type)

--- a/core/trino-main/src/test/java/io/trino/connector/system/TestSystemSplit.java
+++ b/core/trino-main/src/test/java/io/trino/connector/system/TestSystemSplit.java
@@ -18,6 +18,8 @@ import io.trino.spi.HostAddress;
 import io.trino.spi.predicate.TupleDomain;
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
+
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -26,12 +28,13 @@ public class TestSystemSplit
     @Test
     public void testSerialization()
     {
-        SystemSplit expected = new SystemSplit(HostAddress.fromParts("127.0.0.1", 0), TupleDomain.all());
+        SystemSplit expected = new SystemSplit(HostAddress.fromParts("127.0.0.1", 0), TupleDomain.all(), Optional.of("catalog"));
 
         JsonCodec<SystemSplit> codec = jsonCodec(SystemSplit.class);
         SystemSplit actual = codec.fromJson(codec.toJson(expected));
 
         assertThat(actual.getAddresses()).isEqualTo(expected.getAddresses());
         assertThat(actual.getConstraint()).isEqualTo(expected.getConstraint());
+        assertThat(actual.getCatalogName()).isEqualTo(expected.getCatalogName());
     }
 }

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -212,6 +212,11 @@
                                 </item>
                                 <!-- Backwards incompatible changes since the previous release -->
                                 <!-- Any exclusions below can be deleted after each release -->
+                                <item>
+                                    <code>java.method.numberOfParametersChanged</code>
+                                    <old>method io.trino.spi.connector.RecordCursor io.trino.spi.connector.SystemTable::cursor(io.trino.spi.connector.ConnectorTransactionHandle, io.trino.spi.connector.ConnectorSession, io.trino.spi.predicate.TupleDomain&lt;java.lang.Integer&gt;, java.util.Set&lt;java.lang.Integer&gt;)</old>
+                                    <new>method io.trino.spi.connector.RecordCursor io.trino.spi.connector.SystemTable::cursor(io.trino.spi.connector.ConnectorTransactionHandle, io.trino.spi.connector.ConnectorSession, io.trino.spi.predicate.TupleDomain&lt;java.lang.Integer&gt;, java.util.Set&lt;java.lang.Integer&gt;, io.trino.spi.connector.ConnectorSplit)</new>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/SystemTable.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/SystemTable.java
@@ -15,6 +15,7 @@ package io.trino.spi.connector;
 
 import io.trino.spi.predicate.TupleDomain;
 
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -42,7 +43,12 @@ public interface SystemTable
         throw new UnsupportedOperationException();
     }
 
-    default RecordCursor cursor(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint, Set<Integer> requiredColumns)
+    default RecordCursor cursor(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            TupleDomain<Integer> constraint,
+            Set<Integer> requiredColumns,
+            ConnectorSplit split)
     {
         return cursor(transactionHandle, session, constraint);
     }
@@ -56,5 +62,10 @@ public interface SystemTable
     default ConnectorPageSource pageSource(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
     {
         throw new UnsupportedOperationException();
+    }
+
+    default Optional<ConnectorSplitSource> splitSource(ConnectorSession connectorSession, TupleDomain<ColumnHandle> constraint)
+    {
+        return Optional.empty();
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

This PR implements parallelization of table retrieval at the catalog level by generating a split for each catalog.

Benchmark results for the following query (9 catalogs, 822 schemas, 17835 tables):

```sql
SELECT * FROM system.jdbc.tables;
```

![image](https://github.com/user-attachments/assets/f5b7ef43-b793-4e94-9143-160d01f936ba)

The chart compares the execution time of the query above between `master` and the changes introduced in this PR and https://github.com/trinodb/trino/pull/24110.

### Question

Since this PR requires changes to the SPI (`io.trino.spi.connector.SystemTable`), I'm wondering how to approach them. Should I introduce a new `cursor` method to the `SystemTable` interface? Currently, I have extended an existing one.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Improve performance of querying system.jdbc.tables for multiple catalogs. ({issue}`24159`)
```
