### PR TITLE
Fix native S3 config docs

### DIFF
--- a/docs/src/main/sphinx/object-storage/file-system-s3.md
+++ b/docs/src/main/sphinx/object-storage/file-system-s3.md
@@ -25,9 +25,9 @@ support:
   - Activate the native implementation for S3 storage support. Defaults to
     `false`. Set to `true` to use S3 and enable all other properties.
 * - `s3.endpoint`
-  - Required endpoint URL for S3.
+  - S3 service endpoint URL to communicate with.
 * - `s3.region`
-  - Required region name for S3.
+  - S3 region to communicate with.
 * - `s3.path-style-access`
   - Use path-style access for all requests to S3
 * - `s3.exclusive-create`


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Current docs don't match the implementation and hence are incorrect and create confusion for user and make it more likely that users misconfigure things in the common usecases.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Neither region nor endpoint are required. The defaults are auto-discovered by the AWS SDK.

The region might only need to be specified if running outside of EC2 or AWS SDK related settings/environment variables haven't been configured or if using a S3-compatible system where there is a single fixed region always.

The endpoint is also similarly usually not needed to be specified in real S3 unless using something like private endpoints. It's really only necessary when using a S3-compatible system.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.