### PR TITLE
Document sort direction and null order in Iceberg

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -1502,6 +1502,18 @@ CREATE TABLE example.customers.orders (
 WITH (sorted_by = ARRAY['order_date'])
 ```
 
+You can explicitly configure sort directions or null ordering in the following way:
+
+```
+CREATE TABLE example.customers.orders (
+    order_id BIGINT,
+    order_date DATE,
+    account_number BIGINT,
+    customer VARCHAR,
+    country VARCHAR)
+WITH (sorted_by = ARRAY['order_date DESC NULLS FIRST', 'order_id ASC NULLS LAST'])
+```
+
 Sorting can be combined with partitioning on the same column. For example:
 
 ```


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
A trivial doc update to describe how users can explicitly specify sort directions or null ordering when we create a sorted table of Apache Iceberg.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
We found no Trino document mentioning the advanced parameters of `sorted_by` [while developing Apache Hive](https://github.com/apache/hive/pull/5541#discussion_r1875869433). Simply, we misunderstood that Trino would not have the capability at first glance. I believe some people would love the information.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: