### PR TITLE
trino/hive: Honor ignore-absent-partitions option

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
@@ -671,7 +671,7 @@ public class BackgroundHiveSplitLoader
     private static void checkPartitionLocationExists(TrinoFileSystem fileSystem, Location location)
     {
         try {
-            if (!fileSystem.directoryExists(location).orElse(true)) {
+            if (!fileSystem.directoryExists(location).orElse(!ignoreAbsentPartitions)) {
                 throw new TrinoException(HIVE_FILE_NOT_FOUND, "Partition location does not exist: " + location);
             }
         }


### PR DESCRIPTION
## Description
Per documentation, Hive plugin for Trino should Honor property "hive.ignore-absent-partitions=true"
At the moment, it throws error 
```
TrinoExternalError(type=EXTERNAL, name=HIVE_FILE_NOT_FOUND, message="Partition location does not exist: gs://<bucket name here>/.../.../.../.../")
``` 
## Additional context and related issues
Code is changed to skip exception only if this property is set;
Otherwise, the old behavior is preserved

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

* This resolves issue #23893
