### PR TITLE
Allow setting catalog type in Iceberg query runner

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
@@ -290,21 +290,20 @@ public final class IcebergQueryRunner
         }
     }
 
-    public static final class IcebergGlueQueryRunnerMain
+    public static final class IcebergExternalQueryRunnerMain
     {
-        private IcebergGlueQueryRunnerMain() {}
+        private IcebergExternalQueryRunnerMain() {}
 
         public static void main(String[] args)
                 throws Exception
         {
-            // Requires AWS credentials, which can be provided any way supported by the DefaultProviderChain
-            // See https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
+            // Please set Iceberg connector properties via VM options. e.g. -Diceberg.catalog.type=glue -D..
             @SuppressWarnings("resource")
             QueryRunner queryRunner = icebergQueryRunnerMainBuilder()
-                    .setIcebergProperties(ImmutableMap.of("iceberg.catalog.type", "glue"))
+                    .setIcebergProperties(ImmutableMap.of("iceberg.catalog.type", System.getProperty("iceberg.catalog.type")))
                     .build();
 
-            Logger log = Logger.get(IcebergGlueQueryRunnerMain.class);
+            Logger log = Logger.get(IcebergExternalQueryRunnerMain.class);
             log.info("======== SERVER STARTED ========");
             log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());
         }


### PR DESCRIPTION
## Description

Thus, we can connect to SaaS catalogs besides Glue more easily. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
