### PR TITLE
Test Alluxio modules as part of file system job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,6 +344,8 @@ jobs:
             !:trino-exasol,
             !:trino-faulttolerant-tests,
             !:trino-filesystem,
+            !:trino-filesystem-alluxio,
+            !:trino-filesystem-cache-alluxio,
             !:trino-filesystem-azure,
             !:trino-filesystem-gcs,
             !:trino-filesystem-manager,
@@ -435,6 +437,8 @@ jobs:
             - modules:
                 - lib/trino-filesystem
                 - lib/trino-filesystem-azure
+                - lib/trino-filesystem-alluxio
+                - lib/trino-filesystem-cache-alluxio
                 - lib/trino-filesystem-manager
                 - lib/trino-filesystem-s3
                 - lib/trino-hdfs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,6 +439,7 @@ jobs:
                 - lib/trino-filesystem-azure
                 - lib/trino-filesystem-alluxio
                 - lib/trino-filesystem-cache-alluxio
+                - lib/trino-filesystem-gcs
                 - lib/trino-filesystem-manager
                 - lib/trino-filesystem-s3
                 - lib/trino-hdfs

--- a/lib/trino-filesystem-gcs/pom.xml
+++ b/lib/trino-filesystem-gcs/pom.xml
@@ -194,7 +194,8 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <excludes>
-                                <exclude>**/TestGcsFileSystem*.java</exclude>
+                                <exclude>**/TestGcsFileSystem.java</exclude>
+                                <exclude>**/TestGcsFileSystemWithEncryption.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>
@@ -211,7 +212,8 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <includes>
-                                <include>**/TestGcsFileSystem*.java</include>
+                                <include>**/TestGcsFileSystem.java</include>
+                                <include>**/TestGcsFileSystemWithEncryption.java</include>
                             </includes>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
## Description

Group related modules and minimize time for `test-other-modules`.

This also fixes `trino-filesystem-gcs` which wasn't running the non-cloud tests.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
