### PR TITLE
Fix Exasol flaky tests. Avoid exposing not required ports

### DIFF
--- a/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestingExasolServer.java
+++ b/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestingExasolServer.java
@@ -47,7 +47,9 @@ public class TestingExasolServer
 
     public TestingExasolServer()
     {
-        container = new ExasolContainer<>("8.27.0").withRequiredServices(ExasolService.JDBC);
+        container = new ExasolContainer<>("8.27.0")
+                .withExposedPorts(8563)
+                .withRequiredServices(ExasolService.JDBC);
         cleanup = startOrReuse(container);
         executeAsSys(format("CREATE USER %s IDENTIFIED BY \"%s\"", TEST_USER, TEST_PASSWORD));
         executeAsSys("GRANT CREATE SESSION TO " + TEST_USER);

--- a/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestingExasolServer.java
+++ b/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestingExasolServer.java
@@ -47,7 +47,7 @@ public class TestingExasolServer
 
     public TestingExasolServer()
     {
-        container = new ExasolContainer<>("8.27.0")
+        container = new ExasolContainer<>("8.32.0")
                 .withExposedPorts(8563)
                 .withRequiredServices(ExasolService.JDBC);
         cleanup = startOrReuse(container);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Fixes #22698.

The CI pipeline runs several tests that boot up an Exasol container, using `testcontainers`. An Exasol container by default exposes 4 ports for different services. Docker tries to allocate and map ephemeral ports. 

Due to an issue in docker, when it fails to allocate a port in can mess up with the process that was using this port (see https://github.com/moby/moby/pull/48132)

The issue only happens when more than one port is exported, so the fix is rather simple: we only export in the container the strictly needed port for JDBC: 8563



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:


