### PR TITLE
Add originalUser and authenticatedUser as selectors available for resource group selection

### DIFF
--- a/core/trino-main/src/main/java/io/trino/dispatcher/DispatchManager.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/DispatchManager.java
@@ -44,6 +44,7 @@ import io.trino.spi.QueryId;
 import io.trino.spi.TrinoException;
 import io.trino.spi.resourcegroups.SelectionContext;
 import io.trino.spi.resourcegroups.SelectionCriteria;
+import io.trino.spi.security.Identity;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import org.weakref.jmx.Flatten;
@@ -229,6 +230,8 @@ public class DispatchManager
                     sessionContext.getIdentity().getPrincipal().isPresent(),
                     sessionContext.getIdentity().getUser(),
                     sessionContext.getIdentity().getGroups(),
+                    sessionContext.getOriginalIdentity().getUser(),
+                    sessionContext.getAuthenticatedIdentity().map(Identity::getUser),
                     sessionContext.getSource(),
                     sessionContext.getClientTags(),
                     sessionContext.getResourceEstimates(),

--- a/core/trino-spi/src/main/java/io/trino/spi/resourcegroups/SelectionCriteria.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/resourcegroups/SelectionCriteria.java
@@ -26,6 +26,8 @@ public final class SelectionCriteria
     private final boolean authenticated;
     private final String user;
     private final Set<String> userGroups;
+    private final String originalUser;
+    private final Optional<String> authenticatedUser;
     private final Optional<String> source;
     private final Set<String> clientTags;
     private final ResourceEstimates resourceEstimates;
@@ -35,6 +37,8 @@ public final class SelectionCriteria
             boolean authenticated,
             String user,
             Set<String> userGroups,
+            String originalUser,
+            Optional<String> authenticatedUser,
             Optional<String> source,
             Set<String> clientTags,
             ResourceEstimates resourceEstimates,
@@ -43,10 +47,37 @@ public final class SelectionCriteria
         this.authenticated = authenticated;
         this.user = requireNonNull(user, "user is null");
         this.userGroups = requireNonNull(userGroups, "userGroups is null");
+        this.originalUser = requireNonNull(originalUser, "originalUser is null");
+        this.authenticatedUser = requireNonNull(authenticatedUser, "authenticatedUser is null");
         this.source = requireNonNull(source, "source is null");
         this.clientTags = Set.copyOf(requireNonNull(clientTags, "clientTags is null"));
         this.resourceEstimates = requireNonNull(resourceEstimates, "resourceEstimates is null");
         this.queryType = requireNonNull(queryType, "queryType is null");
+    }
+
+    /**
+     * @deprecated Use {@link #SelectionCriteria(boolean, String, Set, String, Optional, Optional, Set, ResourceEstimates, Optional)} instead.
+     */
+    @Deprecated(since = "474", forRemoval = true)
+    public SelectionCriteria(
+            boolean authenticated,
+            String user,
+            Set<String> userGroups,
+            Optional<String> source,
+            Set<String> clientTags,
+            ResourceEstimates resourceEstimates,
+            Optional<String> queryType)
+    {
+        this(
+                authenticated,
+                user,
+                userGroups,
+                user,
+                Optional.empty(),
+                source,
+                clientTags,
+                resourceEstimates,
+                queryType);
     }
 
     public boolean isAuthenticated()
@@ -62,6 +93,16 @@ public final class SelectionCriteria
     public Set<String> getUserGroups()
     {
         return userGroups;
+    }
+
+    public String getOriginalUser()
+    {
+        return originalUser;
+    }
+
+    public Optional<String> getAuthenticatedUser()
+    {
+        return authenticatedUser;
     }
 
     public Optional<String> getSource()
@@ -91,6 +132,8 @@ public final class SelectionCriteria
                 .add("authenticated=" + authenticated)
                 .add("user='" + user + "'")
                 .add("userGroups=" + userGroups)
+                .add("originalUser=" + originalUser)
+                .add("authenticatedUser=" + authenticatedUser)
                 .add("source=" + source)
                 .add("clientTags=" + clientTags)
                 .add("resourceEstimates=" + resourceEstimates)

--- a/docs/src/main/sphinx/admin/resource-groups-example.json
+++ b/docs/src/main/sphinx/admin/resource-groups-example.json
@@ -89,6 +89,14 @@
       "group": "admin"
     },
     {
+      "originalUser": "bob",
+      "group": "admin"
+    },
+    {
+      "authenticatedUser": "bob",
+      "group": "admin"
+    },
+    {
       "userGroup": "admin",
       "group": "admin"
     },

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/AbstractResourceConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/AbstractResourceConfigurationManager.java
@@ -96,6 +96,8 @@ public abstract class AbstractResourceConfigurationManager
             selectors.add(new StaticSelector(
                     spec.getUserRegex(),
                     spec.getUserGroupRegex(),
+                    spec.getOriginalUserRegex(),
+                    spec.getAuthenticatedUserRegex(),
                     spec.getSourceRegex(),
                     spec.getClientTags(),
                     spec.getResourceEstimate(),

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/SelectorSpec.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/SelectorSpec.java
@@ -28,6 +28,8 @@ public class SelectorSpec
 {
     private final Optional<Pattern> userRegex;
     private final Optional<Pattern> userGroupRegex;
+    private final Optional<Pattern> originalUserRegex;
+    private final Optional<Pattern> authenticatedUserRegex;
     private final Optional<Pattern> sourceRegex;
     private final Optional<String> queryType;
     private final Optional<List<String>> clientTags;
@@ -38,6 +40,8 @@ public class SelectorSpec
     public SelectorSpec(
             @JsonProperty("user") Optional<Pattern> userRegex,
             @JsonProperty("userGroup") Optional<Pattern> userGroupRegex,
+            @JsonProperty("originalUser") Optional<Pattern> originalUserRegex,
+            @JsonProperty("authenticatedUser") Optional<Pattern> authenticatedUserRegex,
             @JsonProperty("source") Optional<Pattern> sourceRegex,
             @JsonProperty("queryType") Optional<String> queryType,
             @JsonProperty("clientTags") Optional<List<String>> clientTags,
@@ -46,6 +50,8 @@ public class SelectorSpec
     {
         this.userRegex = requireNonNull(userRegex, "userRegex is null");
         this.userGroupRegex = requireNonNull(userGroupRegex, "userGroupRegex is null");
+        this.originalUserRegex = requireNonNull(originalUserRegex, "originalUserRegex is null");
+        this.authenticatedUserRegex = requireNonNull(authenticatedUserRegex, "authenticatedUserRegex is null");
         this.sourceRegex = requireNonNull(sourceRegex, "sourceRegex is null");
         this.queryType = requireNonNull(queryType, "queryType is null");
         this.clientTags = requireNonNull(clientTags, "clientTags is null");
@@ -61,6 +67,16 @@ public class SelectorSpec
     public Optional<Pattern> getUserGroupRegex()
     {
         return userGroupRegex;
+    }
+
+    public Optional<Pattern> getOriginalUserRegex()
+    {
+        return originalUserRegex;
+    }
+
+    public Optional<Pattern> getAuthenticatedUserRegex()
+    {
+        return authenticatedUserRegex;
     }
 
     public Optional<Pattern> getSourceRegex()
@@ -103,6 +119,10 @@ public class SelectorSpec
                 userRegex.map(Pattern::flags).equals(that.userRegex.map(Pattern::flags)) &&
                 userGroupRegex.map(Pattern::pattern).equals(that.userGroupRegex.map(Pattern::pattern)) &&
                 userGroupRegex.map(Pattern::flags).equals(that.userGroupRegex.map(Pattern::flags)) &&
+                originalUserRegex.map(Pattern::pattern).equals(that.originalUserRegex.map(Pattern::pattern)) &&
+                originalUserRegex.map(Pattern::flags).equals(that.originalUserRegex.map(Pattern::flags)) &&
+                authenticatedUserRegex.map(Pattern::pattern).equals(that.authenticatedUserRegex.map(Pattern::pattern)) &&
+                authenticatedUserRegex.map(Pattern::flags).equals(that.authenticatedUserRegex.map(Pattern::flags)) &&
                 sourceRegex.map(Pattern::pattern).equals(that.sourceRegex.map(Pattern::pattern))) &&
                 sourceRegex.map(Pattern::flags).equals(that.sourceRegex.map(Pattern::flags)) &&
                 queryType.equals(that.queryType) &&
@@ -118,6 +138,10 @@ public class SelectorSpec
                 userRegex.map(Pattern::flags),
                 userGroupRegex.map(Pattern::pattern),
                 userGroupRegex.map(Pattern::flags),
+                originalUserRegex.map(Pattern::pattern),
+                originalUserRegex.map(Pattern::flags),
+                authenticatedUserRegex.map(Pattern::pattern),
+                authenticatedUserRegex.map(Pattern::flags),
                 sourceRegex.map(Pattern::pattern),
                 sourceRegex.map(Pattern::flags),
                 queryType,
@@ -133,6 +157,10 @@ public class SelectorSpec
                 .add("userFlags", userRegex.map(Pattern::flags))
                 .add("userGroupRegex", userGroupRegex)
                 .add("userGroupFlags", userGroupRegex.map(Pattern::flags))
+                .add("originalUserRegex", originalUserRegex)
+                .add("originalUserFlags", originalUserRegex.map(Pattern::flags))
+                .add("authenticatedUserRegex", authenticatedUserRegex)
+                .add("authenticatedUserFlags", authenticatedUserRegex.map(Pattern::flags))
                 .add("sourceRegex", sourceRegex)
                 .add("sourceFlags", sourceRegex.map(Pattern::flags))
                 .add("queryType", queryType)

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/StaticSelector.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/StaticSelector.java
@@ -15,7 +15,6 @@ package io.trino.plugin.resourcegroups;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import io.trino.spi.resourcegroups.ResourceGroupId;
 import io.trino.spi.resourcegroups.SelectionContext;
@@ -27,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -41,13 +42,8 @@ public class StaticSelector
     private static final String SOURCE_VARIABLE = "SOURCE";
 
     private final Optional<Pattern> userRegex;
-    private final Optional<Pattern> userGroupRegex;
-    private final Optional<Pattern> sourceRegex;
-    private final Set<String> clientTags;
-    private final Optional<SelectorResourceEstimate> selectorResourceEstimate;
-    private final Optional<String> queryType;
     private final ResourceGroupIdTemplate group;
-    private final Set<String> variableNames;
+    private final List<SelectionMatcher> selectionMatchers;
 
     public StaticSelector(
             Optional<Pattern> userRegex,
@@ -59,18 +55,35 @@ public class StaticSelector
             ResourceGroupIdTemplate group)
     {
         this.userRegex = requireNonNull(userRegex, "userRegex is null");
-        this.userGroupRegex = requireNonNull(userGroupRegex, "userGroupRegex is null");
-        this.sourceRegex = requireNonNull(sourceRegex, "sourceRegex is null");
+        requireNonNull(userGroupRegex, "userGroupRegex is null");
+        requireNonNull(sourceRegex, "sourceRegex is null");
         requireNonNull(clientTags, "clientTags is null");
-        this.clientTags = ImmutableSet.copyOf(clientTags.orElse(ImmutableList.of()));
-        this.selectorResourceEstimate = requireNonNull(selectorResourceEstimate, "selectorResourceEstimate is null");
-        this.queryType = requireNonNull(queryType, "queryType is null");
+        requireNonNull(selectorResourceEstimate, "selectorResourceEstimate is null");
+        requireNonNull(queryType, "queryType is null");
         this.group = requireNonNull(group, "group is null");
 
         HashSet<String> variableNames = new HashSet<>(ImmutableList.of(USER_VARIABLE, SOURCE_VARIABLE));
-        userRegex.ifPresent(u -> addNamedGroups(u, variableNames));
-        sourceRegex.ifPresent(s -> addNamedGroups(s, variableNames));
-        this.variableNames = ImmutableSet.copyOf(variableNames);
+        this.selectionMatchers = ImmutableList.<Optional<SelectionMatcher>>builder()
+                .add(userRegex.map(userRegexValue -> {
+                    addNamedGroups(userRegexValue, variableNames);
+                    return new PatternMatcher(variableNames, userRegexValue, SelectionCriteria::getUser);
+                }))
+                .add(sourceRegex.map(sourceRegexValue -> {
+                    addNamedGroups(sourceRegexValue, variableNames);
+                    return new PatternMatcher(variableNames, sourceRegexValue, criteria -> criteria.getSource().orElse(""));
+                }))
+                .add(userGroupRegex.map(userGroupRegexValue ->
+                    new BasicMatcher(criteria -> criteria.getUserGroups().stream().anyMatch(userGroup -> userGroupRegexValue.matcher(userGroup).matches()))))
+                .add(queryType.map(queryTypeValue ->
+                    new BasicMatcher(criteria -> queryTypeValue.equalsIgnoreCase(criteria.getQueryType().orElse("")))))
+                .add(selectorResourceEstimate.map(selectorResourceEstimateValue ->
+                    new BasicMatcher(criteria -> selectorResourceEstimateValue.match(criteria.getResourceEstimates()))))
+                .add(clientTags.map(clientTagsValue ->
+                    new BasicMatcher(criteria -> criteria.getTags().containsAll(clientTagsValue))))
+                .build()
+                .stream()
+                .flatMap(Optional::stream) // remove any empty optionals
+                .toList();
 
         Set<String> unresolvedVariables = Sets.difference(group.getVariableNames(), variableNames);
         checkArgument(unresolvedVariables.isEmpty(), "unresolved variables %s in resource group ID '%s', available: %s\"", unresolvedVariables, group, variableNames);
@@ -79,43 +92,12 @@ public class StaticSelector
     @Override
     public Optional<SelectionContext<ResourceGroupIdTemplate>> match(SelectionCriteria criteria)
     {
+        if (!selectionMatchers.stream().allMatch(matcher -> matcher.matches(criteria))) {
+            return Optional.empty();
+        }
         Map<String, String> variables = new HashMap<>();
-
-        if (userRegex.isPresent()) {
-            Matcher userMatcher = userRegex.get().matcher(criteria.getUser());
-            if (!userMatcher.matches()) {
-                return Optional.empty();
-            }
-
-            addVariableValues(userRegex.get(), criteria.getUser(), variables);
-        }
-
-        if (userGroupRegex.isPresent() && criteria.getUserGroups().stream().noneMatch(group -> userGroupRegex.get().matcher(group).matches())) {
-            return Optional.empty();
-        }
-
-        if (sourceRegex.isPresent()) {
-            String source = criteria.getSource().orElse("");
-            if (!sourceRegex.get().matcher(source).matches()) {
-                return Optional.empty();
-            }
-
-            addVariableValues(sourceRegex.get(), source, variables);
-        }
-
-        if (!clientTags.isEmpty() && !criteria.getTags().containsAll(clientTags)) {
-            return Optional.empty();
-        }
-
-        if (selectorResourceEstimate.isPresent() && !selectorResourceEstimate.get().match(criteria.getResourceEstimates())) {
-            return Optional.empty();
-        }
-
-        if (queryType.isPresent()) {
-            String contextQueryType = criteria.getQueryType().orElse("");
-            if (!queryType.get().equalsIgnoreCase(contextQueryType)) {
-                return Optional.empty();
-            }
+        for (SelectionMatcher matcher : selectionMatchers) {
+            matcher.populateVariables(criteria, variables);
         }
 
         variables.putIfAbsent(USER_VARIABLE, criteria.getUser());
@@ -137,19 +119,53 @@ public class StaticSelector
         }
     }
 
-    private void addVariableValues(Pattern pattern, String candidate, Map<String, String> mapping)
+    private interface SelectionMatcher
     {
-        for (String key : variableNames) {
-            Matcher keyMatcher = pattern.matcher(candidate);
-            if (keyMatcher.find()) {
-                try {
-                    String value = keyMatcher.group(key);
+        boolean matches(SelectionCriteria criteria);
+
+        void populateVariables(SelectionCriteria criteria, Map<String, String> variables);
+    }
+
+    private record BasicMatcher(Predicate<SelectionCriteria> matchPredicate)
+            implements SelectionMatcher
+    {
+        @Override
+        public boolean matches(SelectionCriteria criteria)
+        {
+            return matchPredicate.test(criteria);
+        }
+
+        @Override
+        public void populateVariables(SelectionCriteria criteria, Map<String, String> variables)
+        {
+            // no-op
+        }
+    }
+
+    private record PatternMatcher(Set<String> variableNames, Pattern pattern,
+                                  Function<SelectionCriteria, String> valueExtractor)
+            implements SelectionMatcher
+    {
+        @Override
+        public boolean matches(SelectionCriteria criteria)
+        {
+            return pattern.matcher(valueExtractor.apply(criteria)).matches();
+        }
+
+        @Override
+        public void populateVariables(SelectionCriteria criteria, Map<String, String> variables)
+        {
+            Matcher matcher = pattern.matcher(valueExtractor.apply(criteria));
+            if (!matcher.matches()) {
+                return;
+            }
+            Map<String, Integer> namedGroups = matcher.namedGroups();
+            for (String key : variableNames) {
+                if (namedGroups.containsKey(key)) {
+                    String value = matcher.group(namedGroups.get(key));
                     if (value != null) {
-                        mapping.put(key, value);
+                        variables.put(key, value);
                     }
-                }
-                catch (IllegalArgumentException _) {
-                    // there was no capturing group with the specified name
                 }
             }
         }

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/StaticSelector.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/StaticSelector.java
@@ -48,6 +48,8 @@ public class StaticSelector
     public StaticSelector(
             Optional<Pattern> userRegex,
             Optional<Pattern> userGroupRegex,
+            Optional<Pattern> originalUserRegex,
+            Optional<Pattern> authenticatedUserRegex,
             Optional<Pattern> sourceRegex,
             Optional<List<String>> clientTags,
             Optional<SelectorResourceEstimate> selectorResourceEstimate,
@@ -56,6 +58,8 @@ public class StaticSelector
     {
         this.userRegex = requireNonNull(userRegex, "userRegex is null");
         requireNonNull(userGroupRegex, "userGroupRegex is null");
+        requireNonNull(originalUserRegex, "originalUserRegex is null");
+        requireNonNull(authenticatedUserRegex, "authenticatedUserRegex is null");
         requireNonNull(sourceRegex, "sourceRegex is null");
         requireNonNull(clientTags, "clientTags is null");
         requireNonNull(selectorResourceEstimate, "selectorResourceEstimate is null");
@@ -67,6 +71,14 @@ public class StaticSelector
                 .add(userRegex.map(userRegexValue -> {
                     addNamedGroups(userRegexValue, variableNames);
                     return new PatternMatcher(variableNames, userRegexValue, SelectionCriteria::getUser);
+                }))
+                .add(originalUserRegex.map(originalUserRegexValue -> {
+                    addNamedGroups(originalUserRegexValue, variableNames);
+                    return new PatternMatcher(variableNames, originalUserRegexValue, SelectionCriteria::getOriginalUser);
+                }))
+                .add(authenticatedUserRegex.map(authenticatedUserRegexValue -> {
+                    addNamedGroups(authenticatedUserRegexValue, variableNames);
+                    return new PatternMatcher(variableNames, authenticatedUserRegexValue, criteria -> criteria.getAuthenticatedUser().orElse(""));
                 }))
                 .add(sourceRegex.map(sourceRegexValue -> {
                     addNamedGroups(sourceRegexValue, variableNames);

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/DbResourceGroupConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/DbResourceGroupConfigurationManager.java
@@ -379,6 +379,8 @@ public class DbResourceGroupConfigurationManager
                         new SelectorSpec(
                                 selectorRecord.getUserRegex(),
                                 selectorRecord.getUserGroupRegex(),
+                                selectorRecord.getOriginalUserRegex(),
+                                selectorRecord.getAuthenticatedUserRegex(),
                                 selectorRecord.getSourceRegex(),
                                 selectorRecord.getQueryType(),
                                 selectorRecord.getClientTags(),

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/ResourceGroupsDao.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/ResourceGroupsDao.java
@@ -60,7 +60,7 @@ public interface ResourceGroupsDao
     @UseRowMapper(ResourceGroupSpecBuilder.Mapper.class)
     List<ResourceGroupSpecBuilder> getResourceGroups(@Bind("environment") String environment);
 
-    @SqlQuery("SELECT S.resource_group_id, S.priority, S.user_regex, S.source_regex, S.query_type, S.client_tags, S.selector_resource_estimate, S.user_group_regex\n" +
+    @SqlQuery("SELECT S.resource_group_id, S.priority, S.user_regex, S.source_regex, S.original_user_regex, S.authenticated_user_regex, S.query_type, S.client_tags, S.selector_resource_estimate, S.user_group_regex\n" +
             "FROM selectors S\n" +
             "JOIN resource_groups R ON (S.resource_group_id = R.resource_group_id)\n" +
             "WHERE R.environment = :environment\n" +
@@ -73,6 +73,8 @@ public interface ResourceGroupsDao
             "  priority BIGINT NOT NULL,\n" +
             "  user_regex VARCHAR(512),\n" +
             "  user_group_regex VARCHAR(512),\n" +
+            "  original_user_regex VARCHAR(512),\n" +
+            "  authenticated_user_regex VARCHAR(512),\n" +
             "  source_regex VARCHAR(512),\n" +
             "  query_type VARCHAR(512),\n" +
             "  client_tags VARCHAR(512),\n" +

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/SelectorRecord.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/SelectorRecord.java
@@ -35,6 +35,8 @@ public class SelectorRecord
     private final long priority;
     private final Optional<Pattern> userRegex;
     private final Optional<Pattern> userGroupRegex;
+    private final Optional<Pattern> originalUserRegex;
+    private final Optional<Pattern> authenticatedUserRegex;
     private final Optional<Pattern> sourceRegex;
     private final Optional<String> queryType;
     private final Optional<List<String>> clientTags;
@@ -45,6 +47,8 @@ public class SelectorRecord
             long priority,
             Optional<Pattern> userRegex,
             Optional<Pattern> userGroupRegex,
+            Optional<Pattern> originalUserRegex,
+            Optional<Pattern> authenticatedUserRegex,
             Optional<Pattern> sourceRegex,
             Optional<String> queryType,
             Optional<List<String>> clientTags,
@@ -54,6 +58,8 @@ public class SelectorRecord
         this.priority = priority;
         this.userRegex = requireNonNull(userRegex, "userRegex is null");
         this.userGroupRegex = requireNonNull(userGroupRegex, "userGroupRegex is null");
+        this.originalUserRegex = requireNonNull(originalUserRegex, "originalUserRegex is null");
+        this.authenticatedUserRegex = requireNonNull(authenticatedUserRegex, "authenticatedUserRegex is null");
         this.sourceRegex = requireNonNull(sourceRegex, "sourceRegex is null");
         this.queryType = requireNonNull(queryType, "queryType is null");
         this.clientTags = clientTags.map(ImmutableList::copyOf);
@@ -78,6 +84,16 @@ public class SelectorRecord
     public Optional<Pattern> getUserGroupRegex()
     {
         return userGroupRegex;
+    }
+
+    public Optional<Pattern> getOriginalUserRegex()
+    {
+        return originalUserRegex;
+    }
+
+    public Optional<Pattern> getAuthenticatedUserRegex()
+    {
+        return authenticatedUserRegex;
     }
 
     public Optional<Pattern> getSourceRegex()
@@ -115,6 +131,8 @@ public class SelectorRecord
                     resultSet.getLong("priority"),
                     Optional.ofNullable(resultSet.getString("user_regex")).map(Pattern::compile),
                     Optional.ofNullable(resultSet.getString("user_group_regex")).map(Pattern::compile),
+                    Optional.ofNullable(resultSet.getString("original_user_regex")).map(Pattern::compile),
+                    Optional.ofNullable(resultSet.getString("authenticated_user_regex")).map(Pattern::compile),
                     Optional.ofNullable(resultSet.getString("source_regex")).map(Pattern::compile),
                     Optional.ofNullable(resultSet.getString("query_type")),
                     Optional.ofNullable(resultSet.getString("client_tags")).map(LIST_STRING_CODEC::fromJson),

--- a/plugin/trino-resource-group-managers/src/main/resources/db/migration/mysql/V7__add_original_and_authenticated_user_to_selectors.sql
+++ b/plugin/trino-resource-group-managers/src/main/resources/db/migration/mysql/V7__add_original_and_authenticated_user_to_selectors.sql
@@ -1,0 +1,3 @@
+ALTER TABLE selectors
+    ADD COLUMN original_user_regex VARCHAR(512),
+    ADD COLUMN authenticated_user_regex VARCHAR(512);

--- a/plugin/trino-resource-group-managers/src/main/resources/db/migration/oracle/V7__add_original_and_authenticated_user_to_selectors.sql
+++ b/plugin/trino-resource-group-managers/src/main/resources/db/migration/oracle/V7__add_original_and_authenticated_user_to_selectors.sql
@@ -1,0 +1,4 @@
+ALTER TABLE selectors ADD (
+    original_user_regex VARCHAR(512),
+    authenticated_user_regex VARCHAR(512)
+);

--- a/plugin/trino-resource-group-managers/src/main/resources/db/migration/postgresql/V7__add_original_and_authenticated_user_to_selectors.sql
+++ b/plugin/trino-resource-group-managers/src/main/resources/db/migration/postgresql/V7__add_original_and_authenticated_user_to_selectors.sql
@@ -1,0 +1,3 @@
+ALTER TABLE selectors
+    ADD COLUMN original_user_regex VARCHAR(512),
+    ADD COLUMN authenticated_user_regex VARCHAR(512);

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestResourceGroupIdTemplate.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestResourceGroupIdTemplate.java
@@ -48,8 +48,8 @@ public class TestResourceGroupIdTemplate
         ResourceGroupId expected = new ResourceGroupId(new ResourceGroupId(new ResourceGroupId(new ResourceGroupId("test"), "pipeline"), "job_testpipeline_user:user"), "user");
 
         Pattern sourcePattern = Pattern.compile("scheduler.important.(?<pipeline>[^\\[]*).*");
-        StaticSelector selector = new StaticSelector(Optional.empty(), Optional.empty(), Optional.of(sourcePattern), Optional.empty(), Optional.empty(), Optional.empty(), template);
-        SelectionCriteria context = new SelectionCriteria(true, "user", ImmutableSet.of(), Optional.of("scheduler.important.testpipeline[5]"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty());
+        StaticSelector selector = new StaticSelector(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(sourcePattern), Optional.empty(), Optional.empty(), Optional.empty(), template);
+        SelectionCriteria context = new SelectionCriteria(true, "user", ImmutableSet.of(), "user", Optional.empty(), Optional.of("scheduler.important.testpipeline[5]"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty());
 
         assertThat(selector.match(context).map(SelectionContext::getResourceGroupId)).isEqualTo(Optional.of(expected));
     }
@@ -61,8 +61,8 @@ public class TestResourceGroupIdTemplate
         ResourceGroupId expected = new ResourceGroupId(new ResourceGroupId(new ResourceGroupId(new ResourceGroupId("test"), "pipeline"), "testpipeline"), "_s");
 
         Pattern userPattern = Pattern.compile("scheduler.important.(?<pipeline>[^\\[]*).*");
-        StaticSelector selector = new StaticSelector(Optional.of(userPattern), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), template);
-        SelectionCriteria context = new SelectionCriteria(true, "scheduler.important.testpipeline[5]", ImmutableSet.of(), Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty());
+        StaticSelector selector = new StaticSelector(Optional.of(userPattern), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), template);
+        SelectionCriteria context = new SelectionCriteria(true, "scheduler.important.testpipeline[5]", ImmutableSet.of(), "user", Optional.empty(), Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty());
 
         assertThat(selector.match(context).map(SelectionContext::getResourceGroupId)).isEqualTo(Optional.of(expected));
     }
@@ -72,8 +72,8 @@ public class TestResourceGroupIdTemplate
     {
         ResourceGroupIdTemplate template = new ResourceGroupIdTemplate("test.pipeline.${pipeline}.${USER}");
         Pattern sourcePattern = Pattern.compile("scheduler.important.(?<pipeline>[^\\[]*).*");
-        StaticSelector selector = new StaticSelector(Optional.empty(), Optional.empty(), Optional.of(sourcePattern), Optional.empty(), Optional.empty(), Optional.empty(), template);
-        SelectionCriteria context = new SelectionCriteria(true, "user", ImmutableSet.of(), Optional.of("scheduler.testpipeline[5]"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty());
+        StaticSelector selector = new StaticSelector(Optional.empty(), Optional.empty(), Optional.of(sourcePattern), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), template);
+        SelectionCriteria context = new SelectionCriteria(true, "user", ImmutableSet.of(), "user", Optional.empty(), Optional.of("scheduler.testpipeline[5]"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty());
 
         assertThat(selector.match(context)).isEmpty();
     }
@@ -84,8 +84,8 @@ public class TestResourceGroupIdTemplate
         assertThatThrownBy(() -> {
             ResourceGroupIdTemplate template = new ResourceGroupIdTemplate("test.pipeline.${pipeline}.${user}");
             Pattern sourcePattern = Pattern.compile("scheduler.important.(?<pipeline>[^\\[]*).*");
-            StaticSelector selector = new StaticSelector(Optional.empty(), Optional.empty(), Optional.of(sourcePattern), Optional.empty(), Optional.empty(), Optional.empty(), template);
-            SelectionCriteria context = new SelectionCriteria(true, "user", ImmutableSet.of(), Optional.of("scheduler.important.testpipeline[5]"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty());
+            StaticSelector selector = new StaticSelector(Optional.empty(), Optional.empty(), Optional.of(sourcePattern), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), template);
+            SelectionCriteria context = new SelectionCriteria(true, "user", ImmutableSet.of(), "user", Optional.empty(), Optional.of("scheduler.important.testpipeline[5]"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty());
             selector.match(context);
         })
                 .isInstanceOf(IllegalArgumentException.class)
@@ -98,8 +98,8 @@ public class TestResourceGroupIdTemplate
         assertThatThrownBy(() -> {
             ResourceGroupIdTemplate template = new ResourceGroupIdTemplate("test.pipeline.${pipeline}.${USER}");
             Pattern sourcePattern = Pattern.compile("scheduler.important.(testpipeline\\[|(?<pipeline>[^\\[]*)).*");
-            StaticSelector selector = new StaticSelector(Optional.empty(), Optional.empty(), Optional.of(sourcePattern), Optional.empty(), Optional.empty(), Optional.empty(), template);
-            SelectionCriteria context = new SelectionCriteria(true, "user", ImmutableSet.of(), Optional.of("scheduler.important.testpipeline[5]"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty());
+            StaticSelector selector = new StaticSelector(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(sourcePattern), Optional.empty(), Optional.empty(), Optional.empty(), template);
+            SelectionCriteria context = new SelectionCriteria(true, "user", ImmutableSet.of(), "user", Optional.empty(), Optional.of("scheduler.important.testpipeline[5]"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty());
             selector.match(context);
         })
                 .isInstanceOf(IllegalArgumentException.class)

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestStaticSelector.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestStaticSelector.java
@@ -48,6 +48,8 @@ public class TestStaticSelector
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
                 new ResourceGroupIdTemplate("global.foo"));
         assertThat(selector.match(newSelectionCriteria("userA", null, ImmutableSet.of("tag1"), EMPTY_RESOURCE_ESTIMATES)).map(SelectionContext::getResourceGroupId)).isEqualTo(Optional.of(resourceGroupId));
         assertThat(selector.match(newSelectionCriteria("userB", "source", ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES)).map(SelectionContext::getResourceGroupId)).isEqualTo(Optional.of(resourceGroupId));
@@ -65,6 +67,8 @@ public class TestStaticSelector
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
                 new ResourceGroupIdTemplate("global.foo_${USER}_${suffix}"));
         assertThat(selector.match(newSelectionCriteria("userA", null, ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES))).hasValueSatisfying(context -> {
             assertThat(context.getResourceGroupId()).isEqualTo(resourceGroupId);
@@ -73,10 +77,90 @@ public class TestStaticSelector
     }
 
     @Test
+    public void testOriginalUserRegex()
+    {
+        ResourceGroupId resourceGroupId = new ResourceGroupId(new ResourceGroupId("global"), "foo");
+        StaticSelector selector = new StaticSelector(
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(Pattern.compile("originalUser.*")),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                new ResourceGroupIdTemplate("global.foo"));
+        assertThat(selector.match(newSelectionCriteriaUsers("userA", "originalUserA", null)).map(SelectionContext::getResourceGroupId)).hasValue(resourceGroupId);
+        assertThat(selector.match(newSelectionCriteriaUsers("userA", "originalUserB", null)).map(SelectionContext::getResourceGroupId)).hasValue(resourceGroupId);
+        assertThat(selector.match(newSelectionCriteriaUsers("userA", "A.originalUser", null))).isEmpty();
+    }
+
+    @Test
+    public void testOriginalUserRegexCustomGroup()
+    {
+        ResourceGroupId resourceGroupId = new ResourceGroupId(new ResourceGroupId("global"), "foo_originalUserA_A");
+        StaticSelector selector = new StaticSelector(
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(Pattern.compile("(?<original>originalUser(?<suffix>.*))")),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                new ResourceGroupIdTemplate("global.foo_${original}_${suffix}"));
+        assertThat(selector.match(newSelectionCriteriaUsers("userA", "originalUserA", null))).hasValueSatisfying(context -> {
+            assertThat(context.getResourceGroupId()).isEqualTo(resourceGroupId);
+            assertThat(context.getContext().getVariableNames()).containsExactlyInAnyOrder("suffix", "original");
+        });
+    }
+
+    @Test
+    public void testAuthenticatedUserRegex()
+    {
+        ResourceGroupId resourceGroupId = new ResourceGroupId(new ResourceGroupId("global"), "foo");
+        StaticSelector selector = new StaticSelector(
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(Pattern.compile("authenticatedUser.*")),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                new ResourceGroupIdTemplate("global.foo"));
+        assertThat(selector.match(newSelectionCriteriaUsers("userA", "userA", "authenticatedUserA")).map(SelectionContext::getResourceGroupId)).hasValue(resourceGroupId);
+        assertThat(selector.match(newSelectionCriteriaUsers("userA", "userA", "authenticatedUserB")).map(SelectionContext::getResourceGroupId)).hasValue(resourceGroupId);
+        assertThat(selector.match(newSelectionCriteriaUsers("userA", "userA", "A.authenticatedUser"))).isEmpty();
+    }
+
+    @Test
+    public void testAuthenticatedUserRegexCustomGroup()
+    {
+        ResourceGroupId resourceGroupId = new ResourceGroupId(new ResourceGroupId("global"), "foo_authenticatedUser_A");
+        StaticSelector selector = new StaticSelector(
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(Pattern.compile("(?<auth>authenticatedUser)(?<suffix>.*)")),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                new ResourceGroupIdTemplate("global.foo_${auth}_${suffix}"));
+        assertThat(selector.match(newSelectionCriteriaUsers("userA", "userA", "authenticatedUserA"))).hasValueSatisfying(context -> {
+            assertThat(context.getResourceGroupId()).isEqualTo(resourceGroupId);
+            assertThat(context.getContext().getVariableNames()).containsExactlyInAnyOrder("suffix", "auth");
+        });
+    }
+
+    @Test
     public void testSourceRegex()
     {
         ResourceGroupId resourceGroupId = new ResourceGroupId(new ResourceGroupId("global"), "foo");
         StaticSelector selector = new StaticSelector(
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.of(Pattern.compile(".*source.*")),
@@ -94,6 +178,8 @@ public class TestStaticSelector
     {
         ResourceGroupId resourceGroupId = new ResourceGroupId(new ResourceGroupId("global"), "foo");
         StaticSelector selector = new StaticSelector(
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.of(Pattern.compile("$^")),
@@ -114,6 +200,8 @@ public class TestStaticSelector
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
                 Optional.of(ImmutableList.of("tag1", "tag2")),
                 Optional.empty(),
                 Optional.empty(),
@@ -130,6 +218,8 @@ public class TestStaticSelector
         ResourceGroupId resourceGroupId = new ResourceGroupId(new ResourceGroupId("global"), "foo");
 
         StaticSelector smallQuerySelector = new StaticSelector(
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
@@ -183,6 +273,8 @@ public class TestStaticSelector
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
                 Optional.of(new SelectorResourceEstimate(
                         Optional.empty(),
                         Optional.empty(),
@@ -228,6 +320,11 @@ public class TestStaticSelector
 
     private SelectionCriteria newSelectionCriteria(String user, String source, Set<String> tags, ResourceEstimates resourceEstimates)
     {
-        return new SelectionCriteria(true, user, ImmutableSet.of(), Optional.ofNullable(source), tags, resourceEstimates, Optional.empty());
+        return new SelectionCriteria(true, user, ImmutableSet.of(), user, Optional.empty(), Optional.ofNullable(source), tags, resourceEstimates, Optional.empty());
+    }
+
+    private SelectionCriteria newSelectionCriteriaUsers(String user, String originalUser, String authenticatedUser)
+    {
+        return new SelectionCriteria(true, user, ImmutableSet.of(), originalUser, Optional.ofNullable(authenticatedUser), Optional.empty(), Set.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty());
     }
 }

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestingResourceGroups.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestingResourceGroups.java
@@ -78,6 +78,8 @@ final class TestingResourceGroups
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
                         groupIdTemplate));
     }
 
@@ -103,6 +105,8 @@ final class TestingResourceGroups
                     new SelectorSpec(
                             Optional.of(matchLiterals(users)),
                             spec.getUserGroupRegex(),
+                            spec.getOriginalUserRegex(),
+                            spec.getAuthenticatedUserRegex(),
                             spec.getSourceRegex(),
                             spec.getQueryType(),
                             spec.getClientTags(),
@@ -116,6 +120,38 @@ final class TestingResourceGroups
                     new SelectorSpec(
                             spec.getUserRegex(),
                             Optional.of(matchLiterals(groups)),
+                            spec.getOriginalUserRegex(),
+                            spec.getAuthenticatedUserRegex(),
+                            spec.getSourceRegex(),
+                            spec.getQueryType(),
+                            spec.getClientTags(),
+                            spec.getResourceEstimate(),
+                            spec.getGroup()));
+        }
+
+        public SelectorSpecBuilder originalUserPattern(String originalUserPattern)
+        {
+            return new SelectorSpecBuilder(
+                    new SelectorSpec(
+                            spec.getUserRegex(),
+                            spec.getUserGroupRegex(),
+                            Optional.of(Pattern.compile(originalUserPattern)),
+                            spec.getAuthenticatedUserRegex(),
+                            spec.getSourceRegex(),
+                            spec.getQueryType(),
+                            spec.getClientTags(),
+                            spec.getResourceEstimate(),
+                            spec.getGroup()));
+        }
+
+        public SelectorSpecBuilder authenticatedUserPattern(String authenticatedUserPattern)
+        {
+            return new SelectorSpecBuilder(
+                    new SelectorSpec(
+                            spec.getUserRegex(),
+                            spec.getUserGroupRegex(),
+                            spec.getOriginalUserRegex(),
+                            Optional.of(Pattern.compile(authenticatedUserPattern)),
                             spec.getSourceRegex(),
                             spec.getQueryType(),
                             spec.getClientTags(),

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/H2ResourceGroupsDao.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/H2ResourceGroupsDao.java
@@ -80,13 +80,15 @@ public interface H2ResourceGroupsDao
     void deleteResourceGroup(@Bind("resource_group_id") long resourceGroupId);
 
     @SqlUpdate("INSERT INTO selectors\n" +
-            "(resource_group_id, priority, user_regex, user_group_regex, source_regex, query_type, client_tags, selector_resource_estimate)\n" +
-            "VALUES (:resource_group_id, :priority, :user_regex, :user_group_regex, :source_regex, :query_type, :client_tags, :selector_resource_estimate)")
+            "(resource_group_id, priority, user_regex, user_group_regex, original_user_regex, authenticated_user_regex, source_regex, query_type, client_tags, selector_resource_estimate)\n" +
+            "VALUES (:resource_group_id, :priority, :user_regex, :user_group_regex, :original_user_regex, :authenticated_user_regex, :source_regex, :query_type, :client_tags, :selector_resource_estimate)")
     void insertSelector(
             @Bind("resource_group_id") long resourceGroupId,
             @Bind("priority") long priority,
             @Bind("user_regex") String userRegex,
             @Bind("user_group_regex") String userGroupRegex,
+            @Bind("original_user_regex") String originalUserRegex,
+            @Bind("authenticated_user_regex") String authenticatedUserRegex,
             @Bind("source_regex") String sourceRegex,
             @Bind("query_type") String queryType,
             @Bind("client_tags") String clientTags,
@@ -95,28 +97,46 @@ public interface H2ResourceGroupsDao
     @SqlUpdate("UPDATE selectors SET\n" +
             " resource_group_id = :resource_group_id\n" +
             ", user_regex = :user_regex\n" +
+            ", user_group_regex = :user_group_regex\n" +
+            ", original_user_regex = :original_user_regex\n" +
+            ", authenticated_user_regex = :authenticated_user_regex\n" +
             ", source_regex = :source_regex\n" +
             ", client_tags = :client_tags\n" +
             "WHERE resource_group_id = :resource_group_id\n" +
             " AND ((user_regex IS NULL AND :old_user_regex IS NULL) OR user_regex = :old_user_regex)\n" +
+            " AND ((user_group_regex IS NULL AND :old_user_group_regex IS NULL) OR user_group_regex = :old_user_group_regex)\n" +
+            " AND ((original_user_regex IS NULL AND :old_original_user_regex IS NULL) OR original_user_regex = :old_original_user_regex)\n" +
+            " AND ((authenticated_user_regex IS NULL AND :old_authenticated_user_regex IS NULL) OR authenticated_user_regex = :old_authenticated_user_regex)\n" +
             " AND ((source_regex IS NULL AND :old_source_regex IS NULL) OR source_regex = :old_source_regex)\n" +
             " AND ((client_tags IS NULL AND :old_client_tags IS NULL) OR client_tags = :old_client_tags)")
     void updateSelector(
             @Bind("resource_group_id") long resourceGroupId,
             @Bind("user_regex") String newUserRegex,
+            @Bind("user_group_regex") String newUserGroupRegex,
+            @Bind("original_user_regex") String newOriginalUserRegex,
+            @Bind("authenticated_user_regex") String newAuthenticatedUserRegex,
             @Bind("source_regex") String newSourceRegex,
             @Bind("client_tags") String newClientTags,
             @Bind("old_user_regex") String oldUserRegex,
+            @Bind("old_user_group_regex") String oldUserGroupRegex,
+            @Bind("old_original_user_regex") String oldOriginalUserRegex,
+            @Bind("old_authenticated_user_regex") String oldAuthenticatedUserRegex,
             @Bind("old_source_regex") String oldSourceRegex,
             @Bind("old_client_tags") String oldClientTags);
 
     @SqlUpdate("DELETE FROM selectors WHERE resource_group_id = :resource_group_id\n" +
             " AND ((user_regex IS NULL AND :user_regex IS NULL) OR user_regex = :user_regex)\n" +
+            " AND ((user_group_regex IS NULL AND :user_group_regex IS NULL) OR user_group_regex = :user_group_regex)\n" +
+            " AND ((original_user_regex IS NULL AND :original_user_regex IS NULL) OR original_user_regex = :original_user_regex)\n" +
+            " AND ((authenticated_user_regex IS NULL AND :authenticated_user_regex IS NULL) OR authenticated_user_regex = :authenticated_user_regex)\n" +
             " AND ((source_regex IS NULL AND :source_regex IS NULL) OR source_regex = :source_regex)\n" +
             " AND ((client_tags IS NULL AND :client_tags IS NULL) OR client_tags = :client_tags)")
     void deleteSelector(
             @Bind("resource_group_id") long resourceGroupId,
             @Bind("user_regex") String userRegex,
+            @Bind("user_group_regex") String userGroupRegex,
+            @Bind("original_user_regex") String originalUserRegex,
+            @Bind("authenticated_user_regex") String authenticatedUserRegex,
             @Bind("source_regex") String sourceRegex,
             @Bind("client_tags") String clientTags);
 

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupConfigurationManager.java
@@ -77,8 +77,8 @@ public class TestDbResourceGroupConfigurationManager
         // two resource groups are the same except the group for the prod environment has a larger softMemoryLimit
         dao.insertResourceGroup(1, "prod_global", "10MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", null, prodEnvironment);
         dao.insertResourceGroup(2, "dev_global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", null, devEnvironment);
-        dao.insertSelector(1, 1, ".*prod_user.*", null, null, null, null, null);
-        dao.insertSelector(2, 2, ".*dev_user.*", null, null, null, null, null);
+        dao.insertSelector(1, 1, ".*prod_user.*", null, null, null, null, null, null, null);
+        dao.insertSelector(2, 2, ".*dev_user.*", null, null, null, null, null, null, null);
 
         // check the prod configuration
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(listener -> {}, new DbResourceGroupConfig(), daoProvider.get(), prodEnvironment);
@@ -89,7 +89,7 @@ public class TestDbResourceGroupConfigurationManager
         assertEqualsResourceGroup(prodGlobal, "10MB", 1000, 100, 100, WEIGHTED, DEFAULT_WEIGHT, true, Duration.ofHours(1), Duration.ofDays(1));
         assertThat(manager.getSelectors()).hasSize(1);
         ResourceGroupSelector prodSelector = manager.getSelectors().get(0);
-        ResourceGroupId prodResourceGroupId = prodSelector.match(new SelectionCriteria(true, "prod_user", ImmutableSet.of(), Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty())).get().getResourceGroupId();
+        ResourceGroupId prodResourceGroupId = prodSelector.match(new SelectionCriteria(true, "prod_user", ImmutableSet.of(), "prod_user", Optional.empty(), Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty())).get().getResourceGroupId();
         assertThat(prodResourceGroupId.toString()).isEqualTo("prod_global");
 
         // check the dev configuration
@@ -100,7 +100,7 @@ public class TestDbResourceGroupConfigurationManager
         assertEqualsResourceGroup(devGlobal, "1MB", 1000, 100, 100, WEIGHTED, DEFAULT_WEIGHT, true, Duration.ofHours(1), Duration.ofDays(1));
         assertThat(manager.getSelectors()).hasSize(1);
         ResourceGroupSelector devSelector = manager.getSelectors().get(0);
-        ResourceGroupId devResourceGroupId = devSelector.match(new SelectionCriteria(true, "dev_user", ImmutableSet.of(), Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty())).get().getResourceGroupId();
+        ResourceGroupId devResourceGroupId = devSelector.match(new SelectionCriteria(true, "dev_user", ImmutableSet.of(), "dev_user", Optional.empty(), Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty())).get().getResourceGroupId();
         assertThat(devResourceGroupId.toString()).isEqualTo("dev_global");
     }
 
@@ -115,7 +115,7 @@ public class TestDbResourceGroupConfigurationManager
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
         dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", null, ENVIRONMENT);
         dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, 1L, ENVIRONMENT);
-        dao.insertSelector(2, 1, null, null, null, null, null, null);
+        dao.insertSelector(2, 1, null, null, null, null, null, null, null, null);
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(listener -> {}, new DbResourceGroupConfig(), daoProvider.get(), ENVIRONMENT);
         InternalResourceGroup global = new InternalResourceGroup("global", (group, export) -> {}, directExecutor());
         manager.configure(global, new SelectionContext<>(global.getId(), new ResourceGroupIdTemplate("global")));
@@ -139,7 +139,7 @@ public class TestDbResourceGroupConfigurationManager
                     assertThat(ex.getCause()).isInstanceOf(JdbcException.class);
                     assertThat(ex.getCause().getMessage()).startsWith("Unique index or primary key violation");
                 });
-        dao.insertSelector(1, 1, null, null, null, null, null, null);
+        dao.insertSelector(1, 1, null, null, null, null, null, null, null, null);
     }
 
     @Test
@@ -157,7 +157,7 @@ public class TestDbResourceGroupConfigurationManager
                     assertThat(ex.getCause()).isInstanceOf(JdbcException.class);
                     assertThat(ex.getCause().getMessage()).startsWith("Unique index or primary key violation");
                 });
-        dao.insertSelector(2, 2, null, null, null, null, null, null);
+        dao.insertSelector(2, 2, null, null, null, null, null, null, null, null);
     }
 
     @Test
@@ -171,7 +171,7 @@ public class TestDbResourceGroupConfigurationManager
         dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", null, ENVIRONMENT);
         dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, 1L, ENVIRONMENT);
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
-        dao.insertSelector(2, 1, null, null, null, null, null, null);
+        dao.insertSelector(2, 1, null, null, null, null, null, null, null, null);
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(listener -> {}, new DbResourceGroupConfig(), daoProvider.get(), ENVIRONMENT);
         InternalResourceGroup missing = new InternalResourceGroup("missing", (group, export) -> {}, directExecutor());
 
@@ -192,7 +192,7 @@ public class TestDbResourceGroupConfigurationManager
         dao.createSelectorsTable();
         dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", null, ENVIRONMENT);
         dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, 1L, ENVIRONMENT);
-        dao.insertSelector(2, 1, null, null, null, null, null, null);
+        dao.insertSelector(2, 1, null, null, null, null, null, null, null, null);
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(listener -> {}, new DbResourceGroupConfig(), daoProvider.get(), ENVIRONMENT);
         manager.start();
@@ -229,7 +229,7 @@ public class TestDbResourceGroupConfigurationManager
         dao.createExactMatchSelectorsTable();
         dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", null, ENVIRONMENT);
         dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, 1L, ENVIRONMENT);
-        dao.insertSelector(2, 1, null, null, null, null, null, null);
+        dao.insertSelector(2, 1, null, null, null, null, null, null, null, null);
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
         DbResourceGroupConfig config = new DbResourceGroupConfig();
         config.setExactMatchSelectorEnabled(true);
@@ -268,7 +268,7 @@ public class TestDbResourceGroupConfigurationManager
         for (int i = 0; i < numberOfUsers; i++) {
             int priority = randomPriorities[i];
             String user = String.valueOf(priority);
-            dao.insertSelector(1, priority, user, null, ".*", null, null, null);
+            dao.insertSelector(1, priority, user, null, null, null, ".*", null, null, null);
             expectedUsers.add(user);
         }
 
@@ -345,7 +345,7 @@ public class TestDbResourceGroupConfigurationManager
         dao.createResourceGroupsTable();
         dao.createSelectorsTable();
         dao.insertResourceGroup(1, "group", "100%", 100, 100, 100, null, null, null, null, null, null, ENVIRONMENT);
-        dao.insertSelector(1, 1, null, "first matching|second matching", null, null, null, null);
+        dao.insertSelector(1, 1, null, "first matching|second matching", null, null, null, null, null, null);
 
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(
                 listener -> {},
@@ -368,7 +368,7 @@ public class TestDbResourceGroupConfigurationManager
         dao.createResourceGroupsTable();
         dao.createSelectorsTable();
         dao.insertResourceGroup(1, "group", "100%", 100, 100, 100, null, null, null, null, null, null, ENVIRONMENT);
-        dao.insertSelector(1, 1, "Matching user", "Matching group", null, null, null, null);
+        dao.insertSelector(1, 1, "Matching user", "Matching group", null, null, null, null, null, null);
 
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(
                 listener -> {},
@@ -379,6 +379,54 @@ public class TestDbResourceGroupConfigurationManager
         assertThat(manager.match(userAndUserGroupsSelectionCriteria("Matching user", "Not matching group"))).isEmpty();
         assertThat(manager.match(userAndUserGroupsSelectionCriteria("Not matching user", "Matching group"))).isEmpty();
         assertThat(manager.match(userAndUserGroupsSelectionCriteria("Matching user", "Matching group")))
+                .map(SelectionContext::getContext)
+                .isEqualTo(Optional.of(new ResourceGroupIdTemplate("group")));
+    }
+
+    @Test
+    public void testMatchByOriginalUser()
+    {
+        H2DaoProvider daoProvider = setup("selectors");
+        H2ResourceGroupsDao dao = daoProvider.get();
+        dao.createResourceGroupsGlobalPropertiesTable();
+        dao.createResourceGroupsTable();
+        dao.createSelectorsTable();
+        dao.insertResourceGroup(1, "group", "100%", 100, 100, 100, null, null, null, null, null, null, ENVIRONMENT);
+        dao.insertSelector(1, 1, null, null, "foo.+", null, null, null, null, null);
+
+        DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(
+                listener -> {},
+                new DbResourceGroupConfig().setMaxRefreshInterval(new io.airlift.units.Duration(2, MILLISECONDS)).setRefreshInterval(new io.airlift.units.Duration(1, MILLISECONDS)),
+                daoProvider.get(),
+                ENVIRONMENT);
+
+        assertThat(manager.match(identitySelectionCriteria("foo-usr", "other-usr", Optional.empty()))).isEmpty();
+        assertThat(manager.match(identitySelectionCriteria("foo-usr", "other-usr", Optional.of("foo-usr")))).isEmpty();
+        assertThat(manager.match(identitySelectionCriteria("other-usr", "foo-usr", Optional.empty())))
+                .map(SelectionContext::getContext)
+                .isEqualTo(Optional.of(new ResourceGroupIdTemplate("group")));
+    }
+
+    @Test
+    public void testMatchByAuthenticatedUser()
+    {
+        H2DaoProvider daoProvider = setup("selectors");
+        H2ResourceGroupsDao dao = daoProvider.get();
+        dao.createResourceGroupsGlobalPropertiesTable();
+        dao.createResourceGroupsTable();
+        dao.createSelectorsTable();
+        dao.insertResourceGroup(1, "group", "100%", 100, 100, 100, null, null, null, null, null, null, ENVIRONMENT);
+        dao.insertSelector(1, 1, null, null, null, "foo.+", null, null, null, null);
+
+        DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(
+                listener -> {},
+                new DbResourceGroupConfig().setMaxRefreshInterval(new io.airlift.units.Duration(2, MILLISECONDS)).setRefreshInterval(new io.airlift.units.Duration(1, MILLISECONDS)),
+                daoProvider.get(),
+                ENVIRONMENT);
+
+        assertThat(manager.match(identitySelectionCriteria("foo-usr", "foo-usr", Optional.empty()))).isEmpty();
+        assertThat(manager.match(identitySelectionCriteria("foo-usr", "foo-usr", Optional.of("other-usr")))).isEmpty();
+        assertThat(manager.match(identitySelectionCriteria("other-usr", "other-usr", Optional.of("foo-usr"))))
                 .map(SelectionContext::getContext)
                 .isEqualTo(Optional.of(new ResourceGroupIdTemplate("group")));
     }
@@ -405,7 +453,7 @@ public class TestDbResourceGroupConfigurationManager
         dao.createResourceGroupsTable();
         dao.createSelectorsTable();
         dao.insertResourceGroup(1, "global", "80%", 10, null, 1, null, null, null, null, null, null, ENVIRONMENT);
-        dao.insertSelector(1, 1, null, "userGroup", null, null, null, null);
+        dao.insertSelector(1, 1, null, "userGroup", null, null, null, null, null, null);
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(_ -> {}, new DbResourceGroupConfig(), daoProvider.get(), ENVIRONMENT);
 
         Optional<SelectionContext<ResourceGroupIdTemplate>> userGroup = manager.match(userGroupsSelectionCriteria("userGroup"));
@@ -463,7 +511,7 @@ public class TestDbResourceGroupConfigurationManager
 
     private static SelectionCriteria userGroupsSelectionCriteria(String... groups)
     {
-        return new SelectionCriteria(true, "test_user", ImmutableSet.copyOf(groups), Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty());
+        return new SelectionCriteria(true, "test_user", ImmutableSet.copyOf(groups), "test_user", Optional.empty(), Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty());
     }
 
     private static SelectionCriteria userAndUserGroupsSelectionCriteria(String user, String group, String... groups)
@@ -474,9 +522,16 @@ public class TestDbResourceGroupConfigurationManager
                 ImmutableSet.<String>builder()
                         .add(group)
                         .add(groups).build(),
+                user,
+                Optional.empty(),
                 Optional.empty(),
                 ImmutableSet.of(),
                 EMPTY_RESOURCE_ESTIMATES,
                 Optional.empty());
+    }
+
+    private static SelectionCriteria identitySelectionCriteria(String user, String originalUser, Optional<String> authenticatedUser)
+    {
+        return new SelectionCriteria(true, user, ImmutableSet.of(), originalUser, authenticatedUser, Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty());
     }
 }

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbSourceExactMatchSelector.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbSourceExactMatchSelector.java
@@ -53,11 +53,11 @@ public class TestDbSourceExactMatchSelector
 
         DbSourceExactMatchSelector selector = new DbSourceExactMatchSelector("test", dao);
 
-        assertThat(selector.match(new SelectionCriteria(true, "testuser", ImmutableSet.of(), Optional.of("@test@test_pipeline"), ImmutableSet.of("tag"), EMPTY_RESOURCE_ESTIMATES, Optional.empty()))).isEqualTo(Optional.empty());
-        assertThat(selector.match(new SelectionCriteria(true, "testuser", ImmutableSet.of(), Optional.of("@test@test_pipeline"), ImmutableSet.of("tag"), EMPTY_RESOURCE_ESTIMATES, Optional.of(INSERT.name()))).map(SelectionContext::getResourceGroupId)).isEqualTo(Optional.of(resourceGroupId1));
-        assertThat(selector.match(new SelectionCriteria(true, "testuser", ImmutableSet.of(), Optional.of("@test@test_pipeline"), ImmutableSet.of("tag"), EMPTY_RESOURCE_ESTIMATES, Optional.of(SELECT.name()))).map(SelectionContext::getResourceGroupId)).isEqualTo(Optional.of(resourceGroupId2));
-        assertThat(selector.match(new SelectionCriteria(true, "testuser", ImmutableSet.of(), Optional.of("@test@test_pipeline"), ImmutableSet.of("tag"), EMPTY_RESOURCE_ESTIMATES, Optional.of(DELETE.name())))).isEqualTo(Optional.empty());
+        assertThat(selector.match(new SelectionCriteria(true, "testuser", ImmutableSet.of(), "testuser", Optional.empty(), Optional.of("@test@test_pipeline"), ImmutableSet.of("tag"), EMPTY_RESOURCE_ESTIMATES, Optional.empty()))).isEqualTo(Optional.empty());
+        assertThat(selector.match(new SelectionCriteria(true, "testuser", ImmutableSet.of(), "testuser", Optional.empty(), Optional.of("@test@test_pipeline"), ImmutableSet.of("tag"), EMPTY_RESOURCE_ESTIMATES, Optional.of(INSERT.name()))).map(SelectionContext::getResourceGroupId)).isEqualTo(Optional.of(resourceGroupId1));
+        assertThat(selector.match(new SelectionCriteria(true, "testuser", ImmutableSet.of(), "testuser", Optional.empty(), Optional.of("@test@test_pipeline"), ImmutableSet.of("tag"), EMPTY_RESOURCE_ESTIMATES, Optional.of(SELECT.name()))).map(SelectionContext::getResourceGroupId)).isEqualTo(Optional.of(resourceGroupId2));
+        assertThat(selector.match(new SelectionCriteria(true, "testuser", ImmutableSet.of(), "testuser", Optional.empty(), Optional.of("@test@test_pipeline"), ImmutableSet.of("tag"), EMPTY_RESOURCE_ESTIMATES, Optional.of(DELETE.name())))).isEqualTo(Optional.empty());
 
-        assertThat(selector.match(new SelectionCriteria(true, "testuser", ImmutableSet.of(), Optional.of("@test@test_new"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.of(INSERT.name())))).isEqualTo(Optional.empty());
+        assertThat(selector.match(new SelectionCriteria(true, "testuser", ImmutableSet.of(), "testuser", Optional.empty(), Optional.of("@test@test_new"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.of(INSERT.name())))).isEqualTo(Optional.empty());
     }
 }

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestResourceGroupsDao.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestResourceGroupsDao.java
@@ -125,7 +125,9 @@ public class TestResourceGroupsDao
                         2L,
                         1L,
                         Optional.of(Pattern.compile("ping_user")),
-                        Optional.of(Pattern.compile("ping_user_group")),
+                        Optional.of(Pattern.compile("ping_group")),
+                        Optional.of(Pattern.compile("ping_original_user")),
+                        Optional.of(Pattern.compile("ping_auth_user")),
                         Optional.of(Pattern.compile(".*")),
                         Optional.empty(),
                         Optional.empty(),
@@ -136,6 +138,8 @@ public class TestResourceGroupsDao
                         2L,
                         Optional.of(Pattern.compile("admin_user")),
                         Optional.of(Pattern.compile("admin_group")),
+                        Optional.of(Pattern.compile("admin_original_user")),
+                        Optional.of(Pattern.compile("admin_auth_user")),
                         Optional.of(Pattern.compile(".*")),
                         Optional.of(EXPLAIN.name()),
                         Optional.of(ImmutableList.of("tag1", "tag2")),
@@ -149,6 +153,8 @@ public class TestResourceGroupsDao
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
                         Optional.of(SELECTOR_RESOURCE_ESTIMATE)));
 
         dao.insertResourceGroup(1, "admin", "100%", 100, 100, 100, null, null, null, null, null, null, ENVIRONMENT);
@@ -156,21 +162,23 @@ public class TestResourceGroupsDao
         dao.insertResourceGroup(3, "config", "50%", 50, 50, 50, null, null, null, null, null, 1L, ENVIRONMENT);
         dao.insertResourceGroup(4, "config", "50%", 50, 50, 50, null, null, null, null, null, 1L, ENVIRONMENT);
 
-        dao.insertSelector(2, 1, "ping_user", null, ".*", null, null, null);
-        dao.insertSelector(3, 2, "admin_user", null, ".*", EXPLAIN.name(), LIST_STRING_CODEC.toJson(ImmutableList.of("tag1", "tag2")), null);
-        dao.insertSelector(4, 0, null, null, null, null, null, SELECTOR_RESOURCE_ESTIMATE_JSON_CODEC.toJson(SELECTOR_RESOURCE_ESTIMATE));
+        dao.insertSelector(2, 1, "ping_user", "ping_group", "ping_original_user", "ping_auth_user", ".*", null, null, null);
+        dao.insertSelector(3, 2, "admin_user", "admin_group", "admin_original_user", "admin_auth_user", ".*", EXPLAIN.name(), LIST_STRING_CODEC.toJson(ImmutableList.of("tag1", "tag2")), null);
+        dao.insertSelector(4, 0, null, null, null, null, null, null, null, SELECTOR_RESOURCE_ESTIMATE_JSON_CODEC.toJson(SELECTOR_RESOURCE_ESTIMATE));
         List<SelectorRecord> records = dao.getSelectors(ENVIRONMENT);
         compareSelectors(map, records);
     }
 
     private static void testSelectorUpdate(H2ResourceGroupsDao dao, Map<Long, SelectorRecord> map)
     {
-        dao.updateSelector(2, "ping.*", "ping_source", LIST_STRING_CODEC.toJson(ImmutableList.of("tag1")), "ping_user", ".*", null);
+        dao.updateSelector(2, "ping.*", "ping_gr.*", "ping_original.*", "ping_auth.*", "ping_source", LIST_STRING_CODEC.toJson(ImmutableList.of("tag1")), "ping_user", "ping_group", "ping_original_user", "ping_auth_user", ".*", null);
         SelectorRecord updated = new SelectorRecord(
                 2,
                 1L,
                 Optional.of(Pattern.compile("ping.*")),
-                Optional.empty(),
+                Optional.of(Pattern.compile("ping_gr.*")),
+                Optional.of(Pattern.compile("ping_original.*")),
+                Optional.of(Pattern.compile("ping_auth.*")),
                 Optional.of(Pattern.compile("ping_source")),
                 Optional.empty(),
                 Optional.of(ImmutableList.of("tag1")),
@@ -181,38 +189,40 @@ public class TestResourceGroupsDao
 
     private static void testSelectorUpdateNull(H2ResourceGroupsDao dao, Map<Long, SelectorRecord> map)
     {
-        SelectorRecord updated = new SelectorRecord(2, 3L, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+        SelectorRecord updated = new SelectorRecord(2, 3L, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
         map.put(2L, updated);
-        dao.updateSelector(2, null, null, null, "ping.*", "ping_source", LIST_STRING_CODEC.toJson(ImmutableList.of("tag1")));
+        dao.updateSelector(2, null, null, null, null, null, null, "ping.*", "ping_gr.*", "ping_original.*", "ping_auth.*", "ping_source", LIST_STRING_CODEC.toJson(ImmutableList.of("tag1")));
         compareSelectors(map, dao.getSelectors(ENVIRONMENT));
         updated = new SelectorRecord(
                 2,
                 2L,
                 Optional.of(Pattern.compile("ping.*")),
-                Optional.empty(),
+                Optional.of(Pattern.compile("ping_gr.*")),
+                Optional.of(Pattern.compile("ping_original.*")),
+                Optional.of(Pattern.compile("ping_auth.*")),
                 Optional.of(Pattern.compile("ping_source")),
                 Optional.of(EXPLAIN.name()),
                 Optional.of(ImmutableList.of("tag1", "tag2")),
                 Optional.empty());
         map.put(2L, updated);
-        dao.updateSelector(2, "ping.*", "ping_source", LIST_STRING_CODEC.toJson(ImmutableList.of("tag1", "tag2")), null, null, null);
+        dao.updateSelector(2, "ping.*", "ping_gr.*", "ping_original.*", "ping_auth.*", "ping_source", LIST_STRING_CODEC.toJson(ImmutableList.of("tag1", "tag2")), null, null, null, null, null, null);
         compareSelectors(map, dao.getSelectors(ENVIRONMENT));
     }
 
     private static void testSelectorDelete(H2ResourceGroupsDao dao, Map<Long, SelectorRecord> map)
     {
         map.remove(2L);
-        dao.deleteSelector(2, "ping.*", "ping_source", LIST_STRING_CODEC.toJson(ImmutableList.of("tag1", "tag2")));
+        dao.deleteSelector(2, "ping.*", "ping_gr.*", "ping_original.*", "ping_auth.*", "ping_source", LIST_STRING_CODEC.toJson(ImmutableList.of("tag1", "tag2")));
         compareSelectors(map, dao.getSelectors(ENVIRONMENT));
     }
 
     private static void testSelectorDeleteNull(H2ResourceGroupsDao dao, Map<Long, SelectorRecord> map)
     {
-        dao.updateSelector(3, null, null, null, "admin_user", ".*", LIST_STRING_CODEC.toJson(ImmutableList.of("tag1", "tag2")));
-        SelectorRecord nullRegexes = new SelectorRecord(3L, 2L, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+        dao.updateSelector(3, null, null, null, null, null, null, "admin_user", "admin_group", "admin_original_user", "admin_auth_user", ".*", LIST_STRING_CODEC.toJson(ImmutableList.of("tag1", "tag2")));
+        SelectorRecord nullRegexes = new SelectorRecord(3L, 2L, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
         map.put(3L, nullRegexes);
         compareSelectors(map, dao.getSelectors(ENVIRONMENT));
-        dao.deleteSelector(3, null, null, null);
+        dao.deleteSelector(3, null, null, null, null, null, null);
         map.remove(3L);
         compareSelectors(map, dao.getSelectors(ENVIRONMENT));
     }
@@ -223,11 +233,13 @@ public class TestResourceGroupsDao
             return;
         }
 
-        dao.insertSelector(3, 3L, "user1", null, "pipeline", null, null, null);
+        dao.insertSelector(3, 3L, "user1", null, null, null, "pipeline", null, null, null);
         map.put(3L, new SelectorRecord(
                 3L,
                 3L,
                 Optional.of(Pattern.compile("user1")),
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty(),
                 Optional.of(Pattern.compile("pipeline")),
                 Optional.empty(),
@@ -301,7 +313,10 @@ public class TestResourceGroupsDao
             SelectorRecord expected = map.get(record.getResourceGroupId());
             assertThat(record.getResourceGroupId()).isEqualTo(expected.getResourceGroupId());
             assertThat(record.getUserRegex().map(Pattern::pattern)).isEqualTo(expected.getUserRegex().map(Pattern::pattern));
+            assertThat(record.getUserGroupRegex().map(Pattern::pattern)).isEqualTo(expected.getUserGroupRegex().map(Pattern::pattern));
             assertThat(record.getSourceRegex().map(Pattern::pattern)).isEqualTo(expected.getSourceRegex().map(Pattern::pattern));
+            assertThat(record.getOriginalUserRegex().map(Pattern::pattern)).isEqualTo(expected.getOriginalUserRegex().map(Pattern::pattern));
+            assertThat(record.getAuthenticatedUserRegex().map(Pattern::pattern)).isEqualTo(expected.getAuthenticatedUserRegex().map(Pattern::pattern));
             assertThat(record.getSelectorResourceEstimate()).isEqualTo(expected.getSelectorResourceEstimate());
         }
     }

--- a/plugin/trino-resource-group-managers/src/test/resources/resource_groups_config_original_auth_user.json
+++ b/plugin/trino-resource-group-managers/src/test/resources/resource_groups_config_original_auth_user.json
@@ -1,0 +1,40 @@
+{
+  "rootGroups": [
+    {
+      "name": "global",
+      "softMemoryLimit": "1MB",
+      "hardConcurrencyLimit": 100,
+      "maxQueued": 1000,
+      "softCpuLimit": "1h",
+      "hardCpuLimit": "1d",
+      "subGroups": [
+        {
+          "name": "original",
+          "softMemoryLimit": "2MB",
+          "hardConcurrencyLimit": 3,
+          "maxQueued": 4,
+          "schedulingWeight": 5
+        },
+        {
+          "name": "auth",
+          "softMemoryLimit": "2MB",
+          "hardConcurrencyLimit": 3,
+          "maxQueued": 4,
+          "schedulingWeight": 5
+        }
+      ]
+    }
+  ],
+  "selectors": [
+    {
+      "group": "global.original",
+      "originalUser": "usr-original"
+    },
+    {
+      "group": "global.auth",
+      "authenticatedUser": "usr-auth"
+    }
+  ],
+  "cpuQuotaPeriod": "1h"
+}
+

--- a/testing/trino-tests/src/test/java/io/trino/execution/resourcegroups/db/H2TestUtil.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/resourcegroups/db/H2TestUtil.java
@@ -166,13 +166,13 @@ final class H2TestUtil
         dao.insertResourceGroup(5, "dashboard-${USER}", "1MB", 1, 1, 1, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
         dao.insertResourceGroup(6, "no-queueing", "1MB", 0, 1, 1, null, null, null, null, null, null, TEST_ENVIRONMENT_2);
         dao.insertResourceGroup(7, "explain", "1MB", 0, 1, 1, null, null, null, null, null, null, TEST_ENVIRONMENT);
-        dao.insertSelector(2, 10_000, "user.*", null, "test", null, null, null);
-        dao.insertSelector(4, 1_000, "user.*", null, "(?i).*adhoc.*", null, null, null);
-        dao.insertSelector(5, 100, "user.*", null, "(?i).*dashboard.*", null, null, null);
-        dao.insertSelector(4, 10, "user.*", null, null, null, CLIENT_TAGS_CODEC.toJson(ImmutableList.of("tag1", "tag2")), null);
-        dao.insertSelector(2, 1, "user.*", null, null, null, CLIENT_TAGS_CODEC.toJson(ImmutableList.of("tag1")), null);
-        dao.insertSelector(6, 6, ".*", null, ".*", null, null, null);
-        dao.insertSelector(7, 100_000, null, null, null, EXPLAIN.name(), null, null);
+        dao.insertSelector(2, 10_000, "user.*", null, null, null, "test", null, null, null);
+        dao.insertSelector(4, 1_000, "user.*", null, null, null, "(?i).*adhoc.*", null, null, null);
+        dao.insertSelector(5, 100, "user.*", null, null, null, "(?i).*dashboard.*", null, null, null);
+        dao.insertSelector(4, 10, "user.*", null, null, null, null, null, CLIENT_TAGS_CODEC.toJson(ImmutableList.of("tag1", "tag2")), null);
+        dao.insertSelector(2, 1, "user.*", null, null, null, null, null, CLIENT_TAGS_CODEC.toJson(ImmutableList.of("tag1")), null);
+        dao.insertSelector(6, 6, ".*", null, null, null, ".*", null, null, null);
+        dao.insertSelector(7, 100_000, null, null, null, null, null, EXPLAIN.name(), null, null);
 
         int expectedSelectors = 6;
         if (environment.equals(TEST_ENVIRONMENT_2)) {

--- a/testing/trino-tests/src/test/java/io/trino/execution/resourcegroups/db/TestQueuesDb.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/resourcegroups/db/TestQueuesDb.java
@@ -217,13 +217,13 @@ public class TestQueuesDb
         DispatchManager dispatchManager = queryRunner.getCoordinator().getDispatchManager();
         assertThat(dispatchManager.getQueryInfo(queryId).getErrorCode()).isEqualTo(QUERY_REJECTED.toErrorCode());
         int selectorCount = getSelectors(queryRunner).size();
-        dao.insertSelector(4, 100_000, "user.*", null, "(?i).*reject.*", null, null, null);
+        dao.insertSelector(4, 100_000, "user.*", null, null, null, "(?i).*reject.*", null, null, null);
         dbConfigurationManager.load();
         assertThat(getSelectors(queryRunner)).hasSize(selectorCount + 1);
         // Verify the query can be submitted
         queryId = createQuery(queryRunner, rejectingSession(), LONG_LASTING_QUERY);
         waitForQueryState(queryRunner, queryId, RUNNING);
-        dao.deleteSelector(4, "user.*", "(?i).*reject.*", null);
+        dao.deleteSelector(4, "user.*", null, null, null, "(?i).*reject.*", null);
         dbConfigurationManager.load();
         // Verify the query cannot be submitted
         queryId = createQuery(queryRunner, rejectingSession(), LONG_LASTING_QUERY);
@@ -261,7 +261,7 @@ public class TestQueuesDb
         dao.insertResourceGroup(8, "reject-all-queries", "1MB", 0, 0, 0, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
 
         // add a new selector that has a higher priority than the existing dashboard selector and that routes queries to the "reject-all-queries" resource group
-        dao.insertSelector(8, 200, "user.*", null, "(?i).*dashboard.*", null, null, null);
+        dao.insertSelector(8, 200, "user.*", null, null, null, "(?i).*dashboard.*", null, null, null);
 
         // reload the configuration
         dbConfigurationManager.load();
@@ -366,7 +366,7 @@ public class TestQueuesDb
         DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
         int originalSize = getSelectors(queryRunner).size();
         // Add a selector for a non leaf group
-        dao.insertSelector(3, 100, "user.*", null, "(?i).*non-leaf.*", null, null, null);
+        dao.insertSelector(3, 100, "user.*", null, null, null, "(?i).*non-leaf.*", null, null, null);
         dbConfigurationManager.load();
         while (getSelectors(queryRunner).size() != originalSize + 1) {
             MILLISECONDS.sleep(500);
@@ -418,9 +418,9 @@ public class TestQueuesDb
         DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
 
         dao.insertResourceGroup(10, "queued", "80%", 10, null, 1, null, null, null, null, null, null, TEST_ENVIRONMENT);
-        dao.insertSelector(10, 1, null, null, null, null, "[\"queued\"]", null);
+        dao.insertSelector(10, 1, null, null, null, null, null, null, "[\"queued\"]", null);
         dao.insertResourceGroup(11, "running", "80%", 10, null, 2, null, null, null, null, null, null, TEST_ENVIRONMENT);
-        dao.insertSelector(11, 1, null, null, null, null, "[\"running\"]", null);
+        dao.insertSelector(11, 1, null, null, null, null, null, null, "[\"running\"]", null);
         dbConfigurationManager.load();
 
         QueryId firstQueryFromQueuedGroup = createQuery(queryRunner, session("alice", "queued"), LONG_LASTING_QUERY);
@@ -433,10 +433,10 @@ public class TestQueuesDb
 
         dao.deleteSelectors(10);
         dao.insertResourceGroup(12, "subgroup", "80%", 10, null, 1, null, null, null, null, null, 10L, TEST_ENVIRONMENT);
-        dao.insertSelector(12, 1, null, null, null, null, "[\"queued\"]", null);
+        dao.insertSelector(12, 1, null, null, null, null, null, null, "[\"queued\"]", null);
         dao.deleteSelectors(11);
         dao.insertResourceGroup(13, "subgroup", "80%", 10, null, 1, null, null, null, null, null, 11L, TEST_ENVIRONMENT);
-        dao.insertSelector(13, 1, null, null, null, null, "[\"running\"]", null);
+        dao.insertSelector(13, 1, null, null, null, null, null, null, "[\"running\"]", null);
         dbConfigurationManager.load();
 
         QueryId thirdQueryFromQueuedGroup = createQuery(queryRunner, session("alice", "queued"), LONG_LASTING_QUERY);
@@ -459,10 +459,10 @@ public class TestQueuesDb
 
         dao.insertResourceGroup(10, "queued", "80%", 10, null, 3, null, null, null, null, null, null, TEST_ENVIRONMENT);
         dao.insertResourceGroup(11, "subgroup", "80%", 10, null, 1, null, null, null, null, null, 10L, TEST_ENVIRONMENT);
-        dao.insertSelector(11, 1, null, null, null, null, "[\"queued\"]", null);
+        dao.insertSelector(11, 1, null, null, null, null, null, null, "[\"queued\"]", null);
         dao.insertResourceGroup(12, "running", "80%", 10, null, 3, null, null, null, null, null, null, TEST_ENVIRONMENT);
         dao.insertResourceGroup(13, "subgroup", "80%", 10, null, 1, null, null, null, null, null, 12L, TEST_ENVIRONMENT);
-        dao.insertSelector(13, 1, null, null, null, null, "[\"running\"]", null);
+        dao.insertSelector(13, 1, null, null, null, null, null, null, "[\"running\"]", null);
         dbConfigurationManager.load();
 
         QueryId firstQueryFromQueuedGroup = createQuery(queryRunner, session("alice", "queued"), LONG_LASTING_QUERY);
@@ -475,10 +475,10 @@ public class TestQueuesDb
 
         dao.deleteSelectors(11);
         dao.deleteResourceGroup(11);
-        dao.insertSelector(10, 1, null, null, null, null, "[\"queued\"]", null);
+        dao.insertSelector(10, 1, null, null, null, null, null, null, "[\"queued\"]", null);
         dao.deleteSelectors(13);
         dao.deleteResourceGroup(13);
-        dao.insertSelector(12, 1, null, null, null, null, "[\"running\"]", null);
+        dao.insertSelector(12, 1, null, null, null, null, null, null, "[\"running\"]", null);
         dbConfigurationManager.load();
 
         QueryId thirdQueryFromQueuedGroup = createQuery(queryRunner, session("alice", "queued"), LONG_LASTING_QUERY);
@@ -500,7 +500,7 @@ public class TestQueuesDb
         DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
 
         dao.insertResourceGroup(10, "${USER}", "80%", 0, null, 0, null, null, null, null, null, null, TEST_ENVIRONMENT);
-        dao.insertSelector(10, 1, null, null, null, null, "[\"tag\"]", null);
+        dao.insertSelector(10, 1, null, null, null, null, null, null, "[\"tag\"]", null);
         dbConfigurationManager.load();
 
         QueryId firstQuery = createQuery(queryRunner, session("admin", "tag"), LONG_LASTING_QUERY);
@@ -530,7 +530,7 @@ public class TestQueuesDb
         DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
 
         dao.insertResourceGroup(10, "${USER}", "80%", 100, null, 100, null, null, null, null, null, null, TEST_ENVIRONMENT);
-        dao.insertSelector(10, 100, null, null, null, null, "[\"tag\"]", null);
+        dao.insertSelector(10, 100, null, null, null, null, null, null, "[\"tag\"]", null);
         dbConfigurationManager.load();
 
         // create a resource group using config '${USER}'
@@ -545,7 +545,7 @@ public class TestQueuesDb
         waitForQueryState(queryRunner, secondQuery, RUNNING);
 
         dao.insertResourceGroup(11, "${USER}", "80%", 0, null, 0, null, null, null, null, null, null, TEST_ENVIRONMENT);
-        dao.insertSelector(11, 101, null, null, null, null, "[\"tag\"]", null);
+        dao.insertSelector(11, 101, null, null, null, null, null, null, "[\"tag\"]", null);
         dbConfigurationManager.load();
 
         // since the config 'admin' exists the group should not be configured using '${USER}'

--- a/testing/trino-tests/src/test/resources/resource_groups_config_original_user.json
+++ b/testing/trino-tests/src/test/resources/resource_groups_config_original_user.json
@@ -1,0 +1,49 @@
+{
+  "rootGroups": [
+    {
+      "name": "global",
+      "softMemoryLimit": "1MB",
+      "hardConcurrencyLimit": 100,
+      "maxQueued": 1000,
+      "softCpuLimit": "1h",
+      "hardCpuLimit": "1d",
+      "subGroups": [
+        {
+          "name": "a",
+          "softMemoryLimit": "2MB",
+          "hardConcurrencyLimit": 3,
+          "maxQueued": 4
+        },
+        {
+          "name": "b",
+          "softMemoryLimit": "2MB",
+          "hardConcurrencyLimit": 3,
+          "maxQueued": 4
+        },
+        {
+          "name": "c",
+          "softMemoryLimit": "2MB",
+          "hardConcurrencyLimit": 3,
+          "maxQueued": 4
+        }
+      ]
+    }
+  ],
+  "selectors": [
+    {
+      "group": "global.a",
+      "user": "usr-foo",
+      "originalUser": "usr-foo-original"
+    },
+    {
+      "group": "global.b",
+      "originalUser": "usr-foo-original"
+    },
+    {
+      "group": "global.c",
+      "user": "usr-foo"
+    }
+  ],
+  "cpuQuotaPeriod": "1h"
+}
+


### PR DESCRIPTION
## Description
This PR adds the [original user](https://github.com/trinodb/trino/blob/e86635d3c9e2fd1c7bd9aa430cd04e584ab435ef/core/trino-main/src/main/java/io/trino/server/SessionContext.java#L136) and [authenticated user](https://github.com/trinodb/trino/blob/e86635d3c9e2fd1c7bd9aa430cd04e584ab435ef/core/trino-main/src/main/java/io/trino/server/SessionContext.java#L126) as selectors that can be used in resource group selection, allowing for more flexible selection of resource groups based on additional context about the user's identity.

## Additional context and related issues
Currently, [resource group selection](https://trino.io/docs/current/admin/resource-groups.html#selector-rules) can take into account the [current session user](https://github.com/trinodb/trino/blob/e86635d3c9e2fd1c7bd9aa430cd04e584ab435ef/core/trino-main/src/main/java/io/trino/server/SessionContext.java#L131), but doesn't have a way to select based on the original user or authenticated user. In some setups, in may be desirable for resource group selection to be based on these additional metadata, rather than only the current user.

For original user, one sample use case is when `SET SESSION AUTHORIZATION` is used to change the current user for purposes of gaining access to a different set of resources (for example, a table that is accessible by the impersonated user, but not the original user). In this case, it can be desirable to still perform resource group selection based on the original user. For example, let us say that access to widely used table `t_foo` is only granted to user `u_foo`. Many users will impersonate `u_foo` to get access to `t_foo`, and if resource group selection is performed on the impersonated user, they will all share the same resource group, potentially causing contention. It may be desirable to instead perform resource group selection based on the _original_ user to avoid such contention.

For authenticated user, a sample use case may be to identify all queries originating from a certain platform or service. If that platform/service has the ability to impersonate other users for authorization purposes, it may still be desirable to execute all queries in a dedicated resource group. 

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
## Resource Groups
* Add `originalUser` and `authenticatedUser` as resource group selectors. ({issue}`24662`)
```
