### PR TITLE
Minor cleanups on varbinary to varchar coercion

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/VarbinaryToVarcharCoercers.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/VarbinaryToVarcharCoercers.java
@@ -26,7 +26,6 @@ import java.nio.charset.CharsetDecoder;
 import java.util.HexFormat;
 
 import static io.trino.plugin.hive.HiveStorageFormat.ORC;
-import static io.trino.plugin.hive.HiveStorageFormat.PARQUET;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.Varchars.truncateToLength;
 import static java.nio.charset.CodingErrorAction.REPLACE;
@@ -41,9 +40,6 @@ public class VarbinaryToVarcharCoercers
         if (storageFormat == ORC) {
             return new OrcVarbinaryToVarcharCoercer(toType);
         }
-        if (storageFormat == PARQUET) {
-            return new ParquetVarbinaryToVarcharCoercer(toType);
-        }
         return new VarbinaryToVarcharCoercer(toType);
     }
 
@@ -51,31 +47,6 @@ public class VarbinaryToVarcharCoercers
             extends TypeCoercer<VarbinaryType, VarcharType>
     {
         public VarbinaryToVarcharCoercer(VarcharType toType)
-        {
-            super(VARBINARY, toType);
-        }
-
-        @Override
-        protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
-        {
-            try {
-                Slice decodedValue = fromType.getSlice(block, position);
-                if (toType.isUnbounded()) {
-                    toType.writeSlice(blockBuilder, decodedValue);
-                    return;
-                }
-                toType.writeSlice(blockBuilder, truncateToLength(decodedValue, toType.getBoundedLength()));
-            }
-            catch (RuntimeException e) {
-                blockBuilder.appendNull();
-            }
-        }
-    }
-
-    private static class ParquetVarbinaryToVarcharCoercer
-            extends TypeCoercer<VarbinaryType, VarcharType>
-    {
-        public ParquetVarbinaryToVarcharCoercer(VarcharType toType)
         {
             super(VARBINARY, toType);
         }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestVarbinaryToVarcharCoercer.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestVarbinaryToVarcharCoercer.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Test;
 
 import static io.trino.plugin.hive.HiveStorageFormat.ORC;
 import static io.trino.plugin.hive.HiveStorageFormat.PARQUET;
-import static io.trino.plugin.hive.HiveStorageFormat.RCTEXT;
 import static io.trino.plugin.hive.HiveTimestampPrecision.DEFAULT_PRECISION;
 import static io.trino.plugin.hive.coercions.CoercionUtils.createCoercer;
 import static io.trino.plugin.hive.util.HiveTypeTranslator.toHiveType;
@@ -46,35 +45,6 @@ public class TestVarbinaryToVarcharCoercer
     @Test
     public void testVarbinaryToVarcharCoercion()
     {
-        assertVarbinaryToVarcharCoercion(Slices.utf8Slice("abc"), VARBINARY, Slices.utf8Slice("abc"), VARCHAR);
-        assertVarbinaryToVarcharCoercion(Slices.utf8Slice("abc"), VARBINARY, Slices.utf8Slice("ab"), createVarcharType(2));
-        // Invalid UTF-8 encoding
-        assertVarbinaryToVarcharCoercion(Slices.wrappedBuffer(X_CHAR, CONTINUATION_BYTE), VARBINARY, Slices.wrappedBuffer(X_CHAR, CONTINUATION_BYTE), VARCHAR);
-        assertVarbinaryToVarcharCoercion(
-                Slices.wrappedBuffer(X_CHAR, START_4_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE),
-                VARBINARY,
-                Slices.wrappedBuffer(X_CHAR, START_4_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE),
-                VARCHAR);
-        assertVarbinaryToVarcharCoercion(
-                Slices.wrappedBuffer(X_CHAR, START_4_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE, X_CHAR),
-                VARBINARY,
-                Slices.wrappedBuffer(X_CHAR, START_4_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE, X_CHAR),
-                VARCHAR);
-        assertVarbinaryToVarcharCoercion(
-                Slices.wrappedBuffer(X_CHAR, (byte) 0b11101101, (byte) 0xA0, (byte) 0x80),
-                VARBINARY,
-                Slices.wrappedBuffer(X_CHAR, (byte) 0b11101101, (byte) 0xA0, (byte) 0x80),
-                VARCHAR);
-        assertVarbinaryToVarcharCoercion(
-                Slices.wrappedBuffer(X_CHAR, (byte) 0b11101101, (byte) 0xBF, (byte) 0xBF),
-                VARBINARY,
-                Slices.wrappedBuffer(X_CHAR, (byte) 0b11101101, (byte) 0xBF, (byte) 0xBF),
-                VARCHAR);
-    }
-
-    @Test
-    public void testVarbinaryToVarcharCoercionForParquet()
-    {
         assertVarbinaryToVarcharCoercionForParquet(Slices.utf8Slice("abc"), VARBINARY, "abc", VARCHAR);
         assertVarbinaryToVarcharCoercionForParquet(Slices.utf8Slice("abc"), VARBINARY, "ab", createVarcharType(2));
         // Invalid UTF-8 encoding
@@ -96,11 +66,6 @@ public class TestVarbinaryToVarcharCoercer
         assertVarbinaryToVarcharCoercionForOrc(Slices.wrappedBuffer(X_CHAR, START_4_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE, X_CHAR), VARBINARY, "58 f7 bf bf bf 58", VARCHAR);
         assertVarbinaryToVarcharCoercionForOrc(Slices.wrappedBuffer(X_CHAR, (byte) 0b11101101, (byte) 0xA0, (byte) 0x80), VARBINARY, "58 ed a0 80", VARCHAR);
         assertVarbinaryToVarcharCoercionForOrc(Slices.wrappedBuffer(X_CHAR, (byte) 0b11101101, (byte) 0xBF, (byte) 0xBF), VARBINARY, "58 ed bf bf", VARCHAR);
-    }
-
-    private static void assertVarbinaryToVarcharCoercion(Slice actualValue, Type fromType, Slice expectedValue, Type toType)
-    {
-        assertVarbinaryToVarcharCoercion(actualValue, fromType, expectedValue, toType, RCTEXT);
     }
 
     private static void assertVarbinaryToVarcharCoercionForOrc(Slice actualValue, Type fromType, String expectedValue, Type toType)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/BaseTestHiveCoercion.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/BaseTestHiveCoercion.java
@@ -214,14 +214,10 @@ public abstract class BaseTestHiveCoercion
 
         // Additional assertions for VARBINARY coercion
         if (prestoReadColumns.contains("binary_to_string")) {
-            List<Object> hexRepresentedValue = ImmutableList.of("58F7BFBFBF", "58F7BFBFBF58");
+            List<Object> hexRepresentedValue = ImmutableList.of("58EFBFBDEFBFBDEFBFBDEFBFBD", "58EFBFBDEFBFBDEFBFBDEFBFBD58");
 
             if (tableName.toLowerCase(ENGLISH).contains("orc")) {
                 hexRepresentedValue = ImmutableList.of("3538206637206266206266206266", "3538206637206266206266206266203538");
-            }
-
-            if (tableName.toLowerCase(ENGLISH).contains("parquet")) {
-                hexRepresentedValue = ImmutableList.of("58EFBFBDEFBFBDEFBFBDEFBFBD", "58EFBFBDEFBFBDEFBFBDEFBFBD58");
             }
 
             assertQueryResults(

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnUnpartitionedTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnUnpartitionedTable.java
@@ -300,6 +300,8 @@ public class TestHiveCoercionOnUnpartitionedTable
                 .put(columnContext("parquet", "timestamp_map_to_map"), "Unsupported Trino column type (varchar) for Parquet column ([timestamp_map_to_map, key_value, value, timestamp2string] optional int96 timestamp2string)")
                 .put(columnContext("parquet", "string_to_timestamp"), "Unsupported Trino column type (timestamp(3)) for Parquet column ([string_to_timestamp] optional binary string_to_timestamp (STRING))")
                 .put(columnContext("parquet", "timestamp_to_date"), "Unsupported Trino column type (date) for Parquet column ([timestamp_to_date] optional int96 timestamp_to_date))")
+                .put(columnContext("parquet", "binary_to_string"), "Varbinary to Varchar coercion doesn't match with Hive's implementation") // Error message is not matched, this is added for our understanding
+                .put(columnContext("parquet", "binary_to_smaller_varchar"), "Varbinary to Varchar coercion doesn't match with Hive's implementation") // Error message is not matched, this is added for our understanding
                 .buildOrThrow();
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Minor cleanups like removing assertion for un-partitioned parquet tables as we don't support in the reading them like Hive does and unifying the coercion code for non-orc tables. 



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
