### PR TITLE
Add support Hadoop-Compatible File System when use HDFS as exchange type

### DIFF
--- a/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/ExchangeHdfsConfig.java
+++ b/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/ExchangeHdfsConfig.java
@@ -31,6 +31,7 @@ import static io.airlift.units.DataSize.Unit.MEGABYTE;
 public class ExchangeHdfsConfig
 {
     private DataSize hdfsStorageBlockSize = DataSize.of(4, MEGABYTE);
+    private boolean skipDirectorySchemeValidation;
     private List<File> resourceConfigFiles = ImmutableList.of();
 
     @NotNull
@@ -46,6 +47,19 @@ public class ExchangeHdfsConfig
     public ExchangeHdfsConfig setHdfsStorageBlockSize(DataSize hdfsStorageBlockSize)
     {
         this.hdfsStorageBlockSize = hdfsStorageBlockSize;
+        return this;
+    }
+
+    public boolean isSkipDirectorySchemeValidation()
+    {
+        return skipDirectorySchemeValidation;
+    }
+
+    @Config("exchange.hdfs.skip-directory-scheme-validation")
+    @ConfigDescription("Skip directory scheme validation to support hadoop compatible file system")
+    public ExchangeHdfsConfig setSkipDirectorySchemeValidation(boolean skipDirectorySchemeValidation)
+    {
+        this.skipDirectorySchemeValidation = skipDirectorySchemeValidation;
         return this;
     }
 

--- a/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/HdfsExchangeModule.java
+++ b/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/HdfsExchangeModule.java
@@ -25,7 +25,6 @@ import io.trino.spi.TrinoException;
 import java.net.URI;
 import java.util.List;
 
-import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.trino.spi.StandardErrorCode.CONFIGURATION_INVALID;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.lang.String.format;
@@ -47,10 +46,13 @@ public class HdfsExchangeModule
             binder.addError(new TrinoException(CONFIGURATION_INVALID, "Multiple schemes in exchange base directories"));
             return;
         }
+
         String scheme = baseDirectories.get(0).getScheme();
-        if (scheme.equalsIgnoreCase("hdfs")) {
+
+        boolean skipDirectorySchemeValidation = buildConfigObject(ExchangeHdfsConfig.class).isSkipDirectorySchemeValidation();
+
+        if (scheme.equalsIgnoreCase("hdfs") || skipDirectorySchemeValidation) {
             binder.bind(FileSystemExchangeStorage.class).to(HadoopFileSystemExchangeStorage.class).in(Scopes.SINGLETON);
-            configBinder(binder).bindConfig(ExchangeHdfsConfig.class);
         }
         else {
             binder.addError(new TrinoException(NOT_SUPPORTED,

--- a/plugin/trino-exchange-hdfs/src/test/java/io/trino/plugin/exchange/hdfs/TestExchangeHdfsConfig.java
+++ b/plugin/trino-exchange-hdfs/src/test/java/io/trino/plugin/exchange/hdfs/TestExchangeHdfsConfig.java
@@ -35,7 +35,8 @@ public class TestExchangeHdfsConfig
     {
         assertRecordedDefaults(recordDefaults(ExchangeHdfsConfig.class)
                 .setResourceConfigFiles(ImmutableList.of())
-                .setHdfsStorageBlockSize(DataSize.of(4, MEGABYTE)));
+                .setHdfsStorageBlockSize(DataSize.of(4, MEGABYTE))
+                .setSkipDirectorySchemeValidation(false));
     }
 
     @Test
@@ -48,11 +49,13 @@ public class TestExchangeHdfsConfig
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("hdfs.config.resources", resource1 + "," + resource2)
                 .put("exchange.hdfs.block-size", "8MB")
+                .put("exchange.hdfs.skip-directory-scheme-validation", "true")
                 .buildOrThrow();
 
         ExchangeHdfsConfig expected = new ExchangeHdfsConfig()
                 .setResourceConfigFiles(ImmutableList.of(resource1.toString(), resource2.toString()))
-                .setHdfsStorageBlockSize(DataSize.of(8, MEGABYTE));
+                .setHdfsStorageBlockSize(DataSize.of(8, MEGABYTE))
+                .setSkipDirectorySchemeValidation(true);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Add exchange.hdfs.skip-directory-scheme-validation to enable use Hadoop-Compatible File System with HDFS Client.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Add support Hadoop-Compatible File System when use HDFS as exchange type. 
```
