### PR TITLE
Configure SSL for unauthenticated client

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/uri/HttpClientFactory.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/HttpClientFactory.java
@@ -54,43 +54,11 @@ public class HttpClientFactory
         OkHttpClient.Builder builder = unauthenticatedClientBuilder(uri, userAgent);
         setupCookieJar(builder);
 
-        if (!uri.isUseSecureConnection()) {
-            setupInsecureSsl(builder);
-        }
-
         if (uri.hasPassword()) {
             if (!uri.isUseSecureConnection()) {
                 throw new RuntimeException("TLS/SSL is required for authentication with username and password");
             }
             builder.addNetworkInterceptor(basicAuth(uri.getRequiredUser(), uri.getPassword().orElseThrow(() -> new RuntimeException("Password expected"))));
-        }
-
-        if (uri.isUseSecureConnection()) {
-            ConnectionProperties.SslVerificationMode sslVerificationMode = uri.getSslVerification();
-            if (sslVerificationMode.equals(FULL) || sslVerificationMode.equals(CA)) {
-                setupSsl(
-                        builder,
-                        uri.getSslKeyStorePath(),
-                        uri.getSslKeyStorePassword(),
-                        uri.getSslKeyStoreType(),
-                        uri.getSslUseSystemKeyStore(),
-                        uri.getSslTrustStorePath(),
-                        uri.getSslTrustStorePassword(),
-                        uri.getSslTrustStoreType(),
-                        uri.getSslUseSystemTrustStore());
-            }
-            if (sslVerificationMode.equals(FULL)) {
-                uri.getHostnameInCertificate().ifPresent(certHostname ->
-                        setupAlternateHostnameVerification(builder, certHostname));
-            }
-
-            if (sslVerificationMode.equals(CA)) {
-                builder.hostnameVerifier((hostname, session) -> true);
-            }
-
-            if (sslVerificationMode.equals(NONE)) {
-                setupInsecureSsl(builder);
-            }
         }
 
         if (uri.getKerberosRemoteServiceName().isPresent()) {
@@ -145,7 +113,6 @@ public class HttpClientFactory
             builder.addNetworkInterceptor(authenticator);
         }
 
-        uri.getDnsResolver().ifPresent(resolverClass -> builder.dns(instantiateDnsResolver(resolverClass, uri.getDnsResolverContext())::lookup));
         return builder;
     }
 
@@ -157,6 +124,41 @@ public class HttpClientFactory
         setupHttpProxy(builder, uri.getHttpProxy());
         setupTimeouts(builder, toIntExact(uri.getTimeout().toMillis()), TimeUnit.MILLISECONDS);
         setupHttpLogging(builder, uri.getHttpLoggingLevel());
+
+        if (!uri.isUseSecureConnection()) {
+            setupInsecureSsl(builder);
+        }
+
+        if (uri.isUseSecureConnection()) {
+            ConnectionProperties.SslVerificationMode sslVerificationMode = uri.getSslVerification();
+            if (sslVerificationMode.equals(FULL) || sslVerificationMode.equals(CA)) {
+                setupSsl(
+                        builder,
+                        uri.getSslKeyStorePath(),
+                        uri.getSslKeyStorePassword(),
+                        uri.getSslKeyStoreType(),
+                        uri.getSslUseSystemKeyStore(),
+                        uri.getSslTrustStorePath(),
+                        uri.getSslTrustStorePassword(),
+                        uri.getSslTrustStoreType(),
+                        uri.getSslUseSystemTrustStore());
+            }
+            if (sslVerificationMode.equals(FULL)) {
+                uri.getHostnameInCertificate().ifPresent(certHostname ->
+                        setupAlternateHostnameVerification(builder, certHostname));
+            }
+
+            if (sslVerificationMode.equals(CA)) {
+                builder.hostnameVerifier((hostname, session) -> true);
+            }
+
+            if (sslVerificationMode.equals(NONE)) {
+                setupInsecureSsl(builder);
+            }
+        }
+
+        uri.getDnsResolver().ifPresent(resolverClass -> builder.dns(instantiateDnsResolver(resolverClass, uri.getDnsResolverContext())::lookup));
+
         return builder;
     }
 

--- a/client/trino-client/src/main/java/io/trino/client/uri/HttpClientFactory.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/HttpClientFactory.java
@@ -125,10 +125,6 @@ public class HttpClientFactory
         setupTimeouts(builder, toIntExact(uri.getTimeout().toMillis()), TimeUnit.MILLISECONDS);
         setupHttpLogging(builder, uri.getHttpLoggingLevel());
 
-        if (!uri.isUseSecureConnection()) {
-            setupInsecureSsl(builder);
-        }
-
         if (uri.isUseSecureConnection()) {
             ConnectionProperties.SslVerificationMode sslVerificationMode = uri.getSslVerification();
             if (sslVerificationMode.equals(FULL) || sslVerificationMode.equals(CA)) {
@@ -155,6 +151,9 @@ public class HttpClientFactory
             if (sslVerificationMode.equals(NONE)) {
                 setupInsecureSsl(builder);
             }
+        }
+        else {
+            setupInsecureSsl(builder);
         }
 
         uri.getDnsResolver().ifPresent(resolverClass -> builder.dns(instantiateDnsResolver(resolverClass, uri.getDnsResolverContext())::lookup));


### PR DESCRIPTION
Unauthenticated client can connect to the Trino cluster when loading segment data. If cluster has its' own certificate chain - client needs to accept it according to the configuration.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## CLI/JDBC
* Fix loading spooled segment data when cluster is secured ({issue}`issuenumber`)
```
