### PR TITLE
Clean up naming of ranger plugin properties

### DIFF
--- a/docs/src/main/sphinx/security/apache-ranger-access-control.md
+++ b/docs/src/main/sphinx/security/apache-ranger-access-control.md
@@ -15,7 +15,7 @@ To use only Ranger for access control, create the file `etc/access-control.prope
 with the following configuration, and configurations listed in the table below:
 
 ```properties
-access-control.name=apache-ranger
+access-control.name=ranger
 ```
 
 
@@ -39,11 +39,11 @@ The following table lists the configuration properties for the Ranger access con
 
 * - Name
   - Description
-* - `apache-ranger.service.name`
+* - `ranger.service.name`
   - Name of the service having policies to be enforced by the plugin
-* - `apache-ranger.plugin.config.resource`
+* - `ranger.plugin.config.resource`
   - List of Ranger plugin configuration files, comma separated. Relative paths will be resolved dynamically by searching in the classpath.
-* - `apache-ranger.hadoop.config.resource`
+* - `ranger.hadoop.config.resource`
   - List of Hadoop configuration files, comma separated. Relative paths will be resolved dynamically by searching in the classpath.
 :::
 

--- a/plugin/trino-ranger/src/main/java/io/trino/plugin/ranger/RangerConfig.java
+++ b/plugin/trino-ranger/src/main/java/io/trino/plugin/ranger/RangerConfig.java
@@ -34,7 +34,7 @@ public class RangerConfig
         return serviceName;
     }
 
-    @Config("apache-ranger.service.name")
+    @Config("ranger.service.name")
     @ConfigDescription("Name of Ranger service containing policies to enforce")
     public RangerConfig setServiceName(String serviceName)
     {
@@ -47,7 +47,7 @@ public class RangerConfig
         return pluginConfigResource;
     }
 
-    @Config("apache-ranger.plugin.config.resource")
+    @Config("ranger.plugin.config.resource")
     @ConfigDescription("List of paths to Ranger plugin configuration files")
     public RangerConfig setPluginConfigResource(List<File> pluginConfigResource)
     {
@@ -60,7 +60,7 @@ public class RangerConfig
         return hadoopConfigResource;
     }
 
-    @Config("apache-ranger.hadoop.config.resource")
+    @Config("ranger.hadoop.config.resource")
     @ConfigDescription("List of paths to hadoop configuration files")
     @SuppressWarnings("unused")
     public RangerConfig setHadoopConfigResource(List<File> hadoopConfigResource)

--- a/plugin/trino-ranger/src/main/java/io/trino/plugin/ranger/RangerSystemAccessControl.java
+++ b/plugin/trino-ranger/src/main/java/io/trino/plugin/ranger/RangerSystemAccessControl.java
@@ -138,7 +138,7 @@ public class RangerSystemAccessControl
     public RangerSystemAccessControl(RangerConfig config)
             throws Exception
     {
-        checkArgument(!isNullOrEmpty(config.getServiceName()), "apache-ranger.service.name is not configured");
+        checkArgument(!isNullOrEmpty(config.getServiceName()), "ranger.service.name is not configured");
 
         Configuration hadoopConf = new Configuration();
 

--- a/plugin/trino-ranger/src/main/java/io/trino/plugin/ranger/RangerSystemAccessControlFactory.java
+++ b/plugin/trino-ranger/src/main/java/io/trino/plugin/ranger/RangerSystemAccessControlFactory.java
@@ -27,7 +27,7 @@ import static java.util.Objects.requireNonNull;
 public class RangerSystemAccessControlFactory
         implements SystemAccessControlFactory
 {
-    private static final String NAME = "apache-ranger";
+    private static final String NAME = "ranger";
 
     @Override
     public String getName()

--- a/plugin/trino-ranger/src/test/java/io/trino/plugin/ranger/TestApacheRangerPlugin.java
+++ b/plugin/trino-ranger/src/test/java/io/trino/plugin/ranger/TestApacheRangerPlugin.java
@@ -29,6 +29,6 @@ final class TestApacheRangerPlugin
     {
         Plugin plugin = new ApacheRangerPlugin();
         SystemAccessControlFactory factory = getOnlyElement(plugin.getSystemAccessControlFactories());
-        factory.create(Map.of("apache-ranger.service.name", "trino"), new TestingSystemAccessControlContext()).shutdown();
+        factory.create(Map.of("ranger.service.name", "trino"), new TestingSystemAccessControlContext()).shutdown();
     }
 }

--- a/plugin/trino-ranger/src/test/java/io/trino/plugin/ranger/TestRangerConfig.java
+++ b/plugin/trino-ranger/src/test/java/io/trino/plugin/ranger/TestRangerConfig.java
@@ -44,9 +44,9 @@ final class TestRangerConfig
         Path hadoopConfigResourceFile = Files.createTempFile(null, null);
 
         Map<String, String> properties = ImmutableMap.<String, String>builder()
-                .put("apache-ranger.service.name", "trino")
-                .put("apache-ranger.plugin.config.resource", pluginConfigResourceFile.toString())
-                .put("apache-ranger.hadoop.config.resource", hadoopConfigResourceFile.toString())
+                .put("ranger.service.name", "trino")
+                .put("ranger.plugin.config.resource", pluginConfigResourceFile.toString())
+                .put("ranger.hadoop.config.resource", hadoopConfigResourceFile.toString())
                 .buildOrThrow();
 
         RangerConfig expected = new RangerConfig()


### PR DESCRIPTION
These were missed when renaming the plugin module

(x) Release notes are required, with the following suggested text:

```markdown
## Security

* TBD. ({issue}`24392`)
```
