### PR TITLE
Add partial aggregation pushdown support for Vertica

### DIFF
--- a/plugin/trino-vertica/src/main/java/io/trino/plugin/vertica/ImplementAvgBigint.java
+++ b/plugin/trino-vertica/src/main/java/io/trino/plugin/vertica/ImplementAvgBigint.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.vertica;
+
+import io.trino.plugin.jdbc.aggregation.BaseImplementAvgBigint;
+
+public class ImplementAvgBigint
+        extends BaseImplementAvgBigint
+{
+    @Override
+    protected String getRewriteFormatExpression()
+    {
+        return "avg(CAST(%s AS double precision))";
+    }
+}

--- a/plugin/trino-vertica/src/test/java/io/trino/plugin/vertica/TestVerticaTableStatistics.java
+++ b/plugin/trino-vertica/src/test/java/io/trino/plugin/vertica/TestVerticaTableStatistics.java
@@ -279,15 +279,6 @@ public class TestVerticaTableStatistics
 
     @Test
     @Override
-    public void testStatsWithAggregationPushdown()
-    {
-        assertThatThrownBy(super::testStatsWithAggregationPushdown)
-                .hasMessageContaining("Plan does not match");
-        abort("Aggregate pushdown is unsupported in Vertica connector");
-    }
-
-    @Test
-    @Override
     public void testStatsWithTopNPushdown()
     {
         assertThatThrownBy(super::testStatsWithTopNPushdown)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Adding some aggregation pushdowns, except 
- STDDEV and VARIANCE, because in case of situation when function can not be computed (like single value), Vertica returns NaN, but trino returns Null, so to be in line with trino we disable these types of pushdowns for now.
- avg pushdown for decimal values, because, when Vertica cast values to decimal value with some scale, instead of rounding, it just truncate it, but trino rounds values.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
