### PR TITLE
Deprecate iceberg.materialized-views.storage-schema property

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -160,12 +160,6 @@ implementation is used:
 * - `iceberg.hive-catalog-name`
   - Catalog to redirect to when a Hive table is referenced.
   -
-* - `iceberg.materialized-views.storage-schema`
-  - Schema for creating materialized views storage tables. When this property is
-    not configured, storage tables are created in the same schema as the
-    materialized view definition. When the `storage_schema` materialized view
-    property is specified, it takes precedence over this catalog property.
-  - Empty
 * - `iceberg.register-table-procedure.enabled`
   - Enable to allow user to call [`register_table` procedure](iceberg-register-table).
   - `false`
@@ -1677,8 +1671,7 @@ WITH ( format = 'ORC', partitioning = ARRAY['event_date'] )
 ```
 
 By default, the storage table is created in the same schema as the materialized
-view definition. The `iceberg.materialized-views.storage-schema` catalog
-configuration property or `storage_schema` materialized view property can be
+view definition. The `storage_schema` materialized view property can be
 used to specify the schema where the storage table is created.
 
 Creating a materialized view does not automatically populate it with data. You

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -406,12 +406,14 @@ public class IcebergConfig
         return this;
     }
 
+    @Deprecated
     @NotNull
     public Optional<String> getMaterializedViewsStorageSchema()
     {
         return materializedViewsStorageSchema;
     }
 
+    @Deprecated
     @Config("iceberg.materialized-views.storage-schema")
     @ConfigDescription("Schema for creating materialized views storage tables")
     public IcebergConfig setMaterializedViewsStorageSchema(String materializedViewsStorageSchema)


### PR DESCRIPTION
## Description

The recommended way of handling storage tables is to have `iceberg.materialized-views.hide-storage-table` set to true, and not use `iceberg.materialized-views.storage-schema`. `iceberg.materialized-views.hide-storage-table` is already deprecated. We should stick with the default behavior of hiding the storage table from end users, and not having to set a schema for storing them.

## Release notes

```markdown
## Iceberg
* Deprecate the `iceberg.materialized-views.storage-schema` configuration property. ({issue}`24398`)
```
