### PR TITLE
Include deletion vector when filtering active add entries in Delta

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeletionVectorEntry.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeletionVectorEntry.java
@@ -34,6 +34,16 @@ public record DeletionVectorEntry(String storageType, String pathOrInlineDv, Opt
         requireNonNull(offset, "offset is null");
     }
 
+    // https://github.com/delta-io/delta/blob/34f02d8/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/DeletionVectorDescriptor.java#L167-L174
+    public String uniqueId()
+    {
+        String uniqueFileId = storageType + pathOrInlineDv;
+        if (offset.isPresent()) {
+            return uniqueFileId + "@" + offset;
+        }
+        return uniqueFileId;
+    }
+
     public long getRetainedSizeInBytes()
     {
         return INSTANCE_SIZE


### PR DESCRIPTION
## Description

@vkorukanti told us that we are missing deletion vector id in the key. The corresponding delta-kernel code:
* [ActiveAddFilesIterator.java#L176](https://github.com/delta-io/delta/blob/34f02d8/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActiveAddFilesIterator.java#L176)
* [DeletionVectorDescriptor.java](https://github.com/delta-io/delta/blob/34f02d8/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/DeletionVectorDescriptor.java#L167-L174)

Hopefully, solves #22972. This PR doesn't contain tests because the entire steps to reproduce is still unclear. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
