### PR TITLE
Fix S3InputStream's handling of large skips

### DIFF
--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3InputStream.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3InputStream.java
@@ -29,6 +29,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 
+import static java.lang.Math.clamp;
 import static java.lang.Math.max;
 import static java.util.Objects.requireNonNull;
 
@@ -126,14 +127,10 @@ final class S3InputStream
             throws IOException
     {
         ensureOpen();
-        seekStream(false);
 
-        return reconnectStreamIfNecessary(() -> {
-            long skip = doSkip(n);
-            streamPosition += skip;
-            nextReadPosition += skip;
-            return skip;
-        });
+        long skipSize = clamp(n, 0, length != null ? length - nextReadPosition : Integer.MAX_VALUE);
+        nextReadPosition += skipSize;
+        return skipSize;
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

When the skip(n) method is called the MAX_SKIP_BYTES check is skipped, resulting in the call potentially blocking for a long time.

Instead of delegating to the underlying stream, set the nextReadPosition value. This allows the next read to decide if it is best to keep the existing s3 object stream or open a new one.

This behavior matches the implementations for [Azure](https://github.com/trinodb/trino/blob/master/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureInputStream.java#L132) and [GCS](https://github.com/trinodb/trino/blob/master/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsInputStream.java#L141).

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
