### PR TITLE
Fix listing Glue tables with null type

### DIFF
--- a/.mvn/modernizer/violations.xml
+++ b/.mvn/modernizer/violations.xml
@@ -317,4 +317,10 @@
         <version>1.8</version>
         <comment>Use io.trino.plugin.base.util.JsonUtils.jsonFactoryBuilder() instead</comment>
     </violation>
+
+    <violation>
+        <name>software/amazon/awssdk/services/glue/model/Table.tableType:()Ljava/lang/String;</name>
+        <version>1.8</version>
+        <comment>Table type is nullable in Glue model, which is too easy to forget about. Prefer GlueConverter.getTableTypeNullable</comment>
+    </violation>
 </modernizer>

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueConverter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueConverter.java
@@ -40,6 +40,8 @@ import io.trino.plugin.hive.HiveStorageFormat;
 import io.trino.spi.TrinoException;
 import io.trino.spi.function.LanguageFunction;
 import io.trino.spi.security.PrincipalType;
+import jakarta.annotation.Nullable;
+import org.gaul.modernizer_maven_annotations.SuppressModernizer;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.glue.model.BinaryColumnStatisticsData;
 import software.amazon.awssdk.services.glue.model.BooleanColumnStatisticsData;
@@ -117,6 +119,13 @@ final class GlueConverter
 
     private GlueConverter() {}
 
+    @Nullable
+    @SuppressModernizer // Usage of `Table.tableType` is not allowed. Only this method can call that.
+    public static String getTableTypeNullable(software.amazon.awssdk.services.glue.model.Table glueTable)
+    {
+        return glueTable.tableType();
+    }
+
     public static Database fromGlueDatabase(software.amazon.awssdk.services.glue.model.Database glueDb)
     {
         return new Database(
@@ -141,7 +150,7 @@ final class GlueConverter
     public static Table fromGlueTable(software.amazon.awssdk.services.glue.model.Table glueTable, String databaseName)
     {
         // Athena treats a missing table type as EXTERNAL_TABLE.
-        String tableType = firstNonNull(glueTable.tableType(), "EXTERNAL_TABLE");
+        String tableType = firstNonNull(getTableTypeNullable(glueTable), "EXTERNAL_TABLE");
 
         Map<String, String> tableParameters = glueTable.parameters();
         if (glueTable.description() != null) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueConverter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueConverter.java
@@ -90,6 +90,7 @@ import static io.trino.metastore.HiveColumnStatistics.createStringColumnStatisti
 import static io.trino.metastore.Table.TABLE_COMMENT;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_INVALID_METADATA;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_UNSUPPORTED_FORMAT;
+import static io.trino.plugin.hive.TableType.EXTERNAL_TABLE;
 import static io.trino.plugin.hive.ViewReaderUtil.isTrinoMaterializedView;
 import static io.trino.plugin.hive.ViewReaderUtil.isTrinoView;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.metastoreFunctionName;
@@ -118,6 +119,12 @@ final class GlueConverter
     private static final JsonCodec<LanguageFunction> LANGUAGE_FUNCTION_CODEC = JsonCodec.jsonCodec(LanguageFunction.class);
 
     private GlueConverter() {}
+
+    public static String getTableType(software.amazon.awssdk.services.glue.model.Table glueTable)
+    {
+        // Athena treats a missing table type as EXTERNAL_TABLE.
+        return firstNonNull(getTableTypeNullable(glueTable), EXTERNAL_TABLE.name());
+    }
 
     @Nullable
     @SuppressModernizer // Usage of `Table.tableType` is not allowed. Only this method can call that.
@@ -149,8 +156,7 @@ final class GlueConverter
 
     public static Table fromGlueTable(software.amazon.awssdk.services.glue.model.Table glueTable, String databaseName)
     {
-        // Athena treats a missing table type as EXTERNAL_TABLE.
-        String tableType = firstNonNull(getTableTypeNullable(glueTable), "EXTERNAL_TABLE");
+        String tableType = getTableType(glueTable);
 
         Map<String, String> tableParameters = glueTable.parameters();
         if (glueTable.description() != null) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -122,6 +122,7 @@ import static io.trino.plugin.hive.metastore.MetastoreUtil.metastoreFunctionName
 import static io.trino.plugin.hive.metastore.MetastoreUtil.toPartitionName;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.updateStatisticsParameters;
 import static io.trino.plugin.hive.metastore.glue.GlueConverter.fromGlueStatistics;
+import static io.trino.plugin.hive.metastore.glue.GlueConverter.getTableTypeNullable;
 import static io.trino.plugin.hive.metastore.glue.GlueConverter.toGlueColumnStatistics;
 import static io.trino.plugin.hive.metastore.glue.GlueConverter.toGlueDatabaseInput;
 import static io.trino.plugin.hive.metastore.glue.GlueConverter.toGlueFunctionInput;
@@ -448,7 +449,7 @@ public class GlueHiveMetastore
             return glueTables.stream()
                     .map(table -> new TableInfo(
                             new SchemaTableName(databaseName, table.name()),
-                            TableInfo.ExtendedRelationType.fromTableTypeAndComment(table.tableType(), table.parameters().get(TABLE_COMMENT))))
+                            TableInfo.ExtendedRelationType.fromTableTypeAndComment(GlueConverter.getTableTypeNullable(table), table.parameters().get(TABLE_COMMENT))))
                     .toList();
         }
         catch (EntityNotFoundException _) {
@@ -716,7 +717,7 @@ public class GlueHiveMetastore
                 .partitionKeys(table.partitionKeys())
                 .viewOriginalText(table.viewOriginalText())
                 .viewExpandedText(table.viewExpandedText())
-                .tableType(table.tableType())
+                .tableType(getTableTypeNullable(table))
                 .targetTable(table.targetTable())
                 .parameters(table.parameters());
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -449,7 +449,7 @@ public class GlueHiveMetastore
             return glueTables.stream()
                     .map(table -> new TableInfo(
                             new SchemaTableName(databaseName, table.name()),
-                            TableInfo.ExtendedRelationType.fromTableTypeAndComment(GlueConverter.getTableTypeNullable(table), table.parameters().get(TABLE_COMMENT))))
+                            TableInfo.ExtendedRelationType.fromTableTypeAndComment(GlueConverter.getTableType(table), table.parameters().get(TABLE_COMMENT))))
                     .toList();
         }
         catch (EntityNotFoundException _) {

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueConverter.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueConverter.java
@@ -47,6 +47,7 @@ import static io.trino.metastore.TableInfo.ICEBERG_MATERIALIZED_VIEW_COMMENT;
 import static io.trino.plugin.hive.TableType.EXTERNAL_TABLE;
 import static io.trino.plugin.hive.ViewReaderUtil.PRESTO_VIEW_FLAG;
 import static io.trino.plugin.hive.metastore.glue.GlueConverter.PUBLIC_OWNER;
+import static io.trino.plugin.hive.metastore.glue.GlueConverter.getTableTypeNullable;
 import static io.trino.plugin.hive.util.HiveUtil.DELTA_LAKE_PROVIDER;
 import static io.trino.plugin.hive.util.HiveUtil.ICEBERG_TABLE_TYPE_NAME;
 import static io.trino.plugin.hive.util.HiveUtil.ICEBERG_TABLE_TYPE_VALUE;
@@ -246,7 +247,7 @@ class TestGlueConverter
         io.trino.metastore.Table trinoTable = GlueConverter.fromGlueTable(glueTable, glueDatabase.name());
         assertThat(trinoTable.getTableName()).isEqualTo(glueTable.name());
         assertThat(trinoTable.getDatabaseName()).isEqualTo(glueDatabase.name());
-        assertThat(trinoTable.getTableType()).isEqualTo(glueTable.tableType());
+        assertThat(trinoTable.getTableType()).isEqualTo(getTableTypeNullable(glueTable));
         assertThat(trinoTable.getOwner().orElse(null)).isEqualTo(glueTable.owner());
         assertThat(trinoTable.getParameters()).isEqualTo(glueTable.parameters());
         assertColumnList(glueTable.storageDescriptor().columns(), trinoTable.getDataColumns());
@@ -278,7 +279,7 @@ class TestGlueConverter
 
         assertThat(trinoTable.getTableName()).isEqualTo(glueTable.name());
         assertThat(trinoTable.getDatabaseName()).isEqualTo(glueDatabase.name());
-        assertThat(trinoTable.getTableType()).isEqualTo(glueTable.tableType());
+        assertThat(trinoTable.getTableType()).isEqualTo(getTableTypeNullable(glueTable));
         assertThat(trinoTable.getOwner().orElse(null)).isEqualTo(glueTable.owner());
         assertThat(trinoTable.getParameters()).isEqualTo(glueTable.parameters());
         assertThat(trinoTable.getDataColumns()).hasSize(1);


### PR DESCRIPTION
## Description

Fix listing Glue tables when table type is null.
Fixes: https://github.com/trinodb/trino/issues/24834

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Hive
* Fix NullPointerException when listing tables on Glue. ({issue}`24834`)
```
