### PR TITLE
Fix typo in Python docs

### DIFF
--- a/docs/src/main/sphinx/udf/python.md
+++ b/docs/src/main/sphinx/udf/python.md
@@ -40,7 +40,7 @@ value `x` multiplied by two. The example shows declaration as [](udf-inline) and
 invocation with the value `21` to yield the result `42`.
 
 Set the language to `PYTHON` to override the default `SQL` for [](/udf/sql).
-The Python code is enclosed with ``$$` and must use valid formatting.
+The Python code is enclosed with `$$` and must use valid formatting.
 
 ```text
 WITH


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
