### PR TITLE
Add docs for authentication with Preview Web UI

### DIFF
--- a/docs/src/main/sphinx/admin/preview-web-interface.md
+++ b/docs/src/main/sphinx/admin/preview-web-interface.md
@@ -30,3 +30,46 @@ Once activated, users can access the interface in the URL context `/ui/preview`
 after successful login to the [](/admin/web-interface). For example, the full
 URL on a locally running Trino installation or Trino docker container without
 TLS configuration is [http://localhost:8080/ui/preview](http://localhost:8080/ui/preview).
+
+## Authentication
+
+The Preview Web UI requires users to authenticate. If Trino is not configured to
+require authentication, then any username can be used, and no password is
+required or allowed. The UI shows the login dialog for password authentication
+with the password input deactivated. This is also automatically the case if the
+cluster is only configured to use HTTP. Typically, users login with the same
+username that they use for running queries.
+
+If no system access control is installed, then all users are able to view and
+kill any query. This can be restricted by using [query rules](query-rules) with
+the [](/security/built-in-system-access-control). Users always have permission
+to view or kill their own queries.
+
+### Password authentication
+
+Typically, a password-based authentication method such as [LDAP](/security/ldap)
+or [password file](/security/password-file) is used to secure both the Trino
+server and the Web UI. When the Trino server is configured to use a password
+authenticator, the Web UI authentication type is automatically set to `FORM`. In
+this case, the Web UI displays a login form that accepts a username and
+password. 
+
+### Fixed user authentication
+
+If you require the Preview Web UI to be accessible without authentication, you
+can set a fixed username that will be used for all Web UI access by setting the
+authentication type to `FIXED` and setting the username with the `web-ui.user`
+configuration property. If there is a system access control installed, this user
+must have permission to view ,and possibly to kill, queries.
+
+### Other authentication types
+
+The following Preview Web UI authentication types are also supported:
+
+- `CERTIFICATE`, see details in [](/security/certificate)
+- `KERBEROS`, see details in [](/security/kerberos)
+- `JWT`, see details in [](/security/jwt)
+- `OAUTH2`, see details in [](/security/oauth2)
+
+For these authentication types, the username is defined by
+[](/security/user-mapping).


### PR DESCRIPTION
## Description

Just a lift and shift and minor update of the content from the legacy UI .. this enables us to at some stage just remove that old page and UI. Please verify that what is written is actually true and let me know if we should remove or update anything.

Basically we should keep the docs for the preview UI separate and complete. In that realm also .. what do you think if we start adding some docs about each screen .. can be very high level

## Additional context and related issues

#23230 

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

