### PR TITLE
Pin Java version as 23.0.1

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,7 +3,8 @@ description: "Verify checked out commits and setup Java"
 inputs:
   java-version:
     description: "Java version to setup"
-    default: 23
+    # TODO Use 23 once CI failures about a gap in 'America/Bahia_Banderas' are fixed
+    default: 23.0.1
   cache:
     description: "Cache Maven repo (true/false/restore)"
     default: restore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { java-version: 23, cache: 'true', cleanup-node: true }
+          - { java-version: 23.0.1, cache: 'true', cleanup-node: true }
           - { java-version: 24-ea, cache: 'restore', cleanup-node: true }
     timeout-minutes: 45
     steps:
@@ -520,7 +520,7 @@ jobs:
         with:
           cache: restore
           cleanup-node: ${{ format('{0}', matrix.modules == 'plugin/trino-singlestore' || matrix.modules == 'plugin/trino-exasol') }}
-          java-version: ${{ matrix.jdk != '' && matrix.jdk || '23' }}
+          java-version: ${{ matrix.jdk != '' && matrix.jdk || '23.0.1' }}
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"


### PR DESCRIPTION
## Description

23.0.2 upgraded IANA Time Zone Database to 2024b.
It changed a gap in America/Bahia_Banderas.
https://github.com/openjdk/jdk23u/commit/73b2341c670f98fb130c57f80eb1461226da1985

We changed the timezone from `Asia/Katmandu` in https://github.com/prestodb/presto/pull/10128. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
