### PR TITLE
Support MERGE for MySQL connector

### DIFF
--- a/docs/src/main/sphinx/connector/mysql.md
+++ b/docs/src/main/sphinx/connector/mysql.md
@@ -338,6 +338,7 @@ following features:
 - [](/sql/insert), see also [](mysql-insert)
 - [](/sql/update), see also [](mysql-update)
 - [](/sql/delete), see also [](mysql-delete)
+- [](/sql/merge), see also [](mysql-merge)
 - [](/sql/truncate)
 - [](/sql/create-table)
 - [](/sql/create-table-as)
@@ -357,6 +358,10 @@ following features:
 
 (mysql-delete)=
 ```{include} sql-delete-limitation.fragment
+```
+
+(mysql-merge)=
+```{include} non-transactional-merge.fragment
 ```
 
 (mysql-procedures)=

--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteConnectorTest.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteConnectorTest.java
@@ -553,4 +553,11 @@ public class TestIgniteConnectorTest
             assertUpdate("DROP TABLE IF EXISTS " + schemaTableName);
         }
     }
+
+    @Test
+    @Override
+    public void testMergeTargetWithoutPrimaryKeys()
+    {
+        abort("Ignite table always has primary key");
+    }
 }

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlGlobalTransactionMyConnectorSmokeTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlGlobalTransactionMyConnectorSmokeTest.java
@@ -13,9 +13,14 @@
  */
 package io.trino.plugin.mysql;
 
+import io.trino.Session;
 import io.trino.plugin.jdbc.BaseJdbcConnectorSmokeTest;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
+import io.trino.testing.sql.TestTable;
+
+import static io.trino.plugin.jdbc.JdbcWriteSessionProperties.NON_TRANSACTIONAL_MERGE;
+import static java.lang.String.format;
 
 public class TestMySqlGlobalTransactionMyConnectorSmokeTest
         extends BaseJdbcConnectorSmokeTest
@@ -33,14 +38,30 @@ public class TestMySqlGlobalTransactionMyConnectorSmokeTest
     }
 
     @Override
+    protected Session getSession()
+    {
+        Session session = super.getSession();
+        return Session.builder(session)
+                .setCatalogSessionProperty(session.getCatalog().orElseThrow(), NON_TRANSACTIONAL_MERGE, "true")
+                .build();
+    }
+
+    @Override
     protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
     {
-        switch (connectorBehavior) {
-            case SUPPORTS_RENAME_SCHEMA:
-                return false;
+        return switch (connectorBehavior) {
+            case SUPPORTS_MERGE,
+                 SUPPORTS_ROW_LEVEL_UPDATE -> true;
+            case SUPPORTS_RENAME_SCHEMA -> false;
+            default -> super.hasBehavior(connectorBehavior);
+        };
+    }
 
-            default:
-                return super.hasBehavior(connectorBehavior);
-        }
+    @Override
+    protected TestTable createTestTableForWrites(String tablePrefix)
+    {
+        TestTable table = super.createTestTableForWrites(tablePrefix);
+        mySqlServer.execute(format("ALTER TABLE %s ADD PRIMARY KEY (a)", table.getName()));
+        return table;
     }
 }

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
@@ -1041,6 +1041,13 @@ public class TestPhoenixConnectorTest
         assertUpdate("DROP TABLE " + tableName);
     }
 
+    @Test
+    @Override
+    public void testMergeTargetWithoutPrimaryKeys()
+    {
+        abort("Phoenix table always has primary key");
+    }
+
     private byte[] getActualQualifier(String tableName, String columnName)
     {
         String query = "SELECT COLUMN_QUALIFIER FROM SYSTEM.CATALOG WHERE TABLE_NAME = ? AND COLUMN_NAME = ?";

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorSmokeTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorSmokeTest.java
@@ -152,6 +152,11 @@ public abstract class BaseConnectorSmokeTest
         assertUpdate("DROP TABLE " + tableName);
     }
 
+    protected TestTable createTestTableForWrites(String tablePrefix)
+    {
+        return new TestTable(getQueryRunner()::execute, tablePrefix, getCreateTableDefaultDefinition());
+    }
+
     protected String getCreateTableDefaultDefinition()
     {
         return "(a bigint, b double)";
@@ -318,7 +323,7 @@ public abstract class BaseConnectorSmokeTest
             throw new AssertionError("Cannot test UPDATE without INSERT");
         }
 
-        try (TestTable table = newTrinoTable("test_update_", getCreateTableDefaultDefinition())) {
+        try (TestTable table = createTestTableForWrites("test_update_")) {
             assertUpdate("INSERT INTO " + table.getName() + " (a, b) SELECT regionkey, regionkey * 2.5 FROM region", "SELECT count(*) FROM region");
             assertThat(query("SELECT a, b FROM " + table.getName()))
                     .matches(expectedValues("(0, 0.0), (1, 2.5), (2, 5.0), (3, 7.5), (4, 10.0)"));
@@ -344,7 +349,7 @@ public abstract class BaseConnectorSmokeTest
             throw new AssertionError("Cannot test MERGE without INSERT");
         }
 
-        try (TestTable table = newTrinoTable("test_merge_", getCreateTableDefaultDefinition())) {
+        try (TestTable table = createTestTableForWrites("test_merge_")) {
             assertUpdate("INSERT INTO " + table.getName() + " (a, b) SELECT regionkey, regionkey * 2.5 FROM region", "SELECT count(*) FROM region");
             assertThat(query("SELECT a, b FROM " + table.getName()))
                     .matches(expectedValues("(0, 0.0), (1, 2.5), (2, 5.0), (3, 7.5), (4, 10.0)"));

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -4797,7 +4797,7 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_DELETE));
 
-        try (TestTable table = newTrinoTable("test_with_like_", "AS SELECT * FROM nation")) {
+        try (TestTable table = createTestTableForWrites("test_with_like_", "AS SELECT * FROM nation", "nationkey")) {
             assertUpdate("DELETE FROM " + table.getName() + " WHERE name LIKE '%a%'", "VALUES 0");
             assertUpdate("DELETE FROM " + table.getName() + " WHERE name LIKE '%A%'", "SELECT count(*) FROM nation WHERE name LIKE '%A%'");
         }
@@ -5078,7 +5078,7 @@ public abstract class BaseConnectorTest
             return;
         }
 
-        try (TestTable table = createTestTableForWrites("test_update", "AS TABLE tpch.tiny.nation", "name,regionkey")) {
+        try (TestTable table = createTestTableForWrites("test_update", "AS TABLE tpch.tiny.nation", "nationkey,regionkey")) {
             String tableName = table.getName();
             assertUpdate("UPDATE " + tableName + " SET nationkey = 100 + nationkey WHERE regionkey = 2", 5);
             assertThat(query("SELECT * FROM " + tableName))


### PR DESCRIPTION
## Description

The tests that are updated in the `BaseJdbcConnectorTest` because current the implementation of MERGE for Mysql connector requires the table has primary keys, thus modified the table creation logic to use `createTestTableForWrites`, allowing the MySQL connector test class to override it and add primary keys as needed.

## Release notes

```markdown
## MySQL
* Add support for `MERGE` statement. ({issue}`issuenumber`)
```
