### PR TITLE
Add support for filtering queries by client tags in the Web UI

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/ui/TrimmedBasicQueryInfo.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/TrimmedBasicQueryInfo.java
@@ -27,6 +27,7 @@ import io.trino.spi.resourcegroups.ResourceGroupId;
 
 import java.net.URI;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
@@ -53,6 +54,7 @@ public class TrimmedBasicQueryInfo
     private final Optional<ErrorCode> errorCode;
     private final Optional<QueryType> queryType;
     private final RetryPolicy retryPolicy;
+    private final Optional<Set<String>> clientTags;
 
     public TrimmedBasicQueryInfo(BasicQueryInfo queryInfo)
     {
@@ -79,6 +81,7 @@ public class TrimmedBasicQueryInfo
         this.queryStats = requireNonNull(queryInfo.getQueryStats(), "queryStats is null");
         this.queryType = requireNonNull(queryInfo.getQueryType(), "queryType is null");
         this.retryPolicy = requireNonNull(queryInfo.getRetryPolicy(), "retryPolicy is null");
+        this.clientTags = Optional.ofNullable(queryInfo.getSession().getClientTags());
     }
 
     @JsonProperty
@@ -181,6 +184,12 @@ public class TrimmedBasicQueryInfo
     public RetryPolicy getRetryPolicy()
     {
         return retryPolicy;
+    }
+
+    @JsonProperty
+    public Optional<Set<String>> getClientTags()
+    {
+        return clientTags;
     }
 
     @Override

--- a/core/trino-web-ui/src/main/resources/webapp/src/components/QueryList.jsx
+++ b/core/trino-web-ui/src/main/resources/webapp/src/components/QueryList.jsx
@@ -470,6 +470,13 @@ export class QueryList extends React.Component {
                 ) {
                     return true
                 }
+
+                if (
+                    query.clientTags &&
+                    query.clientTags.some((clientTag) => clientTag.toLowerCase().indexOf(term) !== -1)
+                ) {
+                    return true
+                }
             }, this)
         }
     }
@@ -810,7 +817,7 @@ export class QueryList extends React.Component {
                             <input
                                 type="text"
                                 className="form-control form-control-small search-bar"
-                                placeholder="User, source, query ID, query state, resource group, error name, or query text"
+                                placeholder="User, source, query ID, query state, resource group, error name, query text or client tags"
                                 onChange={this.handleSearchStringChange}
                                 value={this.state.searchString}
                             />


### PR DESCRIPTION
## Description
Currently it is not possible to filter out queries in the Web UI by the client tags values which becomes annoying to find specific queries when there are 30 of them running in parallel. This change adds support to filter queries by client tags in Web UI by modifying the `api/query` endpoint response to include additional value and adapting the UI part to do filtering.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( x) Release notes are required, with the following suggested text:
Add support for filtering by query client tags in the Web UI.
