### PR TITLE
Support generating sequences in the Faker connector

### DIFF
--- a/docs/src/main/sphinx/connector/faker.md
+++ b/docs/src/main/sphinx/connector/faker.md
@@ -111,6 +111,9 @@ The following table details all supported column properties.
 * - `allowed_values`
   - List of allowed values. Cannot be set together with the `min`, or `max`
     properties.
+* - `step`
+  - If set, generate sequential values with this step. For date and time columns
+    set this to a duration. Cannot be set for character-based type columns.
 :::
 
 ### Character types

--- a/docs/src/main/sphinx/connector/faker.md
+++ b/docs/src/main/sphinx/connector/faker.md
@@ -175,7 +175,7 @@ Faker supports the following non-character types:
 - `UUID`
 
 You can not use generator expressions for non-character-based columns. To limit
-their data range, set the `min` and/or `max` column properties - see
+their data range, set the `min` and `max` column properties - see
 [](faker-usage).
 
 ### Unsupported types

--- a/plugin/trino-faker/pom.xml
+++ b/plugin/trino-faker/pom.xml
@@ -41,6 +41,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-main</artifactId>
         </dependency>
@@ -116,12 +121,6 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>log-manager</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>units</artifactId>
             <scope>runtime</scope>
         </dependency>
 

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/ColumnInfo.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/ColumnInfo.java
@@ -27,6 +27,7 @@ public record ColumnInfo(FakerColumnHandle handle, ColumnMetadata metadata)
     public static final String MIN_PROPERTY = "min";
     public static final String MAX_PROPERTY = "max";
     public static final String ALLOWED_VALUES_PROPERTY = "allowed_values";
+    public static final String STEP_PROPERTY = "step";
 
     public ColumnInfo
     {

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerConnector.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerConnector.java
@@ -39,6 +39,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.faker.ColumnInfo.ALLOWED_VALUES_PROPERTY;
 import static io.trino.plugin.faker.ColumnInfo.MAX_PROPERTY;
 import static io.trino.plugin.faker.ColumnInfo.MIN_PROPERTY;
+import static io.trino.plugin.faker.ColumnInfo.STEP_PROPERTY;
 import static io.trino.spi.StandardErrorCode.INVALID_COLUMN_PROPERTY;
 import static io.trino.spi.StandardErrorCode.INVALID_SCHEMA_PROPERTY;
 import static io.trino.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
@@ -188,7 +189,12 @@ public class FakerConnector
                         value -> ((List<?>) value).stream()
                                 .map(String.class::cast)
                                 .collect(toImmutableList()),
-                        value -> value));
+                        value -> value),
+                stringProperty(
+                        STEP_PROPERTY,
+                        "If set, generate sequential values with this step. For date and time columns set this to a duration",
+                        null,
+                        false));
     }
 
     private static void checkProperty(boolean expression, ErrorCodeSupplier errorCode, String errorMessage)

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerMetadata.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerMetadata.java
@@ -43,6 +43,8 @@ import io.trino.spi.function.FunctionId;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.SchemaFunctionName;
 import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
+import io.trino.spi.predicate.ValueSet;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.statistics.ComputedStatistics;
 import io.trino.spi.type.BigintType;
@@ -336,7 +338,8 @@ public class FakerMetadata
                         BigintType.BIGINT,
                         0,
                         "",
-                        Domain.all(BigintType.BIGINT)),
+                        Domain.create(ValueSet.ofRanges(Range.greaterThanOrEqual(BigintType.BIGINT, 0L)), false),
+                        ValueSet.of(BigintType.BIGINT, 1L)),
                 ColumnMetadata.builder()
                         .setName(ROW_ID_COLUMN_NAME)
                         .setType(BigintType.BIGINT)

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerPageSource.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerPageSource.java
@@ -250,9 +250,9 @@ class FakerPageSource
 
     private Generator randomValueGenerator(FakerColumnHandle handle)
     {
-        Range range = handle.domain().getValues().getRanges().getSpan();
+        Range genericRange = handle.domain().getValues().getRanges().getSpan();
         if (handle.generator() != null) {
-            if (!range.isAll()) {
+            if (!genericRange.isAll()) {
                 throw new TrinoException(INVALID_ROW_FILTER, "Predicates for columns with a generator expression are not supported");
             }
             return (blockBuilder) -> VARCHAR.writeSlice(blockBuilder, Slices.utf8Slice(faker.expression(handle.generator())));
@@ -260,63 +260,73 @@ class FakerPageSource
         Type type = handle.type();
         // check every type in order defined in StandardTypes
         if (BIGINT.equals(type)) {
-            return (blockBuilder) -> BIGINT.writeLong(blockBuilder, generateLong(range, 1));
+            LongRange range = LongRange.of(genericRange);
+            return (blockBuilder) -> BIGINT.writeLong(blockBuilder, numberBetween(range.low, range.high));
         }
         if (INTEGER.equals(type)) {
-            return (blockBuilder) -> INTEGER.writeLong(blockBuilder, generateInt(range));
+            IntRange range = IntRange.of(genericRange);
+            return (blockBuilder) -> INTEGER.writeLong(blockBuilder, numberBetween(range.low, range.high));
         }
         if (SMALLINT.equals(type)) {
-            return (blockBuilder) -> SMALLINT.writeLong(blockBuilder, generateShort(range));
+            IntRange range = IntRange.of(genericRange, Short.MIN_VALUE, Short.MAX_VALUE);
+            return (blockBuilder) -> SMALLINT.writeLong(blockBuilder, numberBetween(range.low, range.high));
         }
         if (TINYINT.equals(type)) {
-            return (blockBuilder) -> TINYINT.writeLong(blockBuilder, generateTiny(range));
+            IntRange range = IntRange.of(genericRange, Byte.MIN_VALUE, Byte.MAX_VALUE);
+            return (blockBuilder) -> TINYINT.writeLong(blockBuilder, numberBetween(range.low, range.high));
         }
         if (BOOLEAN.equals(type)) {
-            if (!range.isAll()) {
+            if (!genericRange.isAll()) {
                 throw new TrinoException(INVALID_ROW_FILTER, "Range or not a single value predicates for boolean columns are not supported");
             }
             return (blockBuilder) -> BOOLEAN.writeBoolean(blockBuilder, random.nextBoolean());
         }
         if (DATE.equals(type)) {
-            return (blockBuilder) -> DATE.writeLong(blockBuilder, generateInt(range));
+            IntRange range = IntRange.of(genericRange);
+            return (blockBuilder) -> DATE.writeLong(blockBuilder, numberBetween(range.low, range.high));
         }
         if (type instanceof DecimalType decimalType) {
-            return decimalGenerator(range, decimalType);
+            return decimalGenerator(genericRange, decimalType);
         }
         if (REAL.equals(type)) {
-            return (blockBuilder) -> REAL.writeLong(blockBuilder, floatToRawIntBits(generateFloat(range)));
+            FloatRange range = FloatRange.of(genericRange);
+            return (blockBuilder) -> REAL.writeLong(blockBuilder, floatToRawIntBits(range.low + (range.high - range.low) * random.nextFloat()));
         }
         if (DOUBLE.equals(type)) {
-            return (blockBuilder) -> DOUBLE.writeDouble(blockBuilder, generateDouble(range));
+            DoubleRange range = DoubleRange.of(genericRange);
+            return (blockBuilder) -> DOUBLE.writeDouble(blockBuilder, range.low + (range.high - range.low) * random.nextDouble());
         }
         // not supported: HYPER_LOG_LOG, QDIGEST, TDIGEST, P4_HYPER_LOG_LOG
         if (INTERVAL_DAY_TIME.equals(type)) {
-            return (blockBuilder) -> INTERVAL_DAY_TIME.writeLong(blockBuilder, generateLong(range, 1));
+            LongRange range = LongRange.of(genericRange);
+            return (blockBuilder) -> INTERVAL_DAY_TIME.writeLong(blockBuilder, numberBetween(range.low, range.high));
         }
         if (INTERVAL_YEAR_MONTH.equals(type)) {
-            return (blockBuilder) -> INTERVAL_YEAR_MONTH.writeLong(blockBuilder, generateInt(range));
+            IntRange range = IntRange.of(genericRange);
+            return (blockBuilder) -> INTERVAL_YEAR_MONTH.writeLong(blockBuilder, numberBetween(range.low, range.high));
         }
         if (type instanceof TimestampType) {
-            return timestampGenerator(range, (TimestampType) type);
+            return timestampGenerator(genericRange, (TimestampType) type);
         }
         if (type instanceof TimestampWithTimeZoneType) {
-            return timestampWithTimeZoneGenerator(range, (TimestampWithTimeZoneType) type);
+            return timestampWithTimeZoneGenerator(genericRange, (TimestampWithTimeZoneType) type);
         }
         if (type instanceof TimeType timeType) {
             long factor = POWERS_OF_TEN[12 - timeType.getPrecision()];
-            return (blockBuilder) -> timeType.writeLong(blockBuilder, generateLongDefaults(range, factor, 0, PICOSECONDS_PER_DAY));
+            LongRange range = LongRange.of(genericRange, factor, 0, PICOSECONDS_PER_DAY);
+            return (blockBuilder) -> timeType.writeLong(blockBuilder, numberBetween(range.low, range.high) * factor);
         }
         if (type instanceof TimeWithTimeZoneType) {
-            return timeWithTimeZoneGenerator(range, (TimeWithTimeZoneType) type);
+            return timeWithTimeZoneGenerator(genericRange, (TimeWithTimeZoneType) type);
         }
         if (type instanceof VarbinaryType varType) {
-            if (!range.isAll()) {
+            if (!genericRange.isAll()) {
                 throw new TrinoException(INVALID_ROW_FILTER, "Predicates for varbinary columns are not supported");
             }
             return (blockBuilder) -> varType.writeSlice(blockBuilder, sentenceGenerator.get());
         }
         if (type instanceof VarcharType varcharType) {
-            if (!range.isAll()) {
+            if (!genericRange.isAll()) {
                 throw new TrinoException(INVALID_ROW_FILTER, "Predicates for varchar columns are not supported");
             }
             if (varcharType.getLength().isPresent()) {
@@ -326,18 +336,18 @@ class FakerPageSource
             return (blockBuilder) -> varcharType.writeSlice(blockBuilder, sentenceGenerator.get());
         }
         if (type instanceof CharType charType) {
-            if (!range.isAll()) {
+            if (!genericRange.isAll()) {
                 throw new TrinoException(INVALID_ROW_FILTER, "Predicates for char columns are not supported");
             }
             return (blockBuilder) -> charType.writeSlice(blockBuilder, boundedSentenceGenerator.get(charType.getLength()));
         }
         // not supported: ROW, ARRAY, MAP, JSON
         if (type instanceof IpAddressType) {
-            return generateIpV4(range);
+            return generateIpV4(genericRange);
         }
         // not supported: GEOMETRY
         if (type instanceof UuidType) {
-            return generateUUID(range);
+            return generateUUID(genericRange);
         }
 
         throw new IllegalArgumentException("Unsupported type " + type);
@@ -433,116 +443,213 @@ class FakerPageSource
         throw new IllegalArgumentException("Unsupported type " + type);
     }
 
-    private long generateLong(Range range, long factor)
-    {
-        return generateLongDefaults(range, factor, Long.MIN_VALUE, Long.MAX_VALUE);
-    }
-
-    private long generateLongDefaults(Range range, long factor, long min, long max)
-    {
-        return numberBetween(
-                roundDiv((long) range.getLowValue().orElse(min), factor) + (!range.isLowUnbounded() && !range.isLowInclusive() ? 1 : 0),
-                // TODO does the inclusion only apply to positive numbers?
-                roundDiv((long) range.getHighValue().orElse(max), factor) + (!range.isHighUnbounded() && range.isHighInclusive() ? 1 : 0)) * factor;
-    }
-
-    private int generateInt(Range range)
-    {
-        return (int) numberBetween(
-                (long) range.getLowValue().orElse((long) Integer.MIN_VALUE) + (!range.isLowUnbounded() && !range.isLowInclusive() ? 1 : 0),
-                (long) range.getHighValue().orElse((long) Integer.MAX_VALUE) + (!range.isHighUnbounded() && range.isHighInclusive() ? 1 : 0));
-    }
-
-    private short generateShort(Range range)
-    {
-        return (short) numberBetween(
-                (long) range.getLowValue().orElse((long) Short.MIN_VALUE) + (!range.isLowUnbounded() && !range.isLowInclusive() ? 1 : 0),
-                (long) range.getHighValue().orElse((long) Short.MAX_VALUE) + (!range.isHighUnbounded() && range.isHighInclusive() ? 1 : 0));
-    }
-
-    private byte generateTiny(Range range)
-    {
-        return (byte) numberBetween(
-                (long) range.getLowValue().orElse((long) Byte.MIN_VALUE) + (!range.isLowUnbounded() && !range.isLowInclusive() ? 1 : 0),
-                (long) range.getHighValue().orElse((long) Byte.MAX_VALUE) + (!range.isHighUnbounded() && range.isHighInclusive() ? 1 : 0));
-    }
-
-    private float generateFloat(Range range)
-    {
-        // TODO normalize ranges in applyFilter, so they always have bounds
-        float minValue = range.getLowValue().map(v -> intBitsToFloat(toIntExact((long) v))).orElse(Float.MIN_VALUE);
-        if (!range.isLowUnbounded() && !range.isLowInclusive()) {
-            minValue = Math.nextUp(minValue);
-        }
-        float maxValue = range.getHighValue().map(v -> intBitsToFloat(toIntExact((long) v))).orElse(Float.MAX_VALUE);
-        if (!range.isHighUnbounded() && !range.isHighInclusive()) {
-            maxValue = Math.nextDown(maxValue);
-        }
-        return minValue + (maxValue - minValue) * random.nextFloat();
-    }
-
-    private double generateDouble(Range range)
-    {
-        double minValue = (double) range.getLowValue().orElse(Double.MIN_VALUE);
-        if (!range.isLowUnbounded() && !range.isLowInclusive()) {
-            minValue = Math.nextUp(minValue);
-        }
-        double maxValue = (double) range.getHighValue().orElse(Double.MAX_VALUE);
-        if (!range.isHighUnbounded() && !range.isHighInclusive()) {
-            maxValue = Math.nextDown(maxValue);
-        }
-        return minValue + (maxValue - minValue) * random.nextDouble();
-    }
-
-    private Generator decimalGenerator(Range range, DecimalType decimalType)
+    private Generator decimalGenerator(Range genericRange, DecimalType decimalType)
     {
         if (decimalType.isShort()) {
-            long min = -999999999999999999L / POWERS_OF_TEN[18 - decimalType.getPrecision()];
-            long max = 999999999999999999L / POWERS_OF_TEN[18 - decimalType.getPrecision()];
-            return (blockBuilder) -> decimalType.writeLong(blockBuilder, generateLongDefaults(range, 1, min, max));
+            ShortDecimalRange range = ShortDecimalRange.of(genericRange, decimalType.getPrecision());
+            return (blockBuilder) -> decimalType.writeLong(blockBuilder, numberBetween(range.low, range.high));
         }
-        Int128 low = (Int128) range.getLowValue().orElse(Decimals.MIN_UNSCALED_DECIMAL);
-        Int128 high = (Int128) range.getHighValue().orElse(Decimals.MAX_UNSCALED_DECIMAL);
-        if (!range.isLowUnbounded() && !range.isLowInclusive()) {
-            long[] result = new long[2];
-            Int128Math.add(low.getHigh(), low.getLow(), 0, 1, result, 0);
-            low = Int128.valueOf(result);
-        }
-        if (!range.isHighUnbounded() && range.isHighInclusive()) {
-            long[] result = new long[2];
-            Int128Math.add(high.getHigh(), high.getLow(), 0, 1, result, 0);
-            high = Int128.valueOf(result);
-        }
-
+        Int128Range range = Int128Range.of(genericRange);
         BigInteger currentRange = BigInteger.valueOf(Long.MAX_VALUE);
-        BigInteger desiredRange = high.toBigInteger().subtract(low.toBigInteger());
-        Int128 finalLow = low;
+        BigInteger desiredRange = range.high.toBigInteger().subtract(range.low.toBigInteger());
         return (blockBuilder) -> decimalType.writeObject(blockBuilder, Int128.valueOf(
-                new BigInteger(63, random).multiply(desiredRange).divide(currentRange).add(finalLow.toBigInteger())));
+                new BigInteger(63, random).multiply(desiredRange).divide(currentRange).add(range.low.toBigInteger())));
     }
 
-    private Generator timestampGenerator(Range range, TimestampType tzType)
+    private Generator timestampGenerator(Range genericRange, TimestampType tzType)
     {
         if (tzType.isShort()) {
             long factor = POWERS_OF_TEN[6 - tzType.getPrecision()];
-            return (blockBuilder) -> tzType.writeLong(blockBuilder, generateLong(range, factor));
+            LongRange range = LongRange.of(genericRange, factor);
+            return (blockBuilder) -> tzType.writeLong(blockBuilder, numberBetween(range.low, range.high) * factor);
         }
-        LongTimestamp low = (LongTimestamp) range.getLowValue()
-                .orElse(new LongTimestamp(Long.MIN_VALUE, 0));
-        LongTimestamp high = (LongTimestamp) range.getHighValue()
-                .orElse(new LongTimestamp(Long.MAX_VALUE, PICOSECONDS_PER_MICROSECOND - 1));
-        int factor;
+        LongTimestampRange range = LongTimestampRange.of(genericRange, tzType.getPrecision());
         if (tzType.getPrecision() <= 6) {
-            factor = (int) POWERS_OF_TEN[6 - tzType.getPrecision()];
-            low = new LongTimestamp(
-                    roundDiv(low.getEpochMicros(), factor) + (!range.isLowUnbounded() && !range.isLowInclusive() ? 1 : 0),
-                    0);
-            high = new LongTimestamp(
-                    roundDiv(high.getEpochMicros(), factor) + (!range.isHighUnbounded() && range.isHighInclusive() ? 1 : 0),
-                    0);
+            return (blockBuilder) -> {
+                long epochMicros = numberBetween(range.low.getEpochMicros(), range.high.getEpochMicros());
+                tzType.writeObject(blockBuilder, new LongTimestamp(epochMicros * range.factor, 0));
+            };
         }
-        else {
-            factor = (int) POWERS_OF_TEN[12 - tzType.getPrecision()];
+        return (blockBuilder) -> {
+            long epochMicros = numberBetween(range.low.getEpochMicros(), range.high.getEpochMicros());
+            int picosOfMicro;
+            if (epochMicros == range.low.getEpochMicros()) {
+                picosOfMicro = numberBetween(
+                        range.low.getPicosOfMicro(),
+                        range.low.getEpochMicros() == range.high.getEpochMicros() ?
+                                range.high.getPicosOfMicro()
+                                : (int) POWERS_OF_TEN[tzType.getPrecision() - 6] - 1);
+            }
+            else if (epochMicros == range.high.getEpochMicros()) {
+                picosOfMicro = numberBetween(0, range.high.getPicosOfMicro());
+            }
+            else {
+                picosOfMicro = numberBetween(0, (int) POWERS_OF_TEN[tzType.getPrecision() - 6] - 1);
+            }
+            tzType.writeObject(blockBuilder, new LongTimestamp(epochMicros, picosOfMicro * range.factor));
+        };
+    }
+
+    private Generator timestampWithTimeZoneGenerator(Range genericRange, TimestampWithTimeZoneType tzType)
+    {
+        if (tzType.isShort()) {
+            ShortTimestampWithTimeZoneRange range = ShortTimestampWithTimeZoneRange.of(genericRange, tzType.getPrecision());
+            return (blockBuilder) -> {
+                long millis = numberBetween(range.low, range.high) * range.factor;
+                tzType.writeLong(blockBuilder, packDateTimeWithZone(millis, range.defaultTZ));
+            };
+        }
+        LongTimestampWithTimeZoneRange range = LongTimestampWithTimeZoneRange.of(genericRange, tzType.getPrecision());
+        int picosOfMilliHigh = (int) POWERS_OF_TEN[tzType.getPrecision() - 3] - 1;
+        return (blockBuilder) -> {
+            long millis = numberBetween(range.low.getEpochMillis(), range.high.getEpochMillis());
+            int picosOfMilli;
+            if (millis == range.low.getEpochMillis()) {
+                picosOfMilli = numberBetween(
+                        range.low.getPicosOfMilli(),
+                        range.low.getEpochMillis() == range.high.getEpochMillis() ?
+                                range.high.getPicosOfMilli()
+                                : picosOfMilliHigh);
+            }
+            else if (millis == range.high.getEpochMillis()) {
+                picosOfMilli = numberBetween(0, range.high.getPicosOfMilli());
+            }
+            else {
+                picosOfMilli = numberBetween(0, picosOfMilliHigh);
+            }
+            tzType.writeObject(blockBuilder, fromEpochMillisAndFraction(millis, picosOfMilli * range.factor, range.defaultTZ));
+        };
+    }
+
+    private Generator timeWithTimeZoneGenerator(Range genericRange, TimeWithTimeZoneType timeType)
+    {
+        if (timeType.isShort()) {
+            ShortTimeWithTimeZoneRange range = ShortTimeWithTimeZoneRange.of(genericRange, timeType.getPrecision());
+            return (blockBuilder) -> {
+                long nanos = numberBetween(range.low, range.high) * range.factor;
+                timeType.writeLong(blockBuilder, packTimeWithTimeZone(nanos, range.offsetMinutes));
+            };
+        }
+        LongTimeWithTimeZoneRange range = LongTimeWithTimeZoneRange.of(genericRange, timeType.getPrecision());
+        return (blockBuilder) -> {
+            long picoseconds = numberBetween(range.low, range.high) * range.factor;
+            timeType.writeObject(blockBuilder, new LongTimeWithTimeZone(picoseconds, range.offsetMinutes));
+        };
+    }
+
+    private record LongRange(long low, long high)
+    {
+        static LongRange of(Range range)
+        {
+            return of(range, 1, Long.MIN_VALUE, Long.MAX_VALUE);
+        }
+
+        static LongRange of(Range range, long factor)
+        {
+            return of(range, factor, Long.MIN_VALUE, Long.MAX_VALUE);
+        }
+
+        static LongRange of(Range range, long factor, long defaultMin, long defaultMax)
+        {
+            return new LongRange(
+                    roundDiv((long) range.getLowValue().orElse(defaultMin), factor) + (!range.isLowUnbounded() && !range.isLowInclusive() ? 1 : 0),
+                    roundDiv((long) range.getHighValue().orElse(defaultMax), factor) + (!range.isHighUnbounded() && range.isHighInclusive() ? 1 : 0));
+        }
+    }
+
+    private record IntRange(int low, int high)
+    {
+        static IntRange of(Range range)
+        {
+            return of(range, Integer.MIN_VALUE, Integer.MAX_VALUE);
+        }
+
+        static IntRange of(Range range, long defaultMin, long defaultMax)
+        {
+            return new IntRange(
+                    toIntExact((long) range.getLowValue().orElse(defaultMin)) + (!range.isLowUnbounded() && !range.isLowInclusive() ? 1 : 0),
+                    toIntExact((long) range.getHighValue().orElse(defaultMax)) + (!range.isHighUnbounded() && range.isHighInclusive() ? 1 : 0));
+        }
+    }
+
+    private record FloatRange(float low, float high)
+    {
+        static FloatRange of(Range range)
+        {
+            float low = range.getLowValue().map(v -> intBitsToFloat(toIntExact((long) v))).orElse(Float.MIN_VALUE);
+            if (!range.isLowUnbounded() && !range.isLowInclusive()) {
+                low = Math.nextUp(low);
+            }
+            float high = range.getHighValue().map(v -> intBitsToFloat(toIntExact((long) v))).orElse(Float.MAX_VALUE);
+            if (!range.isHighUnbounded() && !range.isHighInclusive()) {
+                high = Math.nextDown(high);
+            }
+            return new FloatRange(low, high);
+        }
+    }
+
+    private record DoubleRange(double low, double high)
+    {
+        static DoubleRange of(Range range)
+        {
+            double low = (double) range.getLowValue().orElse(Double.MIN_VALUE);
+            if (!range.isLowUnbounded() && !range.isLowInclusive()) {
+                low = Math.nextUp(low);
+            }
+            double high = (double) range.getHighValue().orElse(Double.MAX_VALUE);
+            if (!range.isHighUnbounded() && !range.isHighInclusive()) {
+                high = Math.nextDown(high);
+            }
+            return new DoubleRange(low, high);
+        }
+    }
+
+    private record ShortDecimalRange(long low, long high)
+    {
+        static ShortDecimalRange of(Range range, int precision)
+        {
+            long defaultMin = -999999999999999999L / POWERS_OF_TEN[18 - precision];
+            long defaultMax = 999999999999999999L / POWERS_OF_TEN[18 - precision];
+            long low = (long) range.getLowValue().orElse(defaultMin) + (!range.isLowUnbounded() && !range.isLowInclusive() ? 1 : 0);
+            long high = (long) range.getHighValue().orElse(defaultMax) + (!range.isHighUnbounded() && range.isHighInclusive() ? 1 : 0);
+            return new ShortDecimalRange(low, high);
+        }
+    }
+
+    private record Int128Range(Int128 low, Int128 high)
+    {
+        static Int128Range of(Range range)
+        {
+            Int128 low = (Int128) range.getLowValue().orElse(Decimals.MIN_UNSCALED_DECIMAL);
+            Int128 high = (Int128) range.getHighValue().orElse(Decimals.MAX_UNSCALED_DECIMAL);
+            if (!range.isLowUnbounded() && !range.isLowInclusive()) {
+                long[] result = new long[2];
+                Int128Math.add(low.getHigh(), low.getLow(), 0, 1, result, 0);
+                low = Int128.valueOf(result);
+            }
+            if (!range.isHighUnbounded() && range.isHighInclusive()) {
+                long[] result = new long[2];
+                Int128Math.add(high.getHigh(), high.getLow(), 0, 1, result, 0);
+                high = Int128.valueOf(result);
+            }
+            return new Int128Range(low, high);
+        }
+    }
+
+    private record LongTimestampRange(LongTimestamp low, LongTimestamp high, int factor)
+    {
+        static LongTimestampRange of(Range range, int precision)
+        {
+            LongTimestamp low = (LongTimestamp) range.getLowValue().orElse(new LongTimestamp(Long.MIN_VALUE, 0));
+            LongTimestamp high = (LongTimestamp) range.getHighValue().orElse(new LongTimestamp(Long.MAX_VALUE, PICOSECONDS_PER_MICROSECOND - 1));
+            int factor;
+            if (precision <= 6) {
+                factor = (int) POWERS_OF_TEN[6 - precision];
+                low = new LongTimestamp(roundDiv(low.getEpochMicros(), factor) + (!range.isLowUnbounded() && !range.isLowInclusive() ? 1 : 0), 0);
+                high = new LongTimestamp(roundDiv(high.getEpochMicros(), factor) + (!range.isHighUnbounded() && range.isHighInclusive() ? 1 : 0), 0);
+                return new LongTimestampRange(low, high, factor);
+            }
+            factor = (int) POWERS_OF_TEN[12 - precision];
             int lowPicosOfMicro = roundDiv(low.getPicosOfMicro(), factor) + (!range.isLowUnbounded() && !range.isLowInclusive() ? 1 : 0);
             low = new LongTimestamp(
                     low.getEpochMicros() - (lowPicosOfMicro < 0 ? 1 : 0),
@@ -551,130 +658,90 @@ class FakerPageSource
             high = new LongTimestamp(
                     high.getEpochMicros() + (highPicosOfMicro > factor ? 1 : 0),
                     highPicosOfMicro % factor);
+            return new LongTimestampRange(low, high, factor);
         }
-        LongTimestamp finalLow = low;
-        LongTimestamp finalHigh = high;
-        return (blockBuilder) -> {
-            long epochMicros = numberBetween(finalLow.getEpochMicros(), finalHigh.getEpochMicros());
-            if (tzType.getPrecision() <= 6) {
-                epochMicros *= factor;
-                tzType.writeObject(blockBuilder, new LongTimestamp(epochMicros * factor, 0));
-                return;
-            }
-            int picosOfMicro;
-            if (epochMicros == finalLow.getEpochMicros()) {
-                picosOfMicro = numberBetween(
-                        finalLow.getPicosOfMicro(),
-                        finalLow.getEpochMicros() == finalHigh.getEpochMicros() ?
-                                finalHigh.getPicosOfMicro()
-                                : (int) POWERS_OF_TEN[tzType.getPrecision() - 6] - 1);
-            }
-            else if (epochMicros == finalHigh.getEpochMicros()) {
-                picosOfMicro = numberBetween(0, finalHigh.getPicosOfMicro());
-            }
-            else {
-                picosOfMicro = numberBetween(0, (int) POWERS_OF_TEN[tzType.getPrecision() - 6] - 1);
-            }
-            tzType.writeObject(blockBuilder, new LongTimestamp(epochMicros, picosOfMicro * factor));
-        };
     }
 
-    private Generator timestampWithTimeZoneGenerator(Range range, TimestampWithTimeZoneType tzType)
+    private record ShortTimestampWithTimeZoneRange(long low, long high, long factor, TimeZoneKey defaultTZ)
     {
-        if (tzType.isShort()) {
+        static ShortTimestampWithTimeZoneRange of(Range range, int precision)
+        {
             TimeZoneKey defaultTZ = range.getLowValue()
                     .map(v -> unpackZoneKey((long) v))
                     .orElse(range.getHighValue()
                             .map(v -> unpackZoneKey((long) v))
                             .orElse(TimeZoneKey.UTC_KEY));
-            long factor = POWERS_OF_TEN[3 - tzType.getPrecision()];
-            return (blockBuilder) -> {
-                long millis = numberBetween(
-                        roundDiv(unpackMillisUtc((long) range.getLowValue().orElse(Long.MIN_VALUE)), factor) + (!range.isLowUnbounded() && !range.isLowInclusive() ? 1 : 0),
-                        roundDiv(unpackMillisUtc((long) range.getHighValue().orElse(Long.MAX_VALUE)), factor) + (!range.isHighUnbounded() && range.isHighInclusive() ? 1 : 0)) * factor;
-                tzType.writeLong(blockBuilder, packDateTimeWithZone(millis, defaultTZ));
-            };
+            long factor = POWERS_OF_TEN[3 - precision];
+            long low = roundDiv(unpackMillisUtc((long) range.getLowValue().orElse(Long.MIN_VALUE)), factor) + (!range.isLowUnbounded() && !range.isLowInclusive() ? 1 : 0);
+            long high = roundDiv(unpackMillisUtc((long) range.getHighValue().orElse(Long.MAX_VALUE)), factor) + (!range.isHighUnbounded() && range.isHighInclusive() ? 1 : 0);
+            return new ShortTimestampWithTimeZoneRange(low, high, factor, defaultTZ);
         }
-        short defaultTZ = range.getLowValue()
-                .map(v -> ((LongTimestampWithTimeZone) v).getTimeZoneKey())
-                .orElse(range.getHighValue()
-                        .map(v -> ((LongTimestampWithTimeZone) v).getTimeZoneKey())
-                        .orElse(TimeZoneKey.UTC_KEY.getKey()));
-        LongTimestampWithTimeZone low = (LongTimestampWithTimeZone) range.getLowValue()
-                .orElse(fromEpochMillisAndFraction(Long.MIN_VALUE >> 12, 0, defaultTZ));
-        LongTimestampWithTimeZone high = (LongTimestampWithTimeZone) range.getHighValue()
-                .orElse(fromEpochMillisAndFraction(Long.MAX_VALUE >> 12, PICOSECONDS_PER_MILLISECOND - 1, defaultTZ));
-        if (low.getTimeZoneKey() != high.getTimeZoneKey()) {
-            throw new TrinoException(INVALID_ROW_FILTER, "Range boundaries for timestamp with time zone columns must have the same time zone");
-        }
-        int factor = (int) POWERS_OF_TEN[12 - tzType.getPrecision()];
-        int lowPicosOfMilli = roundDiv(low.getPicosOfMilli(), factor) + (!range.isLowUnbounded() && !range.isLowInclusive() ? 1 : 0);
-        low = fromEpochMillisAndFraction(
-                low.getEpochMillis() - (lowPicosOfMilli < 0 ? 1 : 0),
-                (lowPicosOfMilli + factor) % factor,
-                low.getTimeZoneKey());
-        int highPicosOfMilli = roundDiv(high.getPicosOfMilli(), factor) + (!range.isHighUnbounded() && range.isHighInclusive() ? 1 : 0);
-        high = fromEpochMillisAndFraction(
-                high.getEpochMillis() + (highPicosOfMilli > factor ? 1 : 0),
-                highPicosOfMilli % factor,
-                high.getTimeZoneKey());
-        LongTimestampWithTimeZone finalLow = low;
-        LongTimestampWithTimeZone finalHigh = high;
-        return (blockBuilder) -> {
-            long millis = numberBetween(finalLow.getEpochMillis(), finalHigh.getEpochMillis());
-            int picosOfMilli;
-            if (millis == finalLow.getEpochMillis()) {
-                picosOfMilli = numberBetween(
-                        finalLow.getPicosOfMilli(),
-                        finalLow.getEpochMillis() == finalHigh.getEpochMillis() ?
-                                finalHigh.getPicosOfMilli()
-                                : (int) POWERS_OF_TEN[tzType.getPrecision() - 3] - 1);
-            }
-            else if (millis == finalHigh.getEpochMillis()) {
-                picosOfMilli = numberBetween(0, finalHigh.getPicosOfMilli());
-            }
-            else {
-                picosOfMilli = numberBetween(0, (int) POWERS_OF_TEN[tzType.getPrecision() - 3] - 1);
-            }
-            tzType.writeObject(blockBuilder, fromEpochMillisAndFraction(millis, picosOfMilli * factor, defaultTZ));
-        };
     }
 
-    private Generator timeWithTimeZoneGenerator(Range range, TimeWithTimeZoneType timeType)
+    private record LongTimestampWithTimeZoneRange(LongTimestampWithTimeZone low, LongTimestampWithTimeZone high, int factor, short defaultTZ)
     {
-        if (timeType.isShort()) {
+        static LongTimestampWithTimeZoneRange of(Range range, int precision)
+        {
+            short defaultTZ = range.getLowValue()
+                    .map(v -> ((LongTimestampWithTimeZone) v).getTimeZoneKey())
+                    .orElse(range.getHighValue()
+                            .map(v -> ((LongTimestampWithTimeZone) v).getTimeZoneKey())
+                            .orElse(TimeZoneKey.UTC_KEY.getKey()));
+            LongTimestampWithTimeZone low = (LongTimestampWithTimeZone) range.getLowValue().orElse(fromEpochMillisAndFraction(Long.MIN_VALUE >> 12, 0, defaultTZ));
+            LongTimestampWithTimeZone high = (LongTimestampWithTimeZone) range.getHighValue().orElse(fromEpochMillisAndFraction(Long.MAX_VALUE >> 12, PICOSECONDS_PER_MILLISECOND - 1, defaultTZ));
+            if (low.getTimeZoneKey() != high.getTimeZoneKey()) {
+                throw new TrinoException(INVALID_ROW_FILTER, "Range boundaries for timestamp with time zone columns must have the same time zone");
+            }
+            int factor = (int) POWERS_OF_TEN[12 - precision];
+            int lowPicosOfMilli = roundDiv(low.getPicosOfMilli(), factor) + (!range.isLowUnbounded() && !range.isLowInclusive() ? 1 : 0);
+            low = fromEpochMillisAndFraction(
+                    low.getEpochMillis() - (lowPicosOfMilli < 0 ? 1 : 0),
+                    (lowPicosOfMilli + factor) % factor,
+                    low.getTimeZoneKey());
+            int highPicosOfMilli = roundDiv(high.getPicosOfMilli(), factor) + (!range.isHighUnbounded() && range.isHighInclusive() ? 1 : 0);
+            high = fromEpochMillisAndFraction(
+                    high.getEpochMillis() + (highPicosOfMilli > factor ? 1 : 0),
+                    highPicosOfMilli % factor,
+                    high.getTimeZoneKey());
+            return new LongTimestampWithTimeZoneRange(low, high, factor, defaultTZ);
+        }
+    }
+
+    private record ShortTimeWithTimeZoneRange(long low, long high, long factor, int offsetMinutes)
+    {
+        static ShortTimeWithTimeZoneRange of(Range range, int precision)
+        {
             int offsetMinutes = range.getLowValue()
                     .map(v -> unpackOffsetMinutes((long) v))
                     .orElse(range.getHighValue()
                             .map(v -> unpackOffsetMinutes((long) v))
                             .orElse(0));
-            long factor = POWERS_OF_TEN[9 - timeType.getPrecision()];
+            long factor = POWERS_OF_TEN[9 - precision];
             long low = roundDiv(range.getLowValue().map(v -> unpackTimeNanos((long) v)).orElse(0L), factor) + (!range.isLowUnbounded() && !range.isLowInclusive() ? 1 : 0);
             long high = roundDiv(range.getHighValue().map(v -> unpackTimeNanos((long) v)).orElse(NANOSECONDS_PER_DAY), factor) + (!range.isHighUnbounded() && range.isHighInclusive() ? 1 : 0);
-            return (blockBuilder) -> {
-                long nanos = numberBetween(low, high) * factor;
-                timeType.writeLong(blockBuilder, packTimeWithTimeZone(nanos, offsetMinutes));
-            };
+            return new ShortTimeWithTimeZoneRange(low, high, factor, offsetMinutes);
         }
-        int offsetMinutes = range.getLowValue()
-                .map(v -> ((LongTimeWithTimeZone) v).getOffsetMinutes())
-                .orElse(range.getHighValue()
-                        .map(v -> ((LongTimeWithTimeZone) v).getOffsetMinutes())
-                        .orElse(0));
-        LongTimeWithTimeZone low = (LongTimeWithTimeZone) range.getLowValue()
-                .orElse(new LongTimeWithTimeZone(0, offsetMinutes));
-        LongTimeWithTimeZone high = (LongTimeWithTimeZone) range.getHighValue()
-                .orElse(new LongTimeWithTimeZone(PICOSECONDS_PER_DAY, offsetMinutes));
-        if (low.getOffsetMinutes() != high.getOffsetMinutes()) {
-            throw new TrinoException(INVALID_ROW_FILTER, "Range boundaries for time with time zone columns must have the same time zone");
+    }
+
+    private record LongTimeWithTimeZoneRange(long low, long high, int factor, int offsetMinutes)
+    {
+        static LongTimeWithTimeZoneRange of(Range range, int precision)
+        {
+            int offsetMinutes = range.getLowValue()
+                    .map(v -> ((LongTimeWithTimeZone) v).getOffsetMinutes())
+                    .orElse(range.getHighValue()
+                            .map(v -> ((LongTimeWithTimeZone) v).getOffsetMinutes())
+                            .orElse(0));
+            LongTimeWithTimeZone low = (LongTimeWithTimeZone) range.getLowValue().orElse(new LongTimeWithTimeZone(0, offsetMinutes));
+            LongTimeWithTimeZone high = (LongTimeWithTimeZone) range.getHighValue().orElse(new LongTimeWithTimeZone(PICOSECONDS_PER_DAY, offsetMinutes));
+            if (low.getOffsetMinutes() != high.getOffsetMinutes()) {
+                throw new TrinoException(INVALID_ROW_FILTER, "Range boundaries for time with time zone columns must have the same time zone");
+            }
+            int factor = (int) POWERS_OF_TEN[12 - precision];
+            long longLow = roundDiv(low.getPicoseconds(), factor) + (!range.isLowUnbounded() && !range.isLowInclusive() ? 1 : 0);
+            long longHigh = roundDiv(high.getPicoseconds(), factor) + (!range.isHighUnbounded() && range.isHighInclusive() ? 1 : 0);
+            return new LongTimeWithTimeZoneRange(longLow, longHigh, factor, offsetMinutes);
         }
-        int factor = (int) POWERS_OF_TEN[12 - timeType.getPrecision()];
-        long longLow = roundDiv(low.getPicoseconds(), factor) + (!range.isLowUnbounded() && !range.isLowInclusive() ? 1 : 0);
-        long longHigh = roundDiv(high.getPicoseconds(), factor) + (!range.isHighUnbounded() && range.isHighInclusive() ? 1 : 0);
-        return (blockBuilder) -> {
-            long picoseconds = numberBetween(longLow, longHigh) * factor;
-            timeType.writeObject(blockBuilder, new LongTimeWithTimeZone(picoseconds, offsetMinutes));
-        };
     }
 
     private int numberBetween(int min, int max)

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerPageSource.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerPageSource.java
@@ -290,11 +290,11 @@ class FakerPageSource
         }
         if (REAL.equals(type)) {
             FloatRange range = FloatRange.of(genericRange);
-            return (blockBuilder) -> REAL.writeLong(blockBuilder, floatToRawIntBits(range.low + (range.high - range.low) * random.nextFloat()));
+            return (blockBuilder) -> REAL.writeLong(blockBuilder, floatToRawIntBits(range.low == range.high ? range.low : random.nextFloat(range.low, range.high)));
         }
         if (DOUBLE.equals(type)) {
             DoubleRange range = DoubleRange.of(genericRange);
-            return (blockBuilder) -> DOUBLE.writeDouble(blockBuilder, range.low + (range.high - range.low) * random.nextDouble());
+            return (blockBuilder) -> DOUBLE.writeDouble(blockBuilder, range.low == range.high ? range.low : random.nextDouble(range.low, range.high));
         }
         // not supported: HYPER_LOG_LOG, QDIGEST, TDIGEST, P4_HYPER_LOG_LOG
         if (INTERVAL_DAY_TIME.equals(type)) {
@@ -581,8 +581,8 @@ class FakerPageSource
                 low = Math.nextUp(low);
             }
             float high = range.getHighValue().map(v -> intBitsToFloat(toIntExact((long) v))).orElse(Float.MAX_VALUE);
-            if (!range.isHighUnbounded() && !range.isHighInclusive()) {
-                high = Math.nextDown(high);
+            if (!range.isHighUnbounded() && range.isHighInclusive()) {
+                high = Math.nextUp(high);
             }
             return new FloatRange(low, high);
         }
@@ -597,8 +597,8 @@ class FakerPageSource
                 low = Math.nextUp(low);
             }
             double high = (double) range.getHighValue().orElse(Double.MAX_VALUE);
-            if (!range.isHighUnbounded() && !range.isHighInclusive()) {
-                high = Math.nextDown(high);
+            if (!range.isHighUnbounded() && range.isHighInclusive()) {
+                high = Math.nextUp(high);
             }
             return new DoubleRange(low, high);
         }

--- a/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerQueries.java
+++ b/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerQueries.java
@@ -311,8 +311,8 @@ final class TestFakerQueries
                 .add(new TestDataType("rnd_decimal3", "decimal(38,0)", Map.of("min", "99999999999999999999999999999999999999"), "count(distinct rnd_decimal3)", "1"))
                 .add(new TestDataType("rnd_decimal4", "decimal(38,38)", Map.of("min", "0.99999999999999999999999999999999999999"), "count(distinct rnd_decimal4)", "1"))
                 .add(new TestDataType("rnd_decimal5", "decimal(5,2)", Map.of("min", "999.99"), "count(distinct rnd_decimal5)", "1"))
-                .add(new TestDataType("rnd_real", "real", Map.of("min", "1.4E45"), "count(distinct rnd_real)", "1"))
-                .add(new TestDataType("rnd_double", "double", Map.of("min", "4.9E324"), "count(distinct rnd_double)", "1"))
+                .add(new TestDataType("rnd_real", "real", Map.of("min", "3.4028235E38"), "count(distinct rnd_real)", "1"))
+                .add(new TestDataType("rnd_double", "double", Map.of("min", "1.7976931348623157E308"), "count(distinct rnd_double)", "1"))
                 // interval literals can't represent smallest possible values allowed by the engine, so they're not included here
                 // can't test timestamps because their extreme values cannot be expressed as literals
                 .add(new TestDataType("rnd_time", "time", Map.of("min", "23:59:59.999"), "count(distinct rnd_time)", "1"))

--- a/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerQueries.java
+++ b/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerQueries.java
@@ -385,6 +385,51 @@ final class TestFakerQueries
         }
     }
 
+    @Test
+    void testSelectStepProperties()
+    {
+        // small step in small ranges that produce only 10 unique values for 1000 rows
+        List<TestDataType> testCases = ImmutableList.<TestDataType>builder()
+                .add(new TestDataType("rnd_bigint", "bigint", Map.of("min", "0", "max", "9", "step", "1"), "count(distinct rnd_bigint)", "10"))
+                .add(new TestDataType("rnd_integer", "integer", Map.of("min", "0", "max", "9", "step", "1"), "count(distinct rnd_integer)", "10"))
+                .add(new TestDataType("rnd_smallint", "smallint", Map.of("min", "0", "max", "9", "step", "1"), "count(distinct rnd_smallint)", "10"))
+                .add(new TestDataType("rnd_tinyint", "tinyint", Map.of("min", "0", "max", "9", "step", "1"), "count(distinct rnd_tinyint)", "10"))
+                .add(new TestDataType("rnd_date", "date", Map.of("min", "2022-03-01", "max", "2022-03-10", "step", "1d"), "count(distinct rnd_date)", "10"))
+                .add(new TestDataType("rnd_decimal1", "decimal", Map.of("min", "0", "max", "9", "step", "1"), "count(distinct rnd_decimal1)", "10"))
+                .add(new TestDataType("rnd_decimal2", "decimal(18,5)", Map.of("min", "0.00000", "max", "0.00009", "step", "0.00001"), "count(distinct rnd_decimal2)", "10"))
+                .add(new TestDataType("rnd_decimal3", "decimal(38,0)", Map.of("min", "0", "max", "9", "step", "1"), "count(distinct rnd_decimal3)", "10"))
+                .add(new TestDataType("rnd_decimal4", "decimal(38,38)", Map.of("min", "0.00000000000000000000000000000000000000", "max", "0.00000000000000000000000000000000000009", "step", "0.00000000000000000000000000000000000001"), "count(distinct rnd_decimal4)", "10"))
+                .add(new TestDataType("rnd_decimal5", "decimal(5,2)", Map.of("min", "0.00", "max", "1.09", "step", "0.01"), "count(distinct rnd_decimal5)", "110"))
+                .add(new TestDataType("rnd_real", "real", Map.of("min", "0.0", "max", "1.3E-44", "step", "1.4E-45"), "count(distinct rnd_real)", "10"))
+                .add(new TestDataType("rnd_double", "double", Map.of("min", "0.0", "max", "4.4E-323", "step", "4.9E-324"), "count(distinct rnd_double)", "10"))
+                .add(new TestDataType("rnd_interval1", "interval day to second", Map.of("min", "0.000", "max", "0.009", "step", "0.001"), "count(distinct rnd_interval1)", "10"))
+                .add(new TestDataType("rnd_interval2", "interval year to month", Map.of("min", "0", "max", "9", "step", "1"), "count(distinct rnd_interval2)", "10"))
+                .add(new TestDataType("rnd_timestamp", "timestamp", Map.of("min", "2022-03-21 00:00:00.000", "max", "2022-03-21 00:00:00.009", "step", "1ms"), "count(distinct rnd_timestamp)", "10"))
+                .add(new TestDataType("rnd_timestamp0", "timestamp(0)", Map.of("min", "2022-03-21 00:00:00", "max", "2022-03-21 00:00:09", "step", "1s"), "count(distinct rnd_timestamp0)", "10"))
+                .add(new TestDataType("rnd_timestamp6", "timestamp(6)", Map.of("min", "2022-03-21 00:00:00.000000", "max", "2022-03-21 00:00:00.000009", "step", "1us"), "count(distinct rnd_timestamp6)", "10"))
+                .add(new TestDataType("rnd_timestamp9", "timestamp(9)", Map.of("min", "2022-03-21 00:00:00.000000000", "max", "2022-03-21 00:00:00.000009000", "step", "1us"), "count(distinct rnd_timestamp9)", "10"))
+                .add(new TestDataType("rnd_timestamptz", "timestamp with time zone", Map.of("min", "2022-03-21 00:00:00.000 +01:00", "max", "2022-03-21 00:00:00.009 +01:00", "step", "1ms"), "count(distinct rnd_timestamptz)", "10"))
+                .add(new TestDataType("rnd_timestamptz0", "timestamp(0) with time zone", Map.of("min", "2022-03-21 00:00:00 +01:00", "max", "2022-03-21 00:00:09 +01:00", "step", "1s"), "count(distinct rnd_timestamptz0)", "10"))
+                .add(new TestDataType("rnd_timestamptz6", "timestamp(6) with time zone", Map.of("min", "2022-03-21 00:00:00.000000 +01:00", "max", "2022-03-21 00:00:00.009000 +01:00", "step", "1ms"), "count(distinct rnd_timestamptz6)", "10"))
+                .add(new TestDataType("rnd_timestamptz9", "timestamp(9) with time zone", Map.of("min", "2022-03-21 00:00:00.000000000 +01:00", "max", "2022-03-21 00:00:00.009000000 +01:00", "step", "1ms"), "count(distinct rnd_timestamptz9)", "10"))
+                .add(new TestDataType("rnd_time", "time", Map.of("min", "01:02:03.456", "max", "01:02:03.465", "step", "1ms"), "count(distinct rnd_time)", "10"))
+                .add(new TestDataType("rnd_time0", "time(0)", Map.of("min", "01:02:03", "max", "01:02:12", "step", "1s"), "count(distinct rnd_time0)", "10"))
+                .add(new TestDataType("rnd_time6", "time(6)", Map.of("min", "01:02:03.000456", "max", "01:02:03.000465", "step", "1us"), "count(distinct rnd_time6)", "10"))
+                .add(new TestDataType("rnd_time9", "time(9)", Map.of("min", "01:02:03.000000456", "max", "01:02:03.000000465", "step", "1ns"), "count(distinct rnd_time9)", "10"))
+                .add(new TestDataType("rnd_timetz", "time with time zone", Map.of("min", "01:02:03.456 +01:00", "max", "01:02:03.465 +01:00", "step", "1ms"), "count(distinct rnd_timetz)", "10"))
+                .add(new TestDataType("rnd_timetz0", "time(0) with time zone", Map.of("min", "01:02:03 +01:00", "max", "01:02:12 +01:00", "step", "1s"), "count(distinct rnd_timetz0)", "10"))
+                .add(new TestDataType("rnd_timetz6", "time(6) with time zone", Map.of("min", "01:02:03.000456 +01:00", "max", "01:02:03.000465 +01:00", "step", "1us"), "count(distinct rnd_timetz6)", "10"))
+                .add(new TestDataType("rnd_timetz9", "time(9) with time zone", Map.of("min", "01:02:03.000000456 +01:00", "max", "01:02:03.000000465 +01:00", "step", "1ns"), "count(distinct rnd_timetz9)", "10"))
+                .add(new TestDataType("rnd_timetz12", "time(12) with time zone", Map.of("min", "01:02:03.000000000456 +01:00", "max", "01:02:03.000000009456 +01:00", "step", "1ns"), "count(distinct rnd_timetz12)", "10"))
+                .build();
+
+        for (TestDataType testCase : testCases) {
+            try (TestTable table = new TestTable(getQueryRunner()::execute, "step_small_" + testCase.name(), "(%s)".formatted(testCase.columnSchema()))) {
+                assertQuery("SELECT %s FROM %s".formatted(testCase.queryExpression(), table.getName()), "VALUES (%s)".formatted(testCase.expectedValue()));
+            }
+        }
+    }
+
     private record TestDataType(String name, String type, Map<String, String> properties, String queryExpression, String expectedValue)
     {
         public TestDataType(String name, String type, String queryExpression, String expectedValue)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Support generating sequences in the Faker connector. It might be useful for columns representing primary keys, which often use sequences. Another use case would be equal distribution of values in temporal columns.

There's also no other easy way of generating sequences for timestamps, since the `sequence` function has a limit of 10k elements, and the `sequence` table function doesn't support temporal types at all.

It's a prerequisite for #24585

There are a few limitations:
* not checking for overflows for large steps
* small increments are not supported in some cases - like nanosecond steps with timestamp(9) 

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Faker
* Support generating sequences in the Faker connector. ({issue}`24590`)
```
