### PR TITLE
Promote procedure function from experimental in SQL Server

### DIFF
--- a/docs/src/main/sphinx/connector/sqlserver.md
+++ b/docs/src/main/sphinx/connector/sqlserver.md
@@ -393,7 +393,7 @@ FROM
 The `procedure` function allows you to run stored procedures on the underlying
 database directly. It requires syntax native to SQL Server, because the full query
 is pushed down and processed in SQL Server. In order to use this table function set
-`sqlserver.experimental.stored-procedure-table-function-enabled` to `true`.
+`sqlserver.stored-procedure-table-function-enabled` to `true`.
 
 :::{note}
 The `procedure` function does not support running StoredProcedures that return multiple statements,

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerConfig.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerConfig.java
@@ -15,6 +15,7 @@ package io.trino.plugin.sqlserver;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.LegacyConfig;
 
 public class SqlServerConfig
 {
@@ -67,7 +68,8 @@ public class SqlServerConfig
         return storedProcedureTableFunctionEnabled;
     }
 
-    @Config("sqlserver.experimental.stored-procedure-table-function-enabled")
+    @Config("sqlserver.stored-procedure-table-function-enabled")
+    @LegacyConfig("sqlserver.experimental.stored-procedure-table-function-enabled")
     @ConfigDescription("Allows accessing Stored procedure as a table function")
     public SqlServerConfig setStoredProcedureTableFunctionEnabled(boolean storedProcedureTableFunctionEnabled)
     {

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConfig.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConfig.java
@@ -41,7 +41,7 @@ public class TestSqlServerConfig
                 .put("sqlserver.bulk-copy-for-write.enabled", "true")
                 .put("sqlserver.bulk-copy-for-write.lock-destination-table", "true")
                 .put("sqlserver.snapshot-isolation.disabled", "true")
-                .put("sqlserver.experimental.stored-procedure-table-function-enabled", "true")
+                .put("sqlserver.stored-procedure-table-function-enabled", "true")
                 .buildOrThrow();
 
         SqlServerConfig expected = new SqlServerConfig()

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConnectorTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConnectorTest.java
@@ -48,7 +48,7 @@ public class TestSqlServerConnectorTest
     {
         sqlServer = closeAfterClass(new TestingSqlServer());
         return SqlServerQueryRunner.builder(sqlServer)
-                .addConnectorProperties(Map.of("sqlserver.experimental.stored-procedure-table-function-enabled", "true"))
+                .addConnectorProperties(Map.of("sqlserver.stored-procedure-table-function-enabled", "true"))
                 .setInitialTables(REQUIRED_TPCH_TABLES)
                 .build();
     }


### PR DESCRIPTION
## Description

The procedure has been experimental since version 411 https://github.com/trinodb/trino/pull/16696

## Release notes

```markdown
## SQL Server
* Rename `sqlserver.experimental.stored-procedure-table-function-enabled` config property to `sqlserver.stored-procedure-table-function-enabled`. ({issue}`issuenumber`)
```
