### PR TITLE
Support unpartitioned tables in Kudu

### DIFF
--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/properties/KuduTableProperties.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/properties/KuduTableProperties.java
@@ -41,6 +41,7 @@ import java.util.Optional;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.base.util.JsonUtils.parseJson;
+import static io.trino.plugin.kudu.properties.RangePartitionDefinition.EMPTY_RANGE_PARTITION;
 import static io.trino.spi.StandardErrorCode.GENERIC_USER_ERROR;
 import static io.trino.spi.session.PropertyMetadata.integerProperty;
 import static io.trino.spi.session.PropertyMetadata.stringProperty;
@@ -133,7 +134,8 @@ public final class KuduTableProperties
         requireNonNull(tableProperties);
 
         @SuppressWarnings("unchecked")
-        List<String> hashColumns = (List<String>) tableProperties.get(PARTITION_BY_HASH_COLUMNS);
+        List<String> hashColumns = (List<String>) tableProperties.getOrDefault(PARTITION_BY_HASH_COLUMNS, ImmutableList.of());
+
         @SuppressWarnings("unchecked")
         List<String> hashColumns2 = (List<String>) tableProperties.getOrDefault(PARTITION_BY_HASH_COLUMNS_2, ImmutableList.of());
 
@@ -153,9 +155,13 @@ public final class KuduTableProperties
         }
 
         @SuppressWarnings("unchecked")
-        List<String> rangeColumns = (List<String>) tableProperties.get(PARTITION_BY_RANGE_COLUMNS);
+        List<String> rangeColumns = (List<String>) tableProperties.getOrDefault(PARTITION_BY_RANGE_COLUMNS, ImmutableList.of());
         if (!rangeColumns.isEmpty()) {
             design.setRange(new RangePartitionDefinition(rangeColumns));
+        }
+
+        if (!design.hasPartitions()) {
+            design.setRange(EMPTY_RANGE_PARTITION);
         }
 
         return design;

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/properties/RangePartitionDefinition.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/properties/RangePartitionDefinition.java
@@ -21,6 +21,8 @@ import static java.util.Objects.requireNonNull;
 
 public record RangePartitionDefinition(List<String> columns)
 {
+    public static final RangePartitionDefinition EMPTY_RANGE_PARTITION = new RangePartitionDefinition(ImmutableList.of());
+
     public RangePartitionDefinition
     {
         columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Fix #24661 

The current Kudu connector does not support unpartitioned tables, as it assumes the existence of partition keys. However, Kudu itself allows the creation of unpartitioned tables. Interacting with such tables may result in issues like the error partitioning information is missing, as mentioned in #24661.

Refer [IMPALA-5546](https://issues.apache.org/jira/browse/IMPALA-5546), unpartitioned tables can be handled by using range partitions without specifying any columns.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## kudu
* Support unpartitioned table. ({issue}`24661`)
```
