### PR TITLE
Fix column level lineage miss when use unnest

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -1605,9 +1605,9 @@ class StatementAnalyzer
         @Override
         protected Scope visitUnnest(Unnest node, Optional<Scope> scope)
         {
-            ImmutableMap.Builder<NodeRef<Expression>, List<Field>> mappings = ImmutableMap.builder();
+            ImmutableMap.Builder<NodeRef<Expression>, List<Field>> mappingsBuilder = ImmutableMap.builder();
 
-            ImmutableList.Builder<Field> outputFields = ImmutableList.builder();
+            ImmutableList.Builder<Field> outputFieldsBuilder = ImmutableList.builder();
             for (Expression expression : node.getExpressions()) {
                 verifyNoAggregateWindowOrGroupingFunctions(session, functionResolver, accessControl, expression, "UNNEST");
                 List<Field> expressionOutputs = new ArrayList<>();
@@ -1634,8 +1634,8 @@ class StatementAnalyzer
                     throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "Cannot unnest type: " + expressionType);
                 }
 
-                outputFields.addAll(expressionOutputs);
-                mappings.put(NodeRef.of(expression), expressionOutputs);
+                outputFieldsBuilder.addAll(expressionOutputs);
+                mappingsBuilder.put(NodeRef.of(expression), expressionOutputs);
             }
 
             Optional<Field> ordinalityField = Optional.empty();
@@ -1643,11 +1643,11 @@ class StatementAnalyzer
                 ordinalityField = Optional.of(Field.newUnqualified(Optional.empty(), BIGINT));
             }
 
-            ordinalityField.ifPresent(outputFields::add);
+            ordinalityField.ifPresent(outputFieldsBuilder::add);
 
-            analysis.setUnnest(node, new UnnestAnalysis(mappings.buildOrThrow(), ordinalityField));
+            analysis.setUnnest(node, new UnnestAnalysis(mappingsBuilder.buildOrThrow(), ordinalityField));
 
-            return createAndAssignScope(node, scope, outputFields.build());
+            return createAndAssignScope(node, scope, outputFieldsBuilder.build());
         }
 
         @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Fixes [#16946](https://github.com/trinodb/trino/issues/16946)

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix column level lineage miss when use unnest. ({issue}`16946`)
```
