### PR TITLE
Support multiple state filters on getAllQueryInfo API

### DIFF
--- a/core/trino-main/src/test/java/io/trino/server/TestQueryResource.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestQueryResource.java
@@ -163,12 +163,17 @@ public class TestQueryResource
         assertThat(infos).isEmpty();
         assertStateCounts(infos, 0, 0, 0);
 
+        infos = getQueryInfos("/v1/query?state=finished&state=failed&state=running");
+        assertThat(infos).hasSize(3);
+        assertStateCounts(infos, 2, 1, 0);
+
         server.getAccessControl().deny(privilege("query", VIEW_QUERY));
         try {
             assertThat(getQueryInfos("/v1/query")).isEmpty();
             assertThat(getQueryInfos("/v1/query?state=finished")).isEmpty();
             assertThat(getQueryInfos("/v1/query?state=failed")).isEmpty();
             assertThat(getQueryInfos("/v1/query?state=running")).isEmpty();
+            assertThat(getQueryInfos("/v1/query?state=finished&state=failed&state=running")).isEmpty();
         }
         finally {
             server.getAccessControl().reset();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Addresses #24461. Non-breaking.

Enhancing getAllQueryInfo API to accept multiple state filters. This adds flexibility for clients to request for query infos belonging to more than one state in a single request.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
