### PR TITLE
Remove <name> from trino-ranger pom

### DIFF
--- a/plugin/trino-ranger/pom.xml
+++ b/plugin/trino-ranger/pom.xml
@@ -12,7 +12,6 @@
     <artifactId>trino-ranger</artifactId>
 
     <packaging>trino-plugin</packaging>
-    <name>Trino - Apache Ranger access control</name>
     <description>Trino - Apache Ranger access control</description>
 
     <properties>


### PR DESCRIPTION
We are not using it for other modules which results in the build output being inconsistent

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
