### PR TITLE
Pin openpolicyagent/opa version as 0.70.0

### DIFF
--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/OpaContainer.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/OpaContainer.java
@@ -38,7 +38,7 @@ public class OpaContainer
 
     public OpaContainer()
     {
-        this.container = new GenericContainer<>(DockerImageName.parse("openpolicyagent/opa:latest"))
+        this.container = new GenericContainer<>(DockerImageName.parse("openpolicyagent/opa:0.70.0"))
                 .withCommand("run", "--server", "--addr", ":%d".formatted(OPA_PORT), "--set", "decision_logs.console=true")
                 .withExposedPorts(OPA_PORT)
                 .waitingFor(Wait.forListeningPort());


### PR DESCRIPTION
## Description

Version 1.0.0~ doesn't pass CI. 

Fixes #24559

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
