### PR TITLE
Update Java to 23.0.2

### DIFF
--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/BaseTestJdbcResultSet.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/BaseTestJdbcResultSet.java
@@ -273,25 +273,6 @@ public abstract class BaseTestJdbcResultSet
                 assertThat(rs.getString(column)).isEqualTo(localDate.toString());
             });
 
-            // date which midnight does not exist in test JVM zone
-            checkRepresentation(connectedStatement.getStatement(), "DATE '1970-01-01'", Types.DATE, (rs, column) -> {
-                LocalDate localDate = LocalDate.of(1970, 1, 1);
-                Date sqlDate = Date.valueOf(localDate);
-
-                assertThat(rs.getObject(column)).isEqualTo(sqlDate);
-                assertThat(rs.getObject(column, Date.class)).isEqualTo(sqlDate);
-                assertThat(rs.getObject(column, LocalDate.class)).isEqualTo(localDate);
-                assertThat(rs.getDate(column)).isEqualTo(sqlDate);
-                assertThatThrownBy(() -> rs.getTime(column))
-                        .isInstanceOf(IllegalArgumentException.class)
-                        .hasMessage("Expected column to be a time type but is date");
-                assertThatThrownBy(() -> rs.getTimestamp(column))
-                        .isInstanceOf(IllegalArgumentException.class)
-                        .hasMessage("Expected column to be a timestamp type but is date");
-
-                assertThat(rs.getString(column)).isEqualTo(localDate.toString());
-            });
-
             // the Julian-Gregorian calendar "default cut-over"
             checkRepresentation(connectedStatement.getStatement(), "DATE '1582-10-04'", Types.DATE, (rs, column) -> {
                 LocalDate localDate = LocalDate.of(1582, 10, 4);

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcPreparedStatement.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcPreparedStatement.java
@@ -1093,11 +1093,11 @@ public class TestJdbcPreparedStatement
         assertBind((ps, i) -> ps.setObject(i, date, Types.TIMESTAMP_WITH_TIMEZONE), explicitPrepare)
                 .isInvalid("Cannot convert instance of java.time.LocalDate to timestamp with time zone");
 
-        LocalDate jvmGapDate = LocalDate.of(1970, 1, 1);
+        LocalDate jvmGapDate = LocalDate.of(1932, 4, 1);
         checkIsGap(ZoneId.systemDefault(), jvmGapDate.atTime(LocalTime.MIDNIGHT));
 
         assertBind((ps, i) -> ps.setObject(i, jvmGapDate), explicitPrepare)
-                .resultsIn("date", "DATE '1970-01-01'")
+                .resultsIn("date", "DATE '1932-04-01'")
                 .roundTripsAs(Types.DATE, Date.valueOf(jvmGapDate));
 
         assertBind((ps, i) -> ps.setObject(i, jvmGapDate, Types.DATE), explicitPrepare)

--- a/core/jdk/current
+++ b/core/jdk/current
@@ -1,1 +1,1 @@
-temurin/jdk-23.0.1+11
+temurin/jdk-23.0.2+7

--- a/core/jdk/temurin/jdk-22.0.2+9/amd64
+++ b/core/jdk/temurin/jdk-22.0.2+9/amd64
@@ -1,1 +1,0 @@
-distributionUrl=https://api.adoptium.net/v3/binary/version/jdk-22.0.2+9/linux/x64/jdk/hotspot/normal/eclipse?project=jdk

--- a/core/jdk/temurin/jdk-22.0.2+9/arm64
+++ b/core/jdk/temurin/jdk-22.0.2+9/arm64
@@ -1,1 +1,0 @@
-distributionUrl=https://api.adoptium.net/v3/binary/version/jdk-22.0.2+9/linux/aarch64/jdk/hotspot/normal/eclipse?project=jdk

--- a/core/jdk/temurin/jdk-22.0.2+9/ppc64le
+++ b/core/jdk/temurin/jdk-22.0.2+9/ppc64le
@@ -1,1 +1,0 @@
-distributionUrl=https://api.adoptium.net/v3/binary/version/jdk-22.0.2+9/linux/ppc64le/jdk/hotspot/normal/eclipse?project=jdk

--- a/core/jdk/temurin/jdk-23.0.1+11/amd64
+++ b/core/jdk/temurin/jdk-23.0.1+11/amd64
@@ -1,1 +1,0 @@
-distributionUrl=https://api.adoptium.net/v3/binary/version/jdk-23.0.1+11/linux/x64/jdk/hotspot/normal/eclipse?project=jdk

--- a/core/jdk/temurin/jdk-23.0.1+11/arm64
+++ b/core/jdk/temurin/jdk-23.0.1+11/arm64
@@ -1,1 +1,0 @@
-distributionUrl=https://api.adoptium.net/v3/binary/version/jdk-23.0.1+11/linux/aarch64/jdk/hotspot/normal/eclipse?project=jdk

--- a/core/jdk/temurin/jdk-23.0.1+11/ppc64le
+++ b/core/jdk/temurin/jdk-23.0.1+11/ppc64le
@@ -1,1 +1,0 @@
-distributionUrl=https://api.adoptium.net/v3/binary/version/jdk-23.0.1+11/linux/ppc64le/jdk/hotspot/normal/eclipse?project=jdk

--- a/core/jdk/temurin/jdk-23.0.2+7/amd64
+++ b/core/jdk/temurin/jdk-23.0.2+7/amd64
@@ -1,0 +1,1 @@
+distributionUrl=https://api.adoptium.net/v3/binary/version/jdk-23.0.2+7/linux/x64/jdk/hotspot/normal/eclipse?project=jdk

--- a/core/jdk/temurin/jdk-23.0.2+7/arm64
+++ b/core/jdk/temurin/jdk-23.0.2+7/arm64
@@ -1,0 +1,1 @@
+distributionUrl=https://api.adoptium.net/v3/binary/version/jdk-23.0.2+7/linux/aarch64/jdk/hotspot/normal/eclipse?project=jdk

--- a/core/jdk/temurin/jdk-23.0.2+7/ppc64le
+++ b/core/jdk/temurin/jdk-23.0.2+7/ppc64le
@@ -1,0 +1,1 @@
+distributionUrl=https://api.adoptium.net/v3/binary/version/jdk-23.0.2+7/linux/ppc64le/jdk/hotspot/normal/eclipse?project=jdk

--- a/core/trino-server-rpm/src/test/java/io/trino/server/rpm/ServerIT.java
+++ b/core/trino-server-rpm/src/test/java/io/trino/server/rpm/ServerIT.java
@@ -75,8 +75,8 @@ public class ServerIT
             throws Exception
     {
         // Release names as in the https://api.adoptium.net/q/swagger-ui/#/Release%20Info/getReleaseNames
-        testInstall("jdk-23.0.1+11", "/usr/lib/jvm/temurin-23", "23");
-        testUninstall("jdk-23.0.1+11", "/usr/lib/jvm/temurin-23");
+        testInstall("jdk-23.0.2+7", "/usr/lib/jvm/temurin-23", "23");
+        testUninstall("jdk-23.0.2+7", "/usr/lib/jvm/temurin-23");
     }
 
     private void testInstall(String temurinReleaseName, String javaHome, String expectedJavaVersion)

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraTypeMapping.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraTypeMapping.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.TestInstance;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
@@ -81,7 +80,7 @@ public class TestCassandraTypeMapping
     private final LocalDateTime afterEpoch = LocalDateTime.of(2019, 3, 18, 10, 1, 17, 987_000_000);
 
     private final ZoneId jvmZone = ZoneId.systemDefault();
-    private final LocalDateTime timeGapInJvmZone1 = LocalDateTime.of(1970, 1, 1, 0, 13, 42);
+    private final LocalDateTime timeGapInJvmZone1 = LocalDateTime.of(1932, 4, 1, 0, 13, 42);
     private final LocalDateTime timeGapInJvmZone2 = LocalDateTime.of(2018, 4, 1, 2, 13, 55, 123_000_000);
     private final LocalDateTime timeDoubledInJvmZone = LocalDateTime.of(2018, 10, 28, 1, 33, 17, 456_000_000);
 
@@ -104,7 +103,7 @@ public class TestCassandraTypeMapping
     public void setUp()
     {
         checkState(jvmZone.getId().equals("America/Bahia_Banderas"), "This test assumes certain JVM time zone");
-        LocalDate dateOfLocalTimeChangeForwardAtMidnightInJvmZone = LocalDate.of(1970, 1, 1);
+        LocalDate dateOfLocalTimeChangeForwardAtMidnightInJvmZone = LocalDate.of(1932, 4, 1);
         checkIsGap(jvmZone, dateOfLocalTimeChangeForwardAtMidnightInJvmZone.atStartOfDay());
         checkIsGap(jvmZone, timeGapInJvmZone1);
         checkIsGap(jvmZone, timeGapInJvmZone2);
@@ -516,9 +515,6 @@ public class TestCassandraTypeMapping
     public void testTime()
     {
         for (ZoneId sessionZone : timezones()) {
-            LocalTime timeGapInJvmZone = LocalTime.of(0, 12, 34, 567_000_000);
-            checkIsGap(jvmZone, timeGapInJvmZone.atDate(LocalDate.ofEpochDay(0)));
-
             Session session = Session.builder(getSession())
                     .setTimeZoneKey(TimeZoneKey.getTimeZoneKey(sessionZone.getId()))
                     .build();

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseTypeMapping.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseTypeMapping.java
@@ -70,7 +70,7 @@ public abstract class BaseClickHouseTypeMapping
     // no DST in 1970, but has DST in later years (e.g. 2018)
     private final ZoneId vilnius = ZoneId.of("Europe/Vilnius");
 
-    // minutes offset change since 1970-01-01, no DST
+    // minutes offset change since 1932-04-01, no DST
     private final ZoneId kathmandu = ZoneId.of("Asia/Kathmandu");
 
     protected TestingClickHouseServer clickhouseServer;
@@ -79,7 +79,7 @@ public abstract class BaseClickHouseTypeMapping
     public void setUp()
     {
         checkState(jvmZone.getId().equals("America/Bahia_Banderas"), "This test assumes certain JVM time zone");
-        LocalDate dateOfLocalTimeChangeForwardAtMidnightInJvmZone = LocalDate.of(1970, 1, 1);
+        LocalDate dateOfLocalTimeChangeForwardAtMidnightInJvmZone = LocalDate.of(1932, 4, 1);
         checkIsGap(jvmZone, dateOfLocalTimeChangeForwardAtMidnightInJvmZone.atStartOfDay());
 
         LocalDate dateOfLocalTimeChangeForwardAtMidnightInSomeZone = LocalDate.of(1983, 4, 1);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeReadTimestamps.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeReadTimestamps.java
@@ -19,6 +19,7 @@ import io.trino.Session;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.QueryRunner;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -106,6 +107,7 @@ public class TestDeltaLakeReadTimestamps
     }
 
     @Test
+    @Disabled("This test assumes specific tzdb version and it will fail on mismatch between Spark and Trino tzdb versions")
     public void timestampReadMapping()
     {
         ZoneId jvmZone = getJvmTestTimeZone();

--- a/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestExasolTypeMapping.java
+++ b/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestExasolTypeMapping.java
@@ -52,7 +52,7 @@ final class TestExasolTypeMapping
     private TestingExasolServer exasolServer;
 
     private static final ZoneId jvmZone = ZoneId.systemDefault();
-    private static final LocalDateTime timeGapInJvmZone1 = LocalDateTime.of(1970, 1, 1, 0, 13, 42);
+    private static final LocalDateTime timeGapInJvmZone1 = LocalDateTime.of(1932, 4, 1, 0, 13, 42);
     private static final LocalDateTime timeGapInJvmZone2 = LocalDateTime.of(2018, 4, 1, 2, 13, 55, 123_000_000);
     private static final LocalDateTime timeDoubledInJvmZone = LocalDateTime.of(2018, 10, 28, 1, 33, 17, 456_000_000);
 

--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteTypeMapping.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteTypeMapping.java
@@ -73,7 +73,7 @@ public class TestIgniteTypeMapping
     public void setUp()
     {
         checkState(jvmZone.getId().equals("America/Bahia_Banderas"), "This test assumes certain JVM time zone");
-        checkIsGap(jvmZone, LocalDate.of(1970, 1, 1));
+        checkIsGap(jvmZone, LocalDate.of(1932, 4, 1));
         checkIsGap(vilnius, LocalDate.of(1983, 4, 1));
         verify(vilnius.getRules().getValidOffsets(LocalDate.of(1983, 10, 1).atStartOfDay().minusMinutes(1)).size() == 2);
     }

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduTypeMapping.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduTypeMapping.java
@@ -51,7 +51,7 @@ final class TestKuduTypeMapping
         extends AbstractTestQueryFramework
 {
     private final ZoneId jvmZone = ZoneId.systemDefault();
-    private final LocalDateTime timeGapInJvmZone1 = LocalDateTime.of(1970, 1, 1, 0, 13, 42);
+    private final LocalDateTime timeGapInJvmZone1 = LocalDateTime.of(1932, 4, 1, 0, 13, 42);
     private final LocalDateTime timeGapInJvmZone2 = LocalDateTime.of(2018, 4, 1, 2, 13, 55, 123_000_000);
     private final LocalDateTime timeDoubledInJvmZone = LocalDateTime.of(2018, 10, 28, 1, 33, 17, 456_000_000);
 
@@ -68,7 +68,7 @@ final class TestKuduTypeMapping
     public void setUp()
     {
         checkState(jvmZone.getId().equals("America/Bahia_Banderas"), "This test assumes certain JVM time zone");
-        LocalDate dateOfLocalTimeChangeForwardAtMidnightInJvmZone = LocalDate.of(1970, 1, 1);
+        LocalDate dateOfLocalTimeChangeForwardAtMidnightInJvmZone = LocalDate.of(1932, 4, 1);
         checkIsGap(jvmZone, dateOfLocalTimeChangeForwardAtMidnightInJvmZone.atStartOfDay());
         checkIsGap(jvmZone, timeGapInJvmZone1);
         checkIsGap(jvmZone, timeGapInJvmZone2);

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbTypeMapping.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbTypeMapping.java
@@ -87,7 +87,7 @@ public class TestMariaDbTypeMapping
     public void setUp()
     {
         checkState(jvmZone.getId().equals("America/Bahia_Banderas"), "This test assumes certain JVM time zone");
-        checkIsGap(jvmZone, LocalDate.of(1970, 1, 1));
+        checkIsGap(jvmZone, LocalDate.of(1932, 4, 1));
         checkIsGap(vilnius, LocalDate.of(1983, 4, 1));
         verify(vilnius.getRules().getValidOffsets(LocalDate.of(1983, 10, 1).atStartOfDay().minusMinutes(1)).size() == 2);
     }

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTimeMappingsWithServerTimeZone.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTimeMappingsWithServerTimeZone.java
@@ -601,7 +601,6 @@ public class TestMySqlTimeMappingsWithServerTimeZone
     @Test
     public void testUnsupportedTimestampWithTimeZoneValues()
     {
-        // The range for TIMESTAMP values is '1970-01-01 00:00:01.000000' to '2038-01-19 03:14:07.499999'
         try (TestTable table = new TestTable(mySqlServer::execute, "tpch.test_unsupported_timestamp", "(data TIMESTAMP)")) {
             // Verify MySQL writes -- the server timezone is set to Pacific/Apia, so we have to account for that when inserting into MySQL
             assertMySqlQueryFails(
@@ -613,8 +612,8 @@ public class TestMySqlTimeMappingsWithServerTimeZone
 
             // Verify Trino writes
             assertQueryFails(
-                    "INSERT INTO " + table.getName() + " VALUES (TIMESTAMP '1970-01-01 00:00:00 UTC')", // min - 1
-                    "Failed to insert data: Data truncation: Incorrect datetime value: '1969-12-31 16:00:00' for column 'data' at row 1");
+                    "INSERT INTO " + table.getName() + " VALUES (TIMESTAMP '1932-04-01 00:00:00 UTC')", // min - 1
+                    "Failed to insert data: Data truncation: Incorrect datetime value: '1932-03-31 17:00:00' for column 'data' at row 1");
             assertQueryFails(
                     "INSERT INTO " + table.getName() + " VALUES (TIMESTAMP '2038-01-19 03:14:08 UTC')", // max + 1
                     "Failed to insert data: Data truncation: Incorrect datetime value: '2038-01-18 21:14:08' for column 'data' at row 1");

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTypeMapping.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTypeMapping.java
@@ -93,7 +93,7 @@ public class TestMySqlTypeMapping
     public void setUp()
     {
         checkState(jvmZone.getId().equals("America/Bahia_Banderas"), "This test assumes certain JVM time zone");
-        LocalDate dateOfLocalTimeChangeForwardAtMidnightInJvmZone = LocalDate.of(1970, 1, 1);
+        LocalDate dateOfLocalTimeChangeForwardAtMidnightInJvmZone = LocalDate.of(1932, 4, 1);
         verify(jvmZone.getRules().getValidOffsets(dateOfLocalTimeChangeForwardAtMidnightInJvmZone.atStartOfDay()).isEmpty());
 
         LocalDate dateOfLocalTimeChangeForwardAtMidnightInSomeZone = LocalDate.of(1983, 4, 1);
@@ -1109,8 +1109,8 @@ public class TestMySqlTypeMapping
 
             // Verify Trino writes
             assertQueryFails(
-                    "INSERT INTO " + table.getName() + " VALUES (TIMESTAMP '1970-01-01 00:00:00 UTC')", // min - 1
-                    "Failed to insert data: Data truncation: Incorrect datetime value: '1969-12-31 16:00:00' for column 'data' at row 1");
+                    "INSERT INTO " + table.getName() + " VALUES (TIMESTAMP '1932-04-01 00:00:00 UTC')", // min - 1
+                    "Failed to insert data: Data truncation: Incorrect datetime value: '1932-03-31 17:00:00' for column 'data' at row 1");
             assertQueryFails(
                     "INSERT INTO " + table.getName() + " VALUES (TIMESTAMP '2038-01-19 03:14:08 UTC')", // max + 1
                     "Failed to insert data: Data truncation: Incorrect datetime value: '2038-01-18 21:14:08' for column 'data' at row 1");

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestingMySqlServer.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestingMySqlServer.java
@@ -32,7 +32,7 @@ import static org.testcontainers.containers.MySQLContainer.MYSQL_PORT;
 public class TestingMySqlServer
         implements AutoCloseable
 {
-    public static final String DEFAULT_IMAGE_8 = "mysql:8.0.36";
+    public static final String DEFAULT_IMAGE_8 = "mysql:8.0.41";
     public static final String DEFAULT_IMAGE = DEFAULT_IMAGE_8;
     public static final String LEGACY_IMAGE = "mysql:5.7.44"; // oldest available on RDS
 

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/AbstractTestOracleTypeMapping.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/AbstractTestOracleTypeMapping.java
@@ -87,7 +87,7 @@ public abstract class AbstractTestOracleTypeMapping
     private static final String NO_SUPPORTED_COLUMNS = "Table '.*' has no supported columns \\(all \\d+ columns are not supported\\)";
 
     private final ZoneId jvmZone = ZoneId.systemDefault();
-    private final LocalDateTime timeGapInJvmZone1 = LocalDateTime.of(1970, 1, 1, 0, 13, 42);
+    private final LocalDateTime timeGapInJvmZone1 = LocalDateTime.of(1932, 4, 1, 0, 13, 42);
     private final LocalDateTime timeGapInJvmZone2 = LocalDateTime.of(2018, 4, 1, 2, 13, 55, 123_000_000);
     private final LocalDateTime timeDoubledInJvmZone = LocalDateTime.of(2018, 10, 28, 1, 33, 17, 456_000_000);
 
@@ -104,7 +104,7 @@ public abstract class AbstractTestOracleTypeMapping
     public void setUp()
     {
         checkState(jvmZone.getId().equals("America/Bahia_Banderas"), "This test assumes certain JVM time zone");
-        LocalDate dateOfLocalTimeChangeForwardAtMidnightInJvmZone = LocalDate.of(1970, 1, 1);
+        LocalDate dateOfLocalTimeChangeForwardAtMidnightInJvmZone = LocalDate.of(1932, 4, 1);
         checkIsGap(jvmZone, dateOfLocalTimeChangeForwardAtMidnightInJvmZone.atStartOfDay());
         checkIsGap(jvmZone, timeGapInJvmZone1);
         checkIsGap(jvmZone, timeGapInJvmZone2);

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixTypeMapping.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixTypeMapping.java
@@ -91,7 +91,7 @@ public class TestPhoenixTypeMapping
     public void setUp()
     {
         checkState(jvmZone.getId().equals("America/Bahia_Banderas"), "This test assumes certain JVM time zone");
-        LocalDate dateOfLocalTimeChangeForwardAtMidnightInJvmZone = LocalDate.of(1970, 1, 1);
+        LocalDate dateOfLocalTimeChangeForwardAtMidnightInJvmZone = LocalDate.of(1932, 4, 1);
         checkIsGap(jvmZone, dateOfLocalTimeChangeForwardAtMidnightInJvmZone.atStartOfDay());
 
         LocalDate dateOfLocalTimeChangeForwardAtMidnightInSomeZone = LocalDate.of(1983, 4, 1);

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -46,7 +46,6 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -114,8 +113,6 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 public class TestPostgreSqlTypeMapping
         extends AbstractTestQueryFramework
 {
-    private static final LocalDate EPOCH_DAY = LocalDate.ofEpochDay(0);
-
     protected TestingPostgreSqlServer postgreSqlServer;
 
     private final LocalDateTime beforeEpoch = LocalDateTime.of(1958, 1, 1, 13, 18, 3, 123_000_000);
@@ -123,7 +120,7 @@ public class TestPostgreSqlTypeMapping
     private final LocalDateTime afterEpoch = LocalDateTime.of(2019, 3, 18, 10, 1, 17, 987_000_000);
 
     private final ZoneId jvmZone = ZoneId.systemDefault();
-    private final LocalDateTime timeGapInJvmZone1 = LocalDateTime.of(1970, 1, 1, 0, 13, 42);
+    private final LocalDateTime timeGapInJvmZone1 = LocalDateTime.of(1932, 4, 1, 0, 13, 42);
     private final LocalDateTime timeGapInJvmZone2 = LocalDateTime.of(2018, 4, 1, 2, 13, 55, 123_000_000);
     private final LocalDateTime timeDoubledInJvmZone = LocalDateTime.of(2018, 10, 28, 1, 33, 17, 456_000_000);
 
@@ -913,7 +910,7 @@ public class TestPostgreSqlTypeMapping
 
     private SqlDataTypeTest arrayDateTest(Function<String, String> arrayTypeFactory)
     {
-        LocalDate dateOfLocalTimeChangeForwardAtMidnightInJvmZone = LocalDate.of(1970, 1, 1);
+        LocalDate dateOfLocalTimeChangeForwardAtMidnightInJvmZone = LocalDate.of(1932, 4, 1);
         checkIsGap(jvmZone, dateOfLocalTimeChangeForwardAtMidnightInJvmZone.atStartOfDay());
 
         LocalDate dateOfLocalTimeChangeForwardAtMidnightInSomeZone = LocalDate.of(1983, 4, 1);
@@ -1173,9 +1170,6 @@ public class TestPostgreSqlTypeMapping
 
     private void testTime(ZoneId sessionZone)
     {
-        LocalTime timeGapInJvmZone = LocalTime.of(0, 12, 34, 567_000_000);
-        checkIsGap(jvmZone, timeGapInJvmZone.atDate(EPOCH_DAY));
-
         Session session = Session.builder(getSession())
                 .setTimeZoneKey(TimeZoneKey.getTimeZoneKey(sessionZone.getId()))
                 .build();
@@ -1649,9 +1643,7 @@ public class TestPostgreSqlTypeMapping
             // test all standard cases with precision 3 and 6 to make sure the long and short TIMESTAMP WITH TIME ZONE
             // is gap friendly.
             DataType<List<ZonedDateTime>> dataType = arrayOfTimestampWithTimeZoneDataType(precision, insertWithTrino);
-
-            tests.addRoundTrip(dataType, asList(epoch.atZone(UTC), epoch.atZone(kathmandu)));
-            tests.addRoundTrip(dataType, asList(beforeEpoch.atZone(kathmandu), beforeEpoch.atZone(UTC)));
+            tests.addRoundTrip(dataType, asList(beforeEpoch.atZone(jvmZone), beforeEpoch.atZone(UTC)));
             tests.addRoundTrip(dataType, asList(afterEpoch.atZone(UTC), afterEpoch.atZone(kathmandu)));
             tests.addRoundTrip(dataType, asList(timeDoubledInJvmZone.atZone(UTC)));
             tests.addRoundTrip(dataType, asList(timeDoubledInJvmZone.atZone(kathmandu)));

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestingPostgreSqlServer.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestingPostgreSqlServer.java
@@ -53,7 +53,7 @@ import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 public class TestingPostgreSqlServer
         implements AutoCloseable
 {
-    public static final String DEFAULT_IMAGE_NAME = "postgres:11";
+    public static final String DEFAULT_IMAGE_NAME = "postgres:12";
 
     private static final String USER = "test";
     private static final String PASSWORD = "test";

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftTypeMapping.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftTypeMapping.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.Test;
 import java.sql.SQLException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.List;
@@ -82,7 +81,6 @@ public class TestRedshiftTypeMapping
     private static final ZoneId testZone = TestingSession.DEFAULT_TIME_ZONE_KEY.getZoneId();
 
     private final ZoneId jvmZone = ZoneId.systemDefault();
-    private final LocalDateTime timeGapInJvmZone = LocalDate.EPOCH.atStartOfDay();
     private final LocalDateTime timeDoubledInJvmZone = LocalDateTime.of(2018, 10, 28, 1, 33, 17, 456_789_000);
 
     // using two non-JVM zones so that we don't need to worry what the backend's system zone is
@@ -96,24 +94,18 @@ public class TestRedshiftTypeMapping
     private final ZoneId kathmandu = ZoneId.of("Asia/Kathmandu");
     private final LocalDateTime timeGapInKathmandu = LocalDateTime.of(1986, 1, 1, 0, 13, 7);
 
-    private final LocalDate dayOfMidnightGapInJvmZone = LocalDate.EPOCH;
     private final LocalDate dayOfMidnightGapInVilnius = LocalDate.of(1983, 4, 1);
     private final LocalDate dayAfterMidnightSetBackInVilnius = LocalDate.of(1983, 10, 1);
 
     public TestRedshiftTypeMapping()
     {
         // Timestamps
-        checkIsGap(jvmZone, timeGapInJvmZone);
         checkIsDoubled(jvmZone, timeDoubledInJvmZone);
         checkIsGap(vilnius, timeGapInVilnius);
         checkIsDoubled(vilnius, timeDoubledInVilnius);
         checkIsGap(kathmandu, timeGapInKathmandu);
 
-        // Times
-        checkIsGap(jvmZone, LocalTime.of(0, 0, 0).atDate(LocalDate.EPOCH));
-
         // Dates
-        checkIsGap(jvmZone, dayOfMidnightGapInJvmZone.atStartOfDay());
         checkIsGap(vilnius, dayOfMidnightGapInVilnius.atStartOfDay());
         checkIsDoubled(vilnius, dayAfterMidnightSetBackInVilnius.atStartOfDay().minusNanos(1));
     }

--- a/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/BaseSingleStoreTypeMapping.java
+++ b/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/BaseSingleStoreTypeMapping.java
@@ -98,9 +98,9 @@ public abstract class BaseSingleStoreTypeMapping
     public void setUp()
     {
         checkState(jvmZone.getId().equals("America/Bahia_Banderas"), "This test assumes certain JVM time zone");
-        LocalDate dateOfLocalTimeChangeForwardAtMidnightInJvmZone = LocalDate.of(1970, 1, 1);
+        LocalDate dateOfLocalTimeChangeForwardAtMidnightInJvmZone = LocalDate.of(1932, 4, 1);
         checkIsGap(jvmZone, dateOfLocalTimeChangeForwardAtMidnightInJvmZone.atStartOfDay());
-        LocalDateTime timeGapInJvmZone1 = LocalDateTime.of(1970, 1, 1, 0, 13, 42);
+        LocalDateTime timeGapInJvmZone1 = LocalDateTime.of(1932, 4, 1, 0, 13, 42);
         checkIsGap(jvmZone, timeGapInJvmZone1);
         LocalDateTime timeGapInJvmZone2 = LocalDateTime.of(2018, 4, 1, 2, 13, 55, 123_000_000);
         checkIsGap(jvmZone, timeGapInJvmZone2);

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerTypeMapping.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerTypeMapping.java
@@ -69,7 +69,7 @@ public abstract class BaseSqlServerTypeMapping
         extends AbstractTestQueryFramework
 {
     private final ZoneId jvmZone = ZoneId.systemDefault();
-    private final LocalDateTime timeGapInJvmZone1 = LocalDateTime.of(1970, 1, 1, 0, 13, 42);
+    private final LocalDateTime timeGapInJvmZone1 = LocalDateTime.of(1932, 4, 1, 0, 13, 42);
     private final LocalDateTime timeGapInJvmZone2 = LocalDateTime.of(2018, 4, 1, 2, 13, 55, 123_000_000);
     private final LocalDateTime timeDoubledInJvmZone = LocalDateTime.of(2018, 10, 28, 1, 33, 17, 456_000_000);
 
@@ -88,7 +88,7 @@ public abstract class BaseSqlServerTypeMapping
     public void setUp()
     {
         checkState(jvmZone.getId().equals("America/Bahia_Banderas"), "This test assumes certain JVM time zone");
-        LocalDate dateOfLocalTimeChangeForwardAtMidnightInJvmZone = LocalDate.of(1970, 1, 1);
+        LocalDate dateOfLocalTimeChangeForwardAtMidnightInJvmZone = LocalDate.of(1932, 4, 1);
         checkIsGap(jvmZone, dateOfLocalTimeChangeForwardAtMidnightInJvmZone.atStartOfDay());
         checkIsGap(jvmZone, timeGapInJvmZone1);
         checkIsGap(jvmZone, timeGapInJvmZone2);

--- a/pom.xml
+++ b/pom.xml
@@ -161,10 +161,7 @@
         <air.release.preparation-goals>clean verify -DskipTests</air.release.preparation-goals>
         <!--
           America/Bahia_Banderas has:
-           - offset change since 1970 (offset Jan 1970: -08:00, offset Jan 2018: -06:00)
            - DST (e.g. at 2017-04-02 02:00:00 clocks turned forward 1 hour; 2017-10-29 02:00:00 clocks turned backward 1 hour)
-           - has forward offset change on first day of epoch (1970-01-01 00:00:00 clocks turned forward 1 hour)
-           - had forward change at midnight (1970-01-01 00:00:00 clocks turned forward 1 hour)
           -->
         <air.test.timezone>America/Bahia_Banderas</air.test.timezone>
         <!-- Be conservative about memory allotment, because tests start background process (e.g. docker containers) -->
@@ -202,7 +199,7 @@
         <dep.httpcore5.version>5.3.2</dep.httpcore5.version>
         <dep.iceberg.version>1.7.1</dep.iceberg.version>
         <dep.jna.version>5.16.0</dep.jna.version>
-        <dep.joda.version>2.12.7</dep.joda.version>
+        <dep.joda.version>2.13.0</dep.joda.version>
         <dep.jsonwebtoken.version>0.12.6</dep.jsonwebtoken.version>
         <dep.jts.version>1.20.0</dep.jts.version>
         <dep.kafka-clients.version>3.9.0</dep.kafka-clients.version>

--- a/testing/trino-test-jdbc-compatibility-old-driver/src/test/java/io/trino/TestJdbcResultSetCompatibilityOldDriver.java
+++ b/testing/trino-test-jdbc-compatibility-old-driver/src/test/java/io/trino/TestJdbcResultSetCompatibilityOldDriver.java
@@ -37,4 +37,18 @@ public class TestJdbcResultSetCompatibilityOldDriver
         assertThat(TestJdbcResultSet.class.getPackage().getImplementationVersion())
                 .isEqualTo(VERSION_UNDER_TEST.get().toString());
     }
+
+    @Override
+    @Test
+    public void testDate()
+            throws Exception
+    {
+        try {
+            super.testDate();
+        }
+        catch (AssertionError e) {
+            // Old drivers are bundled with outdated tzdata which causes some of the tested dates to have a different representation
+            assertThat(e).hasMessageContaining("1970-01-01");
+        }
+    }
 }

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -46,7 +46,6 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -192,20 +191,6 @@ public abstract class AbstractTestEngineOnlyQueries
         // This tests that both Trino runner and H2 can return TIMESTAMP value that never happened in JVM's zone (e.g. is not representable using java.sql.Timestamp)
         @Language("SQL") String sql = DateTimeFormatter.ofPattern("'SELECT TIMESTAMP '''uuuu-MM-dd HH:mm:ss.SSS''").format(localTimeThatDidNotExist);
         assertThat(computeScalar(sql)).isEqualTo(localTimeThatDidNotExist); // this tests Trino and the QueryRunner
-        assertQuery(sql); // this tests H2QueryRunner
-
-        LocalDate localDateThatDidNotHaveMidnight = LocalDate.of(1970, 1, 1);
-        checkState(ZoneId.systemDefault().getRules().getValidOffsets(localDateThatDidNotHaveMidnight.atStartOfDay()).isEmpty(), "This test assumes certain JVM time zone");
-        // This tests that both Trino runner and H2 can return DATE value for a day which midnight never happened in JVM's zone (e.g. is not exactly representable using java.sql.Date)
-        sql = DateTimeFormatter.ofPattern("'SELECT DATE '''uuuu-MM-dd''").format(localDateThatDidNotHaveMidnight);
-        assertThat(computeScalar(sql)).isEqualTo(localDateThatDidNotHaveMidnight); // this tests Trino and the QueryRunner
-        assertQuery(sql); // this tests H2QueryRunner
-
-        LocalTime localTimeThatDidNotOccurOn19700101 = LocalTime.of(0, 10);
-        checkState(ZoneId.systemDefault().getRules().getValidOffsets(localTimeThatDidNotOccurOn19700101.atDate(LocalDate.ofEpochDay(0))).isEmpty(), "This test assumes certain JVM time zone");
-        checkState(!Objects.equals(java.sql.Time.valueOf(localTimeThatDidNotOccurOn19700101).toLocalTime(), localTimeThatDidNotOccurOn19700101), "This test assumes certain JVM time zone");
-        sql = DateTimeFormatter.ofPattern("'SELECT TIME '''HH:mm:ss''").format(localTimeThatDidNotOccurOn19700101);
-        assertThat(computeScalar(sql)).isEqualTo(localTimeThatDidNotOccurOn19700101); // this tests Trino and the QueryRunner
         assertQuery(sql); // this tests H2QueryRunner
     }
 

--- a/testing/trino-testing/src/test/java/io/trino/testing/TestH2QueryRunner.java
+++ b/testing/trino-testing/src/test/java/io/trino/testing/TestH2QueryRunner.java
@@ -38,7 +38,7 @@ public class TestH2QueryRunner
             assertThat(rows.getOnlyValue()).isEqualTo(LocalDate.of(2018, 1, 13).atStartOfDay());
 
             // date, which midnight was skipped in JVM zone
-            LocalDate forwardOffsetChangeAtMidnightInJvmZone = LocalDate.of(1970, 1, 1);
+            LocalDate forwardOffsetChangeAtMidnightInJvmZone = LocalDate.of(1927, 6, 10);
             checkState(ZoneId.systemDefault().getRules().getValidOffsets(forwardOffsetChangeAtMidnightInJvmZone.atStartOfDay()).isEmpty(), "This test assumes certain JVM time zone");
             rows = h2QueryRunner.execute(TEST_SESSION, DateTimeFormatter.ofPattern("'SELECT DATE '''uuuu-MM-dd''").format(forwardOffsetChangeAtMidnightInJvmZone), ImmutableList.of(TIMESTAMP_MILLIS));
             assertThat(rows.getOnlyValue()).isEqualTo(forwardOffsetChangeAtMidnightInJvmZone.atStartOfDay());


### PR DESCRIPTION
This brings updated timezonedb to version 2024b
(https://github.com/openjdk/jdk23u/commit/73b2341c670f98fb130c57f80eb1461226da1985) which amends historical timezone definitions for Mexico/Bahia_Banderas that we use for testing timezone gap around the unix timestamp epoch.

Corresponding Joda time update also has these timezone definitions updated. PostgreSQL test server was upgraded to 12 to correctly handle
UTC around epoch. MySQL was updated to 8.0.41 due to the same reason.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
