### PR TITLE
Add Trino 466 release notes

### DIFF
--- a/docs/src/main/sphinx/release.md
+++ b/docs/src/main/sphinx/release.md
@@ -6,6 +6,7 @@
 ```{toctree}
 :maxdepth: 1
 
+release/release-466
 release/release-465
 release/release-464
 release/release-463

--- a/docs/src/main/sphinx/release/release-466.md
+++ b/docs/src/main/sphinx/release/release-466.md
@@ -1,0 +1,73 @@
+# Release 466 (27 Nov 2024)
+
+## General
+
+* Add support for changing the type of row fields when they are in a columns of
+  type `map`. ({issue}`24248`)
+* Remove the requirement for a Python runtime on Trino cluster nodes. ({issue}`24271`)
+* Improve performance of queries involving `GROUP BY` and joins. ({issue}`23812`)
+* Improve client protocol throughput by introducing the [spooling
+  protocol](protocol-spooling). ({issue}`24214`)
+
+## Security
+
+* Add support for [data access control with Apache
+  Ranger](/security/apache-ranger-access-control), including support for
+  column masking, row filtering, and audit logging. ({issue}`22675`)
+
+## JDBC driver
+
+* Improve throughput by automatically using the [spooling
+  protocol](jdbc-spooling-protocol) when it is configured on the Trino cluster,
+  and add the parameter `encoding` to optionally set the preferred encoding from
+  the JDBC driver. ({issue}`24214`)
+* Improve decompression performance when running the client with Java 22 or
+  newer. ({issue}`24263`)
+* Improve performance `java.sql.DatabaseMetaData.getTables()`. ({issue}`24159`,
+  {issue}`24110`)
+
+## Server RPM
+
+* Remove Python requirement. ({issue}`24271`)
+
+## Docker image
+
+* Remove Python runtime and libraries. ({issue}`24271`)
+
+## CLI
+
+* Improve throughput by automatically use the [spooling
+  protocol](cli-spooling-protocol) when it is configured on the Trino cluster,
+  and add the option `--encoding` to optionally set the preferred encoding from
+  the CLI. ({issue}`24214`)
+* Improve decompression performance when running the CLI with Java 22 or newer. ({issue}`24263`)
+
+## BigQuery connector
+
+* Add support for `LIMIT` pushdown. ({issue}`23937`)
+
+## Iceberg connector
+
+* Add support for the [object store file
+  layout](https://iceberg.apache.org/docs/latest/aws/#object-store-file-layout).
+  ({issue}`8861`)
+* Add support for changing field types inside a map. ({issue}`24248`)
+* Improve performance of queries with selective joins. ({issue}`24277`)
+* Fix failure when reading columns containing nested row types that differ from
+  the schema of the underlying Parquet data. ({issue}`22922`)
+
+## Phoenix connector
+
+* Improve performance for `MERGE` statements. ({issue}`24075`)
+
+## SQL Server connector
+
+* Rename the `sqlserver.experimental.stored-procedure-table-function-enabled`
+  configuration property to `sqlserver.stored-procedure-table-function-enabled`.
+  ({issue}`24239`)
+
+## SPI
+
+* Add `ConnectorSplit` argument to the `SystemTable.cursor()` method. ({issue}`24159`)
+* Add support for partial row updates to the `ConnectorMetadata.beginMerge()`
+  method. ({issue}`24075`)


### PR DESCRIPTION
## Description

Assemble the release notes for the upcoming Trino 466 release.

## Additional context and related issues

See https://github.com/trinodb/trino/pulls?q=is%3Apr+is%3Aclosed+milestone%3A466

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

## Verification for each pull request

Format: PR/issue number, ✅ / ❌ rn ✅ / ❌ docs
✅ rn - release note added and verified, or assessed to be not necessary, set to ❌ rn before completion
✅ docs - need for docs assessed and merged, or assessed to be not necessary, set to ❌ docs before completion

## 21 Nov 2024

* #23812 ✅ rn ✅ docs
* #24211 ✅ rn ✅ docs
* #24193 ✅ rn ✅ docs
* #24214 ✅ rn ✅ docs, #23836
* #24215 ✅ rn ✅ docs
* #20555 ✅ rn ✅ docs
* #24223 ✅ rn ✅ docs

## 22 Nov 2024

* #24226 ✅ rn ✅ docs
* #24110 ❌ rn ✅ docs
* #24231 ✅ rn ✅ docs
* #24159 ❌ rn ✅ docs
* #24233 ✅ rn ✅ docs
* #24075 ✅ rn ✅ docs
* #24232 ✅ rn ✅ docs
* #24221 ✅ rn ✅ docs

## 23 Nov 2024

* #22675 ✅ rn ✅ docs
* #24237 ✅ rn ✅ docs

## 24 Nov 2024

* #24238 ✅ rn ✅ docs

## 25 Nov 2024

* #24239 ✅ rn ✅ docs
* #24245 ✅ rn ✅ docs
* #24246 ✅ rn ✅ docs
* #24191 ✅ rn ✅ docs
* #24252 ✅ rn ✅ docs
* #24254 ✅ rn ✅ docs

## 26 Nov 2024

* #24257 ✅ rn ✅ docs
* #24021 ✅ rn ❌ docs, #24285
* #24260 ✅ rn ✅ docs
* #24267 ✅ rn ✅ docs
* #24212 ✅ rn ✅ docs
* #24248 ❌ rn ❌ docs

## 27 Nov 2024

* #24271 ✅ rn ✅ docs
* #24262 ✅ rn ✅ docs
* #24273 ✅ rn ✅ docs
* #24270 ✅ rn ✅ docs
* #24243 ✅ rn ✅ docs
* #23002 ✅ rn ✅ docs
* #24276 ✅ rn ✅ docs
* #24277 ✅ rn ✅ docs
* #24263 ✅ rn ✅ docs
* #24268 ✅ rn ✅ docs
* #24283 ✅ rn ✅ docs
* #23836 ✅ rn ✅ docs
