### PR TITLE
Disable HTTP/2 for internal communication

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/TaskManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TaskManagerConfig.java
@@ -74,7 +74,7 @@ public class TaskManagerConfig
     private Duration clientTimeout = new Duration(2, TimeUnit.MINUTES);
     private Duration infoMaxAge = new Duration(15, TimeUnit.MINUTES);
 
-    private Duration statusRefreshMaxWait = new Duration(3, TimeUnit.SECONDS);
+    private Duration statusRefreshMaxWait = new Duration(1, TimeUnit.SECONDS);
     private Duration infoUpdateInterval = new Duration(3, TimeUnit.SECONDS);
     private Duration taskTerminationTimeout = new Duration(1, TimeUnit.MINUTES);
 

--- a/core/trino-main/src/main/java/io/trino/server/InternalCommunicationConfig.java
+++ b/core/trino-main/src/main/java/io/trino/server/InternalCommunicationConfig.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 public class InternalCommunicationConfig
 {
     private String sharedSecret;
-    private boolean http2Enabled = true;
+    private boolean http2Enabled;
     private boolean httpsRequired;
     private String keyStorePath;
     private String keyStorePassword;

--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -350,13 +350,21 @@ public class ServerMainModule
 
         // exchange client
         binder.bind(DirectExchangeClientSupplier.class).to(DirectExchangeClientFactory.class).in(Scopes.SINGLETON);
+
+        InternalCommunicationConfig internalCommunicationConfig = buildConfigObject(InternalCommunicationConfig.class);
+
         install(internalHttpClientModule("exchange", ForExchange.class)
                 .withConfigDefaults(config -> {
                     config.setIdleTimeout(new Duration(30, SECONDS));
                     config.setRequestTimeout(new Duration(10, SECONDS));
-                    config.setMaxConnectionsPerServer(64);
                     config.setMaxContentLength(DataSize.of(32, MEGABYTE));
                     config.setMaxRequestsQueuedPerDestination(65536);
+                    if (internalCommunicationConfig.isHttp2Enabled()) {
+                        config.setMaxConnectionsPerServer(64);
+                    }
+                    else {
+                        config.setMaxConnectionsPerServer(250);
+                    }
                 }).build());
 
         configBinder(binder).bindConfig(DirectExchangeClientConfig.class);

--- a/core/trino-main/src/test/java/io/trino/execution/TestTaskManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestTaskManagerConfig.java
@@ -42,7 +42,7 @@ public class TestTaskManagerConfig
                 .setThreadPerDriverSchedulerEnabled(true)
                 .setInitialSplitsPerNode(Runtime.getRuntime().availableProcessors() * 2)
                 .setSplitConcurrencyAdjustmentInterval(new Duration(100, TimeUnit.MILLISECONDS))
-                .setStatusRefreshMaxWait(new Duration(3, TimeUnit.SECONDS))
+                .setStatusRefreshMaxWait(new Duration(1, TimeUnit.SECONDS))
                 .setInfoUpdateInterval(new Duration(3, TimeUnit.SECONDS))
                 .setTaskTerminationTimeout(new Duration(1, TimeUnit.MINUTES))
                 .setPerOperatorCpuTimerEnabled(true)

--- a/core/trino-main/src/test/java/io/trino/server/TestInternalCommunicationConfig.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestInternalCommunicationConfig.java
@@ -32,7 +32,7 @@ public class TestInternalCommunicationConfig
     {
         assertRecordedDefaults(recordDefaults(InternalCommunicationConfig.class)
                 .setSharedSecret(null)
-                .setHttp2Enabled(true)
+                .setHttp2Enabled(false)
                 .setHttpsRequired(false)
                 .setKeyStorePath(null)
                 .setKeyStorePassword(null)
@@ -50,7 +50,7 @@ public class TestInternalCommunicationConfig
 
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("internal-communication.shared-secret", "secret")
-                .put("internal-communication.http2.enabled", "false")
+                .put("internal-communication.http2.enabled", "true")
                 .put("internal-communication.https.required", "true")
                 .put("internal-communication.https.keystore.path", keystoreFile.toString())
                 .put("internal-communication.https.keystore.key", "key-key")
@@ -61,7 +61,7 @@ public class TestInternalCommunicationConfig
 
         InternalCommunicationConfig expected = new InternalCommunicationConfig()
                 .setSharedSecret("secret")
-                .setHttp2Enabled(false)
+                .setHttp2Enabled(true)
                 .setHttpsRequired(true)
                 .setKeyStorePath(keystoreFile.toString())
                 .setKeyStorePassword("key-key")


### PR DESCRIPTION
There were reports of cluster instability after the HTTP/2 was enabled for internal communication. This requires more investigation and testing.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
