### PR TITLE
Skip varchar columns when detecting dictionaries in Faker connector

### DIFF
--- a/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerQueries.java
+++ b/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerQueries.java
@@ -592,4 +592,24 @@ final class TestFakerQueries
             assertThat(createTable).containsPattern("nullable integer WITH \\(null_probability = 1E0\\)");
         }
     }
+
+    @Test
+    void testCreateTableAsSelectVarchar()
+    {
+        String source = """
+                        SELECT * FROM tpch.tiny.orders
+                        """;
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "varchars", "AS " + source)) {
+            String createTable = (String) computeScalar("SHOW CREATE TABLE " + table.getName());
+            assertThat(createTable).containsPattern("orderkey bigint WITH \\(max = '60000', min = '1', null_probability = 0E0, step = '1'\\)");
+            assertThat(createTable).containsPattern("custkey bigint WITH \\(allowed_values = ARRAY\\['.*'], null_probability = 0E0\\)");
+            assertThat(createTable).containsPattern("orderstatus varchar\\(1\\)");
+            assertThat(createTable).containsPattern("totalprice double WITH \\(max = '.*', min = '.*', null_probability = 0E0\\)");
+            assertThat(createTable).containsPattern("orderdate date WITH \\(max = '1998-08-02', min = '1992-01-01', null_probability = 0E0\\)");
+            assertThat(createTable).containsPattern("orderpriority varchar\\(15\\)");
+            assertThat(createTable).containsPattern("clerk varchar\\(15\\)");
+            assertThat(createTable).containsPattern("shippriority integer WITH \\(allowed_values = ARRAY\\['0'], null_probability = 0E0\\)");
+            assertThat(createTable).containsPattern("comment varchar\\(79\\)");
+        }
+    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

This fixes an issue introduced in #24590, which hasn't been released yet.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
