### PR TITLE
Skip non-existent MBeans in JmxRecordSetProvider

### DIFF
--- a/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxRecordSetProvider.java
+++ b/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxRecordSetProvider.java
@@ -29,6 +29,7 @@ import io.trino.spi.connector.RecordSet;
 import io.trino.spi.type.Type;
 
 import javax.management.Attribute;
+import javax.management.InstanceNotFoundException;
 import javax.management.JMException;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -228,7 +229,12 @@ public class JmxRecordSetProvider
     {
         ImmutableList.Builder<List<Object>> rows = ImmutableList.builder();
         for (String objectName : tableHandle.objectNames()) {
-            rows.add(getLiveRow(objectName, columns, 0));
+            try {
+                rows.add(getLiveRow(objectName, columns, 0));
+            }
+            catch (InstanceNotFoundException _) {
+                // Ignore if the object doesn't exist. This might happen when it exists on the coordinator but has not yet been created on the worker.
+            }
         }
         return rows.build();
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

When dynamic catalogs are enabled, and multiple catalogs use the same connector, querying a metric associated with the connector may return results only from the coordinator if not all catalogs have been used yet. This happens because the corresponding MBeans haven't been registered on the workers.

With this change, the query will return results from workers for catalogs that have already been used and whose MBeans have been registered, while gracefully skipping non-existent MBeans.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix querying non-existent JMX metrics. ({issue}`issuenumber`)
```
