### PR TITLE
Clarify that spooling locations must not be shared

### DIFF
--- a/docs/src/main/sphinx/admin/properties-client-protocol.md
+++ b/docs/src/main/sphinx/admin/properties-client-protocol.md
@@ -154,11 +154,14 @@ Examples:
 * `s3://my-spooling-bucket/my-segments/`
 
 :::{caution}
-When using the same object storage for spooling from multiple Trino clusters,
-you must use separate locations for each cluster. For example:
+The specified object storage location must not be used for spooling for another
+Trino cluster or any object storage catalog. When using the same object storage
+for multiple services, you must use separate locations for each one. For
+example:
 
-* `s3://my-spooling-bucket/my-segments/cluster1`
-* `s3://my-spooling-bucket/my-segments/cluster2`
+* `s3://my-spooling-bucket/my-segments/cluster1-spooling`
+* `s3://my-spooling-bucket/my-segments/cluster2-spooling`
+* `s3://my-spooling-bucket/my-segments/iceberg-catalog`
 :::
 
 ### `fs.segment.ttl`

--- a/docs/src/main/sphinx/client/client-protocol.md
+++ b/docs/src/main/sphinx/client/client-protocol.md
@@ -59,6 +59,8 @@ on a Trino cluster:
   [](prop-protocol-spooling).
 * Choose a suitable object storage that is accessible to your Trino cluster and
   your clients.
+* Create a location in your object storage that is not shared with any object
+  storage catalog or spooling for any other Trino clusters.
 * Configure the object storage in `etc/spooling-manager.properties` using the
   [](prop-spooling-file-system).
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

New spooling protocol documentation ought to clarify that the object storage location used for spooling must not be shared with either an object storage catalog or another Trino cluster's spooling.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

N/A

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
