### PR TITLE
Allow configuring `parquet_bloom_filter_columns` with `SET PROPERTIES` in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -986,7 +986,7 @@ public final class IcebergUtil
                 .snapshotId();
     }
 
-    private static void checkFormatForProperty(FileFormat actualStorageFormat, FileFormat expectedStorageFormat, String propertyName)
+    public static void checkFormatForProperty(FileFormat actualStorageFormat, FileFormat expectedStorageFormat, String propertyName)
     {
         if (actualStorageFormat != expectedStorageFormat) {
             throw new TrinoException(INVALID_TABLE_PROPERTY, format("Cannot specify %s table property for storage format: %s", propertyName, actualStorageFormat));


### PR DESCRIPTION
## Release notes

```markdown
## Iceberg
* Allow configuring the `parquet_bloom_filter_columns` table property. ({issue}`24573`)
```
