### PR TITLE
Fix TDigestHistogram -> DistributionSnapshot convertion

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/DistributionSnapshot.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DistributionSnapshot.java
@@ -110,15 +110,15 @@ public record DistributionSnapshot(long total, double min, double max, double p0
                 distribution.getTotal(),
                 distribution.getMin(),
                 distribution.getMax(),
-                distribution.getPercentile(0.01),
-                distribution.getPercentile(0.05),
-                distribution.getPercentile(0.10),
-                distribution.getPercentile(0.25),
-                distribution.getPercentile(0.50),
-                distribution.getPercentile(0.75),
-                distribution.getPercentile(0.90),
-                distribution.getPercentile(0.95),
-                distribution.getPercentile(0.99));
+                distribution.getPercentile(1),
+                distribution.getPercentile(5),
+                distribution.getPercentile(10),
+                distribution.getPercentile(25),
+                distribution.getPercentile(50),
+                distribution.getPercentile(75),
+                distribution.getPercentile(90),
+                distribution.getPercentile(95),
+                distribution.getPercentile(99));
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/execution/TestDistributionSnapshot.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestDistributionSnapshot.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution;
+
+import io.airlift.stats.TDigest;
+import io.trino.plugin.base.metrics.TDigestHistogram;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestDistributionSnapshot
+{
+    @Test
+    void testConvertFromTDigestHistogram()
+    {
+        TDigest digest = new TDigest();
+        digest.add(1.0);
+        digest.add(10.0);
+        digest.add(10.0);
+        digest.add(1.0);
+        digest.add(4.0);
+        digest.add(5.0);
+        digest.add(1.0);
+        digest.add(3.0);
+        digest.add(7.0);
+
+        TDigestHistogram histogram = new TDigestHistogram(digest);
+        DistributionSnapshot snapshot = new DistributionSnapshot(histogram);
+
+        assertThat(snapshot.total()).isEqualTo(9);
+        assertThat(snapshot.min()).isEqualTo(1.0);
+        assertThat(snapshot.max()).isEqualTo(10.0);
+        assertThat(snapshot.p01()).isEqualTo(1.0);
+        assertThat(snapshot.p05()).isEqualTo(1.0);
+        assertThat(snapshot.p10()).isEqualTo(1.0);
+        assertThat(snapshot.p25()).isEqualTo(1.0);
+        assertThat(snapshot.p50()).isEqualTo(4.0);
+        assertThat(snapshot.p75()).isEqualTo(7.0);
+        assertThat(snapshot.p90()).isEqualTo(10.0);
+        assertThat(snapshot.p95()).isEqualTo(10.0);
+        assertThat(snapshot.p99()).isEqualTo(10.0);
+    }
+}


### PR DESCRIPTION
Percentiles were calculated incorrectly.
As a result DistributionSnapshot stored in final query info were incorrect.
