### PR TITLE
Fix unary expressions

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -550,7 +550,7 @@ predicate[ParserRuleContext value]
 valueExpression
     : primaryExpression                                                                 #valueExpressionDefault
     | valueExpression AT timeZoneSpecifier                                              #atTimeZone
-    | operator=(MINUS | PLUS) valueExpression                                           #arithmeticUnary
+    | operator=(MINUS | PLUS) primaryExpression                                         #arithmeticUnary
     | left=valueExpression operator=(ASTERISK | SLASH | PERCENT) right=valueExpression  #arithmeticBinary
     | left=valueExpression operator=(PLUS | MINUS) right=valueExpression                #arithmeticBinary
     | left=valueExpression CONCAT right=valueExpression                                 #concatenation

--- a/core/trino-main/src/test/java/io/trino/type/TestIntegerOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestIntegerOperators.java
@@ -24,6 +24,7 @@ import static io.trino.spi.StandardErrorCode.DIVISION_BY_ZERO;
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.INVALID_LITERAL;
 import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
+import static io.trino.spi.StandardErrorCode.SYNTAX_ERROR;
 import static io.trino.spi.function.OperatorType.ADD;
 import static io.trino.spi.function.OperatorType.DIVIDE;
 import static io.trino.spi.function.OperatorType.EQUAL;
@@ -83,6 +84,10 @@ public class TestIntegerOperators
 
         assertThat(assertions.expression("+INTEGER '17'"))
                 .isEqualTo(17);
+
+        assertTrinoExceptionThrownBy(assertions.expression("++INTEGER '17'")::evaluate)
+                .hasErrorCode(SYNTAX_ERROR)
+                .hasMessageContaining("mismatched input '+'. Expecting: <expression>");
     }
 
     @Test
@@ -96,6 +101,10 @@ public class TestIntegerOperators
 
         assertTrinoExceptionThrownBy(assertions.expression("INTEGER '-" + Integer.MIN_VALUE + "'")::evaluate)
                 .hasErrorCode(INVALID_LITERAL);
+
+        assertTrinoExceptionThrownBy(assertions.expression("-++-INTEGER '17'")::evaluate)
+                .hasErrorCode(SYNTAX_ERROR)
+                .hasMessageContaining("mismatched input '+'. Expecting: <expression>, <integer>, DECIMAL_VALUE, DOUBLE_VALUE");
     }
 
     @Test

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -2291,7 +2291,7 @@ class AstBuilder
     @Override
     public Node visitArithmeticUnary(SqlBaseParser.ArithmeticUnaryContext context)
     {
-        Expression child = (Expression) visit(context.valueExpression());
+        Expression child = (Expression) visit(context.primaryExpression());
 
         return switch (context.operator.getType()) {
             case SqlBaseLexer.MINUS -> ArithmeticUnaryExpression.negative(getLocation(context), child);

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -263,7 +263,6 @@ import static io.trino.sql.parser.TreeNodes.qualifiedName;
 import static io.trino.sql.parser.TreeNodes.rowType;
 import static io.trino.sql.parser.TreeNodes.simpleType;
 import static io.trino.sql.testing.TreeAssertions.assertFormattedSql;
-import static io.trino.sql.tree.ArithmeticUnaryExpression.negative;
 import static io.trino.sql.tree.ArithmeticUnaryExpression.positive;
 import static io.trino.sql.tree.ComparisonExpression.Operator.EQUAL;
 import static io.trino.sql.tree.DateTimeDataType.Type.TIMESTAMP;
@@ -689,54 +688,10 @@ public class TestSqlParser
         assertThat(expression("+ 9"))
                 .isEqualTo(positive(location(1, 1), new LongLiteral(location(1, 3), "9")));
 
-        assertThat(expression("++9"))
-                .isEqualTo(positive(location(1, 1), positive(location(1, 2), new LongLiteral(location(1, 3), "9"))));
-        assertThat(expression("+ +9"))
-                .isEqualTo(positive(location(1, 1), positive(location(1, 3), new LongLiteral(location(1, 4), "9"))));
-        assertThat(expression("+ + 9"))
-                .isEqualTo(positive(location(1, 1), positive(location(1, 3), new LongLiteral(location(1, 5), "9"))));
-
-        assertThat(expression("+++9"))
-                .isEqualTo(positive(location(1, 1), positive(location(1, 2), positive(location(1, 3), new LongLiteral(location(1, 4), "9")))));
-        assertThat(expression("+ + +9"))
-                .isEqualTo(positive(location(1, 1), positive(location(1, 3), positive(location(1, 5), new LongLiteral(location(1, 6), "9")))));
-        assertThat(expression("+ + + 9"))
-                .isEqualTo(positive(location(1, 1), positive(location(1, 3), positive(location(1, 5), new LongLiteral(location(1, 7), "9")))));
-
         assertThat(expression("-9"))
                 .isEqualTo(new LongLiteral(location(1, 1), "-9"));
         assertThat(expression("- 9"))
                 .isEqualTo(new LongLiteral(location(1, 1), "-9"));
-
-        assertThat(expression("- + 9"))
-                .isEqualTo(negative(location(1, 1), positive(location(1, 3), new LongLiteral(location(1, 5), "9"))));
-        assertThat(expression("-+9"))
-                .isEqualTo(negative(location(1, 1), positive(location(1, 2), new LongLiteral(location(1, 3), "9"))));
-
-        assertThat(expression("+ - + 9"))
-                .isEqualTo(positive(location(1, 1), negative(location(1, 3), positive(location(1, 5), new LongLiteral(location(1, 7), "9")))));
-        assertThat(expression("+-+9"))
-                .isEqualTo(positive(location(1, 1), negative(location(1, 2), positive(location(1, 3), new LongLiteral(location(1, 4), "9")))));
-
-        assertThat(expression("- -9"))
-                .isEqualTo(negative(location(1, 1), new LongLiteral(location(1, 3), "-9")));
-        assertThat(expression("- - 9"))
-                .isEqualTo(negative(location(1, 1), new LongLiteral(location(1, 3), "-9")));
-
-        assertThat(expression("- + - + 9"))
-                .isEqualTo(negative(location(1, 1), positive(location(1, 3), negative(location(1, 5), positive(location(1, 7), new LongLiteral(location(1, 9), "9"))))));
-        assertThat(expression("-+-+9"))
-                .isEqualTo(negative(location(1, 1), positive(location(1, 2), negative(location(1, 3), positive(location(1, 4), new LongLiteral(location(1, 5), "9"))))));
-
-        assertThat(expression("+ - + - + 9"))
-                .isEqualTo(positive(location(1, 1), negative(location(1, 3), positive(location(1, 5), negative(location(1, 7), positive(location(1, 9), new LongLiteral(location(1, 11), "9")))))));
-        assertThat(expression("+-+-+9"))
-                .isEqualTo(positive(location(1, 1), negative(location(1, 2), positive(location(1, 3), negative(location(1, 4), positive(location(1, 5), new LongLiteral(location(1, 6), "9")))))));
-
-        assertThat(expression("- - -9"))
-                .isEqualTo(negative(location(1, 1), negative(location(1, 3), new LongLiteral(location(1, 5), "-9"))));
-        assertThat(expression("- - - 9"))
-                .isEqualTo(negative(location(1, 1), negative(location(1, 3), new LongLiteral(location(1, 5), "-9"))));
     }
 
     @Test


### PR DESCRIPTION
Unary expressions should apply to primaryExpressions, not to expressions themselves which allows for weird syntax like -+-----+ expression.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
