### PR TITLE
Test the effectiveness of partial partition pruning

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergFileOperations.java
@@ -23,6 +23,7 @@ import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.metastore.HiveMetastore;
 import io.trino.plugin.iceberg.util.FileOperationUtils;
 import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.sql.planner.plan.FilterNode;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
@@ -507,6 +508,62 @@ public class TestIcebergFileOperations
                         .add(new FileOperation(SNAPSHOT, "InputFile.newStream"))
                         .add(new FileOperation(MANIFEST, "InputFile.newStream"))
                         .build());
+    }
+
+    @Test
+    public void testPartialTimestampPartitionPruningEffectivenessWithPartitionTransform()
+    {
+        testPartialTimestampPartitionPruningEffectivenessWithPartitionTransform("hour(d)", 4);
+        testPartialTimestampPartitionPruningEffectivenessWithPartitionTransform("day(d)", 2);
+        testPartialTimestampPartitionPruningEffectivenessWithPartitionTransform("month(d)", 2);
+        testPartialTimestampPartitionPruningEffectivenessWithPartitionTransform("year(d)", 2);
+        testPartialTimestampPartitionPruningEffectivenessWithPartitionTransform("bucket(d, 4)", 2);
+    }
+
+    private void testPartialTimestampPartitionPruningEffectivenessWithPartitionTransform(String partitionTransform, int expectedDataFileOperations)
+    {
+        String tableName = "test_transform_timestamp" + randomNameSuffix();
+        assertUpdate(format("CREATE TABLE %s (d TIMESTAMP(6), b BIGINT) WITH (partitioning = ARRAY['%s'])", tableName, partitionTransform));
+
+        @Language("SQL") String values =
+                """
+                VALUES
+                    (NULL, 101),
+                    (TIMESTAMP '1969-12-25 15:13:12.876543', 8),
+                    (TIMESTAMP '1969-12-30 18:47:33.345678', 9),
+                    (TIMESTAMP '1969-12-31 00:00:00.000000', 10),
+                    (TIMESTAMP '1969-12-31 05:06:07.234567', 11),
+                    (TIMESTAMP '1970-01-01 12:03:08.456789', 12),
+                    (TIMESTAMP '2015-01-01 10:01:23.123456', 1),
+                    (TIMESTAMP '2015-01-01 11:10:02.987654', 2),
+                    (TIMESTAMP '2015-01-01 12:55:00.456789', 3),
+                    (TIMESTAMP '2015-05-15 13:05:01.234567', 4),
+                    (TIMESTAMP '2015-05-15 14:21:02.345678', 5),
+                    (TIMESTAMP '2020-02-21 15:11:11.876543', 6),
+                    (TIMESTAMP '2020-02-21 16:12:12.654321', 7)
+                """;
+        assertUpdate("INSERT INTO " + tableName + " " + values, 13);
+        assertQuery("SELECT * FROM " + tableName, values);
+
+        @Language("SQL") String selectQuery = "SELECT * FROM " + tableName + " WHERE d >= TIMESTAMP '2015-05-15 01:23:45.678901'";
+        assertThat(query(selectQuery)).isNotFullyPushedDown(FilterNode.class);
+
+        assertFileSystemAccesses(
+                getSession(),
+                selectQuery,
+                ALL_FILES,
+                ImmutableMultiset.<FileOperationUtils.FileOperation>builder()
+                        .add(new FileOperationUtils.FileOperation(METADATA_JSON, "InputFile.newStream"))
+                        .add(new FileOperationUtils.FileOperation(SNAPSHOT, "InputFile.newStream"))
+                        .add(new FileOperationUtils.FileOperation(MANIFEST, "InputFile.newStream"))
+                        .add(new FileOperationUtils.FileOperation(SNAPSHOT, "InputFile.length"))
+                        .addCopies(new FileOperationUtils.FileOperation(DATA, "InputFile.newInput"), expectedDataFileOperations)
+                        .build());
+
+        assertThat((long) computeScalar("SELECT COUNT(DISTINCT file_path) FROM \"" + tableName + "$files\""))
+                .isGreaterThan(expectedDataFileOperations);
+
+        assertUpdate("DROP TABLE " + tableName);
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

This test showcases that there is partition pruning done at the Iceberg metadata layer even though EXPLAIN showcases that a filter that does not fully match the partition transform is not being pushed down.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Fixes https://github.com/trinodb/trino/issues/19266
Cosmetic changes applied on https://github.com/trinodb/trino/pull/24483

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
