### PR TITLE
Indicate certain string functions cannot fail

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/ir/IrExpressions.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/IrExpressions.java
@@ -40,6 +40,14 @@ public class IrExpressions
             builtinFunctionName("try_cast"),
             builtinFunctionName("$not"),
             builtinFunctionName("substring"),
+            builtinFunctionName("trim"),
+            builtinFunctionName("ltrim"),
+            builtinFunctionName("rtrim"),
+            builtinFunctionName("replace"),
+            builtinFunctionName("reverse"),
+            builtinFunctionName("lower"),
+            builtinFunctionName("upper"),
+            builtinFunctionName("to_utf8"),
             builtinFunctionName(LIKE_FUNCTION_NAME));
 
     private IrExpressions() {}

--- a/core/trino-main/src/main/java/io/trino/sql/ir/IrExpressions.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/IrExpressions.java
@@ -34,6 +34,14 @@ import static io.trino.type.LikeFunctions.LIKE_FUNCTION_NAME;
 
 public class IrExpressions
 {
+    // TODO: these should be attributes of the function
+    private static final List<CatalogSchemaFunctionName> NEVER_FAIL = ImmutableList.of(
+            builtinFunctionName("length"),
+            builtinFunctionName("try_cast"),
+            builtinFunctionName("$not"),
+            builtinFunctionName("substring"),
+            builtinFunctionName(LIKE_FUNCTION_NAME));
+
     private IrExpressions() {}
 
     public static Expression ifExpression(Expression condition, Expression trueCase)
@@ -113,14 +121,7 @@ public class IrExpressions
 
     private static boolean mayFail(ResolvedFunction function)
     {
-        // TODO: these should be attributes of the function
-        CatalogSchemaFunctionName name = function.name();
-        return !name.equals(builtinFunctionName("length")) &&
-                !name.equals(builtinFunctionName("try_cast")) &&
-                !name.equals(builtinFunctionName("$not")) &&
-                !name.equals(builtinFunctionName("substring")) &&
-                !name.equals(builtinFunctionName(LIKE_FUNCTION_NAME)) &&
-                !isDynamicFilterFunction(function.name());
+        return !NEVER_FAIL.contains(function.name()) && !isDynamicFilterFunction(function.name());
     }
 
     public static Expression not(Metadata metadata, Expression expression)


### PR DESCRIPTION
This allows the optimizer to be more aggressive during predicate pushdown.

(x) Release notes are required, with the following suggested text:

```markdown
## General
* Improve performance when using various string functions in queries involving joins. ({issue}`24182`)
```
