### PR TITLE
Fix DoubleRange resolution for NaN values

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/statistics/DoubleRange.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/statistics/DoubleRange.java
@@ -52,6 +52,9 @@ public class DoubleRange
                     min,
                     max));
         }
+        if (isNaN(min.getAsDouble()) || isNaN(max.getAsDouble())) {
+            return Optional.empty();
+        }
         return Optional.of(new DoubleRange(min.getAsDouble(), max.getAsDouble()));
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergStatistics.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergStatistics.java
@@ -1143,6 +1143,21 @@ public class TestIcebergStatistics
                         "(null, null, DOUBLE '25')");
     }
 
+    @Test
+    public void testNaN()
+    {
+        String tableName = "test_nan";
+        assertUpdate("CREATE TABLE " + tableName + " AS SELECT 1 AS c1, double 'NaN' AS c2", 1);
+        assertQuery(
+                "SHOW STATS FOR " + tableName,
+                """
+                VALUES
+                  ('c1', null, 1.0, 0.0, null, 1, 1),
+                  ('c2', null, 1.0, 0.0, null, null, null),
+                  (null, null, null, null, 1.0, null, null)
+                """);
+    }
+
     private long getCurrentSnapshotId(String tableName)
     {
         return (long) computeActual(format("SELECT snapshot_id FROM \"%s$snapshots\" ORDER BY committed_at DESC FETCH FIRST 1 ROW WITH TIES", tableName))


### PR DESCRIPTION
## Description

Connector objects may contain columns that contain only `NaN` values. When these values are passed to `DoubleRange` ctor, an exception occurs. Depending on the context, this may lead to either silent fallback to empty stats (e.g., `SHOW STATS` will give the user misleading values), or cause exceptions within an optimizer.

This PR fixes the problem, normalizing ranges with NaN to empty range. 

## Additional context and related issues

Originally this problem was observed during careful analysis of `BaseIcebergConnectorTest.testPartitionedByDoubleWithNaN` behavior. One may think that this is an Iceberg issue, which we may fix around Iceberg's `TableStatisticsReader.makeTableStatistics` class. However, other engines may also legitimately expose NaN as their stats, so it seems that it is better to fix it completely at the SPI level.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix query failures or wrong output in `SHOW STATS` when a connector returns NaN values for table statistics. ({issue}`24315`)
```
