### PR TITLE
Document using statistics in the Faker connector

### DIFF
--- a/docs/src/main/sphinx/sql/select.md
+++ b/docs/src/main/sphinx/sql/select.md
@@ -1039,6 +1039,7 @@ ORDER BY regionkey FETCH FIRST ROW WITH TIES;
 (5 rows)
 ```
 
+(tablesample)=
 ## TABLESAMPLE
 
 There are multiple sample methods:

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerConfig.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerConfig.java
@@ -80,7 +80,7 @@ public class FakerConfig
     @ConfigDescription(
             """
             If true, when creating a table using existing data, columns with the number of distinct values close to
-            the number of rows will be treated as sequences""")
+            the number of rows are treated as sequences""")
     public FakerConfig setSequenceDetectionEnabled(boolean value)
     {
         this.sequenceDetectionEnabled = value;
@@ -96,7 +96,7 @@ public class FakerConfig
     @ConfigDescription(
             """
             If true, when creating a table using existing data, columns with a low number of distinct values
-            will have the allowed_values column property populated with random values""")
+            are treated as dictionaries, and get the allowed_values column property populated with random values""")
     public FakerConfig setDictionaryDetectionEnabled(boolean value)
     {
         this.dictionaryDetectionEnabled = value;

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerConnector.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerConnector.java
@@ -131,14 +131,14 @@ public class FakerConnector
                         SchemaInfo.SEQUENCE_DETECTION_ENABLED,
                         """
                         If true, when creating a table using existing data, columns with the number of distinct values close to
-                        the number of rows will be treated as sequences""",
+                        the number of rows are treated as sequences""",
                         null,
                         false),
                 booleanProperty(
                         SchemaInfo.DICTIONARY_DETECTION_ENABLED,
                         """
                         If true, when creating a table using existing data, columns with a low number of distinct values
-                        will have the allowed_values column property populated with random values""",
+                        are treated as dictionaries, and get the allowed_values column property populated with random values""",
                         null,
                         false));
     }
@@ -163,14 +163,14 @@ public class FakerConnector
                         TableInfo.SEQUENCE_DETECTION_ENABLED,
                         """
                         If true, when creating a table using existing data, columns with the number of distinct values close to
-                        the number of rows will be treated as sequences""",
+                        the number of rows are treated as sequences""",
                         null,
                         false),
                 booleanProperty(
                         TableInfo.DICTIONARY_DETECTION_ENABLED,
                         """
                         If true, when creating a table using existing data, columns with a low number of distinct values
-                        will have the allowed_values column property populated with random values""",
+                        are treated as dictionaries, and get the allowed_values column property populated with random values""",
                         null,
                         false));
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Follow up to #24585. I ran the Vale linter and it spotted usages of `will`, so I also fixed that in the config and schema/table/column property descriptions.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
