### PR TITLE
Fix correctness issue when writing deletion vectors in Delta Lake

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
@@ -408,6 +408,7 @@ public class DeltaLakeMergeSink
     {
         String tablePath = rootTableLocation.toString();
         String sourceRelativePath = relativePath(tablePath, sourcePath);
+        DeletionVectorEntry oldDeletionVector = deletionVectors.get(sourceRelativePath);
 
         DeletionVectorEntry deletionVectorEntry;
         try {
@@ -426,7 +427,7 @@ public class DeltaLakeMergeSink
                     deletion.partitionValues,
                     readStatistics(parquetMetadata, dataColumns, rowCount),
                     Optional.of(deletionVectorEntry));
-            DeltaLakeMergeResult result = new DeltaLakeMergeResult(deletion.partitionValues, Optional.of(sourceRelativePath), Optional.empty(), Optional.of(newFileInfo));
+            DeltaLakeMergeResult result = new DeltaLakeMergeResult(deletion.partitionValues, Optional.of(sourceRelativePath), Optional.ofNullable(oldDeletionVector), Optional.of(newFileInfo));
             return utf8Slice(mergeResultJsonCodec.toJson(result));
         }
         catch (Throwable e) {

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
@@ -1393,6 +1393,16 @@ public class TestDeltaLakeBasic
     }
 
     @Test
+    void testDeletionVectorsRepeat()
+    {
+        try (TestTable table = newTrinoTable("test_dv", "(x int) WITH (deletion_vectors_enabled = true)", List.of("1", "2", "3"))) {
+            assertUpdate("DELETE FROM " + table.getName() + " WHERE x = 1", 1);
+            assertUpdate("DELETE FROM " + table.getName() + " WHERE x = 2", 1);
+            assertThat(query("SELECT * FROM " + table.getName())).matches("VALUES 3");
+        }
+    }
+
+    @Test
     public void testUnsupportedVacuumDeletionVectors()
             throws Exception
     {


### PR DESCRIPTION
## Description

We should inherit the old deletion vector entry in `remove`. 
Fixes #24648

## Release notes

```markdown
## Delta Lake
* Fix incorrect results when writing with deletion vectors. ({issue}`24648`)
```
