### PR TITLE
Fix query runners failing to expose local ports

### DIFF
--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/TestContainers.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/TestContainers.java
@@ -73,7 +73,7 @@ public final class TestContainers
 
     public static void exposeFixedPorts(GenericContainer<?> container)
     {
-        checkState(isEnvSet("CONTINUOUS_INTEGRATION"), "" +
+        checkState(!isEnvSet("CONTINUOUS_INTEGRATION"), "" +
                 "Exposing fixed ports should not be used in regular test code. This could break parallel test execution. " +
                 "This method is supposed to be invoked from local development helpers only e.g. QueryRunner.main(), " +
                 "hence it should never run on CI");


### PR DESCRIPTION
The logic was mistakenly inverted in
a99d96ece15113d4edf204f5a5345b26f5c9721f.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.