### PR TITLE
Read latest metadata and protocol entry backwards

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/MetadataAndProtocolEntries.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/MetadataAndProtocolEntries.java
@@ -17,7 +17,6 @@ import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
 import io.trino.plugin.deltalake.transactionlog.ProtocolEntry;
 
 import java.util.Optional;
-import java.util.stream.Stream;
 
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
@@ -29,20 +28,6 @@ public record MetadataAndProtocolEntries(Optional<MetadataEntry> metadata, Optio
     public MetadataAndProtocolEntries(MetadataEntry metadata, ProtocolEntry protocol)
     {
         this(Optional.ofNullable(metadata), Optional.ofNullable(protocol));
-    }
-
-    public Stream<Object> stream()
-    {
-        if (metadata.isPresent() && protocol.isPresent()) {
-            return Stream.of(metadata.get(), protocol.get());
-        }
-        if (metadata.isPresent()) {
-            return Stream.of(metadata.get());
-        }
-        if (protocol.isPresent()) {
-            return Stream.of(protocol.get());
-        }
-        return Stream.of();
     }
 
     public long getRetainedSizeInBytes()

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
@@ -28,6 +28,7 @@ import io.trino.plugin.deltalake.metastore.DeltaLakeTableMetadataScheduler;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
+import io.trino.testing.sql.TestTable;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -1179,6 +1180,68 @@ public class TestDeltaLakeFileOperations
                         .build());
 
         assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testReadMetadataAndProtocolEntry()
+    {
+        try (TestTable table = newTrinoTable("test_read_metadata_protocol", "(data int , part varchar) WITH (checkpoint_interval = 3)")) {
+            assertFileSystemAccesses(
+                    "SHOW CREATE TABLE " + table.getName(),
+                    ImmutableMultiset.<FileOperation>builder()
+                            .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000000.json", "InputFile.length"))
+                            .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000000.json", "InputFile.newStream"))
+                            .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000001.json", "InputFile.length"))
+                            .add(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", "InputFile.newStream"))
+                            .build());
+
+            // read all files
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (1, 'aa')", 1);
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (2, 'bb')", 1);
+            assertFileSystemAccesses(
+                    "SHOW CREATE TABLE " + table.getName(),
+                    ImmutableMultiset.<FileOperation>builder()
+                            .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000000.json", "InputFile.length"))
+                            .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000000.json", "InputFile.newStream"))
+                            .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000001.json", "InputFile.length"))
+                            .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000001.json", "InputFile.newStream"))
+                            .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000002.json", "InputFile.length"))
+                            .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000002.json", "InputFile.newStream"))
+                            .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000003.json", "InputFile.length"))
+                            .add(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", "InputFile.newStream"))
+                            .build());
+
+            // generate a new checkpoint
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (3, 'cc')", 1);
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (4, 'dd')", 1);
+            assertFileSystemAccesses(
+                    "SHOW CREATE TABLE " + table.getName(),
+                    ImmutableMultiset.<FileOperation>builder()
+                            .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000004.json", "InputFile.length"))
+                            .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000004.json", "InputFile.newStream"))
+                            .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000005.json", "InputFile.length"))
+                            .add(new FileOperation(CHECKPOINT, "00000000000000000003.checkpoint.parquet", "InputFile.newInput"))
+                            .add(new FileOperation(CHECKPOINT, "00000000000000000003.checkpoint.parquet", "InputFile.length"))
+                            .add(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", "InputFile.newStream"))
+                            .build());
+
+            // generate metadata entry and protocol entry in a transaction log after the latest checkpoint
+            assertUpdate("ALTER TABLE " + table.getName() + " ADD COLUMN y int");
+
+            // read from checkpoint and all active logs
+            assertFileSystemAccesses(
+                    "SHOW CREATE TABLE " + table.getName(),
+                    ImmutableMultiset.<FileOperation>builder()
+                            .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000004.json", "InputFile.length"))
+                            .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000004.json", "InputFile.newStream"))
+                            .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000005.json", "InputFile.length"))
+                            .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000005.json", "InputFile.newStream"))
+                            .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000006.json", "InputFile.length"))
+                            .add(new FileOperation(CHECKPOINT, "00000000000000000003.checkpoint.parquet", "InputFile.newInput"))
+                            .add(new FileOperation(CHECKPOINT, "00000000000000000003.checkpoint.parquet", "InputFile.length"))
+                            .add(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", "InputFile.newStream"))
+                            .build());
+        }
     }
 
     private int countCdfFilesForKey(String partitionValue)

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
@@ -1228,7 +1228,7 @@ public class TestDeltaLakeFileOperations
             // generate metadata entry and protocol entry in a transaction log after the latest checkpoint
             assertUpdate("ALTER TABLE " + table.getName() + " ADD COLUMN y int");
 
-            // read from checkpoint and all active logs
+            // no need to read checkpoint file
             assertFileSystemAccesses(
                     "SHOW CREATE TABLE " + table.getName(),
                     ImmutableMultiset.<FileOperation>builder()
@@ -1237,8 +1237,6 @@ public class TestDeltaLakeFileOperations
                             .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000005.json", "InputFile.length"))
                             .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000005.json", "InputFile.newStream"))
                             .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000006.json", "InputFile.length"))
-                            .add(new FileOperation(CHECKPOINT, "00000000000000000003.checkpoint.parquet", "InputFile.newInput"))
-                            .add(new FileOperation(CHECKPOINT, "00000000000000000003.checkpoint.parquet", "InputFile.length"))
                             .add(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", "InputFile.newStream"))
                             .build());
         }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestTransactionLogAccess.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestTransactionLogAccess.java
@@ -396,26 +396,23 @@ public class TestTransactionLogAccess
     }
 
     @Test
-    public void testAllGetProtocolEntries()
+    public void testGetProtocolEntry()
             throws Exception
     {
-        testAllGetProtocolEntries("person", "databricks73/person");
-        testAllGetProtocolEntries("person_without_last_checkpoint", "databricks73/person_without_last_checkpoint");
-        testAllGetProtocolEntries("person_without_old_jsons", "databricks73/person_without_old_jsons");
-        testAllGetProtocolEntries("person_without_checkpoints", "databricks73/person_without_checkpoints");
+        testGetProtocolEntry("person", "databricks73/person");
+        testGetProtocolEntry("person_without_last_checkpoint", "databricks73/person_without_last_checkpoint");
+        testGetProtocolEntry("person_without_old_jsons", "databricks73/person_without_old_jsons");
+        testGetProtocolEntry("person_without_checkpoints", "databricks73/person_without_checkpoints");
     }
 
-    private void testAllGetProtocolEntries(String tableName, String resourcePath)
+    private void testGetProtocolEntry(String tableName, String resourcePath)
             throws Exception
     {
         setupTransactionLogAccessFromResources(tableName, resourcePath);
 
-        try (Stream<ProtocolEntry> protocolEntryStream = transactionLogAccess.getProtocolEntries(SESSION, tableSnapshot)) {
-            List<ProtocolEntry> protocolEntries = protocolEntryStream.toList();
-            assertThat(protocolEntries).hasSize(1);
-            assertThat(protocolEntries.get(0).minReaderVersion()).isEqualTo(1);
-            assertThat(protocolEntries.get(0).minWriterVersion()).isEqualTo(2);
-        }
+        ProtocolEntry protocolEntry = transactionLogAccess.getProtocolEntry(SESSION, tableSnapshot);
+        assertThat(protocolEntry.minReaderVersion()).isEqualTo(1);
+        assertThat(protocolEntry.minWriterVersion()).isEqualTo(2);
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Close #24570 

Try read metadata or protocol from transaction tail backwards, otherwise read from checkpoint stream. 

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Delta Lake
* Improve query planning performance on delta tables. ({issue}`24570`)
```
