### PR TITLE
Rename docs to Ranger access control

### DIFF
--- a/docs/src/main/sphinx/redirects.txt
+++ b/docs/src/main/sphinx/redirects.txt
@@ -9,3 +9,4 @@ connector/hive-security.md object-storage/file-system-hdfs.md
 connector/atop.md connector/removed.md
 connector/localfile.md connector/removed.md
 connector/accumulo.md connector/removed.md
+security/apache-ranger-access-control.md security/ranger-access-control.md

--- a/docs/src/main/sphinx/release/release-466.md
+++ b/docs/src/main/sphinx/release/release-466.md
@@ -12,7 +12,7 @@
 ## Security
 
 * Add support for [data access control with Apache
-  Ranger](/security/apache-ranger-access-control), including support for
+  Ranger](/security/ranger-access-control), including support for
   column masking, row filtering, and audit logging. ({issue}`22675`)
 
 ## JDBC driver

--- a/docs/src/main/sphinx/security.md
+++ b/docs/src/main/sphinx/security.md
@@ -51,7 +51,7 @@ security/group-file
 security/built-in-system-access-control
 security/file-system-access-control
 security/opa-access-control
-security/apache-ranger-access-control
+security/ranger-access-control
 ```
 
 ## Security inside the cluster

--- a/docs/src/main/sphinx/security/built-in-system-access-control.md
+++ b/docs/src/main/sphinx/security/built-in-system-access-control.md
@@ -44,7 +44,7 @@ Trino offers the following built-in system access control implementations:
     [](/security/opa-access-control).
 * - `ranger`
   - Use Apache Ranger policies for authorization. See
-    [](/security/apache-ranger-access-control).
+    [](/security/ranger-access-control).
 :::
 
 If you want to limit access on a system level in any other way than the ones

--- a/docs/src/main/sphinx/security/overview.md
+++ b/docs/src/main/sphinx/security/overview.md
@@ -116,7 +116,7 @@ To implement access control, use:
   the catalog, schema, or table level.
 - [](opa-access-control), where you use Open Policy Agent to make access control
   decisions on a fined-grained level.
-- [](apache-ranger-access-control), where you use Apache Ranger to make fine-grained
+- [](ranger-access-control), where you use Apache Ranger to make fine-grained
   access control decisions, apply dynamic row-filters and column-masking at
   query execution time, and generate audit logs.
 

--- a/docs/src/main/sphinx/security/ranger-access-control.md
+++ b/docs/src/main/sphinx/security/ranger-access-control.md
@@ -1,6 +1,9 @@
-# Apache Ranger access control
+# Ranger access control
 
-The Apache Ranger access control plugin supports use of Apache Ranger policies to authorize data access in Trino on catalogs, schemas, tables, and columns. The plugin also supports column-masking, row-filtering and audit logging.
+The Ranger access control plugin supports use of [Apache
+Ranger](https://ranger.apache.org/) policies to authorize data access in Trino
+on catalogs, schemas, tables, and columns. The plugin also supports
+column-masking, row-filtering and audit logging.
 
 ## Requirements
 

--- a/docs/src/main/sphinx/security/ranger-access-control.md
+++ b/docs/src/main/sphinx/security/ranger-access-control.md
@@ -9,25 +9,28 @@ column-masking, row-filtering and audit logging.
 
 * Access to a Apache Ranger deployment with the desired authorization policies.
 * Access to an audit store using Solr, HDFS, Log4J, or S3 to save audit logs.
-* Apache Ranger 2.5.0 and greater include the required Trino service definition. Earlier versions of Apache Ranger require an update of the service definition available in the version [here](
-  https://github.com/apache/ranger/blob/ranger-2.5/agents-common/src/main/resources/service-defs/ranger-servicedef-trino.json).
+* Apache Ranger 2.5.0 and greater include the required Trino service definition.
+  Earlier versions of Apache Ranger require an [update to the service definition
+  available on
+  GitHub](https://github.com/apache/ranger/blob/ranger-2.5/agents-common/src/main/resources/service-defs/ranger-servicedef-trino.json).
 
 ## Configuration
 
-To use only Ranger for access control, create the file `etc/access-control.properties` on the coordinator,
-with the following configuration, and configurations listed in the table below:
+To use only Ranger for access control, create the file
+`etc/access-control.properties` on the coordinator, with the following
+configuration, and configurations listed in the table below:
 
 ```properties
 access-control.name=ranger
 ```
 
-
-To combine Ranger access control with file-based or other access control systems, create the file
-`etc/access-control.properties` on the coordinator, with the following configuration that lists
-multiple access control configuration file paths:
+To combine Ranger access control with file-based or other access control
+systems, create the file `etc/access-control.properties` on the coordinator,
+with the following configuration that lists multiple access control
+configuration file paths:
 
 ```properties
-access-control.config-files=etc/trino/file-based.properties,etc/trino/apache-ranger.properties
+access-control.config-files=etc/trino/file-based.properties,etc/trino/ranger.properties
 ```
 
 Order the configuration files list in the desired order of the different systems
@@ -36,22 +39,25 @@ specified files.
 
 The following table lists the configuration properties for the Ranger access control:
 
-:::{list-table} Apache Ranger access control configuration properties
+:::{list-table} Ranger access control configuration properties
 :widths: 30, 70
 :header-rows: 1
 
 * - Name
   - Description
 * - `ranger.service.name`
-  - Name of the service having policies to be enforced by the plugin
+  - Name of the service on Ranger with the policies to enforce.
 * - `ranger.plugin.config.resource`
-  - List of Ranger plugin configuration files, comma separated. Relative paths will be resolved dynamically by searching in the classpath.
+  - Comma-separated list of Ranger plugin configuration files. Relative paths
+    are resolved dynamically by searching on the classpath.
 * - `ranger.hadoop.config.resource`
-  - List of Hadoop configuration files, comma separated. Relative paths will be resolved dynamically by searching in the classpath.
+  - Comma-separated list of Hadoop configuration files. Relative paths are
+    resolved dynamically by searching on the classpath. 
 :::
 
 ### ranger-trino-security.xml
-```
+
+```xml
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 <configuration xmlns:xi="http://www.w3.org/2001/XInclude">
   <property>
@@ -93,7 +99,8 @@ The following table lists the configuration properties for the Ranger access con
 ```
 
 ### ranger-trino-audit.xml
-```
+
+```xml
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 <configuration xmlns:xi="http://www.w3.org/2001/XInclude">
   <property>
@@ -117,7 +124,8 @@ The following table lists the configuration properties for the Ranger access con
 ```
 
 ### ranger-policymgr-ssl.xml
-```
+
+```xml
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 <configuration xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- properties used for 2-way SSL between the Trino plugin and Apache Ranger server -->
@@ -161,7 +169,13 @@ The following table lists the configuration properties for the Ranger access con
 
 ## Required policies
 
-* Users will need permission to execute queries in Trino. Without a policy in Apache Ranger to grant this permission, users will not be able to execute any query.
-  * To allow this, create a policy in Apache Ranger for `queryId` resource having value `*`, with `execute` permission for user `{USER}`.
-* Users will need permission to impersonate themselves in Trino. Without a policy in Apache Ranger to grant this permission, users will not be able to execute any query.
-  * To allow this, create a policy in Apache Ranger for `trinouser` resource having value `{USER}`, with `impersonate` permission for user `{USER}`.
+* Users must have permission to execute queries in Trino. Without a policy in
+  Apache Ranger to grant this permission, users are not be able to execute any
+  query.
+  * To allow this, create a policy in Apache Ranger for a `queryId` resource
+    with a value `*` and with the `execute` permission for the user `{USER}`.
+* Users must have permission to impersonate themselves in Trino. Without a
+  policy in Apache Ranger to grant this permission, users are not able to
+  execute any query.
+  * To allow this, create a policy in Apache Ranger for a `trinouser` resource
+    with value `{USER}` and with the `impersonate` permission for user `{USER}`.


### PR DESCRIPTION
## Description

Following the convention for all other plugins that are related to an Apache project.

## Additional context and related issues

Follow up to https://github.com/trinodb/trino/pull/24392

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
