### PR TITLE
 Fix connection leakage in native Azure filesystem

### DIFF
--- a/lib/trino-filesystem-azure/pom.xml
+++ b/lib/trino-filesystem-azure/pom.xml
@@ -24,7 +24,7 @@
 
         <dependency>
             <groupId>com.azure</groupId>
-            <artifactId>azure-core-http-okhttp</artifactId>
+            <artifactId>azure-core-http-netty</artifactId>
         </dependency>
 
         <dependency>
@@ -36,10 +36,6 @@
             <groupId>com.azure</groupId>
             <artifactId>azure-identity</artifactId>
             <exclusions>
-                <exclusion>
-                    <groupId>com.azure</groupId>
-                    <artifactId>azure-core-http-netty</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>com.nimbusds</groupId>
                     <artifactId>oauth2-oidc-sdk</artifactId>
@@ -54,34 +50,16 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-storage-blob</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.azure</groupId>
-                    <artifactId>azure-core-http-netty</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-storage-common</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.azure</groupId>
-                    <artifactId>azure-core-http-netty</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-storage-file-datalake</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.azure</groupId>
-                    <artifactId>azure-core-http-netty</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
@@ -95,11 +73,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>configuration</artifactId>
         </dependency>
@@ -110,8 +83,23 @@
         </dependency>
 
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.projectreactor.netty</groupId>
+            <artifactId>reactor-netty-core</artifactId>
         </dependency>
 
         <dependency>

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemFactory.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemFactory.java
@@ -86,7 +86,6 @@ public class AzureFileSystemFactory
         HttpClientOptions clientOptions = new HttpClientOptions();
         clientOptions.setTracingOptions(tracingOptions);
         clientOptions.setApplicationId(applicationId);
-        clientOptions.setMaximumConnectionPoolSize(maxHttpRequests);
         httpClient = createAzureHttpClient(connectionProvider, eventLoopGroup, clientOptions);
     }
 
@@ -118,10 +117,6 @@ public class AzureFileSystemFactory
 
     public static HttpClient createAzureHttpClient(ConnectionProvider connectionProvider, EventLoopGroup eventLoopGroup, HttpClientOptions clientOptions)
     {
-        Integer poolSize = clientOptions.getMaximumConnectionPoolSize();
-        int maximumConnectionPoolSize = (poolSize != null && poolSize > 0) ? poolSize : 5;
-        clientOptions.setMaximumConnectionPoolSize(maximumConnectionPoolSize);
-
         return new NettyAsyncHttpClientBuilder()
                 .proxy(clientOptions.getProxyOptions())
                 .configuration(clientOptions.getConfiguration())

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemFactory.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemFactory.java
@@ -14,22 +14,22 @@
 package io.trino.filesystem.azure;
 
 import com.azure.core.http.HttpClient;
-import com.azure.core.http.okhttp.OkHttpAsyncHttpClientBuilder;
+import com.azure.core.http.netty.NettyAsyncHttpClientBuilder;
 import com.azure.core.tracing.opentelemetry.OpenTelemetryTracingOptions;
 import com.azure.core.util.HttpClientOptions;
 import com.azure.core.util.TracingOptions;
 import com.google.inject.Inject;
 import io.airlift.units.DataSize;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
 import io.opentelemetry.api.OpenTelemetry;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.spi.security.ConnectorIdentity;
 import jakarta.annotation.PreDestroy;
-import okhttp3.ConnectionPool;
-import okhttp3.Dispatcher;
-import okhttp3.OkHttpClient;
+import reactor.netty.resources.ConnectionProvider;
 
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ExecutionException;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
@@ -44,8 +44,9 @@ public class AzureFileSystemFactory
     private final int maxWriteConcurrency;
     private final DataSize maxSingleUploadSize;
     private final TracingOptions tracingOptions;
-    private final OkHttpClient okHttpClient;
     private final HttpClient httpClient;
+    private final ConnectionProvider connectionProvider;
+    private final EventLoopGroup eventLoopGroup;
 
     @Inject
     public AzureFileSystemFactory(OpenTelemetry openTelemetry, AzureAuth azureAuth, AzureFileSystemConfig config)
@@ -80,24 +81,33 @@ public class AzureFileSystemFactory
         this.maxWriteConcurrency = maxWriteConcurrency;
         this.maxSingleUploadSize = requireNonNull(maxSingleUploadSize, "maxSingleUploadSize is null");
         this.tracingOptions = new OpenTelemetryTracingOptions().setOpenTelemetry(openTelemetry);
-
-        Dispatcher dispatcher = new Dispatcher();
-        dispatcher.setMaxRequests(maxHttpRequests);
-        dispatcher.setMaxRequestsPerHost(maxHttpRequests);
-        okHttpClient = new OkHttpClient.Builder()
-                .dispatcher(dispatcher)
-                .build();
+        this.connectionProvider = ConnectionProvider.create(applicationId, maxHttpRequests);
+        this.eventLoopGroup = new NioEventLoopGroup(maxHttpRequests);
         HttpClientOptions clientOptions = new HttpClientOptions();
         clientOptions.setTracingOptions(tracingOptions);
         clientOptions.setApplicationId(applicationId);
-        httpClient = createAzureHttpClient(okHttpClient, clientOptions);
+        clientOptions.setMaximumConnectionPoolSize(maxHttpRequests);
+        httpClient = createAzureHttpClient(connectionProvider, eventLoopGroup, clientOptions);
     }
 
     @PreDestroy
     public void destroy()
     {
-        okHttpClient.dispatcher().executorService().shutdownNow();
-        okHttpClient.connectionPool().evictAll();
+        if (connectionProvider != null) {
+            connectionProvider.dispose();
+        }
+        if (eventLoopGroup != null) {
+            try {
+                eventLoopGroup.shutdownGracefully().get();
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+            catch (ExecutionException _) {
+                // ignored
+            }
+        }
     }
 
     @Override
@@ -106,20 +116,21 @@ public class AzureFileSystemFactory
         return new AzureFileSystem(httpClient, tracingOptions, auth, endpoint, readBlockSize, writeBlockSize, maxWriteConcurrency, maxSingleUploadSize);
     }
 
-    public static HttpClient createAzureHttpClient(OkHttpClient okHttpClient, HttpClientOptions clientOptions)
+    public static HttpClient createAzureHttpClient(ConnectionProvider connectionProvider, EventLoopGroup eventLoopGroup, HttpClientOptions clientOptions)
     {
         Integer poolSize = clientOptions.getMaximumConnectionPoolSize();
-        // By default, OkHttp uses a maximum idle connection count of 5.
         int maximumConnectionPoolSize = (poolSize != null && poolSize > 0) ? poolSize : 5;
+        clientOptions.setMaximumConnectionPoolSize(maximumConnectionPoolSize);
 
-        return new OkHttpAsyncHttpClientBuilder(okHttpClient)
+        return new NettyAsyncHttpClientBuilder()
                 .proxy(clientOptions.getProxyOptions())
                 .configuration(clientOptions.getConfiguration())
-                .connectionTimeout(clientOptions.getConnectTimeout())
+                .connectTimeout(clientOptions.getConnectTimeout())
                 .writeTimeout(clientOptions.getWriteTimeout())
                 .readTimeout(clientOptions.getReadTimeout())
-                .connectionPool(new ConnectionPool(maximumConnectionPoolSize,
-                        clientOptions.getConnectionIdleTimeout().toMillis(), TimeUnit.MILLISECONDS))
+                .responseTimeout(clientOptions.getResponseTimeout())
+                .connectionProvider(connectionProvider)
+                .eventLoopGroup(eventLoopGroup)
                 .build();
     }
 }

--- a/plugin/trino-delta-lake/pom.xml
+++ b/plugin/trino-delta-lake/pom.xml
@@ -261,10 +261,6 @@
             <scope>runtime</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>com.azure</groupId>
-                    <artifactId>azure-core-http-netty</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>com.fasterxml.jackson.dataformat</groupId>
                     <artifactId>jackson-dataformat-xml</artifactId>
                 </exclusion>
@@ -284,8 +280,26 @@
         </dependency>
 
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk-trace</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.projectreactor.netty</groupId>
+            <artifactId>reactor-netty-core</artifactId>
             <scope>runtime</scope>
         </dependency>
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAdlsConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAdlsConnectorSmokeTest.java
@@ -23,11 +23,13 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteSource;
 import com.google.common.io.Resources;
 import com.google.common.reflect.ClassPath;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
 import io.trino.plugin.hive.containers.HiveHadoop;
 import io.trino.testing.QueryRunner;
-import okhttp3.OkHttpClient;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.TestInstance;
+import reactor.netty.resources.ConnectionProvider;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -77,13 +79,14 @@ public class TestDeltaLakeAdlsConnectorSmokeTest
             throws Exception
     {
         String connectionString = format("DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;EndpointSuffix=core.windows.net", account, accessKey);
-        OkHttpClient okHttpClient = new OkHttpClient.Builder().build();
-        closeAfterClass(() -> {
-            okHttpClient.dispatcher().executorService().shutdownNow();
-            okHttpClient.connectionPool().evictAll();
-        });
+        ConnectionProvider provider = ConnectionProvider.create("TestDeltaLakeAdsl");
+        closeAfterClass(provider::dispose);
+
+        EventLoopGroup eventLoopGroup = new NioEventLoopGroup();
+        closeAfterClass(eventLoopGroup::shutdownGracefully);
+
         BlobServiceClient blobServiceClient = new BlobServiceClientBuilder().connectionString(connectionString)
-                .httpClient(createAzureHttpClient(okHttpClient, new HttpClientOptions()))
+                .httpClient(createAzureHttpClient(provider, eventLoopGroup, new HttpClientOptions()))
                 .buildClient();
         this.azureContainerClient = blobServiceClient.getBlobContainerClient(container);
 

--- a/pom.xml
+++ b/pom.xml
@@ -900,6 +900,12 @@
                 <version>3.7.2</version>
             </dependency>
 
+            <dependency>
+                <groupId>io.projectreactor.netty</groupId>
+                <artifactId>reactor-netty-core</artifactId>
+                <version>1.1.21</version>
+            </dependency>
+
             <!-- io.confluent:kafka-avro-serializer uses multiple versions of this transitive dependency -->
             <dependency>
                 <groupId>io.swagger.core.v3</groupId>


### PR DESCRIPTION
This solves an issue with connection leaks that are happening for Azure Storage SDK
when OkHttp is used. OkHttp is not actively maintained, which makes the default,
Netty implementation, a better choice for the future as it's actively maintained
and tested.

Fixes https://github.com/trinodb/trino/issues/24116

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
