### PR TITLE
Do not show column names in access error messages

### DIFF
--- a/core/trino-main/src/test/java/io/trino/security/TestAccessControlManager.java
+++ b/core/trino-main/src/test/java/io/trino/security/TestAccessControlManager.java
@@ -152,7 +152,7 @@ public class TestAccessControlManager
                 assertThatThrownBy(
                         () -> accessControlManager.checkCanSelectFromColumns(securityContext, new QualifiedObjectName(TEST_CATALOG_NAME, "schema", "table"), ImmutableSet.of("column")))
                         .isInstanceOf(AccessDeniedException.class)
-                        .hasMessage("Access Denied: Cannot select from columns [column] in table or view schema.table"));
+                        .hasMessage("Access Denied: Cannot select from table or view schema.table"));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -5822,7 +5822,7 @@ public class TestAnalyzer
                 "SELECT * FROM fresh_materialized_view",
                 accessControlManager)
                 .hasErrorCode(PERMISSION_DENIED)
-                .hasMessage("Access Denied: Cannot select from columns [a, b] in table or view tpch.s1.fresh_materialized_view");
+                .hasMessage("Access Denied: Cannot select from table or view tpch.s1.fresh_materialized_view");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestColumnMask.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestColumnMask.java
@@ -787,7 +787,7 @@ public class TestColumnMask
                         .expression("custkey")
                         .build());
         assertThat(assertions.query("SELECT orderkey FROM orders"))
-                .failure().hasMessage("Access Denied: Cannot select from columns [orderkey, custkey] in table or view local.tiny.orders");
+                .failure().hasMessage("Access Denied: Cannot select from table or view local.tiny.orders");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestFilterInaccessibleColumns.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestFilterInaccessibleColumns.java
@@ -149,7 +149,7 @@ public class TestFilterInaccessibleColumns
 
         // Select all columns explicitly
         assertThat(assertions.query("SELECT nationkey, name, regionkey, comment FROM nation WHERE name = 'FRANCE'"))
-                .failure().hasMessage("Access Denied: Cannot select from columns [nationkey, regionkey, name, comment] in table or view test_catalog.tiny.nation");
+                .failure().hasMessage("Access Denied: Cannot select from table or view test_catalog.tiny.nation");
     }
 
     @Test
@@ -185,7 +185,7 @@ public class TestFilterInaccessibleColumns
                         .build());
         accessControl.deny(privilege(USER, "nation.comment", SELECT_COLUMN));
         assertThat(assertions.query("SELECT * FROM nation WHERE name = 'FRANCE'"))
-                .failure().hasMessage("Access Denied: Cannot select from columns [nationkey, regionkey, name, comment] in table or view test_catalog.tiny.nation");
+                .failure().hasMessage("Access Denied: Cannot select from table or view test_catalog.tiny.nation");
     }
 
     @Test
@@ -204,7 +204,7 @@ public class TestFilterInaccessibleColumns
         accessControl.rowFilter(table, USER, filter);
 
         assertThat(assertions.query(user(USER), "SELECT * FROM nation WHERE name = 'FRANCE'"))
-                .failure().hasMessage("Access Denied: Cannot select from columns [nationkey, regionkey, name, comment] in table or view test_catalog.tiny.nation");
+                .failure().hasMessage("Access Denied: Cannot select from table or view test_catalog.tiny.nation");
         assertThat(assertions.query(user(ADMIN), "SELECT * FROM nation WHERE name = 'FRANCE'"))
                 .matches("VALUES (BIGINT '6', CAST('FRANCE' AS VARCHAR(25)), BIGINT '3', CAST('refully final requests. regular, ironi' AS VARCHAR(152)))");
     }
@@ -244,7 +244,7 @@ public class TestFilterInaccessibleColumns
                         .build());
 
         assertThat(assertions.query("SELECT * FROM nation WHERE name = 'FRANCE'"))
-                .failure().hasMessage("Access Denied: Cannot select from columns [nationkey, regionkey, name, comment] in table or view test_catalog.tiny.nation");
+                .failure().hasMessage("Access Denied: Cannot select from table or view test_catalog.tiny.nation");
     }
 
     @Test
@@ -286,7 +286,7 @@ public class TestFilterInaccessibleColumns
         accessControl.columnMask(table, "comment", USER, mask);
 
         assertThat(assertions.query(user(USER), "SELECT * FROM nation WHERE name = 'FRANCE'"))
-                .failure().hasMessage("Access Denied: Cannot select from columns [nationkey, regionkey, name, comment] in table or view test_catalog.tiny.nation");
+                .failure().hasMessage("Access Denied: Cannot select from table or view test_catalog.tiny.nation");
         assertThat(assertions.query(user(ADMIN), "SELECT * FROM nation WHERE name = 'CANADA'"))
                 .matches("VALUES (BIGINT '3', CAST('CANADA' AS VARCHAR(25)), BIGINT '1', CAST('masked-comment' AS VARCHAR(152)))");
     }
@@ -299,7 +299,7 @@ public class TestFilterInaccessibleColumns
         // Hide name but use it in the query predicate
         accessControl.deny(privilege(USER, "nation.name", SELECT_COLUMN));
         assertThat(assertions.query("SELECT * FROM nation WHERE name = 'FRANCE'"))
-                .failure().hasMessage("Access Denied: Cannot select from columns [nationkey, regionkey, name, comment] in table or view test_catalog.tiny.nation");
+                .failure().hasMessage("Access Denied: Cannot select from table or view test_catalog.tiny.nation");
     }
 
     @Test
@@ -348,7 +348,7 @@ public class TestFilterInaccessibleColumns
 
         accessControl.deny(privilege(USER, "nation.name", SELECT_COLUMN));
         assertThat(assertions.query("SELECT * FROM (SELECT concat(name,'-test') FROM nation WHERE name = 'FRANCE')"))
-                .failure().hasMessage("Access Denied: Cannot select from columns [name] in table or view test_catalog.tiny.nation");
+                .failure().hasMessage("Access Denied: Cannot select from table or view test_catalog.tiny.nation");
     }
 
     private Session user(String user)

--- a/core/trino-spi/src/main/java/io/trino/spi/security/AccessDeniedException.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/AccessDeniedException.java
@@ -391,14 +391,26 @@ public class AccessDeniedException
         throw new AccessDeniedException(format("Cannot truncate table %s%s", tableName, formatExtraInfo(extraInfo)));
     }
 
+    @Deprecated
     public static void denyUpdateTableColumns(String tableName, Set<String> updatedColumnNames)
     {
-        denyUpdateTableColumns(tableName, updatedColumnNames, null);
+        denyUpdateTableColumns(tableName, (String) null);
     }
 
+    @Deprecated
     public static void denyUpdateTableColumns(String tableName, Set<String> updatedColumnNames, String extraInfo)
     {
-        throw new AccessDeniedException(format("Cannot update columns %s in table %s%s", updatedColumnNames, tableName, formatExtraInfo(extraInfo)));
+        denyUpdateTableColumns(tableName, extraInfo);
+    }
+
+    public static void denyUpdateTableColumns(String tableName)
+    {
+        denyUpdateTableColumns(tableName, (String) null);
+    }
+
+    public static void denyUpdateTableColumns(String tableName, String extraInfo)
+    {
+        throw new AccessDeniedException(format("Cannot update columns in table %s%s", tableName, formatExtraInfo(extraInfo)));
     }
 
     public static void denyCreateView(String viewName)
@@ -646,14 +658,26 @@ public class AccessDeniedException
         throw new AccessDeniedException(format("Cannot set catalog session property %s", propertyName));
     }
 
+    @Deprecated
     public static void denySelectColumns(String tableName, Collection<String> columnNames)
     {
-        denySelectColumns(tableName, columnNames, null);
+        denySelectColumns(tableName, (String) null);
     }
 
+    @Deprecated
     public static void denySelectColumns(String tableName, Collection<String> columnNames, String extraInfo)
     {
-        throw new AccessDeniedException(format("Cannot select from columns %s in table or view %s%s", columnNames, tableName, formatExtraInfo(extraInfo)));
+        denySelectColumns(tableName, extraInfo);
+    }
+
+    public static void denySelectColumns(String tableName)
+    {
+        denySelectColumns(tableName, (String) null);
+    }
+
+    public static void denySelectColumns(String tableName, String extraInfo)
+    {
+        throw new AccessDeniedException(format("Cannot select from table or view %s%s", tableName, formatExtraInfo(extraInfo)));
     }
 
     public static void denyCreateRole(String roleName)

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -3485,7 +3485,7 @@ public class TestDeltaLakeConnectorTest
 
         assertAccessDenied(
                 "SELECT * FROM TABLE(system.table_changes(CURRENT_SCHEMA, '" + tableName + "', 0))",
-                "Cannot select from columns .*",
+                "Cannot select from table or view .*" + tableName,
                 privilege(tableName, SELECT_COLUMN));
 
         assertUpdate("DROP TABLE " + tableName);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSystemTables.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSystemTables.java
@@ -123,7 +123,7 @@ public class TestDeltaLakeSystemTables
                     privilege(table.getName(), SELECT_COLUMN));
             assertAccessDenied(
                     "SELECT * FROM \"" + table.getName() + "$transactions\"",
-                    "Cannot select from columns .*",
+                    "Cannot select from table or view .*.\"" + table.getName() + "\\$transactions\"",
                     privilege(table.getName() + "$transactions", SELECT_COLUMN));
         }
     }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestSqlStandardAccessControlChecks.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestSqlStandardAccessControlChecks.java
@@ -106,11 +106,11 @@ public class TestSqlStandardAccessControlChecks
     public void testAccessControlUpdate()
     {
         assertQueryFailure(() -> bobExecutor.executeQuery(format("UPDATE %s SET month=3, day=22", tableName)))
-                .hasMessageContaining("Access Denied: Cannot update columns [month, day] in table default.%s", tableName);
+                .hasMessageContaining("Access Denied: Cannot update columns in table default.%s", tableName);
 
         aliceExecutor.executeQuery(format("GRANT INSERT ON %s TO bob", tableName));
         assertQueryFailure(() -> bobExecutor.executeQuery(format("UPDATE %s SET month=3, day=22", tableName)))
-                .hasMessageContaining("Access Denied: Cannot update columns [month, day] in table default.%s", tableName);
+                .hasMessageContaining("Access Denied: Cannot update columns in table default.%s", tableName);
 
         aliceExecutor.executeQuery(format("GRANT UPDATE ON %s TO bob", tableName));
         assertQueryFailure(() -> bobExecutor.executeQuery(format("UPDATE %s SET month=3, day=22", tableName)))

--- a/testing/trino-tests/src/test/java/io/trino/security/TestAccessControl.java
+++ b/testing/trino-tests/src/test/java/io/trino/security/TestAccessControl.java
@@ -304,47 +304,47 @@ public class TestAccessControl
         assertAccessDenied("CREATE TABLE foo AS SELECT * FROM orders", "Cannot create table .*.foo.*", privilege("foo", CREATE_TABLE));
         assertAccessDenied("ALTER TABLE orders SET PROPERTIES field_length = 32", "Cannot set table properties to .*.orders.*", privilege("orders", SET_TABLE_PROPERTIES));
         assertAccessDenied("ALTER TABLE orders ALTER COLUMN orderkey SET DATA TYPE char(100)", "Cannot alter a column for table .*.orders.*", privilege("orders", ALTER_COLUMN));
-        assertAccessDenied("SELECT * FROM nation", "Cannot select from columns \\[nationkey, regionkey, name, comment] in table .*.nation.*", privilege("nation.nationkey", SELECT_COLUMN));
-        assertAccessDenied("SELECT * FROM (SELECT * FROM nation)", "Cannot select from columns \\[nationkey, regionkey, name, comment] in table .*.nation.*", privilege("nation.nationkey", SELECT_COLUMN));
-        assertAccessDenied("SELECT name FROM (SELECT * FROM nation)", "Cannot select from columns \\[nationkey, regionkey, name, comment] in table .*.nation.*", privilege("nation.nationkey", SELECT_COLUMN));
+        assertAccessDenied("SELECT * FROM nation", "Cannot select from table or view .*.nation.*", privilege("nation.nationkey", SELECT_COLUMN));
+        assertAccessDenied("SELECT * FROM (SELECT * FROM nation)", "Cannot select from table or view .*.nation.*", privilege("nation.nationkey", SELECT_COLUMN));
+        assertAccessDenied("SELECT name FROM (SELECT * FROM nation)", "Cannot select from table or view .*.nation.*", privilege("nation.nationkey", SELECT_COLUMN));
         assertAccessAllowed("SELECT name FROM nation", privilege("nationkey", SELECT_COLUMN));
-        assertAccessDenied("SELECT n1.nationkey, n2.regionkey FROM nation n1, nation n2", "Cannot select from columns \\[nationkey, regionkey] in table .*.nation.*", privilege("nation.nationkey", SELECT_COLUMN));
-        assertAccessDenied("SELECT count(name) as c FROM nation where comment > 'abc' GROUP BY regionkey having max(nationkey) > 10", "Cannot select from columns \\[nationkey, regionkey, name, comment] in table .*.nation.*", privilege("nation.nationkey", SELECT_COLUMN));
-        assertAccessDenied("SELECT 1 FROM region, nation where region.regionkey = nation.nationkey", "Cannot select from columns \\[nationkey] in table .*.nation.*", privilege("nation.nationkey", SELECT_COLUMN));
-        assertAccessDenied("SELECT count(*) FROM nation", "Cannot select from columns \\[] in table .*.nation.*", privilege("nation", SELECT_COLUMN));
-        assertAccessDenied("WITH t1 AS (SELECT * FROM nation) SELECT * FROM t1", "Cannot select from columns \\[nationkey, regionkey, name, comment] in table .*.nation.*", privilege("nation.nationkey", SELECT_COLUMN));
+        assertAccessDenied("SELECT n1.nationkey, n2.regionkey FROM nation n1, nation n2", "Cannot select from table or view .*.nation.*", privilege("nation.nationkey", SELECT_COLUMN));
+        assertAccessDenied("SELECT count(name) as c FROM nation where comment > 'abc' GROUP BY regionkey having max(nationkey) > 10", "Cannot select from table or view .*.nation.*", privilege("nation.nationkey", SELECT_COLUMN));
+        assertAccessDenied("SELECT 1 FROM region, nation where region.regionkey = nation.nationkey", "Cannot select from table or view .*.nation.*", privilege("nation.nationkey", SELECT_COLUMN));
+        assertAccessDenied("SELECT count(*) FROM nation", "Cannot select from table or view .*.nation.*", privilege("nation", SELECT_COLUMN));
+        assertAccessDenied("WITH t1 AS (SELECT * FROM nation) SELECT * FROM t1", "Cannot select from table or view .*.nation.*", privilege("nation.nationkey", SELECT_COLUMN));
         assertAccessAllowed("SELECT name AS my_alias FROM nation", privilege("my_alias", SELECT_COLUMN));
         assertAccessAllowed("SELECT my_alias from (SELECT name AS my_alias FROM nation)", privilege("my_alias", SELECT_COLUMN));
-        assertAccessDenied("SELECT name AS my_alias FROM nation", "Cannot select from columns \\[name] in table .*.nation.*", privilege("nation.name", SELECT_COLUMN));
+        assertAccessDenied("SELECT name AS my_alias FROM nation", "Cannot select from table or view .*.nation.*", privilege("nation.name", SELECT_COLUMN));
         assertAccessAllowed("SELECT 1 FROM mock.default.test_materialized_view");
-        assertAccessDenied("SELECT 1 FROM mock.default.test_materialized_view", "Cannot select from columns.*", privilege("test_materialized_view", SELECT_COLUMN));
+        assertAccessDenied("SELECT 1 FROM mock.default.test_materialized_view", "Cannot select from table or view .*.test_materialized_view", privilege("test_materialized_view", SELECT_COLUMN));
         assertAccessAllowed("SELECT * FROM mock.default.test_materialized_view");
-        assertAccessDenied("SELECT * FROM mock.default.test_materialized_view", "Cannot select from columns.*", privilege("test_materialized_view", SELECT_COLUMN));
+        assertAccessDenied("SELECT * FROM mock.default.test_materialized_view", "Cannot select from table or view .*.test_materialized_view", privilege("test_materialized_view", SELECT_COLUMN));
         assertAccessAllowed("SELECT 1 FROM mock.default.test_view_definer");
-        assertAccessDenied("SELECT 1 FROM mock.default.test_view_definer", "Cannot select from columns.*", privilege("test_view_definer", SELECT_COLUMN));
+        assertAccessDenied("SELECT 1 FROM mock.default.test_view_definer", "Cannot select from table or view .*.test_view_definer", privilege("test_view_definer", SELECT_COLUMN));
         assertAccessAllowed("SELECT * FROM mock.default.test_view_definer");
-        assertAccessDenied("SELECT * FROM mock.default.test_view_definer", "Cannot select from columns.*", privilege("test_view_definer", SELECT_COLUMN));
+        assertAccessDenied("SELECT * FROM mock.default.test_view_definer", "Cannot select from table or view .*.test_view_definer", privilege("test_view_definer", SELECT_COLUMN));
         assertAccessAllowed("SELECT 1 FROM mock.default.test_view_invoker");
-        assertAccessDenied("SELECT 1 FROM mock.default.test_view_invoker", "Cannot select from columns.*", privilege("test_view_invoker", SELECT_COLUMN));
+        assertAccessDenied("SELECT 1 FROM mock.default.test_view_invoker", "Cannot select from table or view .*.test_view_invoker", privilege("test_view_invoker", SELECT_COLUMN));
         assertAccessAllowed("SELECT * FROM mock.default.test_view_invoker");
-        assertAccessDenied("SELECT * FROM mock.default.test_view_invoker", "Cannot select from columns.*", privilege("test_view_invoker", SELECT_COLUMN));
+        assertAccessDenied("SELECT * FROM mock.default.test_view_invoker", "Cannot select from table or view .*.test_view_invoker", privilege("test_view_invoker", SELECT_COLUMN));
         // with current implementation this next block of checks is redundant to `SELECT 1 FROM ..`, but it is not obvious unless details of how
         // semantics analyzer works are known
         assertAccessAllowed("SELECT count(*) FROM mock.default.test_materialized_view");
-        assertAccessDenied("SELECT count(*) FROM mock.default.test_materialized_view", "Cannot select from columns.*", privilege("test_materialized_view", SELECT_COLUMN));
+        assertAccessDenied("SELECT count(*) FROM mock.default.test_materialized_view", "Cannot select from table or view .*.test_materialized_view", privilege("test_materialized_view", SELECT_COLUMN));
         assertAccessAllowed("SELECT count(*) FROM mock.default.test_view_invoker");
-        assertAccessDenied("SELECT count(*) FROM mock.default.test_view_invoker", "Cannot select from columns.*", privilege("test_view_invoker", SELECT_COLUMN));
+        assertAccessDenied("SELECT count(*) FROM mock.default.test_view_invoker", "Cannot select from table or view .*.test_view_invoker", privilege("test_view_invoker", SELECT_COLUMN));
         assertAccessAllowed("SELECT count(*) FROM mock.default.test_view_definer");
-        assertAccessDenied("SELECT count(*) FROM mock.default.test_view_definer", "Cannot select from columns.*", privilege("test_view_definer", SELECT_COLUMN));
+        assertAccessDenied("SELECT count(*) FROM mock.default.test_view_definer", "Cannot select from table or view .*.test_view_definer", privilege("test_view_definer", SELECT_COLUMN));
 
         assertAccessDenied(
                 "SELECT orders.custkey, lineitem.quantity FROM orders JOIN lineitem USING (orderkey)",
-                "Cannot select from columns \\[orderkey, custkey] in table .*",
+                "Cannot select from table or view .*.orders",
                 privilege("orders.orderkey", SELECT_COLUMN));
 
         assertAccessDenied(
                 "SELECT orders.custkey, lineitem.quantity FROM orders JOIN lineitem USING (orderkey)",
-                "Cannot select from columns \\[orderkey, quantity] in table .*",
+                "Cannot select from table or view .*.lineitem",
                 privilege("lineitem.orderkey", SELECT_COLUMN));
 
         assertAccessDenied("SHOW CREATE TABLE orders", "Cannot show create table for .*.orders.*", privilege("orders", SHOW_CREATE_TABLE));
@@ -357,15 +357,15 @@ public class TestAccessControl
         assertAccessAllowed("SHOW STATS FOR lineitem", privilege("orders", SELECT_COLUMN));
         assertAccessAllowed("SHOW STATS FOR (SELECT * FROM lineitem)");
         assertAccessAllowed("SHOW STATS FOR (SELECT * FROM lineitem)", privilege("orders", SELECT_COLUMN));
-        assertAccessDenied("SHOW STATS FOR (SELECT * FROM nation)", "Cannot select from columns \\[nationkey, regionkey, name, comment] in table or view .*.nation", privilege("nation", SELECT_COLUMN));
-        assertAccessDenied("SHOW STATS FOR (SELECT nationkey FROM nation)", "Cannot select from columns \\[nationkey] in table or view .*.nation", privilege("nation", SELECT_COLUMN));
-        assertAccessDenied("SHOW STATS FOR (SELECT nationkey FROM nation)", "Cannot select from columns \\[nationkey] in table or view .*.nation", privilege("nation.nationkey", SELECT_COLUMN));
-        assertAccessDenied("SHOW STATS FOR (SELECT *, nationkey FROM nation)", "Cannot select from columns \\[nationkey, regionkey, name, comment] in table or view .*.nation", privilege("nation.nationkey", SELECT_COLUMN));
-        assertAccessDenied("SHOW STATS FOR (SELECT *, * FROM nation)", "Cannot select from columns \\[nationkey, regionkey, name, comment] in table or view .*.nation", privilege("nation.nationkey", SELECT_COLUMN));
-        assertAccessDenied("SHOW STATS FOR (SELECT linenumber, orderkey FROM lineitem)", "Cannot select from columns \\[linenumber, orderkey] in table or view .*.lineitem.*", privilege("lineitem", SELECT_COLUMN));
-        assertAccessDenied("SHOW STATS FOR (SELECT linenumber, orderkey, quantity FROM lineitem)", "Cannot select from columns \\[linenumber, orderkey, quantity] in table or view .*.lineitem.*", privilege("lineitem.linenumber", SELECT_COLUMN), privilege("lineitem.orderkey", SELECT_COLUMN));
-        assertAccessDenied("SHOW STATS FOR (SELECT nationkey FROM nation)", "Cannot select from columns \\[nationkey] in table or view .*.nation.*", privilege("nation", SELECT_COLUMN));
-        assertAccessDenied("SHOW STATS FOR (SELECT * FROM nation)", "Cannot select from columns \\[nationkey, regionkey, name, comment] in table or view .*.nation.*", privilege("nation", SELECT_COLUMN));
+        assertAccessDenied("SHOW STATS FOR (SELECT * FROM nation)", "Cannot select from table or view .*.nation", privilege("nation", SELECT_COLUMN));
+        assertAccessDenied("SHOW STATS FOR (SELECT nationkey FROM nation)", "Cannot select from table or view .*.nation", privilege("nation", SELECT_COLUMN));
+        assertAccessDenied("SHOW STATS FOR (SELECT nationkey FROM nation)", "Cannot select from table or view .*.nation", privilege("nation.nationkey", SELECT_COLUMN));
+        assertAccessDenied("SHOW STATS FOR (SELECT *, nationkey FROM nation)", "Cannot select from table or view .*.nation", privilege("nation.nationkey", SELECT_COLUMN));
+        assertAccessDenied("SHOW STATS FOR (SELECT *, * FROM nation)", "Cannot select from table or view .*.nation", privilege("nation.nationkey", SELECT_COLUMN));
+        assertAccessDenied("SHOW STATS FOR (SELECT linenumber, orderkey FROM lineitem)", "Cannot select from table or view .*.lineitem.*", privilege("lineitem", SELECT_COLUMN));
+        assertAccessDenied("SHOW STATS FOR (SELECT linenumber, orderkey, quantity FROM lineitem)", "Cannot select from table or view .*.lineitem.*", privilege("lineitem.linenumber", SELECT_COLUMN), privilege("lineitem.orderkey", SELECT_COLUMN));
+        assertAccessDenied("SHOW STATS FOR (SELECT nationkey FROM nation)", "Cannot select from table or view .*.nation.*", privilege("nation", SELECT_COLUMN));
+        assertAccessDenied("SHOW STATS FOR (SELECT * FROM nation)", "Cannot select from table or view .*.nation.*", privilege("nation", SELECT_COLUMN));
     }
 
     @Test
@@ -446,7 +446,7 @@ public class TestAccessControl
                 privilege(viewOwnerSession.getUser(), "orders", SELECT_COLUMN));
         assertAccessDenied(
                 "SELECT * FROM " + invokerViewName,
-                "Cannot select from columns \\[.*] in table .*.orders.*",
+                "Cannot select from table .*.orders.*",
                 privilege(getSession().getUser(), "orders", SELECT_COLUMN));
 
         // verify that groups are set inside access control
@@ -502,7 +502,7 @@ public class TestAccessControl
         systemSecurityMetadata.grantRoles(getSession(), Set.of("view_owner_role_without_access"), Set.of(viewOwnerPrincipal), false, Optional.empty());
         assertThatThrownBy(() -> getQueryRunner().execute(viewOwnerSession,
                 "SELECT * FROM " + viewName))
-                .hasMessageMatching("Access Denied: Cannot select from columns \\[.*] in table or view \\w+\\.\\w+\\.orders");
+                .hasMessageMatching("Access Denied: Cannot select from table or view \\w+\\.\\w+\\.orders");
 
         systemSecurityMetadata.revokeRoles(getSession(), Set.of("view_owner_role_without_access"), Set.of(viewOwnerPrincipal), false, Optional.empty());
         getQueryRunner().execute(viewOwnerSession, "SELECT * FROM " + viewName);
@@ -541,7 +541,7 @@ public class TestAccessControl
         getQueryRunner().getAccessControl()
                 .denyIdentityTable((identity, table) -> !(identity.getEnabledRoles().contains("view_owner_role_without_access") && "orders".equals(table)));
         systemSecurityMetadata.grantRoles(getSession(), Set.of("view_owner_role_without_access"), Set.of(viewOwnerPrincipal), false, Optional.empty());
-        String errorMessage = "Access Denied: Cannot select from columns \\[.*] in table or view \\w+\\.\\w+\\.orders";
+        String errorMessage = "Access Denied: Cannot select from table or view \\w+\\.\\w+\\.orders";
 
         getQueryRunner().execute(viewOwnerSession, "SELECT * FROM orders");
         assertThatThrownBy(() -> getQueryRunner().execute(viewOwnerSession, "SELECT * FROM " + viewName))
@@ -808,7 +808,7 @@ public class TestAccessControl
 
         assertAccessDenied(
                 "SELECT * FROM TABLE(exclude_columns(TABLE(nation), descriptor(regionkey, comment)))",
-                "Cannot select from columns \\[nationkey, name] in table .*.nation.*",
+                "Cannot select from table or view .*.nation.*",
                 privilege("nation.nationkey", SELECT_COLUMN));
     }
 
@@ -819,8 +819,8 @@ public class TestAccessControl
 
         assertAccessAllowed("ANALYZE nation");
         assertAccessDenied("ANALYZE nation", "Cannot ANALYZE \\(missing insert privilege\\) table .*.nation.*", privilege("nation", INSERT_TABLE));
-        assertAccessDenied("ANALYZE nation", "Cannot select from columns \\[.*] in table or view .*.nation", privilege("nation", SELECT_COLUMN));
-        assertAccessDenied("ANALYZE nation", "Cannot select from columns \\[.*nationkey.*] in table or view .*.nation", privilege("nation.nationkey", SELECT_COLUMN));
+        assertAccessDenied("ANALYZE nation", "Cannot select from table or view .*.nation", privilege("nation", SELECT_COLUMN));
+        assertAccessDenied("ANALYZE nation", "Cannot select from table or view .*.nation", privilege("nation.nationkey", SELECT_COLUMN));
     }
 
     @Test
@@ -992,7 +992,7 @@ public class TestAccessControl
     {
         reset();
 
-        assertAccessDenied("DELETE FROM orders WHERE orderkey < 12", "Cannot select from columns \\[orderkey] in table or view .*.orders.*", privilege("orders.orderkey", SELECT_COLUMN));
+        assertAccessDenied("DELETE FROM orders WHERE orderkey < 12", "Cannot select from table or view .*\\.orders.*", privilege("orders.orderkey", SELECT_COLUMN));
         assertAccessAllowed("DELETE FROM orders WHERE orderkey < 12", privilege("orders" + ".orderdate", SELECT_COLUMN));
         assertAccessAllowed("DELETE FROM orders", privilege("orders", SELECT_COLUMN));
     }
@@ -1010,8 +1010,8 @@ public class TestAccessControl
     {
         reset();
 
-        assertAccessDenied("UPDATE orders SET orderkey=123", "Cannot update columns \\[orderkey] in table .*", privilege("orders", UPDATE_TABLE));
-        assertAccessDenied("UPDATE orders SET orderkey=123 WHERE custkey < 12", "Cannot select from columns \\[custkey] in table or view .*.default.orders", privilege("orders.custkey", SELECT_COLUMN));
+        assertAccessDenied("UPDATE orders SET orderkey=123", "Cannot update columns in table .*", privilege("orders", UPDATE_TABLE));
+        assertAccessDenied("UPDATE orders SET orderkey=123 WHERE custkey < 12", "Cannot select from table or view .*.default.orders", privilege("orders.custkey", SELECT_COLUMN));
         assertAccessAllowed("UPDATE orders SET orderkey=123", privilege("orders", SELECT_COLUMN));
     }
 
@@ -1046,12 +1046,12 @@ public class TestAccessControl
 
         // Show that without SELECT on the source table, the MERGE fails regardless of which case is included
         for (String mergeCase : ImmutableList.of(deleteCase, updateCase, insertCase)) {
-            assertAccessDenied(baseMergeSql + mergeCase, "Cannot select from columns .* in table or view " + sourceName, privilege(sourceTable, SELECT_COLUMN));
+            assertAccessDenied(baseMergeSql + mergeCase, "Cannot select from table or view " + sourceName, privilege(sourceTable, SELECT_COLUMN));
         }
 
         // Show that without SELECT on the target table, the MERGE fails regardless of which case is included
         for (String mergeCase : ImmutableList.of(deleteCase, updateCase, insertCase)) {
-            assertAccessDenied(baseMergeSql + mergeCase, "Cannot select from columns .* in table or view " + targetName, privilege(targetTable, SELECT_COLUMN));
+            assertAccessDenied(baseMergeSql + mergeCase, "Cannot select from table or view " + targetName, privilege(targetTable, SELECT_COLUMN));
         }
 
         // Show that without INSERT on the target table, the MERGE fails
@@ -1061,7 +1061,7 @@ public class TestAccessControl
         assertAccessDenied(baseMergeSql + deleteCase, "Cannot delete from table " + targetName, privilege(targetTable, DELETE_TABLE));
 
         // Show that without UPDATE on the target table, the MERGE fails
-        assertAccessDenied(baseMergeSql + updateCase, "Cannot update columns \\[nation_name] in table " + targetName, privilege(targetTable, UPDATE_TABLE));
+        assertAccessDenied(baseMergeSql + updateCase, "Cannot update columns in table " + targetName, privilege(targetTable, UPDATE_TABLE));
 
         assertAccessAllowed(
                 """

--- a/testing/trino-tests/src/test/java/io/trino/security/TestAccessControlTableRedirection.java
+++ b/testing/trino-tests/src/test/java/io/trino/security/TestAccessControlTableRedirection.java
@@ -125,7 +125,7 @@ public class TestAccessControlTableRedirection
         assertAccessAllowed("SELECT * FROM redirection_source");
         assertAccessDenied(
                 "SELECT * FROM redirection_source",
-                "Cannot select from columns \\[data_column, id_column] in table or view test_catalog.test_schema.redirection_target",
+                "Cannot select from table or view test_catalog.test_schema.redirection_target",
                 privilege("redirection_target.data_column", SELECT_COLUMN));
     }
 

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestTableFunctionInvocation.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestTableFunctionInvocation.java
@@ -142,12 +142,12 @@ public class TestTableFunctionInvocation
     {
         assertAccessDenied(
                 "SELECT boolean_column FROM TABLE(system.simple_table_function(column => 'boolean_column', ignored => 1))",
-                "Cannot select from columns .*",
+                "Cannot select from table or view " + TESTING_CATALOG + "\\.system\\.simple_table",
                 privilege("simple_table.boolean_column", SELECT_COLUMN));
 
         assertAccessDenied(
                 "SELECT boolean_column FROM TABLE(system.simple_table_function(column => 'boolean_column', ignored => 1))",
-                "Cannot select from columns .*",
+                "Cannot select from table or view " + TESTING_CATALOG + "\\.system\\.simple_table",
                 privilege("simple_table", SELECT_COLUMN));
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
To avoid information disclosure, it would be better not to show column names in error messages for column-level access errors.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
https://github.com/trinodb/trino/pull/24873


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
