### PR TITLE
Allow system tables to do system level access control

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/DefaultCatalogFactory.java
+++ b/core/trino-main/src/main/java/io/trino/connector/DefaultCatalogFactory.java
@@ -178,7 +178,9 @@ public class DefaultCatalogFactory
                 new SystemConnector(
                         nodeManager,
                         systemTablesProvider,
-                        transactionId -> transactionManager.getConnectorTransaction(transactionId, catalogHandle)));
+                        transactionId -> transactionManager.getConnectorTransaction(transactionId, catalogHandle),
+                        accessControl,
+                        catalogHandle.getCatalogName().toString()));
 
         return new CatalogConnector(
                 catalogHandle,

--- a/core/trino-main/src/main/java/io/trino/connector/system/SystemConnector.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/SystemConnector.java
@@ -14,6 +14,7 @@
 package io.trino.connector.system;
 
 import io.trino.metadata.InternalNodeManager;
+import io.trino.security.AccessControl;
 import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.ConnectorPageSourceProvider;
 import io.trino.spi.connector.ConnectorSession;
@@ -38,15 +39,19 @@ public class SystemConnector
     public SystemConnector(
             InternalNodeManager nodeManager,
             SystemTablesProvider tables,
-            Function<TransactionId, ConnectorTransactionHandle> transactionHandleFunction)
+            Function<TransactionId, ConnectorTransactionHandle> transactionHandleFunction,
+            AccessControl accessControl,
+            String catalogName)
     {
         requireNonNull(nodeManager, "nodeManager is null");
         requireNonNull(tables, "tables is null");
         requireNonNull(transactionHandleFunction, "transactionHandleFunction is null");
+        requireNonNull(accessControl, "accessControl is null");
+        requireNonNull(catalogName, "catalogName is null");
 
         this.metadata = new SystemTablesMetadata(tables);
         this.splitManager = new SystemSplitManager(nodeManager, tables);
-        this.pageSourceProvider = new SystemPageSourceProvider(tables);
+        this.pageSourceProvider = new SystemPageSourceProvider(tables, accessControl, catalogName);
         this.transactionHandleFunction = transactionHandleFunction;
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/SystemTable.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/SystemTable.java
@@ -53,6 +53,17 @@ public interface SystemTable
         return cursor(transactionHandle, session, constraint);
     }
 
+    default RecordCursor cursor(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            TupleDomain<Integer> constraint,
+            Set<Integer> requiredColumns,
+            ConnectorSplit split,
+            ConnectorAccessControl accessControl)
+    {
+        return cursor(transactionHandle, session, constraint, requiredColumns, split);
+    }
+
     /**
      * Create a page source for the data in this table.
      *
@@ -62,6 +73,15 @@ public interface SystemTable
     default ConnectorPageSource pageSource(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
     {
         throw new UnsupportedOperationException();
+    }
+
+    default ConnectorPageSource pageSource(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            TupleDomain<Integer> constraint,
+            ConnectorAccessControl accessControl)
+    {
+        return pageSource(transactionHandle, session, constraint);
     }
 
     default Optional<ConnectorSplitSource> splitSource(ConnectorSession connectorSession, TupleDomain<ColumnHandle> constraint)

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeSystemTable.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeSystemTable.java
@@ -16,6 +16,7 @@ package io.trino.plugin.base.classloader;
 import com.google.inject.Inject;
 import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplit;
@@ -82,10 +83,36 @@ public class ClassLoaderSafeSystemTable
     }
 
     @Override
+    public RecordCursor cursor(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            TupleDomain<Integer> constraint,
+            Set<Integer> requiredColumns,
+            ConnectorSplit split,
+            ConnectorAccessControl accessControl)
+    {
+        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
+            return delegate.cursor(transactionHandle, session, constraint, requiredColumns, split, accessControl);
+        }
+    }
+
+    @Override
     public ConnectorPageSource pageSource(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
     {
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
             return delegate.pageSource(transactionHandle, session, constraint);
+        }
+    }
+
+    @Override
+    public ConnectorPageSource pageSource(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            TupleDomain<Integer> constraint,
+            ConnectorAccessControl accessControl)
+    {
+        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
+            return delegate.pageSource(transactionHandle, session, constraint, accessControl);
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
This is an initial proposal to add an option to do access control checks during system table reads.
The goal here is to open this for discussion with some concrete option on a table.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
This is related to an effort to add an iceberg system table that lists only iceberg tables (https://github.com/trinodb/trino/pull/24469).
A system table like that has to filter the table list using the `AccessControl#filterTables` method but up until now, `AccessControl` was not available for system tables.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
