### PR TITLE
Test iceberg_tables function with TrinoSnowflakeCatalog

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/snowflake/TestIcebergSnowflakeCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/snowflake/TestIcebergSnowflakeCatalogConnectorSmokeTest.java
@@ -688,8 +688,8 @@ public class TestIcebergSnowflakeCatalogConnectorSmokeTest
     @Override
     public void testIcebergTablesFunction()
     {
-        assertThatThrownBy(super::testIcebergTablesFunction)
-                .hasMessageContaining("schemaPath is not supported for Iceberg snowflake catalog");
+        assertThat(query("SELECT * FROM TABLE(iceberg.system.iceberg_tables(SCHEMA_NAME => '%s'))".formatted(SNOWFLAKE_TEST_SCHEMA.toLowerCase(ENGLISH))))
+                .matches("SELECT table_schema, table_name FROM iceberg.information_schema.tables WHERE table_schema='%s'".formatted(SNOWFLAKE_TEST_SCHEMA.toLowerCase(ENGLISH)));
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Implement a simple test for the `system.iceberg_tables table` function for the `TrinoSnowflakeCatalog`.
Since `TrinoSnowflakeCatalog` is read only the original generic test does not work.
Theoretically, we could apply the modifications directly on the snowflake to match the generic test with multiple schemas. However, that seems like an overkill given the implementation just delegates to the `listTables` method and maps the results.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
