### PR TITLE
Fix refresh-period configuration documentation

### DIFF
--- a/docs/src/main/sphinx/connector/jdbc-case-insensitive-matching.fragment
+++ b/docs/src/main/sphinx/connector/jdbc-case-insensitive-matching.fragment
@@ -47,9 +47,9 @@ configured above is forwarded to `CaseSensitiveName.tablex`, and a query on
 
 By default, when a change is made to the mapping configuration file, Trino must
 be restarted to load the changes. Optionally, you can set the
-`case-insensitive-name-mapping.refresh-period` to have Trino refresh the
-properties without requiring a restart:
+`case-insensitive-name-matching.config-file.refresh-period` to have Trino
+refresh the properties without requiring a restart:
 
 ```properties
-case-insensitive-name-mapping.refresh-period=30s
+case-insensitive-name-matching.config-file.refresh-period=30s
 ```


### PR DESCRIPTION
Fix the refresh-period configuration for
`case-insensitive-name-matching.config-file`.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

There are errors in the existing documentation for [Case insensitive matching](https://trino.io/docs/current/connector/oracle.html#case-insensitive-matching). The field 
`case-insensitive-name-mapping.refresh-period` is not valid, it should be `case-insensitive-name-matching.config-file.refresh-period`.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

