### PR TITLE
Reduce task.info.max-age to 5m

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/TaskManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TaskManagerConfig.java
@@ -72,7 +72,7 @@ public class TaskManagerConfig
     private int pagePartitioningBufferPoolSize = 8;
 
     private Duration clientTimeout = new Duration(2, TimeUnit.MINUTES);
-    private Duration infoMaxAge = new Duration(15, TimeUnit.MINUTES);
+    private Duration infoMaxAge = new Duration(5, TimeUnit.MINUTES);
 
     private Duration statusRefreshMaxWait = new Duration(1, TimeUnit.SECONDS);
     private Duration infoUpdateInterval = new Duration(3, TimeUnit.SECONDS);

--- a/core/trino-main/src/test/java/io/trino/execution/TestTaskManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestTaskManagerConfig.java
@@ -51,7 +51,7 @@ public class TestTaskManagerConfig
                 .setMinDrivers(Runtime.getRuntime().availableProcessors() * 2 * 2)
                 .setMinDriversPerTask(3)
                 .setMaxDriversPerTask(Integer.MAX_VALUE)
-                .setInfoMaxAge(new Duration(15, TimeUnit.MINUTES))
+                .setInfoMaxAge(new Duration(5, TimeUnit.MINUTES))
                 .setClientTimeout(new Duration(2, TimeUnit.MINUTES))
                 .setMaxIndexMemoryUsage(DataSize.of(64, Unit.MEGABYTE))
                 .setShareIndexLoading(false)


### PR DESCRIPTION
Default 15m sometiems causes some significant OOM issues on workers.

Related to https://github.com/trinodb/trino/pull/24729

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
