### PR TITLE
Support renaming Hudi table

### DIFF
--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiMetadata.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiMetadata.java
@@ -247,6 +247,13 @@ public class HudiMetadata
     }
 
     @Override
+    public void renameTable(ConnectorSession session, ConnectorTableHandle tableHandle, SchemaTableName newTableName)
+    {
+        SchemaTableName schemaTableName = ((HudiTableHandle) tableHandle).getSchemaTableName();
+        metastore.renameTable(schemaTableName.getSchemaName(), schemaTableName.getTableName(), newTableName.getSchemaName(), newTableName.getTableName());
+    }
+
+    @Override
     public Iterator<RelationColumnsMetadata> streamRelationColumns(
             ConnectorSession session,
             Optional<String> schemaName,

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/BaseHudiConnectorSmokeTest.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/BaseHudiConnectorSmokeTest.java
@@ -32,7 +32,6 @@ public abstract class BaseHudiConnectorSmokeTest
                  SUPPORTS_MERGE,
                  SUPPORTS_CREATE_SCHEMA,
                  SUPPORTS_CREATE_TABLE,
-                 SUPPORTS_RENAME_TABLE,
                  SUPPORTS_CREATE_VIEW,
                  SUPPORTS_CREATE_MATERIALIZED_VIEW,
                  SUPPORTS_COMMENT_ON_COLUMN -> false;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Adding support for renaming a Hudi table through the Metastore. 

The scope of renaming by the Metastore client will depend on the type of table (external vs. managed):
	•	External Tables: The rename operation applies only to the metadata in the Metastore. The underlying data location on the storage layer remains unchanged.
	•	Managed Tables: The rename operation applies to both the Metastore and the corresponding table directory on the storage layer. The table directory will be renamed to reflect the new table name.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
