### PR TITLE
Remove 'LOCAL TEMPORARY' from DuckDbClient

### DIFF
--- a/plugin/trino-duckdb/src/main/java/io/trino/plugin/duckdb/DuckDbClient.java
+++ b/plugin/trino-duckdb/src/main/java/io/trino/plugin/duckdb/DuckDbClient.java
@@ -130,7 +130,7 @@ public final class DuckDbClient
     @Override
     protected Optional<List<String>> getTableTypes()
     {
-        return Optional.of(ImmutableList.of("BASE TABLE", "LOCAL TEMPORARY", "VIEW"));
+        return Optional.of(ImmutableList.of("BASE TABLE", "VIEW"));
     }
 
     @Override


### PR DESCRIPTION
## Description

I don't remember why I put this table type in the initial PR. 
Let me remove this type because all tests pass without it. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
