### PR TITLE
Add operation_metrics to $history table in Delta Lake

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.md
+++ b/docs/src/main/sphinx/connector/delta-lake.md
@@ -752,11 +752,11 @@ SELECT * FROM "test_table$history"
 ```
 
 ```text
- version |               timestamp               | user_id | user_name |  operation   |         operation_parameters          |                 cluster_id      | read_version |  isolation_level  | is_blind_append
----------+---------------------------------------+---------+-----------+--------------+---------------------------------------+---------------------------------+--------------+-------------------+----------------
-       2 | 2023-01-19 07:40:54.684 Europe/Vienna | trino   | trino     | WRITE        | {queryId=20230119_064054_00008_4vq5t} | trino-406-trino-coordinator     |            2 | WriteSerializable | true
-       1 | 2023-01-19 07:40:41.373 Europe/Vienna | trino   | trino     | ADD COLUMNS  | {queryId=20230119_064041_00007_4vq5t} | trino-406-trino-coordinator     |            0 | WriteSerializable | true
-       0 | 2023-01-19 07:40:10.497 Europe/Vienna | trino   | trino     | CREATE TABLE | {queryId=20230119_064010_00005_4vq5t} | trino-406-trino-coordinator     |            0 | WriteSerializable | true
+ version |               timestamp               | user_id | user_name |  operation   |         operation_parameters          |                 cluster_id      | read_version |  isolation_level  | is_blind_append | operation_metrics              
+---------+---------------------------------------+---------+-----------+--------------+---------------------------------------+---------------------------------+--------------+-------------------+-----------------+-------------------
+       2 | 2023-01-19 07:40:54.684 Europe/Vienna | trino   | trino     | WRITE        | {queryId=20230119_064054_00008_4vq5t} | trino-406-trino-coordinator     |            2 | WriteSerializable | true            | {}
+       1 | 2023-01-19 07:40:41.373 Europe/Vienna | trino   | trino     | ADD COLUMNS  | {queryId=20230119_064041_00007_4vq5t} | trino-406-trino-coordinator     |            0 | WriteSerializable | true            | {}
+       0 | 2023-01-19 07:40:10.497 Europe/Vienna | trino   | trino     | CREATE TABLE | {queryId=20230119_064010_00005_4vq5t} | trino-406-trino-coordinator     |            0 | WriteSerializable | true            | {}
 ```
 
 The output of the query has the following history columns:
@@ -798,7 +798,10 @@ The output of the query has the following history columns:
 * - `is_blind_append`
   - `BOOLEAN`
   - Whether or not the operation appended data
-:::
+* - `operation_metrics`
+  - `map(VARCHAR, VARCHAR)`
+  - Metrics of the operation
+  :::
 
 (delta-lake-partitions-table)=
 ##### `$partitions` table

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeHistoryTable.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeHistoryTable.java
@@ -68,7 +68,8 @@ public class DeltaLakeHistoryTable
                                 .add(new ColumnMetadata("read_version", BIGINT))
                                 .add(new ColumnMetadata("isolation_level", VARCHAR))
                                 .add(new ColumnMetadata("is_blind_append", BOOLEAN))
-                                //TODO add support for operationMetrics, userMetadata, engineInfo
+                                .add(new ColumnMetadata("operation_metrics", typeManager.getType(mapType(VARCHAR.getTypeSignature(), VARCHAR.getTypeSignature()))))
+                                //TODO add support for userMetadata, engineInfo
                                 .build()));
     }
 
@@ -101,7 +102,12 @@ public class DeltaLakeHistoryTable
             pagesBuilder.appendBigint(commitInfoEntry.readVersion());
             write(commitInfoEntry.isolationLevel(), pagesBuilder);
             commitInfoEntry.isBlindAppend().ifPresentOrElse(pagesBuilder::appendBoolean, pagesBuilder::appendNull);
-
+            if (commitInfoEntry.operationMetrics() == null) {
+                pagesBuilder.appendNull();
+            }
+            else {
+                pagesBuilder.appendVarcharVarcharMap(commitInfoEntry.operationMetrics());
+            }
             pagesBuilder.endRow();
         });
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSystemTables.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSystemTables.java
@@ -73,7 +73,8 @@ public class TestDeltaLakeSystemTables
                     ('cluster_id', 'varchar', '', ''),
                     ('read_version', 'bigint', '', ''),
                     ('isolation_level', 'varchar', '', ''),
-                    ('is_blind_append', 'boolean', '', '')
+                    ('is_blind_append', 'boolean', '', ''),
+                    ('operation_metrics', 'map(varchar, varchar)', '', '')
                     """);
 
             // Test the contents of history system table


### PR DESCRIPTION
## Release notes

```markdown
## Delta Lake
* Add `operation_metrics` column to`$history` metadata table.
```
