### PR TITLE
Inject execution interceptors using multibinder

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/ForGlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/ForGlueHiveMetastore.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.metastore.glue;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@BindingAnnotation
+public @interface ForGlueHiveMetastore {}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveExecutionInterceptor.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveExecutionInterceptor.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.hive.metastore.glue;
 
+import com.google.inject.Inject;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
@@ -24,9 +25,10 @@ public class GlueHiveExecutionInterceptor
 {
     private final boolean skipArchive;
 
-    GlueHiveExecutionInterceptor(boolean isSkipArchive)
+    @Inject
+    GlueHiveExecutionInterceptor(GlueHiveMetastoreConfig config)
     {
-        this.skipArchive = isSkipArchive;
+        this.skipArchive = config.isSkipArchive();
     }
 
     @Override

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveGlueMetadataListing.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveGlueMetadataListing.java
@@ -16,7 +16,6 @@ package io.trino.plugin.hive;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
-import io.opentelemetry.api.OpenTelemetry;
 import io.trino.Session;
 import io.trino.plugin.hive.metastore.glue.GlueHiveMetastore;
 import io.trino.plugin.hive.metastore.glue.GlueHiveMetastoreConfig;
@@ -27,6 +26,7 @@ import io.trino.testing.QueryRunner;
 import io.trino.tpch.TpchTable;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableSet;
 import software.amazon.awssdk.services.glue.GlueClient;
 import software.amazon.awssdk.services.glue.model.CreateTableRequest;
 import software.amazon.awssdk.services.glue.model.TableInput;
@@ -124,7 +124,7 @@ public class TestHiveGlueMetadataListing
     {
         GlueHiveMetastoreConfig glueConfig = new GlueHiveMetastoreConfig()
                 .setDefaultWarehouseDir(dataDirectory.toString());
-        try (GlueClient glueClient = createGlueClient(glueConfig, OpenTelemetry.noop())) {
+        try (GlueClient glueClient = createGlueClient(glueConfig, ImmutableSet.of())) {
             TableInput tableInput = TableInput.builder()
                     .name(FAILING_TABLE_WITH_NULL_STORAGE_DESCRIPTOR_NAME)
                     .tableType("HIVE")

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveConcurrentModificationGlueMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveConcurrentModificationGlueMetastore.java
@@ -13,9 +13,9 @@
  */
 package io.trino.plugin.hive.metastore.glue;
 
-import io.opentelemetry.api.OpenTelemetry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableSet;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.retries.api.RefreshRetryTokenRequest;
@@ -36,7 +36,7 @@ public class TestHiveConcurrentModificationGlueMetastore
     @Test
     public void testGlueClientShouldRetryConcurrentModificationException()
     {
-        try (GlueClient glueClient = createGlueClient(new GlueHiveMetastoreConfig(), OpenTelemetry.noop())) {
+        try (GlueClient glueClient = createGlueClient(new GlueHiveMetastoreConfig(), ImmutableSet.of())) {
             ClientOverrideConfiguration clientOverrideConfiguration = glueClient.serviceClientConfiguration().overrideConfiguration();
             RetryStrategy retryStrategy = clientOverrideConfiguration.retryStrategy().orElseThrow();
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestingGlueHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestingGlueHiveMetastore.java
@@ -13,7 +13,7 @@
  */
 package io.trino.plugin.hive.metastore.glue;
 
-import io.opentelemetry.api.OpenTelemetry;
+import com.google.common.collect.ImmutableSet;
 import io.trino.plugin.hive.metastore.glue.GlueHiveMetastore.TableKind;
 import software.amazon.awssdk.services.glue.GlueClient;
 
@@ -52,7 +52,7 @@ public final class TestingGlueHiveMetastore
     {
         GlueHiveMetastoreConfig glueConfig = new GlueHiveMetastoreConfig()
                 .setDefaultWarehouseDir(warehouseUri.toString());
-        GlueClient glueClient = createGlueClient(glueConfig, OpenTelemetry.noop());
+        GlueClient glueClient = createGlueClient(glueConfig, ImmutableSet.of());
         registerResource.accept(glueClient);
         return new GlueHiveMetastore(
                 glueClient,


### PR DESCRIPTION
Inject execution interceptors using multibinder

The GlueMetastoreModule is not truly following the inversion of control
paradigm. Many things are created directly in the methods without using
injection. Using set multibinder for execution interceptors allows to
independently define execution interceptors and use Guice injection.

Co-authored-by: Grzegorz Kokosiński <grzegorz@starburstdata.com>
