### PR TITLE
Clarify Phoenix requirement

### DIFF
--- a/docs/src/main/sphinx/connector/phoenix.md
+++ b/docs/src/main/sphinx/connector/phoenix.md
@@ -21,6 +21,11 @@ To query HBase data through Phoenix, you need:
 - Network access from the Trino coordinator and workers to the ZooKeeper
   servers. The default port is 2181.
 - A compatible version of Phoenix: all 5.x versions starting from 5.2.0 are supported.
+- The Trino [](jvm-config) must allow using the Java security manager:
+  ```text
+  # https://bugs.openjdk.org/browse/JDK-8327134
+  -Djava.security.manager=allow
+  ```
 
 ## Configuration
 

--- a/docs/src/main/sphinx/installation/deployment.md
+++ b/docs/src/main/sphinx/installation/deployment.md
@@ -139,8 +139,6 @@ The following provides a good starting point for creating `etc/jvm.config`:
 -Dfile.encoding=UTF-8
 # Allow loading dynamic agent used by JOL
 -XX:+EnableDynamicAgentLoading
-# https://bugs.openjdk.org/browse/JDK-8327134
--Djava.security.manager=allow
 ```
 
 You must adjust the value for the memory used by Trino, specified with `-Xmx`

--- a/docs/src/main/sphinx/release/release-464.md
+++ b/docs/src/main/sphinx/release/release-464.md
@@ -53,3 +53,7 @@
   ({issue}`23906`)
 * Fix incorrect column constraints when using the `migrate` procedure on tables
   that contain `NULL` values. ({issue}`23928`)
+
+## Phoenix connector
+
+* {{breaking}} Require JVM configuration to allow the Java security manager. ({issue}`24207`)


### PR DESCRIPTION
## Description

For now we only know of the Phoenix connector being affected as a result of it loading Hadoop libraries. We do not add this for the object storage connectors since the old file system stuff with Hadoop dependencies is considered legacy. And we are not aware of other connectors with this problem.

## Additional context and related issues

Follow up to https://github.com/trinodb/trino/pull/24203

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
