### PR TITLE
Deny duplicate files in Iceberg `add_files` & `add_files_from_table` procedure

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -603,10 +603,6 @@ location, to an existing Iceberg table.
  
 The data files must be the Parquet, ORC, or Avro file format.
 
-:::{warning}
-The procedure does not check if files are already present in the target table.
-:::
-
 The procedure adds the files to the target table, specified after `ALTER TABLE`,
 and loads them from the source table specified with the required parameters
 `schema_name` and `table_name`. The source table must be accessible in the same

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrationUtils.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrationUtils.java
@@ -15,6 +15,7 @@ package io.trino.plugin.iceberg.procedure;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.log.Logger;
 import io.trino.filesystem.FileEntry;
 import io.trino.filesystem.FileIterator;
@@ -42,6 +43,7 @@ import io.trino.spi.connector.SchemaTableName;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.PartitionSpec;
@@ -50,6 +52,7 @@ import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.avro.Avro;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.mapping.MappingUtil;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.types.Types;
@@ -69,6 +72,7 @@ import static io.trino.plugin.base.util.Procedures.checkProcedureArgument;
 import static io.trino.plugin.hive.HiveMetadata.extractHiveStorageFormat;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_COMMIT_ERROR;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isMergeManifestsOnWrite;
+import static io.trino.spi.StandardErrorCode.ALREADY_EXISTS;
 import static io.trino.spi.StandardErrorCode.CONSTRAINT_VIOLATION;
 import static io.trino.spi.StandardErrorCode.NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -272,6 +276,18 @@ public final class MigrationUtils
                 .map(Types.NestedField::fieldId)
                 .collect(toImmutableSet());
 
+        ImmutableSet.Builder<String> existingFilesBuilder = ImmutableSet.builder();
+        try (CloseableIterable<FileScanTask> iterator = table.newScan().planFiles()) {
+            for (FileScanTask fileScanTask : iterator) {
+                DataFile dataFile = fileScanTask.file();
+                existingFilesBuilder.add(dataFile.path().toString());
+            }
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        Set<String> existingFiles = existingFilesBuilder.build();
+
         if (!requiredFields.isEmpty()) {
             for (DataFile dataFile : dataFiles) {
                 Map<Integer, Long> nullValueCounts = firstNonNull(dataFile.nullValueCounts(), Map.of());
@@ -295,7 +311,12 @@ public final class MigrationUtils
             }
             log.debug("Append data %d data files", dataFiles.size());
             AppendFiles appendFiles = isMergeManifestsOnWrite(session) ? transaction.newAppend() : transaction.newFastAppend();
-            dataFiles.forEach(appendFiles::appendFile);
+            for (DataFile dataFile : dataFiles) {
+                if (existingFiles.contains(dataFile.path().toString())) {
+                    throw new TrinoException(ALREADY_EXISTS, "File already exists: " + dataFile.path());
+                }
+                appendFiles.appendFile(dataFile);
+            }
             appendFiles.commit();
             transaction.commitTransaction();
             log.debug("Successfully added files to %s table", table.name());

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/procedure/TestIcebergAddFilesProcedure.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/procedure/TestIcebergAddFilesProcedure.java
@@ -574,7 +574,30 @@ final class TestIcebergAddFilesProcedure
     @Test
     void testAddDuplicatedFiles()
     {
-        // TODO Consider adding 'check_duplicate_files' option like Spark
+        String hiveTableName = "test_add_files_" + randomNameSuffix();
+        String icebergTableName = "test_add_files_" + randomNameSuffix();
+
+        assertUpdate("CREATE TABLE hive.tpch." + hiveTableName + " AS SELECT 1 x", 1);
+        assertUpdate("CREATE TABLE iceberg.tpch." + icebergTableName + " AS SELECT 2 x", 1);
+        String path = (String) computeScalar("SELECT \"$path\" FROM hive.tpch." + hiveTableName);
+
+        assertUpdate("ALTER TABLE " + icebergTableName + " EXECUTE add_files('" + path + "', 'ORC')");
+
+        assertQueryFails(
+                "ALTER TABLE " + icebergTableName + " EXECUTE add_files('" + path + "', 'ORC')",
+                ".*File already exists.*");
+        assertQueryFails(
+                "ALTER TABLE " + icebergTableName + " EXECUTE add_files(location=>'" + path + "', format=>'ORC')",
+                ".*File already exists.*");
+        assertQuery("SELECT * FROM iceberg.tpch." + icebergTableName, "VALUES 1, 2");
+
+        assertUpdate("DROP TABLE hive.tpch." + hiveTableName);
+        assertUpdate("DROP TABLE iceberg.tpch." + icebergTableName);
+    }
+
+    @Test
+    void testAddDuplicatedFilesFromTable()
+    {
         String hiveTableName = "test_add_files_" + randomNameSuffix();
         String icebergTableName = "test_add_files_" + randomNameSuffix();
 
@@ -582,9 +605,14 @@ final class TestIcebergAddFilesProcedure
         assertUpdate("CREATE TABLE iceberg.tpch." + icebergTableName + " AS SELECT 2 x", 1);
 
         assertUpdate("ALTER TABLE " + icebergTableName + " EXECUTE add_files_from_table('tpch', '" + hiveTableName + "')");
-        assertUpdate("ALTER TABLE " + icebergTableName + " EXECUTE add_files_from_table('tpch', '" + hiveTableName + "')");
 
-        assertQuery("SELECT * FROM iceberg.tpch." + icebergTableName, "VALUES 1, 2, 1");
+        assertQueryFails(
+                "ALTER TABLE " + icebergTableName + " EXECUTE add_files_from_table('tpch', '" + hiveTableName + "')",
+                ".*File already exists.*");
+        assertQueryFails(
+                "ALTER TABLE " + icebergTableName + " EXECUTE add_files_from_table(schema_name=>'tpch', table_name=>'" + hiveTableName + "')",
+                ".*File already exists.*");
+        assertQuery("SELECT * FROM iceberg.tpch." + icebergTableName, "VALUES 1, 2");
 
         assertUpdate("DROP TABLE hive.tpch." + hiveTableName);
         assertUpdate("DROP TABLE iceberg.tpch." + icebergTableName);


### PR DESCRIPTION
## Description

Fixes #23678

## Release notes

```markdown
## Iceberg
* Disallow adding duplicate files in `add_files` and `add_files_from_table` procedure. ({issue}`24188`)
```
