### PR TITLE
Remove experimental warning for Python UDF

### DIFF
--- a/docs/src/main/sphinx/release/release-468.md
+++ b/docs/src/main/sphinx/release/release-468.md
@@ -2,7 +2,7 @@
 
 ## General
 
-* Add experimental support for [](/udf/python). ({issue}`24378`)
+* Add support for [](/udf/python). ({issue}`24378`)
 * Add cluster overview to the [](/admin/preview-web-interface). ({issue}`23600`)
 * Add new node states `DRAINING` and `DRAINED` to make it possible to reactivate
   a draining worker node. ({issue}`24444 `)

--- a/docs/src/main/sphinx/udf/python.md
+++ b/docs/src/main/sphinx/udf/python.md
@@ -4,10 +4,6 @@ A Python user-defined function is a [user-defined function](/udf) that uses the
 [Python programming language and statements](python-udf-lang) for the definition
 of the function.
 
-:::{warning}
-Python user-defined functions are an experimental feature.
-:::
-
 ## Python UDF declaration
 
 Declare a Python UDF as [inline](udf-inline) or [catalog UDF](udf-catalog) with


### PR DESCRIPTION
## Description

The feature is essentially stable and completely usable. No need to scare users away.
Discussed with @electrum 

## Additional context and related issues



## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
