### PR TITLE
Use executor service for iceberg scan planning system tables

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/AllManifestsTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/AllManifestsTable.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -38,7 +39,7 @@ import static org.apache.iceberg.MetadataTableType.ALL_MANIFESTS;
 public class AllManifestsTable
         extends BaseSystemTable
 {
-    public AllManifestsTable(SchemaTableName tableName, Table icebergTable)
+    public AllManifestsTable(SchemaTableName tableName, Table icebergTable, ExecutorService executor)
     {
         super(requireNonNull(icebergTable, "icebergTable is null"),
                 new ConnectorTableMetadata(requireNonNull(tableName, "tableName is null"), ImmutableList.<ColumnMetadata>builder()
@@ -55,7 +56,8 @@ public class AllManifestsTable
                                 RowType.field("lower_bound", VARCHAR),
                                 RowType.field("upper_bound", VARCHAR)))))
                         .build()),
-                ALL_MANIFESTS);
+                ALL_MANIFESTS,
+                executor);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -199,6 +199,7 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -404,6 +405,7 @@ public class IcebergMetadata
     private final Optional<HiveMetastoreFactory> metastoreFactory;
     private final boolean addFilesProcedureEnabled;
     private final Predicate<String> allowedExtraProperties;
+    private final ExecutorService executor;
 
     private final Map<IcebergTableHandle, AtomicReference<TableStatistics>> tableStatisticsCache = new ConcurrentHashMap<>();
 
@@ -419,7 +421,8 @@ public class IcebergMetadata
             TableStatisticsWriter tableStatisticsWriter,
             Optional<HiveMetastoreFactory> metastoreFactory,
             boolean addFilesProcedureEnabled,
-            Predicate<String> allowedExtraProperties)
+            Predicate<String> allowedExtraProperties,
+            ExecutorService executor)
     {
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.trinoCatalogHandle = requireNonNull(trinoCatalogHandle, "trinoCatalogHandle is null");
@@ -430,6 +433,7 @@ public class IcebergMetadata
         this.metastoreFactory = requireNonNull(metastoreFactory, "metastoreFactory is null");
         this.addFilesProcedureEnabled = addFilesProcedureEnabled;
         this.allowedExtraProperties = requireNonNull(allowedExtraProperties, "allowedExtraProperties is null");
+        this.executor = requireNonNull(executor, "executor is null");
     }
 
     @Override
@@ -689,14 +693,14 @@ public class IcebergMetadata
         return switch (tableType) {
             case DATA, MATERIALIZED_VIEW_STORAGE -> throw new VerifyException("Unexpected table type: " + tableType); // Handled above.
             case HISTORY -> Optional.of(new HistoryTable(tableName, table));
-            case METADATA_LOG_ENTRIES -> Optional.of(new MetadataLogEntriesTable(tableName, table));
-            case SNAPSHOTS -> Optional.of(new SnapshotsTable(tableName, typeManager, table));
-            case PARTITIONS -> Optional.of(new PartitionsTable(tableName, typeManager, table, getCurrentSnapshotId(table)));
-            case ALL_MANIFESTS -> Optional.of(new AllManifestsTable(tableName, table));
+            case METADATA_LOG_ENTRIES -> Optional.of(new MetadataLogEntriesTable(tableName, table, executor));
+            case SNAPSHOTS -> Optional.of(new SnapshotsTable(tableName, typeManager, table, executor));
+            case PARTITIONS -> Optional.of(new PartitionsTable(tableName, typeManager, table, getCurrentSnapshotId(table), executor));
+            case ALL_MANIFESTS -> Optional.of(new AllManifestsTable(tableName, table, executor));
             case MANIFESTS -> Optional.of(new ManifestsTable(tableName, table, getCurrentSnapshotId(table)));
-            case FILES -> Optional.of(new FilesTable(tableName, typeManager, table, getCurrentSnapshotId(table)));
+            case FILES -> Optional.of(new FilesTable(tableName, typeManager, table, getCurrentSnapshotId(table), executor));
             case PROPERTIES -> Optional.of(new PropertiesTable(tableName, table));
-            case REFS -> Optional.of(new RefsTable(tableName, table));
+            case REFS -> Optional.of(new RefsTable(tableName, table, executor));
         };
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadataFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadataFactory.java
@@ -25,6 +25,7 @@ import io.trino.spi.security.ConnectorIdentity;
 import io.trino.spi.type.TypeManager;
 
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Predicate;
 
 import static java.util.Objects.requireNonNull;
@@ -40,6 +41,7 @@ public class IcebergMetadataFactory
     private final Optional<HiveMetastoreFactory> metastoreFactory;
     private final boolean addFilesProcedureEnabled;
     private final Predicate<String> allowedExtraProperties;
+    private final ExecutorService executor;
 
     @Inject
     public IcebergMetadataFactory(
@@ -50,6 +52,7 @@ public class IcebergMetadataFactory
             IcebergFileSystemFactory fileSystemFactory,
             TableStatisticsWriter tableStatisticsWriter,
             @RawHiveMetastoreFactory Optional<HiveMetastoreFactory> metastoreFactory,
+            @ForIcebergScanPlanning ExecutorService executor,
             IcebergConfig config)
     {
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
@@ -59,6 +62,7 @@ public class IcebergMetadataFactory
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.tableStatisticsWriter = requireNonNull(tableStatisticsWriter, "tableStatisticsWriter is null");
         this.metastoreFactory = requireNonNull(metastoreFactory, "metastoreFactory is null");
+        this.executor = requireNonNull(executor, "executor is null");
         this.addFilesProcedureEnabled = config.isAddFilesProcedureEnabled();
         if (config.getAllowedExtraProperties().equals(ImmutableList.of("*"))) {
             this.allowedExtraProperties = _ -> true;
@@ -79,6 +83,7 @@ public class IcebergMetadataFactory
                 tableStatisticsWriter,
                 metastoreFactory,
                 addFilesProcedureEnabled,
-                allowedExtraProperties);
+                allowedExtraProperties,
+                executor);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/MetadataLogEntriesTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/MetadataLogEntriesTable.java
@@ -21,6 +21,8 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.type.TimeZoneKey;
 import org.apache.iceberg.Table;
 
+import java.util.concurrent.ExecutorService;
+
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
@@ -38,12 +40,13 @@ public class MetadataLogEntriesTable
     private static final String LATEST_SCHEMA_ID_COLUMN_NAME = "latest_schema_id";
     private static final String LATEST_SEQUENCE_NUMBER_COLUMN_NAME = "latest_sequence_number";
 
-    public MetadataLogEntriesTable(SchemaTableName tableName, Table icebergTable)
+    public MetadataLogEntriesTable(SchemaTableName tableName, Table icebergTable, ExecutorService executor)
     {
         super(
                 requireNonNull(icebergTable, "icebergTable is null"),
                 createConnectorTableMetadata(requireNonNull(tableName, "tableName is null")),
-                METADATA_LOG_ENTRIES);
+                METADATA_LOG_ENTRIES,
+                executor);
     }
 
     private static ConnectorTableMetadata createConnectorTableMetadata(SchemaTableName tableName)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/RefsTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/RefsTable.java
@@ -22,6 +22,7 @@ import io.trino.spi.type.TimeZoneKey;
 import org.apache.iceberg.Table;
 
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.IntegerType.INTEGER;
@@ -41,12 +42,13 @@ public class RefsTable
             .add(new ColumnMetadata("max_snapshot_age_in_ms", BIGINT))
             .build();
 
-    public RefsTable(SchemaTableName tableName, Table icebergTable)
+    public RefsTable(SchemaTableName tableName, Table icebergTable, ExecutorService executor)
     {
         super(
                 requireNonNull(icebergTable, "icebergTable is null"),
                 new ConnectorTableMetadata(requireNonNull(tableName, "tableName is null"), COLUMNS),
-                REFS);
+                REFS,
+                executor);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/SnapshotsTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/SnapshotsTable.java
@@ -24,6 +24,7 @@ import io.trino.spi.type.TypeSignature;
 import org.apache.iceberg.Table;
 
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
@@ -42,14 +43,15 @@ public class SnapshotsTable
     private static final String MANIFEST_LIST_COLUMN_NAME = "manifest_list";
     private static final String SUMMARY_COLUMN_NAME = "summary";
 
-    public SnapshotsTable(SchemaTableName tableName, TypeManager typeManager, Table icebergTable)
+    public SnapshotsTable(SchemaTableName tableName, TypeManager typeManager, Table icebergTable, ExecutorService executor)
     {
         super(
                 requireNonNull(icebergTable, "icebergTable is null"),
                 createConnectorTableMetadata(
                         requireNonNull(tableName, "tableName is null"),
                         requireNonNull(typeManager, "typeManager is null")),
-                SNAPSHOTS);
+                SNAPSHOTS,
+                executor);
     }
 
     private static ConnectorTableMetadata createConnectorTableMetadata(SchemaTableName tableName, TypeManager typeManager)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/BaseTrinoCatalogTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/BaseTrinoCatalogTest.java
@@ -48,6 +48,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
+import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static io.trino.metastore.TableInfo.ExtendedRelationType.TABLE;
 import static io.trino.metastore.TableInfo.ExtendedRelationType.TRINO_VIEW;
@@ -120,7 +121,8 @@ public abstract class BaseTrinoCatalogTest
                     new TableStatisticsWriter(new NodeVersion("test-version")),
                     Optional.empty(),
                     false,
-                    _ -> false);
+                    _ -> false,
+                    newDirectExecutorService());
             assertThat(icebergMetadata.schemaExists(SESSION, namespace)).as("icebergMetadata.schemaExists(namespace)")
                     .isFalse();
             assertThat(icebergMetadata.schemaExists(SESSION, schema)).as("icebergMetadata.schemaExists(schema)")

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestTrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestTrinoGlueCatalog.java
@@ -51,6 +51,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_FILE_SYSTEM_FACTORY;
 import static io.trino.plugin.iceberg.IcebergFileFormat.PARQUET;
@@ -139,7 +140,8 @@ public class TestTrinoGlueCatalog
                     new TableStatisticsWriter(new NodeVersion("test-version")),
                     Optional.empty(),
                     false,
-                    _ -> false);
+                    _ -> false,
+                    newDirectExecutorService());
             assertThat(icebergMetadata.schemaExists(SESSION, databaseName)).as("icebergMetadata.schemaExists(databaseName)")
                     .isFalse();
             assertThat(icebergMetadata.schemaExists(SESSION, trinoSchemaName)).as("icebergMetadata.schemaExists(trinoSchemaName)")

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestTrinoNessieCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestTrinoNessieCatalog.java
@@ -46,6 +46,7 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_FILE_SYSTEM_STATS;
@@ -189,7 +190,8 @@ public class TestTrinoNessieCatalog
                     new TableStatisticsWriter(new NodeVersion("test-version")),
                     Optional.empty(),
                     false,
-                    _ -> false);
+                    _ -> false,
+                    newDirectExecutorService());
             assertThat(icebergMetadata.schemaExists(SESSION, namespace)).as("icebergMetadata.schemaExists(namespace)")
                     .isTrue();
             assertThat(icebergMetadata.schemaExists(SESSION, schema)).as("icebergMetadata.schemaExists(schema)")

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
@@ -45,6 +45,7 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static io.trino.metastore.TableInfo.ExtendedRelationType.OTHER_VIEW;
 import static io.trino.plugin.iceberg.catalog.rest.IcebergRestCatalogConfig.SessionType.NONE;
@@ -127,7 +128,8 @@ public class TestTrinoRestCatalog
                     new TableStatisticsWriter(new NodeVersion("test-version")),
                     Optional.empty(),
                     false,
-                    _ -> false);
+                    _ -> false,
+                    newDirectExecutorService());
             assertThat(icebergMetadata.schemaExists(SESSION, namespace)).as("icebergMetadata.schemaExists(namespace)")
                     .isTrue();
             assertThat(icebergMetadata.schemaExists(SESSION, schema)).as("icebergMetadata.schemaExists(schema)")

--- a/plugin/trino-iceberg/src/test/java/org/apache/iceberg/snowflake/TestTrinoSnowflakeCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/org/apache/iceberg/snowflake/TestTrinoSnowflakeCatalog.java
@@ -58,6 +58,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static io.trino.plugin.iceberg.catalog.snowflake.TestIcebergSnowflakeCatalogConnectorSmokeTest.S3_ACCESS_KEY;
 import static io.trino.plugin.iceberg.catalog.snowflake.TestIcebergSnowflakeCatalogConnectorSmokeTest.S3_REGION;
@@ -223,7 +224,8 @@ public class TestTrinoSnowflakeCatalog
                 new TableStatisticsWriter(new NodeVersion("test-version")),
                 Optional.empty(),
                 false,
-                _ -> false);
+                _ -> false,
+                newDirectExecutorService());
         assertThat(icebergMetadata.schemaExists(SESSION, namespace)).as("icebergMetadata.schemaExists(namespace)")
                 .isTrue();
         assertThat(icebergMetadata.schemaExists(SESSION, schema)).as("icebergMetadata.schemaExists(schema)")


### PR DESCRIPTION
## Description
Use existing executor service for scans on system tables in iceberg to prevent excessive cpu/heap usage.
This is especially prevalent for system with high core count.
The existing code was using the threadpool of iceberg library for system tables and another threadpool provided by Trino for normal table scans.

## Additional context and related issues
https://trinodb.slack.com/archives/CJ6UC075E/p1733411820070579

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Avoid excessive resource usage on coordinator from iceberg system table scans. ({issue}`24396`)
```
