### PR TITLE
Update docs with updated Postgres version

### DIFF
--- a/docs/src/main/sphinx/connector/postgresql.md
+++ b/docs/src/main/sphinx/connector/postgresql.md
@@ -19,7 +19,7 @@ PostgreSQL instances.
 
 To connect to PostgreSQL, you need:
 
-- PostgreSQL 11.x or higher.
+- PostgreSQL 12.x or higher.
 - Network access from the Trino coordinator and workers to PostgreSQL.
   Port 5432 is the default port.
 

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTimeMappingsWithServerTimeZone.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTimeMappingsWithServerTimeZone.java
@@ -601,6 +601,7 @@ public class TestMySqlTimeMappingsWithServerTimeZone
     @Test
     public void testUnsupportedTimestampWithTimeZoneValues()
     {
+        // The range for supported TIMESTAMP values in MySQL is '1970-01-01 00:00:01.000000' to '2038-01-19 03:14:07.499999'
         try (TestTable table = new TestTable(mySqlServer::execute, "tpch.test_unsupported_timestamp", "(data TIMESTAMP)")) {
             // Verify MySQL writes -- the server timezone is set to Pacific/Apia, so we have to account for that when inserting into MySQL
             assertMySqlQueryFails(


### PR DESCRIPTION
Since 1350a8b8aa8079911b3d3696377b1ece14c6174a we switched testing to 12

Some follow-up from https://github.com/trinodb/trino/pull/24787

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
