### PR TITLE
Add Trino 468 release notes

### DIFF
--- a/docs/src/main/sphinx/release.md
+++ b/docs/src/main/sphinx/release.md
@@ -6,6 +6,7 @@
 ```{toctree}
 :maxdepth: 1
 
+release/release-468
 release/release-467
 release/release-466
 release/release-465

--- a/docs/src/main/sphinx/release/release-468.md
+++ b/docs/src/main/sphinx/release/release-468.md
@@ -1,0 +1,51 @@
+# Release 468 (17 Dec 2024)
+
+## General
+
+* Add experimental support for [](/udf/python). ({issue}`24378`)
+* Add cluster overview to the [](/admin/preview-web-interface). ({issue}`23600`)
+* Add new node states `DRAINING` and `DRAINED` to make it possible to reactivate
+  a draining worker node. ({issue}`24444 `)
+
+## BigQuery connector
+
+* Improve performance when reading external
+  [BigLake](https://cloud.google.com/bigquery/docs/biglake-intro) tables. ({issue}`21016`)
+
+## Delta Lake connector
+
+* {{breaking}} Reduce coordinator memory usage for the Delta table metadata
+  cache and enable configuration `delta.metadata.cache-max-retained-size` to
+  control memory usage. Remove the configuration property
+  `delta.metadata.cache-size` and increase the default for
+  `delta.metadata.cache-ttl` to `30m`. ({issue}`24432`)
+
+## Hive connector
+
+* Enable mismatched bucket execution optimization by default. This can be
+  disabled with `hive.optimize-mismatched-bucket-count` configuration property
+  and the `optimize_mismatched_bucket_count` session property. ({issue}`23432`)
+* Improve performance by deactivating bucket execution when not useful in query
+  processing. ({issue}`23432`)
+
+## Iceberg connector
+
+* Improve performance when running a join or aggregation on a bucketed table
+  with bucketed execution. This can be deactivated with the
+  `iceberg.bucket-execution` configuration property and the
+  `bucket_execution_enabled` session property. ({issue}`23432`)
+* Deprecate the `iceberg.materialized-views.storage-schema` configuration
+  property. ({issue}`24398`)  
+* {{breaking}} Rename the `partitions` column in the `$manifests` metadata table
+  to `partition_summaries`. ({issue}`24103`)
+* Avoid excessive resource usage on coordinator when reading Iceberg system
+  tables. ({issue}`24396`)
+
+## PostgreSQL connector
+
+* Add support for non-transactional [MERGE statements](/sql/merge). ({issue}`23034`)
+
+## SPI
+
+* Add partitioning push down, which a connector can use to activate optional
+  partitioning or choose between multiple partitioning strategies. ({issue}`23432`)


### PR DESCRIPTION
## Description

Assemble the release notes for the upcoming Trino 467 release.

## Additional context and related issues

See https://github.com/trinodb/trino/pulls?q=is%3Apr+is%3Aclosed+milestone%3A468

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

## Verification for each pull request

Format: PR/issue number, ✅ / ❌ rn ✅ / ❌ docs
✅ rn - release note added and verified, or assessed to be not necessary, set to ❌ rn before completion
✅ docs - need for docs assessed and merged, or assessed to be not necessary, set to ❌ docs before completion

## 6 Dec 2024

* #24235 ✅ rn ✅ docs

## 7 Dec 2024

* #24391 ✅ rn ✅ docs
* #23655 ✅ rn ✅ docs
* #23432 ✅ rn ✅ docs
* #24105 ✅ rn ✅ docs
* #24378 ✅ rn ✅ docs
* #23518 ✅ rn ✅ docs

## 8 Dec 2024

* #24406 ✅ rn ✅ docs
* #24411 ✅ rn ✅ docs

## 9 Dec 2024

* #24413 ✅ rn ✅ docs
* #23034 ✅ rn ✅ docs
* #24401 ✅ rn ✅ docs
* #24422 ✅ rn ✅ docs
* #24398 ✅ rn ✅ docs

## 10 Dec 2024

* #24429 ✅ rn ✅ docs
* #24431 ✅ rn ✅ docs
* #24397 ✅ rn ✅ docs
* #24103 ✅ rn ✅ docs
* #24439 ✅ rn ✅ docs
* #24439 ✅ rn ✅ docs
* #24442 ✅ rn ✅ docs

## 11 Dec 2024

* #24404 ✅ rn ✅ docs
* #24305 ✅ rn ✅ docs
* #24445 ✅ rn ✅ docs
* #24450 ✅ rn ✅ docs
* #22974 ✅ rn ✅ docs

## 12 Dec 2024

* #24416 ✅ rn ✅ docs
* #24130 ✅ rn ✅ docs
* #23600 ✅ rn ✅ docs
* #24396 ✅ rn ✅ docs
* #24463 ✅ rn ✅ docs

## 13 Dec 2024

* #24432 ✅ rn ✅ docs
* #24468 ✅ rn ✅ docs
* #24224 ✅ rn ✅ docs
* #24426 ✅ rn ✅ docs

## 14 Dec 2024

no merged PRs

## 15 Dec 2024

* #24477 ✅ rn ✅ docs

## 16 Dec 2024

* #24465 ✅ rn ✅ docs
* #24444 ✅ rn ✅ docs
* #24485 ✅ rn ✅ docs
* #24441 ✅ rn ✅ docs
* #24502 ✅ rn ✅ docs

## 17 Dec 2024

* #24500 ✅ rn ✅ docs
* #24506 ✅ rn ✅ docs