### PR TITLE
Write timestamp value with NANOSECOND precision in on avro files in Hive Connector

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/HiveFormatsErrorCode.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/HiveFormatsErrorCode.java
@@ -26,6 +26,7 @@ public enum HiveFormatsErrorCode
 {
     HIVE_INVALID_METADATA(12, EXTERNAL),
     HIVE_UNSERIALIZABLE_JSON_VALUE(44, USER_ERROR),
+    HIVE_UNSUPPORTED_FORMAT(19, EXTERNAL),
     /**/;
 
     private final ErrorCode errorCode;


### PR DESCRIPTION
Fixes https://github.com/trinodb/trino/issues/20342

Able to write timestamp nanosecond precision value on Avro files for hive connector.

<img width="543" alt="Screenshot 2025-01-24 at 12 38 56 AM" src="https://github.com/user-attachments/assets/44646789-4929-4ee0-a3a7-6f16c3597351" />

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
