### PR TITLE
Extend AbstractTestQueryFramework in TestRedshiftUnload

### DIFF
--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftUnload.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftUnload.java
@@ -17,7 +17,7 @@ import com.google.common.collect.ImmutableList;
 import io.trino.Session;
 import io.trino.operator.OperatorInfo;
 import io.trino.operator.SplitOperatorInfo;
-import io.trino.testing.AbstractTestQueries;
+import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.sql.SqlExecutor;
 import io.trino.testing.sql.TestTable;
@@ -40,6 +40,7 @@ import static io.trino.plugin.redshift.TestingRedshiftServer.TEST_SCHEMA;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
 import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.tpch.TpchTable.NATION;
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
@@ -48,7 +49,7 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 @TestInstance(PER_CLASS)
 @Execution(CONCURRENT)
 final class TestRedshiftUnload
-        extends AbstractTestQueries
+        extends AbstractTestQueryFramework
 {
     private static final String S3_UNLOAD_ROOT = requiredNonEmptySystemProperty("test.redshift.s3.unload.root");
     private static final String AWS_REGION = requiredNonEmptySystemProperty("test.redshift.aws.region");
@@ -67,7 +68,7 @@ final class TestRedshiftUnload
                                 "s3.region", AWS_REGION,
                                 "s3.aws-access-key", AWS_ACCESS_KEY,
                                 "s3.aws-secret-key", AWS_SECRET_KEY))
-                .setInitialTables(REQUIRED_TPCH_TABLES)
+                .setInitialTables(List.of(NATION))
                 .build();
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

AbstractTestQueries was extended to cover different Trino query shapes.
However, it may not be necessary as there are query shape duplicates in 
AbstractTestQueries. Additionally, AbstractTestQueries doesn't cover 
different query shapes.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
