### PR TITLE
Inform user what are extractable date/time fields

### DIFF
--- a/core/trino-main/src/test/java/io/trino/operator/scalar/time/TestExtract.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/time/TestExtract.java
@@ -147,7 +147,7 @@ public class TestExtract
     {
         assertTrinoExceptionThrownBy(assertions.expression("EXTRACT(MILLISECOND FROM TIME '12:34:56')")::evaluate)
                 .hasErrorCode(SYNTAX_ERROR)
-                .hasMessage("line 1:12: Invalid EXTRACT field: MILLISECOND");
+                .hasMessageStartingWith("line 1:12: Invalid EXTRACT field MILLISECOND, valid fields are: ");
 
         assertThat(assertions.expression("millisecond(TIME '12:34:56')")).matches("BIGINT '0'");
         assertThat(assertions.expression("millisecond(TIME '12:34:56.1')")).matches("BIGINT '100'");

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestExtract.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestExtract.java
@@ -336,7 +336,7 @@ public class TestExtract
     {
         assertTrinoExceptionThrownBy(assertions.expression("EXTRACT(MILLISECOND FROM TIMESTAMP '2020-05-10 12:34:56')")::evaluate)
                 .hasErrorCode(SYNTAX_ERROR)
-                .hasMessage("line 1:12: Invalid EXTRACT field: MILLISECOND");
+                .hasMessageStartingWith("line 1:12: Invalid EXTRACT field MILLISECOND, valid fields are: ");
 
         assertThat(assertions.expression("millisecond(TIMESTAMP '2020-05-10 12:34:56')")).matches("BIGINT '0'");
         assertThat(assertions.expression("millisecond(TIMESTAMP '2020-05-10 12:34:56.1')")).matches("BIGINT '100'");
@@ -490,7 +490,7 @@ public class TestExtract
     {
         assertTrinoExceptionThrownBy(assertions.expression("EXTRACT(WEEK_OF_YEAR FROM TIMESTAMP '2020-05-10 12:34:56')")::evaluate)
                 .hasErrorCode(SYNTAX_ERROR)
-                .hasMessage("line 1:12: Invalid EXTRACT field: WEEK_OF_YEAR");
+                .hasMessageStartingWith("line 1:12: Invalid EXTRACT field WEEK_OF_YEAR, valid fields are: ");
 
         assertThat(assertions.expression("week_of_year(TIMESTAMP '2020-05-10 12:34:56')")).matches("BIGINT '19'");
         assertThat(assertions.expression("week_of_year(TIMESTAMP '2020-05-10 12:34:56.1')")).matches("BIGINT '19'");

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamptz/TestExtract.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamptz/TestExtract.java
@@ -306,7 +306,7 @@ public class TestExtract
     {
         assertTrinoExceptionThrownBy(assertions.expression("EXTRACT(MILLISECOND FROM TIMESTAMP '2020-05-10 12:34:56 Asia/Kathmandu')")::evaluate)
                 .hasErrorCode(SYNTAX_ERROR)
-                .hasMessage("line 1:12: Invalid EXTRACT field: MILLISECOND");
+                .hasMessageStartingWith("line 1:12: Invalid EXTRACT field MILLISECOND, valid fields are: ");
 
         assertThat(assertions.expression("millisecond(TIMESTAMP '2020-05-10 12:34:56 Asia/Kathmandu')")).matches("BIGINT '0'");
         assertThat(assertions.expression("millisecond(TIMESTAMP '2020-05-10 12:34:56.1 Asia/Kathmandu')")).matches("BIGINT '100'");
@@ -611,7 +611,7 @@ public class TestExtract
     {
         assertTrinoExceptionThrownBy(assertions.expression("EXTRACT(WEEK_OF_YEAR FROM TIMESTAMP '2020-05-10 12:34:56 Asia/Kathmandu')")::evaluate)
                 .hasErrorCode(SYNTAX_ERROR)
-                .hasMessage("line 1:12: Invalid EXTRACT field: WEEK_OF_YEAR");
+                .hasMessageStartingWith("line 1:12: Invalid EXTRACT field WEEK_OF_YEAR, valid fields are: ");
 
         assertThat(assertions.expression("week_of_year(TIMESTAMP '2020-05-10 12:34:56 Asia/Kathmandu')")).matches("BIGINT '19'");
         assertThat(assertions.expression("week_of_year(TIMESTAMP '2020-05-10 12:34:56.1 Asia/Kathmandu')")).matches("BIGINT '19'");

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timetz/TestExtract.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timetz/TestExtract.java
@@ -148,7 +148,7 @@ public class TestExtract
     {
         assertTrinoExceptionThrownBy(assertions.expression("EXTRACT(MILLISECOND FROM TIME '12:34:56+08:35')")::evaluate)
                 .hasErrorCode(SYNTAX_ERROR)
-                .hasMessage("line 1:12: Invalid EXTRACT field: MILLISECOND");
+                .hasMessageStartingWith("line 1:12: Invalid EXTRACT field MILLISECOND, valid fields are: ");
 
         assertThat(assertions.expression("millisecond(TIME '12:34:56+08:35')")).matches("BIGINT '0'");
         assertThat(assertions.expression("millisecond(TIME '12:34:56.1+08:35')")).matches("BIGINT '100'");

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -317,6 +317,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -364,6 +365,7 @@ import static io.trino.sql.tree.TableFunctionDescriptorArgument.descriptorArgume
 import static io.trino.sql.tree.TableFunctionDescriptorArgument.nullDescriptorArgument;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
 class AstBuilder
@@ -2426,7 +2428,13 @@ class AstBuilder
             field = Extract.Field.valueOf(fieldString.toUpperCase(ENGLISH));
         }
         catch (IllegalArgumentException e) {
-            throw parseError("Invalid EXTRACT field: " + fieldString, context);
+            throw parseError(
+                    "Invalid EXTRACT field %s, valid fields are: %s".formatted(
+                            fieldString,
+                            Stream.of(Extract.Field.values())
+                                    .map(Enum::name)
+                                    .collect(joining(", "))),
+                    context);
         }
         return new Extract(getLocation(context), (Expression) visit(context.valueExpression()), field);
     }


### PR DESCRIPTION
Make the error message for invalid `extract` more helpful.


relates to https://github.com/trinodb/trino/issues/24175