### PR TITLE
Improve TopN Performance

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/MergeOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/MergeOperator.java
@@ -53,9 +53,9 @@ public class MergeOperator
         private final PlanNodeId sourceId;
         private final DirectExchangeClientSupplier directExchangeClientSupplier;
         private final PagesSerdeFactory serdeFactory;
-        private final List<Type> types;
         private final List<Integer> outputChannels;
         private final List<Type> outputTypes;
+        private final List<Type> sortTypes;
         private final List<Integer> sortChannels;
         private final List<SortOrder> sortOrder;
         private final OrderingCompiler orderingCompiler;
@@ -76,9 +76,10 @@ public class MergeOperator
             this.sourceId = requireNonNull(sourceId, "sourceId is null");
             this.directExchangeClientSupplier = requireNonNull(directExchangeClientSupplier, "directExchangeClientSupplier is null");
             this.serdeFactory = requireNonNull(serdeFactory, "serdeFactory is null");
-            this.types = requireNonNull(types, "types is null");
             this.outputChannels = requireNonNull(outputChannels, "outputChannels is null");
+            requireNonNull(types, "types is null");
             this.outputTypes = mappedCopy(outputChannels, types::get);
+            this.sortTypes = mappedCopy(sortChannels, types::get);
             this.sortChannels = requireNonNull(sortChannels, "sortChannels is null");
             this.sortOrder = requireNonNull(sortOrder, "sortOrder is null");
             this.orderingCompiler = requireNonNull(orderingCompiler, "orderingCompiler is null");
@@ -95,13 +96,12 @@ public class MergeOperator
         {
             checkState(!closed, "Factory is already closed");
             OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, sourceId, MergeOperator.class.getSimpleName());
-
             return new MergeOperator(
                     operatorContext,
                     sourceId,
                     directExchangeClientSupplier,
                     serdeFactory.createDeserializer(driverContext.getSession().getExchangeEncryptionKey().map(Ciphers::deserializeAesEncryptionKey)),
-                    orderingCompiler.compilePageWithPositionComparator(types, sortChannels, sortOrder),
+                    orderingCompiler.compilePageWithPositionComparator(sortTypes, sortChannels, sortOrder),
                     outputChannels,
                     outputTypes);
         }

--- a/core/trino-main/src/main/java/io/trino/operator/OrderByOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OrderByOperator.java
@@ -349,9 +349,13 @@ public class OrderByOperator
                 .add(WorkProcessor.fromIterator(sortedPagesIndex))
                 .build();
 
+        List<Type> sortTypes = sortChannels.stream()
+                .map(sourceTypes::get)
+                .collect(toImmutableList());
+
         return mergeSortedPages(
                 sortedStreams,
-                orderingCompiler.compilePageWithPositionComparator(sourceTypes, sortChannels, sortOrder),
+                orderingCompiler.compilePageWithPositionComparator(sortTypes, sortChannels, sortOrder),
                 sourceTypes,
                 operatorContext.aggregateUserMemoryContext(),
                 operatorContext.getDriverContext().getYieldSignal());

--- a/core/trino-main/src/main/java/io/trino/operator/SimplePageWithPositionComparator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/SimplePageWithPositionComparator.java
@@ -13,11 +13,12 @@
  */
 package io.trino.operator;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Ints;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.connector.SortOrder;
+import io.trino.spi.function.InvocationConvention;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
 
@@ -35,35 +36,37 @@ import static java.util.Objects.requireNonNull;
 public class SimplePageWithPositionComparator
         implements PageWithPositionComparator
 {
-    private final List<Integer> sortChannels;
-    private final List<MethodHandle> orderingOperators;
+    private static final InvocationConvention INVOCATION_CONVENTION = simpleConvention(FAIL_ON_NULL, BLOCK_POSITION, BLOCK_POSITION);
+
+    private final int[] sortChannels;
+    private final MethodHandle[] orderingOperators;
 
     public SimplePageWithPositionComparator(List<Type> sortTypes, List<Integer> sortChannels, List<SortOrder> sortOrders, TypeOperators typeOperators)
     {
-        this.sortChannels = ImmutableList.copyOf(requireNonNull(sortChannels, "sortChannels is null"));
+        requireNonNull(sortChannels, "sortChannels is null");
         requireNonNull(sortTypes, "sortTypes is null");
         requireNonNull(sortOrders, "sortOrders is null");
         checkArgument(sortTypes.size() == sortChannels.size(), "sortTypes and sortChannels must be the same size");
         checkArgument(sortTypes.size() == sortOrders.size(), "sortTypes and sortOrders must be the same size");
-        ImmutableList.Builder<MethodHandle> orderingOperators = ImmutableList.builder();
-        for (int index = 0; index < sortChannels.size(); index++) {
+        this.sortChannels = Ints.toArray(sortChannels);
+        this.orderingOperators = new MethodHandle[this.sortChannels.length];
+        for (int index = 0; index < this.sortChannels.length; index++) {
             Type type = sortTypes.get(index);
             SortOrder sortOrder = sortOrders.get(index);
-            orderingOperators.add(typeOperators.getOrderingOperator(type, sortOrder, simpleConvention(FAIL_ON_NULL, BLOCK_POSITION, BLOCK_POSITION)));
+            orderingOperators[index] = typeOperators.getOrderingOperator(type, sortOrder, INVOCATION_CONVENTION);
         }
-        this.orderingOperators = orderingOperators.build();
     }
 
     @Override
     public int compareTo(Page left, int leftPosition, Page right, int rightPosition)
     {
         try {
-            for (int i = 0; i < sortChannels.size(); i++) {
-                int sortChannel = sortChannels.get(i);
+            for (int i = 0; i < sortChannels.length; i++) {
+                int sortChannel = sortChannels[i];
                 Block leftBlock = left.getBlock(sortChannel);
                 Block rightBlock = right.getBlock(sortChannel);
 
-                MethodHandle orderingOperator = orderingOperators.get(i);
+                MethodHandle orderingOperator = orderingOperators[i];
                 int compare = (int) orderingOperator.invokeExact(leftBlock, leftPosition, rightBlock, rightPosition);
                 if (compare != 0) {
                     return compare;

--- a/core/trino-main/src/main/java/io/trino/operator/SimplePageWithPositionEqualsAndHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/SimplePageWithPositionEqualsAndHash.java
@@ -39,13 +39,13 @@ public class SimplePageWithPositionEqualsAndHash
     {
         requireNonNull(channelTypes, "channelTypes is null");
         this.equalityChannels = new IntArrayList(requireNonNull(equalityChannels, "equalityChannels is null"));
-        checkArgument(channelTypes.size() >= equalityChannels.size(), "channelTypes cannot have fewer columns then equalityChannels");
+        checkArgument(channelTypes.size() == equalityChannels.size(), "channelTypes and equalityChannels must have the same size");
 
         // Use IS DISTINCT FROM for equality, because it evaluates NULL and NaN values as distinct (unlike SQL EQUALS)
         ImmutableList.Builder<BlockPositionIsIdentical> identicalOperators = ImmutableList.builder();
         ImmutableList.Builder<BlockPositionHashCode> hashOperators = ImmutableList.builder();
         for (int index = 0; index < equalityChannels.size(); index++) {
-            Type type = channelTypes.get(this.equalityChannels.getInt(index));
+            Type type = channelTypes.get(index);
             identicalOperators.add(blockTypeOperators.getIdenticalOperator(type));
             hashOperators.add(blockTypeOperators.getHashCodeOperator(type));
         }

--- a/core/trino-main/src/main/java/io/trino/operator/SimplePageWithPositionEqualsAndHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/SimplePageWithPositionEqualsAndHash.java
@@ -13,15 +13,13 @@
  */
 package io.trino.operator;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Ints;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
 import io.trino.type.BlockTypeOperators;
 import io.trino.type.BlockTypeOperators.BlockPositionHashCode;
 import io.trino.type.BlockTypeOperators.BlockPositionIsIdentical;
-import it.unimi.dsi.fastutil.ints.IntArrayList;
-import it.unimi.dsi.fastutil.ints.IntList;
 
 import java.util.List;
 
@@ -31,36 +29,34 @@ import static java.util.Objects.requireNonNull;
 public class SimplePageWithPositionEqualsAndHash
         implements PageWithPositionEqualsAndHash
 {
-    private final IntList equalityChannels;
-    private final List<BlockPositionIsIdentical> identicalOperators;
-    private final List<BlockPositionHashCode> hashOperators;
+    private final int[] equalityChannels;
+    private final BlockPositionIsIdentical[] identicalOperators;
+    private final BlockPositionHashCode[] hashOperators;
 
     public SimplePageWithPositionEqualsAndHash(List<Type> channelTypes, List<Integer> equalityChannels, BlockTypeOperators blockTypeOperators)
     {
         requireNonNull(channelTypes, "channelTypes is null");
-        this.equalityChannels = new IntArrayList(requireNonNull(equalityChannels, "equalityChannels is null"));
         checkArgument(channelTypes.size() == equalityChannels.size(), "channelTypes and equalityChannels must have the same size");
+        this.equalityChannels = Ints.toArray(requireNonNull(equalityChannels, "equalityChannels is null"));
 
         // Use IS DISTINCT FROM for equality, because it evaluates NULL and NaN values as distinct (unlike SQL EQUALS)
-        ImmutableList.Builder<BlockPositionIsIdentical> identicalOperators = ImmutableList.builder();
-        ImmutableList.Builder<BlockPositionHashCode> hashOperators = ImmutableList.builder();
-        for (int index = 0; index < equalityChannels.size(); index++) {
+        this.identicalOperators = new BlockPositionIsIdentical[this.equalityChannels.length];
+        this.hashOperators = new BlockPositionHashCode[this.equalityChannels.length];
+        for (int index = 0; index < this.identicalOperators.length; index++) {
             Type type = channelTypes.get(index);
-            identicalOperators.add(blockTypeOperators.getIdenticalOperator(type));
-            hashOperators.add(blockTypeOperators.getHashCodeOperator(type));
+            identicalOperators[index] = blockTypeOperators.getIdenticalOperator(type);
+            hashOperators[index] = blockTypeOperators.getHashCodeOperator(type);
         }
-        this.identicalOperators = identicalOperators.build();
-        this.hashOperators = hashOperators.build();
     }
 
     @Override
     public boolean equals(Page left, int leftPosition, Page right, int rightPosition)
     {
-        for (int i = 0; i < equalityChannels.size(); i++) {
-            int equalityChannel = equalityChannels.getInt(i);
+        for (int i = 0; i < equalityChannels.length; i++) {
+            int equalityChannel = equalityChannels[i];
             Block leftBlock = left.getBlock(equalityChannel);
             Block rightBlock = right.getBlock(equalityChannel);
-            if (!identicalOperators.get(i).isIdentical(leftBlock, leftPosition, rightBlock, rightPosition)) {
+            if (!identicalOperators[i].isIdentical(leftBlock, leftPosition, rightBlock, rightPosition)) {
                 return false;
             }
         }
@@ -71,10 +67,10 @@ public class SimplePageWithPositionEqualsAndHash
     public long hashCode(Page page, int position)
     {
         long hashCode = 0;
-        for (int i = 0; i < equalityChannels.size(); i++) {
-            int equalityChannel = equalityChannels.getInt(i);
+        for (int i = 0; i < equalityChannels.length; i++) {
+            int equalityChannel = equalityChannels[i];
             Block block = page.getBlock(equalityChannel);
-            hashCode = 31 * hashCode + hashOperators.get(i).hashCodeNullSafe(block, position);
+            hashCode = 31 * hashCode + hashOperators[i].hashCodeNullSafe(block, position);
         }
         return hashCode;
     }

--- a/core/trino-main/src/main/java/io/trino/operator/TopNOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TopNOperator.java
@@ -17,15 +17,12 @@ import com.google.common.collect.ImmutableList;
 import io.trino.memory.context.MemoryTrackingContext;
 import io.trino.operator.WorkProcessor.TransformationState;
 import io.trino.spi.Page;
-import io.trino.spi.connector.SortOrder;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeOperators;
 import io.trino.sql.planner.plan.PlanNodeId;
 
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.operator.WorkProcessorOperatorAdapter.createAdapterOperatorFactory;
 import static java.util.Objects.requireNonNull;
 
@@ -40,11 +37,9 @@ public class TopNOperator
             PlanNodeId planNodeId,
             List<? extends Type> types,
             int n,
-            List<Integer> sortChannels,
-            List<SortOrder> sortOrders,
-            TypeOperators typeOperators)
+            PageWithPositionComparator comparator)
     {
-        return createAdapterOperatorFactory(new Factory(operatorId, planNodeId, types, n, sortChannels, sortOrders, typeOperators));
+        return createAdapterOperatorFactory(new Factory(operatorId, planNodeId, types, n, comparator));
     }
 
     private static class Factory
@@ -54,9 +49,7 @@ public class TopNOperator
         private final PlanNodeId planNodeId;
         private final List<Type> sourceTypes;
         private final int n;
-        private final List<Integer> sortChannels;
-        private final List<SortOrder> sortOrders;
-        private final TypeOperators typeOperators;
+        private final PageWithPositionComparator comparator;
         private boolean closed;
 
         private Factory(
@@ -64,17 +57,13 @@ public class TopNOperator
                 PlanNodeId planNodeId,
                 List<? extends Type> types,
                 int n,
-                List<Integer> sortChannels,
-                List<SortOrder> sortOrders,
-                TypeOperators typeOperators)
+                PageWithPositionComparator comparator)
         {
             this.operatorId = operatorId;
             this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
             this.sourceTypes = ImmutableList.copyOf(requireNonNull(types, "types is null"));
             this.n = n;
-            this.sortChannels = ImmutableList.copyOf(requireNonNull(sortChannels, "sortChannels is null"));
-            this.sortOrders = ImmutableList.copyOf(requireNonNull(sortOrders, "sortOrders is null"));
-            this.typeOperators = typeOperators;
+            this.comparator = requireNonNull(comparator, "comparator is null");
         }
 
         @Override
@@ -88,9 +77,7 @@ public class TopNOperator
                     sourcePages,
                     sourceTypes,
                     n,
-                    sortChannels,
-                    sortOrders,
-                    typeOperators);
+                    comparator);
         }
 
         @Override
@@ -120,7 +107,7 @@ public class TopNOperator
         @Override
         public Factory duplicate()
         {
-            return new Factory(operatorId, planNodeId, sourceTypes, n, sortChannels, sortOrders, typeOperators);
+            return new Factory(operatorId, planNodeId, sourceTypes, n, comparator);
         }
     }
 
@@ -131,24 +118,19 @@ public class TopNOperator
             WorkProcessor<Page> sourcePages,
             List<Type> types,
             int n,
-            List<Integer> sortChannels,
-            List<SortOrder> sortOrders,
-            TypeOperators typeOperators)
+            PageWithPositionComparator comparator)
     {
         if (n == 0) {
             pages = WorkProcessor.of();
         }
         else {
-            List<Type> sortTypes = sortChannels.stream()
-                    .map(types::get)
-                    .collect(toImmutableList());
             pages = sourcePages.transform(
                     new TopNPages(
                             new TopNProcessor(
                                     memoryTrackingContext.aggregateUserMemoryContext(),
                                     types,
                                     n,
-                                    new SimplePageWithPositionComparator(sortTypes, sortChannels, sortOrders, typeOperators))));
+                                    comparator)));
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/TopNProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TopNProcessor.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Collections.emptyIterator;
 import static java.util.Objects.requireNonNull;
 
@@ -55,9 +56,12 @@ public class TopNProcessor
             outputIterator = emptyIterator();
         }
         else {
+            List<Type> sortTypes = sortChannels.stream()
+                    .map(types::get)
+                    .collect(toImmutableList());
             topNBuilder = new GroupedTopNRowNumberBuilder(
                     types,
-                    new SimplePageWithPositionComparator(types, sortChannels, sortOrders, typeOperators),
+                    new SimplePageWithPositionComparator(sortTypes, sortChannels, sortOrders, typeOperators),
                     n,
                     false,
                     new int[0],

--- a/core/trino-main/src/main/java/io/trino/operator/TopNProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TopNProcessor.java
@@ -16,17 +16,13 @@ package io.trino.operator;
 import io.trino.memory.context.AggregatedMemoryContext;
 import io.trino.memory.context.LocalMemoryContext;
 import io.trino.spi.Page;
-import io.trino.spi.connector.SortOrder;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeOperators;
-import jakarta.annotation.Nullable;
 
 import java.util.Iterator;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Collections.emptyIterator;
 import static java.util.Objects.requireNonNull;
 
@@ -37,41 +33,30 @@ public class TopNProcessor
 {
     private final LocalMemoryContext localUserMemoryContext;
 
-    @Nullable
-    private GroupedTopNBuilder topNBuilder;
+    private final GroupedTopNRowNumberBuilder topNBuilder;
     private Iterator<Page> outputIterator;
 
     public TopNProcessor(
             AggregatedMemoryContext aggregatedMemoryContext,
             List<Type> types,
             int n,
-            List<Integer> sortChannels,
-            List<SortOrder> sortOrders, TypeOperators typeOperators)
+            PageWithPositionComparator comparator)
     {
         requireNonNull(aggregatedMemoryContext, "aggregatedMemoryContext is null");
+        checkArgument(n > 0, "n must be > 0, found: %s", n);
         this.localUserMemoryContext = aggregatedMemoryContext.newLocalMemoryContext(TopNProcessor.class.getSimpleName());
-        checkArgument(n >= 0, "n must be positive");
 
-        if (n == 0) {
-            outputIterator = emptyIterator();
-        }
-        else {
-            List<Type> sortTypes = sortChannels.stream()
-                    .map(types::get)
-                    .collect(toImmutableList());
-            topNBuilder = new GroupedTopNRowNumberBuilder(
-                    types,
-                    new SimplePageWithPositionComparator(sortTypes, sortChannels, sortOrders, typeOperators),
-                    n,
-                    false,
-                    new int[0],
-                    new NoChannelGroupByHash());
-        }
+        topNBuilder = new GroupedTopNRowNumberBuilder(
+                types,
+                comparator,
+                n,
+                false,
+                new int[0],
+                new NoChannelGroupByHash());
     }
 
     public void addInput(Page page)
     {
-        requireNonNull(topNBuilder, "topNBuilder is null");
         boolean done = topNBuilder.processPage(requireNonNull(page, "page is null")).process();
         // there is no grouping so work will always be done
         verify(done);
@@ -103,7 +88,6 @@ public class TopNProcessor
 
     private void updateMemoryReservation()
     {
-        requireNonNull(topNBuilder, "topNBuilder is null");
         localUserMemoryContext.setBytes(topNBuilder.getEstimatedSizeInBytes());
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/TopNRankingOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TopNRankingOperator.java
@@ -292,7 +292,7 @@ public class TopNRankingOperator
         }
         if (rankingType == RankingType.RANK) {
             PageWithPositionComparator comparator = new SimplePageWithPositionComparator(sortTypes, sortChannels, sortOrders, typeOperators);
-            PageWithPositionEqualsAndHash equalsAndHash = new SimplePageWithPositionEqualsAndHash(ImmutableList.copyOf(sourceTypes), sortChannels, blockTypeOperators);
+            PageWithPositionEqualsAndHash equalsAndHash = new SimplePageWithPositionEqualsAndHash(sortTypes, sortChannels, blockTypeOperators);
             return () -> new GroupedTopNRankBuilder(
                     sourceTypes,
                     comparator,

--- a/core/trino-main/src/main/java/io/trino/operator/TopNRankingOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TopNRankingOperator.java
@@ -35,6 +35,7 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.operator.GroupByHash.createGroupByHash;
 import static java.util.Objects.requireNonNull;
 
@@ -276,8 +277,11 @@ public class TopNRankingOperator
             int[] groupByChannels,
             Supplier<GroupByHash> groupByHashSupplier)
     {
+        List<Type> sortTypes = sortChannels.stream()
+                .map(sourceTypes::get)
+                .collect(toImmutableList());
         if (rankingType == RankingType.ROW_NUMBER) {
-            PageWithPositionComparator comparator = new SimplePageWithPositionComparator(sourceTypes, sortChannels, sortOrders, typeOperators);
+            PageWithPositionComparator comparator = new SimplePageWithPositionComparator(sortTypes, sortChannels, sortOrders, typeOperators);
             return () -> new GroupedTopNRowNumberBuilder(
                     sourceTypes,
                     comparator,
@@ -287,7 +291,7 @@ public class TopNRankingOperator
                     groupByHashSupplier.get());
         }
         if (rankingType == RankingType.RANK) {
-            PageWithPositionComparator comparator = new SimplePageWithPositionComparator(sourceTypes, sortChannels, sortOrders, typeOperators);
+            PageWithPositionComparator comparator = new SimplePageWithPositionComparator(sortTypes, sortChannels, sortOrders, typeOperators);
             PageWithPositionEqualsAndHash equalsAndHash = new SimplePageWithPositionEqualsAndHash(ImmutableList.copyOf(sourceTypes), sortChannels, blockTypeOperators);
             return () -> new GroupedTopNRankBuilder(
                     sourceTypes,

--- a/core/trino-main/src/main/java/io/trino/operator/WindowOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WindowOperator.java
@@ -328,6 +328,9 @@ public class WindowOperator
                     sortChannels,
                     windowFunctionDefinitions);
 
+            List<Type> unGroupedOrderTypes = unGroupedOrderChannels.stream()
+                    .map(sourceTypes::get)
+                    .collect(toImmutableList());
             this.spillablePagesToPagesIndexes = Optional.of(new SpillablePagesToPagesIndexes(
                     inMemoryPagesIndexWithHashStrategies,
                     mergedPagesIndexWithHashStrategies,
@@ -335,7 +338,7 @@ public class WindowOperator
                     orderChannels,
                     ordering,
                     spillerFactory,
-                    orderingCompiler.compilePageWithPositionComparator(sourceTypes, unGroupedOrderChannels, unGroupedOrdering)));
+                    orderingCompiler.compilePageWithPositionComparator(unGroupedOrderTypes, unGroupedOrderChannels, unGroupedOrdering)));
 
             this.outputPages = pageBuffer.pages()
                     .flatTransform(spillablePagesToPagesIndexes.get())

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/LocalMergeSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/LocalMergeSourceOperator.java
@@ -74,7 +74,10 @@ public class LocalMergeSourceOperator
             checkState(!closed, "Factory is already closed");
 
             OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, LocalMergeSourceOperator.class.getSimpleName());
-            PageWithPositionComparator comparator = orderingCompiler.compilePageWithPositionComparator(types, sortChannels, orderings);
+            List<Type> sortTypes = sortChannels.stream()
+                    .map(types::get)
+                    .collect(toImmutableList());
+            PageWithPositionComparator comparator = orderingCompiler.compilePageWithPositionComparator(sortTypes, sortChannels, orderings);
             List<LocalExchangeSource> sources = IntStream.range(0, localExchange.getBufferCount())
                     .boxed()
                     .map(index -> localExchange.getNextSource())

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -1056,6 +1056,9 @@ public class LocalExecutionPlanner
 
             List<Symbol> orderBySymbols = node.getOrderingScheme().orderBy();
             List<Integer> sortChannels = getChannelsForSymbols(orderBySymbols, source.getLayout());
+            List<Type> sortTypes = sortChannels.stream()
+                    .map(channel -> source.getTypes().get(channel))
+                    .collect(toImmutableList());
             List<SortOrder> sortOrder = orderBySymbols.stream()
                     .map(symbol -> node.getOrderingScheme().ordering(symbol))
                     .collect(toImmutableList());
@@ -1078,14 +1081,13 @@ public class LocalExecutionPlanner
                     partitionChannels,
                     partitionTypes,
                     sortChannels,
-                    sortOrder,
                     node.getMaxRankingPerPartition(),
                     isPartial,
                     hashChannel,
                     1000,
                     maxPartialTopNMemorySize,
                     hashStrategyCompiler,
-                    plannerContext.getTypeOperators(),
+                    orderingCompiler.compilePageWithPositionComparator(sortTypes, sortChannels, sortOrder),
                     blockTypeOperators);
 
             return new PhysicalOperation(operatorFactory, makeLayout(node), source);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -1835,10 +1835,13 @@ public class LocalExecutionPlanner
 
             List<Symbol> orderBySymbols = node.getOrderingScheme().orderBy();
 
+            List<Type> sortTypes = new ArrayList<>();
             List<Integer> sortChannels = new ArrayList<>();
             List<SortOrder> sortOrders = new ArrayList<>();
             for (Symbol symbol : orderBySymbols) {
-                sortChannels.add(source.getLayout().get(symbol));
+                int sortChannel = source.getLayout().get(symbol);
+                sortTypes.add(source.getTypes().get(sortChannel));
+                sortChannels.add(sortChannel);
                 sortOrders.add(node.getOrderingScheme().ordering(symbol));
             }
 
@@ -1847,9 +1850,7 @@ public class LocalExecutionPlanner
                     node.getId(),
                     source.getTypes(),
                     (int) node.getCount(),
-                    sortChannels,
-                    sortOrders,
-                    plannerContext.getTypeOperators());
+                    orderingCompiler.compilePageWithPositionComparator(sortTypes, sortChannels, sortOrders));
 
             return new PhysicalOperation(operator, source.getLayout(), source);
         }

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupedTopNRankBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupedTopNRankBuilder.java
@@ -89,7 +89,7 @@ public class BenchmarkGroupedTopNRankBuilder
                     ImmutableList.of(DESC_NULLS_LAST, ASC_NULLS_FIRST),
                     typeOperators);
             equalsAndHash = new SimplePageWithPositionEqualsAndHash(
-                    types,
+                    ImmutableList.of(types.get(EXTENDED_PRICE), types.get(STATUS)),
                     ImmutableList.of(EXTENDED_PRICE, STATUS),
                     blockTypeOperators);
 

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupedTopNRankBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupedTopNRankBuilder.java
@@ -84,7 +84,7 @@ public class BenchmarkGroupedTopNRankBuilder
             TypeOperators typeOperators = new TypeOperators();
             BlockTypeOperators blockTypeOperators = new BlockTypeOperators(typeOperators);
             comparator = new SimplePageWithPositionComparator(
-                    types,
+                    ImmutableList.of(types.get(EXTENDED_PRICE), types.get(STATUS)),
                     ImmutableList.of(EXTENDED_PRICE, STATUS),
                     ImmutableList.of(DESC_NULLS_LAST, ASC_NULLS_FIRST),
                     typeOperators);

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupedTopNRankBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupedTopNRankBuilder.java
@@ -18,6 +18,7 @@ import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
+import io.trino.sql.gen.OrderingCompiler;
 import io.trino.tpch.LineItem;
 import io.trino.tpch.LineItemGenerator;
 import io.trino.type.BlockTypeOperators;
@@ -36,6 +37,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.jmh.Benchmarks.benchmark;
 import static io.trino.spi.connector.SortOrder.ASC_NULLS_FIRST;
 import static io.trino.spi.connector.SortOrder.DESC_NULLS_LAST;
@@ -83,14 +85,19 @@ public class BenchmarkGroupedTopNRankBuilder
             types = ImmutableList.of(DOUBLE, DOUBLE, VARCHAR, BIGINT);
             TypeOperators typeOperators = new TypeOperators();
             BlockTypeOperators blockTypeOperators = new BlockTypeOperators(typeOperators);
-            comparator = new SimplePageWithPositionComparator(
-                    ImmutableList.of(types.get(EXTENDED_PRICE), types.get(STATUS)),
-                    ImmutableList.of(EXTENDED_PRICE, STATUS),
-                    ImmutableList.of(DESC_NULLS_LAST, ASC_NULLS_FIRST),
-                    typeOperators);
+            OrderingCompiler orderingCompiler = new OrderingCompiler(typeOperators);
+            List<Integer> sortChannels = ImmutableList.of(EXTENDED_PRICE, STATUS);
+            List<Type> sortTypes = sortChannels.stream()
+                    .map(types::get)
+                    .collect(toImmutableList());
+
+            comparator = orderingCompiler.compilePageWithPositionComparator(
+                    sortTypes,
+                    sortChannels,
+                    ImmutableList.of(DESC_NULLS_LAST, ASC_NULLS_FIRST));
             equalsAndHash = new SimplePageWithPositionEqualsAndHash(
-                    ImmutableList.of(types.get(EXTENDED_PRICE), types.get(STATUS)),
-                    ImmutableList.of(EXTENDED_PRICE, STATUS),
+                    sortTypes,
+                    sortChannels,
                     blockTypeOperators);
 
             page = createInputPage(positions, types);

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupedTopNRowNumberBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupedTopNRowNumberBuilder.java
@@ -59,7 +59,7 @@ public class BenchmarkGroupedTopNRowNumberBuilder
     {
         private final List<Type> types = ImmutableList.of(DOUBLE, DOUBLE, VARCHAR, DOUBLE);
         private final PageWithPositionComparator comparator = new SimplePageWithPositionComparator(
-                types,
+                ImmutableList.of(types.get(EXTENDED_PRICE), types.get(SHIP_DATE)),
                 ImmutableList.of(EXTENDED_PRICE, SHIP_DATE),
                 ImmutableList.of(DESC_NULLS_LAST, ASC_NULLS_FIRST),
                 new TypeOperators());

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupedTopNRowNumberBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupedTopNRowNumberBuilder.java
@@ -43,7 +43,6 @@ import static io.trino.spi.connector.SortOrder.ASC_NULLS_FIRST;
 import static io.trino.spi.connector.SortOrder.DESC_NULLS_LAST;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DoubleType.DOUBLE;
-import static io.trino.spi.type.VarcharType.VARCHAR;
 
 @State(Scope.Thread)
 @OutputTimeUnit(TimeUnit.SECONDS)
@@ -60,7 +59,7 @@ public class BenchmarkGroupedTopNRowNumberBuilder
     @State(Scope.Thread)
     public static class BenchmarkData
     {
-        private final List<Type> types = ImmutableList.of(DOUBLE, DOUBLE, VARCHAR, DOUBLE);
+        private final List<Type> types = ImmutableList.of(DOUBLE, DOUBLE, DATE, DOUBLE);
 
         @Param({"1", "10", "100"})
         private int topN = 1;

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupedTopNRowNumberBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupedTopNRowNumberBuilder.java
@@ -16,8 +16,10 @@ package io.trino.operator;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
+import io.trino.spi.connector.SortOrder;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
+import io.trino.sql.gen.OrderingCompiler;
 import io.trino.tpch.LineItem;
 import io.trino.tpch.LineItemGenerator;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -35,6 +37,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.jmh.Benchmarks.benchmark;
 import static io.trino.spi.connector.SortOrder.ASC_NULLS_FIRST;
 import static io.trino.spi.connector.SortOrder.DESC_NULLS_LAST;
@@ -58,11 +61,6 @@ public class BenchmarkGroupedTopNRowNumberBuilder
     public static class BenchmarkData
     {
         private final List<Type> types = ImmutableList.of(DOUBLE, DOUBLE, VARCHAR, DOUBLE);
-        private final PageWithPositionComparator comparator = new SimplePageWithPositionComparator(
-                ImmutableList.of(types.get(EXTENDED_PRICE), types.get(SHIP_DATE)),
-                ImmutableList.of(EXTENDED_PRICE, SHIP_DATE),
-                ImmutableList.of(DESC_NULLS_LAST, ASC_NULLS_FIRST),
-                new TypeOperators());
 
         @Param({"1", "10", "100"})
         private int topN = 1;
@@ -78,11 +76,19 @@ public class BenchmarkGroupedTopNRowNumberBuilder
         @Param("100")
         private int addPageCalls = 1;
 
+        private PageWithPositionComparator comparator;
         private Page page;
 
         @Setup
         public void setup()
         {
+            OrderingCompiler orderingCompiler = new OrderingCompiler(new TypeOperators());
+            List<Integer> sortColumns = ImmutableList.of(EXTENDED_PRICE, SHIP_DATE);
+            List<Type> sortTypes = sortColumns.stream()
+                    .map(types::get)
+                    .collect(toImmutableList());
+            List<SortOrder> sortOrders = ImmutableList.of(DESC_NULLS_LAST, ASC_NULLS_FIRST);
+            comparator = orderingCompiler.compilePageWithPositionComparator(sortTypes, sortColumns, sortOrders);
             page = createInputPage(positions, types);
         }
 

--- a/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRankBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRankBuilder.java
@@ -82,7 +82,7 @@ public class TestGroupedTopNRankBuilder
         GroupedTopNBuilder groupedTopNBuilder = new GroupedTopNRankBuilder(
                 types,
                 new SimplePageWithPositionComparator(ImmutableList.of(types.get(0)), ImmutableList.of(0), ImmutableList.of(ASC_NULLS_LAST), typeOperators),
-                new SimplePageWithPositionEqualsAndHash(types, ImmutableList.of(0), blockTypeOperators),
+                new SimplePageWithPositionEqualsAndHash(ImmutableList.of(types.get(0)), ImmutableList.of(0), blockTypeOperators),
                 3,
                 produceRanking,
                 new int[0],
@@ -148,7 +148,7 @@ public class TestGroupedTopNRankBuilder
         GroupedTopNBuilder groupedTopNBuilder = new GroupedTopNRankBuilder(
                 types,
                 new SimplePageWithPositionComparator(ImmutableList.of(types.get(1)), ImmutableList.of(1), ImmutableList.of(ASC_NULLS_LAST), typeOperators),
-                new SimplePageWithPositionEqualsAndHash(types, ImmutableList.of(1), blockTypeOperators),
+                new SimplePageWithPositionEqualsAndHash(ImmutableList.of(types.get(1)), ImmutableList.of(1), blockTypeOperators),
                 3,
                 produceRanking,
                 new int[] {0},
@@ -230,7 +230,7 @@ public class TestGroupedTopNRankBuilder
         GroupedTopNBuilder groupedTopNBuilder = new GroupedTopNRankBuilder(
                 types,
                 new SimplePageWithPositionComparator(ImmutableList.of(types.get(1)), ImmutableList.of(1), ImmutableList.of(ASC_NULLS_LAST), typeOperators),
-                new SimplePageWithPositionEqualsAndHash(types, ImmutableList.of(1), blockTypeOperators),
+                new SimplePageWithPositionEqualsAndHash(ImmutableList.of(types.get(1)), ImmutableList.of(1), blockTypeOperators),
                 5,
                 false,
                 new int[] {0},

--- a/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRankBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRankBuilder.java
@@ -81,7 +81,7 @@ public class TestGroupedTopNRankBuilder
 
         GroupedTopNBuilder groupedTopNBuilder = new GroupedTopNRankBuilder(
                 types,
-                new SimplePageWithPositionComparator(types, ImmutableList.of(0), ImmutableList.of(ASC_NULLS_LAST), typeOperators),
+                new SimplePageWithPositionComparator(ImmutableList.of(types.get(0)), ImmutableList.of(0), ImmutableList.of(ASC_NULLS_LAST), typeOperators),
                 new SimplePageWithPositionEqualsAndHash(types, ImmutableList.of(0), blockTypeOperators),
                 3,
                 produceRanking,
@@ -147,7 +147,7 @@ public class TestGroupedTopNRankBuilder
         GroupByHash groupByHash = createGroupByHash(types.get(0), NOOP, typeOperators);
         GroupedTopNBuilder groupedTopNBuilder = new GroupedTopNRankBuilder(
                 types,
-                new SimplePageWithPositionComparator(types, ImmutableList.of(1), ImmutableList.of(ASC_NULLS_LAST), typeOperators),
+                new SimplePageWithPositionComparator(ImmutableList.of(types.get(1)), ImmutableList.of(1), ImmutableList.of(ASC_NULLS_LAST), typeOperators),
                 new SimplePageWithPositionEqualsAndHash(types, ImmutableList.of(1), blockTypeOperators),
                 3,
                 produceRanking,
@@ -229,7 +229,7 @@ public class TestGroupedTopNRankBuilder
         GroupByHash groupByHash = createGroupByHash(types.get(0), unblock::get, typeOperators);
         GroupedTopNBuilder groupedTopNBuilder = new GroupedTopNRankBuilder(
                 types,
-                new SimplePageWithPositionComparator(types, ImmutableList.of(1), ImmutableList.of(ASC_NULLS_LAST), typeOperators),
+                new SimplePageWithPositionComparator(ImmutableList.of(types.get(1)), ImmutableList.of(1), ImmutableList.of(ASC_NULLS_LAST), typeOperators),
                 new SimplePageWithPositionEqualsAndHash(types, ImmutableList.of(1), blockTypeOperators),
                 5,
                 false,

--- a/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRowNumberBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRowNumberBuilder.java
@@ -83,7 +83,7 @@ public class TestGroupedTopNRowNumberBuilder
         GroupByHash groupByHash = createGroupByHash(ImmutableList.of(types.get(0)), NOOP);
         GroupedTopNBuilder groupedTopNBuilder = new GroupedTopNRowNumberBuilder(
                 types,
-                new SimplePageWithPositionComparator(types, ImmutableList.of(1), ImmutableList.of(ASC_NULLS_LAST), TYPE_OPERATORS_CACHE),
+                new SimplePageWithPositionComparator(ImmutableList.of(types.get(1)), ImmutableList.of(1), ImmutableList.of(ASC_NULLS_LAST), TYPE_OPERATORS_CACHE),
                 2,
                 produceRowNumbers,
                 new int[] {0},
@@ -155,7 +155,7 @@ public class TestGroupedTopNRowNumberBuilder
 
         GroupedTopNBuilder groupedTopNBuilder = new GroupedTopNRowNumberBuilder(
                 types,
-                new SimplePageWithPositionComparator(types, ImmutableList.of(1), ImmutableList.of(ASC_NULLS_LAST), TYPE_OPERATORS_CACHE),
+                new SimplePageWithPositionComparator(ImmutableList.of(types.get(1)), ImmutableList.of(1), ImmutableList.of(ASC_NULLS_LAST), TYPE_OPERATORS_CACHE),
                 5,
                 produceRowNumbers,
                 new int[0],
@@ -209,7 +209,7 @@ public class TestGroupedTopNRowNumberBuilder
         GroupByHash groupByHash = createGroupByHash(ImmutableList.of(types.get(0)), unblock::get);
         GroupedTopNBuilder groupedTopNBuilder = new GroupedTopNRowNumberBuilder(
                 types,
-                new SimplePageWithPositionComparator(types, ImmutableList.of(1), ImmutableList.of(ASC_NULLS_LAST), TYPE_OPERATORS_CACHE),
+                new SimplePageWithPositionComparator(ImmutableList.of(types.get(1)), ImmutableList.of(1), ImmutableList.of(ASC_NULLS_LAST), TYPE_OPERATORS_CACHE),
                 5,
                 false,
                 new int[] {0},

--- a/core/trino-main/src/test/java/io/trino/operator/TestTopNRankingOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestTopNRankingOperator.java
@@ -22,6 +22,7 @@ import io.trino.spi.Page;
 import io.trino.spi.connector.SortOrder;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
+import io.trino.sql.gen.OrderingCompiler;
 import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.testing.MaterializedResult;
 import io.trino.type.BlockTypeOperators;
@@ -64,6 +65,7 @@ public class TestTopNRankingOperator
     private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed(getClass().getSimpleName() + "-%s"));
     private final ScheduledExecutorService scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed(getClass().getSimpleName() + "-scheduledExecutor-%s"));
     private final TypeOperators typeOperators = new TypeOperators();
+    private final OrderingCompiler orderingCompiler = new OrderingCompiler(typeOperators);
     private final FlatHashStrategyCompiler hashStrategyCompiler = new FlatHashStrategyCompiler(typeOperators);
     private final BlockTypeOperators blockTypeOperators = new BlockTypeOperators(typeOperators);
 
@@ -106,14 +108,13 @@ public class TestTopNRankingOperator
                     Ints.asList(0),
                     ImmutableList.of(VARCHAR),
                     Ints.asList(1),
-                    ImmutableList.of(SortOrder.ASC_NULLS_LAST),
                     3,
                     false,
                     Optional.empty(),
                     10,
                     Optional.empty(),
                     hashStrategyCompiler,
-                    typeOperators,
+                    orderingCompiler.compilePageWithPositionComparator(ImmutableList.of(DOUBLE), Ints.asList(1), ImmutableList.of(SortOrder.ASC_NULLS_LAST)),
                     blockTypeOperators);
 
             MaterializedResult expected = resultBuilder(driverContext.getSession(), DOUBLE, VARCHAR, BIGINT)
@@ -162,14 +163,13 @@ public class TestTopNRankingOperator
                     Ints.asList(),
                     ImmutableList.of(),
                     Ints.asList(1),
-                    ImmutableList.of(SortOrder.ASC_NULLS_LAST),
                     3,
                     partial,
                     Optional.empty(),
                     10,
                     partial ? Optional.of(DataSize.ofBytes(1)) : Optional.empty(),
                     hashStrategyCompiler,
-                    typeOperators,
+                    orderingCompiler.compilePageWithPositionComparator(ImmutableList.of(DOUBLE), Ints.asList(1), ImmutableList.of(SortOrder.ASC_NULLS_LAST)),
                     blockTypeOperators);
 
             MaterializedResult expected;
@@ -228,14 +228,13 @@ public class TestTopNRankingOperator
                     Ints.asList(),
                     ImmutableList.of(),
                     Ints.asList(1),
-                    ImmutableList.of(SortOrder.ASC_NULLS_LAST),
                     3,
                     partial,
                     Optional.empty(),
                     10,
                     partial ? Optional.of(DataSize.of(1, DataSize.Unit.BYTE)) : Optional.empty(),
                     hashStrategyCompiler,
-                    typeOperators,
+                    orderingCompiler.compilePageWithPositionComparator(ImmutableList.of(DOUBLE), Ints.asList(1), ImmutableList.of(SortOrder.ASC_NULLS_LAST)),
                     blockTypeOperators);
 
             TopNRankingOperator operator = (TopNRankingOperator) operatorFactory.createOperator(driverContext);
@@ -272,14 +271,13 @@ public class TestTopNRankingOperator
                 ImmutableList.of(0),
                 ImmutableList.of(type),
                 Ints.asList(0),
-                ImmutableList.of(SortOrder.ASC_NULLS_LAST),
                 3,
                 false,
                 Optional.empty(),
                 10,
                 Optional.empty(),
                 hashStrategyCompiler,
-                typeOperators,
+                orderingCompiler.compilePageWithPositionComparator(ImmutableList.of(type), Ints.asList(0), ImmutableList.of(SortOrder.ASC_NULLS_LAST)),
                 blockTypeOperators);
 
         // get result with yield; pick a relatively small buffer for heaps
@@ -333,14 +331,13 @@ public class TestTopNRankingOperator
                 Ints.asList(0),
                 ImmutableList.of(VARCHAR),
                 Ints.asList(1),
-                ImmutableList.of(ASC_NULLS_FIRST),
                 3,
                 false,
                 Optional.empty(),
                 10,
                 Optional.empty(),
                 hashStrategyCompiler,
-                typeOperators,
+                orderingCompiler.compilePageWithPositionComparator(ImmutableList.of(DOUBLE), Ints.asList(1), ImmutableList.of(ASC_NULLS_FIRST)),
                 blockTypeOperators);
 
         MaterializedResult expected = resultBuilder(driverContext.getSession(), DOUBLE, VARCHAR, BIGINT)

--- a/core/trino-main/src/test/java/io/trino/util/TestMergeSortedPages.java
+++ b/core/trino-main/src/test/java/io/trino/util/TestMergeSortedPages.java
@@ -323,7 +323,7 @@ public class TestMergeSortedPages
                 ImmutableList.of(WorkProcessor.fromIterable(rowPagesBuilder(types)
                         .row(1)
                         .build())),
-                new SimplePageWithPositionComparator(types, ImmutableList.of(0), ImmutableList.of(DESC_NULLS_LAST), TYPE_OPERATORS_CACHE),
+                new SimplePageWithPositionComparator(ImmutableList.of(types.get(0)), ImmutableList.of(0), ImmutableList.of(DESC_NULLS_LAST), TYPE_OPERATORS_CACHE),
                 ImmutableList.of(0),
                 types,
                 (pageBuilder, pageWithPosition) -> pageBuilder.isFull(),
@@ -358,7 +358,7 @@ public class TestMergeSortedPages
         List<Type> types = ImmutableList.of(INTEGER);
         WorkProcessor<Page> mergedPages = MergeSortedPages.mergeSortedPages(
                 ImmutableList.of(WorkProcessor.fromIterable(rowPagesBuilder(types).build())),
-                new SimplePageWithPositionComparator(types, ImmutableList.of(0), ImmutableList.of(DESC_NULLS_LAST), TYPE_OPERATORS_CACHE),
+                new SimplePageWithPositionComparator(ImmutableList.of(types.get(0)), ImmutableList.of(0), ImmutableList.of(DESC_NULLS_LAST), TYPE_OPERATORS_CACHE),
                 ImmutableList.of(0),
                 types,
                 (pageBuilder, pageWithPosition) -> pageBuilder.isFull(),
@@ -381,7 +381,10 @@ public class TestMergeSortedPages
         List<WorkProcessor<Page>> pageProducers = sortedPages.stream()
                 .map(WorkProcessor::fromIterable)
                 .collect(toImmutableList());
-        PageWithPositionComparator comparator = new SimplePageWithPositionComparator(types, sortChannels, sortOrder, TYPE_OPERATORS_CACHE);
+        List<Type> sortTypes = sortChannels.stream()
+                .map(types::get)
+                .collect(toImmutableList());
+        PageWithPositionComparator comparator = new SimplePageWithPositionComparator(sortTypes, sortChannels, sortOrder, TYPE_OPERATORS_CACHE);
 
         AggregatedMemoryContext memoryContext = newSimpleAggregatedMemoryContext().newAggregatedMemoryContext();
         WorkProcessor<Page> mergedPages = MergeSortedPages.mergeSortedPages(


### PR DESCRIPTION
## Description
Improves performance of `TopNOperator` and `TopNRankingOperator` by switching them to use code generated comparators instead of `SimplePageWithPositionComparator`. Also performs small flattening improvements and adds validation checks to `OrderingCompiler` logic.

[BenchmarkTopNOperator results](https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/pettyjamesm/5fca924fd2ea456d633b5b9d3322ecb1/raw/626e2085dd1ece17f7a32923a40ea7f4a8a12507/benchmarktopnoperator_baseline.json,https://gist.githubusercontent.com/pettyjamesm/5fca924fd2ea456d633b5b9d3322ecb1/raw/626e2085dd1ece17f7a32923a40ea7f4a8a12507/benchmarktopnoperator_improved.json) show a 10-40% improvement

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

