### PR TITLE
Allow configuring `orc_bloom_filter_columns` with `SET PROPERTIES` in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -867,7 +867,7 @@ public final class IcebergUtil
         List<String> orcBloomFilterColumns = IcebergTableProperties.getOrcBloomFilterColumns(tableMetadata.getProperties());
         if (!orcBloomFilterColumns.isEmpty()) {
             checkFormatForProperty(fileFormat.toIceberg(), FileFormat.ORC, ORC_BLOOM_FILTER_COLUMNS_PROPERTY);
-            validateOrcBloomFilterColumns(tableMetadata, orcBloomFilterColumns);
+            validateOrcBloomFilterColumns(tableMetadata.getColumns(), orcBloomFilterColumns);
             propertiesBuilder.put(ORC_BLOOM_FILTER_COLUMNS, Joiner.on(",").join(orcBloomFilterColumns));
             propertiesBuilder.put(ORC_BLOOM_FILTER_FPP, String.valueOf(IcebergTableProperties.getOrcBloomFilterFpp(tableMetadata.getProperties())));
         }
@@ -993,9 +993,9 @@ public final class IcebergUtil
         }
     }
 
-    private static void validateOrcBloomFilterColumns(ConnectorTableMetadata tableMetadata, List<String> orcBloomFilterColumns)
+    public static void validateOrcBloomFilterColumns(List<ColumnMetadata> columns, List<String> orcBloomFilterColumns)
     {
-        Set<String> allColumns = tableMetadata.getColumns().stream()
+        Set<String> allColumns = columns.stream()
                 .map(ColumnMetadata::getName)
                 .collect(toImmutableSet());
         if (!allColumns.containsAll(orcBloomFilterColumns)) {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -7476,12 +7476,8 @@ public abstract class BaseIcebergConnectorTest
 
         assertUpdate("CREATE TABLE " + tableName + " (a bigint)");
 
-        assertQueryFails("ALTER TABLE " + tableName + " SET PROPERTIES orc_bloom_filter_columns = ARRAY['a']",
-                "The following properties cannot be updated: orc_bloom_filter_columns");
         assertQueryFails("ALTER TABLE " + tableName + " SET PROPERTIES location = '/var/data/table/', orc_bloom_filter_fpp = 0.5",
                 "The following properties cannot be updated: location, orc_bloom_filter_fpp");
-        assertQueryFails("ALTER TABLE " + tableName + " SET PROPERTIES format = 'ORC', orc_bloom_filter_columns = ARRAY['a']",
-                "The following properties cannot be updated: orc_bloom_filter_columns");
 
         assertUpdate("DROP TABLE " + tableName);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcWithBloomFilters.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcWithBloomFilters.java
@@ -14,12 +14,13 @@
 package io.trino.plugin.iceberg;
 
 import io.trino.testing.BaseOrcWithBloomFiltersTest;
-import io.trino.testing.MaterializedResult;
 import io.trino.testing.QueryRunner;
+import io.trino.testing.sql.TestTable;
 import org.junit.jupiter.api.Test;
 
-import static io.trino.testing.MaterializedResult.resultBuilder;
-import static io.trino.testing.QueryAssertions.assertContains;
+import java.util.Map;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,6 +33,7 @@ public class TestIcebergOrcWithBloomFilters
             throws Exception
     {
         return IcebergQueryRunner.builder()
+                .addIcebergProperty("iceberg.file-format", "ORC")
                 .addIcebergProperty("hive.orc.bloom-filters.enabled", "true")
                 .addIcebergProperty("hive.orc.default-bloom-filter-fpp", "0.001")
                 .build();
@@ -55,14 +57,60 @@ public class TestIcebergOrcWithBloomFilters
                 "orc_bloom_filter_columns = array['a','b']," +
                 "orc_bloom_filter_fpp = 0.1)");
 
-        MaterializedResult actualProperties = computeActual("SELECT * FROM \"" + tableName + "$properties\"");
-        assertThat(actualProperties).isNotNull();
-        MaterializedResult expectedProperties = resultBuilder(getSession())
-                .row("write.orc.bloom.filter.columns", "a,b")
-                .row("write.orc.bloom.filter.fpp", "0.1").build();
-        assertContains(actualProperties, expectedProperties);
+        assertThat(getTableProperties(tableName))
+                .containsEntry("write.orc.bloom.filter.columns", "a,b")
+                .containsEntry("write.orc.bloom.filter.fpp", "0.1");
 
         assertThat((String) computeScalar("SHOW CREATE TABLE " + tableName))
                 .contains("orc_bloom_filter_columns", "orc_bloom_filter_fpp");
+    }
+
+    @Test
+    void testBloomFilterPropertiesArePersistedDuringSetProperties()
+    {
+        String tableName = "test_metadata_write_properties_" + randomNameSuffix();
+        assertQuerySucceeds("CREATE TABLE " + tableName + "(A bigint, b bigint, c bigint)");
+
+        assertUpdate("ALTER TABLE " + tableName + " SET PROPERTIES orc_bloom_filter_columns = ARRAY['a','B']");
+        assertThat(getTableProperties(tableName))
+                .containsEntry("write.orc.bloom.filter.columns", "a,b");
+
+        assertUpdate("ALTER TABLE " + tableName + " SET PROPERTIES orc_bloom_filter_columns = ARRAY['a']");
+        assertThat(getTableProperties(tableName))
+                .containsEntry("write.orc.bloom.filter.columns", "a");
+
+        assertUpdate("ALTER TABLE " + tableName + " SET PROPERTIES orc_bloom_filter_columns = ARRAY[]");
+        assertThat(getTableProperties(tableName))
+                .doesNotContainKey("write.orc.bloom.filter.columns");
+    }
+
+    @Test
+    void testInvalidBloomFilterProperties()
+    {
+        String tableName = "test_invalid_bloom_filter_properties_" + randomNameSuffix();
+        assertQueryFails(
+                "CREATE TABLE " + tableName + "(x int) WITH (orc_bloom_filter_columns = ARRAY['missing_column'])",
+                "\\QOrc bloom filter columns [missing_column] not present in schema");
+
+        assertQuerySucceeds("CREATE TABLE " + tableName + "(x array(integer))");
+        assertQueryFails(
+                "ALTER TABLE " + tableName + " SET PROPERTIES orc_bloom_filter_columns = ARRAY['missing_column']",
+                "\\QOrc bloom filter columns [missing_column] not present in schema");
+    }
+
+    @Test
+    void testInvalidOrcBloomFilterPropertiesOnParquet()
+    {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_orc_bloom_filter", "(x int) WITH (format = 'PARQUET')")) {
+            assertQueryFails(
+                    "ALTER TABLE " + table.getName() + " SET PROPERTIES orc_bloom_filter_columns = ARRAY['x']",
+                    "Cannot specify orc_bloom_filter_columns table property for storage format: PARQUET");
+        }
+    }
+
+    private Map<String, String> getTableProperties(String tableName)
+    {
+        return computeActual("SELECT key, value FROM \"" + tableName + "$properties\"").getMaterializedRows().stream()
+                .collect(toImmutableMap(row -> (String) row.getField(0), row -> (String) row.getField(1)));
     }
 }


### PR DESCRIPTION
## Release notes

```markdown
## Iceberg
* Allow configuring the `orc_bloom_filter_columns` table property. ({issue}`24584`)
```
