### PR TITLE
Fix gcs.endpoint property name in docs

### DIFF
--- a/docs/src/main/sphinx/object-storage/file-system-gcs.md
+++ b/docs/src/main/sphinx/object-storage/file-system-gcs.md
@@ -24,9 +24,10 @@ Storage file system support:
     all other properties.
 * - `gcs.project-id`
   - Identifier for the project on Google Cloud Storage.
-* - `azure.endpoint`
+* - `gcs.endpoint`
   - Optional URL for the Google Cloud Storage endpoint. Configure this property
-    if your storage is accessed using a custom URL, for example `http://storage.example.com:8000`.
+    if your storage is accessed using a custom URL, for example
+    `http://storage.example.com:8000`.
 * - `gcs.client.max-retries`
   - Maximum number of RPC attempts. Defaults to 20.
 * - `gcs.client.backoff-scale-factor`


### PR DESCRIPTION
## Description

Silly cut and paste typo we missed in review.

## Additional context and related issues

#24645 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
