### PR TITLE
[WIP] Allow underscores in varbinary literals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ product-test-reports
 **/dependency-reduced-pom.xml
 core/trino-web-ui/src/main/resources/webapp/dist/
 .node
+*.swo
+*.swp

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestVarbinaryFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestVarbinaryFunctions.java
@@ -72,6 +72,8 @@ public class TestVarbinaryFunctions
     {
         assertThat(assertions.expression("X'58F7'"))
                 .isEqualTo(sqlVarbinaryFromHex("58F7"));
+        assertThat(assertions.expression("X' 0123_4567 __ 89ab_CDEF'"))
+                .isEqualTo(sqlVarbinaryFromHex("0123456789ABCDEF"));
     }
 
     @Test

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/BinaryLiteral.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/BinaryLiteral.java
@@ -25,8 +25,10 @@ import static java.util.Objects.requireNonNull;
 public class BinaryLiteral
         extends Literal
 {
-    // the grammar could possibly include whitespace in the value it passes to us
-    private static final CharMatcher WHITESPACE_MATCHER = CharMatcher.whitespace();
+    // the grammar could possibly include whitespace or underscores in the value it passes to us
+    private static final CharMatcher IGNORED_CHARS_MATCHER = CharMatcher.whitespace()
+            .or(CharMatcher.is('_'))
+            .precomputed();
     private static final CharMatcher HEX_DIGIT_MATCHER = CharMatcher.inRange('A', 'F')
             .or(CharMatcher.inRange('0', '9'))
             .precomputed();
@@ -37,7 +39,7 @@ public class BinaryLiteral
     {
         super(location);
         requireNonNull(value, "value is null");
-        String hexString = WHITESPACE_MATCHER.removeFrom(value).toUpperCase(ENGLISH);
+        String hexString = IGNORED_CHARS_MATCHER.removeFrom(value).toUpperCase(ENGLISH);
         if (!HEX_DIGIT_MATCHER.matchesAllOf(hexString)) {
             throw new ParsingException("Binary literal can only contain hexadecimal digits", location);
         }

--- a/docs/src/main/sphinx/language/types.md
+++ b/docs/src/main/sphinx/language/types.md
@@ -179,7 +179,8 @@ SELECT from_utf8(x'65683F');
 ```
 
 Binary literals ignore any whitespace or underscore characters. For example, the literal
-`X'0123_4567 89ab_cdef'` is equivalent to `X'0123456789abcdef'`.
+`X'0123_4567 89ab_cdef'` is equivalent to `X'0123456789abcdef'`. The string must have an
+even number of hexadecimal digits.
 
 :::{note}
 Binary strings with length are not yet supported: `varbinary(n)`

--- a/docs/src/main/sphinx/language/types.md
+++ b/docs/src/main/sphinx/language/types.md
@@ -178,8 +178,8 @@ The binary data has to use hexadecimal format. For example, the binary form of
 SELECT from_utf8(x'65683F');
 ```
 
-Binary literals ignore any whitespace characters. For example, the literal
-`X'FFFF 0FFF  3FFF FFFF'` is equivalent to `X'FFFF0FFF3FFFFFFF'`.
+Binary literals ignore any whitespace or underscore characters. For example, the literal
+`X'0123_4567 89ab_cdef'` is equivalent to `X'0123456789abcdef'`.
 
 :::{note}
 Binary strings with length are not yet supported: `varbinary(n)`

--- a/docs/src/main/sphinx/language/types.md
+++ b/docs/src/main/sphinx/language/types.md
@@ -49,9 +49,9 @@ Integer numbers can be expressed as numeric literals in the following formats:
   for decimal `9` or `0b101010` for decimal `42``.
 
 Underscore characters are ignored within literal values, and can be used to
-increase readability. For example, decimal integer `123_456.789_123` is
-equivalent to `123456.789123`. Preceding and trailing underscores are not
-permitted.
+increase readability. For example, decimal integer `123_456` is equivalent to 
+`123456`. Preceding underscores, trailing underscores, and consecutive underscores
+are not permitted.
 
 Integers are supported by the following data types.
 
@@ -83,8 +83,8 @@ Floating-point, fixed-precision numbers can be expressed as numeric literal
 using scientific notation such as `1.03e1` and are cast as `DOUBLE` data type.
 Underscore characters are ignored within literal values, and can be used to
 increase readability. For example, value `123_456.789e4` is equivalent to
-`123456.789e4`. Preceding underscores, trailing underscores, and underscores
-beside the comma (`.`) are not permitted.
+`123456.789e4`. Preceding underscores, trailing underscores, consecutive
+underscores, and underscores beside the comma (`.`) are not permitted.
 
 ### `REAL`
 
@@ -108,8 +108,8 @@ are supported by the `DECIMAL` data type.
 
 Underscore characters are ignored within literal values, and can be used to
 increase readability. For example, decimal `123_456.789_123` is equivalent to
-`123456.789123`. Preceding underscores, trailing underscores, and underscores
-beside the comma (`.`) are not permitted.
+`123456.789123`. Preceding underscores, trailing underscores, consecutive
+underscores, and underscores beside the comma (`.`) are not permitted.
 
 Leading zeros in literal values are permitted and ignored. For example,
 `000123.456` is equivalent to `123.456`.
@@ -177,6 +177,9 @@ The binary data has to use hexadecimal format. For example, the binary form of
 ```sql
 SELECT from_utf8(x'65683F');
 ```
+
+Binary literals ignore any whitespace characters. For example, the literal
+`X'FFFF 0FFF  3FFF FFFF'` is equivalent to `X'FFFF0FFF3FFFFFFF'`.
 
 :::{note}
 Binary strings with length are not yet supported: `varbinary(n)`


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Allow underscores in addition to whitespace within varbinary literals.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This PR has #24774 as a dependency.

This change was a minor point in the discussion of #23682, but I thought it
would be a good starting point to me as a contributor.

Numeric literals allow underscores for readability, and a developer (like me)
may expect that varbinary literals would use the same pattern. This syntax is more
lenient than the one for numbers, ignoring any number of underscores (or whitespace)
in the string.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Allow underscores in varbinary literals ({23682}`23682`)
```
