### PR TITLE
Cast table properties based on its type in Faker connector

### DIFF
--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerMetadata.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerMetadata.java
@@ -260,7 +260,8 @@ public class FakerMetadata
                         oldInfo.properties().entrySet().stream()
                                 .filter(entry -> !properties.containsKey(entry.getKey())),
                         properties.entrySet().stream()
-                                .filter(entry -> entry.getValue().isPresent()))
+                                .filter(entry -> entry.getValue().isPresent())
+                                .map(entry -> Map.entry(entry.getKey(), entry.getValue().get())))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         tables.put(tableName, oldInfo.withProperties(newProperties));
     }

--- a/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerQueries.java
+++ b/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerQueries.java
@@ -402,4 +402,14 @@ final class TestFakerQueries
             return "%s %s NOT NULL%s".formatted(name, type, propertiesSchema.isEmpty() ? "" : " WITH (%s)".formatted(propertiesSchema));
         }
     }
+
+    @Test
+    void testSetTableProperties()
+    {
+        try (TestTable table = newTrinoTable("set_table_properties", "(id INTEGER, name VARCHAR)")) {
+            assertUpdate("ALTER TABLE " + table.getName() + " SET PROPERTIES default_limit = 100");
+            assertThat((String) computeScalar("SHOW CREATE TABLE " + table.getName()))
+                    .contains("default_limit = 100");
+        }
+    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Fixes setTableProperties on Faker connector. Table properties are now read, cast and set based on the predefined property type. 

Previously it tried to set java.util.Optional values from properties map directly causing type compatibility issues. Along with the fix a test case has been added to validate intended behavior.


## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
