### PR TITLE
Prohibit use of `Files` util class from AssertJ to create temporary directories

### DIFF
--- a/.mvn/modernizer/violations.xml
+++ b/.mvn/modernizer/violations.xml
@@ -323,4 +323,25 @@
         <version>1.8</version>
         <comment>Table type is nullable in Glue model, which is too easy to forget about. Prefer GlueConverter.getTableTypeNullable</comment>
     </violation>
+
+    <violation>
+        <name>org/assertj/core/util/Files.newTemporaryFile:()Ljava/io/File;</name>
+        <version>1.1</version>
+        <comment>Use @TempDir instead</comment>
+    </violation>
+    <violation>
+        <name>org/assertj/core/util/Files.newTemporaryFolder:()Ljava/io/File;</name>
+        <version>1.1</version>
+        <comment>Use @TempDir instead</comment>
+    </violation>
+    <violation>
+        <name>org/assertj/core/util/Files.temporaryFolder:()Ljava/io/File;</name>
+        <version>1.1</version>
+        <comment>Use @TempDir instead</comment>
+    </violation>
+    <violation>
+        <name>org/assertj/core/util/Files.temporaryFolderPath:()Ljava/lang/String;</name>
+        <version>1.1</version>
+        <comment>Use @TempDir instead</comment>
+    </violation>
 </modernizer>

--- a/core/trino-main/src/test/java/io/trino/security/TestFileBasedSystemAccessControl.java
+++ b/core/trino-main/src/test/java/io/trino/security/TestFileBasedSystemAccessControl.java
@@ -34,18 +34,20 @@ import io.trino.spi.security.Identity;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.transaction.TransactionManager;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import javax.security.auth.kerberos.KerberosPrincipal;
 
-import java.io.File;
 import java.io.UncheckedIOException;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static com.google.common.io.Files.copy;
 import static com.google.common.io.Resources.getResource;
 import static io.trino.plugin.base.security.FileBasedAccessControlConfig.SECURITY_CONFIG_FILE;
 import static io.trino.plugin.base.security.FileBasedAccessControlConfig.SECURITY_REFRESH_PERIOD;
@@ -55,9 +57,9 @@ import static io.trino.testing.TestingEventListenerManager.emptyEventListenerMan
 import static io.trino.testing.TransactionBuilder.transaction;
 import static io.trino.transaction.InMemoryTransactionManager.createTestTransactionManager;
 import static java.lang.Thread.sleep;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.util.Files.newTemporaryFile;
 
 public class TestFileBasedSystemAccessControl
 {
@@ -86,6 +88,7 @@ public class TestFileBasedSystemAccessControl
 
     @Test
     public void testCanImpersonateUserOperations()
+            throws Exception
     {
         TransactionManager transactionManager = createTestTransactionManager();
         AccessControlManager accessControlManager = newAccessControlManager(transactionManager, "catalog_impersonation.json");
@@ -151,7 +154,7 @@ public class TestFileBasedSystemAccessControl
                 DefaultSystemAccessControl.NAME);
         accessControlManager.loadSystemAccessControl(
                 FileBasedSystemAccessControl.NAME,
-                ImmutableMap.of("security.config-file", new File("../../docs/src/main/sphinx/security/user-impersonation.json").getAbsolutePath()));
+                ImmutableMap.of("security.config-file", Paths.get("../../docs/src/main/sphinx/security/user-impersonation.json").toAbsolutePath().toString()));
 
         accessControlManager.checkCanImpersonateUser(admin, "charlie");
         assertThatThrownBy(() -> accessControlManager.checkCanImpersonateUser(admin, "bob"))
@@ -166,6 +169,7 @@ public class TestFileBasedSystemAccessControl
 
     @Test
     public void testCanSetUserOperations()
+            throws Exception
     {
         TransactionManager transactionManager = createTestTransactionManager();
         AccessControlManager accessControlManager = newAccessControlManager(transactionManager, "catalog_principal.json");
@@ -193,6 +197,7 @@ public class TestFileBasedSystemAccessControl
 
     @Test
     public void testSystemInformation()
+            throws Exception
     {
         TransactionManager transactionManager = createTestTransactionManager();
         Metadata metadata = TestMetadataManager.builder().withTransactionManager(transactionManager).build();
@@ -222,6 +227,7 @@ public class TestFileBasedSystemAccessControl
 
     @Test
     public void testCatalogOperations()
+            throws Exception
     {
         TransactionManager transactionManager = createTestTransactionManager();
         Metadata metadata = TestMetadataManager.builder().withTransactionManager(transactionManager).build();
@@ -241,6 +247,7 @@ public class TestFileBasedSystemAccessControl
 
     @Test
     public void testCatalogOperationsReadOnly()
+            throws Exception
     {
         TransactionManager transactionManager = createTestTransactionManager();
         Metadata metadata = TestMetadataManager.builder().withTransactionManager(transactionManager).build();
@@ -260,6 +267,7 @@ public class TestFileBasedSystemAccessControl
 
     @Test
     public void testSchemaOperations()
+            throws Exception
     {
         TransactionManager transactionManager = createTestTransactionManager();
         Metadata metadata = TestMetadataManager.builder().withTransactionManager(transactionManager).build();
@@ -284,6 +292,7 @@ public class TestFileBasedSystemAccessControl
 
     @Test
     public void testSchemaOperationsReadOnly()
+            throws Exception
     {
         TransactionManager transactionManager = createTestTransactionManager();
         Metadata metadata = TestMetadataManager.builder().withTransactionManager(transactionManager).build();
@@ -321,6 +330,7 @@ public class TestFileBasedSystemAccessControl
 
     @Test
     public void testTableOperations()
+            throws Exception
     {
         TransactionManager transactionManager = createTestTransactionManager();
         Metadata metadata = TestMetadataManager.builder().withTransactionManager(transactionManager).build();
@@ -470,6 +480,7 @@ public class TestFileBasedSystemAccessControl
 
     @Test
     public void testTableOperationsReadOnly()
+            throws Exception
     {
         TransactionManager transactionManager = createTestTransactionManager();
         Metadata metadata = TestMetadataManager.builder().withTransactionManager(transactionManager).build();
@@ -532,6 +543,7 @@ public class TestFileBasedSystemAccessControl
 
     @Test
     public void testViewOperations()
+            throws Exception
     {
         TransactionManager transactionManager = createTestTransactionManager();
         Metadata metadata = TestMetadataManager.builder().withTransactionManager(transactionManager).build();
@@ -649,6 +661,7 @@ public class TestFileBasedSystemAccessControl
 
     @Test
     public void testViewOperationsReadOnly()
+            throws Exception
     {
         TransactionManager transactionManager = createTestTransactionManager();
         Metadata metadata = TestMetadataManager.builder().withTransactionManager(transactionManager).build();
@@ -689,6 +702,7 @@ public class TestFileBasedSystemAccessControl
 
     @Test
     public void testMaterializedViewAccess()
+            throws Exception
     {
         TransactionManager transactionManager = createTestTransactionManager();
         Metadata metadata = TestMetadataManager.builder().withTransactionManager(transactionManager).build();
@@ -748,6 +762,7 @@ public class TestFileBasedSystemAccessControl
 
     @Test
     public void testReadOnlyMaterializedViewAccess()
+            throws Exception
     {
         TransactionManager transactionManager = createTestTransactionManager();
         Metadata metadata = TestMetadataManager.builder().withTransactionManager(transactionManager).build();
@@ -797,7 +812,7 @@ public class TestFileBasedSystemAccessControl
     }
 
     @Test
-    public void testRefreshing()
+    public void testRefreshing(@TempDir Path tempDir)
             throws Exception
     {
         TransactionManager transactionManager = createTestTransactionManager();
@@ -810,12 +825,11 @@ public class TestFileBasedSystemAccessControl
                 OpenTelemetry.noop(),
                 new SecretsResolver(ImmutableMap.of()),
                 DefaultSystemAccessControl.NAME);
-        File configFile = newTemporaryFile();
-        configFile.deleteOnExit();
-        copy(new File(getResourcePath("catalog.json")), configFile);
+        Path configFile = tempDir.resolve("catalog.json");
+        Files.copy(getResourcePath("catalog.json"), configFile, REPLACE_EXISTING);
 
         accessControlManager.loadSystemAccessControl(FileBasedSystemAccessControl.NAME, ImmutableMap.of(
-                SECURITY_CONFIG_FILE, configFile.getAbsolutePath(),
+                SECURITY_CONFIG_FILE, configFile.toAbsolutePath().toString(),
                 SECURITY_REFRESH_PERIOD, "1ms"));
 
         transaction(transactionManager, metadata, accessControlManager)
@@ -825,7 +839,7 @@ public class TestFileBasedSystemAccessControl
                     accessControlManager.checkCanCreateView(new SecurityContext(transactionId, alice, queryId, queryStart), aliceView);
                 });
 
-        copy(new File(getResourcePath("security-config-file-with-unknown-rules.json")), configFile);
+        Files.copy(getResourcePath("security-config-file-with-unknown-rules.json"), configFile, REPLACE_EXISTING);
         sleep(2);
 
         assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager)
@@ -842,7 +856,7 @@ public class TestFileBasedSystemAccessControl
                 .isInstanceOf(UncheckedIOException.class)
                 .hasMessageStartingWith("Failed to convert JSON tree node");
 
-        copy(new File(getResourcePath("catalog.json")), configFile);
+        Files.copy(getResourcePath("catalog.json"), configFile, REPLACE_EXISTING);
         sleep(2);
 
         transaction(transactionManager, metadata, accessControlManager)
@@ -868,6 +882,7 @@ public class TestFileBasedSystemAccessControl
     }
 
     private AccessControlManager newAccessControlManager(TransactionManager transactionManager, String resourceName)
+            throws URISyntaxException
     {
         AccessControlManager accessControlManager = new AccessControlManager(
                 NodeVersion.UNKNOWN,
@@ -878,25 +893,21 @@ public class TestFileBasedSystemAccessControl
                 new SecretsResolver(ImmutableMap.of()),
                 DefaultSystemAccessControl.NAME);
 
-        accessControlManager.loadSystemAccessControl(FileBasedSystemAccessControl.NAME, ImmutableMap.of("security.config-file", getResourcePath(resourceName)));
+        accessControlManager.loadSystemAccessControl(FileBasedSystemAccessControl.NAME, ImmutableMap.of("security.config-file", getResourcePath(resourceName).toString()));
 
         return accessControlManager;
     }
 
-    private String getResourcePath(String resourceName)
+    private Path getResourcePath(String resourceName)
+            throws URISyntaxException
     {
-        try {
-            return new File(getResource(resourceName).toURI()).getPath();
-        }
-        catch (URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
+        return Paths.get(getResource(resourceName).toURI());
     }
 
     @Test
     public void parseUnknownRules()
     {
-        assertThatThrownBy(() -> parse(getResourcePath("security-config-file-with-unknown-rules.json")))
+        assertThatThrownBy(() -> parse(getResourcePath("security-config-file-with-unknown-rules.json").toString()))
                 .hasMessageContaining("Failed to convert JSON tree node");
     }
 

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestFileBasedAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestFileBasedAccessControl.java
@@ -16,16 +16,16 @@ package io.trino.plugin.base.security;
 import com.google.common.collect.ImmutableMap;
 import io.trino.spi.connector.ConnectorAccessControl;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.Map;
 
 public class TestFileBasedAccessControl
         extends BaseFileBasedConnectorAccessControlTest
 {
     @Override
-    protected ConnectorAccessControl createAccessControl(File configFile, Map<String, String> properties)
+    protected ConnectorAccessControl createAccessControl(Path configFile, Map<String, String> properties)
     {
         return createAccessControl(ImmutableMap.<String, String>builder().putAll(properties).put("security.config-file",
-                configFile.getAbsolutePath()).buildOrThrow());
+                configFile.toAbsolutePath().toString()).buildOrThrow());
     }
 }

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestFileBasedSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestFileBasedSystemAccessControl.java
@@ -16,18 +16,18 @@ package io.trino.plugin.base.security;
 import com.google.common.collect.ImmutableMap;
 import io.trino.spi.security.SystemAccessControl;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.Map;
 
 public class TestFileBasedSystemAccessControl
         extends BaseFileBasedSystemAccessControlTest
 {
     @Override
-    protected SystemAccessControl newFileBasedSystemAccessControl(File configFile, Map<String, String> properties)
+    protected SystemAccessControl newFileBasedSystemAccessControl(Path configFile, Map<String, String> properties)
     {
         return newFileBasedSystemAccessControl(ImmutableMap.<String, String>builder()
                 .putAll(properties)
-                .put("security.config-file", configFile.getAbsolutePath())
+                .put("security.config-file", configFile.toAbsolutePath().toString())
                 .put("bootstrap.quiet", "true")
                 .buildOrThrow());
     }

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestHttpFileBasedAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestHttpFileBasedAccessControl.java
@@ -20,8 +20,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Map;
 
 import static io.airlift.testing.Closeables.closeAll;
@@ -43,15 +43,10 @@ public class TestHttpFileBasedAccessControl
     }
 
     @Override
-    protected ConnectorAccessControl createAccessControl(File configFile, Map<String, String> properties)
+    protected ConnectorAccessControl createAccessControl(Path configFile, Map<String, String> properties)
     {
-        try {
-            String dataUrl = testingHttpServer.resource(configFile.getCanonicalFile().getAbsolutePath()).toString();
-            return createAccessControl(ImmutableMap.<String, String>builder().putAll(properties).put("security.config-file",
-                            dataUrl).buildOrThrow());
-        }
-        catch (IOException e) {
-            throw new RuntimeException("Error while creating SystemAccessControl", e);
-        }
+        String dataUrl = testingHttpServer.resource(configFile.normalize().toAbsolutePath().toString()).toString();
+        return createAccessControl(ImmutableMap.<String, String>builder().putAll(properties).put("security.config-file",
+                        dataUrl).buildOrThrow());
     }
 }

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestHttpFileBasedSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestHttpFileBasedSystemAccessControl.java
@@ -20,8 +20,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Map;
 
 import static io.airlift.testing.Closeables.closeAll;
@@ -43,14 +43,9 @@ public class TestHttpFileBasedSystemAccessControl
     }
 
     @Override
-    protected SystemAccessControl newFileBasedSystemAccessControl(File configFile, Map<String, String> properties)
+    protected SystemAccessControl newFileBasedSystemAccessControl(Path configFile, Map<String, String> properties)
     {
-        try {
-            String dataUrl = testingHttpServer.resource(configFile.getCanonicalFile().getAbsolutePath()).toString();
-            return newFileBasedSystemAccessControl(ImmutableMap.<String, String>builder().putAll(properties).put("security.config-file", dataUrl).buildOrThrow());
-        }
-        catch (IOException e) {
-            throw new RuntimeException("Error while creating SystemAccessControl", e);
-        }
+        String dataUrl = testingHttpServer.resource(configFile.normalize().toAbsolutePath().toString()).toString();
+        return newFileBasedSystemAccessControl(ImmutableMap.<String, String>builder().putAll(properties).put("security.config-file", dataUrl).buildOrThrow());
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
@@ -35,9 +35,9 @@ import io.trino.testing.containers.Minio;
 import io.trino.tpch.TpchTable;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.rest.DelegatingRestSessionCatalog;
-import org.assertj.core.util.Files;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
@@ -199,8 +199,8 @@ public final class IcebergQueryRunner
         public static void main(String[] args)
                 throws Exception
         {
-            File warehouseLocation = Files.newTemporaryFolder();
-            warehouseLocation.deleteOnExit();
+            Path warehouseLocation = Files.createTempDirectory(null);
+            warehouseLocation.toFile().deleteOnExit();
 
             Catalog backend = backendCatalog(warehouseLocation);
 
@@ -213,7 +213,7 @@ public final class IcebergQueryRunner
 
             @SuppressWarnings("resource")
             QueryRunner queryRunner = icebergQueryRunnerMainBuilder()
-                    .setBaseDataDir(Optional.of(warehouseLocation.toPath()))
+                    .setBaseDataDir(Optional.of(warehouseLocation))
                     .setIcebergProperties(ImmutableMap.of(
                             "iceberg.catalog.type", "rest",
                             "iceberg.rest-catalog.uri", testServer.getBaseUrl().toString()))
@@ -233,15 +233,15 @@ public final class IcebergQueryRunner
         public static void main(String[] args)
                 throws Exception
         {
-            File warehouseLocation = Files.newTemporaryFolder();
-            warehouseLocation.deleteOnExit();
+            Path warehouseLocation = Files.createTempDirectory(null);
+            warehouseLocation.toFile().deleteOnExit();
 
             @SuppressWarnings("resource")
-            TestingPolarisCatalog polarisCatalog = new TestingPolarisCatalog(warehouseLocation.getPath());
+            TestingPolarisCatalog polarisCatalog = new TestingPolarisCatalog(warehouseLocation.toString());
 
             @SuppressWarnings("resource")
             QueryRunner queryRunner = icebergQueryRunnerMainBuilder()
-                    .setBaseDataDir(Optional.of(warehouseLocation.toPath()))
+                    .setBaseDataDir(Optional.of(warehouseLocation))
                     .addIcebergProperty("iceberg.catalog.type", "rest")
                     .addIcebergProperty("iceberg.rest-catalog.uri", polarisCatalog.restUri() + "/api/catalog")
                     .addIcebergProperty("iceberg.rest-catalog.warehouse", TestingPolarisCatalog.WAREHOUSE)
@@ -264,8 +264,8 @@ public final class IcebergQueryRunner
         public static void main(String[] args)
                 throws Exception
         {
-            File warehouseLocation = Files.newTemporaryFolder();
-            warehouseLocation.deleteOnExit();
+            Path warehouseLocation = Files.createTempDirectory(null);
+            warehouseLocation.toFile().deleteOnExit();
 
             @SuppressWarnings("resource")
             UnityCatalogContainer unityCatalog = new UnityCatalogContainer("unity", "tpch");
@@ -273,7 +273,7 @@ public final class IcebergQueryRunner
             @SuppressWarnings("resource")
             QueryRunner queryRunner = IcebergQueryRunner.builder()
                     .addCoordinatorProperty("http-server.http.port", "8080")
-                    .setBaseDataDir(Optional.of(warehouseLocation.toPath()))
+                    .setBaseDataDir(Optional.of(warehouseLocation))
                     .addIcebergProperty("iceberg.security", "read_only")
                     .addIcebergProperty("iceberg.catalog.type", "rest")
                     .addIcebergProperty("iceberg.rest-catalog.uri", unityCatalog.uri() + "/iceberg")
@@ -447,8 +447,8 @@ public final class IcebergQueryRunner
         public static void main(String[] args)
                 throws Exception
         {
-            File warehouseLocation = Files.newTemporaryFolder();
-            warehouseLocation.deleteOnExit();
+            Path warehouseLocation = Files.createTempDirectory(null);
+            warehouseLocation.toFile().deleteOnExit();
 
             TestingIcebergJdbcServer server = new TestingIcebergJdbcServer();
 
@@ -461,7 +461,7 @@ public final class IcebergQueryRunner
                             .put("iceberg.jdbc-catalog.connection-user", USER)
                             .put("iceberg.jdbc-catalog.connection-password", PASSWORD)
                             .put("iceberg.jdbc-catalog.catalog-name", "tpch")
-                            .put("iceberg.jdbc-catalog.default-warehouse-dir", warehouseLocation.getAbsolutePath())
+                            .put("iceberg.jdbc-catalog.default-warehouse-dir", warehouseLocation.toAbsolutePath().toString())
                             .buildOrThrow())
                     .setInitialTables(TpchTable.getTables())
                     .build();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/BaseTrinoCatalogTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/BaseTrinoCatalogTest.java
@@ -75,7 +75,8 @@ public abstract class BaseTrinoCatalogTest
 {
     private static final Logger LOG = Logger.get(BaseTrinoCatalogTest.class);
 
-    protected abstract TrinoCatalog createTrinoCatalog(boolean useUniqueTableLocations);
+    protected abstract TrinoCatalog createTrinoCatalog(boolean useUniqueTableLocations)
+            throws IOException;
 
     protected Map<String, Object> defaultNamespaceProperties(String newNamespaceName)
     {
@@ -84,6 +85,7 @@ public abstract class BaseTrinoCatalogTest
 
     @Test
     public void testCreateNamespaceWithLocation()
+            throws Exception
     {
         TrinoCatalog catalog = createTrinoCatalog(false);
         String namespace = "test_create_namespace_with_location_" + randomNameSuffix();
@@ -100,6 +102,7 @@ public abstract class BaseTrinoCatalogTest
 
     @Test
     public void testNonLowercaseNamespace()
+            throws Exception
     {
         TrinoCatalog catalog = createTrinoCatalog(false);
 
@@ -313,6 +316,7 @@ public abstract class BaseTrinoCatalogTest
 
     @Test
     public void testUseUniqueTableLocations()
+            throws Exception
     {
         TrinoCatalog catalog = createTrinoCatalog(true);
         String namespace = "test_unique_table_locations_" + randomNameSuffix();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergPolarisCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergPolarisCatalogConnectorSmokeTest.java
@@ -24,15 +24,14 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
 import org.apache.iceberg.BaseTable;
-import org.assertj.core.util.Files;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Isolated;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
 
@@ -54,7 +53,7 @@ final class TestIcebergPolarisCatalogConnectorSmokeTest
         extends BaseIcebergConnectorSmokeTest
 {
     private TestingPolarisCatalog polarisCatalog;
-    private File warehouseLocation;
+    private Path warehouseLocation;
 
     public TestIcebergPolarisCatalogConnectorSmokeTest()
     {
@@ -75,11 +74,11 @@ final class TestIcebergPolarisCatalogConnectorSmokeTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        warehouseLocation = Files.newTemporaryFolder();
-        polarisCatalog = closeAfterClass(new TestingPolarisCatalog(warehouseLocation.getPath()));
+        warehouseLocation = Files.createTempDirectory(null);
+        polarisCatalog = closeAfterClass(new TestingPolarisCatalog(warehouseLocation.toString()));
 
         return IcebergQueryRunner.builder()
-                .setBaseDataDir(Optional.of(warehouseLocation.toPath()))
+                .setBaseDataDir(Optional.of(warehouseLocation))
                 .addIcebergProperty("iceberg.file-format", format.name())
                 .addIcebergProperty("iceberg.register-table-procedure.enabled", "true")
                 .addIcebergProperty("iceberg.writer-sort-buffer-size", "1MB")

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogCaseInsensitiveMapping.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogCaseInsensitiveMapping.java
@@ -24,15 +24,14 @@ import org.apache.iceberg.jdbc.JdbcCatalog;
 import org.apache.iceberg.rest.DelegatingRestSessionCatalog;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.view.ViewBuilder;
-import org.assertj.core.util.Files;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
@@ -64,8 +63,8 @@ final class TestIcebergRestCatalogCaseInsensitiveMapping
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        File warehouseLocation = Files.newTemporaryFolder();
-        closeAfterClass(() -> deleteRecursively(warehouseLocation.toPath(), ALLOW_INSECURE));
+        Path warehouseLocation = Files.createTempDirectory(null);
+        closeAfterClass(() -> deleteRecursively(warehouseLocation, ALLOW_INSECURE));
 
         backend = closeAfterClass((JdbcCatalog) backendCatalog(warehouseLocation));
 
@@ -78,7 +77,7 @@ final class TestIcebergRestCatalogCaseInsensitiveMapping
         closeAfterClass(testServer::stop);
 
         return IcebergQueryRunner.builder(LOWERCASE_SCHEMA)
-                .setBaseDataDir(Optional.of(warehouseLocation.toPath()))
+                .setBaseDataDir(Optional.of(warehouseLocation))
                 .addIcebergProperty("iceberg.catalog.type", "rest")
                 .addIcebergProperty("iceberg.rest-catalog.uri", testServer.getBaseUrl().toString())
                 .addIcebergProperty("iceberg.rest-catalog.case-insensitive-name-matching", "true")

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogNestedNamespaceConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogNestedNamespaceConnectorSmokeTest.java
@@ -29,12 +29,11 @@ import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.jdbc.JdbcCatalog;
 import org.apache.iceberg.rest.DelegatingRestSessionCatalog;
-import org.assertj.core.util.Files;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
@@ -56,7 +55,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 final class TestIcebergRestCatalogNestedNamespaceConnectorSmokeTest
         extends BaseIcebergConnectorSmokeTest
 {
-    private File warehouseLocation;
+    private Path warehouseLocation;
     private JdbcCatalog backend;
 
     public TestIcebergRestCatalogNestedNamespaceConnectorSmokeTest()
@@ -77,8 +76,8 @@ final class TestIcebergRestCatalogNestedNamespaceConnectorSmokeTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        warehouseLocation = Files.newTemporaryFolder();
-        closeAfterClass(() -> deleteRecursively(warehouseLocation.toPath(), ALLOW_INSECURE));
+        warehouseLocation = Files.createTempDirectory(null);
+        closeAfterClass(() -> deleteRecursively(warehouseLocation, ALLOW_INSECURE));
 
         backend = closeAfterClass((JdbcCatalog) backendCatalog(warehouseLocation));
 
@@ -95,7 +94,7 @@ final class TestIcebergRestCatalogNestedNamespaceConnectorSmokeTest
                         .setCatalog(ICEBERG_CATALOG)
                         .setSchema(nestedSchema)
                         .build())
-                .setBaseDataDir(Optional.of(warehouseLocation.toPath()))
+                .setBaseDataDir(Optional.of(warehouseLocation))
                 .build();
 
         Map<String, String> nestedNamespaceDisabled = ImmutableMap.<String, String>builder()

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergTrinoRestCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergTrinoRestCatalogConnectorSmokeTest.java
@@ -29,14 +29,13 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.jdbc.JdbcCatalog;
 import org.apache.iceberg.rest.DelegatingRestSessionCatalog;
 import org.apache.iceberg.types.Types;
-import org.assertj.core.util.Files;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
 
@@ -57,7 +56,7 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 public class TestIcebergTrinoRestCatalogConnectorSmokeTest
         extends BaseIcebergConnectorSmokeTest
 {
-    private File warehouseLocation;
+    private Path warehouseLocation;
 
     private JdbcCatalog backend;
 
@@ -81,8 +80,8 @@ public class TestIcebergTrinoRestCatalogConnectorSmokeTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        warehouseLocation = Files.newTemporaryFolder();
-        closeAfterClass(() -> deleteRecursively(warehouseLocation.toPath(), ALLOW_INSECURE));
+        warehouseLocation = Files.createTempDirectory(null);
+        closeAfterClass(() -> deleteRecursively(warehouseLocation, ALLOW_INSECURE));
 
         backend = closeAfterClass((JdbcCatalog) backendCatalog(warehouseLocation));
 
@@ -95,7 +94,7 @@ public class TestIcebergTrinoRestCatalogConnectorSmokeTest
         closeAfterClass(testServer::stop);
 
         return IcebergQueryRunner.builder()
-                .setBaseDataDir(Optional.of(warehouseLocation.toPath()))
+                .setBaseDataDir(Optional.of(warehouseLocation))
                 .setIcebergProperties(
                         ImmutableMap.<String, String>builder()
                                 .put("iceberg.file-format", format.name())

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergUnityRestCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergUnityRestCatalogConnectorSmokeTest.java
@@ -21,12 +21,11 @@ import io.trino.plugin.iceberg.containers.UnityCatalogContainer;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
-import org.assertj.core.util.Files;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
 
@@ -38,12 +37,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 final class TestIcebergUnityRestCatalogConnectorSmokeTest
         extends BaseIcebergConnectorSmokeTest
 {
-    private final File warehouseLocation;
+    private final Path warehouseLocation;
 
     public TestIcebergUnityRestCatalogConnectorSmokeTest()
+            throws IOException
     {
         super(new IcebergConfig().getFileFormat().toIceberg());
-        warehouseLocation = Files.newTemporaryFolder();
+        warehouseLocation = Files.createTempDirectory(null);
     }
 
     @Override
@@ -61,11 +61,11 @@ final class TestIcebergUnityRestCatalogConnectorSmokeTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        closeAfterClass(() -> deleteRecursively(warehouseLocation.toPath(), ALLOW_INSECURE));
+        closeAfterClass(() -> deleteRecursively(warehouseLocation, ALLOW_INSECURE));
         UnityCatalogContainer unityCatalog = closeAfterClass(new UnityCatalogContainer("unity", "tpch"));
 
         DistributedQueryRunner queryRunner = IcebergQueryRunner.builder()
-                .setBaseDataDir(Optional.of(warehouseLocation.toPath()))
+                .setBaseDataDir(Optional.of(warehouseLocation))
                 .addIcebergProperty("iceberg.file-format", format.name())
                 .addIcebergProperty("iceberg.security", "read_only")
                 .addIcebergProperty("iceberg.catalog.type", "rest")

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
@@ -31,10 +31,11 @@ import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.type.TestingTypeManager;
 import org.apache.iceberg.rest.DelegatingRestSessionCatalog;
 import org.apache.iceberg.rest.RESTSessionCatalog;
-import org.assertj.core.util.Files;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
 
@@ -57,14 +58,16 @@ public class TestTrinoRestCatalog
 {
     @Override
     protected TrinoCatalog createTrinoCatalog(boolean useUniqueTableLocations)
+            throws IOException
     {
         return createTrinoRestCatalog(useUniqueTableLocations, ImmutableMap.of());
     }
 
     private static TrinoRestCatalog createTrinoRestCatalog(boolean useUniqueTableLocations, Map<String, String> properties)
+            throws IOException
     {
-        File warehouseLocation = Files.newTemporaryFolder();
-        warehouseLocation.deleteOnExit();
+        Path warehouseLocation = Files.createTempDirectory(null);
+        warehouseLocation.toFile().deleteOnExit();
 
         String catalogName = "iceberg_rest";
         RESTSessionCatalog restSessionCatalog = DelegatingRestSessionCatalog
@@ -91,6 +94,7 @@ public class TestTrinoRestCatalog
     @Test
     @Override
     public void testNonLowercaseNamespace()
+            throws Exception
     {
         TrinoCatalog catalog = createTrinoCatalog(false);
 
@@ -138,6 +142,7 @@ public class TestTrinoRestCatalog
 
     @Test
     public void testPrefix()
+            throws Exception
     {
         TrinoCatalog catalog = createTrinoRestCatalog(false, ImmutableMap.of("prefix", "dev"));
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

`@TempDir` should be used where possible, and `Files` from the JDK otherwise.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

There are plenty of other places where `@TempDir` could be used - left as a follow-up.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
