### PR TITLE
Move DirectTrinoClient to a non-testing package

### DIFF
--- a/core/trino-main/src/main/java/io/trino/client/direct/DirectTrinoClient.java
+++ b/core/trino-main/src/main/java/io/trino/client/direct/DirectTrinoClient.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.testing;
+package io.trino.client.direct;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;

--- a/core/trino-main/src/main/java/io/trino/testing/TestingDirectTrinoClient.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingDirectTrinoClient.java
@@ -15,6 +15,7 @@ package io.trino.testing;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.Session;
+import io.trino.client.direct.DirectTrinoClient;
 import io.trino.dispatcher.DispatchManager;
 import io.trino.dispatcher.DispatchQuery;
 import io.trino.execution.QueryInfo;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

This originted in testing code, but it is being repurposed as a general-purpose utility, so it should not be in a `testing` package.

The tests for this class are in the `testing/trino-tests` module in class `io.trino.tests.TestLocalQueries`, so they are not moved along with it.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
  * It's *technically* user-visible, but I don't think we're advertising this feature

( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
