### PR TITLE
Allow to pass step length in Loki connector

### DIFF
--- a/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiRecordSet.java
+++ b/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiRecordSet.java
@@ -49,7 +49,7 @@ public class LokiRecordSet
 
         // Execute the query
         try {
-            this.result = lokiClient.rangeQuery(split.query(), split.start(), split.end());
+            this.result = lokiClient.rangeQuery(split.query(), split.start(), split.end(), split.step());
         }
         catch (LokiClientException e) {
             throw new TrinoException(LOKI_CLIENT_ERROR, e);

--- a/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiSplit.java
+++ b/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiSplit.java
@@ -19,7 +19,7 @@ import java.time.Instant;
 
 import static java.util.Objects.requireNonNull;
 
-public record LokiSplit(String query, Instant start, Instant end)
+public record LokiSplit(String query, Instant start, Instant end, int step)
         implements ConnectorSplit
 {
     public LokiSplit

--- a/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiSplitManager.java
+++ b/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiSplitManager.java
@@ -42,7 +42,7 @@ public class LokiSplitManager
     {
         final LokiTableHandle table = (LokiTableHandle) connectorTableHandle;
 
-        List<ConnectorSplit> splits = ImmutableList.of(new LokiSplit(table.query(), table.start(), table.end()));
+        List<ConnectorSplit> splits = ImmutableList.of(new LokiSplit(table.query(), table.start(), table.end(), table.step()));
 
         log.debug("created %d splits", splits.size());
         return new FixedSplitSource(splits);

--- a/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiTableHandle.java
+++ b/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiTableHandle.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
-public record LokiTableHandle(String query, Instant start, Instant end, List<ColumnHandle> columnHandles)
+public record LokiTableHandle(String query, Instant start, Instant end, int step, List<ColumnHandle> columnHandles)
         implements ConnectorTableHandle
 {
     public LokiTableHandle


### PR DESCRIPTION
## Description

The Loki API allows to pass the step length in seconds. This change updates the client and adds an optional `STEP` parameter to the query range table function.

This allows us to simplify the integration test as well.

Fixes #24861
