### PR TITLE
Move Vertica module to separate CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,7 +379,8 @@ jobs:
             !:trino-sqlserver,
             !:trino-test-jdbc-compatibility-old-server,
             !:trino-tests,
-            !:trino-thrift'
+            !:trino-thrift,
+            !:trino-vertica'
       - name: Upload test results
         uses: ./.github/actions/process-test-results
         if: always()
@@ -482,6 +483,7 @@ jobs:
             - { modules: plugin/trino-snowflake }
             - { modules: plugin/trino-snowflake, profile: cloud-tests }
             - { modules: plugin/trino-sqlserver }
+            - { modules: plugin/trino-vertica }
             - { modules: testing/trino-faulttolerant-tests, profile: default }
             - { modules: testing/trino-faulttolerant-tests, profile: test-fault-tolerant-delta }
             - { modules: testing/trino-faulttolerant-tests, profile: test-fault-tolerant-hive }


### PR DESCRIPTION
## Description

The tests take ~5 minutes, so that warrants its own job, rather than running in `test-other-modules`.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
