### PR TITLE
Update to oryd/hydra:v1.11.10 for OAuth testing

### DIFF
--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestingHydraIdentityProvider.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestingHydraIdentityProvider.java
@@ -71,7 +71,7 @@ import static java.util.Objects.requireNonNull;
 public class TestingHydraIdentityProvider
         implements AutoCloseable
 {
-    private static final String HYDRA_IMAGE = "oryd/hydra:v1.10.6";
+    private static final String HYDRA_IMAGE = "oryd/hydra:v1.11.10";
     private static final String ISSUER = "https://localhost:4444/";
     private static final String DSN = "postgres://hydra:mysecretpassword@database:5432/hydra?sslmode=disable";
 

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/HydraIdentityProvider.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/HydraIdentityProvider.java
@@ -36,7 +36,7 @@ public class HydraIdentityProvider
     private static final int TTL_ACCESS_TOKEN_IN_SECONDS = 5;
     private static final int TTL_REFRESH_TOKEN_IN_SECONDS = 15;
 
-    private static final String HYDRA_IMAGE = "oryd/hydra:v1.10.6";
+    private static final String HYDRA_IMAGE = "oryd/hydra:v1.11.10";
     private static final String DSN = "postgres://hydra:mysecretpassword@hydra-db:5432/hydra?sslmode=disable";
     private final PortBinder binder;
     private final DockerFiles.ResourceProvider configDir;


### PR DESCRIPTION
## Description

Fix build issues on newer OS/hardware. Use latest 1.x release since 2.x causes container start issues without further changes.

## Additional context and related issues

Discovered fix in https://github.com/trinodb/trino-gateway/pull/577

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
