### PR TITLE
Add small delay for dynamic filters in iceberg scans

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -125,7 +125,7 @@ implementation is used:
 * - `iceberg.dynamic-filtering.wait-timeout`
   - Maximum duration to wait for completion of dynamic filters during split
     generation.
-  - `0s`
+  - `1s`
 * - `iceberg.delete-schema-locations-fallback`
   - Whether schema locations are deleted when Trino can't determine whether
     they contain external files.

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -64,7 +64,7 @@ public class IcebergConfig
     private int maxPartitionsPerWriter = 100;
     private boolean uniqueTableLocation = true;
     private CatalogType catalogType = HIVE_METASTORE;
-    private Duration dynamicFilteringWaitTimeout = new Duration(0, SECONDS);
+    private Duration dynamicFilteringWaitTimeout = new Duration(1, SECONDS);
     private boolean tableStatisticsEnabled = true;
     private boolean extendedStatisticsEnabled = true;
     private boolean collectExtendedStatisticsOnWrite = true;

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
@@ -37,7 +37,7 @@ import static io.trino.plugin.iceberg.IcebergFileFormat.ORC;
 import static io.trino.plugin.iceberg.IcebergFileFormat.PARQUET;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.HOURS;
-import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class TestIcebergConfig
 {
@@ -51,7 +51,7 @@ public class TestIcebergConfig
                 .setMaxPartitionsPerWriter(100)
                 .setUniqueTableLocation(true)
                 .setCatalogType(HIVE_METASTORE)
-                .setDynamicFilteringWaitTimeout(new Duration(0, MINUTES))
+                .setDynamicFilteringWaitTimeout(new Duration(1, SECONDS))
                 .setTableStatisticsEnabled(true)
                 .setExtendedStatisticsEnabled(true)
                 .setCollectExtendedStatisticsOnWrite(true)


### PR DESCRIPTION
## Description
Waiting a short time for dynamic filters to arrive can be highly beneficial for some queries with selective joins


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
https://github.com/trinodb/trino/pull/23945 caused regressions on some TPCDS queries due to splits generation getting faster and not allowing enough time for dynamic filters to arrive.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Improve performance of queries with selective joins. ({issue}`24277`)
```
