### PR TITLE
Rename JsonCodec used by trino client

### DIFF
--- a/client/trino-cli/src/test/java/io/trino/cli/TestQueryRunner.java
+++ b/client/trino-cli/src/test/java/io/trino/cli/TestQueryRunner.java
@@ -18,9 +18,9 @@ import io.airlift.units.Duration;
 import io.trino.client.ClientSession;
 import io.trino.client.ClientTypeSignature;
 import io.trino.client.Column;
-import io.trino.client.JsonCodec;
 import io.trino.client.QueryResults;
 import io.trino.client.StatementStats;
+import io.trino.client.TrinoJsonCodec;
 import io.trino.client.TypedQueryData;
 import io.trino.client.uri.PropertyName;
 import io.trino.client.uri.TrinoUri;
@@ -46,7 +46,7 @@ import static com.google.common.net.HttpHeaders.SET_COOKIE;
 import static io.trino.cli.ClientOptions.OutputFormat.CSV;
 import static io.trino.cli.TerminalUtils.getTerminal;
 import static io.trino.client.ClientStandardTypes.BIGINT;
-import static io.trino.client.JsonCodec.jsonCodec;
+import static io.trino.client.TrinoJsonCodec.jsonCodec;
 import static io.trino.client.auth.external.ExternalRedirectStrategy.PRINT;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,7 +55,7 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
 @TestInstance(PER_METHOD)
 public class TestQueryRunner
 {
-    private static final JsonCodec<QueryResults> QUERY_RESULTS_CODEC = jsonCodec(QueryResults.class);
+    private static final TrinoJsonCodec<QueryResults> QUERY_RESULTS_CODEC = jsonCodec(QueryResults.class);
     private MockWebServer server;
 
     @BeforeEach

--- a/client/trino-client/src/main/java/io/trino/client/ClientTypeSignatureParameter.java
+++ b/client/trino-client/src/main/java/io/trino/client/ClientTypeSignatureParameter.java
@@ -145,7 +145,7 @@ public class ClientTypeSignatureParameter
     public static class ClientTypeSignatureParameterDeserializer
             extends JsonDeserializer<ClientTypeSignatureParameter>
     {
-        private static final ObjectMapper MAPPER = JsonCodec.OBJECT_MAPPER_SUPPLIER.get();
+        private static final ObjectMapper MAPPER = TrinoJsonCodec.OBJECT_MAPPER_SUPPLIER.get();
 
         @Override
         public ClientTypeSignatureParameter deserialize(JsonParser jp, DeserializationContext ctxt)

--- a/client/trino-client/src/main/java/io/trino/client/JsonResponse.java
+++ b/client/trino-client/src/main/java/io/trino/client/JsonResponse.java
@@ -108,7 +108,7 @@ public final class JsonResponse<T>
                 .toString();
     }
 
-    public static <T> JsonResponse<T> execute(JsonCodec<T> codec, Call.Factory client, Request request, OptionalLong materializedJsonSizeLimit)
+    public static <T> JsonResponse<T> execute(TrinoJsonCodec<T> codec, Call.Factory client, Request request, OptionalLong materializedJsonSizeLimit)
     {
         try (Response response = client.newCall(request).execute()) {
             ResponseBody responseBody = requireNonNull(response.body());

--- a/client/trino-client/src/main/java/io/trino/client/StatementClientV1.java
+++ b/client/trino-client/src/main/java/io/trino/client/StatementClientV1.java
@@ -57,8 +57,8 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.net.HttpHeaders.ACCEPT_ENCODING;
 import static com.google.common.net.HttpHeaders.USER_AGENT;
 import static io.trino.client.HttpStatusCodes.shouldRetry;
-import static io.trino.client.JsonCodec.jsonCodec;
 import static io.trino.client.ProtocolHeaders.TRINO_HEADERS;
+import static io.trino.client.TrinoJsonCodec.jsonCodec;
 import static java.lang.String.format;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
@@ -71,7 +71,7 @@ class StatementClientV1
         implements StatementClient
 {
     private static final MediaType MEDIA_TYPE_TEXT = MediaType.parse("text/plain; charset=utf-8");
-    private static final JsonCodec<QueryResults> QUERY_RESULTS_CODEC = jsonCodec(QueryResults.class);
+    private static final TrinoJsonCodec<QueryResults> QUERY_RESULTS_CODEC = jsonCodec(QueryResults.class);
 
     private static final Splitter COLLECTION_HEADER_SPLITTER = Splitter.on('=').limit(2).trimResults();
     private static final String USER_AGENT_VALUE = StatementClientV1.class.getSimpleName() +

--- a/client/trino-client/src/main/java/io/trino/client/TrinoJsonCodec.java
+++ b/client/trino-client/src/main/java/io/trino/client/TrinoJsonCodec.java
@@ -34,7 +34,7 @@ import java.util.function.Supplier;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
-public class JsonCodec<T>
+public class TrinoJsonCodec<T>
 {
     // copy of https://github.com/airlift/airlift/blob/master/json/src/main/java/io/airlift/json/ObjectMapperProvider.java
     static final Supplier<ObjectMapper> OBJECT_MAPPER_SUPPLIER = () -> {
@@ -64,16 +64,16 @@ public class JsonCodec<T>
                 .build();
     };
 
-    public static <T> JsonCodec<T> jsonCodec(Class<T> type)
+    public static <T> TrinoJsonCodec<T> jsonCodec(Class<T> type)
     {
-        return new JsonCodec<>(OBJECT_MAPPER_SUPPLIER.get(), type);
+        return new TrinoJsonCodec<>(OBJECT_MAPPER_SUPPLIER.get(), type);
     }
 
     private final ObjectMapper mapper;
     private final Type type;
     private final JavaType javaType;
 
-    private JsonCodec(ObjectMapper mapper, Type type)
+    private TrinoJsonCodec(ObjectMapper mapper, Type type)
     {
         this.mapper = requireNonNull(mapper, "mapper is null");
         this.type = requireNonNull(type, "type is null");

--- a/client/trino-client/src/main/java/io/trino/client/auth/external/HttpTokenPoller.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/external/HttpTokenPoller.java
@@ -18,8 +18,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.failsafe.Failsafe;
 import dev.failsafe.FailsafeException;
 import dev.failsafe.RetryPolicy;
-import io.trino.client.JsonCodec;
 import io.trino.client.JsonResponse;
+import io.trino.client.TrinoJsonCodec;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -36,8 +36,8 @@ import java.util.function.Supplier;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.net.HttpHeaders.USER_AGENT;
 import static io.trino.client.HttpStatusCodes.shouldRetry;
-import static io.trino.client.JsonCodec.jsonCodec;
 import static io.trino.client.JsonResponse.execute;
+import static io.trino.client.TrinoJsonCodec.jsonCodec;
 import static java.lang.String.format;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static java.net.HttpURLConnection.HTTP_OK;
@@ -47,7 +47,7 @@ import static java.util.Objects.requireNonNull;
 public class HttpTokenPoller
         implements TokenPoller
 {
-    private static final JsonCodec<TokenPollRepresentation> TOKEN_POLL_CODEC = jsonCodec(TokenPollRepresentation.class);
+    private static final TrinoJsonCodec<TokenPollRepresentation> TOKEN_POLL_CODEC = jsonCodec(TokenPollRepresentation.class);
     private static final String USER_AGENT_VALUE = "TrinoTokenPoller/" +
             firstNonNull(HttpTokenPoller.class.getPackage().getImplementationVersion(), "unknown");
 

--- a/client/trino-client/src/test/java/io/trino/client/TestQueryResults.java
+++ b/client/trino-client/src/test/java/io/trino/client/TestQueryResults.java
@@ -18,13 +18,13 @@ import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.google.common.base.Strings;
 import org.junit.jupiter.api.Test;
 
-import static io.trino.client.JsonCodec.jsonCodec;
+import static io.trino.client.TrinoJsonCodec.jsonCodec;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestQueryResults
 {
-    private static final JsonCodec<QueryResults> QUERY_RESULTS_CODEC = jsonCodec(QueryResults.class);
+    private static final TrinoJsonCodec<QueryResults> QUERY_RESULTS_CODEC = jsonCodec(QueryResults.class);
 
     private static final String GOLDEN_VALUE = "{\n" +
             "  \"id\" : \"20160128_214710_00012_rk68b\",\n" +

--- a/client/trino-client/src/test/java/io/trino/client/TestRetry.java
+++ b/client/trino-client/src/test/java/io/trino/client/TestRetry.java
@@ -34,8 +34,8 @@ import java.util.stream.Stream;
 
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static com.google.common.net.MediaType.JSON_UTF_8;
-import static io.trino.client.JsonCodec.jsonCodec;
 import static io.trino.client.StatementClientFactory.newStatementClient;
+import static io.trino.client.TrinoJsonCodec.jsonCodec;
 import static io.trino.spi.type.StandardTypes.INTEGER;
 import static io.trino.spi.type.StandardTypes.VARCHAR;
 import static java.lang.String.format;
@@ -48,7 +48,7 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
 public class TestRetry
 {
     private MockWebServer server;
-    private static final JsonCodec<QueryResults> QUERY_RESULTS_CODEC = jsonCodec(QueryResults.class);
+    private static final TrinoJsonCodec<QueryResults> QUERY_RESULTS_CODEC = jsonCodec(QueryResults.class);
 
     @BeforeEach
     public void setup()

--- a/client/trino-client/src/test/java/io/trino/client/TestTrinoJsonCodec.java
+++ b/client/trino-client/src/test/java/io/trino/client/TestTrinoJsonCodec.java
@@ -18,18 +18,18 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 
-import static io.trino.client.JsonCodec.jsonCodec;
+import static io.trino.client.TrinoJsonCodec.jsonCodec;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class TestJsonCodec
+public class TestTrinoJsonCodec
 {
     @Test
     public void testTrailingContent()
             throws Exception
     {
-        JsonCodec<ClientTypeSignature> codec = jsonCodec(ClientTypeSignature.class);
+        TrinoJsonCodec<ClientTypeSignature> codec = jsonCodec(ClientTypeSignature.class);
 
         String json = "{\"rawType\":\"bigint\",\"arguments\":[]}";
         assertThat(codec.fromJson(json).getRawType()).isEqualTo("bigint");

--- a/core/trino-main/src/test/java/io/trino/server/protocol/TestQueryDataSerialization.java
+++ b/core/trino-main/src/test/java/io/trino/server/protocol/TestQueryDataSerialization.java
@@ -16,15 +16,16 @@ package io.trino.server.protocol;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.airlift.json.JsonCodec;
 import io.airlift.json.JsonCodecFactory;
 import io.airlift.json.ObjectMapperProvider;
 import io.trino.client.ClientTypeSignature;
 import io.trino.client.Column;
-import io.trino.client.JsonCodec;
 import io.trino.client.QueryData;
 import io.trino.client.QueryResults;
 import io.trino.client.ResultRowsDecoder;
 import io.trino.client.StatementStats;
+import io.trino.client.TrinoJsonCodec;
 import io.trino.client.TypedQueryData;
 import io.trino.client.spooling.DataAttributes;
 import io.trino.client.spooling.EncodedQueryData;
@@ -38,7 +39,7 @@ import java.util.OptionalDouble;
 import java.util.Set;
 
 import static io.trino.client.ClientStandardTypes.BIGINT;
-import static io.trino.client.JsonCodec.jsonCodec;
+import static io.trino.client.TrinoJsonCodec.jsonCodec;
 import static io.trino.client.spooling.DataAttribute.ROWS_COUNT;
 import static io.trino.client.spooling.DataAttribute.ROW_OFFSET;
 import static io.trino.client.spooling.DataAttribute.SCHEMA;
@@ -54,8 +55,8 @@ import static org.assertj.core.api.Fail.fail;
 public class TestQueryDataSerialization
 {
     private static final List<Column> COLUMNS_LIST = ImmutableList.of(new Column("_col0", "bigint", new ClientTypeSignature("bigint")));
-    private static final JsonCodec<QueryResults> CLIENT_CODEC = jsonCodec(QueryResults.class);
-    private static final io.airlift.json.JsonCodec<QueryResults> SERVER_CODEC = new JsonCodecFactory(new ObjectMapperProvider()
+    private static final TrinoJsonCodec<QueryResults> CLIENT_CODEC = jsonCodec(QueryResults.class);
+    private static final JsonCodec<QueryResults> SERVER_CODEC = new JsonCodecFactory(new ObjectMapperProvider()
             .withModules(Set.of(new QueryDataJacksonModule())))
             .jsonCodec(QueryResults.class);
 

--- a/core/trino-main/src/test/java/io/trino/server/protocol/TestQueryResultsSerialization.java
+++ b/core/trino-main/src/test/java/io/trino/server/protocol/TestQueryResultsSerialization.java
@@ -15,15 +15,16 @@ package io.trino.server.protocol;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableList;
+import io.airlift.json.JsonCodec;
 import io.airlift.json.JsonCodecFactory;
 import io.airlift.json.ObjectMapperProvider;
 import io.trino.client.ClientTypeSignature;
 import io.trino.client.Column;
-import io.trino.client.JsonCodec;
 import io.trino.client.QueryData;
 import io.trino.client.QueryResults;
 import io.trino.client.ResultRowsDecoder;
 import io.trino.client.StatementStats;
+import io.trino.client.TrinoJsonCodec;
 import io.trino.client.TypedQueryData;
 import io.trino.server.protocol.spooling.QueryDataJacksonModule;
 import org.junit.jupiter.api.Test;
@@ -35,7 +36,7 @@ import java.util.OptionalDouble;
 import java.util.Set;
 
 import static io.trino.client.ClientStandardTypes.BIGINT;
-import static io.trino.client.JsonCodec.jsonCodec;
+import static io.trino.client.TrinoJsonCodec.jsonCodec;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -45,11 +46,11 @@ public class TestQueryResultsSerialization
     private static final List<Column> COLUMNS = ImmutableList.of(new Column("_col0", BIGINT, new ClientTypeSignature("bigint")));
 
     // As close as possible to the server mapper (client mapper differs)
-    private static final io.airlift.json.JsonCodec<QueryResults> SERVER_CODEC = new JsonCodecFactory(new ObjectMapperProvider()
+    private static final JsonCodec<QueryResults> SERVER_CODEC = new JsonCodecFactory(new ObjectMapperProvider()
             .withModules(Set.of(new QueryDataJacksonModule())))
             .jsonCodec(QueryResults.class);
 
-    private static final JsonCodec<QueryResults> CLIENT_CODEC = jsonCodec(QueryResults.class);
+    private static final TrinoJsonCodec<QueryResults> CLIENT_CODEC = jsonCodec(QueryResults.class);
 
     @Test
     public void testNullDataSerialization()

--- a/testing/trino-testing/pom.xml
+++ b/testing/trino-testing/pom.xml
@@ -19,11 +19,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_annotations</artifactId>
         </dependency>
@@ -61,6 +56,11 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>http-server</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>json</artifactId>
         </dependency>
 
         <dependency>

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestingTrinoClient.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestingTrinoClient.java
@@ -140,7 +140,7 @@ public abstract class AbstractTestingTrinoClient<T>
             throw new QueryFailedException(queryId, "Query failed: " + results.getError().getMessage());
 
             // dump query info to console for debugging (NOTE: not pretty printed)
-            // JsonCodec<QueryInfo> queryInfoJsonCodec = createCodecFactory().prettyPrint().jsonCodec(QueryInfo.class);
+            // TrinoJsonCodec<QueryInfo> queryInfoJsonCodec = createCodecFactory().prettyPrint().jsonCodec(QueryInfo.class);
             // log.info("\n" + queryInfoJsonCodec.toJson(queryInfo));
         }
     }

--- a/testing/trino-testing/src/main/java/io/trino/testing/LocalSpoolingManager.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/LocalSpoolingManager.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.errorprone.annotations.DoNotCall;
 import io.airlift.slice.Slice;
-import io.trino.client.JsonCodec;
+import io.trino.client.TrinoJsonCodec;
 import io.trino.spi.Plugin;
 import io.trino.spi.spool.SpooledLocation;
 import io.trino.spi.spool.SpooledLocation.DirectLocation;
@@ -47,14 +47,14 @@ import java.util.concurrent.atomic.AtomicLong;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static io.airlift.slice.Slices.utf8Slice;
-import static io.trino.client.JsonCodec.jsonCodec;
+import static io.trino.client.TrinoJsonCodec.jsonCodec;
 import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static java.util.Objects.requireNonNull;
 
 public class LocalSpoolingManager
         implements SpoolingManager
 {
-    private static final JsonCodec<LocalSpooledSegmentHandle> HANDLE_CODEC = jsonCodec(LocalSpooledSegmentHandle.class);
+    private static final TrinoJsonCodec<LocalSpooledSegmentHandle> HANDLE_CODEC = jsonCodec(LocalSpooledSegmentHandle.class);
     private final Path rootPath;
     private final AtomicLong segmentId = new AtomicLong();
 

--- a/testing/trino-testing/src/main/java/io/trino/testing/LocalSpoolingManager.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/LocalSpoolingManager.java
@@ -16,10 +16,9 @@ package io.trino.testing;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.errorprone.annotations.DoNotCall;
+import io.airlift.json.JsonCodec;
 import io.airlift.slice.Slice;
-import io.trino.client.TrinoJsonCodec;
 import io.trino.spi.Plugin;
 import io.trino.spi.spool.SpooledLocation;
 import io.trino.spi.spool.SpooledLocation.DirectLocation;
@@ -46,15 +45,15 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.io.MoreFiles.deleteRecursively;
+import static io.airlift.json.JsonCodec.jsonCodec;
 import static io.airlift.slice.Slices.utf8Slice;
-import static io.trino.client.TrinoJsonCodec.jsonCodec;
 import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static java.util.Objects.requireNonNull;
 
 public class LocalSpoolingManager
         implements SpoolingManager
 {
-    private static final TrinoJsonCodec<LocalSpooledSegmentHandle> HANDLE_CODEC = jsonCodec(LocalSpooledSegmentHandle.class);
+    private static final JsonCodec<LocalSpooledSegmentHandle> HANDLE_CODEC = jsonCodec(LocalSpooledSegmentHandle.class);
     private final Path rootPath;
     private final AtomicLong segmentId = new AtomicLong();
 
@@ -96,12 +95,7 @@ public class LocalSpoolingManager
     @Override
     public SpooledSegmentHandle handle(Slice identifier, Map<String, List<String>> headers)
     {
-        try {
-            return HANDLE_CODEC.fromJson(identifier.toStringUtf8());
-        }
-        catch (JsonProcessingException e) {
-            throw new UncheckedIOException(e);
-        }
+        return HANDLE_CODEC.fromJson(identifier.toStringUtf8());
     }
 
     @Override


### PR DESCRIPTION
Having both io.trino.client.JsonCodec and io.airlift.json.JsonCodec resulted in confusing mistakes.
