### PR TITLE
Reorder filters based on selectivity at runtime

### DIFF
--- a/core/trino-main/src/main/java/io/trino/FeaturesConfig.java
+++ b/core/trino-main/src/main/java/io/trino/FeaturesConfig.java
@@ -129,6 +129,7 @@ public class FeaturesConfig
     private boolean forceSpillingJoin;
 
     private boolean columnarFilterEvaluationEnabled = true;
+    private boolean adaptiveFilterReorderingEnabled = true;
 
     private boolean externalExchangeEncryptionEnabled = true;
 
@@ -506,6 +507,19 @@ public class FeaturesConfig
     public FeaturesConfig setColumnarFilterEvaluationEnabled(boolean columnarFilterEvaluationEnabled)
     {
         this.columnarFilterEvaluationEnabled = columnarFilterEvaluationEnabled;
+        return this;
+    }
+
+    public boolean isAdaptiveFilterReorderingEnabled()
+    {
+        return adaptiveFilterReorderingEnabled;
+    }
+
+    @Config("experimental.adaptive-filter-reordering.enabled")
+    @ConfigDescription("Reorder conjunctive/disjunctive filter terms at runtime based on observed selectivity and performance")
+    public FeaturesConfig setAdaptiveFilterReorderingEnabled(boolean adaptiveFilterReorderingEnabled)
+    {
+        this.adaptiveFilterReorderingEnabled = adaptiveFilterReorderingEnabled;
         return this;
     }
 

--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -217,6 +217,7 @@ public final class SystemSessionProperties
     public static final String IDLE_WRITER_MIN_DATA_SIZE_THRESHOLD = "idle_writer_min_data_size_threshold";
     public static final String CLOSE_IDLE_WRITERS_TRIGGER_DURATION = "close_idle_writers_trigger_duration";
     public static final String COLUMNAR_FILTER_EVALUATION_ENABLED = "columnar_filter_evaluation_enabled";
+    public static final String ADAPTIVE_FILTER_REORDERING_ENABLED = "adaptive_filter_reordering_enabled";
     public static final String SPOOLING_ENABLED = "spooling_enabled";
     public static final String DEBUG_ADAPTIVE_PLANNER = "debug_adaptive_planner";
     public static final String SOURCE_PAGES_VALIDATION_ENABLED = "output_pages_validation_enabled";
@@ -1110,6 +1111,11 @@ public final class SystemSessionProperties
                         COLUMNAR_FILTER_EVALUATION_ENABLED,
                         "Enables columnar evaluation of filters",
                         featuresConfig.isColumnarFilterEvaluationEnabled(),
+                        false),
+                booleanProperty(
+                        ADAPTIVE_FILTER_REORDERING_ENABLED,
+                        "Reorder conjunctive/disjunctive filter terms at runtime based on observed selectivity and performance",
+                        featuresConfig.isAdaptiveFilterReorderingEnabled(),
                         false),
                 integerProperty(PAGE_PARTITIONING_BUFFER_POOL_SIZE,
                         "Maximum number of free buffers in the per task partitioned page buffer pool. Setting this to zero effectively disables the pool",
@@ -2025,6 +2031,11 @@ public final class SystemSessionProperties
     public static boolean isColumnarFilterEvaluationEnabled(Session session)
     {
         return session.getSystemProperty(COLUMNAR_FILTER_EVALUATION_ENABLED, Boolean.class);
+    }
+
+    public static boolean isAdaptiveFilterReorderingEnabled(Session session)
+    {
+        return session.getSystemProperty(ADAPTIVE_FILTER_REORDERING_ENABLED, Boolean.class);
     }
 
     public static boolean isSpoolingEnabled(Session session)

--- a/core/trino-main/src/main/java/io/trino/sql/gen/ExpressionCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/ExpressionCompiler.java
@@ -51,6 +51,7 @@ public class ExpressionCompiler
 
     public Function<DynamicFilter, PageProcessor> compilePageProcessor(
             boolean columnarFilterEvaluationEnabled,
+            boolean filterReorderingEnabled,
             Optional<Expression> filter,
             Optional<DynamicPageFilter> dynamicPageFilter,
             List<? extends Expression> projections,
@@ -59,7 +60,7 @@ public class ExpressionCompiler
             OptionalInt initialBatchSize)
     {
         Optional<Supplier<PageFilter>> filterFunctionSupplier = Optional.empty();
-        Optional<Supplier<FilterEvaluator>> columnarFilterEvaluatorSupplier = createColumnarFilterEvaluator(columnarFilterEvaluationEnabled, filter, layout, columnarFilterCompiler);
+        Optional<Supplier<FilterEvaluator>> columnarFilterEvaluatorSupplier = createColumnarFilterEvaluator(columnarFilterEvaluationEnabled, filter, layout, columnarFilterCompiler, filterReorderingEnabled);
         if (columnarFilterEvaluatorSupplier.isEmpty()) {
             filterFunctionSupplier = filter.map(expression -> pageFunctionCompiler.compileFilter(expression, layout, classNameSuffix));
         }
@@ -89,7 +90,7 @@ public class ExpressionCompiler
     @VisibleForTesting
     public Supplier<PageProcessor> compilePageProcessor(Optional<Expression> filter, List<? extends Expression> projections, Map<Symbol, Integer> layout)
     {
-        return () -> compilePageProcessor(true, filter, Optional.empty(), projections, layout, Optional.empty(), OptionalInt.empty())
+        return () -> compilePageProcessor(true, true, filter, Optional.empty(), projections, layout, Optional.empty(), OptionalInt.empty())
                 .apply(DynamicFilter.EMPTY);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/AndFilterEvaluator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/AndFilterEvaluator.java
@@ -27,12 +27,13 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.sql.gen.columnar.FilterEvaluator.isReorderingSafe;
 import static java.util.Objects.requireNonNull;
 
 public final class AndFilterEvaluator
         implements FilterEvaluator
 {
-    public static Optional<Supplier<FilterEvaluator>> createAndExpressionEvaluator(ColumnarFilterCompiler compiler, Logical logical, Map<Symbol, Integer> layout)
+    public static Optional<Supplier<FilterEvaluator>> createAndExpressionEvaluator(ColumnarFilterCompiler compiler, Logical logical, Map<Symbol, Integer> layout, boolean filterReorderingEnabled)
     {
         checkArgument(logical.operator() == Logical.Operator.AND, "logical %s should be AND", logical);
 
@@ -41,42 +42,49 @@ public final class AndFilterEvaluator
 
         ImmutableList.Builder<Supplier<FilterEvaluator>> builder = ImmutableList.builderWithExpectedSize(terms.size());
         for (Expression expression : terms) {
-            Optional<Supplier<FilterEvaluator>> subExpressionEvaluator = FilterEvaluator.createColumnarFilterEvaluator(expression, layout, compiler);
+            Optional<Supplier<FilterEvaluator>> subExpressionEvaluator = FilterEvaluator.createColumnarFilterEvaluator(expression, layout, compiler, filterReorderingEnabled);
             if (subExpressionEvaluator.isEmpty()) {
                 return Optional.empty();
             }
             builder.add(subExpressionEvaluator.get());
         }
         List<Supplier<FilterEvaluator>> subExpressionEvaluators = builder.build();
+        boolean reorderingSafe = filterReorderingEnabled && isReorderingSafe(compiler.getPlannerContext(), terms);
         return Optional.of(() -> {
             FilterEvaluator[] filterEvaluators = new FilterEvaluator[subExpressionEvaluators.size()];
             for (int i = 0; i < filterEvaluators.length; i++) {
                 filterEvaluators[i] = requireNonNull(subExpressionEvaluators.get(i).get(), "subExpressionEvaluator is null");
             }
-            return new AndFilterEvaluator(filterEvaluators);
+            return new AndFilterEvaluator(filterEvaluators, reorderingSafe);
         });
     }
 
     private final FilterEvaluator[] subFilterEvaluators;
+    private final FilterReorderingProfiler profiler;
 
-    private AndFilterEvaluator(FilterEvaluator[] subFilterEvaluators)
+    private AndFilterEvaluator(FilterEvaluator[] subFilterEvaluators, boolean filterReorderingEnabled)
     {
         checkArgument(subFilterEvaluators.length >= 2, "must have at least 2 subexpressions to AND");
         this.subFilterEvaluators = subFilterEvaluators;
+        this.profiler = new FilterReorderingProfiler(subFilterEvaluators.length, filterReorderingEnabled);
     }
 
     @Override
     public SelectionResult evaluate(ConnectorSession session, SelectedPositions activePositions, SourcePage page)
     {
+        int inputPositions = activePositions.size();
         long filterTimeNanos = 0;
-        for (FilterEvaluator evaluator : subFilterEvaluators) {
+        for (int filterIndex : profiler.getFilterOrder()) {
             if (activePositions.isEmpty()) {
                 break;
             }
+            FilterEvaluator evaluator = subFilterEvaluators[filterIndex];
             SelectionResult result = evaluator.evaluate(session, activePositions, page);
+            profiler.addFilterMetrics(filterIndex, result.filterTimeNanos(), activePositions.size() - result.selectedPositions().size());
             filterTimeNanos += result.filterTimeNanos();
             activePositions = result.selectedPositions();
         }
+        profiler.reorderFilters(inputPositions);
         return new SelectionResult(activePositions, filterTimeNanos);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/ColumnarFilterCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/ColumnarFilterCompiler.java
@@ -38,6 +38,7 @@ import io.trino.operator.project.PageFieldsToInputParametersRewriter;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.function.OperatorType;
+import io.trino.sql.PlannerContext;
 import io.trino.sql.gen.CallSiteBinder;
 import io.trino.sql.ir.Between;
 import io.trino.sql.ir.Call;
@@ -88,6 +89,7 @@ public class ColumnarFilterCompiler
 {
     private static final Logger log = Logger.get(ColumnarFilterCompiler.class);
 
+    private final PlannerContext plannerContext;
     private final FunctionManager functionManager;
     private final Metadata metadata;
     // Optional is used to cache failure to generate filter for unsupported cases
@@ -95,15 +97,16 @@ public class ColumnarFilterCompiler
     private final CacheStatsMBean filterCacheStats;
 
     @Inject
-    public ColumnarFilterCompiler(FunctionManager functionManager, Metadata metadata, CompilerConfig config)
+    public ColumnarFilterCompiler(PlannerContext plannerContext, CompilerConfig config)
     {
-        this(functionManager, metadata, config.getExpressionCacheSize());
+        this(plannerContext, config.getExpressionCacheSize());
     }
 
-    public ColumnarFilterCompiler(FunctionManager functionManager, Metadata metadata, int expressionCacheSize)
+    public ColumnarFilterCompiler(PlannerContext plannerContext, int expressionCacheSize)
     {
-        this.functionManager = requireNonNull(functionManager, "functionManager is null");
-        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
+        this.functionManager = plannerContext.getFunctionManager();
+        this.metadata = plannerContext.getMetadata();
         if (expressionCacheSize > 0) {
             filterCache = buildNonEvictableCache(
                     CacheBuilder.newBuilder()
@@ -128,6 +131,11 @@ public class ColumnarFilterCompiler
     Metadata getMetadata()
     {
         return metadata;
+    }
+
+    PlannerContext getPlannerContext()
+    {
+        return plannerContext;
     }
 
     public Optional<Supplier<ColumnarFilter>> generateFilter(Expression filter, Map<Symbol, Integer> layout)

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/DynamicPageFilter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/DynamicPageFilter.java
@@ -48,6 +48,7 @@ public final class DynamicPageFilter
     private final Map<ColumnHandle, Symbol> columnHandles;
     private final Map<Symbol, Integer> sourceLayout;
     private final double selectivityThreshold;
+    private final boolean filterReorderingEnabled;
 
     @Nullable
     @GuardedBy("this")
@@ -64,7 +65,8 @@ public final class DynamicPageFilter
             Session session,
             Map<Symbol, ColumnHandle> columnHandles,
             Map<Symbol, Integer> sourceLayout,
-            double selectivityThreshold)
+            double selectivityThreshold,
+            boolean filterReorderingEnabled)
     {
         this.session = requireNonNull(session, "session is null");
         this.irExpressionOptimizer = plannerContext.getExpressionOptimizer();
@@ -74,6 +76,7 @@ public final class DynamicPageFilter
                 .collect(toImmutableMap(Map.Entry::getValue, Map.Entry::getKey));
         this.sourceLayout = ImmutableMap.copyOf(sourceLayout);
         this.selectivityThreshold = selectivityThreshold;
+        this.filterReorderingEnabled = filterReorderingEnabled;
     }
 
     // Compiled dynamic filter is fixed per-split and generated duration page source creation.
@@ -121,7 +124,7 @@ public final class DynamicPageFilter
                     Expression expression = domainTranslator.toPredicate(entry.getValue(), symbol.toSymbolReference());
                     // Run the expression derived from TupleDomain through IR optimizer to simplify predicates. E.g. SimplifyContinuousInValues
                     expression = irExpressionOptimizer.process(expression, session, ImmutableMap.of()).orElse(expression);
-                    return createColumnarFilterEvaluator(expression, sourceLayout, compiler);
+                    return createColumnarFilterEvaluator(expression, sourceLayout, compiler, filterReorderingEnabled);
                 })
                 .filter(Optional::isPresent)
                 .map(Optional::get)

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/FilterEvaluator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/FilterEvaluator.java
@@ -20,6 +20,7 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SourcePage;
 import io.trino.spi.function.CatalogSchemaFunctionName;
 import io.trino.spi.type.Type;
+import io.trino.sql.PlannerContext;
 import io.trino.sql.ir.Between;
 import io.trino.sql.ir.Call;
 import io.trino.sql.ir.Comparison;
@@ -32,6 +33,7 @@ import io.trino.sql.ir.Reference;
 import io.trino.sql.planner.DeterminismEvaluator;
 import io.trino.sql.planner.Symbol;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -43,6 +45,7 @@ import static io.trino.sql.gen.columnar.AndFilterEvaluator.createAndExpressionEv
 import static io.trino.sql.gen.columnar.DynamicPageFilter.DynamicFilterEvaluator;
 import static io.trino.sql.gen.columnar.OrFilterEvaluator.createOrExpressionEvaluator;
 import static io.trino.sql.ir.IrExpressions.call;
+import static io.trino.sql.ir.IrExpressions.mayFail;
 import static io.trino.type.UnknownType.UNKNOWN;
 
 /**
@@ -68,15 +71,16 @@ public sealed interface FilterEvaluator
             boolean columnarFilterEvaluationEnabled,
             Optional<Expression> filter,
             Map<Symbol, Integer> layout,
-            ColumnarFilterCompiler columnarFilterCompiler)
+            ColumnarFilterCompiler columnarFilterCompiler,
+            boolean filterReorderingEnabled)
     {
         if (columnarFilterEvaluationEnabled && filter.isPresent()) {
-            return createColumnarFilterEvaluator(filter.get(), layout, columnarFilterCompiler);
+            return createColumnarFilterEvaluator(filter.get(), layout, columnarFilterCompiler, filterReorderingEnabled);
         }
         return Optional.empty();
     }
 
-    static Optional<Supplier<FilterEvaluator>> createColumnarFilterEvaluator(Expression expression, Map<Symbol, Integer> layout, ColumnarFilterCompiler compiler)
+    static Optional<Supplier<FilterEvaluator>> createColumnarFilterEvaluator(Expression expression, Map<Symbol, Integer> layout, ColumnarFilterCompiler compiler, boolean filterReorderingEnabled)
     {
         return switch (expression) {
             case Constant constant when constant.value() instanceof Boolean booleanValue ->
@@ -94,9 +98,9 @@ public sealed interface FilterEvaluator
                 yield createCallExpressionEvaluator(compiler, call, layout);
             }
             case IsNull isNull -> createIsNullExpressionEvaluator(compiler, isNull, layout);
-            case Logical logical when logical.operator() == Logical.Operator.AND -> createAndExpressionEvaluator(compiler, logical, layout);
-            case Logical logical when logical.operator() == Logical.Operator.OR -> createOrExpressionEvaluator(compiler, logical, layout);
-            case Between between -> createBetweenEvaluator(compiler, between, layout);
+            case Logical logical when logical.operator() == Logical.Operator.AND -> createAndExpressionEvaluator(compiler, logical, layout, filterReorderingEnabled);
+            case Logical logical when logical.operator() == Logical.Operator.OR -> createOrExpressionEvaluator(compiler, logical, layout, filterReorderingEnabled);
+            case Between between -> createBetweenEvaluator(compiler, between, layout, filterReorderingEnabled);
             case In in -> createInExpressionEvaluator(compiler, in, layout);
             default -> Optional.empty();
         };
@@ -108,7 +112,14 @@ public sealed interface FilterEvaluator
         return isBuiltinFunctionName(functionName) && functionName.functionName().equals("$not");
     }
 
-    private static Optional<Supplier<FilterEvaluator>> createBetweenEvaluator(ColumnarFilterCompiler compiler, Between between, Map<Symbol, Integer> layout)
+    // Reordering can expose a term that may fail to rows that an earlier term would have filtered out,
+    // changing SQL short-circuit semantics. Only reorder when every term is guaranteed not to fail.
+    static boolean isReorderingSafe(PlannerContext plannerContext, List<Expression> terms)
+    {
+        return terms.stream().noneMatch(term -> mayFail(plannerContext, term));
+    }
+
+    private static Optional<Supplier<FilterEvaluator>> createBetweenEvaluator(ColumnarFilterCompiler compiler, Between between, Map<Symbol, Integer> layout, boolean filterReorderingEnabled)
     {
         // Between requires evaluate once semantic for the value being tested
         // Until we can pre-project it into a temporary variable, we apply columnar evaluation only on Reference
@@ -132,7 +143,8 @@ public sealed interface FilterEvaluator
                         ImmutableList.of(
                                 call(lessThanOrEqual, between.min(), valueExpression),
                                 call(lessThanOrEqual, valueExpression, between.max()))),
-                layout);
+                layout,
+                filterReorderingEnabled);
     }
 
     private static Optional<Supplier<FilterEvaluator>> createInExpressionEvaluator(ColumnarFilterCompiler compiler, In in, Map<Symbol, Integer> layout)

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/FilterReorderingProfiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/FilterReorderingProfiler.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.gen.columnar;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static it.unimi.dsi.fastutil.ints.IntArrays.quickSort;
+
+public final class FilterReorderingProfiler
+{
+    // ORC/Parquet readers ramp up page size in powers of two (1, 2, 4, …, 2048, 8192).
+    // 8191 == (1 << 13) - 1 is the cumulative position count after the first 13 batches;
+    // wait until then before the first reordering to avoid noise from small initial pages.
+    private static final long MIN_SAMPLE_POSITIONS_REORDERING = (1 << 13) - 1;
+
+    private final boolean filterReorderingEnabled;
+    private final int[] filterOrder;
+    private final List<FilterMetrics> filterMetrics;
+    private long sampledPositions;
+
+    public FilterReorderingProfiler(int filterCount, boolean filterReorderingEnabled)
+    {
+        this.filterReorderingEnabled = filterReorderingEnabled;
+        this.filterOrder = new int[filterCount];
+        for (int i = 0; i < filterCount; i++) {
+            this.filterOrder[i] = i;
+        }
+        this.filterMetrics = IntStream.range(0, filterCount)
+                .mapToObj(_ -> new FilterMetrics())
+                .collect(toImmutableList());
+    }
+
+    public int[] getFilterOrder()
+    {
+        return filterOrder;
+    }
+
+    public void addFilterMetrics(int filterIndex, long filterTimeNanos, long filteredPositions)
+    {
+        filterMetrics.get(filterIndex).addFilterMetrics(filterTimeNanos, filteredPositions);
+    }
+
+    public void reorderFilters(int inputPositions)
+    {
+        sampledPositions += inputPositions;
+        // Don't reorder too often due to small pages
+        if (!filterReorderingEnabled || sampledPositions < MIN_SAMPLE_POSITIONS_REORDERING) {
+            return;
+        }
+        sampledPositions = 0;
+        // Scores are cumulative, so once the order has converged it rarely changes.
+        // Skip the sort if adjacent scores are already non-decreasing.
+        if (isOrderStable()) {
+            return;
+        }
+        quickSort(
+                filterOrder,
+                (filterIndex1, filterIndex2) ->
+                        Double.compare(filterMetrics.get(filterIndex1).score(), filterMetrics.get(filterIndex2).score()));
+    }
+
+    private boolean isOrderStable()
+    {
+        for (int i = 1; i < filterOrder.length; i++) {
+            if (filterMetrics.get(filterOrder[i - 1]).score() > filterMetrics.get(filterOrder[i]).score()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static class FilterMetrics
+    {
+        private long totalFilterTimeNanos;
+        private long totalFilteredPositions;
+
+        void addFilterMetrics(long filterTimeNanos, long filteredPositions)
+        {
+            totalFilterTimeNanos += filterTimeNanos;
+            totalFilteredPositions += filteredPositions;
+        }
+
+        double score()
+        {
+            return totalFilterTimeNanos / (1.0 + totalFilteredPositions);
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/OrFilterEvaluator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/OrFilterEvaluator.java
@@ -28,54 +28,77 @@ import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.sql.gen.columnar.FilterEvaluator.isReorderingSafe;
 
 public final class OrFilterEvaluator
         implements FilterEvaluator
 {
-    public static Optional<Supplier<FilterEvaluator>> createOrExpressionEvaluator(ColumnarFilterCompiler compiler, Logical logical, Map<Symbol, Integer> layout)
+    public static Optional<Supplier<FilterEvaluator>> createOrExpressionEvaluator(ColumnarFilterCompiler compiler, Logical logical, Map<Symbol, Integer> layout, boolean filterReorderingEnabled)
     {
         checkArgument(logical.operator() == Logical.Operator.OR, "logical %s should be OR", logical);
         checkArgument(logical.terms().size() >= 2, "OR expression %s should have at least 2 arguments", logical);
 
         ImmutableList.Builder<Supplier<FilterEvaluator>> builder = ImmutableList.builder();
         for (Expression expression : logical.terms()) {
-            Optional<Supplier<FilterEvaluator>> subExpressionEvaluator = FilterEvaluator.createColumnarFilterEvaluator(expression, layout, compiler);
+            Optional<Supplier<FilterEvaluator>> subExpressionEvaluator = FilterEvaluator.createColumnarFilterEvaluator(expression, layout, compiler, filterReorderingEnabled);
             if (subExpressionEvaluator.isEmpty()) {
                 return Optional.empty();
             }
             builder.add(subExpressionEvaluator.get());
         }
         List<Supplier<FilterEvaluator>> subExpressionEvaluators = builder.build();
-        return Optional.of(() -> new OrFilterEvaluator(subExpressionEvaluators.stream().map(Supplier::get).collect(toImmutableList())));
+        boolean reorderingSafe = filterReorderingEnabled && isReorderingSafe(compiler.getPlannerContext(), logical.terms());
+        return Optional.of(() -> new OrFilterEvaluator(
+                subExpressionEvaluators.stream().map(Supplier::get).collect(toImmutableList()),
+                reorderingSafe));
     }
 
     private final List<FilterEvaluator> subFilterEvaluators;
+    private final FilterReorderingProfiler profiler;
 
-    private OrFilterEvaluator(List<FilterEvaluator> subFilterEvaluators)
+    private OrFilterEvaluator(List<FilterEvaluator> subFilterEvaluators, boolean filterReorderingEnabled)
     {
         checkArgument(subFilterEvaluators.size() >= 2, "must have at least 2 subexpressions to OR");
         this.subFilterEvaluators = subFilterEvaluators;
+        this.profiler = new FilterReorderingProfiler(subFilterEvaluators.size(), filterReorderingEnabled);
     }
 
     @Override
     public SelectionResult evaluate(ConnectorSession session, SelectedPositions activePositions, SourcePage page)
     {
+        int inputPositions = activePositions.size();
         long filterTimeNanos = 0;
-        SelectionResult result = subFilterEvaluators.getFirst().evaluate(session, activePositions, page);
+        SelectionResult result = getFirst().evaluate(session, activePositions, page);
         SelectedPositions accumulatedPositions = result.selectedPositions();
+        profiler.addFilterMetrics(getFilterIndex(0), result.filterTimeNanos(), accumulatedPositions.size());
         filterTimeNanos += result.filterTimeNanos();
         activePositions = activePositions.difference(accumulatedPositions);
         for (int index = 1; index < subFilterEvaluators.size() - 1; index++) {
-            FilterEvaluator evaluator = subFilterEvaluators.get(index);
+            int filterIndex = getFilterIndex(index);
+            FilterEvaluator evaluator = subFilterEvaluators.get(filterIndex);
             result = evaluator.evaluate(session, activePositions, page);
             SelectedPositions selectedPositions = result.selectedPositions();
+            profiler.addFilterMetrics(filterIndex, result.filterTimeNanos(), selectedPositions.size());
             filterTimeNanos += result.filterTimeNanos();
             accumulatedPositions = accumulatedPositions.union(selectedPositions);
             activePositions = activePositions.difference(selectedPositions);
         }
-        result = subFilterEvaluators.getLast().evaluate(session, activePositions, page);
+        int filterIndex = getFilterIndex(subFilterEvaluators.size() - 1);
+        result = subFilterEvaluators.get(filterIndex).evaluate(session, activePositions, page);
+        profiler.addFilterMetrics(filterIndex, result.filterTimeNanos(), result.selectedPositions().size());
+        profiler.reorderFilters(inputPositions);
         filterTimeNanos += result.filterTimeNanos();
         accumulatedPositions = accumulatedPositions.union(result.selectedPositions());
         return new SelectionResult(accumulatedPositions, filterTimeNanos);
+    }
+
+    private int getFilterIndex(int index)
+    {
+        return profiler.getFilterOrder()[index];
+    }
+
+    private FilterEvaluator getFirst()
+    {
+        return subFilterEvaluators.get(getFilterIndex(0));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -322,6 +322,7 @@ import static io.trino.SystemSessionProperties.getTaskConcurrency;
 import static io.trino.SystemSessionProperties.getTaskMaxWriterCount;
 import static io.trino.SystemSessionProperties.getTaskMinWriterCount;
 import static io.trino.SystemSessionProperties.getWriterScalingMinDataProcessed;
+import static io.trino.SystemSessionProperties.isAdaptiveFilterReorderingEnabled;
 import static io.trino.SystemSessionProperties.isAdaptivePartialAggregationEnabled;
 import static io.trino.SystemSessionProperties.isColumnarFilterEvaluationEnabled;
 import static io.trino.SystemSessionProperties.isEnableDynamicRowFiltering;
@@ -2099,6 +2100,7 @@ public class LocalExecutionPlanner
 
             try {
                 boolean columnarFilterEvaluationEnabled = isColumnarFilterEvaluationEnabled(session);
+                boolean filterReorderingEnabled = isAdaptiveFilterReorderingEnabled(session);
                 Optional<DynamicPageFilter> dynamicPageFilterFactory = Optional.empty();
                 if (dynamicFilter != DynamicFilter.EMPTY && isEnableDynamicRowFiltering(session)) {
                     dynamicPageFilterFactory = Optional.of(new DynamicPageFilter(
@@ -2106,10 +2108,12 @@ public class LocalExecutionPlanner
                             session,
                             ((TableScanNode) sourceNode).getAssignments(),
                             sourceLayout,
-                            getDynamicRowFilterSelectivityThreshold(session)));
+                            getDynamicRowFilterSelectivityThreshold(session),
+                            filterReorderingEnabled));
                 }
                 Function<DynamicFilter, PageProcessor> pageProcessor = expressionCompiler.compilePageProcessor(
                         columnarFilterEvaluationEnabled,
+                        filterReorderingEnabled,
                         staticFilters,
                         dynamicPageFilterFactory,
                         projections,

--- a/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
+++ b/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
@@ -456,7 +456,7 @@ public class PlanTester
 
         this.plannerContext = new PlannerContext(metadata, typeOperators, blockEncodingSerde, typeManager, functionManager, languageFunctionManager, tracer);
         this.pageFunctionCompiler = new PageFunctionCompiler(functionManager, metadata, typeManager, 0);
-        ColumnarFilterCompiler filterCompiler = new ColumnarFilterCompiler(functionManager, metadata, 0);
+        ColumnarFilterCompiler filterCompiler = new ColumnarFilterCompiler(plannerContext, 0);
         this.expressionCompiler = new ExpressionCompiler(pageFunctionCompiler, filterCompiler);
         this.joinFilterFunctionCompiler = new JoinFilterFunctionCompiler(functionManager, metadata, typeManager);
 

--- a/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
@@ -150,7 +150,7 @@ public final class TaskTestUtils
                 CatalogServiceProvider.fail());
 
         PageFunctionCompiler pageFunctionCompiler = new PageFunctionCompiler(PLANNER_CONTEXT.getFunctionManager(), PLANNER_CONTEXT.getMetadata(), PLANNER_CONTEXT.getTypeManager(), 0);
-        ColumnarFilterCompiler columnarFilterCompiler = new ColumnarFilterCompiler(PLANNER_CONTEXT.getFunctionManager(), PLANNER_CONTEXT.getMetadata(), 0);
+        ColumnarFilterCompiler columnarFilterCompiler = new ColumnarFilterCompiler(PLANNER_CONTEXT, 0);
         return new LocalExecutionPlanner(
                 PLANNER_CONTEXT,
                 Optional.empty(),

--- a/core/trino-main/src/test/java/io/trino/metadata/TestingFunctionResolution.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestingFunctionResolution.java
@@ -132,7 +132,7 @@ public class TestingFunctionResolution
 
     public ColumnarFilterCompiler getColumnarFilterCompiler(int expressionCacheSize)
     {
-        return new ColumnarFilterCompiler(plannerContext.getFunctionManager(), plannerContext.getMetadata(), expressionCacheSize);
+        return new ColumnarFilterCompiler(plannerContext, expressionCacheSize);
     }
 
     public ResolvedFunction resolveOperator(OperatorType operatorType, List<? extends Type> argumentTypes)

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkScanFilterAndProjectOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkScanFilterAndProjectOperator.java
@@ -159,8 +159,8 @@ public class BenchmarkScanFilterAndProjectOperator
                     .collect(toImmutableList());
 
             PageFunctionCompiler pageFunctionCompiler = new PageFunctionCompiler(PLANNER_CONTEXT.getFunctionManager(), PLANNER_CONTEXT.getMetadata(), PLANNER_CONTEXT.getTypeManager(), 0);
-            ColumnarFilterCompiler compiler = new ColumnarFilterCompiler(PLANNER_CONTEXT.getFunctionManager(), PLANNER_CONTEXT.getMetadata(), 0);
-            PageProcessor pageProcessor = new ExpressionCompiler(pageFunctionCompiler, compiler).compilePageProcessor(true, Optional.of(getFilter(type)), Optional.empty(), projections, sourceLayout, Optional.empty(), OptionalInt.empty()).apply(DynamicFilter.EMPTY);
+            ColumnarFilterCompiler compiler = new ColumnarFilterCompiler(PLANNER_CONTEXT, 0);
+            PageProcessor pageProcessor = new ExpressionCompiler(pageFunctionCompiler, compiler).compilePageProcessor(true, true, Optional.of(getFilter(type)), Optional.empty(), projections, sourceLayout, Optional.empty(), OptionalInt.empty()).apply(DynamicFilter.EMPTY);
 
             createTaskContext();
             createScanFilterAndProjectOperatorFactories(createInputPages(types), pageProcessor, columnHandles, types);

--- a/core/trino-main/src/test/java/io/trino/operator/TestColumnarPageProcessor.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestColumnarPageProcessor.java
@@ -99,7 +99,7 @@ public class TestColumnarPageProcessor
         Map<Symbol, Integer> layout = ImmutableMap.of(
                 new Symbol(types.get(0), "$col_0"), 3,
                 new Symbol(types.get(1), "$col_1"), 1);
-        return compiler.compilePageProcessor(true, Optional.empty(), Optional.empty(), projections, layout, Optional.empty(), OptionalInt.of(MAX_BATCH_SIZE))
+        return compiler.compilePageProcessor(true, true, Optional.empty(), Optional.empty(), projections, layout, Optional.empty(), OptionalInt.of(MAX_BATCH_SIZE))
                 .apply(DynamicFilter.EMPTY);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/TestFilterAndProjectOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestFilterAndProjectOperator.java
@@ -107,7 +107,7 @@ public class TestFilterAndProjectOperator
                 col1, new Constant(BIGINT, 5L));
 
         ExpressionCompiler compiler = functionResolution.getExpressionCompiler();
-        Function<DynamicFilter, PageProcessor> processorFactory = compiler.compilePageProcessor(true, Optional.of(filter), Optional.empty(), ImmutableList.of(field0, add5), layout, Optional.empty(), OptionalInt.empty());
+        Function<DynamicFilter, PageProcessor> processorFactory = compiler.compilePageProcessor(true, true, Optional.of(filter), Optional.empty(), ImmutableList.of(field0, add5), layout, Optional.empty(), OptionalInt.empty());
         Supplier<PageProcessor> processor = () -> processorFactory.apply(DynamicFilter.EMPTY);
 
         OperatorFactory operatorFactory = FilterAndProjectOperator.createOperatorFactory(
@@ -156,7 +156,7 @@ public class TestFilterAndProjectOperator
                 col1, new Constant(BIGINT, 10L));
 
         ExpressionCompiler compiler = functionResolution.getExpressionCompiler();
-        Function<DynamicFilter, PageProcessor> processorFactory = compiler.compilePageProcessor(true, Optional.of(filter), Optional.empty(), ImmutableList.of(col1), layout, Optional.empty(), OptionalInt.empty());
+        Function<DynamicFilter, PageProcessor> processorFactory = compiler.compilePageProcessor(true, true, Optional.of(filter), Optional.empty(), ImmutableList.of(col1), layout, Optional.empty(), OptionalInt.empty());
         Supplier<PageProcessor> processor = () -> processorFactory.apply(DynamicFilter.EMPTY);
 
         OperatorFactory operatorFactory = FilterAndProjectOperator.createOperatorFactory(

--- a/core/trino-main/src/test/java/io/trino/operator/TestScanFilterAndProjectOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestScanFilterAndProjectOperator.java
@@ -108,7 +108,7 @@ public class TestScanFilterAndProjectOperator
         FunctionManager functionManager = runner.getPlannerContext().getFunctionManager();
         expressionCompiler = new ExpressionCompiler(
                 new PageFunctionCompiler(functionManager, runner.getPlannerContext().getMetadata(), runner.getPlannerContext().getTypeManager(), 0),
-                new ColumnarFilterCompiler(functionManager, runner.getPlannerContext().getMetadata(), 0));
+                new ColumnarFilterCompiler(runner.getPlannerContext(), 0));
     }
 
     @AfterAll
@@ -132,7 +132,7 @@ public class TestScanFilterAndProjectOperator
         Reference col0 = new Reference(VARCHAR, "$col_0");
         Map<Symbol, Integer> layout = ImmutableMap.of(new Symbol(VARCHAR, "$col_0"), 0);
         List<Expression> projections = ImmutableList.of(col0);
-        Function<DynamicFilter, PageProcessor> processorFactory = expressionCompiler.compilePageProcessor(true, Optional.empty(), Optional.empty(), projections, layout, Optional.empty(), OptionalInt.empty());
+        Function<DynamicFilter, PageProcessor> processorFactory = expressionCompiler.compilePageProcessor(true, true, Optional.empty(), Optional.empty(), projections, layout, Optional.empty(), OptionalInt.empty());
         Supplier<PageProcessor> pageProcessor = () -> processorFactory.apply(DynamicFilter.EMPTY);
 
         ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory factory = new ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory(
@@ -175,7 +175,7 @@ public class TestScanFilterAndProjectOperator
                 new TestingFunctionResolution(runner).resolveOperator(EQUAL, ImmutableList.of(BIGINT, BIGINT)),
                 col0, new Constant(BIGINT, 10L));
         List<Expression> projections = ImmutableList.of(col0);
-        Function<DynamicFilter, PageProcessor> processorFactory = expressionCompiler.compilePageProcessor(true, Optional.of(filter), Optional.empty(), projections, layout, Optional.empty(), OptionalInt.empty());
+        Function<DynamicFilter, PageProcessor> processorFactory = expressionCompiler.compilePageProcessor(true, true, Optional.of(filter), Optional.empty(), projections, layout, Optional.empty(), OptionalInt.empty());
         Supplier<PageProcessor> pageProcessor = () -> processorFactory.apply(DynamicFilter.EMPTY);
 
         ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory factory = new ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory(
@@ -252,7 +252,7 @@ public class TestScanFilterAndProjectOperator
         Reference col0 = new Reference(VARCHAR, "$col_0");
         Map<Symbol, Integer> layout = ImmutableMap.of(new Symbol(VARCHAR, "$col_0"), 0);
         List<Expression> projections = ImmutableList.of(col0);
-        Function<DynamicFilter, PageProcessor> processorFactory = expressionCompiler.compilePageProcessor(true, Optional.empty(), Optional.empty(), projections, layout, Optional.empty(), OptionalInt.empty());
+        Function<DynamicFilter, PageProcessor> processorFactory = expressionCompiler.compilePageProcessor(true, true, Optional.empty(), Optional.empty(), projections, layout, Optional.empty(), OptionalInt.empty());
         Supplier<PageProcessor> pageProcessor = () -> processorFactory.apply(DynamicFilter.EMPTY);
 
         ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory factory = new ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory(
@@ -301,14 +301,14 @@ public class TestScanFilterAndProjectOperator
         FunctionManager functionManager = runner.getPlannerContext().getFunctionManager();
         ExpressionCompiler expressionCompiler = new ExpressionCompiler(
                 new PageFunctionCompiler(functionManager, runner.getPlannerContext().getMetadata(), runner.getPlannerContext().getTypeManager(), 0),
-                new ColumnarFilterCompiler(functionManager, runner.getPlannerContext().getMetadata(), 0));
+                new ColumnarFilterCompiler(runner.getPlannerContext(), 0));
         Reference col0 = new Reference(BIGINT, "$col_0");
         Map<Symbol, Integer> layout = ImmutableMap.of(new Symbol(BIGINT, "$col_0"), 0);
         ImmutableList.Builder<Expression> projections = ImmutableList.builder();
         for (int i = 0; i < totalColumns; i++) {
             projections.add(call(runner.getPlannerContext().getMetadata().resolveBuiltinFunction("generic_long_page_col" + i, fromTypes(BIGINT)), col0));
         }
-        Function<DynamicFilter, PageProcessor> processorFactory = expressionCompiler.compilePageProcessor(true, Optional.empty(), Optional.empty(), projections.build(), layout, Optional.empty(), OptionalInt.of(MAX_BATCH_SIZE));
+        Function<DynamicFilter, PageProcessor> processorFactory = expressionCompiler.compilePageProcessor(true, true, Optional.empty(), Optional.empty(), projections.build(), layout, Optional.empty(), OptionalInt.of(MAX_BATCH_SIZE));
         Supplier<PageProcessor> pageProcessor = () -> processorFactory.apply(DynamicFilter.EMPTY);
 
         ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory factory = new ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory(

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestPageProcessorCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestPageProcessorCompiler.java
@@ -74,8 +74,8 @@ public class TestPageProcessorCompiler
                 new Symbol(arrayType, "$col_1"), 1);
         List<Expression> projections = ImmutableList.of(call(resolvedFunction, col0, col1));
 
-        Function<DynamicFilter, PageProcessor> factory1 = compiler.compilePageProcessor(true, Optional.empty(), Optional.empty(), projections, layout, Optional.empty(), OptionalInt.empty());
-        Function<DynamicFilter, PageProcessor> factory2 = compiler.compilePageProcessor(true, Optional.empty(), Optional.empty(), projections, layout, Optional.empty(), OptionalInt.empty());
+        Function<DynamicFilter, PageProcessor> factory1 = compiler.compilePageProcessor(true, true, Optional.empty(), Optional.empty(), projections, layout, Optional.empty(), OptionalInt.empty());
+        Function<DynamicFilter, PageProcessor> factory2 = compiler.compilePageProcessor(true, true, Optional.empty(), Optional.empty(), projections, layout, Optional.empty(), OptionalInt.empty());
         assertThat(factory1 != factory2).isTrue();
     }
 
@@ -85,7 +85,7 @@ public class TestPageProcessorCompiler
         Map<Symbol, Integer> layout = ImmutableMap.of(
                 new Symbol(BIGINT, "$col_0"), 3,
                 new Symbol(VARCHAR, "$col_1"), 1);
-        PageProcessor processor = compiler.compilePageProcessor(true, Optional.empty(), Optional.empty(),
+        PageProcessor processor = compiler.compilePageProcessor(true, true, Optional.empty(), Optional.empty(),
                         ImmutableList.of(new Reference(BIGINT, "$col_0"), new Reference(VARCHAR, "$col_1")),
                         layout, Optional.empty(), OptionalInt.of(MAX_BATCH_SIZE))
                 .apply(DynamicFilter.EMPTY);
@@ -126,7 +126,7 @@ public class TestPageProcessorCompiler
         ResolvedFunction lessThan = functionResolution.resolveOperator(LESS_THAN, ImmutableList.of(BIGINT, BIGINT));
         Call filter = call(lessThan, lengthVarchar, new Constant(BIGINT, 10L));
 
-        PageProcessor processor = compiler.compilePageProcessor(true, Optional.of(filter), Optional.empty(),
+        PageProcessor processor = compiler.compilePageProcessor(true, true, Optional.of(filter), Optional.empty(),
                         ImmutableList.of(col0), layout, Optional.empty(), OptionalInt.of(MAX_BATCH_SIZE))
                 .apply(DynamicFilter.EMPTY);
 
@@ -169,7 +169,7 @@ public class TestPageProcessorCompiler
         ResolvedFunction lessThan = functionResolution.resolveOperator(LESS_THAN, ImmutableList.of(BIGINT, BIGINT));
         Call filter = call(lessThan, col0, new Constant(BIGINT, 10L));
 
-        PageProcessor processor = compiler.compilePageProcessor(true, Optional.of(filter), Optional.empty(),
+        PageProcessor processor = compiler.compilePageProcessor(true, true, Optional.of(filter), Optional.empty(),
                         ImmutableList.of(col0), layout, Optional.empty(), OptionalInt.of(MAX_BATCH_SIZE))
                 .apply(DynamicFilter.EMPTY);
 
@@ -193,7 +193,7 @@ public class TestPageProcessorCompiler
     public void testSanityColumnarDictionary()
     {
         Map<Symbol, Integer> layout = ImmutableMap.of(new Symbol(VARCHAR, "$col_0"), 2);
-        PageProcessor processor = compiler.compilePageProcessor(true, Optional.empty(), Optional.empty(),
+        PageProcessor processor = compiler.compilePageProcessor(true, true, Optional.empty(), Optional.empty(),
                         ImmutableList.of(new Reference(VARCHAR, "$col_0")), layout, Optional.empty(), OptionalInt.of(MAX_BATCH_SIZE))
                 .apply(DynamicFilter.EMPTY);
 
@@ -225,7 +225,7 @@ public class TestPageProcessorCompiler
                 new Constant(BIGINT, 10L));
         Call lessThanRandomExpression = call(lessThan, col0, random);
 
-        PageProcessor processor = compiler.compilePageProcessor(true, Optional.empty(), Optional.empty(),
+        PageProcessor processor = compiler.compilePageProcessor(true, true, Optional.empty(), Optional.empty(),
                         ImmutableList.of(lessThanRandomExpression), layout, Optional.empty(), OptionalInt.of(MAX_BATCH_SIZE))
                 .apply(DynamicFilter.EMPTY);
 

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestFeaturesConfig.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestFeaturesConfig.java
@@ -66,6 +66,7 @@ public class TestFeaturesConfig
                 .setHideInaccessibleColumns(false)
                 .setForceSpillingJoin(false)
                 .setColumnarFilterEvaluationEnabled(true)
+                .setAdaptiveFilterReorderingEnabled(true)
                 .setLegacyArithmeticDecimalOperators(false)
                 .setExternalExchangeEncryptionEnabled(true));
     }
@@ -101,6 +102,7 @@ public class TestFeaturesConfig
                 .put("hide-inaccessible-columns", "true")
                 .put("force-spilling-join-operator", "true")
                 .put("experimental.columnar-filter-evaluation.enabled", "false")
+                .put("experimental.adaptive-filter-reordering.enabled", "false")
                 .put("deprecated.legacy-arithmetic-decimal-operators", "true")
                 .put("external-exchange-encryption-enabled", "false")
                 .buildOrThrow();
@@ -133,6 +135,7 @@ public class TestFeaturesConfig
                 .setHideInaccessibleColumns(true)
                 .setForceSpillingJoin(true)
                 .setColumnarFilterEvaluationEnabled(false)
+                .setAdaptiveFilterReorderingEnabled(false)
                 .setLegacyArithmeticDecimalOperators(true)
                 .setExternalExchangeEncryptionEnabled(false);
         assertFullMapping(properties, expected);

--- a/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkAndColumnarFilterTpchData.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkAndColumnarFilterTpchData.java
@@ -17,9 +17,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import io.trino.memory.context.LocalMemoryContext;
 import io.trino.metadata.TestingFunctionResolution;
 import io.trino.operator.DriverYieldSignal;
+import io.trino.operator.WorkProcessor;
 import io.trino.operator.project.PageProcessor;
+import io.trino.operator.project.PageProcessorMetrics;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.connector.DynamicFilter;
@@ -43,7 +46,6 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.runner.RunnerException;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -88,7 +90,7 @@ public class BenchmarkAndColumnarFilterTpchData
     private static final Slice MIN_SHIP_DATE = utf8Slice("1994-01-01");
     private static final Slice MAX_SHIP_DATE = utf8Slice("1995-01-01");
 
-    private Page inputPage;
+    private List<Page> inputPages;
     private PageProcessor processor;
 
     @Param({"true", "false"})
@@ -97,13 +99,14 @@ public class BenchmarkAndColumnarFilterTpchData
     @Setup
     public void setup()
     {
-        inputPage = createInputPage();
+        inputPages = createInputPages();
 
         Expression filterExpression = createFilterExpression(FUNCTION_RESOLUTION);
         ExpressionCompiler expressionCompiler = FUNCTION_RESOLUTION.getExpressionCompiler();
         List<? extends Expression> projections = ImmutableList.of(new Reference(DOUBLE, COL_EXTENDED_PRICE));
         processor = expressionCompiler.compilePageProcessor(
                         columnarEvaluationEnabled,
+                        true,
                         Optional.of(filterExpression),
                         Optional.empty(),
                         projections,
@@ -114,31 +117,46 @@ public class BenchmarkAndColumnarFilterTpchData
     }
 
     @Benchmark
-    public List<Optional<Page>> compiled()
+    public long compiled()
     {
-        return ImmutableList.copyOf(
-                processor.process(
-                        null,
-                        new DriverYieldSignal(),
-                        newSimpleAggregatedMemoryContext().newLocalMemoryContext(PageProcessor.class.getSimpleName()),
-                        SourcePage.create(inputPage)));
+        LocalMemoryContext context = newSimpleAggregatedMemoryContext().newLocalMemoryContext(PageProcessor.class.getSimpleName());
+        long outputRows = 0;
+        for (Page inputPage : inputPages) {
+            WorkProcessor<Page> workProcessor = processor.createWorkProcessor(
+                    null,
+                    new DriverYieldSignal(),
+                    context,
+                    new PageProcessorMetrics(),
+                    SourcePage.create(inputPage));
+            while (workProcessor.process() && !workProcessor.isFinished()) {
+                outputRows += workProcessor.getResult().getPositionCount();
+            }
+        }
+        return outputRows;
     }
 
-    private static Page createInputPage()
+    private static List<Page> createInputPages()
     {
-        PageBuilder pageBuilder = new PageBuilder(ImmutableList.of(DOUBLE, DOUBLE, VARCHAR, DOUBLE));
-        LineItemGenerator lineItemGenerator = new LineItemGenerator(1, 1, 1);
-        Iterator<LineItem> iterator = lineItemGenerator.iterator();
-        for (int i = 0; i < 10_000; i++) {
+        PageBuilder pageBuilder = PageBuilder.withMaxPageSize(350 * 1024, ImmutableList.of(DOUBLE, DOUBLE, VARCHAR, DOUBLE));
+        ImmutableList.Builder<Page> pages = ImmutableList.builder();
+        for (LineItem lineItem : new LineItemGenerator(1, 1, 1)) {
             pageBuilder.declarePosition();
 
-            LineItem lineItem = iterator.next();
             DOUBLE.writeDouble(pageBuilder.getBlockBuilder(EXTENDED_PRICE), lineItem.extendedPrice());
             DOUBLE.writeDouble(pageBuilder.getBlockBuilder(DISCOUNT), lineItem.discount());
             VARCHAR.writeSlice(pageBuilder.getBlockBuilder(SHIP_DATE), Slices.wrappedBuffer(LineItemColumn.SHIP_DATE.getString(lineItem).getBytes(UTF_8)));
             DOUBLE.writeDouble(pageBuilder.getBlockBuilder(QUANTITY), lineItem.quantity());
+
+            if (pageBuilder.isFull()) {
+                Page page = pageBuilder.build();
+                pages.add(page);
+                pageBuilder.reset();
+            }
         }
-        return pageBuilder.build();
+        if (!pageBuilder.isEmpty()) {
+            pages.add(pageBuilder.build());
+        }
+        return pages.build();
     }
 
     // where shipdate >= '1994-01-01'

--- a/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkColumnarFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkColumnarFilter.java
@@ -160,6 +160,7 @@ public class BenchmarkColumnarFilter
         ExpressionCompiler expressionCompiler = FUNCTION_RESOLUTION.getExpressionCompiler();
         compiledProcessor = expressionCompiler.compilePageProcessor(
                         columnarEvaluationEnabled,
+                        true,
                         Optional.of(filterProvider.getExpression(type)),
                         Optional.empty(),
                         ImmutableList.of(new Reference(type, COL_0)),

--- a/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkInCodeGenerator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkInCodeGenerator.java
@@ -178,9 +178,10 @@ public class BenchmarkInCodeGenerator
             TypeManager typeManager = functions.getPlannerContext().getTypeManager();
             processor = new ExpressionCompiler(
                     new PageFunctionCompiler(functionManager, metadata, typeManager, 0),
-                    new ColumnarFilterCompiler(functionManager, metadata, 0))
+                    new ColumnarFilterCompiler(functions.getPlannerContext(), 0))
                     .compilePageProcessor(
                             columnarEvaluationEnabled,
+                            true,
                             Optional.of(filter),
                             Optional.empty(),
                             ImmutableList.of(project),

--- a/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkPageProcessor2.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkPageProcessor2.java
@@ -117,11 +117,11 @@ public class BenchmarkPageProcessor2
         types = projections.stream().map(Expression::type).collect(toList());
 
         PageFunctionCompiler pageFunctionCompiler = new PageFunctionCompiler(FUNCTION_MANAGER, METADATA, TYPE_MANAGER, 0);
-        ColumnarFilterCompiler columnarFilterCompiler = new ColumnarFilterCompiler(FUNCTION_MANAGER, METADATA, 0);
+        ColumnarFilterCompiler columnarFilterCompiler = new ColumnarFilterCompiler(FUNCTIONS.getPlannerContext(), 0);
 
         inputPage = createPage(types, dictionaryBlocks);
         pageProcessor = new ExpressionCompiler(pageFunctionCompiler, columnarFilterCompiler)
-                .compilePageProcessor(true, Optional.of(getFilter(type)), Optional.empty(), projections, sourceLayout, Optional.empty(), OptionalInt.empty())
+                .compilePageProcessor(true, true, Optional.of(getFilter(type)), Optional.empty(), projections, sourceLayout, Optional.empty(), OptionalInt.empty())
                 .apply(DynamicFilter.EMPTY);
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestColumnarFilters.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestColumnarFilters.java
@@ -443,7 +443,7 @@ public class TestColumnarFilters
         TestingSourcePage testingPage = new TestingSourcePage(100,
                 createLongSequenceBlock(0, 100),
                 createLongSequenceBlock(0, 100));
-        FilterEvaluator filterEvaluator = createColumnarFilterEvaluator(andFilter, layout, COMPILER).orElseThrow().get();
+        FilterEvaluator filterEvaluator = createColumnarFilterEvaluator(andFilter, layout, COMPILER, true).orElseThrow().get();
         filterEvaluator.evaluate(FULL_CONNECTOR_SESSION, SelectedPositions.positionsRange(0, 100), testingPage);
 
         // col_b (channel 1) should not have been loaded because the first conjunct returned no positions
@@ -470,7 +470,7 @@ public class TestColumnarFilters
         TestingSourcePage testingPage = new TestingSourcePage(100,
                 createLongSequenceBlock(0, 100),
                 createLongSequenceBlock(0, 100));
-        FilterEvaluator filterEvaluator = createColumnarFilterEvaluator(orFilter, layout, COMPILER).orElseThrow().get();
+        FilterEvaluator filterEvaluator = createColumnarFilterEvaluator(orFilter, layout, COMPILER, true).orElseThrow().get();
         filterEvaluator.evaluate(FULL_CONNECTOR_SESSION, SelectedPositions.positionsRange(0, 100), testingPage);
 
         // col_b (channel 1) should not have been loaded because the first conjunct selected all rows
@@ -668,10 +668,11 @@ public class TestColumnarFilters
         return call(FUNCTION_RESOLUTION.resolveFunction("$not", fromTypes(BOOLEAN)), expression);
     }
 
-    private static List<Page> processFilter(List<Page> inputPages, boolean columnarEvaluationEnabled, Expression filter)
+    private static List<Page> processFilter(List<Page> inputPages, boolean columnarEvaluationEnabled, boolean filterReorderingEnabled, Expression filter)
     {
         PageProcessor compiledProcessor = FUNCTION_RESOLUTION.getExpressionCompiler().compilePageProcessor(
                         columnarEvaluationEnabled,
+                        filterReorderingEnabled,
                         Optional.of(filter),
                         Optional.empty(),
                         ImmutableList.of(new Reference(BIGINT, COL_ROW_NUM)),
@@ -921,8 +922,17 @@ public class TestColumnarFilters
 
     private static void verifyFilterInternal(List<Page> inputPages, Expression filter)
     {
-        List<Page> outputPagesExpected = processFilter(inputPages, false, filter);
-        List<Page> outputPagesActual = processFilter(inputPages, true, filter);
+        List<Page> outputPagesExpected = processFilter(inputPages, false, false, filter);
+        // Without filter reordering
+        List<Page> outputPagesActual = processFilter(inputPages, true, false, filter);
+        assertThat(outputPagesExpected).hasSize(outputPagesActual.size());
+
+        for (int pageCount = 0; pageCount < outputPagesActual.size(); pageCount++) {
+            assertPageEquals(ImmutableList.of(BIGINT), outputPagesActual.get(pageCount), outputPagesExpected.get(pageCount));
+        }
+
+        // With filter reordering
+        outputPagesActual = processFilter(inputPages, true, true, filter);
         assertThat(outputPagesExpected).hasSize(outputPagesActual.size());
 
         for (int pageCount = 0; pageCount < outputPagesActual.size(); pageCount++) {
@@ -943,12 +953,12 @@ public class TestColumnarFilters
 
     private static void assertThatColumnarFilterEvaluationIsSupported(Expression filterExpression)
     {
-        assertThat(createColumnarFilterEvaluator(filterExpression, LAYOUT, COMPILER)).isPresent();
+        assertThat(createColumnarFilterEvaluator(filterExpression, LAYOUT, COMPILER, true)).isPresent();
     }
 
     private static void assertThatColumnarFilterEvaluationIsNotSupported(Expression filterExpression)
     {
-        assertThat(createColumnarFilterEvaluator(filterExpression, LAYOUT, COMPILER)).isEmpty();
+        assertThat(createColumnarFilterEvaluator(filterExpression, LAYOUT, COMPILER, true)).isEmpty();
     }
 
     @ScalarFunction("custom_is_distinct_from")

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestDynamicPageFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestDynamicPageFilter.java
@@ -55,7 +55,6 @@ import static io.trino.block.BlockAssertions.createLongsBlock;
 import static io.trino.block.BlockAssertions.createRowBlock;
 import static io.trino.block.BlockAssertions.createStringsBlock;
 import static io.trino.block.BlockAssertions.createTypedLongsBlock;
-import static io.trino.metadata.FunctionManager.createTestingFunctionManager;
 import static io.trino.operator.project.SelectedPositions.positionsRange;
 import static io.trino.spi.predicate.Domain.multipleValues;
 import static io.trino.spi.predicate.Domain.onlyNull;
@@ -75,7 +74,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestDynamicPageFilter
 {
-    private static final ColumnarFilterCompiler COMPILER = new ColumnarFilterCompiler(createTestingFunctionManager(), PLANNER_CONTEXT.getMetadata(), new CompilerConfig());
+    private static final ColumnarFilterCompiler COMPILER = new ColumnarFilterCompiler(PLANNER_CONTEXT, new CompilerConfig());
     private static final Session SESSION = testSessionBuilder().build();
     private static final FullConnectorSession FULL_CONNECTOR_SESSION = new FullConnectorSession(
             testSessionBuilder().build(),
@@ -280,7 +279,8 @@ public class TestDynamicPageFilter
                 SESSION,
                 ImmutableMap.of(symbolA, columnA, symbolB, columnB, symbolC, columnC),
                 ImmutableMap.of(symbolA, 0, symbolB, 1, symbolC, 2),
-                1);
+                1,
+                true);
         SourcePage page = SourcePage.create(new Page(
                 createLongSequenceBlock(0, 101),
                 createLongSequenceBlock(100, 201),
@@ -323,7 +323,8 @@ public class TestDynamicPageFilter
                 SESSION,
                 ImmutableMap.of(symbolA, columnA, symbolB, columnB, symbolC, columnC),
                 ImmutableMap.of(symbolA, 0, symbolB, 1, symbolC, 2),
-                1);
+                1,
+                true);
         SourcePage page = SourcePage.create(new Page(
                 createLongSequenceBlock(0, 101),
                 createLongSequenceBlock(100, 201),

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestFilterReorderingProfiler.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestFilterReorderingProfiler.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.gen;
+
+import io.trino.sql.gen.columnar.FilterReorderingProfiler;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestFilterReorderingProfiler
+{
+    @Test
+    void testReorderingDisabled()
+    {
+        FilterReorderingProfiler profiler = new FilterReorderingProfiler(3, false);
+        profiler.addFilterMetrics(2, 100, 10_000);
+        profiler.addFilterMetrics(1, 100, 1_000);
+        profiler.addFilterMetrics(0, 100, 100);
+
+        profiler.reorderFilters(10_000);
+        assertThat(profiler.getFilterOrder()).containsExactly(0, 1, 2);
+    }
+
+    @Test
+    void testNoReordering()
+    {
+        FilterReorderingProfiler profiler = new FilterReorderingProfiler(3, true);
+        profiler.addFilterMetrics(0, 100, 10_000);
+        profiler.addFilterMetrics(1, 100, 1_000);
+        profiler.addFilterMetrics(2, 100, 100);
+
+        profiler.reorderFilters(10_000);
+        assertThat(profiler.getFilterOrder()).containsExactly(0, 1, 2);
+    }
+
+    @Test
+    void testReorderingBySelectivity()
+    {
+        FilterReorderingProfiler profiler = new FilterReorderingProfiler(3, true);
+        profiler.addFilterMetrics(2, 100, 10_000);
+        profiler.addFilterMetrics(1, 100, 1_000);
+        profiler.addFilterMetrics(0, 100, 100);
+
+        profiler.reorderFilters(10_000);
+        assertThat(profiler.getFilterOrder()).containsExactly(2, 1, 0);
+    }
+
+    @Test
+    void testReorderingByTimeTaken()
+    {
+        FilterReorderingProfiler profiler = new FilterReorderingProfiler(3, true);
+        profiler.addFilterMetrics(0, 1000, 10_000);
+        profiler.addFilterMetrics(1, 100, 10_000);
+        profiler.addFilterMetrics(2, 10, 10_000);
+
+        profiler.reorderFilters(10_000);
+        assertThat(profiler.getFilterOrder()).containsExactly(2, 1, 0);
+    }
+
+    @Test
+    void testReorderingByTimeTakenPerFilteredPosition()
+    {
+        FilterReorderingProfiler profiler = new FilterReorderingProfiler(3, true);
+        profiler.addFilterMetrics(0, 1000, 8_000);
+        profiler.addFilterMetrics(1, 700, 6_000);
+        profiler.addFilterMetrics(2, 600, 4_000);
+
+        profiler.reorderFilters(9_000);
+        assertThat(profiler.getFilterOrder()).containsExactly(1, 0, 2);
+    }
+
+    @Test
+    void testMinSampleSize()
+    {
+        FilterReorderingProfiler profiler = new FilterReorderingProfiler(3, true);
+        profiler.addFilterMetrics(0, 1000, 800);
+        profiler.addFilterMetrics(1, 700, 600);
+        profiler.addFilterMetrics(2, 600, 400);
+
+        profiler.reorderFilters(800);
+        assertThat(profiler.getFilterOrder()).containsExactly(0, 1, 2);
+
+        profiler.addFilterMetrics(0, 1000, 800);
+        profiler.addFilterMetrics(1, 700, 600);
+        profiler.addFilterMetrics(2, 600, 400);
+
+        profiler.reorderFilters(800);
+        assertThat(profiler.getFilterOrder()).containsExactly(0, 1, 2);
+
+        profiler.addFilterMetrics(0, 1000, 1_000);
+        profiler.addFilterMetrics(1, 700, 2_000);
+        profiler.addFilterMetrics(2, 600, 3_000);
+
+        profiler.reorderFilters(7_000);
+        assertThat(profiler.getFilterOrder()).containsExactly(2, 1, 0);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/gen/columnar/TestFilterReorderingSafety.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/columnar/TestFilterReorderingSafety.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.gen.columnar;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.ir.Comparison;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.Logical;
+import io.trino.sql.ir.Reference;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.spi.function.OperatorType.DIVIDE;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.gen.columnar.FilterEvaluator.isReorderingSafe;
+import static io.trino.sql.ir.Comparison.Operator.GREATER_THAN;
+import static io.trino.sql.ir.IrExpressions.call;
+import static io.trino.sql.ir.Logical.Operator.OR;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestFilterReorderingSafety
+{
+    private static final TestingFunctionResolution FUNCTION_RESOLUTION = new TestingFunctionResolution();
+    private static final PlannerContext PLANNER_CONTEXT = FUNCTION_RESOLUTION.getPlannerContext();
+    private static final Reference REF_A = new Reference(BIGINT, "a");
+    private static final Reference REF_B = new Reference(BIGINT, "b");
+    private static final Expression SAFE_A = new Comparison(GREATER_THAN, REF_A, new Constant(BIGINT, 0L));
+    private static final Expression SAFE_B = new Comparison(GREATER_THAN, REF_B, new Constant(BIGINT, 0L));
+
+    @Test
+    void testAllTermsSafe()
+    {
+        assertThat(isReorderingSafe(PLANNER_CONTEXT, ImmutableList.of(SAFE_A, SAFE_B))).isTrue();
+    }
+
+    @Test
+    void testUnsafeTermDisablesReordering()
+    {
+        ResolvedFunction divide = FUNCTION_RESOLUTION.resolveOperator(DIVIDE, ImmutableList.of(BIGINT, BIGINT));
+        Expression unsafe = new Comparison(GREATER_THAN, call(divide, new Constant(BIGINT, 100L), REF_B), new Constant(BIGINT, 0L));
+        assertThat(isReorderingSafe(PLANNER_CONTEXT, ImmutableList.of(SAFE_A, unsafe))).isFalse();
+    }
+
+    @Test
+    void testNestedLogicalWithUnsafeTerm()
+    {
+        ResolvedFunction divide = FUNCTION_RESOLUTION.resolveOperator(DIVIDE, ImmutableList.of(BIGINT, BIGINT));
+        Expression unsafe = new Comparison(GREATER_THAN, call(divide, new Constant(BIGINT, 100L), REF_B), new Constant(BIGINT, 0L));
+        Expression nested = new Logical(OR, ImmutableList.of(SAFE_B, unsafe));
+        assertThat(isReorderingSafe(PLANNER_CONTEXT, ImmutableList.of(SAFE_A, nested))).isFalse();
+    }
+
+    @Test
+    void testSafeDivisionByNonZeroConstant()
+    {
+        ResolvedFunction divide = FUNCTION_RESOLUTION.resolveOperator(DIVIDE, ImmutableList.of(BIGINT, BIGINT));
+        Expression safeDiv = new Comparison(GREATER_THAN, call(divide, REF_A, new Constant(BIGINT, 2L)), new Constant(BIGINT, 0L));
+        assertThat(isReorderingSafe(PLANNER_CONTEXT, ImmutableList.of(SAFE_B, safeDiv))).isTrue();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/util/DynamicFiltersTestUtil.java
+++ b/core/trino-main/src/test/java/io/trino/util/DynamicFiltersTestUtil.java
@@ -36,7 +36,6 @@ import java.util.stream.LongStream;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.airlift.concurrent.MoreFutures.unmodifiableFuture;
-import static io.trino.metadata.FunctionManager.createTestingFunctionManager;
 import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.lang.String.format;
@@ -105,8 +104,9 @@ public final class DynamicFiltersTestUtil
                 testSessionBuilder().build(),
                 columns.buildOrThrow(),
                 layout.buildOrThrow(),
-                selectivityThreshold)
-                .createDynamicPageFilterEvaluator(new ColumnarFilterCompiler(createTestingFunctionManager(), PLANNER_CONTEXT.getMetadata(), 0), dynamicFilter)
+                selectivityThreshold,
+                true)
+                .createDynamicPageFilterEvaluator(new ColumnarFilterCompiler(PLANNER_CONTEXT, 0), dynamicFilter)
                 .get();
     }
 

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/BenchmarkColumnarFilterParquetData.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/BenchmarkColumnarFilterParquetData.java
@@ -42,6 +42,7 @@ import io.trino.sql.planner.Symbol;
 import io.trino.tpch.LineItem;
 import io.trino.tpch.LineItemColumn;
 import io.trino.tpch.TpchColumn;
+import io.trino.type.LikePattern;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
@@ -73,8 +74,10 @@ import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static io.trino.sql.ir.IrExpressions.call;
 import static io.trino.tpch.TpchTable.LINE_ITEM;
+import static io.trino.type.LikePatternType.LIKE_PATTERN;
 
 @State(Scope.Thread)
 @OutputTimeUnit(TimeUnit.SECONDS)
@@ -90,19 +93,23 @@ public class BenchmarkColumnarFilterParquetData
     private static final Symbol SHIP_DATE_SYMBOL = new Symbol(DATE, "ship_date");
     private static final Symbol QUANTITY_SYMBOL = new Symbol(DOUBLE, "quantity");
     private static final Symbol SHIP_MODE_SYMBOL = new Symbol(VARCHAR, "ship_mode");
+    private static final Symbol COMMENT_SYMBOL = new Symbol(VARCHAR, "comment");
 
-    private static final Map<Symbol, Integer> LAYOUT = ImmutableMap.of(
-            EXTENDED_PRICE_SYMBOL, 0,
-            DISCOUNT_SYMBOL, 1,
-            SHIP_DATE_SYMBOL, 2,
-            QUANTITY_SYMBOL, 3,
-            SHIP_MODE_SYMBOL, 4);
+    private static final Map<Symbol, Integer> LAYOUT = ImmutableMap.<Symbol, Integer>builder()
+            .put(EXTENDED_PRICE_SYMBOL, 0)
+            .put(DISCOUNT_SYMBOL, 1)
+            .put(SHIP_DATE_SYMBOL, 2)
+            .put(QUANTITY_SYMBOL, 3)
+            .put(SHIP_MODE_SYMBOL, 4)
+            .put(COMMENT_SYMBOL, 5)
+            .buildOrThrow();
 
     private static final Reference EXTENDED_PRICE = new Reference(DOUBLE, EXTENDED_PRICE_SYMBOL.name());
     private static final Reference DISCOUNT = new Reference(DOUBLE, DISCOUNT_SYMBOL.name());
     private static final Reference SHIP_DATE = new Reference(DATE, SHIP_DATE_SYMBOL.name());
     private static final Reference QUANTITY = new Reference(DOUBLE, QUANTITY_SYMBOL.name());
     private static final Reference SHIP_MODE = new Reference(VARCHAR, SHIP_MODE_SYMBOL.name());
+    private static final Reference COMMENT = new Reference(VARCHAR, COMMENT_SYMBOL.name());
 
     private static final long MIN_SHIP_DATE = LocalDate.parse("1994-01-01").toEpochDay();
     private static final long MAX_SHIP_DATE = LocalDate.parse("1995-01-01").toEpochDay();
@@ -156,7 +163,22 @@ public class BenchmarkColumnarFilterParquetData
             {
                 return new In(SHIP_MODE, ImmutableList.of(new Constant(VARCHAR, SHIP), new Constant(VARCHAR, MAIL)));
             }
-        }
+        },
+        OR {
+            // where comment like 'fur%'
+            //    or discount >= 0.01
+            //    or quantity < 24;
+            @Override
+            Expression getExpression()
+            {
+                return new Logical(
+                        Logical.Operator.OR,
+                        ImmutableList.of(
+                                call(FUNCTION_RESOLUTION.resolveFunction("$like", fromTypes(VARCHAR, LIKE_PATTERN)), COMMENT, new Constant(LIKE_PATTERN, LikePattern.compile("fur%", Optional.empty()))),
+                                call(FUNCTION_RESOLUTION.resolveOperator(LESS_THAN_OR_EQUAL, ImmutableList.of(DOUBLE, DOUBLE)), new Constant(DOUBLE, 0.01), DISCOUNT),
+                                call(FUNCTION_RESOLUTION.resolveOperator(LESS_THAN, ImmutableList.of(DOUBLE, DOUBLE)), QUANTITY, new Constant(DOUBLE, 24.0))));
+            }
+        },
         /**/;
 
         abstract Expression getExpression();
@@ -170,6 +192,7 @@ public class BenchmarkColumnarFilterParquetData
         ExpressionCompiler expressionCompiler = FUNCTION_RESOLUTION.getExpressionCompiler();
         compiledProcessor = expressionCompiler.compilePageProcessor(
                         columnarEvaluationEnabled,
+                        true,
                         Optional.of(filterExpression),
                         Optional.empty(),
                         ImmutableList.of(EXTENDED_PRICE),
@@ -183,7 +206,8 @@ public class BenchmarkColumnarFilterParquetData
                 LineItemColumn.DISCOUNT,
                 LineItemColumn.SHIP_DATE,
                 LineItemColumn.QUANTITY,
-                LineItemColumn.SHIP_MODE);
+                LineItemColumn.SHIP_MODE,
+                LineItemColumn.COMMENT);
         BenchmarkParquetFormatUtils.TestData testData = createTpchDataSet(LINE_ITEM, columns);
 
         dataSource = new TestingParquetDataSource(


### PR DESCRIPTION
## Description
Score sub-filters in an AND/OR expression by time taken per filtered position and reorder them to place most effective filters first.
```
Benchmark                                    (columnarEvaluationEnabled)   Mode  Cnt  Before Score    After Score     Units
BenchmarkAndColumnarFilterTpchData.compiled                         true  thrpt   20  10.568 ± 0.249  53.452 ± 1.006  ops/s

Benchmark                                    (columnarEvaluationEnabled)  (filterProvider)   Mode  Cnt  Before Score    After Score     Units
BenchmarkColumnarFilterParquetData.compiled                         true               AND  thrpt   20  84.269 ± 0.735  86.711 ± 0.282  ops/s
BenchmarkColumnarFilterParquetData.compiled                         true                OR  thrpt   20  33.679 ± 0.327  39.576 ± 0.856  ops/s
```

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Improve performance of simple `AND` and `OR` filters with highly selective terms. ({issue}`issuenumber`)
```
