### PR TITLE
Show only denied columns in Ranger error message

### DIFF
--- a/plugin/trino-ranger/src/test/java/io/trino/plugin/ranger/TestRangerSystemAccessControl.java
+++ b/plugin/trino-ranger/src/test/java/io/trino/plugin/ranger/TestRangerSystemAccessControl.java
@@ -64,6 +64,7 @@ final class TestRangerSystemAccessControl
     private static final CatalogSchemaRoutineName FUNC_ALICE_SCH1_FUNC1 = new CatalogSchemaRoutineName(CATALOG_ALICE, "sch1", "func1");
     private static final CatalogSchemaName SCHEMA_USER_BOB = new CatalogSchemaName(CATALOG_USER_HOME, "bob_schema");
     private static final CatalogSchemaTableName TABLE_USER_BOB_TBL1 = new CatalogSchemaTableName(CATALOG_USER_HOME, SCHEMA_USER_BOB.getSchemaName(), "tbl1");
+    private static final CatalogSchemaTableName TABLE_USER_SCH1_TBL1 = new CatalogSchemaTableName(CATALOG_USER_HOME, "sch1", "tbl1");
 
     @BeforeAll
     public static void setUpBeforeClass()
@@ -224,6 +225,10 @@ final class TestRangerSystemAccessControl
         assertThatThrownBy(() -> accessControlManager.checkCanShowColumns(context(BOB), TABLE_ALICE_SCH1_TBL1)).isInstanceOf(AccessDeniedException.class);
         assertThatThrownBy(() -> accessControlManager.checkCanSelectFromColumns(context(BOB), TABLE_ALICE_SCH1_TBL1, ImmutableSet.of())).isInstanceOf(AccessDeniedException.class);
         assertThatThrownBy(() -> accessControlManager.checkCanUpdateTableColumns(context(BOB), TABLE_ALICE_SCH1_TBL1, Collections.emptySet())).isInstanceOf(AccessDeniedException.class);
+
+        assertThatThrownBy(() -> accessControlManager.checkCanSelectFromColumns(context(BOB), TABLE_USER_SCH1_TBL1, ImmutableSet.of("id", "time")))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("Cannot select from columns [id] in table or view tbl1");
     }
 
     @Test

--- a/plugin/trino-ranger/src/test/resources/trino-policies.json
+++ b/plugin/trino-ranger/src/test/resources/trino-policies.json
@@ -300,6 +300,23 @@
       "policyItems": [
         { "accesses": [ { "type": "select" }, { "type": "insert" }, { "type": "create" }, { "type": "drop" }, { "type": "alter" }, { "type": "show" }, { "type": "grant" }, { "type": "revoke" } ], "users": [ "{USER}" ] }
       ]
+    },
+    {
+      "id":             30,
+      "service":        "dev_trino",
+      "serviceType":    "trino",
+      "name":           "allow access at column-level",
+      "policyType":     0,
+      "policyPriority": 0,
+      "resources": {
+          "catalog": { "values": [ "user-catalog" ] },
+          "schema":  { "values": [ "sch1" ] },
+          "table":   { "values": [ "tbl1" ] },
+          "column":  { "values": [ "time" ] }
+      },
+      "policyItems": [
+          { "accesses": [ { "type": "select" } ], "users": [ "bob" ] }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Description
When column access is denied, the current error message contains all requested columns:
```
Cannot select from columns [id, time] in table or view tbl1
```
With this change, the error message will only contains denied columns:
```
Cannot select from columns [id] in table or view tbl1
```


## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
