### PR TITLE
Fix BaseConnectorTest.testRenameMaterializedView

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -1849,7 +1849,7 @@ public abstract class BaseConnectorTest
             assertUpdate(session, "DROP MATERIALIZED VIEW " + uppercaseName);
         }
 
-        assertThat(getQueryRunner().tableExists(session, originalMaterializedView.toString())).isFalse();
+        assertThat(getQueryRunner().tableExists(session, originalMaterializedView.objectName())).isFalse();
         assertThat(getQueryRunner().tableExists(session, renamedMaterializedView)).isFalse();
         assertThat(getQueryRunner().tableExists(session, testExistsMaterializedViewName)).isFalse();
 


### PR DESCRIPTION
## Description
`BaseConnectorTest.testRenameMaterializedView` passes incorrect value at a certain point when checking for table existence.

## Additional context and related issues

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
