### PR TITLE
Update inline and catalog UDF docs

### DIFF
--- a/docs/src/main/sphinx/udf/python/examples.md
+++ b/docs/src/main/sphinx/udf/python/examples.md
@@ -3,6 +3,96 @@
 After learning about [](/udf/python), the following sections show examples
 of valid Python UDFs. 
 
+The UDFs are suitable as [](udf-inline) or [](udf-catalog),
+after adjusting the name and the example invocations.
+
+## Inline and catalog Python UDFs
+
+The following section shows the differences in usage with inline and catalog
+UDFs with a simple Python UDF example. The same pattern applies to all other
+following sections.
+
+A very simple Python UDF that returns the static int value `42` without
+requiring any input:
+
+```text
+FUNCTION answer()
+LANGUAGE PYTHON
+RETURNS int
+WITH (handler='theanswer')
+AS $$
+def theanswer():
+    return 42
+$$
+```
+
+A full example of this UDF as inline UDF and usage in a string concatenation
+with a cast:
+
+```text
+WITH
+  FUNCTION answer()
+  RETURNS int
+  LANGUAGE PYTHON
+  WITH (handler='theanswer')
+  AS $$
+  def theanswer():
+      return 42
+  $$
+SELECT 'The answer is ' || CAST(answer() as varchar);
+-- The answer is 42
+```
+
+Provided the catalog `example` supports UDF storage in the `default` schema, you
+can use the following:
+
+```text
+CREATE FUNCTION example.default.answer()
+  RETURNS int
+  LANGUAGE PYTHON
+  WITH (handler='theanswer')
+  AS $$
+  def theanswer():
+      return 42
+  $$;
+```
+
+With the UDF stored in the catalog, you can run the UDF multiple times without
+repeated definition:
+
+```sql
+SELECT example.default.answer() + 1; -- 43
+SELECT 'The answer is ' || CAST(example.default.answer() as varchar); -- The answer is 42
+```
+
+Alternatively, you can configure the SQL PATH in the [](config-properties) to a
+catalog and schema that support UDF storage:
+
+```properties
+sql.default-function-catalog=example
+sql.default-function-schema=default
+sql.path=example.default
+```
+
+Now you can manage UDFs without the full path:
+
+```text
+CREATE FUNCTION answer()
+  RETURNS int
+  LANGUAGE PYTHON
+  WITH (handler='theanswer')
+  AS $$
+  def theanswer():
+      return 42
+  $$;
+```
+
+UDF invocation works without the full path:
+
+```sql
+SELECT answer() + 5; -- 47
+```
+
 ## XOR
 
 The following example implements a `xor` function for a logical Exclusive OR

--- a/docs/src/main/sphinx/udf/sql/examples.md
+++ b/docs/src/main/sphinx/udf/sql/examples.md
@@ -15,6 +15,12 @@ statement documentation for further details:
 * [](/udf/sql/loop), [](/udf/sql/repeat), and [](/udf/sql/while) for looping constructs
 * [](/udf/sql/iterate) and [](/udf/sql/leave) for flow control
 
+## Inline and catalog UDFs
+
+The following section shows the differences in usage with inline and catalog
+UDFs with a simple SQL UDF example. The same pattern applies to all other
+following sections.
+
 A very simple SQL UDF that returns a static value without requiring any input:
 
 ```sql
@@ -22,8 +28,6 @@ FUNCTION answer()
 RETURNS BIGINT
 RETURN 42
 ```
-
-## Inline and catalog UDFs
 
 A full example of this UDF as inline UDF and usage in a string concatenation
 with a cast:
@@ -41,7 +45,6 @@ Provided the catalog `example` supports UDF storage in the `default` schema, you
 can use the following:
 
 ```sql
-USE example.default;
 CREATE FUNCTION example.default.answer()
   RETURNS BIGINT
   RETURN 42;
@@ -52,15 +55,16 @@ repeated definition:
 
 ```sql
 SELECT example.default.answer() + 1; -- 43
-SELECT 'The answer is' || CAST(example.default.answer() as varchar); -- The answer is 42
+SELECT 'The answer is ' || CAST(example.default.answer() as varchar); -- The answer is 42
 ```
 
-Alternatively, you can configure the SQL environment in the
-[](config-properties) to a catalog and schema that support UDF storage:
+Alternatively, you can configure the SQL PATH in the [](config-properties) to a
+catalog and schema that support UDF storage:
 
 ```properties
 sql.default-function-catalog=example
 sql.default-function-schema=default
+sql.path=example.default
 ```
 
 Now you can manage UDFs without the full path:


### PR DESCRIPTION
## Description

I first tested catalog UDF with Python in the Trino CLI .. and that didnt work. So I completed the initial linked PR without the example that I am now adding here.

The thing I discovered is that it all works in DBeaver with the JDBC driver, so there must be some parsing issue in the CLI. Let me know if you want me to file a separate issue @electrum 

Basically if I enter the query in the CLI to create the function .. I cant press enter to run it .. it just keeps adding empty lines

<img width="459" alt="image" src="https://github.com/user-attachments/assets/1ee0bcac-0839-40f9-a072-af231019f996" />

So I think we ideally should fix the CLI before the release or before we merge this PR.

Update.. I tested with an old CLI .. will verify with 468-snapshot version.

Further update @electrum  - it works fine with CLI from 468 .. so.. do we need to document that somewhere ..

## Additional context and related issues

#24441

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
