### PR TITLE
Add Paimon Connector for Trino -- Init

### DIFF
--- a/plugin/trino-paimon/pom.xml
+++ b/plugin/trino-paimon/pom.xml
@@ -1,0 +1,268 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.trino</groupId>
+        <artifactId>trino-root</artifactId>
+        <version>471-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>trino-paimon</artifactId>
+    <packaging>trino-plugin</packaging>
+    <description>Trino - Paimon connector</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.cloud.bigdataoss</groupId>
+            <artifactId>gcs-connector</artifactId>
+            <classifier>shaded</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-filesystem</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-filesystem-manager</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-hive</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.github.luben</groupId>
+                    <artifactId>zstd-jni</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-memory-context</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-orc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-parquet</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-plugin-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-bundle</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-column</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.http-client</groupId>
+            <artifactId>google-http-client</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>junit-extensions</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-hdfs</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino.tpch</groupId>
+            <artifactId>tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <configuration>
+                    <ignoredResourcePatterns>
+                        <ignoredResourcePattern>parquet.thrift</ignoredResourcePattern>
+                        <ignoredResourcePattern>google/protobuf/api.proto</ignoredResourcePattern>
+                        <ignoredResourcePattern>google/protobuf/any.proto</ignoredResourcePattern>
+                        <ignoredResourcePattern>google/protobuf/descriptor.proto</ignoredResourcePattern>
+                        <ignoredResourcePattern>google/protobuf/duration.proto</ignoredResourcePattern>
+                        <ignoredResourcePattern>google/protobuf/empty.proto</ignoredResourcePattern>
+                        <ignoredResourcePattern>google/protobuf/field_mask.proto</ignoredResourcePattern>
+                        <ignoredResourcePattern>google/protobuf/source_context.proto</ignoredResourcePattern>
+                        <ignoredResourcePattern>google/protobuf/struct.proto</ignoredResourcePattern>
+                        <ignoredResourcePattern>google/protobuf/timestamp.proto</ignoredResourcePattern>
+                        <ignoredResourcePattern>google/protobuf/type.proto</ignoredResourcePattern>
+                        <ignoredResourcePattern>google/protobuf/wrappers.proto</ignoredResourcePattern>
+                    </ignoredResourcePatterns>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/CatalogType.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/CatalogType.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+public enum CatalogType
+{
+    FILESYSTEM
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/DecimalUtils.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/DecimalUtils.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import io.trino.spi.type.Int128;
+
+import java.math.BigInteger;
+
+/**
+ * Utils for decimal.
+ */
+public final class DecimalUtils
+{
+    private DecimalUtils() {}
+
+    public static BigInteger toBigInteger(Object value)
+    {
+        return ((Int128) value).toBigInteger();
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/DirectPaimonPageSource.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/DirectPaimonPageSource.java
@@ -25,7 +25,7 @@ import java.util.OptionalLong;
 /**
  * Trino {@link ConnectorPageSource}.
  */
-public class DirectTrinoPageSource
+public class DirectPaimonPageSource
         implements ConnectorPageSource
 {
     private final LinkedList<ConnectorPageSource> pageSourceQueue;
@@ -34,7 +34,7 @@ public class DirectTrinoPageSource
     private long completedBytes;
     private long numReturn;
 
-    public DirectTrinoPageSource(
+    public DirectPaimonPageSource(
             LinkedList<ConnectorPageSource> pageSourceQueue, OptionalLong limit)
     {
         this.pageSourceQueue = pageSourceQueue;

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/DirectTrinoPageSource.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/DirectTrinoPageSource.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import io.trino.spi.Page;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.metrics.Metrics;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.LinkedList;
+import java.util.OptionalLong;
+
+/**
+ * Trino {@link ConnectorPageSource}.
+ */
+public class DirectTrinoPageSource
+        implements ConnectorPageSource
+{
+    private final LinkedList<ConnectorPageSource> pageSourceQueue;
+    private final OptionalLong limit;
+    private ConnectorPageSource current;
+    private long completedBytes;
+    private long numReturn;
+
+    public DirectTrinoPageSource(
+            LinkedList<ConnectorPageSource> pageSourceQueue, OptionalLong limit)
+    {
+        this.pageSourceQueue = pageSourceQueue;
+        this.current = pageSourceQueue.poll();
+        this.limit = limit;
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return completedBytes;
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return System.nanoTime();
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return current == null || (current.isFinished() && pageSourceQueue.isEmpty());
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        try {
+            if (current == null) {
+                return null;
+            }
+            if (limit.isPresent() && numReturn >= limit.getAsLong()) {
+                return null;
+            }
+            Page dataPage = current.getNextPage();
+            if (dataPage == null) {
+                advance();
+                return getNextPage();
+            }
+
+            numReturn += dataPage.getPositionCount();
+            return dataPage;
+        }
+        catch (RuntimeException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void advance()
+    {
+        if (current == null) {
+            throw new RuntimeException("Current is null, should not invoke advance");
+        }
+        try {
+            completedBytes += current.getCompletedBytes();
+            current.close();
+        }
+        catch (IOException e) {
+            current = null;
+            close();
+            throw new RuntimeException("error happens while advance and close old page source.");
+        }
+        current = pageSourceQueue.poll();
+    }
+
+    @Override
+    public void close()
+    {
+        try {
+            if (current != null) {
+                current.close();
+            }
+            for (ConnectorPageSource source : pageSourceQueue) {
+                source.close();
+            }
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        return current == null ? null : current.toString();
+    }
+
+    @Override
+    public long getMemoryUsage()
+    {
+        return current == null ? 0 : current.getMemoryUsage();
+    }
+
+    @Override
+    public Metrics getMetrics()
+    {
+        return current == null ? Metrics.EMPTY : current.getMetrics();
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/EncodingUtils.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/EncodingUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import org.apache.paimon.utils.InstantiationUtil;
+
+import java.util.Base64;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Utils for encoding.
+ */
+public final class EncodingUtils
+{
+    private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
+    private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
+
+    private EncodingUtils() {}
+
+    public static <T> String encodeObjectToString(T t)
+    {
+        try {
+            byte[] bytes = InstantiationUtil.serializeObject(t);
+            return new String(BASE64_ENCODER.encode(bytes), UTF_8);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static <T> T decodeStringToObject(String encodedStr)
+    {
+        final byte[] bytes = BASE64_DECODER.decode(encodedStr.getBytes(UTF_8));
+        try {
+            return InstantiationUtil.deserializeObject(bytes, EncodingUtils.class.getClassLoader());
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/FieldNameUtils.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/FieldNameUtils.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.RowType;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Utils for fieldName.
+ */
+public final class FieldNameUtils
+{
+    private FieldNameUtils() {}
+
+    public static List<String> fieldNames(RowType rowType)
+    {
+        return rowType.getFields().stream()
+                .map(DataField::name)
+                .map(String::toLowerCase)
+                .collect(Collectors.toList());
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonColumnHandle.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonColumnHandle.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.type.Type;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.utils.JsonSerdeUtil;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Trino {@link ColumnHandle}.
+ */
+public final class PaimonColumnHandle
+        implements ColumnHandle
+{
+    public static final String TRINO_ROW_ID_NAME = "$row_id";
+    private final String columnName;
+    private final String typeString;
+    private final Type trinoType;
+    private final boolean isRowId;
+    private final int columnId;
+
+    @JsonCreator
+    public PaimonColumnHandle(
+            @JsonProperty("columnName") String columnName,
+            @JsonProperty("typeString") String typeString,
+            @JsonProperty("trinoType") Type trinoType,
+            @JsonProperty("columnId") int columnId)
+    {
+        this.columnName = requireNonNull(columnName, "columnName is null");
+        this.typeString = requireNonNull(typeString, "columnType is null");
+        this.trinoType = requireNonNull(trinoType, "columnType is null");
+        this.isRowId = TRINO_ROW_ID_NAME.equals(columnName);
+        this.columnId = columnId;
+    }
+
+    public static PaimonColumnHandle of(String columnName, DataType columnType, int columnId)
+    {
+        return new PaimonColumnHandle(
+                columnName,
+                JsonSerdeUtil.toJson(columnType),
+                PaimonTypeUtils.fromPaimonType(columnType),
+                columnId);
+    }
+
+    @JsonProperty
+    public String getColumnName()
+    {
+        return columnName;
+    }
+
+    @JsonProperty
+    public String getTypeString()
+    {
+        return typeString;
+    }
+
+    @JsonProperty
+    public Type getTrinoType()
+    {
+        return trinoType;
+    }
+
+    @JsonProperty
+    public boolean isRowId()
+    {
+        return isRowId;
+    }
+
+    @JsonProperty
+    public int getColumnId()
+    {
+        return columnId;
+    }
+
+    public DataType logicalType()
+    {
+        return JsonSerdeUtil.fromJson(typeString, DataType.class);
+    }
+
+    public ColumnMetadata getColumnMetadata()
+    {
+        return new ColumnMetadata(columnName, trinoType);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return columnName.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+
+        PaimonColumnHandle other = (PaimonColumnHandle) obj;
+        return columnName.equals(other.columnName);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "{"
+                + "columnName='"
+                + columnName
+                + '\''
+                + ", typeString='"
+                + typeString
+                + '\''
+                + ", trinoType="
+                + trinoType
+                + '}';
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonConfig.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonConfig.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import jakarta.validation.constraints.NotNull;
+import org.apache.paimon.options.Options;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PaimonConfig
+{
+    private String warehouse;
+    private CatalogType catalogType = CatalogType.FILESYSTEM;
+    private boolean metadataCacheEnabled = true;
+
+    @NotNull
+    public CatalogType getCatalogType()
+    {
+        return catalogType;
+    }
+
+    @Config("paimon.catalog.type")
+    @ConfigDescription("Catalog type with paimon, default is FILESYSTEM")
+    public PaimonConfig setCatalogType(CatalogType catalogType)
+    {
+        this.catalogType = catalogType;
+        return this;
+    }
+
+    public String getWarehouse()
+    {
+        return warehouse;
+    }
+
+    @Config("paimon.warehouse")
+    @ConfigDescription("Warehouse path for paimon, this is the root path for all the tables")
+    public PaimonConfig setWarehouse(String warehouse)
+    {
+        this.warehouse = warehouse;
+        return this;
+    }
+
+    public boolean isMetadataCacheEnabled()
+    {
+        return metadataCacheEnabled;
+    }
+
+    @Config("paimon.metadata-cache.enabled")
+    @ConfigDescription("Enables in-memory caching of metadata files on coordinator if fs.cache.enabled is not set to true")
+    public PaimonConfig setMetadataCacheEnabled(boolean metadataCacheEnabled)
+    {
+        this.metadataCacheEnabled = metadataCacheEnabled;
+        return this;
+    }
+
+    public Options toOptions()
+    {
+        Map<String, String> opMap = new HashMap<>();
+        opMap.put("warehouse", warehouse);
+        return new Options(opMap);
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonConnector.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonConnector.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import com.google.inject.Inject;
+import io.airlift.bootstrap.LifeCycleManager;
+import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata;
+import io.trino.plugin.hive.HiveTransactionHandle;
+import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorPageSourceProvider;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplitManager;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.session.PropertyMetadata;
+import io.trino.spi.transaction.IsolationLevel;
+
+import java.util.List;
+
+import static io.trino.spi.transaction.IsolationLevel.SERIALIZABLE;
+import static io.trino.spi.transaction.IsolationLevel.checkConnectorSupports;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Trino {@link Connector}.
+ */
+public class PaimonConnector
+        implements Connector
+{
+    private final LifeCycleManager lifeCycleManager;
+    private final PaimonTransactionManager transactionManager;
+    private final ConnectorSplitManager trinoSplitManager;
+    private final ConnectorPageSourceProvider trinoPageSourceProvider;
+    private final List<PropertyMetadata<?>> tableProperties;
+    private final List<PropertyMetadata<?>> sessionProperties;
+
+    @Inject
+    public PaimonConnector(
+            LifeCycleManager lifeCycleManager,
+            PaimonTransactionManager transactionManager,
+            ConnectorSplitManager trinoSplitManager,
+            ConnectorPageSourceProvider trinoPageSourceProvider,
+            PaimonTableOptions paimonTableOptions,
+            PaimonSessionProperties paimonSessionProperties)
+    {
+        this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
+        this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+        this.trinoSplitManager = requireNonNull(trinoSplitManager, "trinoSplitManager is null");
+        this.trinoPageSourceProvider =
+                requireNonNull(trinoPageSourceProvider, "trinoRecordSetProvider is null");
+        this.tableProperties = paimonTableOptions.getTableProperties();
+        this.sessionProperties = paimonSessionProperties.getSessionProperties();
+    }
+
+    @Override
+    public ConnectorTransactionHandle beginTransaction(
+            IsolationLevel isolationLevel, boolean readOnly, boolean autoCommit)
+    {
+        checkConnectorSupports(SERIALIZABLE, isolationLevel);
+        ConnectorTransactionHandle transaction = new HiveTransactionHandle(autoCommit);
+        transactionManager.begin(transaction);
+        return transaction;
+    }
+
+    @Override
+    public void commit(ConnectorTransactionHandle transaction)
+    {
+        transactionManager.commit(transaction);
+    }
+
+    @Override
+    public void rollback(ConnectorTransactionHandle transactionHandle)
+    {
+        transactionManager.rollback(transactionHandle);
+    }
+
+    @Override
+    public ConnectorMetadata getMetadata(
+            ConnectorSession session, ConnectorTransactionHandle transactionHandle)
+    {
+        ConnectorMetadata metadata =
+                transactionManager.get(transactionHandle, session.getIdentity());
+        return new ClassLoaderSafeConnectorMetadata(metadata, getClass().getClassLoader());
+    }
+
+    @Override
+    public ConnectorSplitManager getSplitManager()
+    {
+        return trinoSplitManager;
+    }
+
+    @Override
+    public ConnectorPageSourceProvider getPageSourceProvider()
+    {
+        return trinoPageSourceProvider;
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getSessionProperties()
+    {
+        return sessionProperties;
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getTableProperties()
+    {
+        return tableProperties;
+    }
+
+    @Override
+    public void shutdown()
+    {
+        lifeCycleManager.stop();
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonConnectorFactory.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonConnectorFactory.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import com.google.inject.Binder;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.airlift.json.JsonModule;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Tracer;
+import io.trino.filesystem.manager.FileSystemModule;
+import io.trino.plugin.hive.NodeVersion;
+import io.trino.plugin.hive.orc.OrcReaderConfig;
+import io.trino.spi.NodeManager;
+import io.trino.spi.catalog.CatalogName;
+import io.trino.spi.classloader.ThreadContextClassLoader;
+import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorContext;
+import io.trino.spi.connector.ConnectorFactory;
+import io.trino.spi.type.TypeManager;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Trino {@link ConnectorFactory}.
+ */
+public class PaimonConnectorFactory
+        implements ConnectorFactory
+{
+    @Override
+    public String getName()
+    {
+        return "paimon";
+    }
+
+    @Override
+    public Connector create(
+            String catalogName, Map<String, String> config, ConnectorContext context)
+    {
+        return create(catalogName, config, context, new EmptyModule());
+    }
+
+    public Connector create(
+            String catalogName,
+            Map<String, String> config,
+            ConnectorContext context,
+            Module module)
+    {
+        ClassLoader classLoader = PaimonConnectorFactory.class.getClassLoader();
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            Bootstrap app =
+                    new Bootstrap(
+                            new JsonModule(),
+                            new PaimonModule(),
+                            // bind the trino file system module
+                            new PaimonFileSystemModule(catalogName, context),
+                            binder -> {
+                                binder.bind(ClassLoader.class)
+                                        .toInstance(PaimonConnectorFactory.class.getClassLoader());
+                                binder.bind(NodeVersion.class)
+                                        .toInstance(
+                                                new NodeVersion(
+                                                        context.getNodeManager()
+                                                                .getCurrentNode()
+                                                                .getVersion()));
+                                binder.bind(TypeManager.class).toInstance(context.getTypeManager());
+                                binder.bind(OpenTelemetry.class)
+                                        .toInstance(context.getOpenTelemetry());
+                                binder.bind(Tracer.class).toInstance(context.getTracer());
+                                binder.bind(OrcReaderConfig.class)
+                                        .toInstance(new OrcReaderConfig());
+                                binder.bind(CatalogName.class)
+                                        .toInstance(new CatalogName(catalogName));
+                            },
+                            module);
+
+            Injector injector =
+                    app.doNotInitializeLogging()
+                            .setRequiredConfigurationProperties(config)
+                            .initialize();
+
+            return injector.getInstance(PaimonConnector.class);
+        }
+    }
+
+    /**
+     * Empty module for paimon connector factory.
+     */
+    public static class EmptyModule
+            implements Module
+    {
+        @Override
+        public void configure(Binder binder) {}
+    }
+
+    private static class PaimonFileSystemModule
+            extends AbstractConfigurationAwareModule
+    {
+        private final String catalogName;
+        private final NodeManager nodeManager;
+        private final OpenTelemetry openTelemetry;
+
+        public PaimonFileSystemModule(
+                String catalogName, ConnectorContext context)
+        {
+            this.catalogName = requireNonNull(catalogName, "catalogName is null");
+            this.nodeManager = context.getNodeManager();
+            this.openTelemetry = context.getOpenTelemetry();
+        }
+
+        @Override
+        protected void setup(Binder binder)
+        {
+            boolean metadataCacheEnabled = buildConfigObject(PaimonConfig.class).isMetadataCacheEnabled();
+            install(
+                    new FileSystemModule(
+                            catalogName, nodeManager, openTelemetry, metadataCacheEnabled));
+        }
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonFilterConverter.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonFilterConverter.java
@@ -1,0 +1,334 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.BigintType;
+import io.trino.spi.type.BooleanType;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.DateType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.DoubleType;
+import io.trino.spi.type.IntegerType;
+import io.trino.spi.type.LongTimestampWithTimeZone;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RealType;
+import io.trino.spi.type.SmallintType;
+import io.trino.spi.type.TinyintType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarbinaryType;
+import io.trino.spi.type.VarcharType;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.fileindex.FileIndexOptions;
+import org.apache.paimon.predicate.In;
+import org.apache.paimon.predicate.LeafPredicate;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.types.RowType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.spi.type.TimeType.TIME_MILLIS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MILLISECOND;
+import static java.lang.Float.intBitsToFloat;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+import static org.apache.paimon.data.Decimal.fromBigDecimal;
+import static org.apache.paimon.predicate.PredicateBuilder.and;
+import static org.apache.paimon.predicate.PredicateBuilder.or;
+
+/**
+ * Trino filter to flink predicate.
+ */
+public class PaimonFilterConverter
+{
+    private static final Logger LOG = LoggerFactory.getLogger(PaimonFilterConverter.class);
+
+    private final RowType rowType;
+    private final PredicateBuilder builder;
+
+    public PaimonFilterConverter(RowType rowType)
+    {
+        this.rowType = rowType;
+        this.builder = new PredicateBuilder(rowType);
+    }
+
+    public Optional<Predicate> convert(TupleDomain<PaimonColumnHandle> tupleDomain)
+    {
+        return convert(tupleDomain, new LinkedHashMap<>(), new LinkedHashMap<>());
+    }
+
+    public Optional<Predicate> convert(
+            TupleDomain<PaimonColumnHandle> tupleDomain,
+            LinkedHashMap<PaimonColumnHandle, Domain> acceptedDomains,
+            LinkedHashMap<PaimonColumnHandle, Domain> unsupportedDomains)
+    {
+        if (tupleDomain.isAll()) {
+            // TODO alwaysTrue
+            return Optional.empty();
+        }
+
+        if (tupleDomain.getDomains().isEmpty()) {
+            // TODO alwaysFalse
+            return Optional.empty();
+        }
+
+        Map<PaimonColumnHandle, Domain> domainMap = tupleDomain.getDomains().get();
+        List<Predicate> conjuncts = new ArrayList<>();
+        List<String> fieldNames = FieldNameUtils.fieldNames(rowType);
+        for (Map.Entry<PaimonColumnHandle, Domain> entry : domainMap.entrySet()) {
+            PaimonColumnHandle columnHandle = entry.getKey();
+            Domain domain = entry.getValue();
+            String field = columnHandle.getColumnName();
+            Optional<Integer> nestedColumn = FileIndexOptions.topLevelIndexOfNested(field);
+            if (nestedColumn.isPresent()) {
+                int position = nestedColumn.get();
+                field = field.substring(0, position);
+            }
+            int index = fieldNames.indexOf(field);
+            if (index != -1) {
+                try {
+                    conjuncts.add(
+                            toPredicate(
+                                    index,
+                                    columnHandle.getColumnName(),
+                                    columnHandle.getTrinoType(),
+                                    domain));
+                    acceptedDomains.put(columnHandle, domain);
+                    continue;
+                }
+                catch (UnsupportedOperationException exception) {
+                    LOG.warn(
+                            "Unsupported predicate, maybe the type of column is not supported yet.",
+                            exception);
+                }
+            }
+            unsupportedDomains.put(columnHandle, domain);
+        }
+
+        if (conjuncts.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(and(conjuncts));
+    }
+
+    private Predicate toPredicate(int columnIndex, String field, Type type, Domain domain)
+    {
+        if (domain.isAll()) {
+            // TODO alwaysTrue
+            throw new UnsupportedOperationException();
+        }
+        if (domain.getValues().isNone()) {
+            if (domain.isNullAllowed()) {
+                return builder.isNull(columnIndex);
+            }
+            // TODO alwaysFalse
+            throw new UnsupportedOperationException();
+        }
+
+        if (domain.getValues().isAll()) {
+            if (domain.isNullAllowed()) {
+                // TODO alwaysTrue
+                throw new UnsupportedOperationException();
+            }
+            return builder.isNotNull(columnIndex);
+        }
+
+        // TODO support structural types
+        if (type instanceof ArrayType || type instanceof io.trino.spi.type.RowType) {
+            // Fail fast. Ignoring expression could lead to data loss in case of deletions.
+            throw new UnsupportedOperationException();
+        }
+
+        if (type instanceof MapType) {
+            List<Range> orderedRanges = domain.getValues().getRanges().getOrderedRanges();
+            List<Object> values = new ArrayList<>();
+            List<Predicate> predicates = new ArrayList<>();
+            for (Range range : orderedRanges) {
+                if (range.isSingleValue()) {
+                    values.add(
+                            getLiteralValue(
+                                    ((MapType) type).getValueType(), range.getLowBoundedValue()));
+                }
+            }
+            if (!values.isEmpty()) {
+                Predicate predicate =
+                        new LeafPredicate(
+                                In.INSTANCE,
+                                PaimonTypeUtils.toPaimonType(type),
+                                columnIndex,
+                                field,
+                                values);
+                predicates.add(predicate);
+            }
+            return or(predicates);
+        }
+
+        if (type.isOrderable()) {
+            List<Range> orderedRanges = domain.getValues().getRanges().getOrderedRanges();
+            List<Object> values = new ArrayList<>();
+            List<Predicate> predicates = new ArrayList<>();
+            for (Range range : orderedRanges) {
+                if (range.isSingleValue()) {
+                    values.add(getLiteralValue(type, range.getLowBoundedValue()));
+                }
+                else {
+                    predicates.add(toPredicate(columnIndex, range));
+                }
+            }
+
+            if (!values.isEmpty()) {
+                predicates.add(builder.in(columnIndex, values));
+            }
+
+            if (domain.isNullAllowed()) {
+                predicates.add(builder.isNull(columnIndex));
+            }
+            return or(predicates);
+        }
+
+        throw new UnsupportedOperationException();
+    }
+
+    private Predicate toPredicate(int columnIndex, Range range)
+    {
+        Type type = range.getType();
+
+        if (range.isSingleValue()) {
+            Object value = getLiteralValue(type, range.getSingleValue());
+            return builder.equal(columnIndex, value);
+        }
+
+        List<Predicate> conjuncts = new ArrayList<>(2);
+        if (!range.isLowUnbounded()) {
+            Object low = getLiteralValue(type, range.getLowBoundedValue());
+            Predicate lowBound;
+            if (range.isLowInclusive()) {
+                lowBound = builder.greaterOrEqual(columnIndex, low);
+            }
+            else {
+                lowBound = builder.greaterThan(columnIndex, low);
+            }
+            conjuncts.add(lowBound);
+        }
+
+        if (!range.isHighUnbounded()) {
+            Object high = getLiteralValue(type, range.getHighBoundedValue());
+            Predicate highBound;
+            if (range.isHighInclusive()) {
+                highBound = builder.lessOrEqual(columnIndex, high);
+            }
+            else {
+                highBound = builder.lessThan(columnIndex, high);
+            }
+            conjuncts.add(highBound);
+        }
+
+        return and(conjuncts);
+    }
+
+    private Object getLiteralValue(Type type, Object trinoNativeValue)
+    {
+        requireNonNull(trinoNativeValue, "trinoNativeValue is null");
+
+        if (type instanceof BooleanType) {
+            return trinoNativeValue;
+        }
+
+        if (type instanceof TinyintType) {
+            return ((Long) trinoNativeValue).byteValue();
+        }
+
+        if (type instanceof SmallintType) {
+            return ((Long) trinoNativeValue).shortValue();
+        }
+
+        if (type instanceof IntegerType) {
+            return toIntExact((long) trinoNativeValue);
+        }
+
+        if (type instanceof BigintType) {
+            return trinoNativeValue;
+        }
+
+        if (type instanceof RealType) {
+            return intBitsToFloat(toIntExact((long) trinoNativeValue));
+        }
+
+        if (type instanceof DoubleType) {
+            return trinoNativeValue;
+        }
+
+        if (type instanceof DateType) {
+            return toIntExact(((Long) trinoNativeValue));
+        }
+
+        if (type.equals(TIME_MILLIS)) {
+            return (int) ((long) trinoNativeValue / PICOSECONDS_PER_MILLISECOND);
+        }
+
+        if (type.equals(TIMESTAMP_MILLIS)) {
+            return Timestamp.fromEpochMillis((long) trinoNativeValue / 1000);
+        }
+
+        if (type.equals(TIMESTAMP_TZ_MILLIS)) {
+            if (trinoNativeValue instanceof Long) {
+                return trinoNativeValue;
+            }
+            return Timestamp.fromEpochMillis(
+                    ((LongTimestampWithTimeZone) trinoNativeValue).getEpochMillis());
+        }
+
+        if (type instanceof VarcharType || type instanceof CharType) {
+            return BinaryString.fromBytes(((Slice) trinoNativeValue).getBytes());
+        }
+
+        if (type instanceof VarbinaryType) {
+            return ((Slice) trinoNativeValue).getBytes();
+        }
+
+        if (type instanceof DecimalType decimalType) {
+            BigDecimal bigDecimal;
+            if (trinoNativeValue instanceof Long) {
+                bigDecimal =
+                        BigDecimal.valueOf((long) trinoNativeValue)
+                                .movePointLeft(decimalType.getScale());
+            }
+            else {
+                bigDecimal =
+                        new BigDecimal(
+                                DecimalUtils.toBigInteger(trinoNativeValue),
+                                decimalType.getScale());
+            }
+            return fromBigDecimal(
+                    bigDecimal, decimalType.getPrecision(), decimalType.getScale());
+        }
+
+        throw new UnsupportedOperationException("Unsupported type: " + type);
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonFilterExtractor.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonFilterExtractor.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.trino.plugin.paimon.catalog.PaimonTrinoCatalog;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.Constraint;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.expression.Variable;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
+import io.trino.spi.predicate.SortedRangeSet;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.Type;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static io.trino.spi.expression.StandardFunctions.AND_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.IN_PREDICATE_FUNCTION_NAME;
+import static org.apache.paimon.fileindex.FileIndexCommon.toMapKey;
+
+/**
+ * Extract filter from trino.
+ */
+public final class PaimonFilterExtractor
+{
+    public static final String TRINO_MAP_ELEMENT_AT_FUNCTION_NAME = "element_at";
+
+    private PaimonFilterExtractor() {}
+
+    /**
+     * Extract filter from trino , include ExpressionFilter.
+     */
+    public static Optional<TrinoFilter> extract(
+            ConnectorSession session,
+            PaimonTrinoCatalog catalog,
+            PaimonTableHandle paimonTableHandle,
+            Constraint constraint)
+    {
+        TupleDomain<PaimonColumnHandle> oldFilter = paimonTableHandle.getPredicate();
+        TupleDomain<PaimonColumnHandle> newFilter =
+                constraint
+                        .getSummary()
+                        .transformKeys(PaimonColumnHandle.class::cast)
+                        .intersect(oldFilter);
+
+        if (oldFilter.equals(newFilter)) {
+            return Optional.empty();
+        }
+
+        Map<PaimonColumnHandle, Domain> trinoColumnHandleForExpressionFilter =
+                extractTrinoColumnHandleForExpressionFilter(constraint);
+
+        LinkedHashMap<PaimonColumnHandle, Domain> acceptedDomains = new LinkedHashMap<>();
+        LinkedHashMap<PaimonColumnHandle, Domain> unsupportedDomains = new LinkedHashMap<>();
+        new PaimonFilterConverter(paimonTableHandle.table(session, catalog).rowType())
+                .convert(newFilter, acceptedDomains, unsupportedDomains);
+
+        List<String> partitionKeys = paimonTableHandle.table(session, catalog).partitionKeys();
+        LinkedHashMap<PaimonColumnHandle, Domain> unenforcedDomains = new LinkedHashMap<>();
+        acceptedDomains.forEach(
+                (columnHandle, domain) -> {
+                    if (!partitionKeys.contains(columnHandle.getColumnName())) {
+                        unenforcedDomains.put(columnHandle, domain);
+                    }
+                });
+
+        acceptedDomains.putAll(trinoColumnHandleForExpressionFilter);
+
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        TupleDomain<ColumnHandle> remain =
+                (TupleDomain)
+                        TupleDomain.withColumnDomains(unsupportedDomains)
+                                .intersect(TupleDomain.withColumnDomains(unenforcedDomains));
+
+        return Optional.of(new TrinoFilter(TupleDomain.withColumnDomains(acceptedDomains), remain));
+    }
+
+    /**
+     * Extract Expression filter from trino Constraint. Extract Trino Expression filter ( e.g.
+     * element_at(jsonmap, 'a') = '1' ) to TrinoColumnHandle.
+     */
+    public static Map<PaimonColumnHandle, Domain> extractTrinoColumnHandleForExpressionFilter(
+            Constraint constraint)
+    {
+        Map<PaimonColumnHandle, Domain> expressionPredicates = Collections.emptyMap();
+
+        if (constraint.getExpression() instanceof Call expression) {
+            Map<String, ColumnHandle> assignments = constraint.getAssignments();
+
+            if (expression.getFunctionName().equals(EQUAL_OPERATOR_FUNCTION_NAME)) {
+                expressionPredicates = handleExpressionEqualOrIn(assignments, expression, false);
+            }
+            else if (expression.getFunctionName().equals(IN_PREDICATE_FUNCTION_NAME)) {
+                expressionPredicates = handleExpressionEqualOrIn(assignments, expression, true);
+            }
+            else if (expression.getFunctionName().equals(AND_FUNCTION_NAME)) {
+                expressionPredicates = handleAndArguments(assignments, expression);
+            }
+            // TODO: Support "or" clause
+        }
+        return expressionPredicates;
+    }
+
+    /**
+     * Expression filter support the case of "AND" and "IN".
+     */
+    private static Map<PaimonColumnHandle, Domain> handleAndArguments(
+            Map<String, ColumnHandle> assignments, Call expression)
+    {
+        Map<PaimonColumnHandle, Domain> expressionPredicates = new HashMap<>();
+
+        expression.getArguments().stream()
+                .map(argument -> (Call) argument)
+                .forEach(
+                        argument -> {
+                            if (argument.getFunctionName().equals(EQUAL_OPERATOR_FUNCTION_NAME)) {
+                                expressionPredicates.putAll(
+                                        handleExpressionEqualOrIn(assignments, argument, false));
+                            }
+                            else if (argument.getFunctionName()
+                                    .equals(IN_PREDICATE_FUNCTION_NAME)) {
+                                expressionPredicates.putAll(
+                                        handleExpressionEqualOrIn(assignments, argument, true));
+                            }
+                        });
+
+        return expressionPredicates;
+    }
+
+    private static Map<PaimonColumnHandle, Domain> handleExpressionEqualOrIn(
+            Map<String, ColumnHandle> assignments, Call expression, boolean inClause)
+    {
+        Call elementAtExpression = (Call) expression.getArguments().get(0);
+
+        String functionName = elementAtExpression.getFunctionName().getName();
+
+        switch (functionName) {
+            case TRINO_MAP_ELEMENT_AT_FUNCTION_NAME: {
+                Variable columnExpression =
+                        (Variable) elementAtExpression.getArguments().get(0);
+                Constant columnKey = (Constant) elementAtExpression.getArguments().get(1);
+
+                Constant elementAtValue = (Constant) expression.getArguments().get(1);
+                List<Range> values;
+                Type elementType;
+                if (inClause) {
+                    elementType = ((ArrayType) elementAtValue.getType()).getElementType();
+                    values =
+                            elementAtValue.getChildren().stream()
+                                    .filter(a -> ((Constant) a).getValue() != null)
+                                    .map(
+                                            arguemnt ->
+                                                    Range.equal(
+                                                            arguemnt.getType(),
+                                                            ((Constant) arguemnt).getValue()))
+                                    .collect(Collectors.toList());
+                }
+                else {
+                    elementType = elementAtValue.getType();
+                    values =
+                            elementAtValue.getValue() == null
+                                    ? Collections.emptyList()
+                                    : ImmutableList.of(
+                                    Range.equal(
+                                            elementAtValue.getType(),
+                                            elementAtValue.getValue()));
+                }
+                if (columnKey.getValue() == null) {
+                    throw new RuntimeException("Expression pares failed: " + expression);
+                }
+
+                return handleElementAtArguments(
+                        assignments,
+                        columnExpression.getName(),
+                        ((Slice) columnKey.getValue()).toStringUtf8(),
+                        elementType,
+                        values);
+            }
+            default: {
+                return Collections.emptyMap();
+            }
+        }
+    }
+
+    /**
+     * Using paimon, trino only supports element_at function to extract values from map type.
+     */
+    private static Map<PaimonColumnHandle, Domain> handleElementAtArguments(
+            Map<String, ColumnHandle> assignments,
+            String columnName,
+            String nestedName,
+            Type elementType,
+            List<Range> ranges)
+    {
+        Map<PaimonColumnHandle, Domain> expressionPredicates = new HashMap<>();
+        PaimonColumnHandle paimonColumnHandle = (PaimonColumnHandle) assignments.get(columnName);
+        Type trinoType = paimonColumnHandle.getTrinoType();
+        if (trinoType instanceof MapType) {
+            expressionPredicates.put(
+                    PaimonColumnHandle.of(
+                            toMapKey(columnName, nestedName),
+                            PaimonTypeUtils.toPaimonType(trinoType),
+                            paimonColumnHandle.getColumnId()),
+                    Domain.create(SortedRangeSet.copyOf(elementType, ranges), false));
+        }
+        return expressionPredicates;
+    }
+
+    /**
+     * TrinoFilter for paimon trinoMetadata applyFilter.
+     */
+    public static class TrinoFilter
+    {
+        private final TupleDomain<PaimonColumnHandle> filter;
+        private final TupleDomain<ColumnHandle> remainFilter;
+
+        public TrinoFilter(
+                TupleDomain<PaimonColumnHandle> filter, TupleDomain<ColumnHandle> remainFilter)
+        {
+            this.filter = filter;
+            this.remainFilter = remainFilter;
+        }
+
+        public TupleDomain<PaimonColumnHandle> getFilter()
+        {
+            return filter;
+        }
+
+        public TupleDomain<ColumnHandle> getRemainFilter()
+        {
+            return remainFilter;
+        }
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonMergePageSourceWrapper.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonMergePageSourceWrapper.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.RowBlock;
+import io.trino.spi.connector.ConnectorPageSource;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Optional;
+
+/**
+ * Trino {@link ConnectorPageSource}.
+ */
+public class PaimonMergePageSourceWrapper
+        implements ConnectorPageSource
+{
+    private final ConnectorPageSource pageSource;
+    private final HashMap<String, Integer> fieldToIndex;
+
+    public PaimonMergePageSourceWrapper(
+            ConnectorPageSource pageSource, HashMap<String, Integer> fieldToIndex)
+    {
+        this.pageSource = pageSource;
+        this.fieldToIndex = fieldToIndex;
+    }
+
+    public static PaimonMergePageSourceWrapper wrap(
+            ConnectorPageSource pageSource, HashMap<String, Integer> fieldToIndex)
+    {
+        return new PaimonMergePageSourceWrapper(pageSource, fieldToIndex);
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return pageSource.getCompletedBytes();
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return pageSource.getReadTimeNanos();
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return pageSource.isFinished();
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        Page nextPage = pageSource.getNextPage();
+        if (nextPage == null) {
+            return null;
+        }
+        int rowCount = nextPage.getPositionCount();
+
+        Block[] newBlocks = new Block[nextPage.getChannelCount() + 1];
+        Block[] rowIdBlocks = new Block[fieldToIndex.size()];
+        for (int i = 0, idx = 0; i < nextPage.getChannelCount(); i++) {
+            Block block = nextPage.getBlock(i);
+            newBlocks[i] = block;
+            if (fieldToIndex.containsValue(i)) {
+                rowIdBlocks[idx] = block;
+                idx++;
+            }
+        }
+        newBlocks[nextPage.getChannelCount()] =
+                RowBlock.fromNotNullSuppressedFieldBlocks(
+                        rowCount, Optional.of(new boolean[fieldToIndex.size()]), rowIdBlocks);
+
+        return new Page(rowCount, newBlocks);
+    }
+
+    @Override
+    public long getMemoryUsage()
+    {
+        return pageSource.getMemoryUsage();
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        pageSource.close();
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonMetadata.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonMetadata.java
@@ -1,0 +1,592 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import io.airlift.slice.Slice;
+import io.trino.plugin.paimon.catalog.PaimonTrinoCatalog;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorOutputMetadata;
+import io.trino.spi.connector.ConnectorOutputTableHandle;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTableLayout;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.ConnectorTableVersion;
+import io.trino.spi.connector.RetryMode;
+import io.trino.spi.connector.RowChangeParadigm;
+import io.trino.spi.connector.SaveMode;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.SchemaTablePrefix;
+import io.trino.spi.security.TrinoPrincipal;
+import io.trino.spi.statistics.ComputedStatistics;
+import io.trino.spi.type.LongTimestampWithTimeZone;
+import io.trino.spi.type.TimestampWithTimeZoneType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.schema.SchemaChange;
+import org.apache.paimon.table.sink.BatchTableCommit;
+import org.apache.paimon.table.sink.BatchWriteBuilder;
+import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.table.sink.CommitMessageSerializer;
+import org.apache.paimon.utils.StringUtils;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.connector.RowChangeParadigm.DELETE_ROW_AND_INSERT_ROW;
+import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+
+/**
+ * Trino {@link ConnectorMetadata}.
+ */
+public class PaimonMetadata
+        implements ConnectorMetadata
+{
+    private static final String TAG_PREFIX = "tag-";
+
+    protected final PaimonTrinoCatalog catalog;
+
+    public PaimonMetadata(PaimonTrinoCatalog catalog)
+    {
+        this.catalog = catalog;
+    }
+
+    public PaimonTrinoCatalog catalog()
+    {
+        return catalog;
+    }
+
+    @Override
+    public ConnectorOutputTableHandle beginCreateTable(
+            ConnectorSession session,
+            ConnectorTableMetadata tableMetadata,
+            Optional<ConnectorTableLayout> layout,
+            RetryMode retryMode,
+            boolean replace)
+    {
+        createTable(session, tableMetadata, SaveMode.IGNORE);
+        return getTableHandle(session, tableMetadata.getTable(), Collections.emptyMap());
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishCreateTable(
+            ConnectorSession session,
+            ConnectorOutputTableHandle tableHandle,
+            Collection<Slice> fragments,
+            Collection<ComputedStatistics> computedStatistics)
+    {
+        if (fragments.isEmpty()) {
+            return Optional.empty();
+        }
+        return commit(session, (PaimonTableHandle) tableHandle, fragments);
+    }
+
+    private Optional<ConnectorOutputMetadata> commit(
+            ConnectorSession session, PaimonTableHandle insertHandle, Collection<Slice> fragments)
+    {
+        CommitMessageSerializer serializer = new CommitMessageSerializer();
+        List<CommitMessage> commitMessages =
+                fragments.stream()
+                        .map(
+                                slice -> {
+                                    try {
+                                        return serializer.deserialize(
+                                                serializer.getVersion(), slice.getBytes());
+                                    }
+                                    catch (IOException e) {
+                                        throw new RuntimeException(e);
+                                    }
+                                })
+                        .collect(toList());
+
+        if (commitMessages.isEmpty()) {
+            return Optional.empty();
+        }
+
+        BatchWriteBuilder batchWriteBuilder =
+                insertHandle.tableWithDynamicOptions(catalog, session).newBatchWriteBuilder();
+        if (PaimonSessionProperties.enableInsertOverwrite(session)) {
+            batchWriteBuilder.withOverwrite();
+        }
+        try (BatchTableCommit commit = batchWriteBuilder.newCommit()) {
+            commit.commit(commitMessages);
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Failed to commit", e);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public RowChangeParadigm getRowChangeParadigm(
+            ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        return DELETE_ROW_AND_INSERT_ROW;
+    }
+
+    @Override
+    public boolean schemaExists(ConnectorSession session, String schemaName)
+    {
+        try {
+            catalog.getDatabase(session, schemaName);
+            return true;
+        }
+        catch (Catalog.DatabaseNotExistException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public List<String> listSchemaNames(ConnectorSession session)
+    {
+        return catalog.listDatabases(session);
+    }
+
+    @Override
+    public void createSchema(
+            ConnectorSession session,
+            String schemaName,
+            Map<String, Object> properties,
+            TrinoPrincipal owner)
+    {
+        checkArgument(
+                !StringUtils.isNullOrWhitespaceOnly(schemaName),
+                "schemaName cannot be null or empty");
+
+        try {
+            catalog.createDatabase(session, schemaName, true);
+        }
+        catch (Catalog.DatabaseAlreadyExistException e) {
+            throw new RuntimeException(format("database already existed: '%s'", schemaName));
+        }
+    }
+
+    @Override
+    public void dropSchema(ConnectorSession session, String schemaName, boolean cascade)
+    {
+        checkArgument(
+                !StringUtils.isNullOrWhitespaceOnly(schemaName),
+                "schemaName cannot be null or empty");
+        try {
+            catalog.dropDatabase(session, schemaName, false, true);
+        }
+        catch (Catalog.DatabaseNotEmptyException e) {
+            throw new RuntimeException(format("database is not empty: '%s'", schemaName));
+        }
+        catch (Catalog.DatabaseNotExistException e) {
+            throw new RuntimeException(format("database not exists: '%s'", schemaName));
+        }
+    }
+
+    @Override
+    public ConnectorTableHandle getTableHandle(
+            ConnectorSession session,
+            SchemaTableName tableName,
+            Optional<ConnectorTableVersion> startVersion,
+            Optional<ConnectorTableVersion> endVersion)
+    {
+        if (startVersion.isPresent()) {
+            throw new TrinoException(
+                    NOT_SUPPORTED, "Read paimon table with start version is not supported");
+        }
+
+        Map<String, String> dynamicOptions = new HashMap<>();
+        if (endVersion.isPresent()) {
+            ConnectorTableVersion version = endVersion.get();
+            Type versionType = version.getVersionType();
+            switch (version.getPointerType()) {
+                case TEMPORAL: {
+                    if (!(versionType
+                            instanceof TimestampWithTimeZoneType timeZonedVersionType)) {
+                        throw new TrinoException(
+                                NOT_SUPPORTED,
+                                "Unsupported type for table version: "
+                                        + versionType.getDisplayName());
+                    }
+                    long epochMillis =
+                            timeZonedVersionType.isShort()
+                                    ? unpackMillisUtc((long) version.getVersion())
+                                    : ((LongTimestampWithTimeZone) version.getVersion())
+                                    .getEpochMillis();
+                    dynamicOptions.put(
+                            CoreOptions.SCAN_TIMESTAMP_MILLIS.key(),
+                            String.valueOf(epochMillis));
+                    break;
+                }
+                case TARGET_ID: {
+                    String tagOrVersion;
+                    if (versionType instanceof VarcharType) {
+                        tagOrVersion =
+                                BinaryString.fromBytes(
+                                                ((Slice) version.getVersion()).getBytes())
+                                        .toString();
+                    }
+                    else {
+                        tagOrVersion = version.getVersion().toString();
+                    }
+
+                    // if value is not number, set tag option
+                    boolean isNumber = StringUtils.isNumeric(tagOrVersion);
+                    if (!isNumber) {
+                        dynamicOptions.put(CoreOptions.SCAN_TAG_NAME.key(), tagOrVersion);
+                    }
+                    else {
+                        try {
+                            String path =
+                                    catalog.getTable(
+                                                    session,
+                                                    new Identifier(
+                                                            tableName.getSchemaName(),
+                                                            tableName.getTableName()))
+                                            .options()
+                                            .get("path");
+
+                            if (catalog.exists(
+                                    session,
+                                    new Path(path + "/tag/" + TAG_PREFIX + tagOrVersion))) {
+                                dynamicOptions.put(
+                                        CoreOptions.SCAN_TAG_NAME.key(), tagOrVersion);
+                            }
+                            else {
+                                dynamicOptions.put(
+                                        CoreOptions.SCAN_SNAPSHOT_ID.key(), tagOrVersion);
+                            }
+                        }
+                        catch (IOException | Catalog.TableNotExistException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+        return getTableHandle(session, tableName, dynamicOptions);
+    }
+
+    public PaimonTableHandle getTableHandle(
+            ConnectorSession session,
+            SchemaTableName tableName,
+            Map<String, String> dynamicOptions)
+    {
+        try {
+            catalog.getTable(
+                    session,
+                    Identifier.create(tableName.getSchemaName(), tableName.getTableName()));
+            return new PaimonTableHandle(
+                    tableName.getSchemaName(), tableName.getTableName(), dynamicOptions);
+        }
+        catch (Catalog.TableNotExistException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public ConnectorTableMetadata getTableMetadata(
+            ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        return ((PaimonTableHandle) tableHandle).tableMetadata(session, catalog);
+    }
+
+    @Override
+    public void setTableProperties(
+            ConnectorSession session,
+            ConnectorTableHandle tableHandle,
+            Map<String, Optional<Object>> properties)
+    {
+        PaimonTableHandle paimonTableHandle = (PaimonTableHandle) tableHandle;
+        Identifier identifier =
+                new Identifier(paimonTableHandle.getSchemaName(), paimonTableHandle.getTableName());
+        List<SchemaChange> changes = new ArrayList<>();
+        Map<String, String> options =
+                properties.entrySet().stream()
+                        .collect(toMap(Map.Entry::getKey, e -> (String) e.getValue().get()));
+        options.forEach((key, value) -> changes.add(SchemaChange.setOption(key, value)));
+        // TODO: remove options, SET PROPERTIES x = DEFAULT
+        try {
+            catalog.alterTable(session, identifier, changes, false);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(
+                    format("failed to alter table: '%s'", paimonTableHandle.getTableName()), e);
+        }
+    }
+
+    @Override
+    public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
+    {
+        List<SchemaTableName> tables = new ArrayList<>();
+        schemaName
+                .map(Collections::singletonList)
+                .orElseGet(() -> catalog.listDatabases(session))
+                .forEach(schema -> tables.addAll(listTables(session, schema)));
+        return tables;
+    }
+
+    private List<SchemaTableName> listTables(ConnectorSession session, String schema)
+    {
+        try {
+            return catalog.listTables(session, schema).stream()
+                    .map(table -> new SchemaTableName(schema, table))
+                    .collect(toList());
+        }
+        catch (Catalog.DatabaseNotExistException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void createTable(
+            ConnectorSession session, ConnectorTableMetadata tableMetadata, SaveMode saveMode)
+    {
+        SchemaTableName table = tableMetadata.getTable();
+        Identifier identifier = Identifier.create(table.getSchemaName(), table.getTableName());
+
+        try {
+            catalog.createTable(session, identifier, prepareSchema(tableMetadata), false);
+        }
+        catch (Catalog.DatabaseNotExistException e) {
+            throw new RuntimeException(format("database not exists: '%s'", table.getSchemaName()));
+        }
+        catch (Catalog.TableAlreadyExistException e) {
+            switch (saveMode) {
+                case IGNORE:
+                    return;
+                case REPLACE:
+                    try {
+                        catalog.dropTable(session, identifier, false);
+                        catalog.createTable(
+                                session, identifier, prepareSchema(tableMetadata), true);
+                    }
+                    catch (Catalog.DatabaseNotExistException ex) {
+                        throw new RuntimeException(
+                                format("database not existed: '%s'", table.getTableName()));
+                    }
+                    catch (Catalog.TableAlreadyExistException ex) {
+                        throw new RuntimeException(
+                                format("table already exists: '%s'", table.getTableName()));
+                    }
+                    catch (Catalog.TableNotExistException ex) {
+                        throw new RuntimeException(
+                                format("table not exists: '%s'", table.getTableName()));
+                    }
+                    break;
+                case FAIL:
+                    throw new RuntimeException(
+                            format("table already existed: '%s'", table.getTableName()));
+                default:
+                    throw new IllegalArgumentException("Unsupported save mode: " + saveMode);
+            }
+        }
+    }
+
+    private Schema prepareSchema(ConnectorTableMetadata tableMetadata)
+    {
+        Map<String, Object> properties = new HashMap<>(tableMetadata.getProperties());
+        Schema.Builder builder =
+                Schema.newBuilder()
+                        .primaryKey(PaimonTableOptions.getPrimaryKeys(properties))
+                        .partitionKeys(PaimonTableOptions.getPartitionedKeys(properties));
+
+        for (ColumnMetadata column : tableMetadata.getColumns()) {
+            builder.column(
+                    column.getName(),
+                    PaimonTypeUtils.toPaimonType(column.getType()),
+                    column.getComment());
+        }
+
+        PaimonTableOptionUtils.buildOptions(builder, properties);
+
+        return builder.build();
+    }
+
+    @Override
+    public void renameTable(
+            ConnectorSession session,
+            ConnectorTableHandle tableHandle,
+            SchemaTableName newTableName)
+    {
+        PaimonTableHandle oldTableHandle = (PaimonTableHandle) tableHandle;
+        try {
+            catalog.renameTable(
+                    session,
+                    new Identifier(oldTableHandle.getSchemaName(), oldTableHandle.getTableName()),
+                    new Identifier(newTableName.getSchemaName(), newTableName.getTableName()),
+                    false);
+        }
+        catch (Catalog.TableNotExistException e) {
+            throw new RuntimeException(
+                    format("table not exists: '%s'", oldTableHandle.getTableName()));
+        }
+        catch (Catalog.TableAlreadyExistException e) {
+            throw new RuntimeException(
+                    format("table already existed: '%s'", newTableName.getTableName()));
+        }
+    }
+
+    @Override
+    public void dropTable(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        PaimonTableHandle paimonTableHandle = (PaimonTableHandle) tableHandle;
+        try {
+            catalog.dropTable(
+                    session,
+                    new Identifier(
+                            paimonTableHandle.getSchemaName(), paimonTableHandle.getTableName()),
+                    false);
+        }
+        catch (Catalog.TableNotExistException e) {
+            throw new RuntimeException(
+                    format("table not exists: '%s'", paimonTableHandle.getTableName()));
+        }
+    }
+
+    @Override
+    public Map<String, ColumnHandle> getColumnHandles(
+            ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        PaimonTableHandle table = (PaimonTableHandle) tableHandle;
+        Map<String, ColumnHandle> handleMap = new HashMap<>();
+        for (ColumnMetadata column : table.columnMetadatas(session, catalog)) {
+            handleMap.put(column.getName(), table.columnHandle(session, catalog, column.getName()));
+        }
+        return handleMap;
+    }
+
+    @Override
+    public ColumnMetadata getColumnMetadata(
+            ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
+    {
+        return ((PaimonColumnHandle) columnHandle).getColumnMetadata();
+    }
+
+    @Override
+    public Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(
+            ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        requireNonNull(prefix, "prefix is null");
+        List<SchemaTableName> tableNames;
+        if (prefix.getTable().isPresent()) {
+            tableNames = Collections.singletonList(prefix.toSchemaTableName());
+        }
+        else {
+            tableNames = listTables(session, prefix.getSchema());
+        }
+
+        return tableNames.stream()
+                .collect(
+                        toMap(
+                                Function.identity(),
+                                table ->
+                                        getTableHandle(session, table, Collections.emptyMap())
+                                                .columnMetadatas(session, catalog)));
+    }
+
+    @Override
+    public void addColumn(
+            ConnectorSession session, ConnectorTableHandle tableHandle, ColumnMetadata column)
+    {
+        PaimonTableHandle paimonTableHandle = (PaimonTableHandle) tableHandle;
+        Identifier identifier =
+                new Identifier(paimonTableHandle.getSchemaName(), paimonTableHandle.getTableName());
+        List<SchemaChange> changes = new ArrayList<>();
+        changes.add(
+                SchemaChange.addColumn(
+                        column.getName(), PaimonTypeUtils.toPaimonType(column.getType())));
+        try {
+            catalog.alterTable(session, identifier, changes, false);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(
+                    format("failed to alter table: '%s'", paimonTableHandle.getTableName()), e);
+        }
+    }
+
+    @Override
+    public void renameColumn(
+            ConnectorSession session,
+            ConnectorTableHandle tableHandle,
+            ColumnHandle source,
+            String target)
+    {
+        PaimonTableHandle paimonTableHandle = (PaimonTableHandle) tableHandle;
+        Identifier identifier =
+                new Identifier(paimonTableHandle.getSchemaName(), paimonTableHandle.getTableName());
+        PaimonColumnHandle paimonColumnHandle = (PaimonColumnHandle) source;
+        List<SchemaChange> changes = new ArrayList<>();
+        changes.add(SchemaChange.renameColumn(paimonColumnHandle.getColumnName(), target));
+        try {
+            catalog.alterTable(session, identifier, changes, false);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(
+                    format("failed to alter table: '%s'", paimonTableHandle.getTableName()), e);
+        }
+    }
+
+    @Override
+    public void dropColumn(
+            ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle column)
+    {
+        PaimonTableHandle paimonTableHandle = (PaimonTableHandle) tableHandle;
+        Identifier identifier =
+                new Identifier(paimonTableHandle.getSchemaName(), paimonTableHandle.getTableName());
+        PaimonColumnHandle paimonColumnHandle = (PaimonColumnHandle) column;
+        List<SchemaChange> changes = new ArrayList<>();
+        changes.add(SchemaChange.dropColumn(paimonColumnHandle.getColumnName()));
+        try {
+            catalog.alterTable(session, identifier, changes, false);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(
+                    format("failed to alter table: '%s'", paimonTableHandle.getTableName()), e);
+        }
+    }
+
+    public void close()
+    {
+        try {
+            this.catalog.close();
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Error happens while close catalog", e);
+        }
+    }
+
+    public void rollback()
+    {
+        // do nothing
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonMetadataFactory.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonMetadataFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import com.google.inject.Inject;
+import io.trino.plugin.paimon.catalog.PaimonTrinoCatalogFactory;
+import io.trino.spi.security.ConnectorIdentity;
+
+/**
+ * A factory to create {@link PaimonMetadata}.
+ */
+public class PaimonMetadataFactory
+{
+    private final PaimonTrinoCatalogFactory paimonTrinoCatalogFactory;
+
+    @Inject
+    public PaimonMetadataFactory(PaimonTrinoCatalogFactory paimonTrinoCatalogFactory)
+    {
+        this.paimonTrinoCatalogFactory = paimonTrinoCatalogFactory;
+    }
+
+    public PaimonMetadata create(ConnectorIdentity identity)
+    {
+        return new PaimonMetadata(paimonTrinoCatalogFactory.create(identity));
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonModule.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonModule.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorPageSourceProvider;
+import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorSplitManager;
+import io.trino.plugin.base.classloader.ForClassLoaderSafe;
+import io.trino.plugin.base.metrics.FileFormatDataSourceStats;
+import io.trino.plugin.paimon.catalog.PaimonTrinoCatalogFactory;
+import io.trino.spi.connector.ConnectorPageSourceProvider;
+import io.trino.spi.connector.ConnectorSplitManager;
+
+import static com.google.inject.Scopes.SINGLETON;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+/**
+ * Module for binding instance.
+ */
+public class PaimonModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        configBinder(binder).bindConfig(PaimonConfig.class);
+        binder.bind(PaimonMetadataFactory.class).in(SINGLETON);
+        binder.bind(PaimonSessionProperties.class).in(SINGLETON);
+        binder.bind(PaimonTableOptions.class).in(SINGLETON);
+        binder.bind(FileFormatDataSourceStats.class).in(Scopes.SINGLETON);
+        binder.bind(PaimonTransactionManager.class).in(SINGLETON);
+        binder.bind(PaimonTrinoCatalogFactory.class).in(SINGLETON);
+        binder.bind(ConnectorSplitManager.class)
+                .annotatedWith(ForClassLoaderSafe.class)
+                .to(PaimonSplitManager.class)
+                .in(Scopes.SINGLETON);
+        binder.bind(ConnectorSplitManager.class)
+                .to(ClassLoaderSafeConnectorSplitManager.class)
+                .in(Scopes.SINGLETON);
+        binder.bind(ConnectorPageSourceProvider.class)
+                .annotatedWith(ForClassLoaderSafe.class)
+                .to(PaimonPageSourceProvider.class)
+                .in(Scopes.SINGLETON);
+        binder.bind(ConnectorPageSourceProvider.class)
+                .to(ClassLoaderSafeConnectorPageSourceProvider.class)
+                .in(Scopes.SINGLETON);
+
+        binder.bind(PaimonConnector.class).in(Scopes.SINGLETON);
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonOrcDataSource.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonOrcDataSource.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import io.airlift.slice.Slice;
+import io.trino.filesystem.TrinoInput;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.orc.AbstractOrcDataSource;
+import io.trino.orc.OrcDataSourceId;
+import io.trino.orc.OrcReader;
+import io.trino.orc.OrcReaderOptions;
+import io.trino.plugin.base.metrics.FileFormatDataSourceStats;
+
+import java.io.IOException;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Data source to construct {@link OrcReader}.
+ */
+public class PaimonOrcDataSource
+        extends AbstractOrcDataSource
+{
+    private final FileFormatDataSourceStats stats;
+    private final TrinoInput input;
+
+    public PaimonOrcDataSource(
+            TrinoInputFile file, OrcReaderOptions options, FileFormatDataSourceStats stats)
+            throws IOException
+    {
+        super(new OrcDataSourceId(file.location().toString()), file.length(), options);
+        this.stats = requireNonNull(stats, "stats is null");
+        this.input = file.newInput();
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        input.close();
+    }
+
+    @Override
+    protected Slice readTailInternal(int length)
+            throws IOException
+    {
+        long readStart = System.nanoTime();
+        Slice tail = input.readTail(length);
+        stats.readDataBytesPerSecond(tail.length(), System.nanoTime() - readStart);
+        return input.readTail(length);
+    }
+
+    @Override
+    protected void readInternal(long position, byte[] buffer, int bufferOffset, int bufferLength)
+            throws IOException
+    {
+        long readStart = System.nanoTime();
+        input.readFully(position, buffer, bufferOffset, bufferLength);
+        stats.readDataBytesPerSecond(bufferLength, System.nanoTime() - readStart);
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonPageSource.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonPageSource.java
@@ -1,0 +1,398 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import io.airlift.slice.Slice;
+import io.trino.memory.context.AggregatedMemoryContext;
+import io.trino.spi.Page;
+import io.trino.spi.PageBuilder;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.ArrayBlockBuilder;
+import io.trino.spi.block.ArrayValueBuilder;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.MapBlockBuilder;
+import io.trino.spi.block.MapValueBuilder;
+import io.trino.spi.block.RowBlockBuilder;
+import io.trino.spi.block.RowValueBuilder;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Decimals;
+import io.trino.spi.type.LongTimestampWithTimeZone;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarbinaryType;
+import io.trino.spi.type.VarcharType;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.Decimal;
+import org.apache.paimon.data.InternalArray;
+import org.apache.paimon.data.InternalMap;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypeChecks;
+import org.apache.paimon.utils.CloseableIterator;
+import org.apache.paimon.utils.InternalRowUtils;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.OptionalLong;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.Decimals.encodeShortScaledValue;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.LongTimestampWithTimeZone.fromEpochMillisAndFraction;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimeType.TIME_MICROS;
+import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_SECONDS;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Trino {@link ConnectorPageSource}.
+ */
+public class PaimonPageSource
+        implements ConnectorPageSource
+{
+    private static final int ROWS_PER_REQUEST = 4096;
+
+    private final CloseableIterator<InternalRow> iterator;
+    private final OptionalLong limit;
+    private final PageBuilder pageBuilder;
+    private final List<Type> columnTypes;
+    private final List<DataType> logicalTypes;
+    private final AggregatedMemoryContext memoryUsage;
+
+    private boolean isFinished;
+    private long numReturn;
+    private long readBytes;
+    private long readTimeNanos;
+
+    public PaimonPageSource(
+            RecordReader<InternalRow> reader,
+            List<ColumnHandle> projectedColumns,
+            OptionalLong limit,
+            AggregatedMemoryContext memoryUsage)
+    {
+        this.iterator = reader.toCloseableIterator();
+        this.limit = limit;
+        this.columnTypes = new ArrayList<>();
+        this.logicalTypes = new ArrayList<>();
+        for (ColumnHandle handle : projectedColumns) {
+            PaimonColumnHandle paimonColumnHandle = (PaimonColumnHandle) handle;
+            columnTypes.add(paimonColumnHandle.getTrinoType());
+            logicalTypes.add(paimonColumnHandle.logicalType());
+        }
+
+        this.memoryUsage = requireNonNull(memoryUsage, "memoryUsage is null");
+        this.pageBuilder = new PageBuilder(columnTypes);
+    }
+
+    private static void writeSlice(BlockBuilder output, Type type, Object value)
+    {
+        if (type instanceof VarcharType || type instanceof io.trino.spi.type.CharType) {
+            type.writeSlice(output, wrappedBuffer(((BinaryString) value).toBytes()));
+        }
+        else if (type instanceof VarbinaryType) {
+            type.writeSlice(output, wrappedBuffer((byte[]) value));
+        }
+        else {
+            throw new TrinoException(
+                    GENERIC_INTERNAL_ERROR, "Unhandled type for Slice: " + type.getTypeSignature());
+        }
+    }
+
+    private static void writeObject(BlockBuilder output, Type type, Object value)
+    {
+        if (type instanceof DecimalType decimalType) {
+            BigDecimal decimal = ((Decimal) value).toBigDecimal();
+            type.writeObject(output, Decimals.encodeScaledValue(decimal, decimalType.getScale()));
+        }
+        else {
+            throw new TrinoException(
+                    GENERIC_INTERNAL_ERROR,
+                    "Unhandled type for Object: " + type.getTypeSignature());
+        }
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return readBytes;
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return readTimeNanos;
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return isFinished;
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        try {
+            return nextPage();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public long getMemoryUsage()
+    {
+        return memoryUsage.getBytes();
+    }
+
+    @Nullable
+    private Page nextPage()
+            throws IOException
+    {
+        long start = System.nanoTime();
+        int count = 0;
+        while (count < ROWS_PER_REQUEST && !pageBuilder.isFull()) {
+            if (limit.isPresent() && numReturn + count >= limit.getAsLong()) {
+                isFinished = true;
+                break;
+            }
+
+            if (!iterator.hasNext()) {
+                isFinished = true;
+                break;
+            }
+
+            InternalRow row = iterator.next();
+            pageBuilder.declarePosition();
+            count++;
+            for (int i = 0; i < columnTypes.size(); i++) {
+                BlockBuilder output = pageBuilder.getBlockBuilder(i);
+                appendTo(
+                        columnTypes.get(i),
+                        logicalTypes.get(i),
+                        InternalRowUtils.get(row, i, logicalTypes.get(i)),
+                        output);
+            }
+        }
+
+        if (count == 0) {
+            return null;
+        }
+        numReturn += count;
+        Page page = pageBuilder.build();
+        readBytes += page.getSizeInBytes();
+        readTimeNanos += System.nanoTime() - start;
+        pageBuilder.reset();
+        return page;
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        try {
+            this.iterator.close();
+        }
+        catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+
+    protected void appendTo(Type type, DataType logicalType, Object value, BlockBuilder output)
+    {
+        if (value == null) {
+            output.appendNull();
+            return;
+        }
+
+        Class<?> javaType = type.getJavaType();
+        if (javaType == boolean.class) {
+            type.writeBoolean(output, (Boolean) value);
+        }
+        else if (javaType == long.class) {
+            if (type.equals(BIGINT)
+                    || type.equals(INTEGER)
+                    || type.equals(TINYINT)
+                    || type.equals(SMALLINT)
+                    || type.equals(DATE)) {
+                type.writeLong(output, ((Number) value).longValue());
+            }
+            else if (type.equals(REAL)) {
+                type.writeLong(output, Float.floatToIntBits((Float) value));
+            }
+            else if (type instanceof DecimalType decimalType) {
+                BigDecimal decimal = ((Decimal) value).toBigDecimal();
+                type.writeLong(output, encodeShortScaledValue(decimal, decimalType.getScale()));
+            }
+            else if (type.equals(TIMESTAMP_MILLIS) || type.equals(TIMESTAMP_SECONDS)) {
+                type.writeLong(
+                        output,
+                        ((Timestamp) value).getMillisecond() * MICROSECONDS_PER_MILLISECOND);
+            }
+            else if (type.equals(TIMESTAMP_MICROS)) {
+                type.writeLong(output, ((Timestamp) value).toMicros());
+            }
+            else if (type.equals(TIMESTAMP_TZ_MILLIS)) {
+                type.writeLong(
+                        output,
+                        packDateTimeWithZone(((Timestamp) value).getMillisecond(), UTC_KEY));
+            }
+            else if (type.equals(TIME_MICROS)) {
+                type.writeLong(output, ((int) value) * ((long) MICROSECONDS_PER_MILLISECOND));
+            }
+            else {
+                throw new TrinoException(
+                        GENERIC_INTERNAL_ERROR,
+                        format("Unhandled type for %s: %s", javaType.getSimpleName(), type));
+            }
+        }
+        else if (javaType == double.class) {
+            type.writeDouble(output, ((Number) value).doubleValue());
+        }
+        else if (type instanceof DecimalType) {
+            writeObject(output, type, value);
+        }
+        else if (javaType == Slice.class) {
+            writeSlice(output, type, value);
+        }
+        else if (javaType == LongTimestampWithTimeZone.class) {
+            checkArgument(type.equals(TIMESTAMP_TZ_MILLIS));
+            Timestamp timestamp = (Timestamp) value;
+            type.writeObject(
+                    output, fromEpochMillisAndFraction(timestamp.getMillisecond(), 0, UTC_KEY));
+        }
+        else if (type instanceof ArrayType
+                || type instanceof MapType
+                || type instanceof RowType) {
+            writeBlock(output, type, logicalType, value);
+        }
+        else {
+            throw new TrinoException(
+                    GENERIC_INTERNAL_ERROR,
+                    format("Unhandled type for %s: %s", javaType.getSimpleName(), type));
+        }
+    }
+
+    protected void writeBlock(BlockBuilder output, Type type, DataType logicalType, Object value)
+    {
+        if (type instanceof ArrayType) {
+            ArrayBlockBuilder arrayBlockBuilder = (ArrayBlockBuilder) output;
+            try {
+                arrayBlockBuilder.buildEntry(
+                        (ArrayValueBuilder<Throwable>)
+                                elementBuilder -> {
+                                    InternalArray arrayData = (InternalArray) value;
+                                    DataType elementType =
+                                            DataTypeChecks.getNestedTypes(logicalType).get(0);
+                                    for (int i = 0; i < arrayData.size(); i++) {
+                                        appendTo(
+                                                type.getTypeParameters().get(0),
+                                                elementType,
+                                                InternalRowUtils.get(arrayData, i, elementType),
+                                                elementBuilder);
+                                    }
+                                });
+            }
+            catch (Throwable e) {
+                throw new RuntimeException(e);
+            }
+            return;
+        }
+        if (type instanceof RowType) {
+            RowBlockBuilder rowBlockBuilder = (RowBlockBuilder) output;
+            try {
+                rowBlockBuilder.buildEntry(
+                        (RowValueBuilder<Throwable>)
+                                fieldBuilders -> {
+                                    InternalRow rowData = (InternalRow) value;
+                                    for (int index = 0;
+                                            index < type.getTypeParameters().size();
+                                            index++) {
+                                        Type fieldType = type.getTypeParameters().get(index);
+                                        DataType fieldLogicalType =
+                                                ((org.apache.paimon.types.RowType) logicalType)
+                                                        .getTypeAt(index);
+                                        appendTo(
+                                                fieldType,
+                                                fieldLogicalType,
+                                                InternalRowUtils.get(
+                                                        rowData, index, fieldLogicalType),
+                                                fieldBuilders.get(index));
+                                    }
+                                });
+            }
+            catch (Throwable e) {
+                throw new RuntimeException(e);
+            }
+            return;
+        }
+        if (type instanceof MapType) {
+            InternalMap mapData = (InternalMap) value;
+            InternalArray keyArray = mapData.keyArray();
+            InternalArray valueArray = mapData.valueArray();
+            DataType keyType = ((org.apache.paimon.types.MapType) logicalType).getKeyType();
+            DataType valueType = ((org.apache.paimon.types.MapType) logicalType).getValueType();
+            MapBlockBuilder mapBlockBuilder = (MapBlockBuilder) output;
+            try {
+                mapBlockBuilder.buildEntry(
+                        (MapValueBuilder<Throwable>)
+                                (keyBuilder, valueBuilder) -> {
+                                    for (int i = 0; i < keyArray.size(); i++) {
+                                        appendTo(
+                                                type.getTypeParameters().get(0),
+                                                keyType,
+                                                InternalRowUtils.get(keyArray, i, keyType),
+                                                keyBuilder);
+                                        appendTo(
+                                                type.getTypeParameters().get(1),
+                                                valueType,
+                                                InternalRowUtils.get(valueArray, i, valueType),
+                                                valueBuilder);
+                                    }
+                                });
+            }
+            catch (Throwable e) {
+                throw new RuntimeException(e);
+            }
+            return;
+        }
+        throw new TrinoException(
+                GENERIC_INTERNAL_ERROR, "Unhandled type for Block: " + type.getTypeSignature());
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonPageSourceProvider.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonPageSourceProvider.java
@@ -1,0 +1,639 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import com.google.cloud.hadoop.repackaged.gcs.com.google.common.collect.ImmutableList;
+import com.google.cloud.hadoop.repackaged.gcs.com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import io.airlift.units.DataSize;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.memory.context.AggregatedMemoryContext;
+import io.trino.orc.OrcColumn;
+import io.trino.orc.OrcDataSource;
+import io.trino.orc.OrcReader;
+import io.trino.orc.OrcReaderOptions;
+import io.trino.orc.OrcRecordReader;
+import io.trino.orc.TupleDomainOrcPredicate;
+import io.trino.parquet.Column;
+import io.trino.parquet.Field;
+import io.trino.parquet.GroupField;
+import io.trino.parquet.ParquetDataSource;
+import io.trino.parquet.ParquetReaderOptions;
+import io.trino.parquet.PrimitiveField;
+import io.trino.parquet.metadata.FileMetadata;
+import io.trino.parquet.metadata.ParquetMetadata;
+import io.trino.parquet.predicate.TupleDomainParquetPredicate;
+import io.trino.parquet.reader.MetadataReader;
+import io.trino.parquet.reader.ParquetReader;
+import io.trino.parquet.reader.RowGroupInfo;
+import io.trino.plugin.base.metrics.FileFormatDataSourceStats;
+import io.trino.plugin.hive.coercions.TypeCoercer;
+import io.trino.plugin.hive.orc.OrcPageSource;
+import io.trino.plugin.hive.parquet.ParquetPageSource;
+import io.trino.plugin.hive.parquet.ParquetTypeTranslator;
+import io.trino.plugin.paimon.catalog.PaimonTrinoCatalog;
+import io.trino.plugin.paimon.catalog.PaimonTrinoCatalogFactory;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.ConnectorPageSourceProvider;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.DynamicFilter;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.Type;
+import org.apache.paimon.deletionvectors.DeletionVector;
+import org.apache.paimon.fileindex.FileIndexPredicate;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.table.source.DeletionFile;
+import org.apache.paimon.table.source.IndexFile;
+import org.apache.paimon.table.source.RawFile;
+import org.apache.paimon.table.source.ReadBuilder;
+import org.apache.paimon.table.source.Split;
+import org.apache.paimon.types.RowType;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.io.ColumnIO;
+import org.apache.parquet.io.GroupColumnIO;
+import org.apache.parquet.io.MessageColumnIO;
+import org.apache.parquet.io.PrimitiveColumnIO;
+import org.apache.parquet.schema.MessageType;
+import org.joda.time.DateTimeZone;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static io.trino.orc.OrcReader.INITIAL_BATCH_SIZE;
+import static io.trino.parquet.ParquetTypeUtils.getArrayElementColumn;
+import static io.trino.parquet.ParquetTypeUtils.getColumnIO;
+import static io.trino.parquet.ParquetTypeUtils.getDescriptors;
+import static io.trino.parquet.ParquetTypeUtils.getMapKeyValueColumn;
+import static io.trino.parquet.predicate.PredicateUtils.buildPredicate;
+import static io.trino.parquet.predicate.PredicateUtils.getFilteredRowGroups;
+import static io.trino.plugin.hive.orc.OrcTypeTranslator.createCoercer;
+import static io.trino.plugin.hive.parquet.ParquetPageSourceFactory.createDataSource;
+import static java.util.Objects.requireNonNull;
+import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
+import static org.joda.time.DateTimeZone.UTC;
+
+/**
+ * Trino {@link ConnectorPageSourceProvider}.
+ */
+public class PaimonPageSourceProvider
+        implements ConnectorPageSourceProvider
+{
+    private final TrinoFileSystemFactory fileSystemFactory;
+    private final FileFormatDataSourceStats fileFormatDataSourceStats;
+    private final PaimonTrinoCatalogFactory paimonTrinoCatalogFactory;
+
+    @Inject
+    public PaimonPageSourceProvider(
+            TrinoFileSystemFactory fileSystemFactory,
+            PaimonTrinoCatalogFactory paimonTrinoCatalogFactory,
+            FileFormatDataSourceStats fileFormatDataSourceStats)
+    {
+        this.paimonTrinoCatalogFactory =
+                requireNonNull(paimonTrinoCatalogFactory, "paimonTrinoCatalogFactory is null");
+        this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
+        this.fileFormatDataSourceStats =
+                requireNonNull(fileFormatDataSourceStats, "fileFormatDataSourceStats is null");
+    }
+
+    static TupleDomain<ColumnDescriptor> getParquetTupleDomain(
+            MessageType fileSchema,
+            List<PaimonColumnHandle> columns,
+            TupleDomain<PaimonColumnHandle> predicates)
+    {
+        ImmutableMap.Builder<ColumnDescriptor, Domain> predicate = ImmutableMap.builder();
+        Map<Integer, ColumnDescriptor> columnDescriptorMap = new HashMap<>();
+
+        fileSchema
+                .getPaths()
+                .forEach(
+                        path -> {
+                            org.apache.parquet.schema.Type type = fileSchema.getType(path[0]);
+                            if (type.isPrimitive()) {
+                                columnDescriptorMap.put(
+                                        type.getId().intValue(),
+                                        fileSchema.getColumnDescription(path));
+                            }
+                        });
+
+        for (PaimonColumnHandle column : columns) {
+            if (predicates.getDomains().isPresent()) {
+                Domain domain = predicates.getDomains().get().get(column);
+                if (domain != null && columnDescriptorMap.containsKey(column.getColumnId())) {
+                    predicate.put(columnDescriptorMap.get(column.getColumnId()), domain);
+                }
+            }
+        }
+
+        return TupleDomain.withColumnDomains(predicate.build());
+    }
+
+    public static Optional<Field> constructField(Type type, ColumnIO columnIO)
+    {
+        if (columnIO == null) {
+            return Optional.empty();
+        }
+        boolean required = columnIO.getType().getRepetition() != OPTIONAL;
+        int repetitionLevel = columnIO.getRepetitionLevel();
+        int definitionLevel = columnIO.getDefinitionLevel();
+        if (type instanceof io.trino.spi.type.RowType rowType) {
+            GroupColumnIO groupColumnIO = (GroupColumnIO) columnIO;
+            ImmutableList.Builder<Optional<Field>> fieldsBuilder = ImmutableList.builder();
+            List<io.trino.spi.type.RowType.Field> fields = rowType.getFields();
+            boolean structHasParameters = false;
+            for (int i = 0; i < fields.size(); i++) {
+                io.trino.spi.type.RowType.Field rowField = fields.get(i);
+                Optional<Field> field =
+                        constructField(rowField.getType(), groupColumnIO.getChild(i));
+                structHasParameters |= field.isPresent();
+                fieldsBuilder.add(field);
+            }
+            if (structHasParameters) {
+                return Optional.of(
+                        new GroupField(
+                                type,
+                                repetitionLevel,
+                                definitionLevel,
+                                required,
+                                fieldsBuilder.build()));
+            }
+            return Optional.empty();
+        }
+        if (type instanceof MapType mapType) {
+            GroupColumnIO groupColumnIO = (GroupColumnIO) columnIO;
+            GroupColumnIO keyValueColumnIO = getMapKeyValueColumn(groupColumnIO);
+            if (keyValueColumnIO.getChildrenCount() != 2) {
+                return Optional.empty();
+            }
+            Optional<Field> keyField =
+                    constructField(mapType.getKeyType(), keyValueColumnIO.getChild(0));
+            Optional<Field> valueField =
+                    constructField(mapType.getValueType(), keyValueColumnIO.getChild(1));
+            return Optional.of(
+                    new GroupField(
+                            type,
+                            repetitionLevel,
+                            definitionLevel,
+                            required,
+                            ImmutableList.of(keyField, valueField)));
+        }
+        if (type instanceof ArrayType arrayType) {
+            GroupColumnIO groupColumnIO = (GroupColumnIO) columnIO;
+            if (groupColumnIO.getChildrenCount() != 1) {
+                return Optional.empty();
+            }
+            Optional<Field> field =
+                    constructField(
+                            arrayType.getElementType(),
+                            getArrayElementColumn(groupColumnIO.getChild(0)));
+            return Optional.of(
+                    new GroupField(
+                            type,
+                            repetitionLevel,
+                            definitionLevel,
+                            required,
+                            ImmutableList.of(field)));
+        }
+        PrimitiveColumnIO primitiveColumnIO = (PrimitiveColumnIO) columnIO;
+        return Optional.of(
+                new PrimitiveField(
+                        type,
+                        required,
+                        primitiveColumnIO.getColumnDescriptor(),
+                        primitiveColumnIO.getId()));
+    }
+
+    @Override
+    public ConnectorPageSource createPageSource(
+            ConnectorTransactionHandle transaction,
+            ConnectorSession session,
+            ConnectorSplit split,
+            ConnectorTableHandle tableHandle,
+            List<ColumnHandle> columns,
+            // TODO: support dynamic filter
+            DynamicFilter dynamicFilter)
+    {
+        PaimonTrinoCatalog paimonTrinoCatalog = paimonTrinoCatalogFactory.create(session.getIdentity());
+        PaimonTableHandle paimonTableHandle = (PaimonTableHandle) tableHandle;
+        Table table = paimonTableHandle.tableWithDynamicOptions(paimonTrinoCatalog, session);
+        Optional<PaimonColumnHandle> rowId =
+                columns.stream()
+                        .map(PaimonColumnHandle.class::cast)
+                        .filter(PaimonColumnHandle::isRowId)
+                        .findFirst();
+        if (rowId.isPresent()) {
+            List<ColumnHandle> dataColumns =
+                    columns.stream()
+                            .map(PaimonColumnHandle.class::cast)
+                            .filter(column -> !column.isRowId())
+                            .collect(Collectors.toList());
+            Set<String> rowIdFileds =
+                    ((io.trino.spi.type.RowType) rowId.get().getTrinoType())
+                            .getFields().stream()
+                            .map(io.trino.spi.type.RowType.Field::getName)
+                            .map(Optional::get)
+                            .collect(Collectors.toSet());
+
+            HashMap<String, Integer> fieldToIndex = new HashMap<>();
+            for (int i = 0; i < dataColumns.size(); i++) {
+                PaimonColumnHandle paimonColumnHandle =
+                        (PaimonColumnHandle) dataColumns.get(i);
+                if (rowIdFileds.contains(paimonColumnHandle.getColumnName())) {
+                    fieldToIndex.put(paimonColumnHandle.getColumnName(), i);
+                }
+            }
+            return PaimonMergePageSourceWrapper.wrap(
+                    createPageSource(
+                            session,
+                            table,
+                            paimonTableHandle.getPredicate(),
+                            (PaimonSplit) split,
+                            dataColumns,
+                            paimonTableHandle.getLimit()),
+                    fieldToIndex);
+        }
+        else {
+            return createPageSource(
+                    session,
+                    table,
+                    paimonTableHandle.getPredicate(),
+                    (PaimonSplit) split,
+                    columns,
+                    paimonTableHandle.getLimit());
+        }
+    }
+
+    private ConnectorPageSource createPageSource(
+            ConnectorSession session,
+            Table table,
+            TupleDomain<PaimonColumnHandle> filter,
+            PaimonSplit split,
+            List<ColumnHandle> columns,
+            OptionalLong limit)
+    {
+        RowType rowType = table.rowType();
+        List<String> fieldNames = rowType.getFieldNames();
+        List<String> projectedFields =
+                columns.stream()
+                        .map(PaimonColumnHandle.class::cast)
+                        .map(PaimonColumnHandle::getColumnName)
+                        .toList();
+
+        List<PaimonColumnHandle> projectedColumns =
+                columns.stream().map(PaimonColumnHandle.class::cast).toList();
+
+        TrinoFileSystem fileSystem = fileSystemFactory.create(session);
+        Optional<Predicate> paimonFilter = new PaimonFilterConverter(rowType).convert(filter);
+        Optional<ConnectorPageSource> pageSource = Optional.empty();
+
+        try {
+            Split paimonSplit = split.decodeSplit();
+            Optional<List<RawFile>> optionalRawFiles = paimonSplit.convertToRawFiles();
+            if (checkRawFile(optionalRawFiles)) {
+                FileStoreTable fileStoreTable = (FileStoreTable) table;
+                boolean readIndex = fileStoreTable.coreOptions().fileIndexReadEnabled();
+
+                Optional<List<DeletionFile>> deletionFiles = paimonSplit.deletionFiles();
+                Optional<List<IndexFile>> indexFiles =
+                        readIndex ? paimonSplit.indexFiles() : Optional.empty();
+
+                try {
+                    List<RawFile> files = optionalRawFiles.orElseThrow();
+                    LinkedList<ConnectorPageSource> sources = new LinkedList<>();
+
+                    // if file index exists, do the filter.
+                    for (int i = 0; i < files.size(); i++) {
+                        RawFile rawFile = files.get(i);
+                        if (indexFiles.isPresent()) {
+                            IndexFile indexFile = indexFiles.get().get(i);
+                            if (indexFile != null && paimonFilter.isPresent()) {
+                                try (FileIndexPredicate fileIndexPredicate =
+                                        new FileIndexPredicate(
+                                                new Path(indexFile.path()),
+                                                ((FileStoreTable) table).fileIO(),
+                                                rowType)) {
+                                    if (!fileIndexPredicate.evaluate(paimonFilter.get()).remain()) {
+                                        continue;
+                                    }
+                                }
+                            }
+                        }
+                        ConnectorPageSource source =
+                                createDataPageSource(
+                                        rawFile.format(),
+                                        fileSystem.newInputFile(Location.of(rawFile.path())),
+                                        projectedColumns,
+                                        filter);
+
+                        if (deletionFiles.isPresent()) {
+                            source =
+                                    PaimonPageSourceWrapper.wrap(
+                                            source,
+                                            Optional.ofNullable(deletionFiles.get().get(i))
+                                                    .map(
+                                                            deletionFile -> {
+                                                                try {
+                                                                    return DeletionVector.read(
+                                                                            fileStoreTable.fileIO(),
+                                                                            deletionFile);
+                                                                }
+                                                                catch (IOException e) {
+                                                                    throw new RuntimeException(e);
+                                                                }
+                                                            }));
+                        }
+                        sources.add(source);
+                    }
+
+                    pageSource = Optional.of(new DirectTrinoPageSource(sources, limit));
+                }
+                catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            if (pageSource.isEmpty()) {
+                int[] columnIndex =
+                        projectedFields.stream().mapToInt(fieldNames::indexOf).toArray();
+
+                // old read way
+                ReadBuilder read = table.newReadBuilder();
+                paimonFilter.ifPresent(read::withFilter);
+
+                if (!fieldNames.equals(projectedFields)) {
+                    read.withProjection(columnIndex);
+                }
+
+                pageSource = Optional.of(new PaimonPageSource(
+                        read.newRead().executeFilter().createReader(paimonSplit), columns, limit, newSimpleAggregatedMemoryContext()));
+            }
+            return pageSource.get();
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private boolean checkRawFile(Optional<List<RawFile>> optionalRawFiles)
+    {
+        return optionalRawFiles.isPresent() && canUseTrinoPageSource(optionalRawFiles.get());
+    }
+
+    // TODO: support avro
+    private boolean canUseTrinoPageSource(List<RawFile> rawFiles)
+    {
+        for (RawFile rawFile : rawFiles) {
+            if (!(rawFile.format().equals("orc") || rawFile.format().equals("parquet"))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private ConnectorPageSource createDataPageSource(
+            String format,
+            TrinoInputFile inputFile,
+            List<PaimonColumnHandle> columns,
+            TupleDomain<PaimonColumnHandle> predicates)
+    {
+        return switch (format) {
+            case "orc" -> createOrcDataPageSource(
+                    inputFile,
+                    // TODO: pass options to orc read from configuration
+                    new OrcReaderOptions()
+                            // Default tiny stripe size 8 M is too big for paimon.
+                            // Cache stripe will cause more read (I want to read one column,
+                            // but not the whole stripe)
+                            .withTinyStripeThreshold(
+                                    DataSize.of(4, DataSize.Unit.KILOBYTE)),
+                    columns,
+                    predicates);
+            case "parquet" -> createParquetDataPageSource(
+                    // TODO: pass options to parquet read from configuration
+                    inputFile, new ParquetReaderOptions(), columns, predicates);
+            case "avro" -> throw new RuntimeException("Unsupport file format: " + format);
+            default -> throw new RuntimeException("Unsupport file format: " + format);
+        };
+    }
+
+    private ConnectorPageSource createOrcDataPageSource(
+            TrinoInputFile inputFile,
+            OrcReaderOptions options,
+            List<PaimonColumnHandle> columns,
+            TupleDomain<PaimonColumnHandle> predicates)
+    {
+        try {
+            OrcDataSource orcDataSource =
+                    new PaimonOrcDataSource(inputFile, options, fileFormatDataSourceStats);
+            OrcReader reader =
+                    OrcReader.createOrcReader(orcDataSource, options)
+                            .orElseThrow(() -> new RuntimeException("ORC file is zero length"));
+
+            List<OrcColumn> fileColumns = reader.getRootColumn().getNestedColumns();
+            Map<Integer, OrcColumn> fieldsMap = new HashMap<>();
+            fileColumns.forEach(
+                    column ->
+                            fieldsMap.put(
+                                    Integer.parseInt(column.getAttributes().get("paimon.id")),
+                                    column));
+            TupleDomainOrcPredicate.TupleDomainOrcPredicateBuilder predicateBuilder =
+                    TupleDomainOrcPredicate.builder();
+            List<OrcPageSource.ColumnAdaptation> columnAdaptations = new ArrayList<>();
+            List<OrcColumn> fileReadColumns = new ArrayList<>(columns.size());
+            List<Type> fileReadTypes = new ArrayList<>(columns.size());
+
+            for (PaimonColumnHandle column : columns) {
+                OrcColumn orcColumn = fieldsMap.get(column.getColumnId());
+                if (orcColumn == null) {
+                    columnAdaptations.add(
+                            OrcPageSource.ColumnAdaptation.nullColumn(column.getTrinoType()));
+                }
+                else {
+                    Optional<TypeCoercer<? extends Type, ? extends Type>> coercer = createCoercer(orcColumn.getColumnType(), orcColumn.getNestedColumns(), column.getTrinoType());
+                    if (coercer.isPresent()) {
+                        fileReadTypes.add(coercer.get().getFromType());
+                        columnAdaptations.add(
+                                OrcPageSource.ColumnAdaptation.coercedColumn(
+                                        fileReadColumns.size(), coercer.get()));
+                    }
+                    else {
+                        fileReadTypes.add(column.getTrinoType());
+                        columnAdaptations.add(
+                                OrcPageSource.ColumnAdaptation.sourceColumn(fileReadColumns.size()));
+                    }
+                    fileReadColumns.add(orcColumn);
+                    if (predicates.getDomains().isPresent()) {
+                        Domain predicate = predicates.getDomains().get().get(column);
+                        if (predicate != null) {
+                            predicateBuilder.addColumn(orcColumn.getColumnId(), predicate);
+                        }
+                    }
+                }
+            }
+
+            AggregatedMemoryContext memoryUsage = newSimpleAggregatedMemoryContext();
+            OrcRecordReader recordReader =
+                    reader.createRecordReader(
+                            fileReadColumns,
+                            fileReadTypes,
+                            predicateBuilder.build(),
+                            DateTimeZone.UTC,
+                            memoryUsage,
+                            INITIAL_BATCH_SIZE,
+                            RuntimeException::new);
+
+            return new OrcPageSource(
+                    recordReader,
+                    columnAdaptations,
+                    orcDataSource,
+                    Optional.empty(),
+                    Optional.empty(),
+                    memoryUsage,
+                    fileFormatDataSourceStats,
+                    reader.getCompressionKind());
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private ConnectorPageSource createParquetDataPageSource(
+            TrinoInputFile inputFile,
+            ParquetReaderOptions options,
+            List<PaimonColumnHandle> columns,
+            TupleDomain<PaimonColumnHandle> predicates)
+    {
+        try {
+            AggregatedMemoryContext memoryUsage = newSimpleAggregatedMemoryContext();
+            ParquetDataSource dataSource =
+                    createDataSource(
+                            inputFile,
+                            OptionalLong.of(inputFile.length()),
+                            options,
+                            memoryUsage,
+                            fileFormatDataSourceStats);
+            ParquetMetadata parquetMetadata =
+                    MetadataReader.readFooter(dataSource, Optional.empty());
+            FileMetadata fileMetaData = parquetMetadata.getFileMetaData();
+            MessageType fileSchema = fileMetaData.getSchema();
+
+            Map<Integer, org.apache.parquet.schema.Type> fileSchemaMap = new HashMap<>();
+            for (org.apache.parquet.schema.Type field : fileSchema.getFields()) {
+                fileSchemaMap.put(field.getId().intValue(), field);
+            }
+            List<org.apache.parquet.schema.Type> projectedTypes = new ArrayList<>();
+            for (PaimonColumnHandle column : columns) {
+                if (fileSchemaMap.containsKey(column.getColumnId())) {
+                    projectedTypes.add(fileSchemaMap.get(column.getColumnId()));
+                }
+            }
+            MessageType projectedSchema = new MessageType(fileSchema.getName(), projectedTypes);
+            Map<List<String>, ColumnDescriptor> descriptorsByPath =
+                    getDescriptors(fileSchema, projectedSchema);
+            TupleDomain<ColumnDescriptor> parquetTupleDomain =
+                    options.isIgnoreStatistics()
+                            ? TupleDomain.all()
+                            : getParquetTupleDomain(fileSchema, columns, predicates);
+            TupleDomainParquetPredicate parquetPredicate =
+                    buildPredicate(projectedSchema, parquetTupleDomain, descriptorsByPath, UTC);
+            List<RowGroupInfo> rowGroups =
+                    getFilteredRowGroups(
+                            0,
+                            inputFile.length(),
+                            dataSource,
+                            parquetMetadata,
+                            ImmutableList.of(parquetTupleDomain),
+                            ImmutableList.of(parquetPredicate),
+                            descriptorsByPath,
+                            UTC,
+                            1000,
+                            options);
+
+            MessageColumnIO messageColumnIO = getColumnIO(fileSchema, projectedSchema);
+            ParquetPageSource.Builder pageSourceBuilder = ParquetPageSource.builder();
+
+            int parquetSourceChannel = 0;
+            List<Column> returnColumns = new ArrayList<>();
+            for (PaimonColumnHandle columnHandle : columns) {
+                if (fileSchemaMap.containsKey(columnHandle.getColumnId())) {
+                    org.apache.parquet.schema.Type type =
+                            fileSchemaMap.get(columnHandle.getColumnId());
+                    ColumnIO columnIO = messageColumnIO.getChild(type.getName());
+                    Type trinoType = columnHandle.getTrinoType();
+                    Optional<TypeCoercer<? extends Type, ? extends Type>> coercer = Optional.empty();
+                    if (type.isPrimitive()) {
+                        coercer = ParquetTypeTranslator.createCoercer(type.asPrimitiveType().getPrimitiveTypeName(), type.getLogicalTypeAnnotation(), trinoType);
+                    }
+                    if (coercer.isPresent()) {
+                        returnColumns.add(
+                                new Column(
+                                        columnHandle.getColumnName(),
+                                        constructField(coercer.get().getFromType(), columnIO)
+                                                .orElseThrow()));
+                        pageSourceBuilder.addCoercedColumn(parquetSourceChannel++, coercer.get());
+                    }
+                    else {
+                        returnColumns.add(
+                                new Column(
+                                        columnHandle.getColumnName(),
+                                        constructField(columnHandle.getTrinoType(), columnIO)
+                                                .orElseThrow()));
+                        pageSourceBuilder.addSourceColumn(parquetSourceChannel++);
+                    }
+                }
+                else {
+                    pageSourceBuilder.addNullColumn(columnHandle.getTrinoType());
+                }
+            }
+
+            ParquetReader parquetReader =
+                    new ParquetReader(
+                            Optional.ofNullable(fileMetaData.getCreatedBy()),
+                            returnColumns,
+                            rowGroups,
+                            dataSource,
+                            UTC,
+                            memoryUsage,
+                            options,
+                            RuntimeException::new,
+                            Optional.empty(),
+                            Optional.empty());
+
+            return pageSourceBuilder.build(parquetReader);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonPageSourceProvider.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonPageSourceProvider.java
@@ -377,7 +377,7 @@ public class PaimonPageSourceProvider
                         sources.add(source);
                     }
 
-                    pageSource = Optional.of(new DirectTrinoPageSource(sources, limit));
+                    pageSource = Optional.of(new DirectPaimonPageSource(sources, limit));
                 }
                 catch (Exception e) {
                     throw new RuntimeException(e);

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonPageSourceWrapper.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonPageSourceWrapper.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import io.trino.spi.Page;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.metrics.Metrics;
+import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.deletionvectors.DeletionVector;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Wrap {@link ConnectorPageSource} using deletion vector.
+ */
+public class PaimonPageSourceWrapper
+        implements ConnectorPageSource
+{
+    private final ConnectorPageSource source;
+
+    private final Optional<DeletionVector> deletionVector;
+
+    public PaimonPageSourceWrapper(
+            ConnectorPageSource source, Optional<DeletionVector> deletionVector)
+    {
+        this.source = source;
+        this.deletionVector = deletionVector;
+    }
+
+    public static ConnectorPageSource wrap(
+            ConnectorPageSource connectorPageSource, Optional<DeletionVector> deletionVector)
+    {
+        return new PaimonPageSourceWrapper(connectorPageSource, deletionVector);
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return source.getCompletedBytes();
+    }
+
+    @Override
+    public OptionalLong getCompletedPositions()
+    {
+        return source.getCompletedPositions();
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return source.getReadTimeNanos();
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return source.isFinished();
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        int startPosition = (int) source.getCompletedPositions().orElseThrow();
+        Page next = source.getNextPage();
+        if (next == null) {
+            return next;
+        }
+
+        int pageCount = next.getPositionCount();
+
+        return deletionVector
+                .map(
+                        deletionVector ->
+                                convertToRetained(next, deletionVector, startPosition, pageCount))
+                .orElse(next);
+    }
+
+    @VisibleForTesting
+    Page convertToRetained(
+            Page page, DeletionVector deletionVector, int startPosition, int pageCount)
+    {
+        int[] retained = new int[pageCount];
+        int retainedLength = 0;
+        for (int pagePosition = 0; pagePosition < pageCount; pagePosition++) {
+            if (!deletionVector.isDeleted(startPosition + pagePosition)) {
+                retained[retainedLength++] = pagePosition;
+            }
+        }
+        if (retainedLength == pageCount) {
+            return page;
+        }
+
+        return page.getPositions(retained, 0, retainedLength);
+    }
+
+    @Override
+    public long getMemoryUsage()
+    {
+        return source.getMemoryUsage();
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        source.close();
+    }
+
+    @Override
+    public CompletableFuture<?> isBlocked()
+    {
+        return source.isBlocked();
+    }
+
+    @Override
+    public Metrics getMetrics()
+    {
+        return source.getMetrics();
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonPlugin.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonPlugin.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import io.trino.spi.Plugin;
+import io.trino.spi.connector.ConnectorFactory;
+
+import java.util.Collections;
+
+/**
+ * Trino {@link Plugin}.
+ */
+public class PaimonPlugin
+        implements Plugin
+{
+    @Override
+    public Iterable<ConnectorFactory> getConnectorFactories()
+    {
+        return Collections.singletonList(new PaimonConnectorFactory());
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonSessionProperties.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonSessionProperties.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.session.PropertyMetadata;
+
+import java.util.List;
+
+import static io.trino.spi.session.PropertyMetadata.doubleProperty;
+import static io.trino.spi.session.PropertyMetadata.longProperty;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static org.apache.paimon.CoreOptions.SCAN_SNAPSHOT_ID;
+import static org.apache.paimon.CoreOptions.SCAN_TIMESTAMP_MILLIS;
+
+/**
+ * Trino session properties.
+ */
+public class PaimonSessionProperties
+{
+    public static final String SCAN_TIMESTAMP = "scan_timestamp_millis";
+    public static final String SCAN_SNAPSHOT = "scan_snapshot_id";
+    public static final String MINIMUM_SPLIT_WEIGHT = "minimum_split_weight";
+    public static final String INSERT_EXISTING_PARTITIONS_BEHAVIOR =
+            "insert_existing_partitions_behavior";
+
+    private final List<PropertyMetadata<?>> sessionProperties;
+
+    public PaimonSessionProperties()
+    {
+        sessionProperties =
+                ImmutableList.<PropertyMetadata<?>>builder()
+                        .add(
+                                longProperty(
+                                        SCAN_TIMESTAMP,
+                                        SCAN_TIMESTAMP_MILLIS.description().toString(),
+                                        null,
+                                        true))
+                        .add(
+                                longProperty(
+                                        SCAN_SNAPSHOT,
+                                        SCAN_SNAPSHOT_ID.description().toString(),
+                                        null,
+                                        true))
+                        .add(
+                                doubleProperty(
+                                        MINIMUM_SPLIT_WEIGHT, "Minimum split weight", 0.05, false))
+                        .add(
+                                new PropertyMetadata<>(
+                                        INSERT_EXISTING_PARTITIONS_BEHAVIOR,
+                                        "Behavior on insert existing partitions",
+                                        VARCHAR,
+                                        InsertExistingPartitionsBehavior.class,
+                                        InsertExistingPartitionsBehavior.APPEND,
+                                        false,
+                                        value ->
+                                                InsertExistingPartitionsBehavior.valueOf(
+                                                        (String) value),
+                                        InsertExistingPartitionsBehavior::toString))
+                        .build();
+    }
+
+    public static Long getScanTimestampMillis(ConnectorSession session)
+    {
+        return session.getProperty(SCAN_TIMESTAMP, Long.class);
+    }
+
+    public static Long getScanSnapshotId(ConnectorSession session)
+    {
+        return session.getProperty(SCAN_SNAPSHOT, Long.class);
+    }
+
+    public static Double getMinimumSplitWeight(ConnectorSession session)
+    {
+        return session.getProperty(MINIMUM_SPLIT_WEIGHT, Double.class);
+    }
+
+    public static boolean enableInsertOverwrite(ConnectorSession session)
+    {
+        return session.getProperty(
+                INSERT_EXISTING_PARTITIONS_BEHAVIOR, InsertExistingPartitionsBehavior.class)
+                == InsertExistingPartitionsBehavior.OVERWRITE;
+    }
+
+    public List<PropertyMetadata<?>> getSessionProperties()
+    {
+        return sessionProperties;
+    }
+
+    /**
+     * Insert existing partitions behavior.
+     */
+    public enum InsertExistingPartitionsBehavior
+    {
+        ERROR,
+        APPEND,
+        OVERWRITE,
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonSplit.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonSplit.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.HostAddress;
+import io.trino.spi.SplitWeight;
+import io.trino.spi.connector.ConnectorSplit;
+import org.apache.paimon.table.source.Split;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Trino {@link ConnectorSplit}.
+ */
+public class PaimonSplit
+        implements ConnectorSplit
+{
+    private final String splitSerialized;
+
+    private final Double weight;
+
+    @JsonCreator
+    public PaimonSplit(
+            @JsonProperty("splitSerialized") String splitSerialized,
+            @JsonProperty("weight") Double weight)
+    {
+        this.splitSerialized = splitSerialized;
+        this.weight = weight;
+    }
+
+    public static PaimonSplit fromSplit(Split split, Double weight)
+    {
+        return new PaimonSplit(EncodingUtils.encodeObjectToString(split), weight);
+    }
+
+    public Split decodeSplit()
+    {
+        return EncodingUtils.decodeStringToObject(splitSerialized);
+    }
+
+    @JsonProperty
+    public String getSplitSerialized()
+    {
+        return splitSerialized;
+    }
+
+    @JsonProperty
+    public Double getWeight()
+    {
+        return weight;
+    }
+
+    @Override
+    public boolean isRemotelyAccessible()
+    {
+        return true;
+    }
+
+    @Override
+    public List<HostAddress> getAddresses()
+    {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public SplitWeight getSplitWeight()
+    {
+        return SplitWeight.fromProportion(weight);
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonSplitManager.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonSplitManager.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import com.google.inject.Inject;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplitManager;
+import io.trino.spi.connector.ConnectorSplitSource;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.Constraint;
+import io.trino.spi.connector.DynamicFilter;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.table.source.ReadBuilder;
+import org.apache.paimon.table.source.Split;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Trino {@link ConnectorSplitManager}.
+ */
+public class PaimonSplitManager
+        implements ConnectorSplitManager
+{
+    private final PaimonTransactionManager transactionManager;
+
+    @Inject
+    public PaimonSplitManager(PaimonTransactionManager transactionManager)
+    {
+        this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+    }
+
+    @Override
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transaction,
+            ConnectorSession session,
+            ConnectorTableHandle handle,
+            DynamicFilter dynamicFilter,
+            Constraint constraint)
+    {
+        // TODO dynamicFilter?
+        // TODO what is constraint?
+        PaimonMetadata metadata = transactionManager.get(transaction, session.getIdentity());
+        PaimonTableHandle tableHandle = (PaimonTableHandle) handle;
+        Table table = tableHandle.tableWithDynamicOptions(metadata.catalog(), session);
+        ReadBuilder readBuilder = table.newReadBuilder();
+        new PaimonFilterConverter(table.rowType())
+                .convert(tableHandle.getPredicate())
+                .ifPresent(readBuilder::withFilter);
+        tableHandle.getLimit().ifPresent(limit -> readBuilder.withLimit((int) limit));
+        List<Split> splits = readBuilder.dropStats().newScan().plan().splits();
+
+        long maxRowCount = splits.stream().mapToLong(Split::rowCount).max().orElse(0L);
+        double minimumSplitWeight = PaimonSessionProperties.getMinimumSplitWeight(session);
+        return new PaimonSplitSource(
+                splits.stream()
+                        .map(
+                                split ->
+                                        PaimonSplit.fromSplit(
+                                                split,
+                                                Math.min(
+                                                        Math.max(
+                                                                (double) split.rowCount()
+                                                                        / maxRowCount,
+                                                                minimumSplitWeight),
+                                                        1.0)))
+                        .collect(Collectors.toList()),
+                tableHandle.getLimit());
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonSplitSource.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonSplitSource.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.connector.ConnectorSplitSource;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.OptionalLong;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Trino {@link ConnectorSplitSource}.
+ */
+public class PaimonSplitSource
+        implements ConnectorSplitSource
+{
+    private final Queue<PaimonSplit> splits;
+    private final OptionalLong limit;
+    private long count;
+
+    public PaimonSplitSource(List<PaimonSplit> splits, OptionalLong limit)
+    {
+        this.splits = new LinkedList<>(splits);
+        this.limit = limit;
+    }
+
+    protected CompletableFuture<ConnectorSplitBatch> innerGetNextBatch(int maxSize)
+    {
+        List<ConnectorSplit> batch = new ArrayList<>();
+        for (int i = 0; i < maxSize; i++) {
+            PaimonSplit split = splits.poll();
+            if (split == null || (limit.isPresent() && count >= limit.getAsLong())) {
+                break;
+            }
+            count += split.decodeSplit().rowCount();
+            batch.add(split);
+        }
+        return CompletableFuture.completedFuture(new ConnectorSplitBatch(batch, isFinished()));
+    }
+
+    @Override
+    public CompletableFuture<ConnectorSplitBatch> getNextBatch(int maxSize)
+    {
+        return innerGetNextBatch(maxSize);
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public boolean isFinished()
+    {
+        return splits.isEmpty() || (limit.isPresent() && count >= limit.getAsLong());
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonTableHandle.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonTableHandle.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.plugin.paimon.catalog.PaimonTrinoCatalog;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorInsertTableHandle;
+import io.trino.spi.connector.ConnectorOutputTableHandle;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.predicate.TupleDomain;
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.types.DataField;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * Trino {@link ConnectorTableHandle}.
+ */
+public class PaimonTableHandle
+        implements ConnectorTableHandle, ConnectorInsertTableHandle, ConnectorOutputTableHandle
+{
+    private final String schemaName;
+    private final String tableName;
+    private final TupleDomain<PaimonColumnHandle> predicate;
+    private final Set<PaimonColumnHandle> projectedColumns;
+    private final OptionalLong limit;
+    private final Map<String, String> dynamicOptions;
+
+    private transient Table table;
+
+    public PaimonTableHandle(
+            String schemaName, String tableName, Map<String, String> dynamicOptions)
+    {
+        this(
+                schemaName,
+                tableName,
+                dynamicOptions,
+                TupleDomain.all(),
+                Collections.emptySet(),
+                OptionalLong.empty());
+    }
+
+    @JsonCreator
+    public PaimonTableHandle(
+            @JsonProperty("schemaName") String schemaName,
+            @JsonProperty("tableName") String tableName,
+            @JsonProperty("dynamicOptions") Map<String, String> dynamicOptions,
+            @JsonProperty("predicate") TupleDomain<PaimonColumnHandle> predicate,
+            @JsonProperty("projection") Set<PaimonColumnHandle> projectedColumns,
+            @JsonProperty("limit") OptionalLong limit)
+    {
+        this.schemaName = schemaName;
+        this.tableName = tableName;
+        this.dynamicOptions = dynamicOptions;
+        this.predicate = predicate;
+        this.projectedColumns = projectedColumns;
+        this.limit = limit;
+    }
+
+    @JsonProperty
+    public String getSchemaName()
+    {
+        return schemaName;
+    }
+
+    @JsonProperty
+    public String getTableName()
+    {
+        return tableName;
+    }
+
+    @JsonProperty
+    public Map<String, String> getDynamicOptions()
+    {
+        return dynamicOptions;
+    }
+
+    @JsonProperty
+    public TupleDomain<PaimonColumnHandle> getPredicate()
+    {
+        return predicate;
+    }
+
+    @JsonProperty
+    public Set<PaimonColumnHandle> getProjectedColumns()
+    {
+        return projectedColumns;
+    }
+
+    public OptionalLong getLimit()
+    {
+        return limit;
+    }
+
+    public Table tableWithDynamicOptions(PaimonTrinoCatalog catalog, ConnectorSession session)
+    {
+        Table paimonTable = table(session, catalog);
+
+        // see TrinoConnector.getSessionProperties
+        Map<String, String> dynamicOptions = new HashMap<>();
+        Long scanTimestampMills = PaimonSessionProperties.getScanTimestampMillis(session);
+        if (scanTimestampMills != null) {
+            dynamicOptions.put(
+                    CoreOptions.SCAN_TIMESTAMP_MILLIS.key(), scanTimestampMills.toString());
+        }
+        Long scanSnapshotId = PaimonSessionProperties.getScanSnapshotId(session);
+        if (scanSnapshotId != null) {
+            dynamicOptions.put(CoreOptions.SCAN_SNAPSHOT_ID.key(), scanSnapshotId.toString());
+        }
+
+        return !dynamicOptions.isEmpty() ? paimonTable.copy(dynamicOptions) : paimonTable;
+    }
+
+    public Table table(ConnectorSession session, PaimonTrinoCatalog catalog)
+    {
+        if (table != null) {
+            return table;
+        }
+        try {
+            table =
+                    catalog.getTable(session, Identifier.create(schemaName, tableName))
+                            .copy(dynamicOptions);
+        }
+        catch (Catalog.TableNotExistException e) {
+            throw new RuntimeException(e);
+        }
+        return table;
+    }
+
+    public ConnectorTableMetadata tableMetadata(ConnectorSession session, PaimonTrinoCatalog catalog)
+    {
+        return new ConnectorTableMetadata(
+                SchemaTableName.schemaTableName(schemaName, tableName),
+                columnMetadatas(session, catalog),
+                Collections.emptyMap(),
+                Optional.empty());
+    }
+
+    public List<ColumnMetadata> columnMetadatas(ConnectorSession session, PaimonTrinoCatalog catalog)
+    {
+        return table(session, catalog).rowType().getFields().stream()
+                .map(
+                        column ->
+                                ColumnMetadata.builder()
+                                        .setName(column.name())
+                                        .setType(PaimonTypeUtils.fromPaimonType(column.type()))
+                                        .setNullable(column.type().isNullable())
+                                        .setComment(Optional.ofNullable(column.description()))
+                                        .build())
+                .collect(Collectors.toList());
+    }
+
+    public PaimonColumnHandle columnHandle(
+            ConnectorSession session, PaimonTrinoCatalog catalog, String field)
+    {
+        Table paimonTable = table(session, catalog);
+        List<String> lowerCaseFieldNames = FieldNameUtils.fieldNames(paimonTable.rowType());
+        List<String> originFieldNames = paimonTable.rowType().getFieldNames();
+        int index = lowerCaseFieldNames.indexOf(field);
+        checkArgument(index != -1, "Cannot find field %s in schema %s", field, lowerCaseFieldNames);
+        DataField dataField = paimonTable.rowType().getFields().get(index);
+        return PaimonColumnHandle.of(originFieldNames.get(index), dataField.type(), dataField.id());
+    }
+
+    public PaimonTableHandle copy(TupleDomain<PaimonColumnHandle> filter)
+    {
+        return new PaimonTableHandle(
+                schemaName, tableName, dynamicOptions, filter, projectedColumns, limit);
+    }
+
+    public PaimonTableHandle copy(Set<PaimonColumnHandle> projectedColumns)
+    {
+        return new PaimonTableHandle(
+                schemaName, tableName, dynamicOptions, predicate, projectedColumns, limit);
+    }
+
+    public PaimonTableHandle copy(OptionalLong limit)
+    {
+        return new PaimonTableHandle(
+                schemaName, tableName, dynamicOptions, predicate, projectedColumns, limit);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PaimonTableHandle that = (PaimonTableHandle) o;
+        return Objects.equals(dynamicOptions, that.dynamicOptions)
+                && Objects.equals(schemaName, that.schemaName)
+                && Objects.equals(tableName, that.tableName)
+                && Objects.equals(predicate, that.predicate)
+                && Objects.equals(projectedColumns, that.projectedColumns);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(schemaName, tableName, predicate, projectedColumns, dynamicOptions);
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonTableOptionUtils.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonTableOptionUtils.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.options.ConfigOption;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.utils.StringUtils;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * options utils.
+ */
+public final class PaimonTableOptionUtils
+{
+    private PaimonTableOptionUtils() {}
+
+    public static void buildOptions(Schema.Builder builder, Map<String, Object> properties)
+    {
+        List<OptionInfo> optionInfos = PaimonTableOptionUtils.getOptionInfos();
+        for (OptionInfo optionInfo : optionInfos) {
+            if (properties.get(optionInfo.trinoOptionKey) != null
+                    && !StringUtils.isNullOrWhitespaceOnly(
+                    String.valueOf(properties.get(optionInfo.trinoOptionKey)))) {
+                builder.option(
+                        optionInfo.paimonOptionKey,
+                        String.valueOf(properties.get(optionInfo.trinoOptionKey)));
+            }
+        }
+    }
+
+    public static List<OptionInfo> getOptionInfos()
+    {
+        List<OptionInfo> optionInfos = new ArrayList<>();
+        List<OptionWithMetaInfo> optionWithMetaInfos = extractConfigOptions(CoreOptions.class);
+        String className = "";
+        for (OptionWithMetaInfo optionWithMetaInfo : optionWithMetaInfos) {
+            if (shouldSkip(optionWithMetaInfo.field.getName())) {
+                continue;
+            }
+
+            Type genericType = optionWithMetaInfo.field.getGenericType();
+            if (genericType instanceof ParameterizedType parameterizedType) {
+                Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
+                for (Type actualTypeArgument : actualTypeArguments) {
+                    if (actualTypeArgument instanceof Class<?>) {
+                        className = ((Class<?>) actualTypeArgument).getSimpleName();
+                    }
+                }
+            }
+
+            optionInfos.add(
+                    new OptionInfo(
+                            convertOptionKey(optionWithMetaInfo.option.key()),
+                            optionWithMetaInfo.option.key(),
+                            buildClass(className),
+                            isEnum(className),
+                            className));
+        }
+        return optionInfos;
+    }
+
+    private static boolean shouldSkip(String fieldName)
+    {
+        switch (fieldName) {
+            case "PRIMARY_KEY":
+            case "PARTITION":
+            case "FILE_COMPRESSION_PER_LEVEL":
+            case "STREAMING_COMPACT":
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static boolean isEnum(String className)
+    {
+        switch (className) {
+            case "StartupMode":
+            case "MergeEngine":
+            case "ChangelogProducer":
+            case "LogConsistency":
+            case "LogChangelogMode":
+            case "StreamingReadMode":
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static Class<?> buildClass(String className)
+    {
+        switch (className) {
+            case "MergeEngine":
+                return CoreOptions.MergeEngine.class;
+            case "ChangelogProducer":
+                return CoreOptions.ChangelogProducer.class;
+            case "StartupMode":
+                return CoreOptions.StartupMode.class;
+            case "LogConsistency":
+                return CoreOptions.LogConsistency.class;
+            case "LogChangelogMode":
+                return CoreOptions.LogChangelogMode.class;
+            case "StreamingReadMode":
+                return CoreOptions.StreamingReadMode.class;
+            default:
+                return null;
+        }
+    }
+
+    private static String convertOptionKey(String key)
+    {
+        String regex = "[.\\-]";
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(key);
+        return matcher.replaceAll("_");
+    }
+
+    private static List<OptionWithMetaInfo> extractConfigOptions(Class<?> clazz)
+    {
+        try {
+            List<OptionWithMetaInfo> configOptions = new ArrayList<>(8);
+            Field[] fields = clazz.getFields();
+            for (Field field : fields) {
+                if (isConfigOption(field)) {
+                    configOptions.add(
+                            new OptionWithMetaInfo((ConfigOption<?>) field.get(null), field));
+                }
+            }
+            return configOptions;
+        }
+        catch (Exception e) {
+            throw new RuntimeException(
+                    "Failed to extract config options from class " + clazz + '.', e);
+        }
+    }
+
+    private static boolean isConfigOption(Field field)
+    {
+        return field.getType().equals(ConfigOption.class);
+    }
+
+    static class OptionWithMetaInfo
+    {
+        final ConfigOption<?> option;
+        final Field field;
+
+        public OptionWithMetaInfo(ConfigOption<?> option, Field field)
+        {
+            this.option = option;
+            this.field = field;
+        }
+    }
+
+    static class OptionInfo<T>
+    {
+        String trinoOptionKey;
+        String paimonOptionKey;
+        Class<T> clazz;
+        boolean isEnum;
+        String type;
+
+        public OptionInfo(
+                String trinoOptionKey,
+                String paimonOptionKey,
+                Class<T> clazz,
+                boolean isEnum,
+                String type)
+        {
+            this.trinoOptionKey = trinoOptionKey;
+            this.paimonOptionKey = paimonOptionKey;
+            this.clazz = clazz;
+            this.isEnum = isEnum;
+            this.type = type;
+        }
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonTableOptions.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonTableOptions.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.session.PropertyMetadata;
+import io.trino.spi.type.ArrayType;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.trino.spi.session.PropertyMetadata.enumProperty;
+import static io.trino.spi.session.PropertyMetadata.stringProperty;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+
+/**
+ * Trino table options.
+ */
+public class PaimonTableOptions
+{
+    public static final String PRIMARY_KEY_IDENTIFIER = "primary_key";
+    public static final String PARTITIONED_BY_PROPERTY = "partitioned_by";
+
+    private final List<PropertyMetadata<?>> tableProperties;
+
+    public PaimonTableOptions()
+    {
+        ImmutableList.Builder<PropertyMetadata<?>> builder = ImmutableList.builder();
+        List<PaimonTableOptionUtils.OptionInfo> optionInfos = PaimonTableOptionUtils.getOptionInfos();
+        optionInfos.forEach(
+                item -> {
+                    if (item.isEnum) {
+                        builder.add(
+                                enumProperty(
+                                        item.trinoOptionKey, "option", item.clazz, null, false));
+                    }
+                    else {
+                        builder.add(stringProperty(item.trinoOptionKey, "option", null, false));
+                    }
+                });
+
+        builder.add(
+                new PropertyMetadata<>(
+                        PRIMARY_KEY_IDENTIFIER,
+                        "Primary keys for the table.",
+                        new ArrayType(VARCHAR),
+                        List.class,
+                        ImmutableList.of(),
+                        false,
+                        value -> (List<?>) value,
+                        value -> value));
+
+        builder.add(
+                new PropertyMetadata<>(
+                        PARTITIONED_BY_PROPERTY,
+                        "Partition keys for the table.",
+                        new ArrayType(VARCHAR),
+                        List.class,
+                        ImmutableList.of(),
+                        false,
+                        value -> (List<?>) value,
+                        value -> value));
+
+        tableProperties = builder.build();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static List<String> getPrimaryKeys(Map<String, Object> tableProperties)
+    {
+        List<String> primaryKeys = (List<String>) tableProperties.get(PRIMARY_KEY_IDENTIFIER);
+        return primaryKeys == null ? ImmutableList.of() : ImmutableList.copyOf(primaryKeys);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static List<String> getPartitionedKeys(Map<String, Object> tableProperties)
+    {
+        List<String> partitionedKeys = (List<String>) tableProperties.get(PARTITIONED_BY_PROPERTY);
+        return partitionedKeys == null ? ImmutableList.of() : ImmutableList.copyOf(partitionedKeys);
+    }
+
+    public List<PropertyMetadata<?>> getTableProperties()
+    {
+        return tableProperties;
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonTransactionManager.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonTransactionManager.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import com.google.inject.Inject;
+import io.trino.spi.classloader.ThreadContextClassLoader;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.security.ConnectorIdentity;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class PaimonTransactionManager
+{
+    private final PaimonMetadataFactory metadataFactory;
+    private final ClassLoader classLoader;
+    private final ConcurrentMap<ConnectorTransactionHandle, MemoizedMetadata> transactions =
+            new ConcurrentHashMap<>();
+
+    @Inject
+    public PaimonTransactionManager(PaimonMetadataFactory metadataFactory)
+    {
+        this(metadataFactory, Thread.currentThread().getContextClassLoader());
+    }
+
+    public PaimonTransactionManager(PaimonMetadataFactory metadataFactory, ClassLoader classLoader)
+    {
+        this.metadataFactory = requireNonNull(metadataFactory, "metadataFactory is null");
+        this.classLoader = requireNonNull(classLoader, "classLoader is null");
+    }
+
+    public void begin(ConnectorTransactionHandle transactionHandle)
+    {
+        MemoizedMetadata previousValue =
+                transactions.putIfAbsent(transactionHandle, new MemoizedMetadata());
+        checkState(previousValue == null);
+    }
+
+    public PaimonMetadata get(
+            ConnectorTransactionHandle transactionHandle, ConnectorIdentity identity)
+    {
+        return transactions.get(transactionHandle).get(identity);
+    }
+
+    public void commit(ConnectorTransactionHandle transaction)
+    {
+        MemoizedMetadata transactionalMetadata = transactions.remove(transaction);
+        checkArgument(transactionalMetadata != null, "no such transaction: %s", transaction);
+        transactionalMetadata
+                .optionalGet()
+                .ifPresent(PaimonMetadata::close);
+    }
+
+    public void rollback(ConnectorTransactionHandle transaction)
+    {
+        MemoizedMetadata transactionalMetadata = transactions.remove(transaction);
+        checkArgument(transactionalMetadata != null, "no such transaction: %s", transaction);
+        transactionalMetadata
+                .optionalGet()
+                .ifPresent(
+                        metadata -> {
+                            try (ThreadContextClassLoader _ =
+                                    new ThreadContextClassLoader(classLoader)) {
+                                metadata.rollback();
+                            }
+                        });
+    }
+
+    private class MemoizedMetadata
+    {
+        @GuardedBy("this")
+        private PaimonMetadata metadata;
+
+        public synchronized Optional<PaimonMetadata> optionalGet()
+        {
+            return Optional.ofNullable(metadata);
+        }
+
+        public synchronized PaimonMetadata get(ConnectorIdentity identity)
+        {
+            if (metadata == null) {
+                try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
+                    metadata = metadataFactory.create(identity);
+                }
+            }
+            return metadata;
+        }
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonTypeUtils.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/PaimonTypeUtils.java
@@ -1,0 +1,338 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import io.trino.spi.type.BigintType;
+import io.trino.spi.type.IntegerType;
+import io.trino.spi.type.RealType;
+import io.trino.spi.type.SmallintType;
+import io.trino.spi.type.TimestampWithTimeZoneType;
+import io.trino.spi.type.TinyintType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeOperators;
+import io.trino.spi.type.VarbinaryType;
+import io.trino.spi.type.VarcharType;
+import org.apache.paimon.types.ArrayType;
+import org.apache.paimon.types.BigIntType;
+import org.apache.paimon.types.BinaryType;
+import org.apache.paimon.types.BooleanType;
+import org.apache.paimon.types.CharType;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypeDefaultVisitor;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.DateType;
+import org.apache.paimon.types.DecimalType;
+import org.apache.paimon.types.DoubleType;
+import org.apache.paimon.types.FloatType;
+import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.LocalZonedTimestampType;
+import org.apache.paimon.types.MapType;
+import org.apache.paimon.types.MultisetType;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.types.SmallIntType;
+import org.apache.paimon.types.TimeType;
+import org.apache.paimon.types.TimestampType;
+import org.apache.paimon.types.TinyIntType;
+import org.apache.paimon.types.VarBinaryType;
+import org.apache.paimon.types.VarCharType;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+/**
+ * Trino type from Paimon Type.
+ */
+public final class PaimonTypeUtils
+{
+    private PaimonTypeUtils() {}
+
+    public static Type fromPaimonType(DataType type)
+    {
+        return type.accept(PaimonToTrinoTypeVistor.INSTANCE);
+    }
+
+    public static DataType toPaimonType(Type trinoType)
+    {
+        return TrinoToPaimonTypeVistor.INSTANCE.visit(trinoType);
+    }
+
+    private static class PaimonToTrinoTypeVistor
+            extends DataTypeDefaultVisitor<Type>
+    {
+        private static final PaimonToTrinoTypeVistor INSTANCE = new PaimonToTrinoTypeVistor();
+
+        @Override
+        public Type visit(CharType charType)
+        {
+            return io.trino.spi.type.CharType.createCharType(
+                    Math.min(io.trino.spi.type.CharType.MAX_LENGTH, charType.getLength()));
+        }
+
+        @Override
+        public Type visit(VarCharType varCharType)
+        {
+            if (varCharType.getLength() == VarCharType.MAX_LENGTH) {
+                return VarcharType.createUnboundedVarcharType();
+            }
+            return VarcharType.createVarcharType(
+                    varCharType.getLength());
+        }
+
+        @Override
+        public Type visit(BooleanType booleanType)
+        {
+            return io.trino.spi.type.BooleanType.BOOLEAN;
+        }
+
+        @Override
+        public Type visit(BinaryType binaryType)
+        {
+            return VarbinaryType.VARBINARY;
+        }
+
+        @Override
+        public Type visit(VarBinaryType varBinaryType)
+        {
+            return VarbinaryType.VARBINARY;
+        }
+
+        @Override
+        public Type visit(DecimalType decimalType)
+        {
+            return io.trino.spi.type.DecimalType.createDecimalType(
+                    decimalType.getPrecision(), decimalType.getScale());
+        }
+
+        @Override
+        public Type visit(TinyIntType tinyIntType)
+        {
+            return TinyintType.TINYINT;
+        }
+
+        @Override
+        public Type visit(SmallIntType smallIntType)
+        {
+            return SmallintType.SMALLINT;
+        }
+
+        @Override
+        public Type visit(IntType intType)
+        {
+            return IntegerType.INTEGER;
+        }
+
+        @Override
+        public Type visit(BigIntType bigIntType)
+        {
+            return BigintType.BIGINT;
+        }
+
+        @Override
+        public Type visit(FloatType floatType)
+        {
+            return RealType.REAL;
+        }
+
+        @Override
+        public Type visit(DoubleType doubleType)
+        {
+            return io.trino.spi.type.DoubleType.DOUBLE;
+        }
+
+        @Override
+        public Type visit(DateType dateType)
+        {
+            return io.trino.spi.type.DateType.DATE;
+        }
+
+        @Override
+        public Type visit(TimeType timeType)
+        {
+            return io.trino.spi.type.TimeType.TIME_MILLIS;
+        }
+
+        @Override
+        public Type visit(TimestampType timestampType)
+        {
+            int precision = timestampType.getPrecision();
+            if (precision <= 3) {
+                return io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+            }
+            else if (precision <= 6) {
+                return io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+            }
+            else if (precision <= 9) {
+                return io.trino.spi.type.TimestampType.TIMESTAMP_NANOS;
+            }
+            else {
+                return io.trino.spi.type.TimestampType.TIMESTAMP_PICOS;
+            }
+        }
+
+        @Override
+        public Type visit(LocalZonedTimestampType localZonedTimestampType)
+        {
+            int precision = localZonedTimestampType.getPrecision();
+            if (precision <= 3) {
+                return TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+            }
+            else if (precision <= 6) {
+                return TimestampWithTimeZoneType.TIMESTAMP_TZ_MICROS;
+            }
+            else if (precision <= 9) {
+                return TimestampWithTimeZoneType.TIMESTAMP_TZ_NANOS;
+            }
+            else {
+                return TimestampWithTimeZoneType.TIMESTAMP_TZ_PICOS;
+            }
+        }
+
+        @Override
+        public Type visit(ArrayType arrayType)
+        {
+            DataType elementType = arrayType.getElementType();
+            return new io.trino.spi.type.ArrayType(elementType.accept(this));
+        }
+
+        @Override
+        public Type visit(MultisetType multisetType)
+        {
+            return new MapType(multisetType.getElementType(), new IntType()).accept(this);
+        }
+
+        @Override
+        public Type visit(MapType mapType)
+        {
+            return new io.trino.spi.type.MapType(
+                    mapType.getKeyType().accept(this),
+                    mapType.getValueType().accept(this),
+                    new TypeOperators());
+        }
+
+        @Override
+        public Type visit(RowType rowType)
+        {
+            List<io.trino.spi.type.RowType.Field> fields =
+                    rowType.getFields().stream()
+                            .map(
+                                    field ->
+                                            io.trino.spi.type.RowType.field(
+                                                    field.name(), field.type().accept(this)))
+                            .collect(Collectors.toList());
+            return io.trino.spi.type.RowType.from(fields);
+        }
+
+        @Override
+        protected Type defaultMethod(DataType logicalType)
+        {
+            throw new UnsupportedOperationException("Unsupported type: " + logicalType);
+        }
+    }
+
+    private static class TrinoToPaimonTypeVistor
+    {
+        private static final TrinoToPaimonTypeVistor INSTANCE = new TrinoToPaimonTypeVistor();
+
+        private final AtomicInteger currentIndex = new AtomicInteger(0);
+
+        public DataType visit(Type trinoType)
+        {
+            switch (trinoType) {
+                case io.trino.spi.type.CharType charType -> {
+                    return DataTypes.CHAR(
+                            Math.min(
+                                    io.trino.spi.type.CharType.MAX_LENGTH,
+                                    charType.getLength()));
+                }
+                case VarcharType varcharType -> {
+                    Optional<Integer> length = varcharType.getLength();
+                    if (length.isPresent()) {
+                        return DataTypes.VARCHAR(
+                                Math.min(
+                                        VarcharType.MAX_LENGTH,
+                                        ((VarcharType) trinoType).getBoundedLength()));
+                    }
+                    return DataTypes.VARCHAR(VarcharType.MAX_LENGTH);
+                }
+                case io.trino.spi.type.BooleanType _ -> {
+                    return DataTypes.BOOLEAN();
+                }
+                case VarbinaryType _ -> {
+                    return DataTypes.VARBINARY(Integer.MAX_VALUE);
+                }
+                case io.trino.spi.type.DecimalType decimalType -> {
+                    return DataTypes.DECIMAL(
+                            decimalType.getPrecision(),
+                            decimalType.getScale());
+                }
+                case TinyintType _ -> {
+                    return DataTypes.TINYINT();
+                }
+                case SmallintType _ -> {
+                    return DataTypes.SMALLINT();
+                }
+                case IntegerType _ -> {
+                    return DataTypes.INT();
+                }
+                case BigintType _ -> {
+                    return DataTypes.BIGINT();
+                }
+                case RealType _ -> {
+                    return DataTypes.FLOAT();
+                }
+                case io.trino.spi.type.DoubleType _ -> {
+                    return DataTypes.DOUBLE();
+                }
+                case io.trino.spi.type.DateType _ -> {
+                    return DataTypes.DATE();
+                }
+                case io.trino.spi.type.TimeType _ -> {
+                    return new TimeType();
+                }
+                case io.trino.spi.type.TimestampType timestampType -> {
+                    int precision = timestampType.getPrecision();
+                    return new TimestampType(precision);
+                }
+                case TimestampWithTimeZoneType _ -> {
+                    return DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE();
+                }
+                case io.trino.spi.type.ArrayType arrayType -> {
+                    return DataTypes.ARRAY(
+                            visit(arrayType.getElementType()));
+                }
+                case io.trino.spi.type.MapType mapType -> {
+                    return DataTypes.MAP(
+                            visit(mapType.getKeyType()),
+                            visit(mapType.getValueType()));
+                }
+                case io.trino.spi.type.RowType rowType -> {
+                    List<DataField> dataFields =
+                            rowType.getFields().stream()
+                                    .map(
+                                            field ->
+                                                    new DataField(
+                                                            currentIndex.getAndIncrement(),
+                                                            field.getName().get(),
+                                                            visit(field.getType())))
+                                    .collect(Collectors.toList());
+                    return new RowType(true, dataFields);
+                }
+                case null, default -> throw new UnsupportedOperationException("Unsupported type: " + trinoType);
+            }
+        }
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/catalog/PaimonTrinoCatalog.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/catalog/PaimonTrinoCatalog.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon.catalog;
+
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.plugin.paimon.PaimonConfig;
+import io.trino.plugin.paimon.fileio.PaimonFileIO;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.security.ConnectorIdentity;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.Database;
+import org.apache.paimon.catalog.FileSystemCatalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.schema.SchemaChange;
+import org.apache.paimon.table.Table;
+
+import java.io.IOException;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * Trino catalog, use it after set session.
+ */
+public class PaimonTrinoCatalog
+{
+    private final PaimonConfig config;
+
+    private final TrinoFileSystemFactory trinoFileSystemFactory;
+
+    private Catalog current;
+
+    private PaimonFileIO paimonFileIO;
+
+    public PaimonTrinoCatalog(
+            PaimonConfig config,
+            TrinoFileSystemFactory trinoFileSystemFactory,
+            ConnectorIdentity identity)
+    {
+        this.config = config;
+        this.trinoFileSystemFactory = trinoFileSystemFactory;
+        init(identity);
+    }
+
+    public void init(ConnectorIdentity identity)
+    {
+        paimonFileIO = new PaimonFileIO(trinoFileSystemFactory, identity, null);
+        switch (config.getCatalogType()) {
+            case FILESYSTEM:
+                checkArgument(config.getWarehouse() != null, "Warehouse is required for filesystem catalog");
+                current = new FileSystemCatalog(paimonFileIO, new Path(config.getWarehouse()), config.toOptions());
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported catalog type: " + config.getCatalogType());
+        }
+    }
+
+    public boolean exists(ConnectorSession session, Path path)
+            throws IOException
+    {
+        paimonFileIO.setConnectorSession(session);
+        return paimonFileIO.exists(path);
+    }
+
+    public List<String> listDatabases(ConnectorSession session)
+    {
+        paimonFileIO.setConnectorSession(session);
+        return current.listDatabases();
+    }
+
+    public Database getDatabase(ConnectorSession session, String name)
+            throws Catalog.DatabaseNotExistException
+    {
+        paimonFileIO.setConnectorSession(session);
+        return current.getDatabase(name);
+    }
+
+    public void dropDatabase(ConnectorSession session, String s, boolean b, boolean b1)
+            throws Catalog.DatabaseNotExistException, Catalog.DatabaseNotEmptyException
+    {
+        paimonFileIO.setConnectorSession(session);
+        current.dropDatabase(s, b, b1);
+    }
+
+    public Table getTable(ConnectorSession session, Identifier identifier)
+            throws Catalog.TableNotExistException
+    {
+        paimonFileIO.setConnectorSession(session);
+        return current.getTable(identifier);
+    }
+
+    public List<String> listTables(ConnectorSession session, String s)
+            throws Catalog.DatabaseNotExistException
+    {
+        paimonFileIO.setConnectorSession(session);
+        return current.listTables(s);
+    }
+
+    public void dropTable(ConnectorSession session, Identifier identifier, boolean b)
+            throws Catalog.TableNotExistException
+    {
+        paimonFileIO.setConnectorSession(session);
+        current.dropTable(identifier, b);
+    }
+
+    public void createTable(
+            ConnectorSession session, Identifier identifier, Schema schema, boolean ignoreIfExists)
+            throws Catalog.TableAlreadyExistException, Catalog.DatabaseNotExistException
+    {
+        paimonFileIO.setConnectorSession(session);
+        current.createTable(identifier, schema, ignoreIfExists);
+    }
+
+    public void renameTable(
+            ConnectorSession session,
+            Identifier fromTable,
+            Identifier toTable,
+            boolean ignoreIfExistsb)
+            throws Catalog.TableNotExistException, Catalog.TableAlreadyExistException
+    {
+        paimonFileIO.setConnectorSession(session);
+        current.renameTable(fromTable, toTable, ignoreIfExistsb);
+    }
+
+    public void alterTable(
+            ConnectorSession session,
+            Identifier identifier,
+            List<SchemaChange> list,
+            boolean ignoreIfExists)
+            throws Catalog.TableNotExistException,
+            Catalog.ColumnAlreadyExistException,
+            Catalog.ColumnNotExistException
+    {
+        paimonFileIO.setConnectorSession(session);
+        current.alterTable(identifier, list, ignoreIfExists);
+    }
+
+    public void close()
+            throws Exception
+    {
+        if (current != null) {
+            current.close();
+        }
+    }
+
+    public void createDatabase(ConnectorSession session, String name, boolean ignoreIfExists)
+            throws Catalog.DatabaseAlreadyExistException
+    {
+        paimonFileIO.setConnectorSession(session);
+        current.createDatabase(name, ignoreIfExists);
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/catalog/PaimonTrinoCatalogFactory.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/catalog/PaimonTrinoCatalogFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon.catalog;
+
+import com.google.inject.Inject;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.plugin.paimon.PaimonConfig;
+import io.trino.spi.security.ConnectorIdentity;
+
+public class PaimonTrinoCatalogFactory
+{
+    private final PaimonConfig config;
+
+    private final TrinoFileSystemFactory trinoFileSystemFactory;
+
+    @Inject
+    public PaimonTrinoCatalogFactory(
+            PaimonConfig config,
+            TrinoFileSystemFactory trinoFileSystemFactory)
+    {
+        this.config = config;
+        this.trinoFileSystemFactory = trinoFileSystemFactory;
+    }
+
+    public PaimonTrinoCatalog create(ConnectorIdentity identity)
+    {
+        return new PaimonTrinoCatalog(config, trinoFileSystemFactory, identity);
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/fileio/PaimonDirectoryFileStatus.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/fileio/PaimonDirectoryFileStatus.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon.fileio;
+
+import org.apache.paimon.fs.FileStatus;
+import org.apache.paimon.fs.Path;
+
+/**
+ * File status for directory.
+ */
+public class PaimonDirectoryFileStatus
+        implements FileStatus
+{
+    private final Path path;
+
+    public PaimonDirectoryFileStatus(Path path)
+    {
+        this.path = path;
+    }
+
+    @Override
+    public long getLen()
+    {
+        // can't get len by trino file system
+        return -1;
+    }
+
+    @Override
+    public boolean isDir()
+    {
+        return true;
+    }
+
+    @Override
+    public Path getPath()
+    {
+        return path;
+    }
+
+    @Override
+    public long getModificationTime()
+    {
+        // can't get modification time by trino file system
+        return -1;
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/fileio/PaimonFileIO.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/fileio/PaimonFileIO.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon.fileio;
+
+import io.trino.filesystem.FileEntry;
+import io.trino.filesystem.FileIterator;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoOutputFile;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.security.ConnectorIdentity;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.FileStatus;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.fs.SeekableInputStream;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Trino file io for paimon.
+ */
+public class PaimonFileIO
+        implements FileIO
+{
+    private final TrinoFileSystemFactory trinoFileSystemFactory;
+    private final boolean objectStore;
+
+    private TrinoFileSystem trinoFileSystem;
+    private ConnectorSession session;
+
+    public PaimonFileIO(
+            TrinoFileSystemFactory trinoFileSystemFactory,
+            ConnectorIdentity connectorIdentity,
+            @Nullable Path path)
+    {
+        this.trinoFileSystemFactory = trinoFileSystemFactory;
+        this.trinoFileSystem = trinoFileSystemFactory.create(connectorIdentity);
+        this.objectStore = path == null || checkObjectStore(path.toUri().getScheme());
+    }
+
+    private static boolean checkObjectStore(String scheme)
+    {
+        scheme = scheme.toLowerCase(Locale.getDefault());
+        if (!scheme.startsWith("s3")
+                && !scheme.startsWith("emr")
+                && !scheme.startsWith("oss")
+                && !scheme.startsWith("wasb")) {
+            return scheme.startsWith("http") || scheme.startsWith("ftp");
+        }
+        else {
+            return true;
+        }
+    }
+
+    public void setConnectorSession(ConnectorSession session)
+    {
+        if (!session.equals(this.session)) {
+            this.session = session;
+            trinoFileSystem = trinoFileSystemFactory.create(session);
+        }
+    }
+
+    @Override
+    public boolean isObjectStore()
+    {
+        return objectStore;
+    }
+
+    @Override
+    public void configure(CatalogContext catalogContext) {}
+
+    @Override
+    public SeekableInputStream newInputStream(Path path)
+            throws IOException
+    {
+        return new PaimonInputStreamWrapper(
+                trinoFileSystem.newInputFile(Location.of(path.toString())).newStream());
+    }
+
+    @Override
+    public PositionOutputStream newOutputStream(Path path, boolean overwrite)
+            throws IOException
+    {
+        TrinoOutputFile trinoOutputFile =
+                trinoFileSystem.newOutputFile(Location.of(path.toString()));
+
+        try {
+            return new PositionOutputStreamWrapper(trinoOutputFile.create());
+        }
+        catch (FileAlreadyExistsException e) {
+            if (overwrite) {
+                trinoFileSystem.deleteFile(Location.of(path.toString()));
+                return new PositionOutputStreamWrapper(trinoOutputFile.create());
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    public FileStatus getFileStatus(Path path)
+            throws IOException
+    {
+        return status(path);
+    }
+
+    private FileStatus status(Path path)
+            throws IOException
+    {
+        if (trinoFileSystem.directoryExists(Location.of(path.toString())).orElse(false)) {
+            return new PaimonDirectoryFileStatus(path);
+        }
+        else {
+            TrinoInputFile trinoInputFile =
+                    trinoFileSystem.newInputFile(Location.of(path.toString()));
+            return new PaimonFileStatus(
+                    trinoInputFile.length(), path, trinoInputFile.lastModified().getEpochSecond());
+        }
+    }
+
+    @Override
+    public FileStatus[] listStatus(Path path)
+            throws IOException
+    {
+        List<FileStatus> fileStatusList = new ArrayList<>();
+        Location location = Location.of(path.toString());
+        if (trinoFileSystem.directoryExists(location).orElse(false)) {
+            FileIterator fileIterator = trinoFileSystem.listFiles(location);
+            while (fileIterator.hasNext()) {
+                FileEntry fileEntry = fileIterator.next();
+                fileStatusList.add(
+                        new PaimonFileStatus(
+                                fileEntry.length(),
+                                new Path(fileEntry.location().toString()),
+                                fileEntry.lastModified().getEpochSecond()));
+            }
+            trinoFileSystem
+                    .listDirectories(Location.of(path.toString()))
+                    .forEach(
+                            l ->
+                                    fileStatusList.add(
+                                            new PaimonDirectoryFileStatus(new Path(l.toString()))));
+        }
+        return fileStatusList.toArray(new FileStatus[0]);
+    }
+
+    @Override
+    public FileStatus[] listDirectories(Path path)
+            throws IOException
+    {
+        return trinoFileSystem.listDirectories(Location.of(path.toString())).stream()
+                .map(l -> new PaimonDirectoryFileStatus(new Path(l.toString())))
+                .toArray(FileStatus[]::new);
+    }
+
+    @Override
+    public boolean exists(Path path)
+            throws IOException
+    {
+        return trinoFileSystem.directoryExists(Location.of(path.toString())).orElse(false)
+                || existFile(Location.of(path.toString()));
+    }
+
+    private boolean existFile(Location location)
+            throws IOException
+    {
+        try {
+            return trinoFileSystem.newInputFile(location).exists();
+        }
+        catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean delete(Path path, boolean recursive)
+            throws IOException
+    {
+        Location location = Location.of(path.toString());
+        if (trinoFileSystem.directoryExists(location).orElse(false)) {
+            if (!recursive) {
+                if (trinoFileSystem.listFiles(location).hasNext()) {
+                    throw new IOException("Directory " + location + " is not empty");
+                }
+            }
+            trinoFileSystem.deleteDirectory(location);
+            return true;
+        }
+        else if (existFile(location)) {
+            trinoFileSystem.deleteFile(location);
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean mkdirs(Path path)
+            throws IOException
+    {
+        trinoFileSystem.createDirectory(Location.of(path.toString()));
+        return true;
+    }
+
+    @Override
+    public boolean rename(Path source, Path target)
+            throws IOException
+    {
+        Location sourceLocation = Location.of(source.toString());
+        Location targetLocation = Location.of(target.toString());
+        if (trinoFileSystem.directoryExists(sourceLocation).orElse(false)) {
+            trinoFileSystem.renameDirectory(sourceLocation, targetLocation);
+        }
+        else {
+            trinoFileSystem.renameFile(sourceLocation, targetLocation);
+        }
+        return true;
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/fileio/PaimonFileStatus.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/fileio/PaimonFileStatus.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon.fileio;
+
+import org.apache.paimon.fs.FileStatus;
+import org.apache.paimon.fs.Path;
+
+/**
+ * File status for trino file.
+ */
+public class PaimonFileStatus
+        implements FileStatus
+{
+    private final long len;
+    private final Path path;
+    private final long modificationTmie;
+
+    public PaimonFileStatus(long len, Path path, long modificationTmie)
+    {
+        this.len = len;
+        this.path = path;
+        this.modificationTmie = modificationTmie;
+    }
+
+    @Override
+    public long getLen()
+    {
+        return len;
+    }
+
+    @Override
+    public boolean isDir()
+    {
+        return false;
+    }
+
+    @Override
+    public Path getPath()
+    {
+        return path;
+    }
+
+    @Override
+    public long getModificationTime()
+    {
+        return modificationTmie;
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/fileio/PaimonInputStreamWrapper.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/fileio/PaimonInputStreamWrapper.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon.fileio;
+
+import io.trino.filesystem.TrinoInputStream;
+import org.apache.paimon.fs.SeekableInputStream;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Trino input stream wrapper for paimon.
+ */
+public class PaimonInputStreamWrapper
+        extends SeekableInputStream
+{
+    private final TrinoInputStream trinoInputStream;
+
+    public PaimonInputStreamWrapper(TrinoInputStream trinoInputStream)
+    {
+        this.trinoInputStream = requireNonNull(trinoInputStream, "trino input stream is null");
+    }
+
+    @Override
+    public void seek(long l)
+            throws IOException
+    {
+        trinoInputStream.seek(l);
+    }
+
+    @Override
+    public long getPos()
+            throws IOException
+    {
+        return trinoInputStream.getPosition();
+    }
+
+    @Override
+    public int read()
+            throws IOException
+    {
+        return trinoInputStream.read();
+    }
+
+    @Override
+    public int read(byte[] bytes, int off, int len)
+            throws IOException
+    {
+        return trinoInputStream.read(bytes, off, len);
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        trinoInputStream.close();
+    }
+
+    @Override
+    public byte[] readNBytes(int len)
+            throws IOException
+    {
+        return trinoInputStream.readNBytes(len);
+    }
+
+    @Override
+    public int readNBytes(byte[] b, int off, int len)
+            throws IOException
+    {
+        return trinoInputStream.readNBytes(b, off, len);
+    }
+
+    @Override
+    public int read(byte[] b)
+            throws IOException
+    {
+        return trinoInputStream.read(b);
+    }
+
+    @Override
+    public long skip(long n)
+            throws IOException
+    {
+        return trinoInputStream.skip(n);
+    }
+
+    @Override
+    public void skipNBytes(long n)
+            throws IOException
+    {
+        trinoInputStream.skipNBytes(n);
+    }
+
+    @Override
+    public byte[] readAllBytes()
+            throws IOException
+    {
+        return trinoInputStream.readAllBytes();
+    }
+
+    @Override
+    public int available()
+            throws IOException
+    {
+        return trinoInputStream.available();
+    }
+
+    @Override
+    public void mark(int readlimit)
+    {
+        trinoInputStream.mark(readlimit);
+    }
+
+    @Override
+    public void reset()
+            throws IOException
+    {
+        trinoInputStream.reset();
+    }
+
+    @Override
+    public boolean markSupported()
+    {
+        return trinoInputStream.markSupported();
+    }
+
+    @Override
+    public long transferTo(OutputStream out)
+            throws IOException
+    {
+        return trinoInputStream.transferTo(out);
+    }
+}

--- a/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/fileio/PositionOutputStreamWrapper.java
+++ b/plugin/trino-paimon/src/main/java/io/trino/plugin/paimon/fileio/PositionOutputStreamWrapper.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon.fileio;
+
+import org.apache.paimon.fs.PositionOutputStream;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Wrapper of {@link OutputStream}.
+ */
+public class PositionOutputStreamWrapper
+        extends PositionOutputStream
+{
+    private final OutputStream outputStream;
+
+    private long position;
+
+    public PositionOutputStreamWrapper(OutputStream outputStream)
+    {
+        this(outputStream, 0);
+    }
+
+    public PositionOutputStreamWrapper(OutputStream outputStream, long startPosition)
+    {
+        this.outputStream = outputStream;
+        this.position = startPosition;
+    }
+
+    @Override
+    public long getPos()
+    {
+        return position;
+    }
+
+    @Override
+    public void write(int b)
+            throws IOException
+    {
+        position++;
+        outputStream.write(b);
+    }
+
+    @Override
+    public void write(byte[] bytes)
+            throws IOException
+    {
+        position += bytes.length;
+        outputStream.write(bytes);
+    }
+
+    @Override
+    public void write(byte[] bytes, int off, int len)
+            throws IOException
+    {
+        position += len;
+        outputStream.write(bytes, off, len);
+    }
+
+    @Override
+    public void flush()
+            throws IOException
+    {
+        outputStream.flush();
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        outputStream.close();
+    }
+}

--- a/plugin/trino-paimon/src/test/java/io/trino/plugin/paimon/PaimonTestUtils.java
+++ b/plugin/trino-paimon/src/test/java/io/trino/plugin/paimon/PaimonTestUtils.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.CatalogFactory;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.types.BigIntType;
+import org.apache.paimon.types.CharType;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.RowKind;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.types.VarCharType;
+import org.apache.paimon.utils.InstantiationUtil;
+
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.apache.paimon.data.BinaryString.fromString;
+
+/**
+ * presto test util.
+ */
+final class PaimonTestUtils
+{
+    private PaimonTestUtils() {}
+
+    public static byte[] getSerializedTable()
+            throws Exception
+    {
+        String warehouse =
+                Files.createTempDirectory(UUID.randomUUID().toString()).toUri().toString();
+        Path tablePath = new Path(warehouse, "test.db/user");
+        SimpleTableTestHelper testHelper = createTestHelper(tablePath);
+        testHelper.write(GenericRow.of(1, 2L, fromString("1"), fromString("1")));
+        testHelper.write(GenericRow.of(3, 4L, fromString("2"), fromString("2")));
+        testHelper.write(GenericRow.of(5, 6L, fromString("3"), fromString("3")));
+        testHelper.write(
+                GenericRow.ofKind(RowKind.DELETE, 3, 4L, fromString("2"), fromString("2")));
+        testHelper.commit();
+        Map<String, String> config = new HashMap<>();
+        config.put("warehouse", warehouse);
+        Catalog catalog =
+                CatalogFactory.createCatalog(CatalogContext.create(Options.fromMap(config)));
+        Identifier tablePath2 = new Identifier("test", "user");
+        return InstantiationUtil.serializeObject(catalog.getTable(tablePath2));
+    }
+
+    private static SimpleTableTestHelper createTestHelper(Path tablePath)
+            throws Exception
+    {
+        RowType rowType =
+                new RowType(
+                        Arrays.asList(
+                                new DataField(0, "a", new IntType()),
+                                new DataField(1, "b", new BigIntType()),
+                                // test field name has upper case
+                                new DataField(2, "aCa", new VarCharType()),
+                                new DataField(3, "d", new CharType(1))));
+        return new SimpleTableTestHelper(tablePath, rowType);
+    }
+}

--- a/plugin/trino-paimon/src/test/java/io/trino/plugin/paimon/SimpleTableTestHelper.java
+++ b/plugin/trino-paimon/src/test/java/io/trino/plugin/paimon/SimpleTableTestHelper.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.FileStoreTableFactory;
+import org.apache.paimon.table.sink.InnerTableCommit;
+import org.apache.paimon.table.sink.InnerTableWrite;
+import org.apache.paimon.types.RowType;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A simple table test helper to write and commit.
+ */
+final class SimpleTableTestHelper
+{
+    private final InnerTableWrite writer;
+    private final InnerTableCommit commit;
+    private final FileStoreTable table;
+
+    public SimpleTableTestHelper(Path path, RowType rowType)
+            throws Exception
+    {
+        Map<String, String> map = new HashMap<>();
+        map.put("bucket", "1");
+        new SchemaManager(LocalFileIO.create(), path)
+                .createTable(
+                        new Schema(
+                                rowType.getFields(),
+                                Collections.emptyList(),
+                                Collections.singletonList("a"),
+                                map,
+                                ""));
+        FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), path);
+        this.table = table;
+        String user = "user";
+        this.writer = table.newWrite(user);
+        this.commit = table.newCommit(user);
+    }
+
+    public void write(InternalRow row)
+            throws Exception
+    {
+        writer.write(row);
+    }
+
+    public void commit()
+            throws Exception
+    {
+        commit.commit(0, writer.prepareCommit(true, 0));
+    }
+
+    public void createTag(String name)
+    {
+        table.createTag(name);
+    }
+}

--- a/plugin/trino-paimon/src/test/java/io/trino/plugin/paimon/TestPaimonColumnHandle.java
+++ b/plugin/trino-paimon/src/test/java/io/trino/plugin/paimon/TestPaimonColumnHandle.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.json.JsonCodec;
+import io.airlift.json.JsonCodecFactory;
+import io.airlift.json.ObjectMapperProvider;
+import io.trino.spi.type.Type;
+import io.trino.type.TypeDeserializer;
+import org.apache.paimon.types.DataTypes;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for {@link PaimonColumnHandle}.
+ */
+final class TestPaimonColumnHandle
+{
+    @Test
+    void testTrinoColumnHandle()
+    {
+        PaimonColumnHandle expected = PaimonColumnHandle.of("name", DataTypes.STRING(), 0);
+        testRoundTrip(expected);
+    }
+
+    private void testRoundTrip(PaimonColumnHandle expected)
+    {
+        ObjectMapperProvider objectMapperProvider = new ObjectMapperProvider();
+        objectMapperProvider.setJsonDeserializers(
+                ImmutableMap.of(Type.class, new TypeDeserializer(TESTING_TYPE_MANAGER)));
+        JsonCodec<PaimonColumnHandle> codec =
+                new JsonCodecFactory(objectMapperProvider).jsonCodec(PaimonColumnHandle.class);
+
+        String json = codec.toJson(expected);
+        PaimonColumnHandle actual = codec.fromJson(json);
+
+        assertThat(actual).isEqualTo(expected);
+        assertThat(actual.getColumnName()).isEqualTo(expected.getColumnName());
+        assertThat(actual.getTypeString()).isEqualTo(expected.getTypeString());
+        assertThat(actual.getTrinoType()).isEqualTo(expected.getTrinoType());
+    }
+}

--- a/plugin/trino-paimon/src/test/java/io/trino/plugin/paimon/TestPaimonConnectorFactory.java
+++ b/plugin/trino-paimon/src/test/java/io/trino/plugin/paimon/TestPaimonConnectorFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorFactory;
+import io.trino.testing.TestingConnectorContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for {@link PaimonConnectorFactory}.
+ */
+final class TestPaimonConnectorFactory
+{
+    @TempDir java.nio.file.Path tempFile;
+
+    @Test
+    void testCreateConnector()
+    {
+        Map<String, String> config = ImmutableMap.of("paimon.warehouse", tempFile.toString(), "paimon.catalog.type", "filesystem");
+        ConnectorFactory factory = new PaimonConnectorFactory();
+        Connector connector = factory.create("paimon", config, new TestingConnectorContext());
+        assertThat(connector).isNotNull();
+    }
+}

--- a/plugin/trino-paimon/src/test/java/io/trino/plugin/paimon/TestPaimonFilterConverter.java
+++ b/plugin/trino-paimon/src/test/java/io/trino/plugin/paimon/TestPaimonFilterConverter.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slices;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.SmallintType;
+import io.trino.spi.type.TimeZoneKey;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.TinyintType;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.RowType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.LongTimestampWithTimeZone.fromEpochMillisAndFraction;
+import static io.trino.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for {@link PaimonFilterConverter}.
+ */
+public class TestPaimonFilterConverter
+{
+    @Test
+    public void testAll()
+    {
+        RowType rowType =
+                new RowType(Collections.singletonList(new DataField(0, "id", new IntType())));
+        PaimonFilterConverter converter = new PaimonFilterConverter(rowType);
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+
+        PaimonColumnHandle idColumn = PaimonColumnHandle.of("id", new IntType(), 0);
+        TupleDomain<PaimonColumnHandle> isNull =
+                TupleDomain.withColumnDomains(ImmutableMap.of(idColumn, Domain.onlyNull(INTEGER)));
+        Predicate expectedIsNull = builder.isNull(0);
+        Predicate actualIsNull = converter.convert(isNull).get();
+        assertThat(actualIsNull).isEqualTo(expectedIsNull);
+
+        TupleDomain<PaimonColumnHandle> isNotNull =
+                TupleDomain.withColumnDomains(ImmutableMap.of(idColumn, Domain.notNull(INTEGER)));
+        Predicate expectedIsNotNull = builder.isNotNull(0);
+        Predicate actualIsNotNull = converter.convert(isNotNull).get();
+        assertThat(actualIsNotNull).isEqualTo(expectedIsNotNull);
+
+        TupleDomain<PaimonColumnHandle> lt =
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                idColumn,
+                                Domain.create(
+                                        ValueSet.ofRanges(Range.lessThan(INTEGER, 1L)), false)));
+        Predicate expectedLt = builder.lessThan(0, 1);
+        Predicate actualLt = converter.convert(lt).get();
+        assertThat(actualLt).isEqualTo(expectedLt);
+
+        TupleDomain<PaimonColumnHandle> ltEq =
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                idColumn,
+                                Domain.create(
+                                        ValueSet.ofRanges(Range.lessThanOrEqual(INTEGER, 1L)),
+                                        false)));
+        Predicate expectedLtEq = builder.lessOrEqual(0, 1);
+        Predicate actualLtEq = converter.convert(ltEq).get();
+        assertThat(actualLtEq).isEqualTo(expectedLtEq);
+
+        TupleDomain<PaimonColumnHandle> gt =
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                idColumn,
+                                Domain.create(
+                                        ValueSet.ofRanges(Range.greaterThan(INTEGER, 1L)), false)));
+        Predicate expectedGt = builder.greaterThan(0, 1);
+        Predicate actualGt = converter.convert(gt).get();
+        assertThat(actualGt).isEqualTo(expectedGt);
+
+        TupleDomain<PaimonColumnHandle> gtEq =
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                idColumn,
+                                Domain.create(
+                                        ValueSet.ofRanges(Range.greaterThanOrEqual(INTEGER, 1L)),
+                                        false)));
+        Predicate expectedGtEq = builder.greaterOrEqual(0, 1);
+        Predicate actualGtEq = converter.convert(gtEq).get();
+        assertThat(actualGtEq).isEqualTo(expectedGtEq);
+
+        TupleDomain<PaimonColumnHandle> eq =
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(idColumn, Domain.singleValue(INTEGER, 1L)));
+        Predicate expectedEq = builder.equal(0, 1);
+        Predicate actualEq = converter.convert(eq).get();
+        assertThat(actualEq).isEqualTo(expectedEq);
+
+        TupleDomain<PaimonColumnHandle> in =
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                idColumn,
+                                Domain.multipleValues(INTEGER, Arrays.asList(1L, 2L, 3L))));
+        Predicate expectedIn = builder.in(0, Arrays.asList(1, 2, 3));
+        Predicate actualIn = converter.convert(in).get();
+        assertThat(actualIn).isEqualTo(expectedIn);
+    }
+
+    @Test
+    public void testCharType()
+    {
+        RowType rowType =
+                new RowType(
+                        Collections.singletonList(
+                                new DataField(
+                                        0, "date", new org.apache.paimon.types.CharType(10))));
+        PaimonFilterConverter converter = new PaimonFilterConverter(rowType);
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        PaimonColumnHandle idColumn =
+                PaimonColumnHandle.of("date", new org.apache.paimon.types.CharType(10), 0);
+        TupleDomain<PaimonColumnHandle> eq =
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                idColumn,
+                                Domain.singleValue(
+                                        CharType.createCharType(10),
+                                        Slices.utf8Slice("2020-11-11"))));
+        Predicate expectedEqq = builder.equal(0, BinaryString.fromString("2020-11-11"));
+        Predicate actualEqq = converter.convert(eq).get();
+        assertThat(actualEqq).isEqualTo(expectedEqq);
+    }
+
+    @Test
+    public void testTimeStamp()
+    {
+        RowType rowType =
+                new RowType(
+                        Collections.singletonList(
+                                new DataField(
+                                        0, "ts", new org.apache.paimon.types.TimestampType(3))));
+        PaimonFilterConverter converter = new PaimonFilterConverter(rowType);
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        PaimonColumnHandle tsColumn =
+                PaimonColumnHandle.of("ts", new org.apache.paimon.types.TimestampType(3), 0);
+        TupleDomain<PaimonColumnHandle> eq =
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                tsColumn,
+                                Domain.singleValue(
+                                        TimestampType.createTimestampType(3), 1695645403000L)));
+        Predicate expectedEqq = builder.equal(0, Timestamp.fromEpochMillis(1695645403000L / 1000));
+        Predicate actualEqq = converter.convert(eq).get();
+        assertThat(actualEqq).isEqualTo(expectedEqq);
+    }
+
+    @Test
+    public void testTimeStampWithTimeZone()
+    {
+        RowType rowType =
+                new RowType(
+                        Collections.singletonList(
+                                new DataField(
+                                        0,
+                                        "ts",
+                                        new org.apache.paimon.types.LocalZonedTimestampType(3))));
+        PaimonFilterConverter converter = new PaimonFilterConverter(rowType);
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        PaimonColumnHandle tsColumn =
+                PaimonColumnHandle.of(
+                        "ts", new org.apache.paimon.types.LocalZonedTimestampType(3), 0);
+        TupleDomain<PaimonColumnHandle> eq =
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                tsColumn,
+                                Domain.singleValue(
+                                        createTimestampWithTimeZoneType(6),
+                                        fromEpochMillisAndFraction(
+                                                1695645403000L, 0, TimeZoneKey.UTC_KEY))));
+        Predicate expectedEqq =
+                builder.equal(
+                        0,
+                        Timestamp.fromEpochMillis(
+                                fromEpochMillisAndFraction(1695645403000L, 0, TimeZoneKey.UTC_KEY).getEpochMillis()));
+        Predicate actualEqq = converter.convert(eq).get();
+        assertThat(actualEqq).isEqualTo(expectedEqq);
+
+        eq =
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                tsColumn,
+                                Domain.singleValue(
+                                        createTimestampWithTimeZoneType(3), 1695645403000L)));
+        expectedEqq = builder.equal(0, 1695645403000L);
+        actualEqq = converter.convert(eq).get();
+        assertThat(actualEqq).isEqualTo(expectedEqq);
+    }
+
+    @Test
+    public void testTinyint()
+    {
+        RowType rowType =
+                new RowType(
+                        Collections.singletonList(
+                                new DataField(
+                                        0, "tiny", new org.apache.paimon.types.TinyIntType())));
+        PaimonFilterConverter converter = new PaimonFilterConverter(rowType);
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        PaimonColumnHandle idColumn =
+                PaimonColumnHandle.of("tiny", new org.apache.paimon.types.TinyIntType(), 0);
+        TupleDomain<PaimonColumnHandle> eq =
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(idColumn, Domain.singleValue(TinyintType.TINYINT, 127L)));
+        Predicate expectedEqq = builder.equal(0, Byte.MAX_VALUE);
+        Predicate actualEqq = converter.convert(eq).get();
+        assertThat(actualEqq).isEqualTo(expectedEqq);
+    }
+
+    @Test
+    public void testSmallint()
+    {
+        RowType rowType =
+                new RowType(
+                        Collections.singletonList(
+                                new DataField(
+                                        0, "small", new org.apache.paimon.types.SmallIntType())));
+        PaimonFilterConverter converter = new PaimonFilterConverter(rowType);
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        PaimonColumnHandle idColumn =
+                PaimonColumnHandle.of("small", new org.apache.paimon.types.SmallIntType(), 0);
+        TupleDomain<PaimonColumnHandle> eq =
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                idColumn, Domain.singleValue(SmallintType.SMALLINT, 32767L)));
+        Predicate expectedEqq = builder.equal(0, Short.MAX_VALUE);
+        Predicate actualEqq = converter.convert(eq).get();
+        assertThat(actualEqq).isEqualTo(expectedEqq);
+    }
+}

--- a/plugin/trino-paimon/src/test/java/io/trino/plugin/paimon/TestPaimonFilterExtractor.java
+++ b/plugin/trino-paimon/src/test/java/io/trino/plugin/paimon/TestPaimonFilterExtractor.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import com.google.api.client.util.Maps;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.Constraint;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.expression.StandardFunctions;
+import io.trino.spi.expression.Variable;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.BooleanType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
+import org.apache.paimon.types.DataTypes;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.trino.plugin.paimon.PaimonFilterExtractor.TRINO_MAP_ELEMENT_AT_FUNCTION_NAME;
+import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
+import static org.apache.paimon.fileindex.FileIndexCommon.toMapKey;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The test of TestTrinoFilterExtractor.
+ */
+final class TestPaimonFilterExtractor
+{
+    @Test
+    void testExtractTrinoColumnHandleForExpressionFilter()
+    {
+        TupleDomain<ColumnHandle> summary = TupleDomain.all();
+        Type mapType = TESTING_TYPE_MANAGER.fromSqlType("map<varchar,varchar>");
+        String columnName = "map";
+        String mapKeyName = "key";
+        String constantValue = "value";
+        Slice value = Slices.utf8Slice(constantValue);
+        Call elemetAtFuntion =
+                new Call(
+                        BooleanType.BOOLEAN,
+                        new FunctionName(TRINO_MAP_ELEMENT_AT_FUNCTION_NAME),
+                        List.of(
+                                new Variable(columnName, mapType),
+                                new Constant(
+                                        Slices.utf8Slice(mapKeyName),
+                                        VarcharType.createUnboundedVarcharType())));
+        ConnectorExpression expression =
+                new Call(
+                        BooleanType.BOOLEAN,
+                        StandardFunctions.EQUAL_OPERATOR_FUNCTION_NAME,
+                        List.of(
+                                elemetAtFuntion,
+                                new Constant(value, VarcharType.createUnboundedVarcharType())));
+        Map<String, ColumnHandle> assignments = Maps.newHashMap();
+        assignments.put(
+                columnName,
+                PaimonColumnHandle.of(
+                        columnName, DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING()), 0));
+        Constraint constraint = new Constraint(summary, expression, assignments);
+        Map<PaimonColumnHandle, Domain> domainMap =
+                PaimonFilterExtractor.extractTrinoColumnHandleForExpressionFilter(constraint);
+        assertThat(domainMap.size()).isEqualTo(1);
+        Map.Entry<PaimonColumnHandle, Domain> next = domainMap.entrySet().iterator().next();
+        assertThat(next.getKey().getColumnName()).isEqualTo(toMapKey(columnName, mapKeyName));
+        assertThat(
+                next.getValue()
+                        .getValues()
+                        .getRanges()
+                        .getOrderedRanges()
+                        .get(0)
+                        .getLowBoundedValue())
+                .isEqualTo(value);
+    }
+}

--- a/plugin/trino-paimon/src/test/java/io/trino/plugin/paimon/TestPaimonITCase.java
+++ b/plugin/trino-paimon/src/test/java/io/trino/plugin/paimon/TestPaimonITCase.java
@@ -1,0 +1,936 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.MaterializedResult;
+import io.trino.testing.QueryRunner;
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.Decimal;
+import org.apache.paimon.data.GenericArray;
+import org.apache.paimon.data.GenericMap;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.disk.IOManagerImpl;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.schema.SchemaChange;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.FileStoreTableFactory;
+import org.apache.paimon.table.sink.InnerTableCommit;
+import org.apache.paimon.table.sink.InnerTableWrite;
+import org.apache.paimon.types.ArrayType;
+import org.apache.paimon.types.BigIntType;
+import org.apache.paimon.types.CharType;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.MapType;
+import org.apache.paimon.types.RowKind;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.types.VarCharType;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
+
+import java.nio.file.Files;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static io.airlift.testing.Closeables.closeAllSuppress;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.time.ZoneOffset.UTC;
+import static org.apache.paimon.data.BinaryString.fromString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * ITCase for trino connector.
+ */
+final class TestPaimonITCase
+        extends AbstractTestQueryFramework
+{
+    private static final String CATALOG = "paimon";
+    private static final String DB = "default";
+
+    private long t2FirstCommitTimestamp;
+
+    private static SimpleTableTestHelper createTestHelper(Path tablePath)
+            throws Exception
+    {
+        RowType rowType =
+                new RowType(
+                        Arrays.asList(
+                                new DataField(0, "a", new IntType()),
+                                new DataField(1, "b", new BigIntType()),
+                                // test field name has upper case
+                                new DataField(2, "aCa", new VarCharType()),
+                                new DataField(3, "d", new CharType(1))));
+        return new SimpleTableTestHelper(tablePath, rowType);
+    }
+
+    private static String timestampLiteral(long epochMilliSeconds, int precision)
+    {
+        return DateTimeFormatter.ofPattern(
+                        "''yyyy-MM-dd HH:mm:ss." + "S".repeat(precision) + " VV''")
+                .format(Instant.ofEpochMilli(epochMilliSeconds).atZone(UTC));
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        String warehouse =
+                Files.createTempDirectory(UUID.randomUUID().toString()).toUri().toString();
+        // flink sink
+        Path tablePath1 = new Path(warehouse, DB + ".db/t1");
+        SimpleTableTestHelper testHelper1 = createTestHelper(tablePath1);
+        testHelper1.write(GenericRow.of(1, 2L, fromString("1"), fromString("1")));
+        testHelper1.write(GenericRow.of(3, 4L, fromString("2"), fromString("2")));
+        testHelper1.write(GenericRow.of(5, 6L, fromString("3"), fromString("3")));
+        testHelper1.write(
+                GenericRow.ofKind(RowKind.DELETE, 3, 4L, fromString("2"), fromString("2")));
+        testHelper1.commit();
+
+        Path tablePath2 = new Path(warehouse, "default.db/t2");
+        SimpleTableTestHelper testHelper2 = createTestHelper(tablePath2);
+        testHelper2.write(GenericRow.of(1, 2L, fromString("1"), fromString("1")));
+        testHelper2.write(GenericRow.of(3, 4L, fromString("2"), fromString("2")));
+        testHelper2.commit();
+        testHelper2.createTag("1");
+        t2FirstCommitTimestamp = System.currentTimeMillis();
+        testHelper2.write(GenericRow.of(5, 6L, fromString("3"), fromString("3")));
+        testHelper2.write(GenericRow.of(7, 8L, fromString("4"), fromString("4")));
+        testHelper2.commit();
+        testHelper2.createTag("tag-2");
+
+        {
+            Path tablePath3 = new Path(warehouse, "default.db/t3");
+            RowType rowType =
+                    new RowType(
+                            Arrays.asList(
+                                    new DataField(0, "pt", DataTypes.STRING()),
+                                    new DataField(1, "a", new IntType()),
+                                    new DataField(2, "b", new BigIntType()),
+                                    new DataField(3, "c", new BigIntType()),
+                                    new DataField(4, "d", new IntType())));
+            new SchemaManager(LocalFileIO.create(), tablePath3)
+                    .createTable(
+                            new Schema(
+                                    rowType.getFields(),
+                                    Collections.singletonList("pt"),
+                                    Collections.emptyList(),
+                                    new HashMap<>(),
+                                    ""));
+            FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), tablePath3);
+            InnerTableWrite writer = table.newWrite("user");
+            InnerTableCommit commit = table.newCommit("user");
+            writer.write(GenericRow.of(fromString("1"), 1, 1L, 1L, 1));
+            writer.write(GenericRow.of(fromString("1"), 1, 2L, 2L, 2));
+            writer.write(GenericRow.of(fromString("2"), 3, 3L, 3L, 3));
+            commit.commit(0, writer.prepareCommit(true, 0));
+        }
+
+        {
+            Path tablePath = new Path(warehouse, "default.db/empty_t");
+            RowType rowType =
+                    new RowType(
+                            Arrays.asList(
+                                    new DataField(1, "a", new IntType()),
+                                    new DataField(2, "b", new BigIntType())));
+            new SchemaManager(LocalFileIO.create(), tablePath)
+                    .createTable(
+                            new Schema(
+                                    rowType.getFields(),
+                                    Collections.emptyList(),
+                                    Collections.emptyList(),
+                                    new HashMap<>(),
+                                    ""));
+        }
+
+        {
+            Path tablePath4 = new Path(warehouse, "default.db/t4");
+            List<DataField> innerRowFields = new ArrayList<>();
+            innerRowFields.add(new DataField(4, "innercol1", new IntType()));
+            innerRowFields.add(
+                    new DataField(5, "innercol2", new VarCharType(VarCharType.MAX_LENGTH)));
+            RowType rowType =
+                    new RowType(
+                            Arrays.asList(
+                                    new DataField(0, "i", new IntType()),
+                                    new DataField(
+                                            1,
+                                            "map",
+                                            new MapType(
+                                                    new VarCharType(VarCharType.MAX_LENGTH),
+                                                    new VarCharType(VarCharType.MAX_LENGTH))),
+                                    new DataField(2, "innerrow", new RowType(true, innerRowFields)),
+                                    new DataField(3, "array", new ArrayType(new IntType()))));
+            new SchemaManager(LocalFileIO.create(), tablePath4)
+                    .createTable(
+                            new Schema(
+                                    rowType.getFields(),
+                                    Collections.emptyList(),
+                                    Collections.singletonList("i"),
+                                    Collections.singletonMap("bucket", "1"),
+                                    ""));
+            FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), tablePath4);
+            InnerTableWrite writer = table.newWrite("user");
+            InnerTableCommit commit = table.newCommit("user");
+            writer.write(
+                    GenericRow.of(
+                            1,
+                            new GenericMap(
+                                    new HashMap<>(ImmutableMap.of(fromString("1"), fromString("2")))),
+                            GenericRow.of(2, fromString("male")),
+                            new GenericArray(new int[] {1, 2, 3})));
+            commit.commit(0, writer.prepareCommit(true, 0));
+        }
+
+        {
+            Path tablePath6 = new Path(warehouse, "default.db/t99");
+            RowType rowType =
+                    new RowType(
+                            Arrays.asList(
+                                    new DataField(0, "boolean", DataTypes.BOOLEAN()),
+                                    new DataField(1, "tinyint", DataTypes.TINYINT()),
+                                    new DataField(2, "smallint", DataTypes.SMALLINT()),
+                                    new DataField(3, "int", DataTypes.INT()),
+                                    new DataField(4, "bigint", DataTypes.BIGINT()),
+                                    new DataField(5, "float", DataTypes.FLOAT()),
+                                    new DataField(6, "double", DataTypes.DOUBLE()),
+                                    new DataField(7, "char", DataTypes.CHAR(5)),
+                                    new DataField(8, "varchar", DataTypes.VARCHAR(100)),
+                                    new DataField(9, "date", DataTypes.DATE()),
+                                    new DataField(10, "timestamp_0", DataTypes.TIMESTAMP(0)),
+                                    new DataField(11, "timestamp_3", DataTypes.TIMESTAMP(3)),
+                                    new DataField(12, "timestamp_6", DataTypes.TIMESTAMP(6)),
+                                    new DataField(
+                                            13,
+                                            "timestamp_tz",
+                                            DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)),
+                                    new DataField(14, "decimal", DataTypes.DECIMAL(10, 5)),
+                                    new DataField(15, "varbinary", DataTypes.VARBINARY(10)),
+                                    new DataField(16, "array", DataTypes.ARRAY(DataTypes.INT())),
+                                    new DataField(
+                                            17,
+                                            "map",
+                                            DataTypes.MAP(DataTypes.INT(), DataTypes.INT())),
+                                    new DataField(
+                                            18,
+                                            "row",
+                                            DataTypes.ROW(
+                                                    DataTypes.FIELD(100, "q1", DataTypes.INT()),
+                                                    DataTypes.FIELD(101, "q2", DataTypes.INT())))));
+            new SchemaManager(LocalFileIO.create(), tablePath6)
+                    .createTable(
+                            new Schema(
+                                    rowType.getFields(),
+                                    List.of(
+                                            "boolean",
+                                            "tinyint",
+                                            "smallint",
+                                            "int",
+                                            "bigint",
+                                            "float",
+                                            "double",
+                                            "char",
+                                            "varchar",
+                                            "date",
+                                            "timestamp_0",
+                                            "timestamp_3",
+                                            "timestamp_6",
+                                            "timestamp_tz",
+                                            "decimal"),
+                                    List.of(
+                                            "boolean",
+                                            "tinyint",
+                                            "smallint",
+                                            "int",
+                                            "bigint",
+                                            "float",
+                                            "double",
+                                            "char",
+                                            "varchar",
+                                            "date",
+                                            "timestamp_0",
+                                            "timestamp_3",
+                                            "timestamp_6",
+                                            "timestamp_tz",
+                                            "decimal",
+                                            "varbinary"),
+                                    Collections.singletonMap("bucket", "1"),
+                                    ""));
+            FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), tablePath6);
+            InnerTableWrite writer = table.newWrite("user");
+            InnerTableCommit commit = table.newCommit("user");
+            writer.write(
+                    GenericRow.of(
+                            true,
+                            (byte) 1,
+                            (short) 1,
+                            1,
+                            1L,
+                            1.0f,
+                            1.0d,
+                            BinaryString.fromString("char1"),
+                            BinaryString.fromString("varchar1"),
+                            0,
+                            Timestamp.fromMicros(1694505288000000L),
+                            Timestamp.fromMicros(1694505288001000L),
+                            Timestamp.fromMicros(1694505288001001L),
+                            Timestamp.fromMicros(1694505288002001L),
+                            Decimal.fromUnscaledLong(10000, 10, 5),
+                            new byte[] {0x01, 0x02, 0x03},
+                            new GenericArray(new int[] {1, 1, 1}),
+                            new GenericMap(Map.of(1, 1)),
+                            GenericRow.of(1, 1)));
+            commit.commit(0, writer.prepareCommit(true, 0));
+        }
+
+        {
+            Path tablePath7 = new Path(warehouse, "default.db/t100");
+            RowType rowType =
+                    new RowType(
+                            Arrays.asList(
+                                    new DataField(0, "boolean", DataTypes.BOOLEAN()),
+                                    new DataField(1, "tinyint", DataTypes.TINYINT()),
+                                    new DataField(2, "smallint", DataTypes.SMALLINT()),
+                                    new DataField(3, "int", DataTypes.INT()),
+                                    new DataField(4, "bigint", DataTypes.BIGINT()),
+                                    new DataField(5, "float", DataTypes.FLOAT()),
+                                    new DataField(6, "double", DataTypes.DOUBLE()),
+                                    new DataField(7, "char", DataTypes.CHAR(5)),
+                                    new DataField(8, "varchar", DataTypes.VARCHAR(100)),
+                                    new DataField(9, "date", DataTypes.DATE()),
+                                    new DataField(10, "timestamp_0", DataTypes.TIMESTAMP(3)),
+                                    new DataField(11, "timestamp_3", DataTypes.TIMESTAMP(3)),
+                                    new DataField(12, "timestamp_6", DataTypes.TIMESTAMP(6)),
+                                    new DataField(13, "decimal", DataTypes.DECIMAL(10, 5)),
+                                    new DataField(14, "varbinary", DataTypes.VARBINARY(10)),
+                                    new DataField(15, "array", DataTypes.ARRAY(DataTypes.INT())),
+                                    new DataField(
+                                            16,
+                                            "map",
+                                            DataTypes.MAP(DataTypes.INT(), DataTypes.INT())),
+                                    new DataField(
+                                            17,
+                                            "row",
+                                            DataTypes.ROW(
+                                                    DataTypes.FIELD(100, "q1", DataTypes.INT()),
+                                                    DataTypes.FIELD(101, "q2", DataTypes.INT())))));
+            new SchemaManager(LocalFileIO.create(), tablePath7)
+                    .createTable(
+                            new Schema(
+                                    rowType.getFields(),
+                                    Collections.emptyList(),
+                                    Collections.emptyList(),
+                                    Collections.singletonMap("bucket", "-1"),
+                                    ""));
+            FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), tablePath7);
+            InnerTableWrite writer = table.newWrite("user");
+            InnerTableCommit commit = table.newCommit("user");
+            writer.write(
+                    GenericRow.of(
+                            true,
+                            (byte) 1,
+                            (short) 1,
+                            1,
+                            1L,
+                            1.0f,
+                            1.0d,
+                            BinaryString.fromString("char1"),
+                            BinaryString.fromString("varchar1"),
+                            0,
+                            Timestamp.fromMicros(1694505288000000L),
+                            Timestamp.fromMicros(1694505288001000L),
+                            Timestamp.fromMicros(1694505288001001L),
+                            Decimal.fromUnscaledLong(10000, 10, 5),
+                            new byte[] {0x01, 0x02, 0x03},
+                            new GenericArray(new int[] {1, 1, 1}),
+                            new GenericMap(Map.of(1, 1)),
+                            GenericRow.of(1, 1)));
+            commit.commit(0, writer.prepareCommit(true, 0));
+
+            new SchemaManager(LocalFileIO.create(), tablePath7)
+                    .commitChanges(SchemaChange.dropColumn("smallint"));
+            table = FileStoreTableFactory.create(LocalFileIO.create(), tablePath7);
+            writer = table.newWrite("user");
+            commit = table.newCommit("user");
+            writer.write(
+                    GenericRow.of(
+                            true,
+                            (byte) 1,
+                            1,
+                            1L,
+                            1.0f,
+                            1.0d,
+                            BinaryString.fromString("char1"),
+                            BinaryString.fromString("varchar1"),
+                            0,
+                            Timestamp.fromMicros(1694505288000000L),
+                            Timestamp.fromMicros(1694505288001000L),
+                            Timestamp.fromMicros(1694505288001001L),
+                            Decimal.fromUnscaledLong(10000, 10, 5),
+                            new byte[] {0x01, 0x02, 0x03},
+                            new GenericArray(new int[] {1, 1, 1}),
+                            new GenericMap(Map.of(1, 1)),
+                            GenericRow.of(1, 1)));
+            commit.commit(1, writer.prepareCommit(true, 1));
+
+            new SchemaManager(LocalFileIO.create(), tablePath7)
+                    .commitChanges(SchemaChange.addColumn("smallint", DataTypes.SMALLINT()));
+            table = FileStoreTableFactory.create(LocalFileIO.create(), tablePath7);
+            writer = table.newWrite("user");
+            commit = table.newCommit("user");
+            writer.write(
+                    GenericRow.of(
+                            true,
+                            (byte) 1,
+                            1,
+                            1L,
+                            1.0f,
+                            1.0d,
+                            BinaryString.fromString("char1"),
+                            BinaryString.fromString("varchar1"),
+                            0,
+                            Timestamp.fromMicros(1694505288000000L),
+                            Timestamp.fromMicros(1694505288001000L),
+                            Timestamp.fromMicros(1694505288001001L),
+                            Decimal.fromUnscaledLong(10000, 10, 5),
+                            new byte[] {0x01, 0x02, 0x03},
+                            new GenericArray(new int[] {1, 1, 1}),
+                            new GenericMap(Map.of(1, 1)),
+                            GenericRow.of(1, 1),
+                            (short) 1));
+            commit.commit(1, writer.prepareCommit(true, 1));
+
+            new SchemaManager(LocalFileIO.create(), tablePath7)
+                    .commitChanges(SchemaChange.updateColumnType("smallint", DataTypes.STRING()));
+            table = FileStoreTableFactory.create(LocalFileIO.create(), tablePath7);
+            writer = table.newWrite("user");
+            commit = table.newCommit("user");
+            writer.write(
+                    GenericRow.of(
+                            true,
+                            (byte) 1,
+                            1,
+                            1L,
+                            1.0f,
+                            1.0d,
+                            BinaryString.fromString("char1"),
+                            BinaryString.fromString("varchar1"),
+                            0,
+                            Timestamp.fromMicros(1694505288000000L),
+                            Timestamp.fromMicros(1694505288001000L),
+                            Timestamp.fromMicros(1694505288001001L),
+                            Decimal.fromUnscaledLong(10000, 10, 5),
+                            new byte[] {0x01, 0x02, 0x03},
+                            new GenericArray(new int[] {1, 1, 1}),
+                            new GenericMap(Map.of(1, 1)),
+                            GenericRow.of(1, 1),
+                            BinaryString.fromString("10086")));
+            commit.commit(1, writer.prepareCommit(true, 1));
+        }
+
+        {
+            Path tablePath6 = new Path(warehouse, "default.db/t101");
+            RowType rowType =
+                    new RowType(
+                            Arrays.asList(
+                                    new DataField(0, "a", DataTypes.STRING()),
+                                    new DataField(1, "b", DataTypes.INT()),
+                                    new DataField(2, "c", DataTypes.INT())));
+            new SchemaManager(LocalFileIO.create(), tablePath6)
+                    .createTable(
+                            new Schema(
+                                    rowType.getFields(),
+                                    Collections.emptyList(),
+                                    List.of("a"),
+                                    new HashMap<>(ImmutableMap.of(CoreOptions.BUCKET.key(), "1", CoreOptions.DELETION_VECTORS_ENABLED.key(), "true")),
+                                    ""));
+            FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), tablePath6);
+            InnerTableWrite writer = table.newWrite("user");
+            writer.withIOManager(new IOManagerImpl("/tmp"));
+            InnerTableCommit commit = table.newCommit("user");
+            for (int i = 0; i < 10; i++) {
+                writer.write(GenericRow.of(BinaryString.fromString("a" + i), i, i));
+            }
+            commit.commit(0, writer.prepareCommit(true, 0));
+
+            writer.write(GenericRow.ofKind(RowKind.DELETE, BinaryString.fromString("a0"), 0, 0));
+            commit.commit(1, writer.prepareCommit(true, 1));
+        }
+
+        {
+            Path tablePath = new Path(warehouse, "default.db/t102");
+            RowType rowType =
+                    new RowType(
+                            Arrays.asList(
+                                    new DataField(0, "a", DataTypes.STRING()),
+                                    new DataField(1, "b", DataTypes.INT()),
+                                    new DataField(2, "c", DataTypes.INT())));
+            new SchemaManager(LocalFileIO.create(), tablePath)
+                    .createTable(
+                            new Schema(
+                                    rowType.getFields(),
+                                    Collections.emptyList(),
+                                    Collections.emptyList(),
+                                    new HashMap<>(ImmutableMap.of("file-index.bloom-filter.columns", "a,b,c")),
+                                    ""));
+            FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), tablePath);
+            InnerTableWrite writer = table.newWrite("user");
+            writer.withIOManager(new IOManagerImpl("/tmp"));
+            InnerTableCommit commit = table.newCommit("user");
+            for (int i = 0; i < 100; i = i + 3) {
+                writer.write(GenericRow.of(BinaryString.fromString("a" + i), i, i));
+            }
+            commit.commit(0, writer.prepareCommit(true, 0));
+
+            for (int i = 1; i < 100; i = i + 3) {
+                writer.write(GenericRow.of(BinaryString.fromString("a" + i), i, i));
+            }
+            commit.commit(1, writer.prepareCommit(true, 1));
+
+            for (int i = 2; i < 100; i = i + 3) {
+                writer.write(GenericRow.of(BinaryString.fromString("a" + i), i, i));
+            }
+            commit.commit(2, writer.prepareCommit(true, 2));
+        }
+
+        {
+            Path tablePath = new Path(warehouse, "default.db/fixed_bucket_table_wi_pk");
+            RowType rowType =
+                    new RowType(
+                            Arrays.asList(
+                                    new DataField(0, "id", DataTypes.INT()),
+                                    new DataField(1, "name", DataTypes.STRING())));
+            new SchemaManager(LocalFileIO.create(), tablePath)
+                    .createTable(
+                            new Schema(
+                                    rowType.getFields(),
+                                    Collections.emptyList(),
+                                    Collections.emptyList(),
+                                    new HashMap<>(ImmutableMap.of("file.format", "orc", "primary-key", "id", "bucket", "2")),
+                                    ""));
+        }
+
+        {
+            Path tablePath = new Path(warehouse, "default.db/fixed_bucket_table_wo_pk");
+            RowType rowType =
+                    new RowType(
+                            Arrays.asList(
+                                    new DataField(0, "id", DataTypes.INT()),
+                                    new DataField(1, "name", DataTypes.STRING())));
+            new SchemaManager(LocalFileIO.create(), tablePath)
+                    .createTable(
+                            new Schema(
+                                    rowType.getFields(),
+                                    Collections.emptyList(),
+                                    Collections.emptyList(),
+                                    new HashMap<>(ImmutableMap.of("file.format", "orc", "bucket", "2", "bucket-key", "id")),
+                                    ""));
+        }
+
+        {
+            Path tablePath = new Path(warehouse, "default.db/unaware_table");
+            RowType rowType =
+                    new RowType(
+                            Arrays.asList(
+                                    new DataField(0, "id", DataTypes.INT()),
+                                    new DataField(1, "name", DataTypes.STRING())));
+            new SchemaManager(LocalFileIO.create(), tablePath)
+                    .createTable(
+                            new Schema(
+                                    rowType.getFields(),
+                                    Collections.emptyList(),
+                                    Collections.emptyList(),
+                                    new HashMap<>(ImmutableMap.of("file.format", "orc")),
+                                    ""));
+        }
+
+        DistributedQueryRunner queryRunner = null;
+        try {
+            queryRunner =
+                    DistributedQueryRunner.builder(
+                                    testSessionBuilder().setCatalog(CATALOG).setSchema(DB).build())
+                            .build();
+            queryRunner.installPlugin(new PaimonPlugin());
+            Map<String, String> options = new HashMap<>();
+            options.put("paimon.warehouse", warehouse);
+            options.put("paimon.catalog.type", "filesystem");
+            options.put("fs.hadoop.enabled", "true");
+            queryRunner.createCatalog(CATALOG, CATALOG, options);
+            return queryRunner;
+        }
+        catch (Throwable e) {
+            closeAllSuppress(e, queryRunner);
+            throw e;
+        }
+    }
+
+    @Test
+    void testComplexTypes()
+    {
+        assertThat(sql("SELECT * FROM paimon.default.t4"))
+                .isEqualTo("[[1, {1=2}, [2, male], [1, 2, 3]]]");
+    }
+
+    @Test
+    void testEmptyTable()
+    {
+        assertThat(sql("SELECT * FROM paimon.default.empty_t")).isEqualTo("[]");
+    }
+
+    @Test
+    void testProjection()
+    {
+        assertThat(sql("SELECT * FROM paimon.default.t1"))
+                .isEqualTo("[[1, 2, 1, 1], [5, 6, 3, 3]]");
+        assertThat(sql("SELECT a, aCa FROM paimon.default.t1")).isEqualTo("[[1, 1], [5, 3]]");
+        assertThat(sql("SELECT SUM(b) FROM paimon.default.t1")).isEqualTo("[[8]]");
+    }
+
+    @Test
+    void testLimit()
+    {
+        assertThat(sql("SELECT * FROM paimon.default.t1 LIMIT 1")).isEqualTo("[[1, 2, 1, 1]]");
+        assertThat(sql("SELECT * FROM paimon.default.t1 WHERE a = 5 LIMIT 1"))
+                .isEqualTo("[[5, 6, 3, 3]]");
+    }
+
+    @Test
+    void testSystemTable()
+    {
+        assertThat(
+                sql(
+                        "SELECT snapshot_id,schema_id,commit_user,commit_identifier,commit_kind FROM \"t1$snapshots\""))
+                .isEqualTo("[[1, 0, user, 0, APPEND]]");
+    }
+
+    @Test
+    void testFilter()
+    {
+        assertThat(sql("SELECT a, aCa FROM paimon.default.t2 WHERE a < 4"))
+                .isEqualTo("[[1, 1], [3, 2]]");
+    }
+
+    @Test
+    void testGroupByWithCast()
+    {
+        assertThat(
+                sql(
+                        "SELECT pt, a, SUM(b), SUM(d) FROM paimon.default.t3 GROUP BY pt, a ORDER BY pt, a"))
+                .isEqualTo("[[1, 1, 3, 3], [2, 3, 3, 3]]");
+    }
+
+    @Test
+    void testLimitWithPartition()
+    {
+        assertThat(sql("SELECT * FROM paimon.default.t3 WHERE pt = '1' LIMIT 1"))
+                .isEqualTo("[[1, 1, 1, 1, 1]]");
+
+        assertThat(sql("SELECT * FROM paimon.default.t3 WHERE pt = '1' AND b = 2 LIMIT 1"))
+                .isEqualTo("[[1, 1, 2, 2, 2]]");
+    }
+
+    @Test
+    void testShowCreateTable()
+    {
+        assertThat(sql("SHOW CREATE TABLE paimon.default.t3"))
+                .isEqualTo(
+                        "[[CREATE TABLE paimon.default.t3 (\n"
+                                + "   pt varchar,\n"
+                                + "   a integer,\n"
+                                + "   b bigint,\n"
+                                + "   c bigint,\n"
+                                + "   d integer\n"
+                                + ")]]");
+    }
+
+    @Test
+    void testCreateSchema()
+    {
+        sql("CREATE SCHEMA paimon.test");
+        assertThat(sql("SHOW SCHEMAS FROM paimon"))
+                .isEqualTo("[[default], [information_schema], [test]]");
+        sql("DROP SCHEMA paimon.test");
+    }
+
+    @Test
+    void testDropSchema()
+    {
+        sql("CREATE SCHEMA paimon.tpch");
+        sql("DROP SCHEMA paimon.tpch");
+        assertThat(sql("SHOW SCHEMAS FROM paimon")).isEqualTo("[[default], [information_schema]]");
+    }
+
+    @Test
+    void testCreateTable()
+    {
+        sql(
+                "CREATE TABLE orders ("
+                        + "  order_key bigint,"
+                        + "  order_status varchar,"
+                        + "  total_price double,"
+                        + "  order_date date"
+                        + ")"
+                        + "WITH ("
+                        + "file_format = 'ORC',"
+                        + "primary_key = ARRAY['order_key','order_date'],"
+                        + "partitioned_by = ARRAY['order_date'],"
+                        + "bucket = '2',"
+                        + "bucket_key = 'order_key',"
+                        + "changelog_producer = 'input'"
+                        + ")");
+        assertThat(sql("SHOW TABLES FROM paimon.default")).contains("orders");
+        sql("DROP TABLE IF EXISTS paimon.default.orders");
+    }
+
+    @Test
+    void testRenameTable()
+    {
+        sql(
+                "CREATE TABLE testRenameTable ("
+                        + "  order_key bigint,"
+                        + "  order_status varchar,"
+                        + "  total_price double,"
+                        + "  order_date date"
+                        + ")"
+                        + "WITH ("
+                        + "file_format = 'ORC',"
+                        + "primary_key = ARRAY['order_key','order_date'],"
+                        + "partitioned_by = ARRAY['order_date'],"
+                        + "bucket = '2',"
+                        + "bucket_key = 'order_key',"
+                        + "changelog_producer = 'input'"
+                        + ")");
+        sql("ALTER TABLE paimon.default.testRenameTable RENAME TO test_Rename_Table");
+        String result = sql("SHOW TABLES FROM paimon.default");
+        assertThat(result)
+                .doesNotContainIgnoringCase("testRenameTable")
+                .containsIgnoringCase("test_Rename_Table");
+        sql("DROP TABLE IF EXISTS paimon.default.test_Rename_Table");
+    }
+
+    @Test
+    void testDropTable()
+    {
+        sql(
+                "CREATE TABLE testDropTable ("
+                        + "  order_key bigint,"
+                        + "  order_status varchar,"
+                        + "  total_price double,"
+                        + "  order_date date"
+                        + ")"
+                        + "WITH ("
+                        + "file_format = 'ORC',"
+                        + "primary_key = ARRAY['order_key','order_date'],"
+                        + "partitioned_by = ARRAY['order_date'],"
+                        + "bucket = '2',"
+                        + "bucket_key = 'order_key',"
+                        + "changelog_producer = 'input'"
+                        + ")");
+        sql("DROP TABLE IF EXISTS paimon.default.testDropTable");
+        assertThat(sql("SHOW TABLES FROM paimon.default"))
+                .doesNotContainIgnoringCase("testDropTable");
+    }
+
+    @Test
+    void testAddColumn()
+    {
+        sql(
+                "CREATE TABLE testAddColumn ("
+                        + "  order_key bigint,"
+                        + "  order_status varchar,"
+                        + "  total_price double,"
+                        + "  order_date date"
+                        + ")"
+                        + "WITH ("
+                        + "file_format = 'ORC',"
+                        + "primary_key = ARRAY['order_key','order_date'],"
+                        + "partitioned_by = ARRAY['order_date'],"
+                        + "bucket = '2',"
+                        + "bucket_key = 'order_key',"
+                        + "changelog_producer = 'input'"
+                        + ")");
+        sql("ALTER TABLE paimon.default.testAddColumn ADD COLUMN zip varchar");
+        assertThat(sql("SHOW COLUMNS FROM paimon.default.testAddColumn"))
+                .isEqualTo(
+                        "[[order_key, bigint, , ], [order_status, varchar(2147483646), , ], [total_price, double, , ], [order_date, date, , ], [zip, varchar(2147483646), , ]]");
+        sql("DROP TABLE IF EXISTS paimon.default.testAddColumn");
+    }
+
+    @Test
+    void testRenameColumn()
+    {
+        sql(
+                "CREATE TABLE testRenameColumn ("
+                        + "  order_key bigint,"
+                        + "  order_status varchar,"
+                        + "  total_price double,"
+                        + "  order_date date"
+                        + ")"
+                        + "WITH ("
+                        + "file_format = 'ORC',"
+                        + "primary_key = ARRAY['order_key','order_date'],"
+                        + "partitioned_by = ARRAY['order_date'],"
+                        + "bucket = '2',"
+                        + "bucket_key = 'order_key',"
+                        + "changelog_producer = 'input'"
+                        + ")");
+        sql("ALTER TABLE paimon.default.testRenameColumn RENAME COLUMN order_status to g");
+        assertThat(sql("SHOW COLUMNS FROM paimon.default.testRenameColumn"))
+                .isEqualTo(
+                        "[[order_key, bigint, , ], [g, varchar(2147483646), , ], [total_price, double, , ], [order_date, date, , ]]");
+        sql("DROP TABLE IF EXISTS paimon.default.testRenameColumn");
+    }
+
+    @Test
+    void testDropColumn()
+    {
+        sql(
+                "CREATE TABLE testDropColumn ("
+                        + "  order_key bigint,"
+                        + "  order_status varchar,"
+                        + "  total_price double,"
+                        + "  order_date date"
+                        + ")"
+                        + "WITH ("
+                        + "file_format = 'ORC',"
+                        + "primary_key = ARRAY['order_key','order_date'],"
+                        + "partitioned_by = ARRAY['order_date'],"
+                        + "bucket = '2',"
+                        + "bucket_key = 'order_key',"
+                        + "changelog_producer = 'input'"
+                        + ")");
+        sql("ALTER TABLE paimon.default.testDropColumn DROP COLUMN order_status");
+        assertThat(sql("SHOW COLUMNS FROM paimon.default.testDropColumn"))
+                .isEqualTo(
+                        "[[order_key, bigint, , ], [total_price, double, , ], [order_date, date, , ]]");
+        sql("DROP TABLE IF EXISTS paimon.default.testDropColumn");
+    }
+
+    @Test
+    void testSetTableProperties()
+    {
+        sql(
+                "CREATE TABLE testSetTableProperties ("
+                        + "  order_key bigint,"
+                        + "  order_status varchar,"
+                        + "  total_price double,"
+                        + "  order_date date"
+                        + ")"
+                        + "WITH ("
+                        + "file_format = 'ORC',"
+                        + "primary_key = ARRAY['order_key','order_date'],"
+                        + "partitioned_by = ARRAY['order_date'],"
+                        + "bucket = '2',"
+                        + "bucket_key = 'order_key',"
+                        + "changelog_producer = 'input'"
+                        + ")");
+        sql(
+                "ALTER TABLE paimon.default.testSetTableProperties SET PROPERTIES bucket = '4',snapshot_time_retained = '4h'");
+        sql("DROP TABLE IF EXISTS paimon.default.testSetTableProperties");
+    }
+
+    @Test
+    void testAllType()
+    {
+        assertThat(
+                sql(
+                        "SELECT boolean, tinyint, smallint,int,bigint,float,double,char,varchar, date,timestamp_0, "
+                                + "timestamp_3, timestamp_6, decimal, to_hex(varbinary), array, map, row FROM paimon.default.t99"))
+                .isEqualTo(
+                        "[[true, 1, 1, 1, 1, 1.0, 1.0, char1, varchar1, 1970-01-01, "
+                                + "2023-09-12T07:54:48, 2023-09-12T07:54:48.001, 2023-09-12T07:54:48.001001, "
+                                + "0.10000, 010203, [1, 1, 1], {1=1}, [1, 1]]]");
+    }
+
+    @Test
+    void testTimeTravel()
+    {
+        assertThat(sql("SELECT * FROM paimon.default.t2 FOR VERSION AS OF 1"))
+                .isEqualTo("[[1, 2, 1, 1], [3, 4, 2, 2]]");
+        assertThat(sql("SELECT * FROM paimon.default.t2 FOR VERSION AS OF 2"))
+                .isEqualTo("[[1, 2, 1, 1], [3, 4, 2, 2], [5, 6, 3, 3], [7, 8, 4, 4]]");
+
+        assertThat(
+                sql(
+                        "SELECT * FROM paimon.default.t2 FOR TIMESTAMP AS OF TIMESTAMP "
+                                + timestampLiteral(t2FirstCommitTimestamp, 6)))
+                .isEqualTo("[[1, 2, 1, 1], [3, 4, 2, 2]]");
+        assertThat(
+                sql(
+                        "SELECT * FROM paimon.default.t2 FOR TIMESTAMP AS OF TIMESTAMP "
+                                + timestampLiteral(System.currentTimeMillis(), 6)))
+                .isEqualTo("[[1, 2, 1, 1], [3, 4, 2, 2], [5, 6, 3, 3], [7, 8, 4, 4]]");
+    }
+
+    @Test
+    void testTimeTravelWithTag()
+    {
+        // tag or snapshotId is string
+        assertThat(sql("SELECT * FROM paimon.default.t2 FOR VERSION AS OF '1'"))
+                .isEqualTo("[[1, 2, 1, 1], [3, 4, 2, 2]]");
+        assertThat(sql("SELECT * FROM paimon.default.t2 FOR VERSION AS OF 'tag-2'"))
+                .isEqualTo("[[1, 2, 1, 1], [3, 4, 2, 2], [5, 6, 3, 3], [7, 8, 4, 4]]");
+        // tag or snapshotId is int
+        assertThat(sql("SELECT * FROM paimon.default.t2 FOR VERSION AS OF 1"))
+                .isEqualTo("[[1, 2, 1, 1], [3, 4, 2, 2]]");
+    }
+
+    @Test
+    void testSchemaEvolution()
+    {
+        assertThat(
+                sql(
+                        "SELECT boolean, tinyint, smallint, int, bigint,float,double,char,varchar, date,timestamp_0, "
+                                + "timestamp_3, timestamp_6, decimal, to_hex(varbinary), array, map, row FROM paimon.default.t100"))
+                .isEqualTo(
+                        "[[true, 1, null, 1, 1, 1.0, 1.0, char1, varchar1, 1970-01-01, 2023-09-12T07:54:48, 2023-09-12T07:54:48.001, 2023-09-12T07:54:48.001001, 0.10000, 010203, [1, 1, 1], {1=1}, [1, 1]], "
+                                + "[true, 1, null, 1, 1, 1.0, 1.0, char1, varchar1, 1970-01-01, 2023-09-12T07:54:48, 2023-09-12T07:54:48.001, 2023-09-12T07:54:48.001001, 0.10000, 010203, [1, 1, 1], {1=1}, [1, 1]], "
+                                + "[true, 1, 1, 1, 1, 1.0, 1.0, char1, varchar1, 1970-01-01, 2023-09-12T07:54:48, 2023-09-12T07:54:48.001, 2023-09-12T07:54:48.001001, 0.10000, 010203, [1, 1, 1], {1=1}, [1, 1]], "
+                                + "[true, 1, 10086, 1, 1, 1.0, 1.0, char1, varchar1, 1970-01-01, 2023-09-12T07:54:48, 2023-09-12T07:54:48.001, 2023-09-12T07:54:48.001001, 0.10000, 010203, [1, 1, 1], {1=1}, [1, 1]]]");
+    }
+
+    @Test
+    void testDeletionFile()
+    {
+        assertThat(sql("SELECT * FROM paimon.default.t101 WHERE b > 0"))
+                .isEqualTo(
+                        "[[a1, 1, 1], [a2, 2, 2], [a3, 3, 3], [a4, 4, 4], [a5, 5, 5], [a6, 6, 6], [a7, 7, 7], [a8, 8, 8], [a9, 9, 9]]");
+    }
+
+    @Test
+    void testFileIndex()
+    {
+        assertThat(sql("SELECT * FROM paimon.default.t102 where c = 2")).isEqualTo("[[a2, 2, 2]]");
+    }
+
+    private String sql(String sql)
+    {
+        MaterializedResult result = getQueryRunner().execute(sql);
+        return result.getMaterializedRows().toString();
+    }
+}

--- a/plugin/trino-paimon/src/test/java/io/trino/plugin/paimon/TestPaimonPlugin.java
+++ b/plugin/trino-paimon/src/test/java/io/trino/plugin/paimon/TestPaimonPlugin.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.spi.Plugin;
+import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorFactory;
+import io.trino.testing.TestingConnectorContext;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.UUID;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for {@link PaimonPlugin}.
+ */
+final class TestPaimonPlugin
+{
+    @Test
+    void testCreatePrestoConnector()
+            throws IOException
+    {
+        String warehouse =
+                Files.createTempDirectory(UUID.randomUUID().toString()).toUri().toString();
+        Plugin plugin = new PaimonPlugin();
+        ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
+        Connector connector =
+                factory.create(
+                        "paimon",
+                        ImmutableMap.of("paimon.warehouse", warehouse, "paimon.catalog.type", "filesystem"),
+                        new TestingConnectorContext());
+        assertThat(connector).isNotNull();
+    }
+}

--- a/plugin/trino-paimon/src/test/java/io/trino/plugin/paimon/TestPaimonSplit.java
+++ b/plugin/trino-paimon/src/test/java/io/trino/plugin/paimon/TestPaimonSplit.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import io.airlift.json.JsonCodec;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for {@link PaimonSplit}.
+ */
+final class TestPaimonSplit
+{
+    private final JsonCodec<PaimonSplit> codec = JsonCodec.jsonCodec(PaimonSplit.class);
+
+    @Test
+    void testJsonRoundTrip()
+            throws Exception
+    {
+        byte[] serializedTable = PaimonTestUtils.getSerializedTable();
+        PaimonSplit expected = new PaimonSplit(Arrays.toString(serializedTable), 0.1);
+        String json = codec.toJson(expected);
+        PaimonSplit actual = codec.fromJson(json);
+        assertThat(actual.getSplitSerialized()).isEqualTo(expected.getSplitSerialized());
+    }
+}

--- a/plugin/trino-paimon/src/test/java/io/trino/plugin/paimon/TestPaimonTableHandle.java
+++ b/plugin/trino-paimon/src/test/java/io/trino/plugin/paimon/TestPaimonTableHandle.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import io.airlift.json.JsonCodec;
+import io.trino.spi.predicate.TupleDomain;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.OptionalLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for {@link PaimonTableHandle}.
+ */
+final class TestPaimonTableHandle
+{
+    private final JsonCodec<PaimonTableHandle> codec = JsonCodec.jsonCodec(PaimonTableHandle.class);
+
+    @Test
+    void testPrestoTableHandle()
+    {
+        PaimonTableHandle expected =
+                new PaimonTableHandle(
+                        "test",
+                        "user",
+                        Collections.emptyMap(),
+                        TupleDomain.all(),
+                        Collections.emptySet(),
+                        OptionalLong.empty());
+        testRoundTrip(expected);
+    }
+
+    private void testRoundTrip(PaimonTableHandle expected)
+    {
+        String json = codec.toJson(expected);
+        PaimonTableHandle actual = codec.fromJson(json);
+        assertThat(actual).isEqualTo(expected);
+        assertThat(actual.getSchemaName()).isEqualTo(expected.getSchemaName());
+        assertThat(actual.getTableName()).isEqualTo(expected.getTableName());
+        assertThat(actual.getPredicate()).isEqualTo(expected.getPredicate());
+        assertThat(actual.getProjectedColumns()).isEqualTo(expected.getProjectedColumns());
+    }
+}

--- a/plugin/trino-paimon/src/test/java/io/trino/plugin/paimon/TestPaimonTrinoType.java
+++ b/plugin/trino-paimon/src/test/java/io/trino/plugin/paimon/TestPaimonTrinoType.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.paimon;
+
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.BigintType;
+import io.trino.spi.type.BooleanType;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.DateType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.DoubleType;
+import io.trino.spi.type.IntegerType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RealType;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.SmallintType;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.TimestampWithTimeZoneType;
+import io.trino.spi.type.TinyintType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeOperators;
+import io.trino.spi.type.VarbinaryType;
+import io.trino.spi.type.VarcharType;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.TimeType;
+import org.apache.paimon.types.VarCharType;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for {@link PaimonTypeUtils}.
+ */
+final class TestPaimonTrinoType
+{
+    @Test
+    void testFromPaimonType()
+    {
+        Type charType = PaimonTypeUtils.fromPaimonType(DataTypes.CHAR(1));
+        assertThat(requireNonNull(charType).getDisplayName()).isEqualTo("char(1)");
+
+        Type varCharType = PaimonTypeUtils.fromPaimonType(DataTypes.VARCHAR(10));
+        assertThat(requireNonNull(varCharType).getDisplayName()).isEqualTo("varchar(10)");
+
+        Type booleanType = PaimonTypeUtils.fromPaimonType(DataTypes.BOOLEAN());
+        assertThat(requireNonNull(booleanType).getDisplayName()).isEqualTo("boolean");
+
+        Type binaryType = PaimonTypeUtils.fromPaimonType(DataTypes.BINARY(10));
+        assertThat(requireNonNull(binaryType).getDisplayName()).isEqualTo("varbinary");
+
+        Type varBinaryType = PaimonTypeUtils.fromPaimonType(DataTypes.VARBINARY(10));
+        assertThat(requireNonNull(varBinaryType).getDisplayName()).isEqualTo("varbinary");
+
+        assertThat(PaimonTypeUtils.fromPaimonType(DataTypes.DECIMAL(38, 0)).getDisplayName())
+                .isEqualTo("decimal(38,0)");
+
+        org.apache.paimon.types.DecimalType decimal = DataTypes.DECIMAL(2, 2);
+        assertThat(PaimonTypeUtils.fromPaimonType(decimal).getDisplayName())
+                .isEqualTo("decimal(2,2)");
+
+        Type tinyIntType = PaimonTypeUtils.fromPaimonType(DataTypes.TINYINT());
+        assertThat(requireNonNull(tinyIntType).getDisplayName()).isEqualTo("tinyint");
+
+        Type smallIntType = PaimonTypeUtils.fromPaimonType(DataTypes.SMALLINT());
+        assertThat(requireNonNull(smallIntType).getDisplayName()).isEqualTo("smallint");
+
+        Type intType = PaimonTypeUtils.fromPaimonType(DataTypes.INT());
+        assertThat(requireNonNull(intType).getDisplayName()).isEqualTo("integer");
+
+        Type bigIntType = PaimonTypeUtils.fromPaimonType(DataTypes.BIGINT());
+        assertThat(requireNonNull(bigIntType).getDisplayName()).isEqualTo("bigint");
+
+        Type floatType = PaimonTypeUtils.fromPaimonType(DataTypes.FLOAT());
+        assertThat(requireNonNull(floatType).getDisplayName()).isEqualTo("real");
+
+        Type doubleType = PaimonTypeUtils.fromPaimonType(DataTypes.DOUBLE());
+        assertThat(requireNonNull(doubleType).getDisplayName()).isEqualTo("double");
+
+        Type dateType = PaimonTypeUtils.fromPaimonType(DataTypes.DATE());
+        assertThat(requireNonNull(dateType).getDisplayName()).isEqualTo("date");
+
+        Type timeType = PaimonTypeUtils.fromPaimonType(new TimeType());
+        assertThat(requireNonNull(timeType).getDisplayName()).isEqualTo("time(3)");
+
+        Type timestampType6 = PaimonTypeUtils.fromPaimonType(DataTypes.TIMESTAMP());
+        assertThat(requireNonNull(timestampType6).getDisplayName())
+                .isEqualTo("timestamp(6)");
+
+        Type timestampType0 =
+                PaimonTypeUtils.fromPaimonType(new org.apache.paimon.types.TimestampType(3));
+        assertThat(requireNonNull(timestampType0).getDisplayName())
+                .isEqualTo("timestamp(3)");
+
+        Type localZonedTimestampType =
+                PaimonTypeUtils.fromPaimonType(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE());
+        assertThat(requireNonNull(localZonedTimestampType).getDisplayName())
+                .isEqualTo("timestamp(6) with time zone");
+
+        Type arrayType = PaimonTypeUtils.fromPaimonType(DataTypes.ARRAY(DataTypes.STRING()));
+        assertThat(requireNonNull(arrayType).getDisplayName()).isEqualTo("array(varchar)");
+
+        Type multisetType = PaimonTypeUtils.fromPaimonType(DataTypes.MULTISET(DataTypes.STRING()));
+        assertThat(requireNonNull(multisetType).getDisplayName())
+                .isEqualTo("map(varchar, integer)");
+
+        Type mapType =
+                PaimonTypeUtils.fromPaimonType(
+                        DataTypes.MAP(DataTypes.BIGINT(), DataTypes.STRING()));
+        assertThat(requireNonNull(mapType).getDisplayName())
+                .isEqualTo("map(bigint, varchar)");
+
+        Type row =
+                PaimonTypeUtils.fromPaimonType(
+                        DataTypes.ROW(
+                                new DataField(0, "id", new IntType()),
+                                new DataField(1, "name", new VarCharType(Integer.MAX_VALUE))));
+        assertThat(requireNonNull(row).getDisplayName())
+                .isEqualTo("row(id integer, name varchar)");
+    }
+
+    @Test
+    void testToPaimonType()
+    {
+        DataType charType = PaimonTypeUtils.toPaimonType(CharType.createCharType(1));
+        assertThat(charType.asSQLString()).isEqualTo("CHAR(1)");
+
+        DataType varCharType =
+                PaimonTypeUtils.toPaimonType(VarcharType.createUnboundedVarcharType());
+        assertThat(varCharType.asSQLString()).isEqualTo("VARCHAR(2147483646)");
+
+        DataType booleanType = PaimonTypeUtils.toPaimonType(BooleanType.BOOLEAN);
+        assertThat(booleanType.asSQLString()).isEqualTo("BOOLEAN");
+
+        DataType varbinaryType = PaimonTypeUtils.toPaimonType(VarbinaryType.VARBINARY);
+        assertThat(varbinaryType.asSQLString()).isEqualTo("BYTES");
+
+        DataType decimalType = PaimonTypeUtils.toPaimonType(DecimalType.createDecimalType(2, 2));
+        assertThat(decimalType.asSQLString()).isEqualTo("DECIMAL(2, 2)");
+
+        DataType tinyintType = PaimonTypeUtils.toPaimonType(TinyintType.TINYINT);
+        assertThat(tinyintType.asSQLString()).isEqualTo("TINYINT");
+
+        DataType smallintType = PaimonTypeUtils.toPaimonType(SmallintType.SMALLINT);
+        assertThat(smallintType.asSQLString()).isEqualTo("SMALLINT");
+
+        DataType intType = PaimonTypeUtils.toPaimonType(IntegerType.INTEGER);
+        assertThat(intType.asSQLString()).isEqualTo("INT");
+
+        DataType bigintType = PaimonTypeUtils.toPaimonType(BigintType.BIGINT);
+        assertThat(bigintType.asSQLString()).isEqualTo("BIGINT");
+
+        DataType floatType = PaimonTypeUtils.toPaimonType(RealType.REAL);
+        assertThat(floatType.asSQLString()).isEqualTo("FLOAT");
+
+        DataType doubleType = PaimonTypeUtils.toPaimonType(DoubleType.DOUBLE);
+        assertThat(doubleType.asSQLString()).isEqualTo("DOUBLE");
+
+        DataType dateType = PaimonTypeUtils.toPaimonType(DateType.DATE);
+        assertThat(dateType.asSQLString()).isEqualTo("DATE");
+
+        DataType timeType = PaimonTypeUtils.toPaimonType(io.trino.spi.type.TimeType.TIME_MILLIS);
+        assertThat(timeType.asSQLString()).isEqualTo("TIME(0)");
+
+        DataType timestampType0 = PaimonTypeUtils.toPaimonType(TimestampType.TIMESTAMP_SECONDS);
+        assertThat(timestampType0.asSQLString()).isEqualTo("TIMESTAMP(0)");
+
+        DataType timestampType3 = PaimonTypeUtils.toPaimonType(TimestampType.TIMESTAMP_MILLIS);
+        assertThat(timestampType3.asSQLString()).isEqualTo("TIMESTAMP(3)");
+
+        DataType timestampType6 = PaimonTypeUtils.toPaimonType(TimestampType.TIMESTAMP_MICROS);
+        assertThat(timestampType6.asSQLString()).isEqualTo("TIMESTAMP(6)");
+
+        DataType timestampWithTimeZoneType =
+                PaimonTypeUtils.toPaimonType(TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS);
+        assertThat(timestampWithTimeZoneType.asSQLString())
+                .isEqualTo("TIMESTAMP(6) WITH LOCAL TIME ZONE");
+
+        DataType arrayType = PaimonTypeUtils.toPaimonType(new ArrayType(IntegerType.INTEGER));
+        assertThat(arrayType.asSQLString()).isEqualTo("ARRAY<INT>");
+
+        DataType mapType =
+                PaimonTypeUtils.toPaimonType(
+                        new MapType(
+                                IntegerType.INTEGER,
+                                VarcharType.createUnboundedVarcharType(),
+                                new TypeOperators()));
+        assertThat(mapType.asSQLString()).isEqualTo("MAP<INT, VARCHAR(2147483646)>");
+
+        List<RowType.Field> fields = new ArrayList<>();
+        fields.add(new RowType.Field(java.util.Optional.of("id"), IntegerType.INTEGER));
+        fields.add(
+                new RowType.Field(
+                        java.util.Optional.of("name"), VarcharType.createUnboundedVarcharType()));
+        Type type = RowType.from(fields);
+        DataType rowType = PaimonTypeUtils.toPaimonType(type);
+        assertThat(rowType.asSQLString()).isEqualTo("ROW<`id` INT, `name` VARCHAR(2147483646)>");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
         <module>plugin/trino-openlineage</module>
         <module>plugin/trino-opensearch</module>
         <module>plugin/trino-oracle</module>
+        <module>plugin/trino-paimon</module>
         <module>plugin/trino-password-authenticators</module>
         <module>plugin/trino-phoenix5</module>
         <module>plugin/trino-pinot</module>
@@ -201,6 +202,7 @@
         <dep.iceberg.version>1.7.1</dep.iceberg.version>
         <dep.jna.version>5.16.0</dep.jna.version>
         <dep.joda.version>2.13.0</dep.joda.version>
+        <dep.paimon.version>1.0.0</dep.paimon.version>
         <dep.jsonwebtoken.version>0.12.6</dep.jsonwebtoken.version>
         <dep.jts.version>1.20.0</dep.jts.version>
         <dep.kafka-clients.version>3.9.0</dep.kafka-clients.version>
@@ -2013,6 +2015,12 @@
                 <artifactId>orc-format</artifactId>
                 <version>1.0.0</version>
                 <classifier>shaded-protobuf</classifier>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.paimon</groupId>
+                <artifactId>paimon-bundle</artifactId>
+                <version>${dep.paimon.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Description
To reduce review burden, I divided PR(https://github.com/trinodb/trino/pull/24637) into small pull requests.
This is the first pull request, which only contains DDL for Trino-Paimon.  
Which contains: CREATE TABLE, CREATE SCHEMA, DROP SCHEMA, DROP TABLE, RENAME TBALE, ADD COLUMN, 
DROP COLUMN, etc.

I removed `Write To Paimon` and `Read From Paimon` from the whole pull request.

## Additional context and related issues
Linked pull request: https://github.com/trinodb/trino/pull/24637
Linked issue: https://github.com/trinodb/trino/issues/24636

`Paimon` website: https://paimon.apache.org/
`Paimon` github home page： https://github.com/apache/paimon




