### PR TITLE
Close StatementClient when hitting client-side timeout

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/StatementClientV1.java
+++ b/client/trino-client/src/main/java/io/trino/client/StatementClientV1.java
@@ -403,6 +403,7 @@ class StatementClientV1
             if (attempts > 0) {
                 Duration sinceStart = Duration.nanosSince(start);
                 if (sinceStart.compareTo(requestTimeoutNanos) > 0) {
+                    close();
                     state.compareAndSet(State.RUNNING, State.CLIENT_ERROR);
                     throw new RuntimeException(format("Error fetching next (attempts: %s, duration: %s)", attempts, sinceStart), cause);
                 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Currently, `StatementClient.close()` doesn't send a cancel request after hitting the client-side timeout because `state` is changed here:
https://github.com/trinodb/trino/blob/9662e4325d5c0878614e0e885de7e667bae644dd/client/trino-client/src/main/java/io/trino/client/StatementClientV1.java#L405-L408

while `close()` sends a cancel request only when `state` is `RUNNING`:
https://github.com/trinodb/trino/blob/9662e4325d5c0878614e0e885de7e667bae644dd/client/trino-client/src/main/java/io/trino/client/StatementClientV1.java#L553-L562

Since `close()` is called before changing `state` when the thread is interrupted, it looks like applying the same way is natural solution:
https://github.com/trinodb/trino/blob/9662e4325d5c0878614e0e885de7e667bae644dd/client/trino-client/src/main/java/io/trino/client/StatementClientV1.java#L413-L422

However, I have one concern that `state` is changed to `CLIENT_ABORTED` in `close()` in this case, so `state.compareAndSet(State.RUNNING, State.CLIENT_ERROR);` doesn't seem to take effect in the code above. I'm not sure how it should work in this case.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
