### PR TITLE
Fix code formatting in Preview Web UI

### DIFF
--- a/core/trino-web-ui/src/main/resources/webapp-preview/package.json
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/package.json
@@ -10,8 +10,8 @@
     "package": "npm install && npm run build",
     "package:clean": "npm clean-install && npm run build",
     "preview": "vite preview",
-    "prettier:format": "prettier --write \"./src/*.{ts,tsx}\"",
-    "prettier:check": "prettier --check \"./src/*.{ts,tsx}\"",
+    "prettier:format": "prettier --write \"./src/**/*.{ts,tsx}\"",
+    "prettier:check": "prettier --check \"./src/**/*.{ts,tsx}\"",
     "check": "npm install && npm run lint && npm run prettier:check",
     "check:clean": "npm clean-install && npm run lint && npm run prettier:check"
   },

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/api/base.ts
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/api/base.ts
@@ -20,7 +20,7 @@ export interface ApiResponse<T> {
 }
 
 export class ClientApi {
-    axiosInstance: AxiosInstance = axios.create();
+    axiosInstance: AxiosInstance = axios.create()
 
     paramsToQueryString = (params: Record<string, string>): string => {
         let queryString = ''
@@ -32,13 +32,13 @@ export class ClientApi {
 
     fetchData = async <T, P = undefined>(url: string, method: 'GET' | 'POST', params?: P): Promise<ApiResponse<T>> => {
         try {
-            let response: AxiosResponse<T>;
+            let response: AxiosResponse<T>
             if (method === 'GET') {
                 response = await this.axiosInstance.get(url)
             } else if (method === 'POST') {
                 response = await this.axiosInstance.post(url, params)
             } else {
-                throw new Error(`Unsupported HTTP method: ${method}`);
+                throw new Error(`Unsupported HTTP method: ${method}`)
             }
             return {
                 status: response.status,
@@ -53,17 +53,17 @@ export class ClientApi {
                     message: axiosError.message,
                 }
             }
-            throw error;
+            throw error
         }
     }
 
     get = async <T>(url: string, params: Record<string, string> = {}): Promise<ApiResponse<T>> => {
-        return this.fetchData(url + this.paramsToQueryString(params), 'GET');
+        return this.fetchData(url + this.paramsToQueryString(params), 'GET')
     }
 
-    post = async<T>(url: string, body: Record<string, string> = {}): Promise<ApiResponse<T>> => {
-        return this.fetchData(url, 'POST', body);
+    post = async <T>(url: string, body: Record<string, string> = {}): Promise<ApiResponse<T>> => {
+        return this.fetchData(url, 'POST', body)
     }
 }
 
-export const api = new ClientApi();
+export const api = new ClientApi()

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/api/webapp/api.ts
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/api/webapp/api.ts
@@ -14,17 +14,17 @@
 import { api, ApiResponse } from '../base.ts'
 
 export interface Stats {
-    runningQueries: number;
-    blockedQueries: number;
-    queuedQueries: number;
-    activeCoordinators: number;
-    activeWorkers: number;
-    runningDrivers: number;
-    totalAvailableProcessors: number;
-    reservedMemory: number;
-    totalInputRows: number;
-    totalInputBytes: number;
-    totalCpuTimeSecs: number;
+    runningQueries: number
+    blockedQueries: number
+    queuedQueries: number
+    activeCoordinators: number
+    activeWorkers: number
+    runningDrivers: number
+    totalAvailableProcessors: number
+    reservedMemory: number
+    totalInputRows: number
+    totalInputBytes: number
+    totalCpuTimeSecs: number
 }
 
 export async function statsApi(): Promise<ApiResponse<Stats>> {

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/api/webapp/auth.ts
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/api/webapp/auth.ts
@@ -11,26 +11,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { api, ApiResponse } from "../base";
+import { api, ApiResponse } from '../base'
 
-export interface AuthInfo
-{
-    authType: "insecure" | "form" | "fixed" | "oauth2" | null;
-    passwordAllowed: boolean;
-    authenticated: boolean;
-    username?: string;
+export interface AuthInfo {
+    authType: 'insecure' | 'form' | 'fixed' | 'oauth2' | null
+    passwordAllowed: boolean
+    authenticated: boolean
+    username?: string
 }
 
-export type Empty = object;
+export type Empty = object
 
 export async function authInfoApi(): Promise<ApiResponse<AuthInfo>> {
-  return api.get('/ui/preview/auth/info')
+    return api.get('/ui/preview/auth/info')
 }
 
 export async function loginApi(body: Record<string, string>): Promise<ApiResponse<Empty>> {
-  return api.post('/ui/preview/auth/login', body)
+    return api.post('/ui/preview/auth/login', body)
 }
 
 export async function logoutApi(): Promise<ApiResponse<Empty>> {
-  return api.get('/ui/preview/auth/logout')
+    return api.get('/ui/preview/auth/logout')
 }

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/Auth.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/Auth.tsx
@@ -11,33 +11,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Box, CircularProgress, Alert, Typography } from "@mui/material";
+import { Box, CircularProgress, Alert, Typography } from '@mui/material'
 import { useAuth } from './AuthContext'
-import { Texts } from "../constant";
-import { Login } from './Login';
+import { Texts } from '../constant'
+import { Login } from './Login'
 
 export const Auth = () => {
-  const { authInfo, error, loading } = useAuth();
+    const { authInfo, error, loading } = useAuth()
 
-  if (!authInfo) {
-      return (
-          <Box sx={{ p: 10 }} display="flex" flexDirection="column"  alignItems="center" justifyContent="center">
-            {loading ?
-              <>
-                <CircularProgress/>
-                <Typography mt={2}>{Texts.Auth.Authenticating}</Typography>
-              </> : error &&
-              <Alert severity="error">
-                {error}
-              </Alert>
-            }
-          </Box>
-      )
-  }
+    if (!authInfo) {
+        return (
+            <Box sx={{ p: 10 }} display="flex" flexDirection="column" alignItems="center" justifyContent="center">
+                {loading ? (
+                    <>
+                        <CircularProgress />
+                        <Typography mt={2}>{Texts.Auth.Authenticating}</Typography>
+                    </>
+                ) : (
+                    error && <Alert severity="error">{error}</Alert>
+                )}
+            </Box>
+        )
+    }
 
-  if (authInfo.authType === 'form' && !authInfo?.authenticated) {
-    return <Login passwordAllowed={authInfo.passwordAllowed} />
-  }
+    if (authInfo.authType === 'form' && !authInfo?.authenticated) {
+        return <Login passwordAllowed={authInfo.passwordAllowed} />
+    }
 
-  return <div>{Texts.Auth.NotImplementedAuthType}</div>
+    return <div>{Texts.Auth.NotImplementedAuthType}</div>
 }

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/AuthContext.ts
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/AuthContext.ts
@@ -11,27 +11,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { createContext, useContext } from "react";
-import { AuthInfo } from '../api/webapp/auth';
+import { createContext, useContext } from 'react'
+import { AuthInfo } from '../api/webapp/auth'
 
 export interface LogoutParams {
-  redirect?: boolean;
+    redirect?: boolean
 }
 
 interface AuthContextType {
-  authInfo: AuthInfo | null;
-  login: (username: string, password: string) => Promise<void>;
-  logout: (params: LogoutParams) => void;
-  loading: boolean;
-  error: string | null;
+    authInfo: AuthInfo | null
+    login: (username: string, password: string) => Promise<void>
+    logout: (params: LogoutParams) => void
+    loading: boolean
+    error: string | null
 }
 
-export const AuthContext = createContext<AuthContextType | undefined>(undefined);
+export const AuthContext = createContext<AuthContextType | undefined>(undefined)
 
 export const useAuth = (): AuthContextType => {
-  const context = useContext(AuthContext);
-  if (context === undefined) {
-    throw new Error('AuthContext must be used within an AuthProvider');
-  }
-  return context;
-};
+    const context = useContext(AuthContext)
+    if (context === undefined) {
+        throw new Error('AuthContext must be used within an AuthProvider')
+    }
+    return context
+}

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/CodeBlock.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/CodeBlock.tsx
@@ -11,45 +11,49 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Box, useMediaQuery} from '@mui/material';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { materialLight, materialDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
-import { Theme as ThemeStore, useConfigStore } from "../store";
+import { Box, useMediaQuery } from '@mui/material'
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
+import { materialLight, materialDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
+import { Theme as ThemeStore, useConfigStore } from '../store'
 
 export interface ICodeBlockProps {
-  code: string;
-  language: string;
+    code: string
+    language: string
 }
 
 export const CodeBlock = (props: ICodeBlockProps) => {
-  const config = useConfigStore();
-  const { code, language } = props;
-  const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)')
+    const config = useConfigStore()
+    const { code, language } = props
+    const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)')
 
-  const styleToUse = () => {
-    if (config.theme === ThemeStore.Auto) {
-      return prefersDarkMode ? materialDark : materialLight
-    } else if (config.theme === ThemeStore.Dark) {
-      return materialDark
-    } else {
-      return materialLight
+    const styleToUse = () => {
+        if (config.theme === ThemeStore.Auto) {
+            return prefersDarkMode ? materialDark : materialLight
+        } else if (config.theme === ThemeStore.Dark) {
+            return materialDark
+        } else {
+            return materialLight
+        }
     }
-  }
 
-  return (
-      <Box
-          sx={{
-            padding: 0,
-            borderRadius: 0,
-            backgroundColor: '#f5f5f5',
-            overflow: 'auto',
-            maxHeight: '400px',
-            border: '1px solid #ddd',
-          }}
-      >
-        <SyntaxHighlighter language={language} style={styleToUse()} customStyle={{ padding: '4px', margin: 0, borderRadius: 0 }} >
-          {code}
-        </SyntaxHighlighter>
-      </Box>
-  );
+    return (
+        <Box
+            sx={{
+                padding: 0,
+                borderRadius: 0,
+                backgroundColor: '#f5f5f5',
+                overflow: 'auto',
+                maxHeight: '400px',
+                border: '1px solid #ddd',
+            }}
+        >
+            <SyntaxHighlighter
+                language={language}
+                style={styleToUse()}
+                customStyle={{ padding: '4px', margin: 0, borderRadius: 0 }}
+            >
+                {code}
+            </SyntaxHighlighter>
+        </Box>
+    )
 }

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/Dashboard.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/Dashboard.tsx
@@ -11,183 +11,193 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useEffect, useState } from 'react';
-import Typography from '@mui/material/Typography';
-import {
-  Box,
-  Grid2 as Grid,
-} from "@mui/material";
+import { useEffect, useState } from 'react'
+import Typography from '@mui/material/Typography'
+import { Box, Grid2 as Grid } from '@mui/material'
 import { MetricCard } from './MetricCard.tsx'
-import { useSnackbar } from "./SnackbarContext.ts";
-import { ApiResponse } from "../api/base.ts";
-import { statsApi, Stats } from "../api/webapp/api.ts";
-import { Texts } from "../constant.ts";
+import { useSnackbar } from './SnackbarContext.ts'
+import { ApiResponse } from '../api/base.ts'
+import { statsApi, Stats } from '../api/webapp/api.ts'
+import { Texts } from '../constant.ts'
 import {
-  MAX_HISTORY,
-  addExponentiallyWeightedToHistory,
-  addToHistory,
-  formatCount,
-  formatDataSizeBytes,
-  precisionRound,
+    MAX_HISTORY,
+    addExponentiallyWeightedToHistory,
+    addToHistory,
+    formatCount,
+    formatDataSizeBytes,
+    precisionRound,
 } from '../utils/utils.ts'
 
-interface ClusterStats
-{
-  runningQueries: number[];
-  queuedQueries: number[];
-  blockedQueries: number[];
-  activeWorkers: number[];
-  runningDrivers: number[];
-  reservedMemory: number[];
-  rowInputRate: number[];
-  byteInputRate: number[];
-  perWorkerCpuTimeRate: number[];
+interface ClusterStats {
+    runningQueries: number[]
+    queuedQueries: number[]
+    blockedQueries: number[]
+    activeWorkers: number[]
+    runningDrivers: number[]
+    reservedMemory: number[]
+    rowInputRate: number[]
+    byteInputRate: number[]
+    perWorkerCpuTimeRate: number[]
 
-  lastRefresh: number | null;
+    lastRefresh: number | null
 
-  lastInputRows: number
-  lastInputBytes: number;
-  lastCpuTime: number;
+    lastInputRows: number
+    lastInputBytes: number
+    lastCpuTime: number
 }
 
 export const Dashboard = () => {
-  const { showSnackbar } = useSnackbar();
-  const initialFilledHistory = Array(MAX_HISTORY).fill(0);
-  const [clusterStats, setClusterStats] = useState<ClusterStats>({
-    runningQueries: initialFilledHistory,
-    queuedQueries: initialFilledHistory,
-    blockedQueries: initialFilledHistory,
-    activeWorkers: initialFilledHistory,
-    runningDrivers: initialFilledHistory,
-    reservedMemory: initialFilledHistory,
-    rowInputRate: initialFilledHistory,
-    byteInputRate: initialFilledHistory,
-    perWorkerCpuTimeRate: initialFilledHistory,
+    const { showSnackbar } = useSnackbar()
+    const initialFilledHistory = Array(MAX_HISTORY).fill(0)
+    const [clusterStats, setClusterStats] = useState<ClusterStats>({
+        runningQueries: initialFilledHistory,
+        queuedQueries: initialFilledHistory,
+        blockedQueries: initialFilledHistory,
+        activeWorkers: initialFilledHistory,
+        runningDrivers: initialFilledHistory,
+        reservedMemory: initialFilledHistory,
+        rowInputRate: initialFilledHistory,
+        byteInputRate: initialFilledHistory,
+        perWorkerCpuTimeRate: initialFilledHistory,
 
-    lastRefresh: null,
+        lastRefresh: null,
 
-    lastInputRows: 0,
-    lastInputBytes: 0,
-    lastCpuTime: 0,
-  });
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    getClusterStats();
-    const intervalId = setInterval(getClusterStats, 1000);
-    return () => clearInterval(intervalId);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useEffect(() => {
-    if (error) {
-      showSnackbar(error, 'error');
-    }
-  }, [error, showSnackbar])
-
-  const getClusterStats = () => {
-    setError(null);
-    statsApi().then((apiResponse: ApiResponse<Stats>) => {
-      if (apiResponse.status === 200 && apiResponse.data) {
-        const newClusterStats: Stats = apiResponse.data;
-        setClusterStats(prevClusterStats => {
-          let newRowInputRate: number[] = initialFilledHistory;
-          let newByteInputRate: number[] = initialFilledHistory;
-          let newPerWorkerCpuTimeRate: number[] = []
-          if (prevClusterStats.lastRefresh !== null) {
-            const rowsInputSinceRefresh = newClusterStats.totalInputRows - prevClusterStats.lastInputRows
-            const bytesInputSinceRefresh = newClusterStats.totalInputBytes - prevClusterStats.lastInputBytes
-            const cpuTimeSinceRefresh = newClusterStats.totalCpuTimeSecs - prevClusterStats.lastCpuTime
-            const secsSinceRefresh = (Date.now() - prevClusterStats.lastRefresh) / 1000.0
-
-            newRowInputRate = addExponentiallyWeightedToHistory(
-                rowsInputSinceRefresh / secsSinceRefresh,
-                prevClusterStats.rowInputRate
-            )
-            newByteInputRate = addExponentiallyWeightedToHistory(
-                bytesInputSinceRefresh / secsSinceRefresh,
-                prevClusterStats.byteInputRate
-            )
-            newPerWorkerCpuTimeRate = addExponentiallyWeightedToHistory(
-                cpuTimeSinceRefresh / newClusterStats.activeWorkers / secsSinceRefresh,
-                prevClusterStats.perWorkerCpuTimeRate
-            )
-          }
-
-          return {
-            // instantaneous stats
-            runningQueries: addToHistory(newClusterStats.runningQueries, prevClusterStats.runningQueries),
-            queuedQueries: addToHistory(newClusterStats.queuedQueries, prevClusterStats.queuedQueries),
-            blockedQueries: addToHistory(newClusterStats.blockedQueries, prevClusterStats.blockedQueries),
-            activeWorkers: addToHistory(newClusterStats.activeWorkers, prevClusterStats.activeWorkers),
-
-            // moving averages
-            runningDrivers: addExponentiallyWeightedToHistory(
-                newClusterStats.runningDrivers,
-                prevClusterStats.runningDrivers
-            ),
-            reservedMemory: addExponentiallyWeightedToHistory(
-                newClusterStats.reservedMemory,
-                prevClusterStats.reservedMemory
-            ),
-
-            // moving averages for diffs
-            rowInputRate: newRowInputRate,
-            byteInputRate: newByteInputRate,
-            perWorkerCpuTimeRate: newPerWorkerCpuTimeRate,
-
-            lastInputRows: newClusterStats.totalInputRows,
-            lastInputBytes: newClusterStats.totalInputBytes,
-            lastCpuTime: newClusterStats.totalCpuTimeSecs,
-
-            lastRefresh: Date.now(),
-          }
-        });
-        setError(null);
-      } else {
-        setError(`${Texts.Error.Communication} ${apiResponse.status}: ${apiResponse.message}`);
-      }
+        lastInputRows: 0,
+        lastInputBytes: 0,
+        lastCpuTime: 0,
     })
-  };
+    const [error, setError] = useState<string | null>(null)
 
-  return (
-    <>
-      <Box sx={{ pb: 2 }}>
-        <Typography variant="h4">
-          Cluster Overview
-        </Typography>
-      </Box>
-      <Box>
-        <Grid container spacing={3}>
-          <Grid size={{ xs:12, sm: 12, md: 6, lg:4 }}>
-            <MetricCard title="Running Queries" values={clusterStats.runningQueries} />
-          </Grid>
-          <Grid size={{ xs:12, sm: 12, md: 6, lg:4 }}>
-            <MetricCard title="Active Workers" values={clusterStats.activeWorkers} />
-          </Grid>
-          <Grid size={{ xs:12, sm: 12, md: 6, lg:4 }}>
-            <MetricCard title="Rows/sec" values={clusterStats.rowInputRate} numberFormatter={formatCount} />
-          </Grid>
-          <Grid size={{ xs:12, sm: 12, md: 6, lg:4 }}>
-            <MetricCard title="Queued Queries" values={clusterStats.queuedQueries} />
-          </Grid>
-          <Grid size={{ xs:12, sm: 12, md: 6, lg:4 }}>
-            <MetricCard title="Runnable Drivers" values={clusterStats.runningDrivers} numberFormatter={precisionRound} />
-          </Grid>
-          <Grid size={{ xs:12, sm: 12, md: 6, lg:4 }}>
-            <MetricCard title="Bytes/sec" values={clusterStats.byteInputRate} numberFormatter={formatDataSizeBytes} />
-          </Grid>
-          <Grid size={{ xs:12, sm: 12, md: 6, lg:4 }}>
-            <MetricCard title="Blocked Queries" values={clusterStats.blockedQueries} />
-          </Grid>
-          <Grid size={{ xs:12, sm: 12, md: 6, lg:4 }}>
-            <MetricCard title="Reserved Memory (B)" values={clusterStats.reservedMemory} numberFormatter={formatDataSizeBytes} />
-          </Grid>
-          <Grid size={{ xs:12, sm: 12, md: 6, lg:4 }}>
-            <MetricCard title="Worker Parallelism" values={clusterStats.perWorkerCpuTimeRate} numberFormatter={precisionRound} />
-          </Grid>
-        </Grid>
-      </Box>
-    </>
-  );
+    useEffect(() => {
+        getClusterStats()
+        const intervalId = setInterval(getClusterStats, 1000)
+        return () => clearInterval(intervalId)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    useEffect(() => {
+        if (error) {
+            showSnackbar(error, 'error')
+        }
+    }, [error, showSnackbar])
+
+    const getClusterStats = () => {
+        setError(null)
+        statsApi().then((apiResponse: ApiResponse<Stats>) => {
+            if (apiResponse.status === 200 && apiResponse.data) {
+                const newClusterStats: Stats = apiResponse.data
+                setClusterStats((prevClusterStats) => {
+                    let newRowInputRate: number[] = initialFilledHistory
+                    let newByteInputRate: number[] = initialFilledHistory
+                    let newPerWorkerCpuTimeRate: number[] = []
+                    if (prevClusterStats.lastRefresh !== null) {
+                        const rowsInputSinceRefresh = newClusterStats.totalInputRows - prevClusterStats.lastInputRows
+                        const bytesInputSinceRefresh = newClusterStats.totalInputBytes - prevClusterStats.lastInputBytes
+                        const cpuTimeSinceRefresh = newClusterStats.totalCpuTimeSecs - prevClusterStats.lastCpuTime
+                        const secsSinceRefresh = (Date.now() - prevClusterStats.lastRefresh) / 1000.0
+
+                        newRowInputRate = addExponentiallyWeightedToHistory(
+                            rowsInputSinceRefresh / secsSinceRefresh,
+                            prevClusterStats.rowInputRate
+                        )
+                        newByteInputRate = addExponentiallyWeightedToHistory(
+                            bytesInputSinceRefresh / secsSinceRefresh,
+                            prevClusterStats.byteInputRate
+                        )
+                        newPerWorkerCpuTimeRate = addExponentiallyWeightedToHistory(
+                            cpuTimeSinceRefresh / newClusterStats.activeWorkers / secsSinceRefresh,
+                            prevClusterStats.perWorkerCpuTimeRate
+                        )
+                    }
+
+                    return {
+                        // instantaneous stats
+                        runningQueries: addToHistory(newClusterStats.runningQueries, prevClusterStats.runningQueries),
+                        queuedQueries: addToHistory(newClusterStats.queuedQueries, prevClusterStats.queuedQueries),
+                        blockedQueries: addToHistory(newClusterStats.blockedQueries, prevClusterStats.blockedQueries),
+                        activeWorkers: addToHistory(newClusterStats.activeWorkers, prevClusterStats.activeWorkers),
+
+                        // moving averages
+                        runningDrivers: addExponentiallyWeightedToHistory(
+                            newClusterStats.runningDrivers,
+                            prevClusterStats.runningDrivers
+                        ),
+                        reservedMemory: addExponentiallyWeightedToHistory(
+                            newClusterStats.reservedMemory,
+                            prevClusterStats.reservedMemory
+                        ),
+
+                        // moving averages for diffs
+                        rowInputRate: newRowInputRate,
+                        byteInputRate: newByteInputRate,
+                        perWorkerCpuTimeRate: newPerWorkerCpuTimeRate,
+
+                        lastInputRows: newClusterStats.totalInputRows,
+                        lastInputBytes: newClusterStats.totalInputBytes,
+                        lastCpuTime: newClusterStats.totalCpuTimeSecs,
+
+                        lastRefresh: Date.now(),
+                    }
+                })
+                setError(null)
+            } else {
+                setError(`${Texts.Error.Communication} ${apiResponse.status}: ${apiResponse.message}`)
+            }
+        })
+    }
+
+    return (
+        <>
+            <Box sx={{ pb: 2 }}>
+                <Typography variant="h4">Cluster Overview</Typography>
+            </Box>
+            <Box>
+                <Grid container spacing={3}>
+                    <Grid size={{ xs: 12, sm: 12, md: 6, lg: 4 }}>
+                        <MetricCard title="Running Queries" values={clusterStats.runningQueries} />
+                    </Grid>
+                    <Grid size={{ xs: 12, sm: 12, md: 6, lg: 4 }}>
+                        <MetricCard title="Active Workers" values={clusterStats.activeWorkers} />
+                    </Grid>
+                    <Grid size={{ xs: 12, sm: 12, md: 6, lg: 4 }}>
+                        <MetricCard title="Rows/sec" values={clusterStats.rowInputRate} numberFormatter={formatCount} />
+                    </Grid>
+                    <Grid size={{ xs: 12, sm: 12, md: 6, lg: 4 }}>
+                        <MetricCard title="Queued Queries" values={clusterStats.queuedQueries} />
+                    </Grid>
+                    <Grid size={{ xs: 12, sm: 12, md: 6, lg: 4 }}>
+                        <MetricCard
+                            title="Runnable Drivers"
+                            values={clusterStats.runningDrivers}
+                            numberFormatter={precisionRound}
+                        />
+                    </Grid>
+                    <Grid size={{ xs: 12, sm: 12, md: 6, lg: 4 }}>
+                        <MetricCard
+                            title="Bytes/sec"
+                            values={clusterStats.byteInputRate}
+                            numberFormatter={formatDataSizeBytes}
+                        />
+                    </Grid>
+                    <Grid size={{ xs: 12, sm: 12, md: 6, lg: 4 }}>
+                        <MetricCard title="Blocked Queries" values={clusterStats.blockedQueries} />
+                    </Grid>
+                    <Grid size={{ xs: 12, sm: 12, md: 6, lg: 4 }}>
+                        <MetricCard
+                            title="Reserved Memory (B)"
+                            values={clusterStats.reservedMemory}
+                            numberFormatter={formatDataSizeBytes}
+                        />
+                    </Grid>
+                    <Grid size={{ xs: 12, sm: 12, md: 6, lg: 4 }}>
+                        <MetricCard
+                            title="Worker Parallelism"
+                            values={clusterStats.perWorkerCpuTimeRate}
+                            numberFormatter={precisionRound}
+                        />
+                    </Grid>
+                </Grid>
+            </Box>
+        </>
+    )
 }

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/DemoComponents.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/DemoComponents.tsx
@@ -11,119 +11,118 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Typography from '@mui/material/Typography';
+import Typography from '@mui/material/Typography'
 import {
-  Box,
-  Button,
-  Checkbox,
-  Grid2 as Grid,
-  Link,
-  Paper,
-  Stack,
-  Switch,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow
-} from "@mui/material";
+    Box,
+    Button,
+    Checkbox,
+    Grid2 as Grid,
+    Link,
+    Paper,
+    Stack,
+    Switch,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableHead,
+    TableRow,
+} from '@mui/material'
 
 export const DemoComponents = () => {
-  const createData = (
-      name: string,
-      calories: number,
-      fat: number,
-      carbs: number,
-      protein: number,
-  ) => {
-    return { name, calories, fat, carbs, protein };
-  }
+    const createData = (name: string, calories: number, fat: number, carbs: number, protein: number) => {
+        return { name, calories, fat, carbs, protein }
+    }
 
-  const rows = [
-    createData('Frozen yoghurt', 159, 6.0, 24, 4.0),
-    createData('Ice cream sandwich', 237, 9.0, 37, 4.3),
-    createData('Eclair', 262, 16.0, 24, 6.0),
-  ];
+    const rows = [
+        createData('Frozen yoghurt', 159, 6.0, 24, 4.0),
+        createData('Ice cream sandwich', 237, 9.0, 37, 4.3),
+        createData('Eclair', 262, 16.0, 24, 6.0),
+    ]
 
-  return (
-      <>
-        <Box sx={{ pb: 2 }}>
-          <Typography variant="h4">
-            Demo Components
-          </Typography>
-        </Box>
-        <Grid container>
-          <Grid sx={{ py: 1 }} size={{ xs:12 }} container>
-            <Grid size={{ xs:3 }}>Buttons</Grid>
-            <Stack direction="row" spacing={2}>
-              <Button variant="contained">Contained</Button>
-              <Button variant="outlined">Outlined</Button>
-              <Button variant="contained" disabled>Disabled</Button>
-            </Stack>
-          </Grid>
+    return (
+        <>
+            <Box sx={{ pb: 2 }}>
+                <Typography variant="h4">Demo Components</Typography>
+            </Box>
+            <Grid container>
+                <Grid sx={{ py: 1 }} size={{ xs: 12 }} container>
+                    <Grid size={{ xs: 3 }}>Buttons</Grid>
+                    <Stack direction="row" spacing={2}>
+                        <Button variant="contained">Contained</Button>
+                        <Button variant="outlined">Outlined</Button>
+                        <Button variant="contained" disabled>
+                            Disabled
+                        </Button>
+                    </Stack>
+                </Grid>
 
-          <Grid sx={{ py: 1 }} size={{ xs: 12 }} container>
-            <Grid size={{ xs: 3 }}>Secondary Button</Grid>
-            <Stack direction="row" spacing={2}>
-              <Button color="secondary" variant="contained">Contained</Button>
-              <Button color="secondary" variant="outlined">Outlined</Button>
-            </Stack>
-          </Grid>
+                <Grid sx={{ py: 1 }} size={{ xs: 12 }} container>
+                    <Grid size={{ xs: 3 }}>Secondary Button</Grid>
+                    <Stack direction="row" spacing={2}>
+                        <Button color="secondary" variant="contained">
+                            Contained
+                        </Button>
+                        <Button color="secondary" variant="outlined">
+                            Outlined
+                        </Button>
+                    </Stack>
+                </Grid>
 
-          <Grid sx={{ py: 1 }} size={{ xs: 12 }} container>
-            <Grid size={{ xs: 3 }}>Colored Button</Grid>
-            <Stack direction="row" spacing={2}>
-              <Button variant="contained" color="success">Success</Button>
-              <Button variant="contained" color="error">Error</Button>
-            </Stack>
-          </Grid>
+                <Grid sx={{ py: 1 }} size={{ xs: 12 }} container>
+                    <Grid size={{ xs: 3 }}>Colored Button</Grid>
+                    <Stack direction="row" spacing={2}>
+                        <Button variant="contained" color="success">
+                            Success
+                        </Button>
+                        <Button variant="contained" color="error">
+                            Error
+                        </Button>
+                    </Stack>
+                </Grid>
 
-          <Grid sx={{ py: 1 }} size={{ xs: 12 }} container>
-            <Grid size={{ xs: 3 }}>Link</Grid>
-            <Link href="https://trino.io">Trino Website</Link>
-          </Grid>
+                <Grid sx={{ py: 1 }} size={{ xs: 12 }} container>
+                    <Grid size={{ xs: 3 }}>Link</Grid>
+                    <Link href="https://trino.io">Trino Website</Link>
+                </Grid>
 
-          <Grid sx={{ py: 1 }} size={{ xs: 12 }} container>
-            <Grid size={{ xs: 3 }}>Switch</Grid>
-            <Switch />
-          </Grid>
+                <Grid sx={{ py: 1 }} size={{ xs: 12 }} container>
+                    <Grid size={{ xs: 3 }}>Switch</Grid>
+                    <Switch />
+                </Grid>
 
-          <Grid sx={{ py: 1 }} size={{ xs: 12 }} container>
-            <Grid size={{ xs: 3 }}>Checkbox</Grid>
-            <Checkbox defaultChecked />
-          </Grid>
-        </Grid>
+                <Grid sx={{ py: 1 }} size={{ xs: 12 }} container>
+                    <Grid size={{ xs: 3 }}>Checkbox</Grid>
+                    <Checkbox defaultChecked />
+                </Grid>
+            </Grid>
 
-        <TableContainer component={Paper}>
-          <Table sx={{ minWidth: 650 }} aria-label="simple table">
-            <TableHead>
-              <TableRow>
-                <TableCell>Dessert (100g serving)</TableCell>
-                <TableCell align="right">Calories</TableCell>
-                <TableCell align="right">Fat&nbsp;(g)</TableCell>
-                <TableCell align="right">Carbs&nbsp;(g)</TableCell>
-                <TableCell align="right">Protein&nbsp;(g)</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {rows.map((row) => (
-                  <TableRow
-                      key={row.name}
-                      sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
-                  >
-                    <TableCell component="th" scope="row">
-                      {row.name}
-                    </TableCell>
-                    <TableCell align="right">{row.calories}</TableCell>
-                    <TableCell align="right">{row.fat}</TableCell>
-                    <TableCell align="right">{row.carbs}</TableCell>
-                    <TableCell align="right">{row.protein}</TableCell>
-                  </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </TableContainer>
-      </>
-  );
+            <TableContainer component={Paper}>
+                <Table sx={{ minWidth: 650 }} aria-label="simple table">
+                    <TableHead>
+                        <TableRow>
+                            <TableCell>Dessert (100g serving)</TableCell>
+                            <TableCell align="right">Calories</TableCell>
+                            <TableCell align="right">Fat&nbsp;(g)</TableCell>
+                            <TableCell align="right">Carbs&nbsp;(g)</TableCell>
+                            <TableCell align="right">Protein&nbsp;(g)</TableCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {rows.map((row) => (
+                            <TableRow key={row.name} sx={{ '&:last-child td, &:last-child th': { border: 0 } }}>
+                                <TableCell component="th" scope="row">
+                                    {row.name}
+                                </TableCell>
+                                <TableCell align="right">{row.calories}</TableCell>
+                                <TableCell align="right">{row.fat}</TableCell>
+                                <TableCell align="right">{row.carbs}</TableCell>
+                                <TableCell align="right">{row.protein}</TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+            </TableContainer>
+        </>
+    )
 }

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/Layout.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/Layout.tsx
@@ -11,87 +11,75 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { ReactNode, useEffect, useState } from 'react';
-import { useLocation, Link } from "react-router-dom";
+import React, { ReactNode, useEffect, useState } from 'react'
+import { useLocation, Link } from 'react-router-dom'
 import {
-  Avatar,
-  AppBar,
-  Box,
-  Container,
-  IconButton,
-  List,
-  ListItem,
-  ListItemButton,
-  ListItemIcon,
-  ListItemText,
-  Menu,
-  MenuItem,
-  Drawer as MuiDrawer,
-  Toolbar,
-  Tooltip,
-  Typography
-} from '@mui/material';
-import {
-  CSSObject,
-  Theme,
-  styled
-} from '@mui/material/styles';
-import {
-  DarkModeOutlined,
-  LightModeOutlined,
-  SettingsBrightnessOutlined
-} from "@mui/icons-material";
-import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
-import ChevronRightIcon from '@mui/icons-material/ChevronRight';
-import LogoutIcon from '@mui/icons-material/Logout';
-import { Texts } from "../constant";
+    Avatar,
+    AppBar,
+    Box,
+    Container,
+    IconButton,
+    List,
+    ListItem,
+    ListItemButton,
+    ListItemIcon,
+    ListItemText,
+    Menu,
+    MenuItem,
+    Drawer as MuiDrawer,
+    Toolbar,
+    Tooltip,
+    Typography,
+} from '@mui/material'
+import { CSSObject, Theme, styled } from '@mui/material/styles'
+import { DarkModeOutlined, LightModeOutlined, SettingsBrightnessOutlined } from '@mui/icons-material'
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
+import ChevronRightIcon from '@mui/icons-material/ChevronRight'
+import LogoutIcon from '@mui/icons-material/Logout'
+import { Texts } from '../constant'
 import trinoLogo from '../assets/trino.svg'
-import {
-  RouterItem,
-  routers,
-  routersMapper
-} from "../router.tsx";
-import { Theme as ThemeStore, useConfigStore } from "../store";
-import { useAuth } from "./AuthContext";
-import { useSnackbar } from "./SnackbarContext";
+import { RouterItem, routers, routersMapper } from '../router.tsx'
+import { Theme as ThemeStore, useConfigStore } from '../store'
+import { useAuth } from './AuthContext'
+import { useSnackbar } from './SnackbarContext'
 
 interface settingsMenuItem {
-  key: string;
-  caption: string;
-  icon?: ReactNode
-  divider?: boolean;
-  onClick?: () => void;
-  disabled?: boolean;
+    key: string
+    caption: string
+    icon?: ReactNode
+    divider?: boolean
+    onClick?: () => void
+    disabled?: boolean
 }
 
 const openedDrawer = (theme: Theme, width: number): CSSObject => ({
-  width: width,
-  transition: theme.transitions.create('width', {
-    easing: theme.transitions.easing.sharp,
-    duration: theme.transitions.duration.enteringScreen,
-  }),
-  overflowX: 'hidden',
-});
+    width: width,
+    transition: theme.transitions.create('width', {
+        easing: theme.transitions.easing.sharp,
+        duration: theme.transitions.duration.enteringScreen,
+    }),
+    overflowX: 'hidden',
+})
 
 const closedDrawer = (theme: Theme): CSSObject => ({
-  transition: theme.transitions.create('width', {
-    easing: theme.transitions.easing.sharp,
-    duration: theme.transitions.duration.leavingScreen,
-  }),
-  overflowX: 'hidden',
-  width: `calc(${theme.spacing(7)} + 1px)`,
-  [theme.breakpoints.up('sm')]: {
-    width: `calc(${theme.spacing(8)} + 1px)`,
-  },
-});
+    transition: theme.transitions.create('width', {
+        easing: theme.transitions.easing.sharp,
+        duration: theme.transitions.duration.leavingScreen,
+    }),
+    overflowX: 'hidden',
+    width: `calc(${theme.spacing(7)} + 1px)`,
+    [theme.breakpoints.up('sm')]: {
+        width: `calc(${theme.spacing(8)} + 1px)`,
+    },
+})
 
 const DrawerFooter = styled('div')(({ theme }) => ({
-  display: 'flex',
-  flexGrow: 0,
-  alignItems: 'center',
-  justifyContent: 'flex-end',
-  padding: theme.spacing(0, 1.5),
-}));
+    display: 'flex',
+    flexGrow: 0,
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    padding: theme.spacing(0, 1.5),
+}))
 
 // @ts-expect-error TS2339
 const Drawer = styled(MuiDrawer)(({ theme, open, width }) => ({
@@ -100,241 +88,234 @@ const Drawer = styled(MuiDrawer)(({ theme, open, width }) => ({
     whiteSpace: 'nowrap',
     boxSizing: 'border-box',
     ...(open && {
-      ...openedDrawer(theme, width),
-      '& .MuiDrawer-paper': openedDrawer(theme, width),
+        ...openedDrawer(theme, width),
+        '& .MuiDrawer-paper': openedDrawer(theme, width),
     }),
     ...(!open && {
-      ...closedDrawer(theme),
-      '& .MuiDrawer-paper': closedDrawer(theme),
+        ...closedDrawer(theme),
+        '& .MuiDrawer-paper': closedDrawer(theme),
     }),
-  }),
-);
+}))
 
-export const RootLayout = (props: {
-  children: React.ReactNode
-}) => {
-  const config = useConfigStore();
-  const { authInfo, logout, error } = useAuth();
-  const { showSnackbar } = useSnackbar();
-  const location = useLocation();
-  const [drawerOpen, setDrawerOpen] = useState<boolean>(true);
-  const [selectedDrawerItemKey, setSelectedDrawerItemKey] = useState(location.pathname.substring(location.pathname.lastIndexOf('/') + 1));
-  const [anchorElTheme, setAnchorElTheme] = useState<Element | null>(null);
-  const [anchorElUser, setAnchorElUser] = useState<Element | null>(null);
-  const username = authInfo?.username || '';
-  const userInitials = username?.charAt(0).toUpperCase();
+export const RootLayout = (props: { children: React.ReactNode }) => {
+    const config = useConfigStore()
+    const { authInfo, logout, error } = useAuth()
+    const { showSnackbar } = useSnackbar()
+    const location = useLocation()
+    const [drawerOpen, setDrawerOpen] = useState<boolean>(true)
+    const [selectedDrawerItemKey, setSelectedDrawerItemKey] = useState(
+        location.pathname.substring(location.pathname.lastIndexOf('/') + 1)
+    )
+    const [anchorElTheme, setAnchorElTheme] = useState<Element | null>(null)
+    const [anchorElUser, setAnchorElUser] = useState<Element | null>(null)
+    const username = authInfo?.username || ''
+    const userInitials = username?.charAt(0).toUpperCase()
 
-  useEffect(() => {
-    const router = routersMapper[location.pathname];
-    if (router && router.itemKey != null && selectedDrawerItemKey !== router.itemKey) {
-      setSelectedDrawerItemKey(router.itemKey);
+    useEffect(() => {
+        const router = routersMapper[location.pathname]
+        if (router && router.itemKey != null && selectedDrawerItemKey !== router.itemKey) {
+            setSelectedDrawerItemKey(router.itemKey)
+        }
+    }, [location, selectedDrawerItemKey])
+
+    useEffect(() => {
+        if (error) {
+            showSnackbar(error, 'error')
+        }
+    }, [error, showSnackbar])
+
+    const onLogout = () => {
+        logout({ redirect: authInfo?.authType != 'form' })
     }
-  }, [location, selectedDrawerItemKey]);
 
-  useEffect(() => {
-    if (error) {
-      showSnackbar(error, 'error');
+    const openUserMenu = (event: React.MouseEvent) => {
+        setAnchorElUser(event.currentTarget)
     }
-  }, [error, showSnackbar])
 
-  const onLogout = () => {
-    logout({ redirect: authInfo?.authType != 'form', });
-  }
+    const closeUserMenu = () => {
+        setAnchorElUser(null)
+    }
 
-  const openUserMenu = (event: React.MouseEvent) => {
-    setAnchorElUser(event.currentTarget);
-  };
+    const openThemeMenu = (event: React.MouseEvent) => {
+        setAnchorElTheme(event.currentTarget)
+    }
 
-  const closeUserMenu = () => {
-    setAnchorElUser(null);
-  }
+    const closeThemeMenu = () => {
+        setAnchorElTheme(null)
+    }
 
-  const openThemeMenu = (event: React.MouseEvent) => {
-    setAnchorElTheme(event.currentTarget);
-  }
+    const setTheme = (theme: ThemeStore) => {
+        config.update((config) => (config.theme = theme))
+    }
 
-  const closeThemeMenu = () => {
-    setAnchorElTheme(null);
-  }
+    const toggleDrawer = () => {
+        drawerOpen ? setDrawerOpen(false) : setDrawerOpen(true)
+    }
 
-  const setTheme = (theme: ThemeStore) => {
-    config.update((config) => (config.theme = theme));
-  }
+    const settingsMenuItems: settingsMenuItem[] = [
+        {
+            key: 'username',
+            caption: username,
+            divider: true,
+        },
+        {
+            key: 'logout',
+            caption: Texts.Menu.Header.Logout,
+            onClick: () => {
+                closeUserMenu()
+                onLogout()
+            },
+            icon: <LogoutIcon />,
+            disabled: authInfo?.authType === 'fixed',
+        },
+    ]
 
-  const toggleDrawer = () => {
-    drawerOpen ? setDrawerOpen(false) : setDrawerOpen(true);
-  };
-
-  const settingsMenuItems: settingsMenuItem[] = [
-    {
-      key: 'username',
-      caption: username,
-      divider: true,
-    },
-    {
-      key: "logout",
-      caption: Texts.Menu.Header.Logout,
-      onClick: () => { closeUserMenu(); onLogout() },
-      icon: <LogoutIcon />,
-      disabled: authInfo?.authType === 'fixed',
-    },
-  ];
-
-  return (
-    <Box sx={{ display: 'flex' }}>
-      <AppBar position="fixed" sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}>
-        <Toolbar>
-          <Box
-            component="img"
-            sx={{ height: 50 }}
-            alt="logo"
-            src={trinoLogo}
-          />
-          <Typography
-            variant="h6"
-            noWrap
-            component="a"
-            href="/"
-            sx={{
-              mx: 2,
-              display: 'flex',
-              flexGrow: 1,
-              fontFamily: 'roboto',
-              fontWeight: 400,
-              color: 'inherit',
-              textDecoration: 'none',
-            }}
-          >
-            Trino
-          </Typography>
-          <Box sx={{ flexGrow: 0 }}>
-            <Tooltip title={Texts.Menu.Header.Themes}>
-              <IconButton sx={{ mx: 2, color: 'inherit' }} onClick={openThemeMenu}>
-                {config.theme === ThemeStore.Auto ? (
-                  <SettingsBrightnessOutlined />
-                ) : config.theme === ThemeStore.Light ? (
-                  <LightModeOutlined />
-                ) : config.theme === ThemeStore.Dark ? (
-                  <DarkModeOutlined />
-                ) : null}
-              </IconButton>
-            </Tooltip>
-            <Menu
-              sx={{ mt: '45px' }}
-              id="menu-appbar"
-              anchorEl={anchorElTheme}
-              anchorOrigin={{
-                vertical: 'top',
-                horizontal: 'right',
-              }}
-              keepMounted
-              transformOrigin={{
-                vertical: 'top',
-                horizontal: 'right',
-              }}
-              open={Boolean(anchorElTheme)}
-              onClose={closeThemeMenu}
-            >
-              {Object.keys(ThemeStore).map((key) => {
-                const value = ThemeStore[key as keyof typeof ThemeStore];
-                return (
-                  <MenuItem key={key} onClick={() => setTheme(value)}
-                            selected={value === config.theme}>
-                    <ListItemIcon>
-                      {value === ThemeStore.Auto ? (
-                        <SettingsBrightnessOutlined/>
-                      ) : value === ThemeStore.Light ? (
-                        <LightModeOutlined/>
-                      ) : value === ThemeStore.Dark ? (
-                        <DarkModeOutlined/>
-                      ) : null}
-                    </ListItemIcon>
-                    <Typography textAlign="center">{key}</Typography>
-                  </MenuItem>
-                )
-              })}
-            </Menu>
-          </Box>
-          <Box sx={{ flexGrow: 0 }}>
-            <Tooltip title={Texts.Menu.Header.Settings}>
-              <IconButton onClick={openUserMenu} sx={{ p: 0 }}>
-                <Avatar src={config.avatar}>{userInitials}</Avatar>
-              </IconButton>
-            </Tooltip>
-            <Menu
-              sx={{ mt: '45px' }}
-              id="menu-appbar"
-              anchorEl={anchorElUser}
-              anchorOrigin={{
-                vertical: 'top',
-                horizontal: 'right',
-              }}
-              keepMounted
-              transformOrigin={{
-                vertical: 'top',
-                horizontal: 'right',
-              }}
-              open={Boolean(anchorElUser)}
-              onClose={closeUserMenu}
-            >
-              {settingsMenuItems.map((settingsMenuItem) => (
-                <MenuItem
-                    sx={{ justifyContent: 'flex-start' }}
-                    key={settingsMenuItem.key}
-                    divider={settingsMenuItem.divider}
-                    onClick={settingsMenuItem.onClick}
-                    disabled={settingsMenuItem.disabled}
-                >
-                  {settingsMenuItem.icon ?
-                    <ListItemIcon>
-                      {settingsMenuItem.icon}
-                    </ListItemIcon> : <div />}
-                  <Typography>{settingsMenuItem.caption}</Typography>
-
-                </MenuItem>
-              ))}
-            </Menu>
-          </Box>
-        </Toolbar>
-      </AppBar>
-      {/*@ts-expect-error TS2322*/}
-      <Drawer variant="permanent" open={drawerOpen} width={240}>
-        <Toolbar />
-        <Box sx={{ overflowX: 'hidden', flexGrow: 1 }}>
-          <List>
-            {routers.map((routerItem: RouterItem) => (
-              <ListItem
-                key={routerItem.text}
-                disablePadding
-              >
-                {/*@ts-expect-error TS2769*/}
-                <ListItemButton
-                  key={routerItem.itemKey}
-                  component={Link}
-                  to={routerItem.routeProps.path}
-                  selected={routerItem.itemKey === selectedDrawerItemKey}
-                >
-                  <ListItemIcon>
-                    {routerItem.icon}
-                  </ListItemIcon>
-                  <ListItemText primary={routerItem.text} />
-                </ListItemButton>
-              </ListItem>
-            ))}
-          </List>
+    return (
+        <Box sx={{ display: 'flex' }}>
+            <AppBar position="fixed" sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}>
+                <Toolbar>
+                    <Box component="img" sx={{ height: 50 }} alt="logo" src={trinoLogo} />
+                    <Typography
+                        variant="h6"
+                        noWrap
+                        component="a"
+                        href="/"
+                        sx={{
+                            mx: 2,
+                            display: 'flex',
+                            flexGrow: 1,
+                            fontFamily: 'roboto',
+                            fontWeight: 400,
+                            color: 'inherit',
+                            textDecoration: 'none',
+                        }}
+                    >
+                        Trino
+                    </Typography>
+                    <Box sx={{ flexGrow: 0 }}>
+                        <Tooltip title={Texts.Menu.Header.Themes}>
+                            <IconButton sx={{ mx: 2, color: 'inherit' }} onClick={openThemeMenu}>
+                                {config.theme === ThemeStore.Auto ? (
+                                    <SettingsBrightnessOutlined />
+                                ) : config.theme === ThemeStore.Light ? (
+                                    <LightModeOutlined />
+                                ) : config.theme === ThemeStore.Dark ? (
+                                    <DarkModeOutlined />
+                                ) : null}
+                            </IconButton>
+                        </Tooltip>
+                        <Menu
+                            sx={{ mt: '45px' }}
+                            id="menu-appbar"
+                            anchorEl={anchorElTheme}
+                            anchorOrigin={{
+                                vertical: 'top',
+                                horizontal: 'right',
+                            }}
+                            keepMounted
+                            transformOrigin={{
+                                vertical: 'top',
+                                horizontal: 'right',
+                            }}
+                            open={Boolean(anchorElTheme)}
+                            onClose={closeThemeMenu}
+                        >
+                            {Object.keys(ThemeStore).map((key) => {
+                                const value = ThemeStore[key as keyof typeof ThemeStore]
+                                return (
+                                    <MenuItem
+                                        key={key}
+                                        onClick={() => setTheme(value)}
+                                        selected={value === config.theme}
+                                    >
+                                        <ListItemIcon>
+                                            {value === ThemeStore.Auto ? (
+                                                <SettingsBrightnessOutlined />
+                                            ) : value === ThemeStore.Light ? (
+                                                <LightModeOutlined />
+                                            ) : value === ThemeStore.Dark ? (
+                                                <DarkModeOutlined />
+                                            ) : null}
+                                        </ListItemIcon>
+                                        <Typography textAlign="center">{key}</Typography>
+                                    </MenuItem>
+                                )
+                            })}
+                        </Menu>
+                    </Box>
+                    <Box sx={{ flexGrow: 0 }}>
+                        <Tooltip title={Texts.Menu.Header.Settings}>
+                            <IconButton onClick={openUserMenu} sx={{ p: 0 }}>
+                                <Avatar src={config.avatar}>{userInitials}</Avatar>
+                            </IconButton>
+                        </Tooltip>
+                        <Menu
+                            sx={{ mt: '45px' }}
+                            id="menu-appbar"
+                            anchorEl={anchorElUser}
+                            anchorOrigin={{
+                                vertical: 'top',
+                                horizontal: 'right',
+                            }}
+                            keepMounted
+                            transformOrigin={{
+                                vertical: 'top',
+                                horizontal: 'right',
+                            }}
+                            open={Boolean(anchorElUser)}
+                            onClose={closeUserMenu}
+                        >
+                            {settingsMenuItems.map((settingsMenuItem) => (
+                                <MenuItem
+                                    sx={{ justifyContent: 'flex-start' }}
+                                    key={settingsMenuItem.key}
+                                    divider={settingsMenuItem.divider}
+                                    onClick={settingsMenuItem.onClick}
+                                    disabled={settingsMenuItem.disabled}
+                                >
+                                    {settingsMenuItem.icon ? (
+                                        <ListItemIcon>{settingsMenuItem.icon}</ListItemIcon>
+                                    ) : (
+                                        <div />
+                                    )}
+                                    <Typography>{settingsMenuItem.caption}</Typography>
+                                </MenuItem>
+                            ))}
+                        </Menu>
+                    </Box>
+                </Toolbar>
+            </AppBar>
+            {/*@ts-expect-error TS2322*/}
+            <Drawer variant="permanent" open={drawerOpen} width={240}>
+                <Toolbar />
+                <Box sx={{ overflowX: 'hidden', flexGrow: 1 }}>
+                    <List>
+                        {routers.map((routerItem: RouterItem) => (
+                            <ListItem key={routerItem.text} disablePadding>
+                                {/*@ts-expect-error TS2769*/}
+                                <ListItemButton
+                                    key={routerItem.itemKey}
+                                    component={Link}
+                                    to={routerItem.routeProps.path}
+                                    selected={routerItem.itemKey === selectedDrawerItemKey}
+                                >
+                                    <ListItemIcon>{routerItem.icon}</ListItemIcon>
+                                    <ListItemText primary={routerItem.text} />
+                                </ListItemButton>
+                            </ListItem>
+                        ))}
+                    </List>
+                </Box>
+                <DrawerFooter>
+                    <IconButton onClick={toggleDrawer}>
+                        {drawerOpen ? <ChevronLeftIcon /> : <ChevronRightIcon />}
+                    </IconButton>
+                </DrawerFooter>
+            </Drawer>
+            <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
+                <Toolbar />
+                <Container maxWidth="lg">{props.children}</Container>
+            </Box>
         </Box>
-        <DrawerFooter>
-          <IconButton onClick={toggleDrawer}>
-            {drawerOpen ? <ChevronLeftIcon /> : <ChevronRightIcon />}
-          </IconButton>
-        </DrawerFooter>
-      </Drawer>
-      <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
-        <Toolbar />
-        <Container maxWidth="lg">
-          {props.children}
-        </Container>
-      </Box>
-    </Box>
-  );
+    )
 }

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/Login.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/Login.tsx
@@ -11,120 +11,127 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react'
 import {
-  Box,
-  Button,
-  ButtonGroup,
-  Card,
-  CardContent,
-  CircularProgress,
-  Grid2 as Grid,
-  TextField,
-  Typography
-} from '@mui/material';
+    Box,
+    Button,
+    ButtonGroup,
+    Card,
+    CardContent,
+    CircularProgress,
+    Grid2 as Grid,
+    TextField,
+    Typography,
+} from '@mui/material'
 import { useAuth } from './AuthContext'
-import trinoLogo from '../assets/trino.svg';
-import { Texts } from '../constant';
-import { useSnackbar } from "./SnackbarContext.ts";
+import trinoLogo from '../assets/trino.svg'
+import { Texts } from '../constant'
+import { useSnackbar } from './SnackbarContext.ts'
 
 export interface ILoginProps {
-  passwordAllowed: boolean;
+    passwordAllowed: boolean
 }
 
 interface FormElements extends HTMLFormControlsCollection {
-  usernameInput: HTMLInputElement
-  passwordInput: HTMLInputElement
+    usernameInput: HTMLInputElement
+    passwordInput: HTMLInputElement
 }
 
 interface LoginFormElement extends HTMLFormElement {
-  readonly elements: FormElements
+    readonly elements: FormElements
 }
 
 export const Login = (props: ILoginProps) => {
-  const { login, loading, error } = useAuth();
-  const { showSnackbar } = useSnackbar();
-  const { passwordAllowed } = props;
+    const { login, loading, error } = useAuth()
+    const { showSnackbar } = useSnackbar()
+    const { passwordAllowed } = props
 
-  const [usernameError, setUsernameError] = useState<boolean>(false);
-  const [usernameErrorText, setUsernameErrorText] = useState<string>("");
+    const [usernameError, setUsernameError] = useState<boolean>(false)
+    const [usernameErrorText, setUsernameErrorText] = useState<string>('')
 
-  useEffect(() => {
-    if (error) {
-      showSnackbar(error, 'error');
+    useEffect(() => {
+        if (error) {
+            showSnackbar(error, 'error')
+        }
+    }, [error, showSnackbar])
+
+    const handleSubmit = (event: React.FormEvent<LoginFormElement>) => {
+        event.preventDefault()
+        const { usernameInput, passwordInput } = event.currentTarget.elements
+
+        if (usernameInput.value.length == 0) {
+            setUsernameError(true)
+            setUsernameErrorText(Texts.Auth.LoginForm.UsernameMustBeDefined)
+        } else {
+            setUsernameError(false)
+            setUsernameErrorText('')
+            login(usernameInput.value, passwordInput.value)
+        }
     }
-  }, [error, showSnackbar])
 
-  const handleSubmit = (event: React.FormEvent<LoginFormElement>) => {
-    event.preventDefault();
-    const { usernameInput, passwordInput } = event.currentTarget.elements;
+    const formDisabled = loading
 
-    if (usernameInput.value.length == 0) {
-      setUsernameError(true);
-      setUsernameErrorText(Texts.Auth.LoginForm.UsernameMustBeDefined);
-    }
-    else {
-      setUsernameError(false);
-      setUsernameErrorText("");
-      login(usernameInput.value, passwordInput.value);
-    }
-  }
-
-  const formDisabled = loading;
-
-  return (
-      <Box sx={{ p: 10, display: 'flex', justifyContent: 'center' }}>
-        <Grid size={{ xs: 12 }} justifyContent="center" container>
-          <form onSubmit={handleSubmit}>
-            <Card sx={{ px: 2, minWidth: 350 }}>
-              <CardContent sx={{ alignItems: 'center', textAlign: 'center' }}>
-                <Grid justifyContent="center">
-                  <Box component="img" sx={{ height: 80 }} alt="logo" src={trinoLogo} />
-                  <Typography component="h1" variant="h5">
-                    {Texts.Auth.LoginForm.LogIn}
-                  </Typography>
-                  <Box sx={{ py: 1 }}>
-                    <TextField
-                        id="usernameInput"
-                        label={Texts.Auth.LoginForm.Username}
-                        variant="outlined"
-                        error={usernameError}
-                        helperText={usernameErrorText}
-                        disabled={formDisabled}
-                        fullWidth
-                    />
-                  </Box>
-                  <Box sx={{ py: 1 }}>
-                    <TextField
-                        id="passwordInput"
-                        label={passwordAllowed ? Texts.Auth.LoginForm.Password : Texts.Auth.LoginForm.PasswordNotAllowed}
-                        variant={passwordAllowed ? 'outlined' : 'filled'}
-                        type="password"
-                        disabled={formDisabled || !passwordAllowed}
-                        autoComplete="on"
-                        fullWidth
-                    />
-                  </Box>
-                </Grid>
-              </CardContent>
-              <Grid sx={{ py: 2, px: 2 }} justifyContent="space-between" container>
-                {loading ?
-                    <Grid container spacing={2} alignItems="center">
-                      <Grid>
-                        <CircularProgress size={28} />
-                      </Grid>
-                      <Grid>
-                        <Typography>{Texts.Auth.LoginForm.LoggingIn}</Typography>
-                      </Grid>
-                    </Grid> : <div />
-                }
-                <ButtonGroup>
-                  <Button type="submit" disabled={formDisabled}>{Texts.Auth.LoginForm.LogIn}</Button>
-                </ButtonGroup>
-              </Grid>
-            </Card>
-          </form>
-        </Grid>
-      </Box>
-  );
+    return (
+        <Box sx={{ p: 10, display: 'flex', justifyContent: 'center' }}>
+            <Grid size={{ xs: 12 }} justifyContent="center" container>
+                <form onSubmit={handleSubmit}>
+                    <Card sx={{ px: 2, minWidth: 350 }}>
+                        <CardContent sx={{ alignItems: 'center', textAlign: 'center' }}>
+                            <Grid justifyContent="center">
+                                <Box component="img" sx={{ height: 80 }} alt="logo" src={trinoLogo} />
+                                <Typography component="h1" variant="h5">
+                                    {Texts.Auth.LoginForm.LogIn}
+                                </Typography>
+                                <Box sx={{ py: 1 }}>
+                                    <TextField
+                                        id="usernameInput"
+                                        label={Texts.Auth.LoginForm.Username}
+                                        variant="outlined"
+                                        error={usernameError}
+                                        helperText={usernameErrorText}
+                                        disabled={formDisabled}
+                                        fullWidth
+                                    />
+                                </Box>
+                                <Box sx={{ py: 1 }}>
+                                    <TextField
+                                        id="passwordInput"
+                                        label={
+                                            passwordAllowed
+                                                ? Texts.Auth.LoginForm.Password
+                                                : Texts.Auth.LoginForm.PasswordNotAllowed
+                                        }
+                                        variant={passwordAllowed ? 'outlined' : 'filled'}
+                                        type="password"
+                                        disabled={formDisabled || !passwordAllowed}
+                                        autoComplete="on"
+                                        fullWidth
+                                    />
+                                </Box>
+                            </Grid>
+                        </CardContent>
+                        <Grid sx={{ py: 2, px: 2 }} justifyContent="space-between" container>
+                            {loading ? (
+                                <Grid container spacing={2} alignItems="center">
+                                    <Grid>
+                                        <CircularProgress size={28} />
+                                    </Grid>
+                                    <Grid>
+                                        <Typography>{Texts.Auth.LoginForm.LoggingIn}</Typography>
+                                    </Grid>
+                                </Grid>
+                            ) : (
+                                <div />
+                            )}
+                            <ButtonGroup>
+                                <Button type="submit" disabled={formDisabled}>
+                                    {Texts.Auth.LoginForm.LogIn}
+                                </Button>
+                            </ButtonGroup>
+                        </Grid>
+                    </Card>
+                </form>
+            </Grid>
+        </Box>
+    )
 }

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/MetricCard.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/MetricCard.tsx
@@ -11,66 +11,66 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Card from '@mui/material/Card';
-import CardContent from '@mui/material/CardContent';
-import Typography from '@mui/material/Typography';
-import { Grid2 as Grid } from "@mui/material";
-import { SparkLineChart } from '@mui/x-charts/SparkLineChart';
+import Card from '@mui/material/Card'
+import CardContent from '@mui/material/CardContent'
+import Typography from '@mui/material/Typography'
+import { Grid2 as Grid } from '@mui/material'
+import { SparkLineChart } from '@mui/x-charts/SparkLineChart'
 
 interface IMetricCardProps {
-  title: string;
-  values: number[];
-  numberFormatter?: (n: number | null) => string;
+    title: string
+    values: number[]
+    numberFormatter?: (n: number | null) => string
 }
 
 export const MetricCard = (props: IMetricCardProps) => {
-  const { title, values, numberFormatter } = props;
-  const lastValue = values[values.length - 1];
+    const { title, values, numberFormatter } = props
+    const lastValue = values[values.length - 1]
 
-  return (
-    <Card variant="outlined" sx={{ minWidth: 275 }}>
-      <CardContent sx={{ flex: '1 0 auto' }}>
-        <Typography variant="h6" color="info" gutterBottom>
-          {title}
-        </Typography>
-        <Grid container>
-          <Grid sx={{ display: 'flex', flexGrow: 1 }}>
-            <Grid
-                sx={{
-                  display: 'flex',
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                  flexBasis: '0',
-                  flexGrow: 1,
-                }}
-            >
-              <Typography variant="h3" color="textSecondary" sx={{ fontWeight: 'bold' }}>
-                {numberFormatter ? numberFormatter(lastValue) : lastValue}
-              </Typography>
-            </Grid>
-          </Grid>
-          <Grid sx={{ display: 'flex', flexGrow: 1 }}>
-            <Grid
-              sx={{
-                display: 'flex',
-                justifyContent: 'center',
-                alignItems: 'center',
-                flexBasis: '0',
-                flexGrow: 1,
-              }}
-            >
-              <SparkLineChart
-                  data={values}
-                  valueFormatter={numberFormatter}
-                  height={50}
-                  area
-                  showHighlight
-                  showTooltip
-              />
-            </Grid>
-          </Grid>
-        </Grid>
-      </CardContent>
-    </Card>
-  )
+    return (
+        <Card variant="outlined" sx={{ minWidth: 275 }}>
+            <CardContent sx={{ flex: '1 0 auto' }}>
+                <Typography variant="h6" color="info" gutterBottom>
+                    {title}
+                </Typography>
+                <Grid container>
+                    <Grid sx={{ display: 'flex', flexGrow: 1 }}>
+                        <Grid
+                            sx={{
+                                display: 'flex',
+                                justifyContent: 'center',
+                                alignItems: 'center',
+                                flexBasis: '0',
+                                flexGrow: 1,
+                            }}
+                        >
+                            <Typography variant="h3" color="textSecondary" sx={{ fontWeight: 'bold' }}>
+                                {numberFormatter ? numberFormatter(lastValue) : lastValue}
+                            </Typography>
+                        </Grid>
+                    </Grid>
+                    <Grid sx={{ display: 'flex', flexGrow: 1 }}>
+                        <Grid
+                            sx={{
+                                display: 'flex',
+                                justifyContent: 'center',
+                                alignItems: 'center',
+                                flexBasis: '0',
+                                flexGrow: 1,
+                            }}
+                        >
+                            <SparkLineChart
+                                data={values}
+                                valueFormatter={numberFormatter}
+                                height={50}
+                                area
+                                showHighlight
+                                showTooltip
+                            />
+                        </Grid>
+                    </Grid>
+                </Grid>
+            </CardContent>
+        </Card>
+    )
 }

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/SnackbarContext.ts
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/SnackbarContext.ts
@@ -11,19 +11,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { createContext, useContext } from 'react';
-import { SnackbarSeverity } from "./SnackbarProvider";
+import { createContext, useContext } from 'react'
+import { SnackbarSeverity } from './SnackbarProvider'
 
 interface SnackbarContextProps {
-  showSnackbar: (message: string, severity?: SnackbarSeverity) => void;
+    showSnackbar: (message: string, severity?: SnackbarSeverity) => void
 }
 
-export const SnackbarContext = createContext<SnackbarContextProps | undefined>(undefined);
+export const SnackbarContext = createContext<SnackbarContextProps | undefined>(undefined)
 
 export const useSnackbar = (): SnackbarContextProps => {
-  const context = useContext(SnackbarContext);
-  if (context === undefined) {
-    throw new Error('useSnackbar must be used within a SnackbarProvider');
-  }
-  return context;
-};
+    const context = useContext(SnackbarContext)
+    if (context === undefined) {
+        throw new Error('useSnackbar must be used within a SnackbarProvider')
+    }
+    return context
+}

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/SnackbarProvider.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/SnackbarProvider.tsx
@@ -11,50 +11,50 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { ReactNode, useCallback, useState } from "react";
-import Snackbar from "@mui/material/Snackbar";
-import MuiAlert from "@mui/material/Alert";
-import { SnackbarContext } from "./SnackbarContext";
+import React, { ReactNode, useCallback, useState } from 'react'
+import Snackbar from '@mui/material/Snackbar'
+import MuiAlert from '@mui/material/Alert'
+import { SnackbarContext } from './SnackbarContext'
 
-export type SnackbarSeverity = 'error' | 'warning' | 'info' | 'success';
+export type SnackbarSeverity = 'error' | 'warning' | 'info' | 'success'
 
 interface SnackbarState {
-  open: boolean;
-  message: string;
-  severity: SnackbarSeverity;
+    open: boolean
+    message: string
+    severity: SnackbarSeverity
 }
 
 export const SnackbarProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
-  const [snackbar, setSnackbar] = useState<SnackbarState>({
-    open: false,
-    message: '',
-    severity: 'info',
-  });
+    const [snackbar, setSnackbar] = useState<SnackbarState>({
+        open: false,
+        message: '',
+        severity: 'info',
+    })
 
-  const showSnackbar = useCallback((message: string, severity: SnackbarSeverity = 'error') => {
-    setSnackbar({ open: true, message, severity });
-  }, []);
+    const showSnackbar = useCallback((message: string, severity: SnackbarSeverity = 'error') => {
+        setSnackbar({ open: true, message, severity })
+    }, [])
 
-  const handleClose = (_event?: React.SyntheticEvent | Event, reason?: string) => {
-    if (reason === 'clickaway') {
-      return;
+    const handleClose = (_event?: React.SyntheticEvent | Event, reason?: string) => {
+        if (reason === 'clickaway') {
+            return
+        }
+        setSnackbar((prev) => ({ ...prev, open: false }))
     }
-    setSnackbar((prev) => ({ ...prev, open: false }));
-  };
 
-  return (
-    <SnackbarContext.Provider value={{ showSnackbar }}>
-      {children}
-      <Snackbar
-        open={snackbar.open}
-        autoHideDuration={6000}
-        onClose={handleClose}
-        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-      >
-        <MuiAlert onClose={handleClose} severity={snackbar.severity} sx={{ width: '100%' }}>
-          {snackbar.message}
-        </MuiAlert>
-      </Snackbar>
-    </SnackbarContext.Provider>
-  );
-};
+    return (
+        <SnackbarContext.Provider value={{ showSnackbar }}>
+            {children}
+            <Snackbar
+                open={snackbar.open}
+                autoHideDuration={6000}
+                onClose={handleClose}
+                anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+            >
+                <MuiAlert onClose={handleClose} severity={snackbar.severity} sx={{ width: '100%' }}>
+                    {snackbar.message}
+                </MuiAlert>
+            </Snackbar>
+        </SnackbarContext.Provider>
+    )
+}

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/Workers.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/Workers.tsx
@@ -11,22 +11,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-  Box,
-  Typography
-} from "@mui/material";
+import { Box, Typography } from '@mui/material'
 
 export const Workers = () => {
-  return (
-    <>
-      <Box sx={{ pb: 2 }}>
-        <Typography variant="h4">
-          Workers
-        </Typography>
-      </Box>
-      <Typography paragraph>
-        Placeholder for Workers
-      </Typography>
-    </>
-  );
+    return (
+        <>
+            <Box sx={{ pb: 2 }}>
+                <Typography variant="h4">Workers</Typography>
+            </Box>
+            <Typography paragraph>Placeholder for Workers</Typography>
+        </>
+    )
 }

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/store/config.ts
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/store/config.ts
@@ -11,55 +11,55 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { create } from "zustand";
-import { persist } from "zustand/middleware";
-import { StoreKey } from "../constant";
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import { StoreKey } from '../constant'
 
 export enum Theme {
-  Auto = "auto",
-  Dark = "dark",
-  Light = "light",
+    Auto = 'auto',
+    Dark = 'dark',
+    Light = 'light',
 }
 
 export const DEFAULT_CONFIG = {
-  avatar: "",
-  theme: Theme.Auto as Theme,
-};
+    avatar: '',
+    theme: Theme.Auto as Theme,
+}
 
-export type AppConfig = typeof DEFAULT_CONFIG;
+export type AppConfig = typeof DEFAULT_CONFIG
 
 export type AppConfigStore = AppConfig & {
-  reset: () => void;
-  update: (updater: (config: AppConfig) => void) => void;
-};
+    reset: () => void
+    update: (updater: (config: AppConfig) => void) => void
+}
 
 export const useConfigStore = create<AppConfigStore>()(
     persist(
         (set, get) => ({
-          ...DEFAULT_CONFIG,
+            ...DEFAULT_CONFIG,
 
-          reset() {
-            set(() => ({ ...DEFAULT_CONFIG }));
-          },
+            reset() {
+                set(() => ({ ...DEFAULT_CONFIG }))
+            },
 
-          update(updater) {
-            const config = { ...get() };
-            updater(config);
-            set(() => config);
-          },
+            update(updater) {
+                const config = { ...get() }
+                updater(config)
+                set(() => config)
+            },
         }),
         {
-          name: StoreKey.Config,
-          version: 1,
-          migrate(persistedState, version) {
-            const state = persistedState as AppConfig;
+            name: StoreKey.Config,
+            version: 1,
+            migrate(persistedState, version) {
+                const state = persistedState as AppConfig
 
-            if (version < 1) {
-              // merge your old config
-            }
-            /* eslint-disable  @typescript-eslint/no-explicit-any */
-            return state as any;
-          },
-        },
-    ),
-);
+                if (version < 1) {
+                    // merge your old config
+                }
+                /* eslint-disable  @typescript-eslint/no-explicit-any */
+                return state as any
+            },
+        }
+    )
+)

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/store/index.ts
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/store/index.ts
@@ -11,4 +11,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from "./config";
+export * from './config'

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/utils/merge.ts
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/utils/merge.ts
@@ -13,11 +13,11 @@
  */
 /* eslint-disable  @typescript-eslint/no-explicit-any */
 export function merge(target: any, source: any): any {
-  Object.keys(source).forEach(function (key) {
-    if (source[key] && typeof source[key] === "object") {
-      merge((target[key] = target[key] || {}), source[key]);
-      return;
-    }
-    target[key] = source[key];
-  });
+    Object.keys(source).forEach(function (key) {
+        if (source[key] && typeof source[key] === 'object') {
+            merge((target[key] = target[key] || {}), source[key])
+            return
+        }
+        target[key] = source[key]
+    })
 }

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/utils/utils.ts
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/utils/utils.ts
@@ -20,107 +20,107 @@ export const MAX_HISTORY = 60 * 5
 const MOVING_AVERAGE_ALPHA = 0.2
 
 export function addToHistory(value: number, valuesArray: number[]): number[] {
-  if (valuesArray.length === 0) {
-    return valuesArray.concat([value])
-  }
-  return valuesArray.concat([value]).slice(Math.max(valuesArray.length - MAX_HISTORY, 0))
+    if (valuesArray.length === 0) {
+        return valuesArray.concat([value])
+    }
+    return valuesArray.concat([value]).slice(Math.max(valuesArray.length - MAX_HISTORY, 0))
 }
 
 export function addExponentiallyWeightedToHistory(value: number, valuesArray: number[]): number[] {
-  if (valuesArray.length === 0) {
-    return valuesArray.concat([value])
-  }
+    if (valuesArray.length === 0) {
+        return valuesArray.concat([value])
+    }
 
-  let movingAverage = value * MOVING_AVERAGE_ALPHA + valuesArray[valuesArray.length - 1] * (1 - MOVING_AVERAGE_ALPHA)
-  if (value < 1) {
-    movingAverage = 0
-  }
+    let movingAverage = value * MOVING_AVERAGE_ALPHA + valuesArray[valuesArray.length - 1] * (1 - MOVING_AVERAGE_ALPHA)
+    if (value < 1) {
+        movingAverage = 0
+    }
 
-  return valuesArray.concat([movingAverage]).slice(Math.max(valuesArray.length - MAX_HISTORY, 0))
+    return valuesArray.concat([movingAverage]).slice(Math.max(valuesArray.length - MAX_HISTORY, 0))
 }
 
 export function precisionRound(n: number | null): string {
-  if (n === null) {
-    return '';
-  }
+    if (n === null) {
+        return ''
+    }
 
-  if (n === undefined) {
-    return 'n/a'
-  }
-  if (n < 10) {
-    return n.toFixed(2)
-  }
-  if (n < 100) {
-    return n.toFixed(1)
-  }
-  return Math.round(n).toString()
+    if (n === undefined) {
+        return 'n/a'
+    }
+    if (n < 10) {
+        return n.toFixed(2)
+    }
+    if (n < 100) {
+        return n.toFixed(1)
+    }
+    return Math.round(n).toString()
 }
 
 export function formatCount(count: number | null): string {
-  if (count === null) {
-    return '';
-  }
+    if (count === null) {
+        return ''
+    }
 
-  let unit = ''
-  if (count > 1000) {
-    count /= 1000
-    unit = 'K'
-  }
-  if (count > 1000) {
-    count /= 1000
-    unit = 'M'
-  }
-  if (count > 1000) {
-    count /= 1000
-    unit = 'B'
-  }
-  if (count > 1000) {
-    count /= 1000
-    unit = 'T'
-  }
-  if (count > 1000) {
-    count /= 1000
-    unit = 'Q'
-  }
-  return precisionRound(count) + unit
+    let unit = ''
+    if (count > 1000) {
+        count /= 1000
+        unit = 'K'
+    }
+    if (count > 1000) {
+        count /= 1000
+        unit = 'M'
+    }
+    if (count > 1000) {
+        count /= 1000
+        unit = 'B'
+    }
+    if (count > 1000) {
+        count /= 1000
+        unit = 'T'
+    }
+    if (count > 1000) {
+        count /= 1000
+        unit = 'Q'
+    }
+    return precisionRound(count) + unit
 }
 
 export function formatDataSizeBytes(size: number | null): string {
-  return formatDataSizeMinUnit(size, '')
+    return formatDataSizeMinUnit(size, '')
 }
 
 export function formatDataSize(size: number): string {
-  return formatDataSizeMinUnit(size, 'B')
+    return formatDataSizeMinUnit(size, 'B')
 }
 
 function formatDataSizeMinUnit(size: number | null, minUnit: string): string {
-  if (size === null) {
-    return '';
-  }
+    if (size === null) {
+        return ''
+    }
 
-  let unit = minUnit
-  if (size === 0) {
-    return '0' + unit
-  }
-  if (size >= 1024) {
-    size /= 1024
-    unit = 'K' + minUnit
-  }
-  if (size >= 1024) {
-    size /= 1024
-    unit = 'M' + minUnit
-  }
-  if (size >= 1024) {
-    size /= 1024
-    unit = 'G' + minUnit
-  }
-  if (size >= 1024) {
-    size /= 1024
-    unit = 'T' + minUnit
-  }
-  if (size >= 1024) {
-    size /= 1024
-    unit = 'P' + minUnit
-  }
-  return precisionRound(size) + unit
+    let unit = minUnit
+    if (size === 0) {
+        return '0' + unit
+    }
+    if (size >= 1024) {
+        size /= 1024
+        unit = 'K' + minUnit
+    }
+    if (size >= 1024) {
+        size /= 1024
+        unit = 'M' + minUnit
+    }
+    if (size >= 1024) {
+        size /= 1024
+        unit = 'G' + minUnit
+    }
+    if (size >= 1024) {
+        size /= 1024
+        unit = 'T' + minUnit
+    }
+    if (size >= 1024) {
+        size /= 1024
+        unit = 'P' + minUnit
+    }
+    return precisionRound(size) + unit
 }


### PR DESCRIPTION
## Description

The TypeScript code in the preview web UI is currently not properly formatted due to an incorrect Prettier configuration, which does not include recursive formatting for `.ts` and `.tsx` files. This PR resolves the issue by updating the Prettier configuration and reformatting all files to the correct format.

No functional changes are included.

## Additional context and related issues

The fix involves updating the Prettier target in package.json (located [here](https://github.com/trinodb/trino/pull/24691/files#diff-2ff08f9f500a878b341f9d3f32d35221ebb4b6795774c06342d2e277f9021612R13)) by changing the pattern from `./src/*.{ts,tsx}` to `./src/**/*.{ts,tsx}` in order to include all recursive TypeScript files.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
