### PR TITLE
Add system.bucket function to Iceberg

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/CatalogServiceProviderModule.java
+++ b/core/trino-main/src/main/java/io/trino/connector/CatalogServiceProviderModule.java
@@ -21,6 +21,7 @@ import com.google.inject.Singleton;
 import io.trino.SystemSessionPropertiesProvider;
 import io.trino.metadata.AnalyzePropertyManager;
 import io.trino.metadata.CatalogProcedures;
+import io.trino.metadata.CatalogScalarFunctions;
 import io.trino.metadata.CatalogTableFunctions;
 import io.trino.metadata.CatalogTableProcedures;
 import io.trino.metadata.ColumnPropertyManager;
@@ -98,6 +99,13 @@ public class CatalogServiceProviderModule
     public static CatalogServiceProvider<CatalogTableProcedures> createTableProceduresProvider(ConnectorServicesProvider connectorServicesProvider)
     {
         return new ConnectorCatalogServiceProvider<>("table procedures", connectorServicesProvider, ConnectorServices::getTableProcedures);
+    }
+
+    @Provides
+    @Singleton
+    public static CatalogServiceProvider<CatalogScalarFunctions> createScalarFunctionProvider(ConnectorServicesProvider connectorServicesProvider)
+    {
+        return new ConnectorCatalogServiceProvider<>("scalar functions", connectorServicesProvider, ConnectorServices::getScalarFunctions);
     }
 
     @Provides

--- a/core/trino-main/src/main/java/io/trino/metadata/CatalogScalarFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/CatalogScalarFunctions.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.metadata;
+
+import com.google.common.collect.Maps;
+import com.google.errorprone.annotations.ThreadSafe;
+import io.trino.spi.function.SchemaFunctionName;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+
+@ThreadSafe
+public class CatalogScalarFunctions
+{
+    // schema and function name in lowercase
+    private final Map<SchemaFunctionName, SqlScalarFunction> functions;
+
+    public CatalogScalarFunctions(Collection<SqlScalarFunction> functions)
+    {
+        requireNonNull(functions, "functions is null");
+        this.functions = Maps.uniqueIndex(functions, function -> lowerCaseSchemaFunctionName(new SchemaFunctionName(function.getSchemaName().orElseThrow(), function.getFunctionMetadata().getCanonicalName())));
+    }
+
+    public Map<SchemaFunctionName, SqlScalarFunction> listScalarFunctions()
+    {
+        return functions;
+    }
+
+    public Optional<SqlScalarFunction> getScalarFunction(SchemaFunctionName schemaFunctionName)
+    {
+        return Optional.ofNullable(functions.get(lowerCaseSchemaFunctionName(schemaFunctionName)));
+    }
+
+    private static SchemaFunctionName lowerCaseSchemaFunctionName(SchemaFunctionName name)
+    {
+        return new SchemaFunctionName(
+                name.getSchemaName().toLowerCase(ENGLISH),
+                name.getFunctionName().toLowerCase(ENGLISH));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionManager.java
@@ -109,7 +109,7 @@ public class FunctionManager
         }
         else {
             FunctionDependencies functionDependencies = getFunctionDependencies(resolvedFunction);
-            Optional<SqlScalarFunction> function = scalarFunctionRegistry.resolve(resolvedFunction.catalogHandle(), resolvedFunction.name().getSchemaFunctionName());
+            Optional<SqlScalarFunction> function = scalarFunctionRegistry.resolve(resolvedFunction);
             if (function.isPresent()) {
                 return function.get().specialize(resolvedFunction.signature(), functionDependencies).getScalarFunctionImplementation(invocationConvention);
             }

--- a/core/trino-main/src/main/java/io/trino/metadata/ScalarFunctionRegistry.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/ScalarFunctionRegistry.java
@@ -18,7 +18,6 @@ import com.google.inject.Inject;
 import io.trino.connector.CatalogServiceProvider;
 import io.trino.spi.connector.CatalogHandle;
 import io.trino.spi.function.FunctionMetadata;
-import io.trino.spi.function.SchemaFunctionName;
 
 import java.util.List;
 import java.util.Optional;
@@ -56,10 +55,10 @@ public class ScalarFunctionRegistry
      * Resolve table function with given qualified name.
      * Table functions are resolved case-insensitive for consistency with existing scalar function resolution.
      */
-    public Optional<SqlScalarFunction> resolve(CatalogHandle catalogHandle, SchemaFunctionName schemaFunctionName)
+    public Optional<SqlScalarFunction> resolve(ResolvedFunction resolvedFunction)
     {
-        return tableFunctionsProvider.getService(catalogHandle)
-                .getScalarFunction(schemaFunctionName);
+        return tableFunctionsProvider.getService(resolvedFunction.catalogHandle())
+                .getScalarFunction(resolvedFunction.name().getSchemaFunctionName(), resolvedFunction.functionId());
     }
 
     private static FunctionMetadata toFunctionMetadata(SqlScalarFunction tableFunction)

--- a/core/trino-main/src/main/java/io/trino/metadata/ScalarFunctionRegistry.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/ScalarFunctionRegistry.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.metadata;
+
+import com.google.errorprone.annotations.ThreadSafe;
+import com.google.inject.Inject;
+import io.trino.connector.CatalogServiceProvider;
+import io.trino.spi.connector.CatalogHandle;
+import io.trino.spi.function.FunctionMetadata;
+import io.trino.spi.function.SchemaFunctionName;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+@ThreadSafe
+public class ScalarFunctionRegistry
+{
+    private final CatalogServiceProvider<CatalogScalarFunctions> tableFunctionsProvider;
+
+    @Inject
+    public ScalarFunctionRegistry(CatalogServiceProvider<CatalogScalarFunctions> tableFunctionsProvider)
+    {
+        this.tableFunctionsProvider = requireNonNull(tableFunctionsProvider, "tableFunctionsProvider is null");
+    }
+
+    public List<FunctionMetadata> listFunctions(CatalogHandle catalogHandle)
+    {
+        return tableFunctionsProvider.getService(catalogHandle).listScalarFunctions().values().stream()
+                .map(ScalarFunctionRegistry::toFunctionMetadata)
+                .collect(toImmutableList());
+    }
+
+    public List<FunctionMetadata> listFunctions(CatalogHandle catalogHandle, String schemaName)
+    {
+        return tableFunctionsProvider.getService(catalogHandle).listScalarFunctions().values().stream()
+                .filter(function -> function.getSchemaName().map(schema -> schema.equals(schemaName)).orElse(false))
+                .map(ScalarFunctionRegistry::toFunctionMetadata)
+                .collect(toImmutableList());
+    }
+
+    /**
+     * Resolve table function with given qualified name.
+     * Table functions are resolved case-insensitive for consistency with existing scalar function resolution.
+     */
+    public Optional<SqlScalarFunction> resolve(CatalogHandle catalogHandle, SchemaFunctionName schemaFunctionName)
+    {
+        return tableFunctionsProvider.getService(catalogHandle)
+                .getScalarFunction(schemaFunctionName);
+    }
+
+    private static FunctionMetadata toFunctionMetadata(SqlScalarFunction tableFunction)
+    {
+        return tableFunction.getFunctionMetadata();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/metadata/SqlScalarFunction.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SqlScalarFunction.java
@@ -18,14 +18,28 @@ import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.FunctionDependencies;
 import io.trino.spi.function.FunctionMetadata;
 
+import java.util.Optional;
+
 public abstract class SqlScalarFunction
         implements SqlFunction
 {
+    private final Optional<String> schemaName;
     private final FunctionMetadata functionMetadata;
 
     protected SqlScalarFunction(FunctionMetadata functionMetadata)
     {
+        this(Optional.empty(), functionMetadata);
+    }
+
+    protected SqlScalarFunction(Optional<String> schemaName, FunctionMetadata functionMetadata)
+    {
+        this.schemaName = schemaName;
         this.functionMetadata = functionMetadata;
+    }
+
+    public Optional<String> getSchemaName()
+    {
+        return schemaName;
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ParametricScalar.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ParametricScalar.java
@@ -51,7 +51,7 @@ public class ParametricScalar
             ParametricImplementationsGroup<ParametricScalarImplementation> implementations,
             boolean deprecated)
     {
-        super(createFunctionMetadata(signature, details, deprecated, implementations.getFunctionNullability()));
+        super(details.getSchemaName(), createFunctionMetadata(signature, details, deprecated, implementations.getFunctionNullability()));
         this.implementations = requireNonNull(implementations);
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ScalarHeader.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ScalarHeader.java
@@ -34,6 +34,7 @@ import static java.util.Objects.requireNonNull;
 
 public class ScalarHeader
 {
+    private final Optional<String> schemaName;
     private final String name;
     private final Optional<OperatorType> operatorType;
     private final Set<String> aliases;
@@ -41,8 +42,9 @@ public class ScalarHeader
     private final boolean hidden;
     private final boolean deterministic;
 
-    public ScalarHeader(String name, Set<String> aliases, Optional<String> description, boolean hidden, boolean deterministic)
+    public ScalarHeader(Optional<String> schemaName, String name, Set<String> aliases, Optional<String> description, boolean hidden, boolean deterministic)
     {
+        this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.name = requireNonNull(name, "name is null");
         checkArgument(!name.isEmpty());
         this.operatorType = Optional.empty();
@@ -55,6 +57,7 @@ public class ScalarHeader
 
     public ScalarHeader(OperatorType operatorType, Optional<String> description)
     {
+        this.schemaName = Optional.empty();
         this.name = mangleOperatorName(operatorType);
         this.operatorType = Optional.of(operatorType);
         this.description = requireNonNull(description, "description is null");
@@ -72,8 +75,9 @@ public class ScalarHeader
         ImmutableList.Builder<ScalarHeader> builder = ImmutableList.builder();
 
         if (scalarFunction != null) {
+            Optional<String> schemaName = scalarFunction.schema().isEmpty() ? Optional.empty() : Optional.of(scalarFunction.schema());
             String baseName = scalarFunction.value().isEmpty() ? camelToSnake(annotatedName(annotated)) : scalarFunction.value();
-            builder.add(new ScalarHeader(baseName, ImmutableSet.copyOf(scalarFunction.alias()), description, scalarFunction.hidden(), scalarFunction.deterministic()));
+            builder.add(new ScalarHeader(schemaName, baseName, ImmutableSet.copyOf(scalarFunction.alias()), description, scalarFunction.hidden(), scalarFunction.deterministic()));
         }
 
         if (scalarOperator != null) {
@@ -100,6 +104,11 @@ public class ScalarHeader
         }
 
         throw new IllegalArgumentException("Only Classes and Methods are supported as annotated elements.");
+    }
+
+    public Optional<String> getSchemaName()
+    {
+        return schemaName;
     }
 
     public String getName()

--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -79,6 +79,7 @@ import io.trino.metadata.LanguageFunctionManager;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.MetadataManager;
 import io.trino.metadata.ProcedureRegistry;
+import io.trino.metadata.ScalarFunctionRegistry;
 import io.trino.metadata.SystemFunctionBundle;
 import io.trino.metadata.SystemSecurityMetadata;
 import io.trino.metadata.TableFunctionRegistry;
@@ -406,6 +407,7 @@ public class ServerMainModule
         binder.bind(ProcedureRegistry.class).in(Scopes.SINGLETON);
         binder.bind(TableProceduresRegistry.class).in(Scopes.SINGLETON);
         binder.bind(TableFunctionRegistry.class).in(Scopes.SINGLETON);
+        binder.bind(ScalarFunctionRegistry.class).in(Scopes.SINGLETON);
         binder.bind(PlannerContext.class).in(Scopes.SINGLETON);
         binder.bind(LanguageFunctionManager.class).in(Scopes.SINGLETON);
         binder.bind(LanguageFunctionEngineManager.class).in(Scopes.SINGLETON);

--- a/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
+++ b/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
@@ -97,6 +97,7 @@ import io.trino.metadata.MaterializedViewPropertyManager;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.MetadataManager;
 import io.trino.metadata.QualifiedObjectName;
+import io.trino.metadata.ScalarFunctionRegistry;
 import io.trino.metadata.SchemaPropertyManager;
 import io.trino.metadata.SessionPropertyManager;
 import io.trino.metadata.Split;
@@ -234,6 +235,7 @@ import static io.trino.connector.CatalogServiceProviderModule.createMaterialized
 import static io.trino.connector.CatalogServiceProviderModule.createNodePartitioningProvider;
 import static io.trino.connector.CatalogServiceProviderModule.createPageSinkProvider;
 import static io.trino.connector.CatalogServiceProviderModule.createPageSourceProviderFactory;
+import static io.trino.connector.CatalogServiceProviderModule.createScalarFunctionProvider;
 import static io.trino.connector.CatalogServiceProviderModule.createSchemaPropertyManager;
 import static io.trino.connector.CatalogServiceProviderModule.createSplitManagerProvider;
 import static io.trino.connector.CatalogServiceProviderModule.createTableFunctionProvider;
@@ -364,6 +366,7 @@ public class PlanTester
                 groupProvider,
                 blockEncodingSerde,
                 new LanguageFunctionEngineManager());
+        ScalarFunctionRegistry scalarFunctionRegistry = new ScalarFunctionRegistry(createScalarFunctionProvider(catalogManager));
         TableFunctionRegistry tableFunctionRegistry = new TableFunctionRegistry(createTableFunctionProvider(catalogManager));
         Metadata metadata = new MetadataManager(
                 new AllowAllAccessControl(),
@@ -371,6 +374,7 @@ public class PlanTester
                 transactionManager,
                 globalFunctionCatalog,
                 languageFunctionManager,
+                scalarFunctionRegistry,
                 tableFunctionRegistry,
                 typeManager,
                 new NotImplementedQueryManager());
@@ -406,7 +410,7 @@ public class PlanTester
         this.sessionPropertyManager = createSessionPropertyManager(catalogManager, taskManagerConfig, optimizerConfig);
         this.nodePartitioningManager = new NodePartitioningManager(nodeScheduler, typeOperators, createNodePartitioningProvider(catalogManager));
         TableProceduresRegistry tableProceduresRegistry = new TableProceduresRegistry(createTableProceduresProvider(catalogManager));
-        FunctionManager functionManager = new FunctionManager(createFunctionProvider(catalogManager), globalFunctionCatalog, languageFunctionManager);
+        FunctionManager functionManager = new FunctionManager(createFunctionProvider(catalogManager), scalarFunctionRegistry, globalFunctionCatalog, languageFunctionManager);
         this.schemaPropertyManager = createSchemaPropertyManager(catalogManager);
         this.columnPropertyManager = createColumnPropertyManager(catalogManager);
         this.tablePropertyManager = createTablePropertyManager(catalogManager);

--- a/core/trino-main/src/test/java/io/trino/dispatcher/TestLocalDispatchQuery.java
+++ b/core/trino-main/src/test/java/io/trino/dispatcher/TestLocalDispatchQuery.java
@@ -42,12 +42,14 @@ import io.trino.execution.QueryStateMachine;
 import io.trino.execution.StageInfo;
 import io.trino.execution.scheduler.NodeSchedulerConfig;
 import io.trino.execution.warnings.WarningCollector;
+import io.trino.metadata.CatalogScalarFunctions;
 import io.trino.metadata.FunctionManager;
 import io.trino.metadata.GlobalFunctionCatalog;
 import io.trino.metadata.InMemoryNodeManager;
 import io.trino.metadata.InternalNodeManager;
 import io.trino.metadata.LanguageFunctionProvider;
 import io.trino.metadata.Metadata;
+import io.trino.metadata.ScalarFunctionRegistry;
 import io.trino.metadata.SessionPropertyManager;
 import io.trino.operator.OperatorStats;
 import io.trino.plugin.base.security.AllowAllSystemAccessControl;
@@ -136,6 +138,7 @@ public class TestLocalDispatchQuery
                 metadata,
                 new FunctionManager(
                         new ConnectorCatalogServiceProvider<>("function provider", new NoConnectorServicesProvider(), ConnectorServices::getFunctionProvider),
+                        new ScalarFunctionRegistry(_ -> new CatalogScalarFunctions(List.of())),
                         new GlobalFunctionCatalog(
                                 () -> { throw new UnsupportedOperationException(); },
                                 () -> { throw new UnsupportedOperationException(); },

--- a/core/trino-main/src/test/java/io/trino/metadata/TestMetadataManager.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestMetadataManager.java
@@ -100,6 +100,7 @@ public final class TestMetadataManager
                 languageFunctionManager = new LanguageFunctionManager(new SqlParser(), typeManager, _ -> ImmutableSet.of(), blockEncodingSerde, engineManager);
             }
 
+            ScalarFunctionRegistry scalarFunctionRegistry = new ScalarFunctionRegistry(_ -> new CatalogScalarFunctions(ImmutableList.of()));
             TableFunctionRegistry tableFunctionRegistry = new TableFunctionRegistry(_ -> new CatalogTableFunctions(ImmutableList.of()));
 
             return new MetadataManager(
@@ -108,6 +109,7 @@ public final class TestMetadataManager
                     transactionManager,
                     globalFunctionCatalog,
                     languageFunctionManager,
+                    scalarFunctionRegistry,
                     tableFunctionRegistry,
                     typeManager,
                     new NotImplementedQueryManager());

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestingPlannerContext.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestingPlannerContext.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableSet;
 import io.trino.FeaturesConfig;
 import io.trino.connector.CatalogServiceProvider;
 import io.trino.metadata.BlockEncodingManager;
+import io.trino.metadata.CatalogScalarFunctions;
 import io.trino.metadata.FunctionBundle;
 import io.trino.metadata.FunctionManager;
 import io.trino.metadata.GlobalFunctionCatalog;
@@ -26,6 +27,7 @@ import io.trino.metadata.LanguageFunctionEngineManager;
 import io.trino.metadata.LanguageFunctionManager;
 import io.trino.metadata.LanguageFunctionProvider;
 import io.trino.metadata.Metadata;
+import io.trino.metadata.ScalarFunctionRegistry;
 import io.trino.metadata.SystemFunctionBundle;
 import io.trino.metadata.TestMetadataManager;
 import io.trino.metadata.TypeRegistry;
@@ -146,7 +148,8 @@ public final class TestingPlannerContext
                 metadata = builder.build();
             }
 
-            FunctionManager functionManager = new FunctionManager(CatalogServiceProvider.fail(), globalFunctionCatalog, LanguageFunctionProvider.DISABLED);
+            ScalarFunctionRegistry scalarFunctionRegistry = new ScalarFunctionRegistry(_ -> new CatalogScalarFunctions(List.of()));
+            FunctionManager functionManager = new FunctionManager(CatalogServiceProvider.fail(), scalarFunctionRegistry, globalFunctionCatalog, LanguageFunctionProvider.DISABLED);
             globalFunctionCatalog.addFunctions(new InternalFunctionBundle(
                     new JsonExistsFunction(functionManager, metadata, typeManager),
                     new JsonValueFunction(functionManager, metadata, typeManager),

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/Connector.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/Connector.java
@@ -124,6 +124,12 @@ public interface Connector
         return emptySet();
     }
 
+    @Experimental(eta = "2025-07-31")
+    default Set<Class<?>> getFunctions()
+    {
+        return Set.of();
+    }
+
     /**
      * @return the set of procedures provided by this connector
      */

--- a/core/trino-spi/src/main/java/io/trino/spi/function/ScalarFunction.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/ScalarFunction.java
@@ -27,6 +27,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target({METHOD, TYPE})
 public @interface ScalarFunction
 {
+    String schema() default "";
+
     String value() default "";
 
     String[] alias() default {};

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConnector.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConnector.java
@@ -22,6 +22,7 @@ import io.airlift.bootstrap.LifeCycleManager;
 import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
 import io.trino.plugin.hive.HiveTransactionHandle;
+import io.trino.plugin.iceberg.functions.IcebergBucketFunction;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorCapabilities;
@@ -168,6 +169,12 @@ public class IcebergConnector
     public Set<ConnectorTableFunction> getTableFunctions()
     {
         return tableFunctions;
+    }
+
+    @Override
+    public Set<Class<?>> getFunctions()
+    {
+        return ImmutableSet.of(IcebergBucketFunction.class);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -107,6 +107,9 @@ import io.trino.spi.connector.WriterScalingOptions;
 import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.expression.FunctionName;
 import io.trino.spi.expression.Variable;
+import io.trino.spi.function.BoundSignature;
+import io.trino.spi.function.FunctionDependencyDeclaration;
+import io.trino.spi.function.FunctionId;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.NullableValue;
 import io.trino.spi.predicate.TupleDomain;
@@ -2259,6 +2262,12 @@ public class IcebergMetadata
         catch (IOException e) {
             throw new TrinoException(ICEBERG_FILESYSTEM_ERROR, "Failed accessing data for table: " + schemaTableName, e);
         }
+    }
+
+    @Override
+    public FunctionDependencyDeclaration getFunctionDependencies(ConnectorSession session, FunctionId functionId, BoundSignature boundSignature)
+    {
+        return FunctionDependencyDeclaration.NO_DEPENDENCIES;
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/IcebergBucketFunction.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/IcebergBucketFunction.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.functions;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.function.Description;
+import io.trino.spi.function.LiteralParameter;
+import io.trino.spi.function.LiteralParameters;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlNullable;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.type.Int128;
+import io.trino.spi.type.StandardTypes;
+import org.apache.iceberg.transforms.Transforms;
+import org.apache.iceberg.types.Types;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static io.trino.spi.type.Decimals.MAX_SHORT_PRECISION;
+import static io.trino.spi.type.StandardTypes.DATE;
+import static io.trino.spi.type.StandardTypes.INTEGER;
+import static io.trino.spi.type.StandardTypes.VARCHAR;
+
+public final class IcebergBucketFunction
+{
+    private IcebergBucketFunction() {}
+
+    @ScalarFunction(schema = "system", value = "bucket")
+    @Description("The Iceberg bucket transform")
+    @SqlType(INTEGER)
+    @SqlNullable
+    public static Long bucket(@SqlNullable @SqlType(VARCHAR) Slice partitionValue, @SqlType(INTEGER) long numberOfBuckets)
+    {
+        if (partitionValue == null) {
+            return null;
+        }
+        return (long) Transforms.bucket((int) numberOfBuckets)
+                .bind(Types.StringType.get())
+                .apply(partitionValue.toStringUtf8());
+    }
+
+    @ScalarFunction(schema = "system", value = "bucket")
+    @Description("The Iceberg bucket transform")
+    @SqlType(INTEGER)
+    public static long bucket(@SqlType(INTEGER) long partitionValue, @SqlType(INTEGER) long numberOfBuckets)
+    {
+        return Transforms.bucket((int) numberOfBuckets)
+                .bind(Types.IntegerType.get())
+                .apply((int) partitionValue);
+    }
+
+    @ScalarFunction(schema = "system", value = "bucket")
+    @Description("The Iceberg bucket transform")
+    @SqlType(INTEGER)
+    public static long bucket(@SqlNullable @SqlType(StandardTypes.BIGINT) Long partitionValue, @SqlType(INTEGER) long numberOfBuckets)
+    {
+        return Transforms.bucket((int) numberOfBuckets)
+                .bind(Types.LongType.get())
+                .apply(partitionValue);
+    }
+
+    @LiteralParameters({"p", "s"})
+    @ScalarFunction(schema = "system", value = "bucket")
+    @Description("The Iceberg bucket transform")
+    @SqlType(INTEGER)
+    public static long bucket(@LiteralParameter("p") long p, @LiteralParameter("s") long s, @SqlType("decimal(p, s)") Object partitionValue, @SqlType(INTEGER) long numberOfBuckets)
+    {
+        BigInteger unscaledValue;
+        if (p <= MAX_SHORT_PRECISION) {
+            unscaledValue = BigInteger.valueOf((Long) partitionValue);
+        }
+        else {
+            unscaledValue = ((Int128) partitionValue).toBigInteger();
+        }
+        return Transforms.bucket((int) numberOfBuckets)
+                .bind(Types.DecimalType.of((int) p, (int) s))
+                .apply(new BigDecimal(unscaledValue));
+    }
+
+    @LiteralParameters("p")
+    @ScalarFunction(schema = "system", value = "bucket")
+    @Description("The Iceberg bucket transform")
+    @SqlType(INTEGER)
+    public static long bucketTimestamp(@SqlType("timestamp(p) with time zone") long partitionValue, @SqlType(INTEGER) long numberOfBuckets)
+    {
+        return Transforms.bucket((int) numberOfBuckets)
+                .bind(Types.TimestampType.withZone())
+                .apply(partitionValue);
+    }
+
+    @ScalarFunction(schema = "system", value = "bucket")
+    @Description("The Iceberg bucket transform")
+    @SqlType(INTEGER)
+    public static long bucketDate(@SqlType(DATE) long partitionValue, @SqlType(INTEGER) long numberOfBuckets)
+    {
+        // DATE type in Iceberg uses BucketInteger transform which expects Integer value
+        return Transforms.bucket((int) numberOfBuckets)
+                .bind(Types.DateType.get())
+                .apply((int) partitionValue);
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/functions/TestIcebergBucketFunction.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/functions/TestIcebergBucketFunction.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.functions;
+
+import io.trino.metadata.InternalFunctionBundle;
+import io.trino.spi.type.IntegerType;
+import io.trino.sql.query.QueryAssertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static io.trino.spi.StandardErrorCode.FUNCTION_NOT_FOUND;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+final class TestIcebergBucketFunction
+{
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    public void init()
+    {
+        assertions = new QueryAssertions();
+        assertions.addFunctions(InternalFunctionBundle.builder()
+                .scalars(IcebergBucketFunction.class)
+                .build());
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    void testIntegerTypes()
+    {
+        assertThat(assertions.function("bucket", "198765432", "16"))
+                .hasType(IntegerType.INTEGER)
+                .isEqualTo(15);
+
+        assertThat(assertions.function("bucket", "1987654329876", "16"))
+                .hasType(IntegerType.INTEGER)
+                .isEqualTo(15);
+
+        assertThat(assertions.function("bucket", "CAST(null as INTEGER)", "16"))
+                .isNull();
+    }
+
+    @Test
+    void testDecimalType()
+    {
+        assertThat(assertions.function("bucket", "DECIMAL '36.654'", "16"))
+                .hasType(IntegerType.INTEGER)
+                .isEqualTo(1);
+
+        assertThat(assertions.function("bucket", "36.654", "16"))
+                .hasType(IntegerType.INTEGER)
+                .isEqualTo(1);
+
+        assertThat(assertions.function("bucket", "99099.9876", "16"))
+                .hasType(IntegerType.INTEGER)
+                .isEqualTo(15);
+
+        assertThat(assertions.function("bucket", "1110000000000000000000000.0", "16"))
+                .hasType(IntegerType.INTEGER)
+                .isEqualTo(10);
+
+        assertThat(assertions.function("bucket", "CAST(null as DECIMAL(5, 2))", "16"))
+                .isNull();
+
+        assertThat(assertions.function("bucket", "CAST(null as DECIMAL(24, 2))", "16"))
+                .isNull();
+    }
+
+    @Test
+    void testVarcharType()
+    {
+        assertThat(assertions.function("bucket", "'padraig'", "16"))
+                .hasType(IntegerType.INTEGER)
+                .isEqualTo(1);
+
+        assertThat(assertions.function("bucket", "'padraig'", "32"))
+                .hasType(IntegerType.INTEGER)
+                .isEqualTo(17);
+
+        assertThat(assertions.function("bucket", "CAST(null AS VARCHAR)", "16"))
+                .isNull();
+    }
+
+    @Test
+    void testDateType()
+    {
+        assertThat(assertions.function("bucket", "DATE '2024-11-19'", "16"))
+                .hasType(IntegerType.INTEGER)
+                .isEqualTo(11);
+
+        assertThat(assertions.function("bucket", "DATE '2024-01-01'", "16"))
+                .hasType(IntegerType.INTEGER)
+                .isEqualTo(11);
+
+        assertThat(assertions.function("bucket", "DATE '2023-11-01'", "16"))
+                .hasType(IntegerType.INTEGER)
+                .isEqualTo(9);
+
+        assertThat(assertions.function("bucket", "CAST(null as DATE)", "16"))
+                .isNull();
+    }
+
+    @Test
+    void testTimestampType()
+    {
+        assertThat(assertions.function("bucket", "TIMESTAMP '1970-01-30 16:00:00'", "16"))
+                .hasType(IntegerType.INTEGER)
+                .isEqualTo(5);
+
+        assertThat(assertions.function("bucket", "CAST(null as TIMESTAMP)", "16"))
+                .isNull();
+    }
+
+    @Test
+    void testTimestampWithTimeZoneType()
+    {
+        assertThat(assertions.function("bucket", "TIMESTAMP '1988-04-08 14:15:16 +02:09'", "16"))
+                .hasType(IntegerType.INTEGER)
+                .isEqualTo(0);
+
+        assertThat(assertions.function("bucket", "CAST(null as TIMESTAMP WITH TIME ZONE)", "16"))
+                .isNull();
+    }
+
+    @Test
+    void testInvalidArguments()
+    {
+        assertTrinoExceptionThrownBy(() -> assertions.function("bucket", "'abc'")
+                .evaluate())
+                .hasErrorCode(FUNCTION_NOT_FOUND);
+        assertTrinoExceptionThrownBy(() -> assertions.function("bucket", "'abc'", "'abc'", "'abc'")
+                .evaluate())
+                .hasErrorCode(FUNCTION_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
## Description

Add a UDF to expose the iceberg bucket transform via SQL. This can be used to help determine what bucket a value would be placed in. This could be used with the `optimize` procedure to only optimize specific buckets.

Spark has a similar UDF - https://iceberg.apache.org/javadoc/1.5.1/org/apache/iceberg/spark/functions/BucketFunction.html

## Release notes

```markdown
## Iceberg
* Add `system.bucket` function.
```
