### PR TITLE
Grant privileges only on TPCH tables in Redshift query runner

### DIFF
--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/RedshiftQueryRunner.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/RedshiftQueryRunner.java
@@ -125,8 +125,9 @@ public final class RedshiftQueryRunner
                 provisionTables(runner, initialTables);
 
                 // This step is necessary for product tests
-                executeInRedshiftWithRetry(format("GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA %s TO %s", TEST_SCHEMA, GRANTED_USER));
-
+                for (TpchTable<?> table : initialTables) {
+                    executeInRedshiftWithRetry(format("GRANT ALL PRIVILEGES ON TABLE %s.%s TO %s", TEST_SCHEMA, table.getTableName(), GRANTED_USER));
+                }
                 return runner;
             }
             catch (Throwable e) {


### PR DESCRIPTION
Granting privileges on all tables may cause unintended failures, as temporary tables created in one test class may not have been fully dropped or cleaned up from internal Redshift tables while other test class executes grant privileges on all tables.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Closes https://github.com/trinodb/trino/issues/24631

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

