### PR TITLE
Always fire QueryCompletedEvent for DDL queries

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/DataDefinitionExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DataDefinitionExecution.java
@@ -69,6 +69,12 @@ public class DataDefinitionExecution<T extends Statement>
         this.stateMachine = requireNonNull(stateMachine, "stateMachine is null");
         this.parameters = parameters;
         this.warningCollector = requireNonNull(warningCollector, "warningCollector is null");
+        stateMachine.addStateChangeListener(state -> {
+            if (state.isDone() && stateMachine.getFinalQueryInfo().isEmpty()) {
+                // make sure the final query info is set and listeners are triggered
+                stateMachine.updateQueryInfo(Optional.empty());
+            }
+        });
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/testing/StandaloneQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/StandaloneQueryRunner.java
@@ -105,14 +105,20 @@ public final class StandaloneQueryRunner
     @Override
     public MaterializedResult execute(Session session, @Language("SQL") String sql)
     {
-        return executeInternal(session, sql).result();
+        return executeInternal(session, sql).result().get();
     }
 
     @Override
     public MaterializedResultWithPlan executeWithPlan(Session session, String sql)
     {
         TestingDirectTrinoClient.Result result = executeInternal(session, sql);
-        return new MaterializedResultWithPlan(result.queryId(), server.getQueryPlan(result.queryId()), result.result());
+        MaterializedResult materializedRows = result.result().get();
+        return new MaterializedResultWithPlan(result.queryId(), server.getQueryPlan(result.queryId()), materializedRows);
+    }
+
+    public TestingDirectTrinoClient.Result executeWithoutResults(Session session, String sql)
+    {
+        return executeInternal(session, sql);
     }
 
     private TestingDirectTrinoClient.Result executeInternal(Session session, @Language("SQL") String sql)

--- a/core/trino-main/src/main/java/io/trino/testing/TestingDirectTrinoClient.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingDirectTrinoClient.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.execution.QueryState.FINISHED;
@@ -63,7 +64,7 @@ public class TestingDirectTrinoClient
     {
         MaterializedQueryResultsListener queryResultsListener = new MaterializedQueryResultsListener();
         DispatchQuery dispatchQuery = directTrinoClient.execute(sessionContext, sql, queryResultsListener);
-        return new Result(dispatchQuery.getQueryId(), toMaterializedRows(dispatchQuery, queryResultsListener.columnTypes(), queryResultsListener.columnNames(), queryResultsListener.pages()));
+        return new Result(dispatchQuery.getQueryId(), () -> toMaterializedRows(dispatchQuery, queryResultsListener.columnTypes(), queryResultsListener.columnNames(), queryResultsListener.pages()));
     }
 
     private static MaterializedResult toMaterializedRows(DispatchQuery dispatchQuery, List<Type> columnTypes, List<String> columnNames, List<Page> pages)
@@ -137,9 +138,9 @@ public class TestingDirectTrinoClient
         return rows.build();
     }
 
-    record Result(QueryId queryId, MaterializedResult result)
+    public record Result(QueryId queryId, Supplier<MaterializedResult> result)
     {
-        Result
+        public Result
         {
             requireNonNull(queryId, "queryId is null");
             requireNonNull(result, "result is null");

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestQueryCompletedEvent.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestQueryCompletedEvent.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.dispatcher.DispatchQuery;
+import io.trino.plugin.memory.MemoryPlugin;
+import io.trino.spi.Plugin;
+import io.trino.spi.eventlistener.EventListener;
+import io.trino.spi.eventlistener.EventListenerFactory;
+import io.trino.spi.eventlistener.QueryCompletedEvent;
+import io.trino.testing.StandaloneQueryRunner;
+import io.trino.testing.TestingDirectTrinoClient;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static io.trino.execution.QueryState.FINISHED;
+import static io.trino.testing.TestingSession.testSession;
+import static io.trino.testing.assertions.Assert.assertEventually;
+import static java.util.Collections.synchronizedSet;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestQueryCompletedEvent
+{
+    @Test
+    public void testQueryCompletedEventIssued()
+    {
+        try (StandaloneQueryRunner queryRunner = new StandaloneQueryRunner(testSession())) {
+            queryRunner.installPlugin(new MemoryPlugin());
+            queryRunner.createCatalog("memory", "memory");
+            Set<String> queryCompletedQueryIds = synchronizedSet(new HashSet<>());
+            EventListener listener = new EventListener()
+            {
+                @Override
+                public void queryCompleted(QueryCompletedEvent queryCompletedEvent)
+                {
+                    queryCompletedQueryIds.add(queryCompletedEvent.getMetadata().getQueryId());
+                }
+            };
+            queryRunner.installPlugin(new Plugin()
+            {
+                @Override
+                public Iterable<EventListenerFactory> getEventListenerFactories()
+                {
+                    return ImmutableList.of(new EventListenerFactory()
+                    {
+                        @Override
+                        public String getName()
+                        {
+                            return "testQueryCompletedEventIssued";
+                        }
+
+                        @Override
+                        public EventListener create(Map<String, String> config, EventListenerContext context)
+                        {
+                            return listener;
+                        }
+                    });
+                }
+            });
+
+            assertQueryCompletedIssued(queryRunner, queryCompletedQueryIds, "SELECT 1");
+            assertQueryCompletedIssued(queryRunner, queryCompletedQueryIds, "CREATE SCHEMA memory.test_schema");
+            assertQueryCompletedIssued(queryRunner, queryCompletedQueryIds, "DROP SCHEMA memory.test_schema");
+        }
+    }
+
+    private static void assertQueryCompletedIssued(StandaloneQueryRunner queryRunner, Set<String> queryCompletedQueryIds, String sql)
+    {
+        TestingDirectTrinoClient.Result result = queryRunner.executeWithoutResults(testSession(), sql);
+        DispatchQuery query = queryRunner.getCoordinator().getDispatchManager().getQuery(result.queryId());
+        assertThat(query.getState()).isEqualTo(FINISHED);
+        assertEventually(() -> assertThat(queryCompletedQueryIds)
+                .describedAs("query '%s'", sql)
+                .contains(result.queryId().getId()));
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Previously the event was fired because client protocol
is reading the final query info. That is brittle and theoretically
could be removed making DDL queries fail to trigger query completed event.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
A slightly changed version of https://github.com/trinodb/trino/pull/24354


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
