### PR TITLE
Update final query info at the end of DDL statement execution

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/DataDefinitionExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DataDefinitionExecution.java
@@ -149,6 +149,11 @@ public class DataDefinitionExecution<T extends Statement>
                 @Override
                 public void onSuccess(@Nullable Void result)
                 {
+                    stateMachine.addStateChangeListener(newState -> {
+                        if (newState.isDone()) {
+                            stateMachine.updateQueryInfo(Optional.empty());
+                        }
+                    });
                     stateMachine.transitionToFinishing();
                 }
 

--- a/core/trino-main/src/main/java/io/trino/testing/StandaloneQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/StandaloneQueryRunner.java
@@ -105,17 +105,17 @@ public final class StandaloneQueryRunner
     @Override
     public MaterializedResult execute(Session session, @Language("SQL") String sql)
     {
-        return executeInternal(session, sql).result();
+        return executeUnmaterialized(session, sql).result().get();
     }
 
     @Override
     public MaterializedResultWithPlan executeWithPlan(Session session, String sql)
     {
-        TestingDirectTrinoClient.Result result = executeInternal(session, sql);
-        return new MaterializedResultWithPlan(result.queryId(), server.getQueryPlan(result.queryId()), result.result());
+        TestingDirectTrinoClient.Result result = executeUnmaterialized(session, sql);
+        return new MaterializedResultWithPlan(result.queryId(), server.getQueryPlan(result.queryId()), result.result().get());
     }
 
-    private TestingDirectTrinoClient.Result executeInternal(Session session, @Language("SQL") String sql)
+    public TestingDirectTrinoClient.Result executeUnmaterialized(Session session, @Language("SQL") String sql)
     {
         lock.readLock().lock();
         try {

--- a/core/trino-main/src/main/java/io/trino/testing/TestingDirectTrinoClient.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingDirectTrinoClient.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.execution.QueryState.FINISHED;
@@ -73,7 +74,7 @@ public class TestingDirectTrinoClient
             throw new QueryFailedException(dispatchQuery.getQueryId(), Optional.ofNullable(remoteException.getMessage()).orElseGet(remoteException::toString), remoteException);
         }
 
-        return new Result(dispatchQuery.getQueryId(), toMaterializedRows(dispatchQuery, queryResultsListener.columnTypes(), queryResultsListener.columnNames(), queryResultsListener.pages()));
+        return new Result(dispatchQuery.getQueryId(), () -> toMaterializedRows(dispatchQuery, queryResultsListener.columnTypes(), queryResultsListener.columnNames(), queryResultsListener.pages()));
     }
 
     private static MaterializedResult toMaterializedRows(DispatchQuery dispatchQuery, List<Type> columnTypes, List<String> columnNames, List<Page> pages)
@@ -139,9 +140,9 @@ public class TestingDirectTrinoClient
         return rows.build();
     }
 
-    record Result(QueryId queryId, MaterializedResult result)
+    public record Result(QueryId queryId, Supplier<MaterializedResult> result)
     {
-        Result
+        public Result
         {
             requireNonNull(queryId, "queryId is null");
             requireNonNull(result, "result is null");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

For the DML statements, this is handled by the schedulers (pipelined and FTE) by registering a "final query info" listener on query execution stages. Stages don't exist for DDL statements, so no listener like this was installed; the final query info was not updated; and this caused the "query completed" event not to be fired...

...however, this was not a problem in practice, because `DataDefinitionExecution#getQueryInfo` updates the final query info "just in case" it's not present yet. And, as it turns out, every client right now calls this method after the query is finished (via `DispatchQuery#getFullQueryInfo`) to get the results, even for DDL statements. This covered the problem so well that it hasn't been found until now.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This is easy to expose with `DirectTrinoClient` as it does not force the users to call `DispatchQuery#getFullQueryInfo`.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix missing "query completed" event for DDL statements in some situations. ({issue}`issuenumber`)
```
