### PR TITLE
Make configuration and session property names consistent

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/OutputSpoolingOperatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OutputSpoolingOperatorFactory.java
@@ -56,10 +56,10 @@ import static io.trino.server.protocol.spooling.SpooledBlock.SPOOLING_METADATA_S
 import static io.trino.server.protocol.spooling.SpooledBlock.SPOOLING_METADATA_TYPE;
 import static io.trino.server.protocol.spooling.SpooledBlock.createNonSpooledPage;
 import static io.trino.server.protocol.spooling.SpoolingSessionProperties.getInitialSegmentSize;
-import static io.trino.server.protocol.spooling.SpoolingSessionProperties.getMaxInlinedRows;
-import static io.trino.server.protocol.spooling.SpoolingSessionProperties.getMaxInlinedSize;
+import static io.trino.server.protocol.spooling.SpoolingSessionProperties.getInliningMaxRows;
+import static io.trino.server.protocol.spooling.SpoolingSessionProperties.getInliningMaxSize;
 import static io.trino.server.protocol.spooling.SpoolingSessionProperties.getMaxSegmentSize;
-import static io.trino.server.protocol.spooling.SpoolingSessionProperties.isAllowInlining;
+import static io.trino.server.protocol.spooling.SpoolingSessionProperties.isInliningEnabled;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -162,9 +162,9 @@ public class OutputSpoolingOperatorFactory
         {
             this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
             this.controller = new OutputSpoolingController(
-                    isAllowInlining(operatorContext.getSession()),
-                    getMaxInlinedRows(operatorContext.getSession()),
-                    getMaxInlinedSize(operatorContext.getSession()).toBytes(),
+                    isInliningEnabled(operatorContext.getSession()),
+                    getInliningMaxRows(operatorContext.getSession()),
+                    getInliningMaxSize(operatorContext.getSession()).toBytes(),
                     getInitialSegmentSize(operatorContext.getSession()).toBytes(),
                     getMaxSegmentSize(operatorContext.getSession()).toBytes());
             this.userMemoryContext = operatorContext.newLocalUserMemoryContext(OutputSpoolingOperator.class.getSimpleName());

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/SpoolingConfig.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/SpoolingConfig.java
@@ -16,6 +16,7 @@ package io.trino.server.protocol.spooling;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.ConfigSecuritySensitive;
+import io.airlift.configuration.LegacyConfig;
 import io.airlift.units.DataSize;
 import io.airlift.units.MaxDataSize;
 import io.airlift.units.MinDataSize;
@@ -38,9 +39,9 @@ public class SpoolingConfig
     private Optional<SecretKey> sharedSecretKey = Optional.empty();
     private SegmentRetrievalMode retrievalMode = SegmentRetrievalMode.STORAGE;
 
-    private boolean allowInlining = true;
-    private long maximumInlinedRows = 1000;
-    private DataSize maximumInlinedSize = DataSize.of(128, KILOBYTE);
+    private boolean inliningEnabled = true;
+    private long inliningMaxRows = 1000;
+    private DataSize inliningMaxSize = DataSize.of(128, KILOBYTE);
     private DataSize initialSegmentSize = DataSize.of(8, MEGABYTE);
     private DataSize maximumSegmentSize = DataSize.of(16, MEGABYTE);
 
@@ -94,7 +95,8 @@ public class SpoolingConfig
         return maximumSegmentSize;
     }
 
-    @Config("protocol.spooling.maximum-segment-size")
+    @LegacyConfig("protocol.spooling.maximum-segment-size")
+    @Config("protocol.spooling.max-segment-size")
     @ConfigDescription("Maximum size of the spooled segments in bytes")
     public SpoolingConfig setMaximumSegmentSize(DataSize maximumSegmentSize)
     {
@@ -102,46 +104,46 @@ public class SpoolingConfig
         return this;
     }
 
-    public boolean isAllowInlining()
+    public boolean isInliningEnabled()
     {
-        return allowInlining;
+        return inliningEnabled;
     }
 
     @ConfigDescription("Allow spooling protocol to inline data")
     @Config("protocol.spooling.inlining.enabled")
-    public SpoolingConfig setAllowInlining(boolean allowInlining)
+    public SpoolingConfig setInliningEnabled(boolean inliningEnabled)
     {
-        this.allowInlining = allowInlining;
+        this.inliningEnabled = inliningEnabled;
         return this;
     }
 
     @Min(1)
     @Max(1_000_000)
-    public long getMaximumInlinedRows()
+    public long getInliningMaxRows()
     {
-        return maximumInlinedRows;
+        return inliningMaxRows;
     }
 
     @Config("protocol.spooling.inlining.max-rows")
     @ConfigDescription("Maximum number of rows that are allowed to be inlined per worker")
-    public SpoolingConfig setMaximumInlinedRows(long maximumInlinedRows)
+    public SpoolingConfig setInliningMaxRows(long inliningMaxRows)
     {
-        this.maximumInlinedRows = maximumInlinedRows;
+        this.inliningMaxRows = inliningMaxRows;
         return this;
     }
 
     @MinDataSize("1kB")
     @MaxDataSize("1MB")
-    public DataSize getMaximumInlinedSize()
+    public DataSize getInliningMaxSize()
     {
-        return maximumInlinedSize;
+        return inliningMaxSize;
     }
 
     @Config("protocol.spooling.inlining.max-size")
     @ConfigDescription("Maximum size of rows that are allowed to be inlined per worker")
-    public SpoolingConfig setMaximumInlinedSize(DataSize maximumInlinedSize)
+    public SpoolingConfig setInliningMaxSize(DataSize inliningMaxSize)
     {
-        this.maximumInlinedSize = maximumInlinedSize;
+        this.inliningMaxSize = inliningMaxSize;
         return this;
     }
 

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/SpoolingSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/SpoolingSessionProperties.java
@@ -39,9 +39,9 @@ public class SpoolingSessionProperties
     public static final String MAX_SEGMENT_SIZE = "spooling_max_segment_size";
 
     // Inlined segments
-    public static final String ALLOW_INLINING = "spooling_inlining_enabled";
-    public static final String MAX_INLINED_SIZE = "spooling_max_inlined_size";
-    public static final String MAX_INLINED_ROWS = "spooling_max_inlined_rows";
+    public static final String INLINING_ENABLED = "spooling_inlining_enabled";
+    public static final String INLINING_MAX_SIZE = "spooling_inlining_max_size";
+    public static final String INLINING_MAX_ROWS = "spooling_inlining_max_rows";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -62,20 +62,20 @@ public class SpoolingSessionProperties
                         isDataSizeBetween(MAX_SEGMENT_SIZE, DataSize.of(1, KILOBYTE), DataSize.of(128, MEGABYTE)),
                         false))
                 .add(booleanProperty(
-                        ALLOW_INLINING,
+                        INLINING_ENABLED,
                         "Allow inlining initial rows",
-                        spoolingConfig.isAllowInlining(),
+                        spoolingConfig.isInliningEnabled(),
                         false))
                 .add(dataSizeProperty(
-                        MAX_INLINED_SIZE,
+                        INLINING_MAX_SIZE,
                         "Maximum size of inlined data",
-                        spoolingConfig.getMaximumInlinedSize(),
-                        isDataSizeBetween(MAX_INLINED_SIZE, DataSize.of(1, KILOBYTE), DataSize.of(1, MEGABYTE)),
+                        spoolingConfig.getInliningMaxSize(),
+                        isDataSizeBetween(INLINING_MAX_SIZE, DataSize.of(1, KILOBYTE), DataSize.of(1, MEGABYTE)),
                         false))
                 .add(longProperty(
-                        MAX_INLINED_ROWS,
+                        INLINING_MAX_ROWS,
                         "Maximum number of rows that are allowed to be inlined per worker",
-                        spoolingConfig.getMaximumInlinedRows(),
+                        spoolingConfig.getInliningMaxRows(),
                         false))
                 .build();
     }
@@ -103,19 +103,19 @@ public class SpoolingSessionProperties
         return session.getSystemProperty(MAX_SEGMENT_SIZE, DataSize.class);
     }
 
-    public static boolean isAllowInlining(Session session)
+    public static boolean isInliningEnabled(Session session)
     {
-        return session.getSystemProperty(ALLOW_INLINING, Boolean.class);
+        return session.getSystemProperty(INLINING_ENABLED, Boolean.class);
     }
 
-    public static DataSize getMaxInlinedSize(Session session)
+    public static DataSize getInliningMaxSize(Session session)
     {
-        return session.getSystemProperty(MAX_INLINED_SIZE, DataSize.class);
+        return session.getSystemProperty(INLINING_MAX_SIZE, DataSize.class);
     }
 
-    public static long getMaxInlinedRows(Session session)
+    public static long getInliningMaxRows(Session session)
     {
-        return session.getSystemProperty(MAX_INLINED_ROWS, Long.class);
+        return session.getSystemProperty(INLINING_MAX_ROWS, Long.class);
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/server/protocol/spooling/TestSpoolingConfig.java
+++ b/core/trino-main/src/test/java/io/trino/server/protocol/spooling/TestSpoolingConfig.java
@@ -39,9 +39,9 @@ class TestSpoolingConfig
                 .setRetrievalMode(STORAGE)
                 .setInitialSegmentSize(DataSize.of(8, MEGABYTE))
                 .setMaximumSegmentSize(DataSize.of(16, MEGABYTE))
-                .setMaximumInlinedRows(1000)
-                .setMaximumInlinedSize(DataSize.of(128, KILOBYTE))
-                .setAllowInlining(true));
+                .setInliningMaxRows(1000)
+                .setInliningMaxSize(DataSize.of(128, KILOBYTE))
+                .setInliningEnabled(true));
     }
 
     @Test
@@ -54,7 +54,7 @@ class TestSpoolingConfig
                 .put("protocol.spooling.retrieval-mode", "coordinator_storage_redirect")
                 .put("protocol.spooling.inlining.enabled", "false")
                 .put("protocol.spooling.initial-segment-size", "1kB")
-                .put("protocol.spooling.maximum-segment-size", "8kB")
+                .put("protocol.spooling.max-segment-size", "8kB")
                 .put("protocol.spooling.inlining.max-rows", "1024")
                 .put("protocol.spooling.inlining.max-size", "1MB")
                 .buildOrThrow();
@@ -64,9 +64,9 @@ class TestSpoolingConfig
                 .setSharedSecretKey(randomAesEncryptionKey)
                 .setInitialSegmentSize(DataSize.of(1, KILOBYTE))
                 .setMaximumSegmentSize(DataSize.of(8, KILOBYTE))
-                .setMaximumInlinedRows(1024)
-                .setMaximumInlinedSize(DataSize.of(1, MEGABYTE))
-                .setAllowInlining(false);
+                .setInliningMaxRows(1024)
+                .setInliningMaxSize(DataSize.of(1, MEGABYTE))
+                .setInliningEnabled(false);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
It makes it easier to reason about which session property maps to which configuration property.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
