### PR TITLE
[WIP] Parse invalid numbers and throw an error

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -983,6 +983,7 @@ number
     : MINUS? DECIMAL_VALUE  #decimalLiteral
     | MINUS? DOUBLE_VALUE   #doubleLiteral
     | MINUS? INTEGER_VALUE  #integerLiteral
+    | MINUS? INVALID_NUMBER #invalidNumber
     ;
 
 authorizationUser
@@ -1367,6 +1368,23 @@ DOUBLE_VALUE
     | '.' DIGIT+ EXPONENT
     ;
 
+INVALID_NUMBER
+    // Trailing underscore
+    : DIGIT ('_' | DIGIT)* '_'
+    | '0X' ('_' | HEX_DIGIT)* '_'
+    | '0O' ('_' | OCTAL_DIGIT)* '_'
+    | '0B' ('_' | BINARY_DIGIT)* '_'
+    // Consecutive underscores
+    | DECIMAL_INTEGER '__' ('_' | DIGIT)*
+    | HEXADECIMAL_INTEGER '__' ('_' | HEX_DIGIT)*
+    | OCTAL_INTEGER '__' ('_' | OCTAL_DIGIT)*
+    | BINARY_INTEGER '__' ('_' | BINARY_DIGIT)*
+    // Underscore besides comma
+    | DIGIT ('_' | DIGIT)* '_' '.' ('_' | DIGIT)*
+    | DECIMAL_INTEGER '.' '_' ('_' | DIGIT)*
+    | '.' '_' ('_' | DIGIT)*
+    ;
+
 IDENTIFIER
     : (LETTER | '_') (LETTER | DIGIT | '_')*
     ;
@@ -1388,15 +1406,15 @@ fragment DECIMAL_INTEGER
     ;
 
 fragment HEXADECIMAL_INTEGER
-    : '0X' ('_'? (DIGIT | [A-F]))+
+    : '0X' ('_'? HEX_DIGIT)+
     ;
 
 fragment OCTAL_INTEGER
-    : '0O' ('_'? [0-7])+
+    : '0O' ('_'? OCTAL_DIGIT)+
     ;
 
 fragment BINARY_INTEGER
-    : '0B' ('_'? [01])+
+    : '0B' ('_'? BINARY_DIGIT)+
     ;
 
 fragment EXPONENT
@@ -1405,6 +1423,18 @@ fragment EXPONENT
 
 fragment DIGIT
     : [0-9]
+    ;
+
+fragment HEX_DIGIT
+    : [0-9A-F]
+    ;
+
+fragment OCTAL_DIGIT
+    : [0-7]
+    ;
+
+fragment BINARY_DIGIT
+    : [01]
     ;
 
 fragment LETTER

--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -1379,6 +1379,7 @@ INVALID_NUMBER
     | HEXADECIMAL_INTEGER '__' ('_' | HEX_DIGIT)*
     | OCTAL_INTEGER '__' ('_' | OCTAL_DIGIT)*
     | BINARY_INTEGER '__' ('_' | BINARY_DIGIT)*
+    | DIGIT ('_' | DIGIT)* '.' DECIMAL_INTEGER '__' ('_' | DIGIT)*
     // Underscore besides comma
     | DIGIT ('_' | DIGIT)* '_' '.' ('_' | DIGIT)*
     | DECIMAL_INTEGER '.' '_' ('_' | DIGIT)*

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/SqlParser.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/SqlParser.java
@@ -236,6 +236,17 @@ public class SqlParser
         }
 
         @Override
+        public void exitInvalidNumber(SqlBaseParser.InvalidNumberContext context)
+        {
+            Token token = context.INVALID_NUMBER().getSymbol();
+            throw new ParsingException(
+                    "numbers may not contain trailing underscores, consecutive underscores, or underscores besides the decimal point",
+                    null,
+                    token.getLine(),
+                    token.getCharPositionInLine() + 1);
+        }
+
+        @Override
         public void exitNonReserved(SqlBaseParser.NonReservedContext context)
         {
             // we can't modify the tree during rule enter/exit event handling unless we're dealing with a terminal.

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
@@ -33,7 +33,15 @@ public class TestSqlParserErrorHandling
     {
         return Stream.of(
                 Arguments.of("", "line 1:1: mismatched input '<EOF>'. Expecting: <expression>"),
-                Arguments.of("1 + 1 x", "line 1:7: mismatched input 'x'. Expecting: '%', '*', '+', '-', '.', '/', 'AND', 'AT', 'OR', '[', '||', <EOF>, <predicate>"));
+                Arguments.of("1 + 1 x", "line 1:7: mismatched input 'x'. Expecting: '%', '*', '+', '-', '.', '/', 'AND', 'AT', 'OR', '[', '||', <EOF>, <predicate>"),
+                Arguments.of("1_", "line 1:1: numbers may not contain trailing underscores, consecutive underscores, or underscores besides the decimal point"),
+                Arguments.of("1__2", "line 1:1: numbers may not contain trailing underscores, consecutive underscores, or underscores besides the decimal point"),
+                Arguments.of("12_.", "line 1:1: numbers may not contain trailing underscores, consecutive underscores, or underscores besides the decimal point"),
+                Arguments.of("12._", "line 1:1 numbers may not contain trailing underscores, consecutive underscores, or underscores besides the decimal point"),
+                Arguments.of("12._34", "line 1:1 numbers may not contain trailing underscores, consecutive underscores, or underscores besides the decimal point"),
+                Arguments.of("0x_", "line 1:1 numbers may not contain trailing underscores, consecutive underscores, or underscores besides the decimal point"),
+                Arguments.of("0b_", "line 1:1 numbers may not contain trailing underscores, consecutive underscores, or underscores besides the decimal point"),
+                Arguments.of("0o_", "line 1:1 numbers may not contain trailing underscores, consecutive underscores, or underscores besides the decimal point"));
     }
 
     private static Stream<Arguments> statements()
@@ -215,7 +223,7 @@ public class TestSqlParserErrorHandling
                 "line 24:1: mismatched input 'GROUP'. Expecting: '%', ')', '*', '+', ',', '-', '.', '/', 'AND', 'AT', 'FILTER', 'IGNORE', 'OR', 'OVER', 'RESPECT', '[', '||', <predicate>");
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{index}: {0}")
     @MethodSource("statements")
     public void testStatement(String sql, String error)
     {
@@ -224,7 +232,7 @@ public class TestSqlParserErrorHandling
                 .hasMessage(error);
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{index}: {0}")
     @MethodSource("expressions")
     public void testExpression(String sql, String error)
     {

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
@@ -37,11 +37,12 @@ public class TestSqlParserErrorHandling
                 Arguments.of("1_", "line 1:1: numbers may not contain trailing underscores, consecutive underscores, or underscores besides the decimal point"),
                 Arguments.of("1__2", "line 1:1: numbers may not contain trailing underscores, consecutive underscores, or underscores besides the decimal point"),
                 Arguments.of("12_.", "line 1:1: numbers may not contain trailing underscores, consecutive underscores, or underscores besides the decimal point"),
-                Arguments.of("12._", "line 1:1 numbers may not contain trailing underscores, consecutive underscores, or underscores besides the decimal point"),
-                Arguments.of("12._34", "line 1:1 numbers may not contain trailing underscores, consecutive underscores, or underscores besides the decimal point"),
-                Arguments.of("0x_", "line 1:1 numbers may not contain trailing underscores, consecutive underscores, or underscores besides the decimal point"),
-                Arguments.of("0b_", "line 1:1 numbers may not contain trailing underscores, consecutive underscores, or underscores besides the decimal point"),
-                Arguments.of("0o_", "line 1:1 numbers may not contain trailing underscores, consecutive underscores, or underscores besides the decimal point"));
+                Arguments.of("12._", "line 1:1: numbers may not contain trailing underscores, consecutive underscores, or underscores besides the decimal point"),
+                Arguments.of("12._34", "line 1:1: numbers may not contain trailing underscores, consecutive underscores, or underscores besides the decimal point"),
+                Arguments.of("12.3__4", "line 1:1: numbers may not contain trailing underscores, consecutive underscores, or underscores besides the decimal point"),
+                Arguments.of("0x_", "line 1:1: numbers may not contain trailing underscores, consecutive underscores, or underscores besides the decimal point"),
+                Arguments.of("0b_", "line 1:1: numbers may not contain trailing underscores, consecutive underscores, or underscores besides the decimal point"),
+                Arguments.of("0o_", "line 1:1: numbers may not contain trailing underscores, consecutive underscores, or underscores besides the decimal point"));
     }
 
     private static Stream<Arguments> statements()


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Add a rule to parse numbers with invalid placement of underscores, either trailing, consecutive,
or beside the decimal point. Throw an error if such a number is found.

**Note**: numbers with a leading underscore are also invalid, but depending on the context
they are valid identifiers, e.g., `LIMIT _123` is invalid, but `SELECT _123` is not. Detecting these
cases would require deeper changes to the grammar, which may not be warranted just to
produce a better error message.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

#24784 

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## General
* Improve error message for invalid numbers. ({24784}`24784`)
```
