### PR TITLE
Add more details about numeric and varbinary literals

### DIFF
--- a/docs/src/main/sphinx/language/types.md
+++ b/docs/src/main/sphinx/language/types.md
@@ -49,9 +49,9 @@ Integer numbers can be expressed as numeric literals in the following formats:
   for decimal `9` or `0b101010` for decimal `42``.
 
 Underscore characters are ignored within literal values, and can be used to
-increase readability. For example, decimal integer `123_456.789_123` is
-equivalent to `123456.789123`. Preceding and trailing underscores are not
-permitted.
+increase readability. For example, decimal integer `123_456` is equivalent to 
+`123456`. Preceding underscores, trailing underscores, and consecutive underscores
+are not permitted.
 
 Integers are supported by the following data types.
 
@@ -83,8 +83,8 @@ Floating-point, fixed-precision numbers can be expressed as numeric literal
 using scientific notation such as `1.03e1` and are cast as `DOUBLE` data type.
 Underscore characters are ignored within literal values, and can be used to
 increase readability. For example, value `123_456.789e4` is equivalent to
-`123456.789e4`. Preceding underscores, trailing underscores, and underscores
-beside the comma (`.`) are not permitted.
+`123456.789e4`. Preceding underscores, trailing underscores, consecutive
+underscores, and underscores beside the comma (`.`) are not permitted.
 
 ### `REAL`
 
@@ -108,8 +108,8 @@ are supported by the `DECIMAL` data type.
 
 Underscore characters are ignored within literal values, and can be used to
 increase readability. For example, decimal `123_456.789_123` is equivalent to
-`123456.789123`. Preceding underscores, trailing underscores, and underscores
-beside the comma (`.`) are not permitted.
+`123456.789123`. Preceding underscores, trailing underscores, consecutive
+underscores, and underscores beside the comma (`.`) are not permitted.
 
 Leading zeros in literal values are permitted and ignored. For example,
 `000123.456` is equivalent to `123.456`.
@@ -177,6 +177,9 @@ The binary data has to use hexadecimal format. For example, the binary form of
 ```sql
 SELECT from_utf8(x'65683F');
 ```
+
+Binary literals ignore any whitespace characters. For example, the literal
+`X'FFFF 0FFF  3FFF FFFF'` is equivalent to `X'FFFF0FFF3FFFFFFF'`.
 
 :::{note}
 Binary strings with length are not yet supported: `varbinary(n)`


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Refine documentation on accepted literal data types
- Add that consecutive underscores in numbers (e.g., `12__34`) is not permitted
- Add that binary literals allow any number of whitespace characters

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

#23682 

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.