### PR TITLE
Document default value of Iceberg `object_store_enabled` table property

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -878,6 +878,7 @@ connector using a {doc}`WITH </sql/create-table-as>` clause.
     Parquet files. Requires Parquet format. Defaults to `[]`.
 * - `object_store_enabled`
   - Whether Iceberg's [object store file layout](https://iceberg.apache.org/docs/latest/aws/#object-store-file-layout) is enabled. 
+    Defaults to `false`. 
 * - `data_location`
   - Optionally specifies the file system location URI for the table's data files
 * - `extra_properties`


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
