### PR TITLE
Support remote data cache with Alluxio cluster

### DIFF
--- a/lib/trino-filesystem-cache-alluxio/pom.xml
+++ b/lib/trino-filesystem-cache-alluxio/pom.xml
@@ -65,6 +65,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-filesystem-alluxio</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-spi</artifactId>
         </dependency>
 
@@ -86,6 +91,17 @@
         <dependency>
             <groupId>org.alluxio</groupId>
             <artifactId>alluxio-core-common</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-reload4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.alluxio</groupId>
+            <artifactId>alluxio-core-transport</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -159,6 +175,18 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/RemoteAlluxioFileSystemCache.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/RemoteAlluxioFileSystemCache.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.alluxio;
+
+import alluxio.AlluxioURI;
+import alluxio.client.file.FileInStream;
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.FileSystemContext;
+import alluxio.client.file.URIStatus;
+import alluxio.client.file.cache.CacheManager;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.exception.AlluxioException;
+import alluxio.grpc.OpenFilePOptions;
+import alluxio.wire.FileInfo;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+import io.airlift.units.DataSize;
+import io.opentelemetry.api.trace.Tracer;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoInput;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoInputStream;
+import io.trino.filesystem.cache.TrinoFileSystemCache;
+import jakarta.annotation.PreDestroy;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import static java.util.Objects.requireNonNull;
+
+public class RemoteAlluxioFileSystemCache
+        implements TrinoFileSystemCache
+{
+    private static final Logger log = Logger.get(TrinoFileSystemCache.class);
+    private final Tracer tracer;
+    private final FileSystem fileSystem;
+    private final AlluxioConfiguration config;
+    private final AlluxioCacheStats statistics;
+    private final CacheManager cacheManager;
+    private final DataSize pageSize;
+
+    @Inject
+    public RemoteAlluxioFileSystemCache(Tracer tracer, AlluxioFileSystemCacheConfig config, AlluxioCacheStats statistics)
+            throws IOException
+    {
+        this.tracer = requireNonNull(tracer, "tracer is null");
+        this.config = AlluxioConfigurationFactory.create(requireNonNull(config, "config is null"));
+        this.pageSize = config.getCachePageSize();
+        this.cacheManager = CacheManager.Factory.create(this.config);
+        FileSystemContext fsContext = FileSystemContext.create(this.config);
+        this.fileSystem = FileSystem.Factory.create(fsContext);
+        this.statistics = requireNonNull(statistics, "statistics is null");
+    }
+
+    @Override
+    public TrinoInput cacheInput(TrinoInputFile delegate, String key)
+            throws IOException
+    {
+        return new RemoteAlluxioInput(tracer, delegate, key, uriStatus(delegate), new TracingCacheManager(tracer, key, pageSize, cacheManager), config, statistics, openFile(delegate));
+    }
+
+    @Override
+    public TrinoInputStream cacheStream(TrinoInputFile delegate, String key)
+            throws IOException
+    {
+        return new RemoteAlluxioInputStream(tracer, delegate, key, uriStatus(delegate), new TracingCacheManager(tracer, key, pageSize, cacheManager), config, statistics, openFile(delegate));
+    }
+
+    @Override
+    public long cacheLength(TrinoInputFile delegate, String key)
+            throws IOException
+    {
+        return delegate.length();
+    }
+
+    @Override
+    public void expire(Location source)
+            throws IOException
+    {
+        try {
+            AlluxioURI sourceUri = new AlluxioURI(source.toString());
+            if (fileSystem.exists(sourceUri) && !sourceUri.isRoot()) {
+                fileSystem.free(sourceUri);
+            }
+        }
+        catch (AlluxioException e) {
+            log.error(e, "Failed to free the file %s", source);
+        }
+    }
+
+    @Override
+    public void expire(Collection<Location> locations)
+            throws IOException
+    {
+        for (Location location : locations) {
+            try {
+                AlluxioURI locationUri = new AlluxioURI(location.toString());
+                if (fileSystem.exists(locationUri) && !locationUri.isRoot()) {
+                    fileSystem.free(locationUri);
+                }
+            }
+            catch (AlluxioException e) {
+                log.error(e, "Failed to free the file %s", location);
+            }
+        }
+    }
+
+    @PreDestroy
+    public void shutdown()
+            throws Exception
+    {
+        cacheManager.close();
+        fileSystem.close();
+    }
+
+    @VisibleForTesting
+    protected URIStatus uriStatus(TrinoInputFile file)
+            throws IOException
+    {
+        FileInfo info = new FileInfo()
+                .setPath(file.location().toString())
+                .setLength(file.length());
+        return new URIStatus(info);
+    }
+
+    private FileInStream openFile(TrinoInputFile file)
+            throws IOException
+    {
+        try {
+            return fileSystem.openFile(new AlluxioURI(file.location().toString()), OpenFilePOptions.getDefaultInstance());
+        }
+        catch (AlluxioException e) {
+            throw new IOException("fail to open remote cache file", e);
+        }
+    }
+}

--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/RemoteAlluxioFileSystemCacheModule.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/RemoteAlluxioFileSystemCacheModule.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.alluxio;
+
+import alluxio.metrics.MetricsConfig;
+import alluxio.metrics.MetricsSystem;
+import com.google.inject.Binder;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.filesystem.cache.CachingHostAddressProvider;
+import io.trino.filesystem.cache.ConsistentHashingHostAddressProvider;
+import io.trino.filesystem.cache.ConsistentHashingHostAddressProviderConfig;
+import io.trino.filesystem.cache.TrinoFileSystemCache;
+
+import java.util.Properties;
+
+import static com.google.inject.Scopes.SINGLETON;
+import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
+
+public class RemoteAlluxioFileSystemCacheModule
+        extends AbstractConfigurationAwareModule
+{
+    private final boolean isCoordinator;
+
+    public RemoteAlluxioFileSystemCacheModule(boolean isCoordinator)
+    {
+        this.isCoordinator = isCoordinator;
+    }
+
+    @Override
+    protected void setup(Binder binder)
+    {
+        configBinder(binder).bindConfig(AlluxioFileSystemCacheConfig.class);
+        configBinder(binder).bindConfig(ConsistentHashingHostAddressProviderConfig.class);
+        binder.bind(AlluxioCacheStats.class).in(SINGLETON);
+        newExporter(binder).export(AlluxioCacheStats.class).as(generator -> generator.generatedNameOf(AlluxioCacheStats.class));
+
+        if (isCoordinator) {
+            newOptionalBinder(binder, CachingHostAddressProvider.class).setBinding().to(ConsistentHashingHostAddressProvider.class).in(SINGLETON);
+        }
+        binder.bind(TrinoFileSystemCache.class).to(RemoteAlluxioFileSystemCache.class).in(SINGLETON);
+
+        Properties metricProps = new Properties();
+        metricProps.put("sink.jmx.class", "alluxio.metrics.sink.JmxSink");
+        metricProps.put("sink.jmx.domain", "org.alluxio");
+        MetricsSystem.startSinksFromConfig(new MetricsConfig(metricProps));
+    }
+}

--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/RemoteAlluxioInput.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/RemoteAlluxioInput.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.alluxio;
+
+import alluxio.client.file.FileInStream;
+import alluxio.client.file.URIStatus;
+import alluxio.client.file.cache.CacheManager;
+import alluxio.conf.AlluxioConfiguration;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.trino.filesystem.TrinoInput;
+import io.trino.filesystem.TrinoInputFile;
+
+import java.io.EOFException;
+import java.io.IOException;
+
+import static io.trino.filesystem.tracing.CacheSystemAttributes.CACHE_FILE_LOCATION;
+import static io.trino.filesystem.tracing.CacheSystemAttributes.CACHE_FILE_READ_POSITION;
+import static io.trino.filesystem.tracing.CacheSystemAttributes.CACHE_FILE_READ_SIZE;
+import static io.trino.filesystem.tracing.CacheSystemAttributes.CACHE_KEY;
+import static io.trino.filesystem.tracing.Tracing.withTracing;
+import static java.lang.Math.min;
+import static java.util.Objects.checkFromIndexSize;
+import static java.util.Objects.requireNonNull;
+
+public class RemoteAlluxioInput
+        implements TrinoInput
+{
+    private final TrinoInputFile inputFile;
+    private final long fileLength;
+    private final AlluxioCacheStats statistics;
+    private final String cacheKey;
+    private final AlluxioInputHelper helper;
+    private final Tracer tracer;
+    private TrinoInput input;
+    private boolean closed;
+    private final FileInStream stream;
+
+    public RemoteAlluxioInput(
+            Tracer tracer,
+            TrinoInputFile inputFile,
+            String cacheKey,
+            URIStatus status,
+            CacheManager cacheManager,
+            AlluxioConfiguration configuration,
+            AlluxioCacheStats statistics,
+            FileInStream stream)
+    {
+        this.tracer = requireNonNull(tracer, "tracer is null");
+        this.inputFile = requireNonNull(inputFile, "inputFile is null");
+        this.fileLength = requireNonNull(status, "status is null").getLength();
+        this.statistics = requireNonNull(statistics, "statistics is null");
+        this.cacheKey = requireNonNull(cacheKey, "cacheKey is null");
+        this.helper = new AlluxioInputHelper(tracer, inputFile.location(), cacheKey, status, cacheManager, configuration, statistics);
+        this.stream = stream;
+    }
+
+    @Override
+    public void readFully(long position, byte[] buffer, int offset, int length)
+            throws IOException
+    {
+        ensureOpen();
+        checkFromIndexSize(offset, length, buffer.length);
+        if (position < 0) {
+            throw new IOException("Negative seek offset");
+        }
+        if (length == 0) {
+            return;
+        }
+
+        int bytesRead = doRemoteCacheRead(position, buffer, offset, length);
+        if (length > bytesRead && position + bytesRead == fileLength) {
+            throw new EOFException("Read %s of %s requested bytes: %s".formatted(bytesRead, length, inputFile.location()));
+        }
+        doExternalRead(position + bytesRead, buffer, offset + bytesRead, length - bytesRead);
+    }
+
+    private int doExternalRead(long position, byte[] buffer, int offset, int length)
+            throws IOException
+    {
+        if (length == 0) {
+            return 0;
+        }
+
+        Span span = tracer.spanBuilder("Alluxio.readExternal")
+                .setAttribute(CACHE_KEY, cacheKey)
+                .setAttribute(CACHE_FILE_LOCATION, inputFile.location().toString())
+                .setAttribute(CACHE_FILE_READ_SIZE, (long) length)
+                .setAttribute(CACHE_FILE_READ_POSITION, position)
+                .startSpan();
+
+        return withTracing(span, () -> {
+            AlluxioInputHelper.PageAlignedRead aligned = helper.alignRead(position, length);
+            byte[] readBuffer = new byte[aligned.length()];
+            getInput().readFully(aligned.pageStart(), readBuffer, 0, readBuffer.length);
+            System.arraycopy(readBuffer, aligned.pageOffset(), buffer, offset, length);
+            statistics.recordExternalRead(readBuffer.length);
+            return length;
+        });
+    }
+
+    private TrinoInput getInput()
+            throws IOException
+    {
+        if (input == null) {
+            input = inputFile.newInput();
+        }
+        return input;
+    }
+
+    private int doRemoteCacheRead(long position, byte[] buffer, int offset, int length)
+            throws IOException
+    {
+        ensureOpen();
+        checkFromIndexSize(offset, length, buffer.length);
+        if (position + length > inputFile.length()) {
+            throw new IOException("readFully position overflow %s. pos %d + buffer length %d > file size %d"
+                    .formatted(inputFile.location(), position, length, inputFile.length()));
+        }
+        return stream.positionedRead(position, buffer, offset, length);
+    }
+
+    @Override
+    public int readTail(byte[] buffer, int bufferOffset, int bufferLength)
+            throws IOException
+    {
+        ensureOpen();
+        checkFromIndexSize(bufferOffset, bufferLength, buffer.length);
+
+        int readSize = (int) min(fileLength, bufferLength);
+        readFully(fileLength - readSize, buffer, bufferOffset, readSize);
+        return readSize;
+    }
+
+    private void ensureOpen()
+            throws IOException
+    {
+        if (closed) {
+            throw new IOException("Stream closed: " + inputFile.location());
+        }
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        closed = true;
+        if (input != null) {
+            input.close();
+        }
+        stream.close();
+    }
+}

--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/RemoteAlluxioInputStream.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/RemoteAlluxioInputStream.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.alluxio;
+
+import alluxio.client.file.FileInStream;
+import alluxio.client.file.URIStatus;
+import alluxio.client.file.cache.CacheManager;
+import alluxio.conf.AlluxioConfiguration;
+import com.google.common.primitives.Longs;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoInputStream;
+
+import java.io.EOFException;
+import java.io.IOException;
+
+import static com.google.common.base.Verify.verify;
+import static com.google.common.primitives.Ints.saturatedCast;
+import static io.trino.filesystem.tracing.CacheSystemAttributes.CACHE_FILE_LOCATION;
+import static io.trino.filesystem.tracing.CacheSystemAttributes.CACHE_FILE_READ_POSITION;
+import static io.trino.filesystem.tracing.CacheSystemAttributes.CACHE_FILE_READ_SIZE;
+import static io.trino.filesystem.tracing.CacheSystemAttributes.CACHE_KEY;
+import static io.trino.filesystem.tracing.Tracing.withTracing;
+import static java.lang.Integer.max;
+import static java.lang.Math.addExact;
+import static java.lang.Math.min;
+import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
+import static java.util.Objects.checkFromIndexSize;
+import static java.util.Objects.requireNonNull;
+
+public class RemoteAlluxioInputStream
+        extends TrinoInputStream
+{
+    private final TrinoInputFile inputFile;
+    private final long fileLength;
+    private final Location location;
+    private final AlluxioCacheStats statistics;
+    private final String key;
+    private final AlluxioInputHelper helper;
+    private final Tracer tracer;
+    private TrinoInputStream externalStream;
+    private long position;
+    private boolean closed;
+    private FileInStream stream;
+
+    public RemoteAlluxioInputStream(Tracer tracer, TrinoInputFile inputFile, String key, URIStatus status, CacheManager cacheManager, AlluxioConfiguration configuration, AlluxioCacheStats statistics, FileInStream stream)
+    {
+        this.tracer = requireNonNull(tracer, "tracer is null");
+        this.inputFile = requireNonNull(inputFile, "inputFile is null");
+        this.fileLength = requireNonNull(status, "status is null").getLength();
+        this.location = inputFile.location();
+        this.statistics = requireNonNull(statistics, "statistics is null");
+        this.key = requireNonNull(key, "key is null");
+        this.helper = new AlluxioInputHelper(tracer, inputFile.location(), key, status, cacheManager, configuration, statistics);
+        this.stream = stream;
+    }
+
+    @Override
+    public int available()
+            throws IOException
+    {
+        ensureOpen();
+
+        return saturatedCast(fileLength - position);
+    }
+
+    @Override
+    public long getPosition()
+    {
+        return position;
+    }
+
+    private void ensureOpen()
+            throws IOException
+    {
+        if (closed) {
+            throw new IOException("Output stream closed: " + location);
+        }
+    }
+
+    @Override
+    public int read()
+            throws IOException
+    {
+        ensureOpen();
+        byte[] bytes = new byte[1];
+        int n = read(bytes, 0, 1);
+        if (n == 1) {
+            // Converts the byte to an unsigned byte, an integer in the range 0 to 255
+            return bytes[0] & 0xff;
+        }
+        if (n == -1) {
+            return -1;
+        }
+        throw new IOException(format("%d bytes read", n));
+    }
+
+    @Override
+    public int read(byte[] bytes, int offset, int length)
+            throws IOException
+    {
+        ensureOpen();
+
+        checkFromIndexSize(offset, length, bytes.length);
+        if (length == 0) {
+            return 0;
+        }
+        if (position >= fileLength) {
+            return -1;
+        }
+        int bytesRead = doRead(bytes, offset, toIntExact(min(fileLength - position, length)));
+        position += bytesRead;
+        return bytesRead;
+    }
+
+    private int doRead(byte[] bytes, int offset, int length)
+            throws IOException
+    {
+        int bytesRead = doRemoteCacheRead(position, bytes, offset, length);
+        return addExact(bytesRead, doExternalRead0(position + bytesRead, bytes, offset + bytesRead, length - bytesRead));
+    }
+
+    private int doRemoteCacheRead(long position, byte[] buffer, int offset, int length)
+            throws IOException
+    {
+        ensureOpen();
+        checkFromIndexSize(offset, length, buffer.length);
+        if (position + length > inputFile.length()) {
+            throw new IOException("readFully position overflow %s. pos %d + buffer length %d > file size %d"
+                    .formatted(inputFile.location(), position, length, inputFile.length()));
+        }
+        return stream.positionedRead(position, buffer, offset, length);
+    }
+
+    private int doExternalRead0(long readPosition, byte[] buffer, int offset, int length)
+            throws IOException
+    {
+        if (length == 0) {
+            return 0;
+        }
+
+        Span span = tracer.spanBuilder("Alluxio.readExternal")
+                .setAttribute(CACHE_KEY, key)
+                .setAttribute(CACHE_FILE_LOCATION, inputFile.location().toString())
+                .setAttribute(CACHE_FILE_READ_SIZE, (long) length)
+                .setAttribute(CACHE_FILE_READ_POSITION, readPosition)
+                .startSpan();
+
+        return withTracing(span, () -> doExternalReadInternal(readPosition, buffer, offset, length));
+    }
+
+    private int doExternalReadInternal(long readPosition, byte[] buffer, int offset, int length)
+            throws IOException
+    {
+        verify(length > 0, "zero-length or negative read");
+        AlluxioInputHelper.PageAlignedRead aligned = helper.alignRead(readPosition, length);
+        if (externalStream == null) {
+            externalStream = inputFile.newStream();
+        }
+        externalStream.seek(aligned.pageStart());
+        byte[] readBuffer = new byte[aligned.length()];
+        int externalBytesRead = externalStream.readNBytes(readBuffer, 0, aligned.length());
+        if (externalBytesRead < 0) {
+            throw new IOException("Unexpected end of stream");
+        }
+        verify(aligned.length() == externalBytesRead, "invalid number of external bytes read");
+        int bytesToCopy = min(length, max(externalBytesRead - aligned.pageOffset(), 0));
+        System.arraycopy(readBuffer, aligned.pageOffset(), buffer, offset, bytesToCopy);
+        statistics.recordExternalRead(externalBytesRead);
+        return bytesToCopy;
+    }
+
+    @Override
+    public long skip(long n)
+            throws IOException
+    {
+        ensureOpen();
+
+        n = Longs.constrainToRange(n, 0, fileLength - position);
+        position += n;
+        return n;
+    }
+
+    @Override
+    public void skipNBytes(long n)
+            throws IOException
+    {
+        ensureOpen();
+
+        if (n <= 0) {
+            return;
+        }
+
+        long position;
+        try {
+            position = addExact(this.position, n);
+        }
+        catch (ArithmeticException e) {
+            throw new EOFException("Unable to skip %s bytes (position=%s, fileSize=%s): %s".formatted(n, this.position, fileLength, location));
+        }
+        if (position > fileLength) {
+            throw new EOFException("Unable to skip %s bytes (position=%s, fileSize=%s): %s".formatted(n, this.position, fileLength, location));
+        }
+        this.position = position;
+    }
+
+    @Override
+    public void seek(long position)
+            throws IOException
+    {
+        ensureOpen();
+
+        if (position < 0) {
+            throw new IOException("Negative seek offset");
+        }
+        if (position > fileLength) {
+            throw new IOException("Cannot seek to %s. File size is %s: %s".formatted(position, fileLength, location));
+        }
+
+        this.position = position;
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        if (!closed) {
+            closed = true;
+            if (externalStream != null) {
+                externalStream.close();
+                externalStream = null;
+            }
+            stream.close();
+        }
+    }
+}

--- a/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestAlluxioRemoteCacheFileSystem.java
+++ b/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestAlluxioRemoteCacheFileSystem.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.alluxio;
+
+import alluxio.AlluxioURI;
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.FileSystemContext;
+import alluxio.client.file.URIStatus;
+import alluxio.conf.Configuration;
+import alluxio.conf.InstancedConfiguration;
+import alluxio.exception.AlluxioException;
+import alluxio.grpc.DeletePOptions;
+import com.google.common.collect.ImmutableList;
+import io.airlift.units.DataSize;
+import io.trino.filesystem.AbstractTestTrinoFileSystem;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.cache.CacheFileSystem;
+import io.trino.filesystem.cache.DefaultCacheKeyProvider;
+import io.trino.spi.security.ConnectorIdentity;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.stream.Stream;
+
+import static io.airlift.tracing.Tracing.noopTracer;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class TestAlluxioRemoteCacheFileSystem
+        extends AbstractTestTrinoFileSystem
+{
+    private TrinoFileSystem fileSystem;
+    private CacheFileSystem cacheFileSystem;
+    private RemoteAlluxioFileSystemCache cache;
+    private Path tempDirectory;
+
+    private static final String IMAGE_NAME = "alluxio/alluxio:2.9.5";
+    private static final DockerImageName ALLUXIO_IMAGE = DockerImageName.parse(IMAGE_NAME);
+
+    @Container
+    private static final GenericContainer<?> ALLUXIO_MASTER_CONTAINER = createAlluxioMasterContainer();
+
+    @Container
+    private static final GenericContainer<?> ALLUXIO_WORKER_CONTAINER = createAlluxioWorkerContainer();
+
+    private Location rootLocation;
+    private FileSystem alluxioFs;
+    private AlluxioFileSystemFactory alluxioFileSystemFactory;
+
+    @BeforeAll
+    void beforeAll()
+            throws IOException
+    {
+        this.rootLocation = Location.of("alluxio:///");
+        InstancedConfiguration conf = Configuration.copyGlobal();
+        FileSystemContext fsContext = FileSystemContext.create(conf);
+        this.alluxioFs = FileSystem.Factory.create(fsContext);
+        this.alluxioFileSystemFactory = new AlluxioFileSystemFactory(conf);
+        this.fileSystem = alluxioFileSystemFactory.create(ConnectorIdentity.ofUser("alluxio"));
+        // the SSHD container will be stopped by TestContainers on shutdown
+        // https://github.com/trinodb/trino/discussions/21969
+        System.setProperty("ReportLeakedContainers.disabled", "true");
+
+        tempDirectory = Files.createTempDirectory("test");
+        Path cacheDirectory = tempDirectory.resolve("cache");
+        Files.createDirectory(cacheDirectory);
+        AlluxioFileSystemCacheConfig configuration = new AlluxioFileSystemCacheConfig()
+                .setCacheDirectories(ImmutableList.of(cacheDirectory.toAbsolutePath().toString()))
+                .setCachePageSize(DataSize.valueOf("32003B"))
+                .disableTTL()
+                .setMaxCacheSizes(ImmutableList.of(DataSize.valueOf("100MB")));
+        cache = new RemoteAlluxioFileSystemCache(noopTracer(), configuration, new AlluxioCacheStats());
+        cacheFileSystem = new CacheFileSystem(fileSystem, cache, new DefaultCacheKeyProvider());
+    }
+
+    @AfterEach
+    void afterEach()
+            throws IOException, AlluxioException
+    {
+        AlluxioURI root = new AlluxioURI(getRootLocation().toString());
+
+        for (URIStatus status : alluxioFs.listStatus(root)) {
+            alluxioFs.delete(new AlluxioURI(status.getPath()), DeletePOptions.newBuilder().setRecursive(true).build());
+        }
+    }
+
+    @AfterAll
+    void afterAll()
+            throws IOException
+    {
+        cleanupFiles(tempDirectory);
+        Files.delete(tempDirectory);
+        cacheFileSystem = null;
+        alluxioFs = null;
+        rootLocation = null;
+        alluxioFileSystemFactory = null;
+    }
+
+    private void cleanupFiles(Path directory)
+            throws IOException
+    {
+        // tests will leave directories
+        try (Stream<Path> walk = Files.walk(directory)) {
+            Iterator<Path> iterator = walk.sorted(Comparator.reverseOrder()).iterator();
+            while (iterator.hasNext()) {
+                Path path = iterator.next();
+                if (!path.equals(directory)) {
+                    Files.delete(path);
+                }
+            }
+        }
+    }
+
+    @Override
+    protected boolean isHierarchical()
+    {
+        return true;
+    }
+
+    @Override
+    protected final boolean supportsCreateExclusive()
+    {
+        return false;
+    }
+
+    @Override
+    protected boolean supportsIncompleteWriteNoClobber()
+    {
+        return false;
+    }
+
+    @Override
+    protected TrinoFileSystem getFileSystem()
+    {
+        return cacheFileSystem;
+    }
+
+    @Override
+    protected Location getRootLocation()
+    {
+        return rootLocation;
+    }
+
+    @Override
+    protected void verifyFileSystemIsEmpty()
+    {
+        AlluxioURI bucket =
+                AlluxioUtils.convertToAlluxioURI(rootLocation, ((AlluxioFileSystem) fileSystem).getMountRoot());
+        try {
+            assertThat(alluxioFs.listStatus(bucket)).isEmpty();
+        }
+        catch (IOException | AlluxioException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static GenericContainer<?> createAlluxioMasterContainer()
+    {
+        GenericContainer<?> container = new GenericContainer<>(ALLUXIO_IMAGE);
+        container.withCommand("master-only")
+                .withEnv("ALLUXIO_JAVA_OPTS",
+                        "-Dalluxio.security.authentication.type=NOSASL "
+                                + "-Dalluxio.master.hostname=localhost "
+                                + "-Dalluxio.worker.hostname=localhost "
+                                + "-Dalluxio.master.mount.table.root.ufs=/opt/alluxio/underFSStorage "
+                                + "-Dalluxio.master.journal.type=NOOP "
+                                + "-Dalluxio.security.authorization.permission.enabled=false "
+                                + "-Dalluxio.security.authorization.plugins.enabled=false ")
+                .withNetworkMode("host")
+                .withAccessToHost(true)
+                .waitingFor(new LogMessageWaitStrategy()
+                        .withRegEx(".*Primary started*\n")
+                        .withStartupTimeout(Duration.ofMinutes(3)));
+        return container;
+    }
+
+    private static GenericContainer<?> createAlluxioWorkerContainer()
+    {
+        GenericContainer<?> container = new GenericContainer<>(ALLUXIO_IMAGE);
+        container.withCommand("worker-only")
+                .withNetworkMode("host")
+                .withEnv("ALLUXIO_JAVA_OPTS",
+                        "-Dalluxio.security.authentication.type=NOSASL "
+                                + "-Dalluxio.worker.ramdisk.size=128MB "
+                                + "-Dalluxio.worker.hostname=localhost "
+                                + "-Dalluxio.worker.tieredstore.level0.alias=HDD "
+                                + "-Dalluxio.worker.tieredstore.level0.dirs.path=/tmp "
+                                + "-Dalluxio.master.hostname=localhost "
+                                + "-Dalluxio.security.authorization.permission.enabled=false "
+                                + "-Dalluxio.security.authorization.plugins.enabled=false ")
+                .withAccessToHost(true)
+                .dependsOn(ALLUXIO_MASTER_CONTAINER)
+                .waitingFor(Wait.forLogMessage(".*Alluxio worker started.*\n", 1));
+        return container;
+    }
+}

--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemConfig.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemConfig.java
@@ -22,7 +22,7 @@ public class FileSystemConfig
     private boolean nativeAzureEnabled;
     private boolean nativeS3Enabled;
     private boolean nativeGcsEnabled;
-    private boolean cacheEnabled;
+    private FileSystemCacheType cacheType = FileSystemCacheType.NO_CACHE;
 
     public boolean isHadoopEnabled()
     {
@@ -84,15 +84,22 @@ public class FileSystemConfig
         return this;
     }
 
-    public boolean isCacheEnabled()
+    public FileSystemCacheType getFileSystemCacheType()
     {
-        return cacheEnabled;
+        return cacheType;
     }
 
-    @Config("fs.cache.enabled")
-    public FileSystemConfig setCacheEnabled(boolean enabled)
+    @Config("fs.cache.type")
+    public FileSystemConfig setFileSystemCacheType(FileSystemCacheType cacheType)
     {
-        this.cacheEnabled = enabled;
+        this.cacheType = cacheType;
         return this;
+    }
+
+    public enum FileSystemCacheType
+    {
+        LOCAL_CACHE,
+        REMOTE_CACHE,
+        NO_CACHE
     }
 }

--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemModule.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemModule.java
@@ -27,6 +27,7 @@ import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.filesystem.alluxio.AlluxioFileSystemCacheModule;
 import io.trino.filesystem.alluxio.AlluxioFileSystemFactory;
 import io.trino.filesystem.alluxio.AlluxioFileSystemModule;
+import io.trino.filesystem.alluxio.RemoteAlluxioFileSystemCacheModule;
 import io.trino.filesystem.azure.AzureFileSystemFactory;
 import io.trino.filesystem.azure.AzureFileSystemModule;
 import io.trino.filesystem.cache.CacheFileSystemFactory;
@@ -126,8 +127,17 @@ public class FileSystemModule
         newOptionalBinder(binder, MemoryFileSystemCache.class);
 
         boolean isCoordinator = nodeManager.getCurrentNode().isCoordinator();
-        if (config.isCacheEnabled()) {
-            install(new AlluxioFileSystemCacheModule(isCoordinator));
+        switch (config.getFileSystemCacheType()) {
+            case NO_CACHE:
+                break;
+            case LOCAL_CACHE:
+                install(new AlluxioFileSystemCacheModule(nodeManager.getCurrentNode().isCoordinator()));
+                break;
+            case REMOTE_CACHE:
+                install(new RemoteAlluxioFileSystemCacheModule(nodeManager.getCurrentNode().isCoordinator()));
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported file system cache type: " + config.getFileSystemCacheType());
         }
         if (coordinatorFileCaching) {
             install(new MemoryFileSystemCacheModule(isCoordinator));

--- a/lib/trino-filesystem-manager/src/test/java/io/trino/filesystem/manager/TestFileSystemConfig.java
+++ b/lib/trino-filesystem-manager/src/test/java/io/trino/filesystem/manager/TestFileSystemConfig.java
@@ -33,7 +33,7 @@ public class TestFileSystemConfig
                 .setNativeAzureEnabled(false)
                 .setNativeS3Enabled(false)
                 .setNativeGcsEnabled(false)
-                .setCacheEnabled(false));
+                .setFileSystemCacheType(FileSystemConfig.FileSystemCacheType.NO_CACHE));
     }
 
     @Test
@@ -45,7 +45,7 @@ public class TestFileSystemConfig
                 .put("fs.native-azure.enabled", "true")
                 .put("fs.native-s3.enabled", "true")
                 .put("fs.native-gcs.enabled", "true")
-                .put("fs.cache.enabled", "true")
+                .put("fs.cache.type", "LOCAL_CACHE")
                 .buildOrThrow();
 
         FileSystemConfig expected = new FileSystemConfig()
@@ -54,7 +54,7 @@ public class TestFileSystemConfig
                 .setNativeAzureEnabled(true)
                 .setNativeS3Enabled(true)
                 .setNativeGcsEnabled(true)
-                .setCacheEnabled(true);
+                .setFileSystemCacheType(FileSystemConfig.FileSystemCacheType.LOCAL_CACHE);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConfig.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConfig.java
@@ -579,7 +579,7 @@ public class DeltaLakeConfig
     }
 
     @Config("delta.fs.cache.disable-transaction-log-caching")
-    @ConfigDescription("Disable filesystem caching of the _delta_log directory (effective only when fs.cache.enabled=true)")
+    @ConfigDescription("Disable filesystem caching of the _delta_log directory (effective only when fs.cache.type=LOCAL_CACHE)")
     public DeltaLakeConfig setDeltaLogFileSystemCacheDisabled(boolean deltaLogFileSystemCacheDisabled)
     {
         this.deltaLogFileSystemCacheDisabled = deltaLogFileSystemCacheDisabled;

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAlluxioCacheFileOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAlluxioCacheFileOperations.java
@@ -52,7 +52,7 @@ public class TestDeltaLakeAlluxioCacheFileOperations
         return DeltaLakeQueryRunner.builder()
                 .setCoordinatorProperties(ImmutableMap.of("node-scheduler.include-coordinator", "false"))
                 .setDeltaProperties(ImmutableMap.<String, String>builder()
-                        .put("fs.cache.enabled", "true")
+                        .put("fs.cache.type", "LOCAL_CACHE")
                         .put("fs.cache.directories", cacheDirectory.toAbsolutePath().toString())
                         .put("fs.cache.max-sizes", "100MB")
                         .put("delta.enable-non-concurrent-writes", "true")

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAlluxioCacheMinioAndHmsConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAlluxioCacheMinioAndHmsConnectorSmokeTest.java
@@ -65,7 +65,7 @@ public class TestDeltaLakeAlluxioCacheMinioAndHmsConnectorSmokeTest
     {
         return ImmutableMap.<String, String>builder()
                 .putAll(super.deltaStorageConfiguration())
-                .put("fs.cache.enabled", "true")
+                .put("fs.cache.type", "LOCAL_CACHE")
                 .put("fs.cache.directories", cacheDirectory.toAbsolutePath().toString())
                 .put("fs.cache.max-sizes", "100MB")
                 .buildOrThrow();

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAlluxioCacheMutableTransactionLog.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAlluxioCacheMutableTransactionLog.java
@@ -47,7 +47,7 @@ public class TestDeltaLakeAlluxioCacheMutableTransactionLog
         return DeltaLakeQueryRunner.builder()
                 .setCoordinatorProperties(ImmutableMap.of("node-scheduler.include-coordinator", "false"))
                 .setDeltaProperties(ImmutableMap.<String, String>builder()
-                        .put("fs.cache.enabled", "true")
+                        .put("fs.cache.type", "LOCAL_CACHE")
                         .put("fs.cache.directories", cacheDirectory.toAbsolutePath().toString())
                         .put("fs.cache.max-sizes", "100MB")
                         .put("delta.enable-non-concurrent-writes", "true")

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveAlluxioCacheFileOperations.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveAlluxioCacheFileOperations.java
@@ -54,7 +54,7 @@ public class TestHiveAlluxioCacheFileOperations
         closeAfterClass(() -> deleteRecursively(metastoreDirectory, ALLOW_INSECURE));
 
         Map<String, String> hiveProperties = ImmutableMap.<String, String>builder()
-                .put("fs.cache.enabled", "true")
+                .put("fs.cache.type", "LOCAL_CACHE")
                 .put("fs.cache.directories", cacheDirectory.toAbsolutePath().toString())
                 .put("fs.cache.max-sizes", "100MB")
                 .put("hive.metastore", "file")

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -518,7 +518,7 @@ public class IcebergConfig
     }
 
     @Config("iceberg.metadata-cache.enabled")
-    @ConfigDescription("Enables in-memory caching of metadata files on coordinator if fs.cache.enabled is not set to true")
+    @ConfigDescription("Enables in-memory caching of metadata files on coordinator if fs.cache.type is set to NO_CACHE")
     public IcebergConfig setMetadataCacheEnabled(boolean metadataCacheEnabled)
     {
         this.metadataCacheEnabled = metadataCacheEnabled;

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergAlluxioCacheFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergAlluxioCacheFileOperations.java
@@ -60,7 +60,7 @@ public class TestIcebergAlluxioCacheFileOperations
         closeAfterClass(() -> deleteRecursively(metastoreDirectory, ALLOW_INSECURE));
 
         Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()
-                .put("fs.cache.enabled", "true")
+                .put("fs.cache.type", "LOCAL_CACHE")
                 .put("fs.cache.directories", cacheDirectory.toAbsolutePath().toString())
                 .put("fs.cache.max-sizes", "100MB")
                 .put("iceberg.metadata-cache.enabled", "false")

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMinioParquetCachingConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMinioParquetCachingConnectorSmokeTest.java
@@ -52,7 +52,7 @@ public class TestIcebergMinioParquetCachingConnectorSmokeTest
     public ImmutableMap<String, String> getAdditionalIcebergProperties()
     {
         return ImmutableMap.<String, String>builder()
-                .put("fs.cache.enabled", "true")
+                .put("fs.cache.type", "LOCAL_CACHE")
                 .put("fs.cache.directories", cacheDirectory.toAbsolutePath().toString())
                 .put("fs.cache.max-sizes", "100MB")
                 .buildOrThrow();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Add `RemoteAlluxioFileSystemCacheModule` to support the remote data cache functionality with alluxio cluster as a standalone service.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
