### PR TITLE
Remove deprecated method addColumn from JdbcClient

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -513,13 +513,6 @@ public class CachingJdbcClient
     }
 
     @Override
-    public void addColumn(ConnectorSession session, JdbcTableHandle handle, ColumnMetadata column)
-    {
-        delegate.addColumn(session, handle, column);
-        invalidateTableCaches(handle.asPlainTable().getSchemaTableName());
-    }
-
-    @Override
     public void addColumn(ConnectorSession session, JdbcTableHandle handle, ColumnMetadata column, ColumnPosition position)
     {
         delegate.addColumn(session, handle, column, position);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
@@ -380,12 +380,6 @@ public abstract class ForwardingJdbcClient
     }
 
     @Override
-    public void addColumn(ConnectorSession session, JdbcTableHandle handle, ColumnMetadata column)
-    {
-        delegate().addColumn(session, handle, column);
-    }
-
-    @Override
     public void addColumn(ConnectorSession session, JdbcTableHandle handle, ColumnMetadata column, ColumnPosition position)
     {
         delegate().addColumn(session, handle, column, position);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
@@ -185,15 +185,6 @@ public interface JdbcClient
         throw new TrinoException(NOT_SUPPORTED, "This connector does not support setting column comments");
     }
 
-    /**
-     * @deprecated use {@link #addColumn(ConnectorSession, JdbcTableHandle, ColumnMetadata, ColumnPosition)} which add column with position
-     */
-    @Deprecated
-    default void addColumn(ConnectorSession session, JdbcTableHandle handle, ColumnMetadata column)
-    {
-        addColumn(session, handle, column, new ColumnPosition.Last());
-    }
-
     void addColumn(ConnectorSession session, JdbcTableHandle handle, ColumnMetadata column, ColumnPosition position);
 
     void dropColumn(ConnectorSession session, JdbcTableHandle handle, JdbcColumnHandle column);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/RetryingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/RetryingJdbcClient.java
@@ -302,13 +302,6 @@ public class RetryingJdbcClient
     }
 
     @Override
-    public void addColumn(ConnectorSession session, JdbcTableHandle handle, ColumnMetadata column)
-    {
-        // no retrying as it could be not idempotent operation
-        delegate.addColumn(session, handle, column);
-    }
-
-    @Override
     public void addColumn(ConnectorSession session, JdbcTableHandle handle, ColumnMetadata column, ColumnPosition position)
     {
         // no retrying as it could be not idempotent operation

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
@@ -295,12 +295,6 @@ public final class StatisticsAwareJdbcClient
     }
 
     @Override
-    public void addColumn(ConnectorSession session, JdbcTableHandle handle, ColumnMetadata column)
-    {
-        stats.getAddColumn().wrap(() -> delegate().addColumn(session, handle, column));
-    }
-
-    @Override
     public void addColumn(ConnectorSession session, JdbcTableHandle handle, ColumnMetadata column, ColumnPosition position)
     {
         stats.getAddColumn().wrap(() -> delegate().addColumn(session, handle, column, position));


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
