### PR TITLE
Support non-lower case variables in functions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutineAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutineAnalyzer.java
@@ -89,6 +89,7 @@ import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
 import static io.trino.sql.analyzer.TypeSignatureTranslator.toTypeSignature;
 import static java.lang.String.format;
 import static java.util.Collections.nCopies;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Predicate.not;
 
@@ -629,6 +630,9 @@ public class SqlRoutineAnalyzer
     private static String identifierValue(Identifier name)
     {
         // TODO: this should use getCanonicalValue()
-        return name.getValue();
+        // stop-gap: lowercasing for now to match what is happening during analysis;
+        // otherwise we do not support non-lowercase variables in functions.
+        // Rework as part of https://github.com/trinodb/trino/pull/24829
+        return name.getValue().toLowerCase(ENGLISH);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutinePlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutinePlanner.java
@@ -85,6 +85,7 @@ import static io.trino.sql.planner.LogicalPlanner.buildLambdaDeclarationToSymbol
 import static io.trino.sql.relational.Expressions.call;
 import static io.trino.sql.relational.Expressions.constantNull;
 import static io.trino.sql.relational.Expressions.field;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
 public final class SqlRoutinePlanner
@@ -360,7 +361,10 @@ public final class SqlRoutinePlanner
         private static String identifierValue(Identifier name)
         {
             // TODO: this should use getCanonicalValue()
-            return name.getValue();
+            // stop-gap: lowercasing for now to match what is happening during analysis;
+            // otherwise we do not support non-lowercase variables in functions.
+            // Rework as part of https://github.com/trinodb/trino/pull/24829
+            return name.getValue().toLowerCase(ENGLISH);
         }
     }
 

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -6652,6 +6652,19 @@ public abstract class AbstractTestEngineOnlyQueries
                 """))
                 .matches("VALUES 256");
 
+        assertThat(query(
+                """
+                WITH
+                  FUNCTION fun_with_uppercase_var()
+                  RETURNS int
+                  BEGIN
+                    DECLARE R int DEFAULT 7;
+                    RETURN R;
+                  END
+                SELECT fun_with_uppercase_var()
+                """))
+                .matches("VALUES 7");
+
         // invoke function on data from connector to prevent constant folding on the coordinator
         assertThat(query(
                 """


### PR DESCRIPTION
fixes: https://github.com/trinodb/trino/issues/24460
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Allow non-lower case variables in user defined functions. ({issue}`issuenumber`)
```
