### PR TITLE
Improve JSON Decoders

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/json/JsonDeserializer.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/json/JsonDeserializer.java
@@ -225,21 +225,24 @@ public class JsonDeserializer
     private abstract static class Decoder
     {
         private final Type type;
+        private final boolean isScalarType;
 
         public Decoder(Type type)
         {
             this.type = requireNonNull(type, "type is null");
+            this.isScalarType = isScalarType(type);
         }
 
         public final void decode(JsonParser parser, BlockBuilder builder)
                 throws IOException
         {
-            if (parser.currentToken() == VALUE_NULL) {
+            JsonToken currentToken = parser.currentToken();
+            if (currentToken == VALUE_NULL) {
                 builder.appendNull();
                 return;
             }
 
-            if (isScalarType(type) && !parser.currentToken().isScalarValue()) {
+            if (isScalarType && !currentToken.isScalarValue()) {
                 throw invalidJson(type + " value must be a scalar json value");
             }
             decodeValue(parser, builder);

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/json/JsonDeserializer.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/json/JsonDeserializer.java
@@ -228,7 +228,7 @@ public class JsonDeserializer
 
         public Decoder(Type type)
         {
-            this.type = type;
+            this.type = requireNonNull(type, "type is null");
         }
 
         public final void decode(JsonParser parser, BlockBuilder builder)
@@ -344,7 +344,7 @@ public class JsonDeserializer
         public DecimalDecoder(DecimalType decimalType)
         {
             super(decimalType);
-            this.decimalType = decimalType;
+            this.decimalType = requireNonNull(decimalType, "decimalType is null");
         }
 
         @Override
@@ -431,8 +431,8 @@ public class JsonDeserializer
         public TimestampDecoder(TimestampType timestampType, Function<String, DecodedTimestamp> timestampParser)
         {
             super(timestampType);
-            this.timestampType = timestampType;
-            this.timestampParser = timestampParser;
+            this.timestampType = requireNonNull(timestampType, "timestampType is null");
+            this.timestampParser = requireNonNull(timestampParser, "timestampParser is null");
         }
 
         @Override
@@ -487,7 +487,7 @@ public class JsonDeserializer
         public VarcharDecoder(VarcharType varcharType)
         {
             super(varcharType);
-            this.varcharType = varcharType;
+            this.varcharType = requireNonNull(varcharType, "varcharType is null");
         }
 
         @Override
@@ -506,7 +506,7 @@ public class JsonDeserializer
         public CharDecoder(CharType charType)
         {
             super(charType);
-            this.charType = charType;
+            this.charType = requireNonNull(charType, "charType is null");
         }
 
         @Override
@@ -525,7 +525,7 @@ public class JsonDeserializer
         public ArrayDecoder(ArrayType arrayType, Decoder elementDecoder)
         {
             super(arrayType);
-            this.elementDecoder = elementDecoder;
+            this.elementDecoder = requireNonNull(elementDecoder, "elementDecoder is null");
         }
 
         @Override
@@ -562,8 +562,8 @@ public class JsonDeserializer
             super(mapType);
             this.keyType = mapType.getKeyType();
             this.valueType = mapType.getValueType();
-            this.valueDecoder = valueDecoder;
-            this.timestampParser = timestampParser;
+            this.valueDecoder = requireNonNull(valueDecoder, "valueDecoder is null");
+            this.timestampParser = requireNonNull(timestampParser, "timestampParser is null");
 
             this.distinctMapKeys = new DistinctMapKeys(mapType, true);
             this.keyBlockBuilder = mapType.getKeyType().createBlockBuilder(null, 128);
@@ -679,7 +679,7 @@ public class JsonDeserializer
             checkArgument(this.fieldDecoders.length == fields.size(), "fieldDecoders size mismatch: %s <> %s", this.fieldDecoders.length, fields.size());
             checkArgument(Arrays.stream(this.fieldDecoders).noneMatch(Objects::isNull), "fieldDecoders contains null element");
             this.fieldWritten = new boolean[this.fieldDecoders.length];
-            this.ordinalToFieldPosition = ordinalToFieldPosition;
+            this.ordinalToFieldPosition = requireNonNull(ordinalToFieldPosition, "ordinalToFieldPosition is null");
         }
 
         public void decode(JsonParser parser, PageBuilder builder)

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/json/JsonDeserializer.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/json/JsonDeserializer.java
@@ -661,6 +661,7 @@ public class JsonDeserializer
 
         private final Map<String, Integer> fieldPositions;
         private final Decoder[] fieldDecoders;
+        private final boolean[] fieldWritten;
         private final IntUnaryOperator ordinalToFieldPosition;
 
         public RowDecoder(RowType rowType, Decoder[] fieldDecoders, IntUnaryOperator ordinalToFieldPosition)
@@ -677,6 +678,7 @@ public class JsonDeserializer
             this.fieldDecoders = requireNonNull(fieldDecoders, "fieldDecoders is null");
             checkArgument(this.fieldDecoders.length == fields.size(), "fieldDecoders size mismatch: %s <> %s", this.fieldDecoders.length, fields.size());
             checkArgument(Arrays.stream(this.fieldDecoders).noneMatch(Objects::isNull), "fieldDecoders contains null element");
+            this.fieldWritten = new boolean[this.fieldDecoders.length];
             this.ordinalToFieldPosition = ordinalToFieldPosition;
         }
 
@@ -701,7 +703,7 @@ public class JsonDeserializer
                 throw invalidJson("start of object expected");
             }
 
-            boolean[] fieldWritten = new boolean[fieldDecoders.length];
+            Arrays.fill(fieldWritten, false);
 
             while (nextObjectField(parser)) {
                 String fieldName = parser.getText();


### PR DESCRIPTION
## Description
Minor code cleanup in the Hive and OpenX JSON decoders to improve performance by flattening lists into arrays, avoiding per-row allocation overheads, and avoiding a per-value instanceof check.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
