### PR TITLE
Decode JSONs directly from Slice

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/OkHttpUtil.java
+++ b/client/trino-client/src/main/java/io/trino/client/OkHttpUtil.java
@@ -63,6 +63,7 @@ import static com.google.common.net.HttpHeaders.AUTHORIZATION;
 import static com.google.common.net.HttpHeaders.USER_AGENT;
 import static java.net.Proxy.Type.HTTP;
 import static java.net.Proxy.Type.SOCKS;
+import static java.nio.file.Files.newInputStream;
 import static java.util.Collections.list;
 import static java.util.Objects.requireNonNull;
 
@@ -325,7 +326,7 @@ public final class OkHttpUtil
         catch (IOException | GeneralSecurityException ignored) {
         }
 
-        try (InputStream in = new FileInputStream(trustStorePath)) {
+        try (InputStream in = newInputStream(trustStorePath.toPath())) {
             trustStore.load(in, trustStorePassword.map(String::toCharArray).orElse(null));
         }
         return trustStore;

--- a/core/trino-main/src/main/java/io/trino/operator/SpatialIndexBuilderOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/SpatialIndexBuilderOperator.java
@@ -16,6 +16,7 @@ package io.trino.operator;
 import com.esri.core.geometry.ogc.OGCGeometry;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.slice.Slice;
 import io.trino.geospatial.KdbTreeUtils;
 import io.trino.geospatial.Rectangle;
 import io.trino.memory.context.LocalMemoryContext;
@@ -73,7 +74,7 @@ public class SpatialIndexBuilderOperator
                 OptionalDouble constantRadius,
                 Optional<Integer> partitionChannel,
                 SpatialPredicate spatialRelationshipTest,
-                Optional<String> kdbTreeJson,
+                Optional<Slice> kdbTreeJson,
                 Optional<JoinFilterFunctionFactory> filterFunctionFactory,
                 int expectedPositions,
                 PagesIndex.Factory pagesIndexFactory)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/FailureFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/FailureFunction.java
@@ -35,7 +35,7 @@ public final class FailureFunction
     @SqlType("unknown")
     public static boolean failWithException(@SqlType(StandardTypes.JSON) Slice failureInfoSlice)
     {
-        FailureInfo failureInfo = JSON_CODEC.fromJson(failureInfoSlice.getBytes());
+        FailureInfo failureInfo = JSON_CODEC.fromJson(failureInfoSlice.getInput());
         // wrap the failure in a new exception to append the current stack trace
         throw new TrinoException(StandardErrorCode.GENERIC_USER_ERROR, failureInfo.toException());
     }

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/SpooledBlock.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/SpooledBlock.java
@@ -62,15 +62,15 @@ public record SpooledBlock(Slice identifier, Optional<URI> directUri, Map<String
             return new SpooledBlock(
                     VARCHAR.getSlice(row.getRawFieldBlock(0), 0),
                     Optional.empty(), // Not a direct location
-                    HEADERS_CODEC.fromJson(VARCHAR.getSlice(row.getRawFieldBlock(2), 0).toStringUtf8()),
-                    ATTRIBUTES_CODEC.fromJson(VARCHAR.getSlice(row.getRawFieldBlock(3), 0).toStringUtf8()));
+                    HEADERS_CODEC.fromJson(VARCHAR.getSlice(row.getRawFieldBlock(2), 0).getInput()),
+                    ATTRIBUTES_CODEC.fromJson(VARCHAR.getSlice(row.getRawFieldBlock(3), 0).getInput()));
         }
 
         return new SpooledBlock(
                 VARCHAR.getSlice(row.getRawFieldBlock(0), 0),
                 Optional.of(URI.create(VARCHAR.getSlice(row.getRawFieldBlock(1), 0).toStringUtf8())),
-                HEADERS_CODEC.fromJson(VARCHAR.getSlice(row.getRawFieldBlock(2), 0).toStringUtf8()),
-                ATTRIBUTES_CODEC.fromJson(VARCHAR.getSlice(row.getRawFieldBlock(3), 0).toStringUtf8()));
+                HEADERS_CODEC.fromJson(VARCHAR.getSlice(row.getRawFieldBlock(2), 0).getInput()),
+                ATTRIBUTES_CODEC.fromJson(VARCHAR.getSlice(row.getRawFieldBlock(3), 0).getInput()));
     }
 
     public static SpooledBlock forLocation(SpooledLocation location, DataAttributes attributes)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ExtractSpatialJoins.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ExtractSpatialJoins.java
@@ -20,7 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.errorprone.annotations.FormatMethod;
-import io.airlift.slice.Slices;
+import io.airlift.slice.Slice;
 import io.trino.Session;
 import io.trino.geospatial.KdbTree;
 import io.trino.geospatial.KdbTreeUtils;
@@ -472,9 +472,9 @@ public class ExtractSpatialJoins
                             if (page != null && page.getPositionCount() > 0) {
                                 checkSpatialPartitioningTable(kdbTree.isEmpty(), "Expected exactly one row for table %s, but found more", name);
                                 checkSpatialPartitioningTable(page.getPositionCount() == 1, "Expected exactly one row for table %s, but found %s rows", name, page.getPositionCount());
-                                String kdbTreeJson = VARCHAR.getSlice(page.getBlock(0), 0).toStringUtf8();
+                                Slice slice = VARCHAR.getSlice(page.getBlock(0), 0);
                                 try {
-                                    kdbTree = Optional.of(KdbTreeUtils.fromJson(kdbTreeJson));
+                                    kdbTree = Optional.of(KdbTreeUtils.fromJson(slice));
                                 }
                                 catch (IllegalArgumentException e) {
                                     checkSpatialPartitioningTable(false, "Invalid JSON string for KDB tree: %s", e.getMessage());
@@ -590,7 +590,7 @@ public class ExtractSpatialJoins
         TypeSignature typeSignature = new TypeSignature(KDB_TREE_TYPENAME);
         BuiltinFunctionCallBuilder spatialPartitionsCall = BuiltinFunctionCallBuilder.resolve(plannerContext.getMetadata())
                 .setName("spatial_partitions")
-                .addArgument(typeSignature, new Cast(new Constant(VARCHAR, Slices.utf8Slice(KdbTreeUtils.toJson(kdbTree))), plannerContext.getTypeManager().getType(typeSignature)))
+                .addArgument(typeSignature, new Cast(new Constant(VARCHAR, KdbTreeUtils.toJson(kdbTree)), plannerContext.getTypeManager().getType(typeSignature)))
                 .addArgument(GEOMETRY_TYPE_SIGNATURE, geometry);
         radius.ifPresent(value -> spatialPartitionsCall.addArgument(DOUBLE, value));
         Call partitioningFunction = spatialPartitionsCall.build();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/SpatialJoinNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/SpatialJoinNode.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.Immutable;
+import io.airlift.slice.Slice;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.planner.Symbol;
 
@@ -66,7 +67,7 @@ public class SpatialJoinNode
     private final Expression filter;
     private final Optional<Symbol> leftPartitionSymbol;
     private final Optional<Symbol> rightPartitionSymbol;
-    private final Optional<String> kdbTree;
+    private final Optional<Slice> kdbTree;
     private final DistributionType distributionType;
 
     public enum DistributionType
@@ -85,7 +86,7 @@ public class SpatialJoinNode
             @JsonProperty("filter") Expression filter,
             @JsonProperty("leftPartitionSymbol") Optional<Symbol> leftPartitionSymbol,
             @JsonProperty("rightPartitionSymbol") Optional<Symbol> rightPartitionSymbol,
-            @JsonProperty("kdbTree") Optional<String> kdbTree)
+            @JsonProperty("kdbTree") Optional<Slice> kdbTree)
     {
         super(id);
 
@@ -174,7 +175,7 @@ public class SpatialJoinNode
     }
 
     @JsonProperty("kdbTree")
-    public Optional<String> getKdbTree()
+    public Optional<Slice> getKdbTree()
     {
         return kdbTree;
     }

--- a/core/trino-main/src/main/java/io/trino/type/JsonPath2016Type.java
+++ b/core/trino-main/src/main/java/io/trino/type/JsonPath2016Type.java
@@ -67,8 +67,7 @@ public class JsonPath2016Type
 
         VariableWidthBlock valueBlock = (VariableWidthBlock) block.getUnderlyingValueBlock();
         int valuePosition = block.getUnderlyingValuePosition(position);
-        String json = valueBlock.getSlice(valuePosition).toStringUtf8();
-        return jsonPathCodec.fromJson(json);
+        return jsonPathCodec.fromJson(valueBlock.getSlice(valuePosition).getInput());
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2WebUiAuthenticationFilterWithOpaque.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2WebUiAuthenticationFilterWithOpaque.java
@@ -74,7 +74,7 @@ public class TestOAuth2WebUiAuthenticationFilterWithOpaque
         Request request = new Request.Builder().url("https://localhost:" + hydraIdP.getAuthPort() + "/userinfo").addHeader(AUTHORIZATION, "Bearer " + cookieValue).build();
         try (Response response = httpClient.newCall(request).execute()) {
             assertThat(response.body()).isNotNull();
-            DefaultClaims claims = new DefaultClaims(JsonCodec.mapJsonCodec(String.class, Object.class).fromJson(response.body().bytes()));
+            DefaultClaims claims = new DefaultClaims(JsonCodec.mapJsonCodec(String.class, Object.class).fromJson(response.body().byteStream()));
             assertThat(claims.getSubject()).isEqualTo("foo@bar.com");
             assertThat(claims.get("aud")).isEqualTo(Set.of(TRINO_CLIENT_ID));
         }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
+import io.airlift.slice.Slice;
 import io.trino.Session;
 import io.trino.cost.PlanNodeStatsEstimate;
 import io.trino.cost.StatsProvider;
@@ -523,12 +524,12 @@ public final class PlanMatchPattern
         return spatialJoin(expectedFilter, Optional.empty(), left, right);
     }
 
-    public static PlanMatchPattern spatialJoin(Expression expectedFilter, Optional<String> kdbTree, PlanMatchPattern left, PlanMatchPattern right)
+    public static PlanMatchPattern spatialJoin(Expression expectedFilter, Optional<Slice> kdbTree, PlanMatchPattern left, PlanMatchPattern right)
     {
         return spatialJoin(expectedFilter, kdbTree, Optional.empty(), left, right);
     }
 
-    public static PlanMatchPattern spatialJoin(Expression filter, Optional<String> kdbTree, Optional<List<String>> outputSymbols, PlanMatchPattern left, PlanMatchPattern right)
+    public static PlanMatchPattern spatialJoin(Expression filter, Optional<Slice> kdbTree, Optional<List<String>> outputSymbols, PlanMatchPattern left, PlanMatchPattern right)
     {
         return node(SpatialJoinNode.class, left, right).with(
                 new SpatialJoinMatcher(SpatialJoinNode.Type.INNER, filter, kdbTree, outputSymbols));

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/SpatialJoinMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/SpatialJoinMatcher.java
@@ -13,6 +13,7 @@
  */
 package io.trino.sql.planner.assertions;
 
+import io.airlift.slice.Slice;
 import io.trino.Session;
 import io.trino.cost.StatsProvider;
 import io.trino.metadata.Metadata;
@@ -37,10 +38,10 @@ public class SpatialJoinMatcher
 {
     private final Type type;
     private final Expression filter;
-    private final Optional<String> kdbTree;
+    private final Optional<Slice> kdbTree;
     private final Optional<List<String>> outputSymbols;
 
-    public SpatialJoinMatcher(Type type, Expression filter, Optional<String> kdbTree, Optional<List<String>> outputSymbols)
+    public SpatialJoinMatcher(Type type, Expression filter, Optional<Slice> kdbTree, Optional<List<String>> outputSymbols)
     {
         this.type = type;
         this.filter = requireNonNull(filter, "filter cannot be null");

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Maps;
+import io.airlift.slice.Slice;
 import io.trino.Session;
 import io.trino.cost.PlanNodeStatsEstimate;
 import io.trino.metadata.FunctionResolver;
@@ -1183,7 +1184,7 @@ public class PlanBuilder
             Expression filter,
             Optional<Symbol> leftPartitionSymbol,
             Optional<Symbol> rightPartitionSymbol,
-            Optional<String> kdbTree)
+            Optional<Slice> kdbTree)
     {
         return new SpatialJoinNode(
                 idAllocator.getNextId(),

--- a/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/KdbTreeUtils.java
+++ b/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/KdbTreeUtils.java
@@ -15,6 +15,8 @@ package io.trino.geospatial;
 
 import io.airlift.json.JsonCodec;
 import io.airlift.json.JsonCodecFactory;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 
 import static java.util.Objects.requireNonNull;
 
@@ -24,16 +26,16 @@ public final class KdbTreeUtils
 
     private KdbTreeUtils() {}
 
-    public static KdbTree fromJson(String json)
+    public static KdbTree fromJson(Slice json)
     {
         requireNonNull(json, "json is null");
-        return KDB_TREE_CODEC.fromJson(json);
+        return KDB_TREE_CODEC.fromJson(json.getInput());
     }
 
-    public static String toJson(KdbTree kdbTree)
+    public static Slice toJson(KdbTree kdbTree)
     {
         requireNonNull(kdbTree, "kdbTree is null");
-        return KDB_TREE_CODEC.toJson(kdbTree);
+        return Slices.utf8Slice(KDB_TREE_CODEC.toJson(kdbTree));
     }
 
     public static byte[] toJsonBytes(KdbTree kdbTree)

--- a/lib/trino-hdfs/src/main/java/io/trino/hdfs/cos/ServiceConfig.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/hdfs/cos/ServiceConfig.java
@@ -17,8 +17,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.util.HashSet;
 import java.util.Map;
@@ -29,6 +29,7 @@ import java.util.Set;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.nio.file.Files.newInputStream;
 import static java.util.Objects.requireNonNull;
 
 public class ServiceConfig
@@ -83,8 +84,8 @@ public class ServiceConfig
             return ImmutableMap.of();
         }
         Properties properties = new Properties();
-        try {
-            properties.load(new FileInputStream(configFile));
+        try (InputStream inputStream = newInputStream(configFile.toPath())) {
+            properties.load(inputStream);
         }
         catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
@@ -236,7 +236,7 @@ public class DeltaLakeMergeSink
             long rowPosition = BIGINT.getLong(rowPositionBlock, position);
             Slice partitions = VARCHAR.getSlice(partitionsBlock, position);
 
-            List<String> partitionValues = PARTITIONS_CODEC.fromJson(partitions.toStringUtf8());
+            List<String> partitionValues = PARTITIONS_CODEC.fromJson(partitions.getInput());
 
             FileDeletion deletion = fileDeletions.computeIfAbsent(filePath, _ -> new FileDeletion(partitionValues));
 
@@ -329,7 +329,7 @@ public class DeltaLakeMergeSink
         List<Slice> fragments = new ArrayList<>();
 
         insertPageSink.finish().join().stream()
-                .map(Slice::getBytes)
+                .map(Slice::getInput)
                 .map(dataFileInfoCodec::fromJson)
                 .map(info -> new DeltaLakeMergeResult(info.partitionValues(), Optional.empty(), Optional.empty(), Optional.of(info)))
                 .map(mergeResultJsonCodec::toJsonBytes)
@@ -347,7 +347,7 @@ public class DeltaLakeMergeSink
 
         if (cdfEnabled && cdfPageSink != null) { // cdf may be enabled but there may be no update/deletion so sink was not instantiated
             MoreFutures.getDone(cdfPageSink.finish()).stream()
-                    .map(Slice::getBytes)
+                    .map(Slice::getInput)
                     .map(dataFileInfoCodec::fromJson)
                     .map(info -> new DeltaLakeMergeResult(info.partitionValues(), Optional.empty(), Optional.empty(), Optional.of(info)))
                     .map(mergeResultJsonCodec::toJsonBytes)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -1579,7 +1579,7 @@ public class DeltaLakeMetadata
         String location = handle.location();
 
         List<DataFileInfo> dataFileInfos = fragments.stream()
-                .map(Slice::getBytes)
+                .map(Slice::getInput)
                 .map(dataFileInfoCodec::fromJson)
                 .collect(toImmutableList());
 
@@ -2162,7 +2162,7 @@ public class DeltaLakeMetadata
         DeltaLakeInsertTableHandle handle = (DeltaLakeInsertTableHandle) insertHandle;
 
         List<DataFileInfo> dataFileInfos = fragments.stream()
-                .map(Slice::getBytes)
+                .map(Slice::getInput)
                 .map(dataFileInfoCodec::fromJson)
                 .collect(toImmutableList());
 
@@ -2487,7 +2487,7 @@ public class DeltaLakeMetadata
         DeltaLakeTableHandle handle = mergeHandle.tableHandle();
 
         List<DeltaLakeMergeResult> mergeResults = fragments.stream()
-                .map(Slice::getBytes)
+                .map(Slice::getInput)
                 .map(mergeResultJsonCodec::fromJson)
                 .collect(toImmutableList());
 
@@ -2763,7 +2763,7 @@ public class DeltaLakeMetadata
 
         // files to be added
         List<DataFileInfo> dataFileInfos = fragments.stream()
-                .map(Slice::getBytes)
+                .map(Slice::getInput)
                 .map(dataFileInfoCodec::fromJson)
                 .collect(toImmutableList());
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
@@ -117,7 +117,7 @@ public class TestDeltaLakePageSink
             JsonCodec<DataFileInfo> dataFileInfoCodec = new JsonCodecFactory().jsonCodec(DataFileInfo.class);
             Collection<Slice> fragments = getFutureValue(pageSink.finish());
             List<DataFileInfo> dataFileInfos = fragments.stream()
-                    .map(Slice::getBytes)
+                    .map(Slice::getInput)
                     .map(dataFileInfoCodec::fromJson)
                     .collect(toImmutableList());
 

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/local/LocalFileSystemExchangeStorage.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/local/LocalFileSystemExchangeStorage.java
@@ -30,7 +30,6 @@ import io.trino.plugin.exchange.filesystem.FileSystemExchangeStorage;
 import io.trino.plugin.exchange.filesystem.MetricsBuilder;
 import io.trino.plugin.exchange.filesystem.MetricsBuilder.CounterMetricBuilder;
 
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -55,6 +54,7 @@ import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.trino.plugin.exchange.filesystem.MetricsBuilder.SOURCE_FILES_PROCESSED;
 import static java.lang.Math.toIntExact;
 import static java.nio.file.Files.createFile;
+import static java.nio.file.Files.newInputStream;
 import static java.util.Objects.requireNonNull;
 
 public class LocalFileSystemExchangeStorage
@@ -215,9 +215,9 @@ public class LocalFileSystemExchangeStorage
         }
 
         private InputStreamSliceInput getSliceInput(ExchangeSourceFile sourceFile)
-                throws FileNotFoundException
+                throws IOException
         {
-            return new InputStreamSliceInput(new FileInputStream(Paths.get(sourceFile.getFileUri()).toFile()), BUFFER_SIZE_IN_BYTES);
+            return new InputStreamSliceInput(newInputStream(Paths.get(sourceFile.getFileUri())), BUFFER_SIZE_IN_BYTES);
         }
     }
 

--- a/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/KdbTreeCasts.java
+++ b/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/KdbTreeCasts.java
@@ -34,7 +34,7 @@ public final class KdbTreeCasts
     public static Object castVarcharToKdbTree(@SqlType("varchar(x)") Slice json)
     {
         try {
-            return KdbTreeUtils.fromJson(json.toStringUtf8());
+            return KdbTreeUtils.fromJson(json);
         }
         catch (IllegalArgumentException e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, "Invalid JSON string for KDB tree", e);

--- a/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/SpatialPartitioningInternalAggregateFunction.java
+++ b/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/SpatialPartitioningInternalAggregateFunction.java
@@ -93,6 +93,6 @@ public final class SpatialPartitioningInternalAggregateFunction
         // Add a small buffer on the right and upper sides
         Rectangle paddedExtent = new Rectangle(envelope.getXMin(), envelope.getYMin(), Math.nextUp(envelope.getXMax()), Math.nextUp(envelope.getYMax()));
 
-        VARCHAR.writeString(out, KdbTreeUtils.toJson(buildKdbTree(maxItemsPerNode, paddedExtent, samples)));
+        VARCHAR.writeSlice(out, KdbTreeUtils.toJson(buildKdbTree(maxItemsPerNode, paddedExtent, samples)));
     }
 }

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestGeoFunctions.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestGeoFunctions.java
@@ -112,7 +112,7 @@ public class TestGeoFunctions
                 rectangles.add(new Rectangle(x, y, x + 1, y + 2));
             }
         }
-        return KdbTreeUtils.toJson(buildKdbTree(10, new Rectangle(0, 0, 9, 4), rectangles.build()));
+        return KdbTreeUtils.toJson(buildKdbTree(10, new Rectangle(0, 0, 9, 4), rectangles.build())).toStringUtf8();
     }
 
     private void assertSpatialPartitions(String kdbTreeJson, String wkt, List<Integer> expectedPartitions)

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestKdbTreeCasts.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestKdbTreeCasts.java
@@ -86,6 +86,6 @@ public class TestKdbTreeCasts
                 rectangles.add(new Rectangle(x, y, x + 1, y + 2));
             }
         }
-        return KdbTreeUtils.toJson(buildKdbTree(100, new Rectangle(0, 0, 9, 4), rectangles.build()));
+        return KdbTreeUtils.toJson(buildKdbTree(100, new Rectangle(0, 0, 9, 4), rectangles.build())).toStringUtf8();
     }
 }

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestPruneSpatialJoinChildrenColumns.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestPruneSpatialJoinChildrenColumns.java
@@ -15,6 +15,7 @@ package io.trino.plugin.geospatial;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slices;
 import io.trino.metadata.ResolvedFunction;
 import io.trino.metadata.TestingFunctionResolution;
 import io.trino.sql.ir.Call;
@@ -144,7 +145,7 @@ public class TestPruneSpatialJoinChildrenColumns
                             new Comparison(LESS_THAN_OR_EQUAL, new Call(TEST_ST_DISTANCE_FUNCTION, ImmutableList.of(new Reference(GEOMETRY, "a"), new Reference(GEOMETRY, "b"))), new Reference(DOUBLE, "r")),
                             Optional.of(leftPartitionSymbol),
                             Optional.of(rightPartitionSymbol),
-                            Optional.of("some nice kdb tree"));
+                            Optional.of(Slices.utf8Slice("some nice kdb tree")));
                 })
                 .doesNotFire();
     }

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialJoinOperator.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialJoinOperator.java
@@ -83,7 +83,7 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
 @TestInstance(PER_METHOD)
 public class TestSpatialJoinOperator
 {
-    private static final String KDB_TREE_JSON = KdbTreeUtils.toJson(
+    private static final Slice KDB_TREE_JSON = KdbTreeUtils.toJson(
             new KdbTree(newInternal(new Rectangle(-2, -2, 15, 15),
                     newInternal(new Rectangle(-2, -2, 6, 15),
                             newLeaf(new Rectangle(-2, -2, 6, 1), 1),
@@ -468,7 +468,7 @@ public class TestSpatialJoinOperator
         return buildIndex(driverContext, spatialRelationshipTest, radiusChannel, Optional.empty(), Optional.empty(), filterFunction, buildPages);
     }
 
-    private PagesSpatialIndexFactory buildIndex(DriverContext driverContext, SpatialPredicate spatialRelationshipTest, Optional<Integer> radiusChannel, Optional<Integer> partitionChannel, Optional<String> kdbTreeJson, Optional<InternalJoinFilterFunction> filterFunction, RowPagesBuilder buildPages)
+    private PagesSpatialIndexFactory buildIndex(DriverContext driverContext, SpatialPredicate spatialRelationshipTest, Optional<Integer> radiusChannel, Optional<Integer> partitionChannel, Optional<Slice> kdbTreeJson, Optional<InternalJoinFilterFunction> filterFunction, RowPagesBuilder buildPages)
     {
         Optional<JoinFilterFunctionCompiler.JoinFilterFunctionFactory> filterFunctionFactory = filterFunction
                 .map(function -> (session, addresses, pages) -> new StandardJoinFilterFunction(function, addresses, pages));

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialJoinPlanning.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialJoinPlanning.java
@@ -15,6 +15,7 @@ package io.trino.plugin.geospatial;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.trino.Session;
 import io.trino.geospatial.KdbTree;
@@ -85,7 +86,7 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 public class TestSpatialJoinPlanning
         extends BasePlanTest
 {
-    private static final String KDB_TREE_JSON = KdbTreeUtils.toJson(new KdbTree(newLeaf(new Rectangle(0, 0, 10, 10), 0)));
+    private static final Slice KDB_TREE_JSON = KdbTreeUtils.toJson(new KdbTree(newLeaf(new Rectangle(0, 0, 10, 10), 0)));
     private static final Expression KDB_TREE_LITERAL = new Constant(KDB_TREE, KdbTreeUtils.fromJson(KDB_TREE_JSON));
 
     private static final TestingFunctionResolution FUNCTIONS = new TestingFunctionResolution(new GeoPlugin());
@@ -109,7 +110,7 @@ public class TestSpatialJoinPlanning
         planTester.installPlugin(new GeoPlugin());
         planTester.createCatalog("tpch", new TpchConnectorFactory(1), ImmutableMap.of());
         planTester.createCatalog("memory", new MemoryConnectorFactory(), ImmutableMap.of());
-        planTester.executeStatement(format("CREATE TABLE kdb_tree AS SELECT '%s' AS v", KDB_TREE_JSON));
+        planTester.executeStatement(format("CREATE TABLE kdb_tree AS SELECT '%s' AS v", KDB_TREE_JSON.toStringUtf8()));
         planTester.executeStatement("CREATE TABLE points (lng, lat, name) AS (VALUES (2.1e0, 2.1e0, 'x'))");
         planTester.executeStatement("CREATE TABLE polygons (wkt, name) AS (VALUES ('POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))', 'a'))");
         return planTester;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -1847,7 +1847,7 @@ public class HiveMetadata
         HiveOutputTableHandle handle = (HiveOutputTableHandle) tableHandle;
 
         List<PartitionUpdate> partitionUpdates = fragments.stream()
-                .map(Slice::getBytes)
+                .map(Slice::getInput)
                 .map(partitionUpdateCodec::fromJson)
                 .collect(toImmutableList());
 
@@ -2086,7 +2086,7 @@ public class HiveMetadata
 
         requireNonNull(fragments, "fragments is null");
         List<PartitionUpdateAndMergeResults> partitionMergeResults = fragments.stream()
-                .map(Slice::getBytes)
+                .map(Slice::getInput)
                 .map(PartitionUpdateAndMergeResults.CODEC::fromJson)
                 .collect(toImmutableList());
 
@@ -2204,7 +2204,7 @@ public class HiveMetadata
         HiveInsertTableHandle handle = (HiveInsertTableHandle) insertHandle;
 
         List<PartitionUpdate> partitionUpdates = fragments.stream()
-                .map(Slice::getBytes)
+                .map(Slice::getInput)
                 .map(partitionUpdateCodec::fromJson)
                 .collect(toImmutableList());
 
@@ -2614,7 +2614,7 @@ public class HiveMetadata
         checkArgument(handle.getWriteDeclarationId().isPresent(), "no write declaration id present in tableExecuteHandle");
 
         List<PartitionUpdate> partitionUpdates = fragments.stream()
-                .map(Slice::getBytes)
+                .map(Slice::getInput)
                 .map(partitionUpdateCodec::fromJson)
                 .collect(toImmutableList());
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1398,7 +1398,8 @@ public class IcebergMetadata
             Collection<ComputedStatistics> computedStatistics)
     {
         List<CommitTaskData> commitTasks = fragments.stream()
-                .map(slice -> commitTaskCodec.fromJson(slice.getBytes()))
+                .map(Slice::getInput)
+                .map(commitTaskCodec::fromJson)
                 .collect(toImmutableList());
 
         if (commitTasks.isEmpty()) {
@@ -1891,7 +1892,8 @@ public class IcebergMetadata
         Set<DeleteFile> fullyAppliedDeleteFiles = scannedDeleteFilesBuilder.build();
 
         List<CommitTaskData> commitTasks = fragments.stream()
-                .map(slice -> commitTaskCodec.fromJson(slice.getBytes()))
+                .map(Slice::getInput)
+                .map(commitTaskCodec::fromJson)
                 .collect(toImmutableList());
 
         Type[] partitionColumnTypes = icebergTable.spec().fields().stream()
@@ -2952,7 +2954,8 @@ public class IcebergMetadata
         Table icebergTable = transaction.table();
 
         List<CommitTaskData> commitTasks = fragments.stream()
-                .map(slice -> commitTaskCodec.fromJson(slice.getBytes()))
+                .map(Slice::getInput)
+                .map(commitTaskCodec::fromJson)
                 .collect(toImmutableList());
 
         if (commitTasks.isEmpty()) {
@@ -3540,7 +3543,8 @@ public class IcebergMetadata
         }
 
         List<CommitTaskData> commitTasks = fragments.stream()
-                .map(slice -> commitTaskCodec.fromJson(slice.getBytes()))
+                .map(Slice::getInput)
+                .map(commitTaskCodec::fromJson)
                 .collect(toImmutableList());
 
         Type[] partitionColumnTypes = icebergTable.spec().fields().stream()

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/file/FileTableDescriptionSupplier.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/file/FileTableDescriptionSupplier.java
@@ -30,6 +30,8 @@ import io.trino.plugin.kafka.schema.TableDescriptionSupplier;
 import io.trino.spi.connector.SchemaTableName;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -37,7 +39,6 @@ import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
-import static java.nio.file.Files.readAllBytes;
 import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
 
@@ -78,8 +79,8 @@ public class FileTableDescriptionSupplier
         for (File file : listFiles(tableDescriptionDir)) {
             if (file.isFile() && file.getName().endsWith(".json")) {
                 KafkaTopicDescription table;
-                try {
-                    table = topicDescriptionCodec.fromJson(readAllBytes(file.toPath()));
+                try (InputStream stream = new FileInputStream(file)) {
+                    table = topicDescriptionCodec.fromJson(stream);
                 }
                 catch (Exception e) {
                     throw new IllegalArgumentException("Failed to get table description file for Kafka: " + file, e);

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/KafkaQueryRunner.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/KafkaQueryRunner.java
@@ -203,7 +203,7 @@ public final class KafkaQueryRunner
             throws IOException
     {
         String fileName = format("/%s/%s.json", table.getSchemaName(), table.getTableName());
-        KafkaTopicDescription tableTemplate = topicDescriptionJsonCodec.fromJson(KafkaQueryRunner.class.getResourceAsStream(fileName).readAllBytes());
+        KafkaTopicDescription tableTemplate = topicDescriptionJsonCodec.fromJson(KafkaQueryRunner.class.getResourceAsStream(fileName));
 
         Optional<KafkaTopicFieldGroup> key = tableTemplate.key()
                 .map(keyTemplate -> new KafkaTopicFieldGroup(

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/util/TestUtils.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/util/TestUtils.java
@@ -36,7 +36,7 @@ public final class TestUtils
     public static Map.Entry<SchemaTableName, KafkaTopicDescription> loadTpchTopicDescription(JsonCodec<KafkaTopicDescription> topicDescriptionJsonCodec, String topicName, SchemaTableName schemaTableName)
             throws IOException
     {
-        KafkaTopicDescription tpchTemplate = topicDescriptionJsonCodec.fromJson(TestUtils.class.getResourceAsStream(format("/tpch/%s.json", schemaTableName.getTableName())).readAllBytes());
+        KafkaTopicDescription tpchTemplate = topicDescriptionJsonCodec.fromJson(TestUtils.class.getResourceAsStream(format("/tpch/%s.json", schemaTableName.getTableName())));
 
         return new AbstractMap.SimpleImmutableEntry<>(
                 schemaTableName,

--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisTableDescriptionSupplier.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisTableDescriptionSupplier.java
@@ -23,7 +23,6 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.connector.SchemaTableName;
 import jakarta.annotation.PreDestroy;
 
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.DirectoryIteratorException;
@@ -37,6 +36,7 @@ import java.util.function.Supplier;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Throwables.throwIfUnchecked;
+import static java.nio.file.Files.newInputStream;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -82,7 +82,7 @@ public class KinesisTableDescriptionSupplier
         try {
             for (Path file : listFiles(Paths.get(tableDescriptionLocation))) {
                 if (Files.isRegularFile(file) && file.getFileName().toString().endsWith("json")) {
-                    try (InputStream stream = new FileInputStream(file.toFile())) {
+                    try (InputStream stream = newInputStream(file)) {
                         KinesisStreamDescription table = streamDescriptionCodec.fromJson(stream);
                         String schemaName = firstNonNull(table.schemaName(), defaultSchema);
                         log.debug("Kinesis table %s %s %s", schemaName, table.tableName(), table);

--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/s3config/S3TableConfigClient.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/s3config/S3TableConfigClient.java
@@ -22,7 +22,6 @@ import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.io.CharStreams;
 import com.google.inject.Inject;
 import io.airlift.json.JsonCodec;
 import io.airlift.log.Logger;
@@ -203,7 +202,7 @@ public class S3TableConfigClient
                 S3Object object = s3client.getObject(new GetObjectRequest(summary.getBucketName(), summary.getKey()));
 
                 try (BufferedReader reader = new BufferedReader(new InputStreamReader(object.getObjectContent(), UTF_8))) {
-                    KinesisStreamDescription table = streamDescriptionCodec.fromJson(CharStreams.toString(reader));
+                    KinesisStreamDescription table = streamDescriptionCodec.fromJson(reader);
                     descriptors.put(summary.getKey(), table);
                     log.info("Put table description into the map from %s", summary.getKey());
                 }

--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryDataFragment.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryDataFragment.java
@@ -39,7 +39,7 @@ public record MemoryDataFragment(HostAddress hostAddress, long rows)
 
     public static MemoryDataFragment fromSlice(Slice fragment)
     {
-        return MEMORY_DATA_FRAGMENT_CODEC.fromJson(fragment.getBytes());
+        return MEMORY_DATA_FRAGMENT_CODEC.fromJson(fragment.getInput());
     }
 
     public static MemoryDataFragment merge(MemoryDataFragment a, MemoryDataFragment b)

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusClient.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusClient.java
@@ -35,6 +35,7 @@ import okhttp3.ResponseBody;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.time.Duration;
 import java.util.List;
@@ -160,8 +161,8 @@ public class PrometheusClient
 
     private Map<String, Object> fetchMetrics(JsonCodec<Map<String, Object>> metricsCodec, URI metadataUri)
     {
-        try (ResponseBody body = fetchUri(metadataUri)) {
-            return metricsCodec.fromJson(body.string());
+        try (ResponseBody body = fetchUri(metadataUri); InputStream inputStream = body.byteStream()) {
+            return metricsCodec.fromJson(inputStream);
         }
         catch (IOException e) {
             throw new TrinoException(PROMETHEUS_UNKNOWN_ERROR, "Error reading metadata", e);

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/util/RedisTestUtils.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/util/RedisTestUtils.java
@@ -64,7 +64,7 @@ public final class RedisTestUtils
     {
         RedisTableDescription tpchTemplate;
         try (InputStream data = RedisTestUtils.class.getResourceAsStream(format("/tpch/%s/%s.json", dataFormat, schemaTableName.getTableName()))) {
-            tpchTemplate = tableDescriptionJsonCodec.fromJson(data.readAllBytes());
+            tpchTemplate = tableDescriptionJsonCodec.fromJson(data);
         }
 
         RedisTableDescription tableDescription = new RedisTableDescription(
@@ -90,7 +90,7 @@ public final class RedisTestUtils
     {
         JsonCodec<RedisTableDescription> tableDescriptionJsonCodec = new CodecSupplier<>(RedisTableDescription.class, queryRunner.getPlannerContext().getTypeManager()).get();
         try (InputStream data = RedisTestUtils.class.getResourceAsStream(format("/simple/%s_value_table.json", valueDataFormat))) {
-            return tableDescriptionJsonCodec.fromJson(data.readAllBytes());
+            return tableDescriptionJsonCodec.fromJson(data);
         }
     }
 }

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/FileResourceGroupConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/FileResourceGroupConfigurationManager.java
@@ -28,9 +28,10 @@ import io.trino.spi.resourcegroups.ResourceGroup;
 import io.trino.spi.resourcegroups.SelectionContext;
 import io.trino.spi.resourcegroups.SelectionCriteria;
 
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
@@ -85,8 +86,8 @@ public class FileResourceGroupConfigurationManager
     static ManagerSpec parseManagerSpec(FileResourceGroupConfig config)
     {
         ManagerSpec managerSpec;
-        try {
-            managerSpec = CODEC.fromJson(Files.readAllBytes(Paths.get(config.getConfigFile())));
+        try (InputStream stream = new FileInputStream(Paths.get(config.getConfigFile()).toFile())) {
+            managerSpec = CODEC.fromJson(stream);
         }
         catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/FileResourceGroupConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/FileResourceGroupConfigurationManager.java
@@ -28,7 +28,6 @@ import io.trino.spi.resourcegroups.ResourceGroup;
 import io.trino.spi.resourcegroups.SelectionContext;
 import io.trino.spi.resourcegroups.SelectionCriteria;
 
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -38,6 +37,7 @@ import java.util.Optional;
 
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 import static java.lang.String.format;
+import static java.nio.file.Files.newInputStream;
 import static java.util.Objects.requireNonNull;
 
 public class FileResourceGroupConfigurationManager
@@ -86,7 +86,7 @@ public class FileResourceGroupConfigurationManager
     static ManagerSpec parseManagerSpec(FileResourceGroupConfig config)
     {
         ManagerSpec managerSpec;
-        try (InputStream stream = new FileInputStream(Paths.get(config.getConfigFile()).toFile())) {
+        try (InputStream stream = newInputStream(Paths.get(config.getConfigFile()))) {
             managerSpec = CODEC.fromJson(stream);
         }
         catch (IOException e) {

--- a/plugin/trino-session-property-managers/src/main/java/io/trino/plugin/session/file/FileSessionPropertyManager.java
+++ b/plugin/trino-session-property-managers/src/main/java/io/trino/plugin/session/file/FileSessionPropertyManager.java
@@ -23,9 +23,10 @@ import io.airlift.json.ObjectMapperProvider;
 import io.trino.plugin.session.AbstractSessionPropertyManager;
 import io.trino.plugin.session.SessionMatchSpec;
 
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -45,8 +46,8 @@ public class FileSessionPropertyManager
     public FileSessionPropertyManager(FileSessionPropertyManagerConfig config)
     {
         Path configurationFile = config.getConfigFile().toPath();
-        try {
-            sessionMatchSpecs = ImmutableList.copyOf(CODEC.fromJson(Files.readAllBytes(configurationFile)));
+        try (InputStream stream = new FileInputStream(configurationFile.toFile())) {
+            sessionMatchSpecs = ImmutableList.copyOf(CODEC.fromJson(stream));
         }
         catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/plugin/trino-session-property-managers/src/main/java/io/trino/plugin/session/file/FileSessionPropertyManager.java
+++ b/plugin/trino-session-property-managers/src/main/java/io/trino/plugin/session/file/FileSessionPropertyManager.java
@@ -27,7 +27,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.nio.file.Path;
 import java.util.List;
 
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
@@ -45,8 +44,7 @@ public class FileSessionPropertyManager
     @Inject
     public FileSessionPropertyManager(FileSessionPropertyManagerConfig config)
     {
-        Path configurationFile = config.getConfigFile().toPath();
-        try (InputStream stream = new FileInputStream(configurationFile.toFile())) {
+        try (InputStream stream = new FileInputStream(config.getConfigFile())) {
             sessionMatchSpecs = ImmutableList.copyOf(CODEC.fromJson(stream));
         }
         catch (IOException e) {

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
         <air.test.jvm.additional-arguments>${air.test.jvm.additional-arguments.default}</air.test.jvm.additional-arguments>
 
         <!-- keep dependency properties sorted -->
-        <dep.airlift.version>296</dep.airlift.version>
+        <dep.airlift.version>297</dep.airlift.version>
         <dep.alluxio.version>2.9.6</dep.alluxio.version>
         <dep.antlr.version>4.13.2</dep.antlr.version>
         <dep.avro.version>1.12.0</dep.avro.version>

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/jdk/TarDownloadingJdkProvider.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/jdk/TarDownloadingJdkProvider.java
@@ -27,7 +27,6 @@ import org.apache.commons.compress.utils.IOUtils;
 import org.testcontainers.utility.DockerImageName;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
@@ -45,6 +44,7 @@ import static io.trino.tests.product.launcher.util.DirectoryUtils.getOnlyDescend
 import static io.trino.tests.product.launcher.util.UriDownloader.download;
 import static java.nio.file.Files.exists;
 import static java.nio.file.Files.isDirectory;
+import static java.nio.file.Files.newInputStream;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
@@ -133,7 +133,7 @@ public abstract class TarDownloadingJdkProvider
     private static void extractTar(Path filePath, Path extractPath)
     {
         try {
-            try (TarArchiveInputStream archiveStream = new TarArchiveInputStream(new GzipCompressorInputStream(new FileInputStream(filePath.toFile())))) {
+            try (TarArchiveInputStream archiveStream = new TarArchiveInputStream(new GzipCompressorInputStream(newInputStream(filePath)))) {
                 TarArchiveEntry entry;
                 while ((entry = archiveStream.getNextTarEntry()) != null) {
                     if (!archiveStream.canReadEntryData(entry)) {


### PR DESCRIPTION
This avoids materialization that happens today:

Slice -> copy bytes -> UTF-8 String/UTF-8 byte[] -> JsonCodec.fromJson

Instead we can just do JsonCodec.fromJson(Slice.getInput()) which doesn't copy bytes from Slice

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
