### PR TITLE
Enable Phoenix product test

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/phoenix/TestPhoenix.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/phoenix/TestPhoenix.java
@@ -28,8 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestPhoenix
         extends ProductTest
 {
-    // TODO: https://github.com/trinodb/trino/issues/21824
-    @Test(groups = {PHOENIX, PROFILE_SPECIFIC_TESTS}, timeOut = 30_000L, enabled = false)
+    @Test(groups = {PHOENIX, PROFILE_SPECIFIC_TESTS})
     public void testCreateTableAsSelect()
     {
         String tableName = "nation_" + UUID.randomUUID().toString().replace("-", "");


### PR DESCRIPTION
## Description

Enable Phoenix product tests.

HBase 2.5.10 has a fix required to stabilize Phoenix tests in the docker environment. Since Phoenix 5.2.1 with HBase 2.5.10-hadoop3 are already used by Trino, the fix is available for trino to consume.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
