### PR TITLE
Suffix S3 path with separator for recursive delete

### DIFF
--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/s3/S3FileSystemExchangeStorage.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/s3/S3FileSystemExchangeStorage.java
@@ -360,7 +360,7 @@ public class S3FileSystemExchangeStorage
 
         ListObjectsV2Request request = ListObjectsV2Request.builder()
                 .bucket(getBucketName(dir))
-                .prefix(keyFromUri(dir))
+                .prefix(keyFromUri(dir) + PATH_SEPARATOR)
                 .build();
 
         return s3AsyncClient.listObjectsV2Paginator(request);


### PR DESCRIPTION
Without trailing path separator the recursive delete operation fails for directory buckets (e.g. S3 Express)

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Fault tolerant execution
* Fix a bug causing fault tolerant execution being not usable with S3 Express ({issue}`issuenumber`)
```
