### PR TITLE
Add missing unit tests on Faker queries

### DIFF
--- a/plugin/trino-blackhole/src/test/java/io/trino/plugin/blackhole/TestBlackHoleSmoke.java
+++ b/plugin/trino-blackhole/src/test/java/io/trino/plugin/blackhole/TestBlackHoleSmoke.java
@@ -249,12 +249,6 @@ final class TestBlackHoleSmoke
         assertUpdate("DROP VIEW " + viewName);
     }
 
-    private String getTableComment(String tableName)
-    {
-        return (String) computeScalar("SELECT comment FROM system.metadata.table_comments " +
-                "WHERE catalog_name = CURRENT_CATALOG AND schema_name = CURRENT_SCHEMA AND table_name = '" + tableName + "'");
-    }
-
     @Test
     void testFieldLength()
     {

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeRegisterTableProcedureTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeRegisterTableProcedureTest.java
@@ -319,13 +319,6 @@ public abstract class BaseDeltaLakeRegisterTableProcedureTest
         throw new IllegalStateException("Location not found in SHOW CREATE TABLE result");
     }
 
-    private String getTableComment(String tableName)
-    {
-        return (String) computeScalar(format(
-                "SELECT comment FROM system.metadata.table_comments WHERE catalog_name = CURRENT_CATALOG AND schema_name = CURRENT_SCHEMA AND table_name = '%s'",
-                tableName));
-    }
-
     protected HiveMetastore metastore()
     {
         return TestingDeltaLakeUtils.getConnectorService(getQueryRunner(), HiveMetastoreFactory.class)

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerMetadata.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerMetadata.java
@@ -64,8 +64,6 @@ import java.util.Optional;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static io.trino.plugin.faker.TableInfo.DEFAULT_LIMIT_PROPERTY;
-import static io.trino.plugin.faker.TableInfo.NULL_PROBABILITY_PROPERTY;
 import static io.trino.spi.StandardErrorCode.INVALID_COLUMN_PROPERTY;
 import static io.trino.spi.StandardErrorCode.INVALID_COLUMN_REFERENCE;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -147,7 +145,7 @@ public class FakerMetadata
             return null;
         }
         long schemaLimit = (long) schema.properties().getOrDefault(SchemaInfo.DEFAULT_LIMIT_PROPERTY, defaultLimit);
-        long tableLimit = (long) tables.get(tableName).properties().getOrDefault(DEFAULT_LIMIT_PROPERTY, schemaLimit);
+        long tableLimit = (long) tables.get(tableName).properties().getOrDefault(TableInfo.DEFAULT_LIMIT_PROPERTY, schemaLimit);
         return new FakerTableHandle(tableName, TupleDomain.all(), tableLimit);
     }
 
@@ -237,15 +235,15 @@ public class FakerMetadata
 
         TableInfo oldInfo = tables.get(tableName);
         ImmutableMap.Builder updatedProperties = ImmutableMap.<String, Object>builder().putAll(oldInfo.properties());
-        if (properties.containsKey(NULL_PROBABILITY_PROPERTY)) {
-            double nullProbability = (double) properties.get(NULL_PROBABILITY_PROPERTY)
+        if (properties.containsKey(TableInfo.NULL_PROBABILITY_PROPERTY)) {
+            double nullProbability = (double) properties.get(TableInfo.NULL_PROBABILITY_PROPERTY)
                     .orElseThrow(() -> new IllegalArgumentException("The null_probability property cannot be empty"));
-            updatedProperties.put(NULL_PROBABILITY_PROPERTY, nullProbability);
+            updatedProperties.put(TableInfo.NULL_PROBABILITY_PROPERTY, nullProbability);
         }
-        if (properties.containsKey(DEFAULT_LIMIT_PROPERTY)) {
-            long defaultLimit = (long) properties.get(DEFAULT_LIMIT_PROPERTY)
+        if (properties.containsKey(TableInfo.DEFAULT_LIMIT_PROPERTY)) {
+            long defaultLimit = (long) properties.get(TableInfo.DEFAULT_LIMIT_PROPERTY)
                     .orElseThrow(() -> new IllegalArgumentException("The default_limit property cannot be empty"));
-            updatedProperties.put(DEFAULT_LIMIT_PROPERTY, defaultLimit);
+            updatedProperties.put(TableInfo.DEFAULT_LIMIT_PROPERTY, defaultLimit);
         }
         tables.put(tableName, oldInfo.withProperties(updatedProperties.buildOrThrow()));
     }
@@ -302,7 +300,7 @@ public class FakerMetadata
         checkTableNotExists(tableMetadata.getTable());
 
         double schemaNullProbability = (double) schema.properties().getOrDefault(SchemaInfo.NULL_PROBABILITY_PROPERTY, nullProbability);
-        double tableNullProbability = (double) tableMetadata.getProperties().getOrDefault(NULL_PROBABILITY_PROPERTY, schemaNullProbability);
+        double tableNullProbability = (double) tableMetadata.getProperties().getOrDefault(TableInfo.NULL_PROBABILITY_PROPERTY, schemaNullProbability);
 
         ImmutableList.Builder<ColumnInfo> columns = ImmutableList.builder();
         int columnId = 0;

--- a/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerQueries.java
+++ b/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerQueries.java
@@ -852,27 +852,21 @@ final class TestFakerQueries
     }
 
     @Test
-    void testRenameTable(){
-            assertUpdate("CREATE TABLE faker.default.original_table (id INTEGER, name VARCHAR)");
-            assertUpdate("ALTER TABLE faker.default.original_table RENAME TO faker.default.renamed_table");
-            assertUpdate("DROP TABLE faker.default.renamed_table");
+    void testRenameTable()
+    {
+        assertUpdate("CREATE TABLE faker.default.original_table (id INTEGER, name VARCHAR)");
+        assertUpdate("ALTER TABLE faker.default.original_table RENAME TO faker.default.renamed_table");
+        assertUpdate("DROP TABLE faker.default.renamed_table");
     }
 
-
     @Test
-    void testSetTableProperties(){
-        try (TestTable table = new TestTable(getQueryRunner()::execute, "table", "(id INTEGER, name VARCHAR)")) {
+    void testSetTableProperties()
+    {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "set_table_properties", "(id INTEGER, name VARCHAR)")) {
             assertUpdate("ALTER TABLE %s SET PROPERTIES default_limit = 100".formatted(table.getName()));
             assertQueryFails("ALTER TABLE %s SET PROPERTIES invalid_property = true".formatted(table.getName()), "(?s).*Catalog 'faker' table property 'invalid_property' does not exist");
-            assertThat(computeActual("SHOW CREATE TABLE %s".formatted(table.getName())).getOnlyValue())
-                    .isEqualTo("""
-                            CREATE TABLE faker.default.%s (
-                               id integer,
-                               name varchar
-                            )
-                            WITH (
-                               default_limit = 100
-                            )""".formatted(table.getName()));
+            assertThat((String) computeScalar("SHOW CREATE TABLE " + table.getName()))
+                    .contains("default_limit = 100");
         }
     }
 
@@ -881,12 +875,7 @@ final class TestFakerQueries
     {
         try (TestTable table = new TestTable(getQueryRunner()::execute, "table_comment", "(id INTEGER, name VARCHAR)")) {
             assertUpdate("COMMENT ON TABLE %s IS 'this is a test table'".formatted(table.getName()));
-            assertThat(computeScalar("SHOW CREATE TABLE %s".formatted(table.getName()))).isEqualTo("""
-                            CREATE TABLE faker.default.%s (
-                               id integer,
-                               name varchar
-                            )
-                            COMMENT 'this is a test table'""".formatted(table.getName()));
+            assertThat(getTableComment(table.getName())).isEqualTo("this is a test table");
         }
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergRegisterTableProcedure.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergRegisterTableProcedure.java
@@ -575,11 +575,6 @@ public class TestIcebergRegisterTableProcedure
         assertThat(metastore.getTable(getSession().getSchema().orElseThrow(), tableName)).as("Table in metastore should be dropped").isEmpty();
     }
 
-    private String getTableComment(String tableName)
-    {
-        return (String) computeScalar("SELECT comment FROM system.metadata.table_comments WHERE catalog_name = 'iceberg' AND schema_name = '" + getSession().getSchema().orElseThrow() + "' AND table_name = '" + tableName + "'");
-    }
-
     private String getColumnComment(String tableName, String columnName)
     {
         return (String) computeScalar("SELECT comment FROM information_schema.columns WHERE table_schema = '" + getSession().getSchema().orElseThrow() + "' AND table_name = '" + tableName + "' AND column_name = '" + columnName + "'");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergPolarisCatalogCaseInsensitiveMapping.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergPolarisCatalogCaseInsensitiveMapping.java
@@ -255,12 +255,6 @@ final class TestIcebergPolarisCatalogCaseInsensitiveMapping
         assertQueryFails("SELECT * FROM " + viewName2, ".*'iceberg.%s.%s' does not exist".formatted(LOWERCASE_SCHEMA, lowercaseViewName2));
     }
 
-    private String getTableComment(String tableName)
-    {
-        return (String) computeScalar("SELECT comment FROM system.metadata.table_comments " +
-                "WHERE catalog_name = 'iceberg' AND schema_name = '" + LOWERCASE_SCHEMA + "' AND table_name = '" + tableName + "'");
-    }
-
     private String getColumnComment(String tableName, String columnName)
     {
         return (String) computeScalar("SELECT comment FROM information_schema.columns " +

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/procedure/TestIcebergMigrateProcedure.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/procedure/TestIcebergMigrateProcedure.java
@@ -436,11 +436,6 @@ public class TestIcebergMigrateProcedure
         assertUpdate("DROP TABLE " + tableName);
     }
 
-    private String getTableComment(String tableName)
-    {
-        return (String) computeScalar("SELECT comment FROM system.metadata.table_comments WHERE catalog_name = 'iceberg' AND schema_name = 'tpch' AND table_name = '" + tableName + "'");
-    }
-
     private String getColumnComment(String tableName, String columnName)
     {
         return (String) computeScalar("SELECT comment FROM information_schema.columns WHERE table_catalog = 'iceberg' AND table_schema = 'tpch' AND table_name = '" + tableName + "' AND column_name = '" + columnName + "'");

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
@@ -743,6 +743,22 @@ public abstract class AbstractTestQueryFramework
         });
     }
 
+    protected String getTableComment(String tableName)
+    {
+        return getTableComment(getSession(), tableName);
+    }
+
+    protected String getTableComment(Session session, String tableName)
+    {
+        return getTableComment(session.getCatalog().orElseThrow(), session.getSchema().orElseThrow(), tableName);
+    }
+
+    protected String getTableComment(String catalogName, String schemaName, String tableName)
+    {
+        String sql = format("SELECT comment FROM system.metadata.table_comments WHERE catalog_name = '%s' AND schema_name = '%s' AND table_name = '%s'", catalogName, schemaName, tableName);
+        return (String) computeScalar(sql);
+    }
+
     private <T> T inTransaction(Session session, Function<Session, T> transactionSessionConsumer)
     {
         return transaction(getQueryRunner().getTransactionManager(), getQueryRunner().getPlannerContext().getMetadata(), getQueryRunner().getAccessControl())

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorSmokeTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorSmokeTest.java
@@ -742,11 +742,6 @@ public abstract class BaseConnectorSmokeTest
         }
     }
 
-    protected String getTableComment(String tableName)
-    {
-        return (String) computeScalar(format("SELECT comment FROM system.metadata.table_comments WHERE catalog_name = '%s' AND schema_name = '%s' AND table_name = '%s'", getSession().getCatalog().orElseThrow(), getSession().getSchema().orElseThrow(), tableName));
-    }
-
     protected String getColumnComment(String tableName, String columnName)
     {
         return (String) computeScalar(format(

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -4252,12 +4252,6 @@ public abstract class BaseConnectorTest
         }
     }
 
-    protected String getTableComment(String catalogName, String schemaName, String tableName)
-    {
-        String sql = format("SELECT comment FROM system.metadata.table_comments WHERE catalog_name = '%s' AND schema_name = '%s' AND table_name = '%s'", catalogName, schemaName, tableName);
-        return (String) computeScalar(sql);
-    }
-
     @Test
     public void testCommentView()
     {


### PR DESCRIPTION
## Description

Fixes #23911

Add missing unit tests to Faker connector methods renameTable, setTableProperties and setTableComment.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
