### PR TITLE
Use Ubi 9 micro image for docker

### DIFF
--- a/core/docker/Dockerfile
+++ b/core/docker/Dockerfile
@@ -27,19 +27,34 @@ RUN \
     mkdir -p "${JAVA_HOME}" && \
     curl -#LfS "${JDK_DOWNLOAD_LINK}" | tar -zx --strip 1 -C "${JAVA_HOME}"
 
+FROM registry.access.redhat.com/ubi9/ubi:latest AS packages
+
+RUN \
+    set -xeuo pipefail && \
+    mkdir -p /tmp/overlay/usr/libexec/ && \
+    touch /tmp/overlay/usr/libexec/grepconf.sh && \
+    chmod +x /tmp/overlay/usr/libexec/grepconf.sh && \
+    yum update -y && \
+    yum install --installroot /tmp/overlay --setopt install_weak_deps=false --nodocs -y \
+      less \
+      curl-minimal grep `# required by health-check` \
+      zlib `#required by java` \
+      shadow-utils `# required by useradd` \
+      tar `# required to support kubectl cp` && \
+      rm -rf /tmp/overlay/var/cache/*
+
 # Use ubi9 minimal as it's more secure
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
 ARG JDK_VERSION
 ARG ARCH
 ENV JAVA_HOME="/usr/lib/jvm/${JDK_VERSION}"
 ENV PATH=$PATH:$JAVA_HOME/bin
 ENV CATALOG_MANAGEMENT=static
 COPY --from=jdk-download $JAVA_HOME $JAVA_HOME
+COPY --from=packages /tmp/overlay /
 
 RUN \
     set -xeu && \
-    microdnf update -y && \
-    microdnf install -y tar less shadow-utils && \
     groupadd trino --gid 1000 && \
     useradd trino --uid 1000 --gid 1000 --create-home && \
     mkdir -p /usr/lib/trino /data/trino && \


### PR DESCRIPTION
This is the most secure and the smallest base image we can use.

Before:

```
✔ Cataloged contents                                                                                                      651b47fea90956f18d4af75da3d1c94e57ec838e417d6ba9ed2948674efe3f14
  ├── ✔ Packages                        [1,071 packages]
  ├── ✔ File digests                    [3,288 files]
  ├── ✔ File metadata                   [3,288 locations]
  └── ✔ Executables                     [336 executables]
✔ Scanned for vulnerabilities     [37 vulnerability matches]
  ├── by severity: 0 critical, 2 high, 8 medium, 27 low, 0 negligible
  └── by status:   5 fixed, 32 not-fixed, 0 ignored
NAME                    INSTALLED            FIXED-IN     TYPE          VULNERABILITY        SEVERITY
bzip2-libs              1.0.8-8.el9                       rpm           CVE-2019-12900       Low
commons-configuration2  2.8.0                2.10.1       java-archive  GHSA-xjp4-hw94-mvp5  Medium
commons-configuration2  2.8.0                2.10.1       java-archive  GHSA-9w38-p64v-xpmv  Medium
curl-minimal            7.76.1-31.el9                     rpm           CVE-2024-9681        Low
curl-minimal            7.76.1-31.el9                     rpm           CVE-2024-7264        Low
gawk                    5.1.0-6.el9          (won't fix)  rpm           CVE-2023-4156        Low
glib2                   2.68.4-14.el9_4.1    (won't fix)  rpm           CVE-2024-52533       Medium
glib2                   2.68.4-14.el9_4.1                 rpm           CVE-2023-32636       Low
gnupg2                  2.3.3-4.el9          (won't fix)  rpm           CVE-2022-3219        Low
libarchive              3.5.3-4.el9          (won't fix)  rpm           CVE-2023-30571       Medium
libatomic               11.5.0-2.el9         (won't fix)  rpm           CVE-2022-27943       Low
libcurl-minimal         7.76.1-31.el9                     rpm           CVE-2024-9681        Low
libcurl-minimal         7.76.1-31.el9                     rpm           CVE-2024-7264        Low
libgcc                  11.5.0-2.el9         (won't fix)  rpm           CVE-2022-27943       Low
libstdc++               11.5.0-2.el9         (won't fix)  rpm           CVE-2022-27943       Low
libxml2                 2.9.13-6.el9_4                    rpm           CVE-2024-34459       Low
libxml2                 2.9.13-6.el9_4       (won't fix)  rpm           CVE-2023-45322       Low
libyaml                 0.2.5-7.el9          (won't fix)  rpm           CVE-2024-35325       Medium
libzstd                 1.5.1-2.el9          (won't fix)  rpm           CVE-2022-4899        Low
ncurses-base            6.2-10.20210508.el9               rpm           CVE-2023-50495       Low
ncurses-base            6.2-10.20210508.el9               rpm           CVE-2023-45918       Low
ncurses-base            6.2-10.20210508.el9  (won't fix)  rpm           CVE-2022-29458       Low
ncurses-libs            6.2-10.20210508.el9               rpm           CVE-2023-50495       Low
ncurses-libs            6.2-10.20210508.el9               rpm           CVE-2023-45918       Low
ncurses-libs            6.2-10.20210508.el9  (won't fix)  rpm           CVE-2022-29458       Low
netty-common            4.1.110.Final        4.1.115      java-archive  GHSA-xq3w-v528-46rv  High
okio                    1.17.5               1.17.6       java-archive  GHSA-w33c-445m-f8w7  Medium
openldap                2.6.6-3.el9                       rpm           CVE-2023-2953        Low
openssl-libs            1:3.2.2-6.el9_5      (won't fix)  rpm           CVE-2024-41996       Low
pcre2                   10.40-6.el9                       rpm           CVE-2022-41409       Low
pcre2-syntax            10.40-6.el9                       rpm           CVE-2022-41409       Low
protobuf-java           3.21.12              3.25.5       java-archive  GHSA-735f-pc8j-v9w8  High
sqlite-libs             3.34.1-7.el9_3                    rpm           CVE-2024-0232        Low
sqlite-libs             3.34.1-7.el9_3       (won't fix)  rpm           CVE-2023-36191       Low
systemd-libs            252-46.el9_5.2                    rpm           CVE-2021-3997        Medium
tar                     2:1.34-7.el9         (won't fix)  rpm           CVE-2005-2541        Medium
tar                     2:1.34-7.el9         (won't fix)  rpm           CVE-2023-39804       Low
```

After:

```
 ✔ Cataloged contents                                                                                                                                             927c6da87ed77d74d843001f37a40f7292fde1501d0d1ccaf6b1ceae1f88fb9f
   ├── ✔ Packages                        [1,029 packages]
   ├── ✔ File digests                    [2,996 files]
   ├── ✔ File metadata                   [2,996 locations]
   └── ✔ Executables                     [358 executables]
 ✔ Scanned for vulnerabilities     [24 vulnerability matches]
   ├── by severity: 0 critical, 2 high, 4 medium, 18 low, 0 negligible
   └── by status:   5 fixed, 19 not-fixed, 0 ignored
NAME                    INSTALLED            FIXED-IN     TYPE          VULNERABILITY        SEVERITY
bzip2-libs              1.0.8-8.el9                       rpm           CVE-2019-12900       Low
commons-configuration2  2.8.0                2.10.1       java-archive  GHSA-xjp4-hw94-mvp5  Medium
commons-configuration2  2.8.0                2.10.1       java-archive  GHSA-9w38-p64v-xpmv  Medium
curl-minimal            7.76.1-31.el9                     rpm           CVE-2024-9681        Low
curl-minimal            7.76.1-31.el9                     rpm           CVE-2024-7264        Low
gawk                    5.1.0-6.el9          (won't fix)  rpm           CVE-2023-4156        Low
libcurl                 7.76.1-31.el9                     rpm           CVE-2024-9681        Low
libcurl                 7.76.1-31.el9                     rpm           CVE-2024-7264        Low
libgcc                  11.5.0-2.el9         (won't fix)  rpm           CVE-2022-27943       Low
ncurses-base            6.2-10.20210508.el9               rpm           CVE-2023-50495       Low
ncurses-base            6.2-10.20210508.el9               rpm           CVE-2023-45918       Low
ncurses-base            6.2-10.20210508.el9  (won't fix)  rpm           CVE-2022-29458       Low
ncurses-libs            6.2-10.20210508.el9               rpm           CVE-2023-50495       Low
ncurses-libs            6.2-10.20210508.el9               rpm           CVE-2023-45918       Low
ncurses-libs            6.2-10.20210508.el9  (won't fix)  rpm           CVE-2022-29458       Low
netty-common            4.1.110.Final        4.1.115      java-archive  GHSA-xq3w-v528-46rv  High
okio                    1.17.5               1.17.6       java-archive  GHSA-w33c-445m-f8w7  Medium
openldap                2.6.6-3.el9                       rpm           CVE-2023-2953        Low
openssl-libs            1:3.2.2-6.el9_5      (won't fix)  rpm           CVE-2024-41996       Low
pcre2                   10.40-6.el9                       rpm           CVE-2022-41409       Low
pcre2-syntax            10.40-6.el9                       rpm           CVE-2022-41409       Low
protobuf-java           3.21.12              3.25.5       java-archive  GHSA-735f-pc8j-v9w8  High
tar                     2:1.34-7.el9         (won't fix)  rpm           CVE-2005-2541        Medium
tar                     2:1.34-7.el9         (won't fix)  rpm           CVE-2023-39804       Low
```

The image size is reduced by 27 MB

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
