### PR TITLE
Sort queries on worker status web ui by descending reserved memory

### DIFF
--- a/core/trino-web-ui/src/main/resources/webapp/src/components/WorkerStatus.jsx
+++ b/core/trino-web-ui/src/main/resources/webapp/src/components/WorkerStatus.jsx
@@ -267,9 +267,14 @@ export class WorkerStatus extends React.Component {
             <div>
                 <table className="table">
                     <tbody>
-                        {Object.keys(queries).map((key) =>
-                            WorkerStatus.renderPoolQuery(key, queries[key][0], queries[key][1], size)
-                        )}
+                        {Object.entries(queries)
+                            .sort(
+                                ([queryA, reservationsA], [queryB, reservationsB]) =>
+                                    reservationsB[0] - reservationsA[0]
+                            )
+                            .map(([query, reservations]) =>
+                                WorkerStatus.renderPoolQuery(query, reservations[0], reservations[1], size)
+                            )}
                     </tbody>
                 </table>
             </div>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
There are the list of queries on the worker status view.

It would be more useful if this list is sorted by memory to find memory consuming queries on the worker.

Before (Queries are listed randomly):
<img width="1214" alt="Screenshot 2025-01-12 at 2 52 42" src="https://github.com/user-attachments/assets/0c8bfaa7-0439-4790-8f72-219610089a2a" />

After (Queries are sorted by reserved memory):
<img width="1234" alt="Screenshot 2025-01-12 at 2 46 53" src="https://github.com/user-attachments/assets/09b2ef73-65d5-43d0-9802-4131f4b178f8" />

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Web UI
* Sort queries on worker status web ui by descending reserved memory. ({issue}`24475`)
```
