### PR TITLE
Explicitly cleanup SqlTask on worker when no longer needed

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/TaskResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/TaskResource.java
@@ -328,6 +328,14 @@ public class TaskResource
         return taskManager.failTask(taskId, failTaskRequest.getFailureInfo().toException());
     }
 
+    @POST
+    @Path("{taskId}/cleanup")
+    public void cleanupTask(@PathParam("taskId") TaskId taskId)
+    {
+        requireNonNull(taskId, "taskId is null");
+        taskManager.cleanupTask(taskId);
+    }
+
     @GET
     @Path("{taskId}/results/{bufferId}/{token}")
     @Produces(TRINO_PAGES)

--- a/core/trino-main/src/main/java/io/trino/server/remotetask/RemoteTaskCleaner.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/RemoteTaskCleaner.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.remotetask;
+
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.StatusResponseHandler.StatusResponse;
+import io.airlift.log.Logger;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.trino.execution.TaskId;
+import io.trino.execution.TaskState;
+
+import java.net.URI;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+
+import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static io.airlift.http.client.Request.Builder.preparePost;
+import static io.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
+import static java.util.Objects.requireNonNull;
+
+public class RemoteTaskCleaner
+{
+    private static final Logger log = Logger.get(RemoteTaskCleaner.class);
+
+    private final TaskId taskId;
+    private final URI taskUri;
+    private final HttpClient httpClient;
+    private final Executor executor;
+    private final Supplier<SpanBuilder> spanBuilderFactory;
+
+    @GuardedBy("this")
+    private boolean taskStatusFetcherStopped;
+
+    @GuardedBy("this")
+    private boolean taskInfoFetcherStopped;
+
+    @GuardedBy("this")
+    private boolean dynamicFilterFetcherStopped;
+
+    @GuardedBy("this")
+    private TaskState taskState;
+
+    public RemoteTaskCleaner(TaskId taskId, URI taskUri, HttpClient httpClient, Executor executor, Supplier<SpanBuilder> spanBuilderFactory)
+    {
+        this.taskId = requireNonNull(taskId, "taskId is null");
+        this.taskUri = requireNonNull(taskUri, "taskUri is null");
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.executor = requireNonNull(executor, "executor is null");
+        this.spanBuilderFactory = requireNonNull(spanBuilderFactory, "spanBuilderFactory is null");
+    }
+
+    public synchronized void markTaskStatusFetcherStopped(TaskState taskState)
+    {
+        if (taskStatusFetcherStopped) {
+            return;
+        }
+        taskStatusFetcherStopped = true;
+        this.taskState = taskState;
+        cleanupIfReady();
+    }
+
+    public synchronized void markTaskInfoFetcherStopped()
+    {
+        if (taskInfoFetcherStopped) {
+            return;
+        }
+        taskInfoFetcherStopped = true;
+        cleanupIfReady();
+    }
+
+    public synchronized void markDynamicFilterFetcherStopped()
+    {
+        if (dynamicFilterFetcherStopped) {
+            return;
+        }
+        dynamicFilterFetcherStopped = true;
+        cleanupIfReady();
+    }
+
+    @GuardedBy("this")
+    private void cleanupIfReady()
+    {
+        if (taskState != TaskState.FINISHED) {
+            // we do not perform early cleanup if task did not finish successfully.
+            // other workers may still reach out for the results; and we have no control over that.
+            return;
+        }
+        if (taskStatusFetcherStopped && taskInfoFetcherStopped && dynamicFilterFetcherStopped) {
+            scheduleCleanupRequest();
+        }
+    }
+
+    private void scheduleCleanupRequest()
+    {
+        executor.execute(
+                () -> {
+                    Request request = preparePost()
+                            .setUri(uriBuilderFrom(taskUri)
+                                    .appendPath("/cleanup")
+                                    .build())
+                            .setSpanBuilder(spanBuilderFactory.get())
+                            .build();
+
+                    StatusResponse response = httpClient.execute(request, createStatusResponseHandler());
+                    if (response.getStatusCode() / 100 != 2) {
+                        log.warn("Failed to cleanup task %s: %s", taskId, response.getStatusCode());
+                    }
+                });
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/remotetask/TaskInfoFetcher.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/TaskInfoFetcher.java
@@ -67,6 +67,7 @@ public class TaskInfoFetcher
     private final TaskId taskId;
     private final Consumer<Throwable> onFail;
     private final ContinuousTaskStatusFetcher taskStatusFetcher;
+    private final RemoteTaskCleaner remoteTaskCleaner;
     private final StateMachine<TaskInfo> taskInfo;
     private final StateMachine<Optional<TaskInfo>> finalTaskInfo;
     private final JsonCodec<TaskInfo> taskInfoCodec;
@@ -100,6 +101,7 @@ public class TaskInfoFetcher
     public TaskInfoFetcher(
             Consumer<Throwable> onFail,
             ContinuousTaskStatusFetcher taskStatusFetcher,
+            RemoteTaskCleaner remoteTaskCleaner,
             TaskInfo initialTask,
             HttpClient httpClient,
             Supplier<SpanBuilder> spanBuilderFactory,
@@ -120,6 +122,7 @@ public class TaskInfoFetcher
         this.taskId = initialTask.taskStatus().getTaskId();
         this.onFail = requireNonNull(onFail, "onFail is null");
         this.taskStatusFetcher = requireNonNull(taskStatusFetcher, "taskStatusFetcher is null");
+        this.remoteTaskCleaner = requireNonNull(remoteTaskCleaner, "remoteTaskCleaner is null");
         this.taskInfo = new StateMachine<>("task " + taskId, executor, initialTask);
         this.finalTaskInfo = new StateMachine<>("task-" + taskId, executor, Optional.empty());
         this.taskInfoCodec = requireNonNull(taskInfoCodec, "taskInfoCodec is null");
@@ -163,6 +166,7 @@ public class TaskInfoFetcher
         if (scheduledFuture != null) {
             scheduledFuture.cancel(true);
         }
+        remoteTaskCleaner.markTaskInfoFetcherStopped();
     }
 
     /**


### PR DESCRIPTION
Currently SqlTask objects are removed from SqlTaskManager.tasks map (cache) after timeout (15 minutes by default). Even though the object is not huge, we observed increased memory pressure up to OOM on busy clusters.

With this PR entries are dropped form SqlTaskManager as soon as they are no longer needed, when coordinator will no longer query for the information

Note: I this code is prone to race condition if last worker to acknowlege task results retransmits acknowlegement. There is a chance that a this point task is already cleaned by cleanup request from coordinator, and entry will get resurected in tasks cache map. This should be extremly rare though, and not cause any problems.