### PR TITLE
Fix table operations failing for ROW type column name containing colon

### DIFF
--- a/lib/trino-metastore/src/main/java/io/trino/metastore/type/TypeInfoUtils.java
+++ b/lib/trino-metastore/src/main/java/io/trino/metastore/type/TypeInfoUtils.java
@@ -294,11 +294,33 @@ public final class TypeInfoUtils
                             break;
                         }
                     }
-                    Token name = expect("name", ">");
-                    if (name.text().equals(">")) {
+                    // Build name from multiple tokens in case name contains colon(:) as colons in name causes name to be tokenized into multiple tokens.
+                    StringBuilder nameParts = new StringBuilder();
+                    String lastTokenString = null;
+                    while (index < typeInfoTokens.size() - 2
+                            && getTypeEntryFromTypeName(typeInfoTokens.get(index + 1).text) == null
+                            && !LIST_TYPE_NAME.equals(typeInfoTokens.get(index + 1).text)
+                            && !MAP_TYPE_NAME.equals(typeInfoTokens.get(index + 1).text)
+                            && !STRUCT_TYPE_NAME.equals(typeInfoTokens.get(index + 1).text)
+                            && !UNION_TYPE_NAME.equals(typeInfoTokens.get(index + 1).text)) {
+                        Token currentToken = peek();
+                        if (currentToken.text.equals(":")) {
+                            nameParts.append(currentToken.text);
+                            index += 1;
+                        }
+                        else {
+                            Token nameToken = expect("name", ">");
+                            lastTokenString = nameToken.text;
+                            if (lastTokenString.equals(">")) {
+                                break;
+                            }
+                            nameParts.append(nameToken.text);
+                        }
+                    }
+                    if (lastTokenString != null && lastTokenString.equals(">")) {
                         break;
                     }
-                    fieldNames.add(name.text());
+                    fieldNames.add(nameParts.toString());
                     expect(":");
                     fieldTypeInfos.add(parseType());
                 }

--- a/lib/trino-metastore/src/main/java/io/trino/metastore/type/TypeInfoUtils.java
+++ b/lib/trino-metastore/src/main/java/io/trino/metastore/type/TypeInfoUtils.java
@@ -296,7 +296,6 @@ public final class TypeInfoUtils
                     }
                     // Build name from multiple tokens in case name contains colon(:) as colons in name causes name to be tokenized into multiple tokens.
                     StringBuilder nameParts = new StringBuilder();
-                    String lastTokenString = null;
                     while (index < typeInfoTokens.size() - 2
                             && getTypeEntryFromTypeName(typeInfoTokens.get(index + 1).text) == null
                             && !LIST_TYPE_NAME.equals(typeInfoTokens.get(index + 1).text)
@@ -310,15 +309,8 @@ public final class TypeInfoUtils
                         }
                         else {
                             Token nameToken = expect("name", ">");
-                            lastTokenString = nameToken.text;
-                            if (lastTokenString.equals(">")) {
-                                break;
-                            }
                             nameParts.append(nameToken.text);
                         }
-                    }
-                    if (lastTokenString != null && lastTokenString.equals(">")) {
-                        break;
                     }
                     fieldNames.add(nameParts.toString());
                     expect(":");

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseS3AndGlueMetastoreTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseS3AndGlueMetastoreTest.java
@@ -241,6 +241,20 @@ public abstract class BaseS3AndGlueMetastoreTest
         }
     }
 
+    @Test
+    public void testRowColumnNameContainingColon()
+    {
+        String tableName = "test_row_field_with_colon_" + randomNameSuffix();
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (a row(\"b:c\" int), b row(\":b::c::\" int), \"::\" row(\":::\" int))");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (ROW(ROW(11), ROW(22), ROW(33)))", 1);
+            assertQuery("SELECT a.\"b:c\", b.\":b::c::\", \"::\".\":::\" FROM " + tableName, "VALUES (11, 22, 33)");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
     protected void testOptimizeWithProvidedTableLocation(boolean partitioned, LocationPattern locationPattern)
     {
         String tableName = "test_optimize_" + randomNameSuffix();


### PR DESCRIPTION
Table operations fail when sub-column in ROW type column contains
colon(`:`) in name in Glue.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix table operations failing for ROW type sub-column name containing colon in Glue. ({issue}`24811`)
```
