### PR TITLE
Load Pinot SPI services using Trino plugin class loader

### DIFF
--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotConnectorFactory.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotConnectorFactory.java
@@ -24,6 +24,7 @@ import io.trino.plugin.pinot.auth.PinotAuthenticationModule;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorFactory;
+import org.apache.pinot.segment.spi.index.IndexService;
 import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
@@ -72,6 +73,16 @@ public class PinotConnectorFactory
                 .setRequiredConfigurationProperties(config)
                 .initialize();
 
+        // Load IndexPlugins using current thread that has the PluginClassLoader in the context.
+        // This ensures that ServiceLoader can discover IndexPlugin implementations.
+        // See https://github.com/trinodb/trino/issues/23130 for details.
+        loadUsingPluginClassLoader();
+
         return injector.getInstance(PinotConnector.class);
+    }
+
+    private void loadUsingPluginClassLoader()
+    {
+        IndexService.getInstance(); // Trigger initialization
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Fixes #23130

Previously, [IndexService](https://github.com/apache/pinot/blob/ef3caa391fe297ca405d39aa6b64b7fdecbe856f/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/IndexService.java#L93) was unable to discover and load the IndexPlugin implementations when using the worker thread context class loader. So loading the IndexService using the main thread (and the plugin class loader in its context) which is able to discover the Index SPI implementations.  


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
