### PR TITLE
Correct memory connector docs

### DIFF
--- a/docs/src/main/sphinx/connector/memory.md
+++ b/docs/src/main/sphinx/connector/memory.md
@@ -101,6 +101,3 @@ in the catalog file.
   or may return partial data.
 - When the coordinator fails/restarts, all metadata about tables is
   lost. The tables remain on the workers, but become inaccessible.
-- This connector does not work properly with multiple
-  coordinators, since each coordinator has different
-  metadata.


### PR DESCRIPTION
## Description

Remove invalid limitation since Trino doesnt support multiple coordinators.

## Additional context and related issues

Replaces https://github.com/trinodb/trino/pull/23968 since we never got CLA.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
