### PR TITLE
Use <arg> instead of <compilerArg> to enable incubator module

### DIFF
--- a/lib/trino-parquet/pom.xml
+++ b/lib/trino-parquet/pom.xml
@@ -238,7 +238,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <configuration>
                         <compilerArgs combine.children="append">
-                            <compilerArg>${extraJavaVectorArgs}</compilerArg>
+                            <arg>${extraJavaVectorArgs}</arg>
                         </compilerArgs>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

`<compilerArg>` does not seem to be a valid child element of `<compilerArgs>`. Even if it seems to work, it conflicts with the `errorprone-compiler` profile, which appends additional compiler arguments using `<arg>` (which is documented to be the correct child element). When there is also `<compilerArg>`, it gets ignored (at least by IDEA's POM importer).

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
