### PR TITLE
Set object_store_enabled as false by default in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableProperties.java
@@ -266,7 +266,7 @@ public class IcebergTableProperties
 
     public static boolean getObjectStoreEnabled(Map<String, Object> tableProperties)
     {
-        return (Boolean) tableProperties.get(OBJECT_STORE_ENABLED_PROPERTY);
+        return (boolean) tableProperties.getOrDefault(OBJECT_STORE_ENABLED_PROPERTY, false);
     }
 
     public static Optional<String> getDataLocation(Map<String, Object> tableProperties)


### PR DESCRIPTION
## Description

Fixes #24222

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
