### PR TITLE
Refactor QueryDataDecoder to return Iterator

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/JsonResultRows.java
+++ b/client/trino-client/src/main/java/io/trino/client/JsonResultRows.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 import static com.fasterxml.jackson.core.JsonParser.Feature.AUTO_CLOSE_SOURCE;
@@ -136,28 +137,16 @@ public final class JsonResultRows
         }
     }
 
-    public static ResultRows forJsonParser(JsonParser parser, List<Column> columns)
+    public static Iterator<List<Object>> forJsonParser(JsonParser parser, List<Column> columns)
+            throws IOException
     {
-        return () -> {
-            try {
-                return new RowWiseIterator(parser, createTypeDecoders(columns));
-            }
-            catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-        };
+        return new RowWiseIterator(parser, createTypeDecoders(columns));
     }
 
-    public static ResultRows forInputStream(InputStream stream, TypeDecoder[] decoders)
+    public static Iterator<List<Object>> forInputStream(InputStream stream, TypeDecoder[] decoders)
+            throws IOException
     {
-        return () -> {
-            try {
-                return new RowWiseIterator(stream, decoders);
-            }
-            catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-        };
+        return new RowWiseIterator(stream, decoders);
     }
 
     @SuppressModernizer // There is no JsonFactory in the client module

--- a/client/trino-client/src/main/java/io/trino/client/OkHttpSegmentLoader.java
+++ b/client/trino-client/src/main/java/io/trino/client/OkHttpSegmentLoader.java
@@ -22,7 +22,6 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 
-import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -65,7 +64,7 @@ public class OkHttpSegmentLoader
         }
 
         if (response.isSuccessful()) {
-            return delegatingInputStream(response, response.body().byteStream(), segment);
+            return response.body().byteStream();
         }
         throw new IOException(format("Could not open segment for streaming, got error '%s' with code %d", response.message(), response.code()));
     }
@@ -93,21 +92,6 @@ public class OkHttpSegmentLoader
                 response.close();
             }
         });
-    }
-
-    private InputStream delegatingInputStream(Response response, InputStream delegate, SpooledSegment segment)
-    {
-        return new FilterInputStream(delegate)
-        {
-            @Override
-            public void close()
-                    throws IOException
-            {
-                try (Response ignored = response; InputStream ignored2 = delegate) {
-                    acknowledge(segment);
-                }
-            }
-        };
     }
 
     private static Headers toHeaders(Map<String, List<String>> headers)

--- a/client/trino-client/src/main/java/io/trino/client/QueryDataDecoder.java
+++ b/client/trino-client/src/main/java/io/trino/client/QueryDataDecoder.java
@@ -17,6 +17,7 @@ import io.trino.client.spooling.DataAttributes;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Iterator;
 import java.util.List;
 
 public interface QueryDataDecoder
@@ -39,7 +40,7 @@ public interface QueryDataDecoder
      *
      * @throws IOException if an I/O error occurs
      */
-    ResultRows decode(InputStream input, DataAttributes segmentAttributes)
+    Iterator<List<Object>> decode(InputStream input, DataAttributes segmentAttributes)
             throws IOException;
 
     String encoding();

--- a/client/trino-client/src/main/java/io/trino/client/ResultRows.java
+++ b/client/trino-client/src/main/java/io/trino/client/ResultRows.java
@@ -40,7 +40,7 @@ public interface ResultRows
         }
     };
 
-    static ResultRows fromIterableRows(Iterable<List<Object>> values)
+    static ResultRows wrapList(List<List<Object>> values)
     {
         return values::iterator;
     }

--- a/client/trino-client/src/main/java/io/trino/client/spooling/InlineSegment.java
+++ b/client/trino-client/src/main/java/io/trino/client/spooling/InlineSegment.java
@@ -15,7 +15,10 @@ package io.trino.client.spooling;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.client.QueryDataDecoder;
 
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import static java.lang.String.format;
@@ -47,5 +50,10 @@ public final class InlineSegment
     public String toString()
     {
         return format("InlineSegment{offset=%d, rows=%d, size=%d}", getOffset(), getRowsCount(), getSegmentSize());
+    }
+
+    public Iterator<List<Object>> toIterator(QueryDataDecoder decoder)
+    {
+        return new InlineSegmentIterator(this, decoder);
     }
 }

--- a/client/trino-client/src/main/java/io/trino/client/spooling/InlineSegmentIterator.java
+++ b/client/trino-client/src/main/java/io/trino/client/spooling/InlineSegmentIterator.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client.spooling;
+
+import com.google.common.collect.AbstractIterator;
+import io.trino.client.QueryDataDecoder;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Iterator;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+// Accessible through the InlineSegment.toIterator
+class InlineSegmentIterator
+        extends AbstractIterator<List<Object>>
+{
+    private InlineSegment segment;
+    private final QueryDataDecoder decoder;
+    private Iterator<List<Object>> iterator;
+
+    public InlineSegmentIterator(InlineSegment segment, QueryDataDecoder decoder)
+    {
+        this.segment = requireNonNull(segment, "segment is null");
+        this.decoder = requireNonNull(decoder, "decoder is null");
+    }
+
+    @Override
+    protected List<Object> computeNext()
+    {
+        if (iterator == null) {
+            try {
+                iterator = decoder.decode(new ByteArrayInputStream(segment.getData()), segment.getMetadata());
+                segment = null;
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        if (iterator.hasNext()) {
+            return iterator.next();
+        }
+        return endOfData();
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/spooling/SpooledSegment.java
+++ b/client/trino-client/src/main/java/io/trino/client/spooling/SpooledSegment.java
@@ -17,8 +17,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
+import io.trino.client.QueryDataDecoder;
 
 import java.net.URI;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -74,5 +76,10 @@ public final class SpooledSegment
     public String toString()
     {
         return format("SpooledSegment{offset=%d, rows=%d, size=%d, headers=%s}", getOffset(), getRowsCount(), getSegmentSize(), headers.keySet());
+    }
+
+    public Iterator<List<Object>> toIterator(SegmentLoader loader, QueryDataDecoder decoder)
+    {
+        return new SpooledSegmentIterator(this, loader, decoder);
     }
 }

--- a/client/trino-client/src/main/java/io/trino/client/spooling/SpooledSegmentIterator.java
+++ b/client/trino-client/src/main/java/io/trino/client/spooling/SpooledSegmentIterator.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client.spooling;
+
+import com.google.common.collect.AbstractIterator;
+import com.google.common.io.Closer;
+import io.trino.client.QueryDataDecoder;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
+import static java.util.Objects.requireNonNull;
+
+// Accessible through the SpooledSegment.toIterator
+class SpooledSegmentIterator
+        extends AbstractIterator<List<Object>>
+{
+    private final SpooledSegment segment;
+    private final long rowsCount;
+    private final SegmentLoader loader;
+    private final QueryDataDecoder decoder;
+    private long currentRow;
+    private boolean loaded;
+    private boolean closed;
+    private Iterator<List<Object>> iterator;
+    private Closer closer = Closer.create();
+
+    public SpooledSegmentIterator(SpooledSegment spooledSegment, SegmentLoader loader, QueryDataDecoder decoder)
+    {
+        this.segment = requireNonNull(spooledSegment, "spooledSegment is null");
+        this.rowsCount = spooledSegment.getRowsCount();
+        this.loader = requireNonNull(loader, "loader is null");
+        this.decoder = requireNonNull(decoder, "decoder is null");
+    }
+
+    public void load()
+    {
+        checkState(!closed, "Iterator is already closed");
+        checkState(!loaded, "Iterator is already loaded");
+
+        checkState(iterator == null, "Iterator should be unloaded");
+        try {
+            InputStream stream = closer.register(loader.load(segment)); // close stream when depleted
+            closer.register(() -> loader.acknowledge(segment)); // acknowledge segment when depleted
+            iterator = decoder.decode(stream, segment.getMetadata());
+            loaded = true;
+        }
+        catch (IOException e) {
+            closed = true;
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public void unload()
+    {
+        checkState(!closed, "Iterator is already closed");
+        closed = true;
+        try {
+            closer.close();
+            iterator = null;
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public long remaining()
+    {
+        return rowsCount - currentRow;
+    }
+
+    @Override
+    protected List<Object> computeNext()
+    {
+        if (!loaded) {
+            load();
+        }
+
+        if (++currentRow > rowsCount) {
+            return endOfData();
+        }
+
+        if (closed) {
+            throw new NoSuchElementException();
+        }
+
+        try {
+            verify(iterator.hasNext(), "Iterator should have more rows, current: %s, count: %s", currentRow, rowsCount);
+            List<Object> rows = iterator.next();
+            if (currentRow == this.rowsCount) {
+                unload(); // Unload when the last row was fetched
+            }
+            return rows;
+        }
+        catch (Exception e) {
+            // Cleanup if decoding has failed
+            unload();
+            throw e;
+        }
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/spooling/encoding/CompressedQueryDataDecoder.java
+++ b/client/trino-client/src/main/java/io/trino/client/spooling/encoding/CompressedQueryDataDecoder.java
@@ -15,13 +15,14 @@ package io.trino.client.spooling.encoding;
 
 import com.google.common.io.ByteStreams;
 import io.trino.client.QueryDataDecoder;
-import io.trino.client.ResultRows;
 import io.trino.client.spooling.DataAttribute;
 import io.trino.client.spooling.DataAttributes;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
@@ -41,7 +42,7 @@ public abstract class CompressedQueryDataDecoder
             throws IOException;
 
     @Override
-    public ResultRows decode(InputStream stream, DataAttributes metadata)
+    public Iterator<List<Object>> decode(InputStream stream, DataAttributes metadata)
             throws IOException
     {
         Optional<Integer> expectedDecompressedSize = metadata.getOptional(DataAttribute.UNCOMPRESSED_SIZE, Integer.class);

--- a/client/trino-client/src/main/java/io/trino/client/spooling/encoding/JsonQueryDataDecoder.java
+++ b/client/trino-client/src/main/java/io/trino/client/spooling/encoding/JsonQueryDataDecoder.java
@@ -17,10 +17,11 @@ import io.trino.client.Column;
 import io.trino.client.JsonDecodingUtils.TypeDecoder;
 import io.trino.client.JsonResultRows;
 import io.trino.client.QueryDataDecoder;
-import io.trino.client.ResultRows;
 import io.trino.client.spooling.DataAttributes;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.util.Iterator;
 import java.util.List;
 
 import static io.trino.client.JsonDecodingUtils.createTypeDecoders;
@@ -37,7 +38,8 @@ public class JsonQueryDataDecoder
     }
 
     @Override
-    public ResultRows decode(InputStream stream, DataAttributes queryAttributes)
+    public Iterator<List<Object>> decode(InputStream stream, DataAttributes queryAttributes)
+            throws IOException
     {
         return JsonResultRows.forInputStream(stream, decoders);
     }

--- a/client/trino-client/src/test/java/io/trino/client/TestResultRowsDecoder.java
+++ b/client/trino-client/src/test/java/io/trino/client/TestResultRowsDecoder.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.CountingInputStream;
+import io.trino.client.spooling.DataAttribute;
 import io.trino.client.spooling.DataAttributes;
 import io.trino.client.spooling.EncodedQueryData;
 import io.trino.client.spooling.Segment;
@@ -25,7 +26,6 @@ import io.trino.client.spooling.SpooledSegment;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
-import java.io.FilterInputStream;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Arrays;
@@ -117,7 +117,7 @@ class TestResultRowsDecoder
         AtomicInteger loaded = new AtomicInteger();
         AtomicInteger acknowledged = new AtomicInteger();
         try (ResultRowsDecoder decoder = new ResultRowsDecoder(new StaticLoader(loaded, acknowledged))) {
-            assertThat(eagerlyMaterialize(decoder.toRows(fromSegments(spooledSegment(), spooledSegment()))))
+            assertThat(eagerlyMaterialize(decoder.toRows(fromSegments(spooledSegment(2), spooledSegment(2)))))
                     .hasSize(4)
                     .containsExactly(ImmutableList.of(2137), ImmutableList.of(1337), ImmutableList.of(2137), ImmutableList.of(1337));
         }
@@ -132,7 +132,7 @@ class TestResultRowsDecoder
         AtomicInteger loaded = new AtomicInteger();
         AtomicInteger acknowledged = new AtomicInteger();
         try (ResultRowsDecoder decoder = new ResultRowsDecoder(new StaticLoader(loaded, acknowledged))) {
-            assertThat(eagerlyMaterialize(decoder.toRows(fromSegments(spooledSegment(), spooledSegment()))))
+            assertThat(eagerlyMaterialize(decoder.toRows(fromSegments(spooledSegment(2), spooledSegment(2)))))
                     .hasSize(4)
                     .containsExactly(ImmutableList.of(2137), ImmutableList.of(1337), ImmutableList.of(2137), ImmutableList.of(1337));
         }
@@ -148,7 +148,7 @@ class TestResultRowsDecoder
                 .reduce("[", (a, b) -> a + "[" + b + "],", String::concat) + "[1337]]";
         CountingInputStream stream = new CountingInputStream(new ByteArrayInputStream(data.getBytes(UTF_8)));
         try (ResultRowsDecoder decoder = new ResultRowsDecoder(loaderFromStream(stream))) {
-            Iterator<List<Object>> iterator = decoder.toRows(fromSegments(spooledSegment())).iterator();
+            Iterator<List<Object>> iterator = decoder.toRows(fromSegments(spooledSegment(2501))).iterator();
             assertThat(stream.getCount()).isEqualTo(0);
             iterator.next();
             assertThat(stream.getCount()).isEqualTo(8000); // Jackson reads data in 8K chunks
@@ -174,7 +174,7 @@ class TestResultRowsDecoder
         AtomicInteger loaded = new AtomicInteger();
         AtomicInteger acknowledged = new AtomicInteger();
         try (ResultRowsDecoder decoder = new ResultRowsDecoder(new StaticLoader(loaded, acknowledged))) {
-            Iterator<List<Object>> iterator = decoder.toRows(fromSegments(spooledSegment(), spooledSegment()))
+            Iterator<List<Object>> iterator = decoder.toRows(fromSegments(spooledSegment(2), spooledSegment(2)))
                     .iterator();
 
             assertThat(loaded.get()).isEqualTo(0);
@@ -216,14 +216,7 @@ class TestResultRowsDecoder
         public InputStream load(SpooledSegment segment)
         {
             loaded.incrementAndGet();
-
-            return new FilterInputStream(new ByteArrayInputStream("[[2137], [1337]]".getBytes(UTF_8))) {
-                @Override
-                public void close()
-                {
-                    acknowledge(segment);
-                }
-            };
+            return new ByteArrayInputStream("[[2137], [1337]]".getBytes(UTF_8));
         }
 
         @Override
@@ -292,8 +285,12 @@ class TestResultRowsDecoder
                 .build());
     }
 
-    private static Segment spooledSegment()
+    private static Segment spooledSegment(long rows)
     {
-        return spooled(URI.create("http://localhost"), URI.create("http://localhost"), DataAttributes.empty(), ImmutableMap.of());
+        DataAttributes attributes = DataAttributes.builder()
+                .set(DataAttribute.ROWS_COUNT, rows)
+                .build();
+
+        return spooled(URI.create("http://localhost"), URI.create("http://localhost"), attributes, ImmutableMap.of());
     }
 }

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestAsyncResultIterator.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestAsyncResultIterator.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
-import static io.trino.client.ResultRows.fromIterableRows;
+import static io.trino.client.ResultRows.wrapList;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -64,7 +64,7 @@ class TestAsyncResultIterator
                     catch (InterruptedException e) {
                         interruptedButSwallowedLatch.countDown();
                     }
-                    return fromIterableRows(ImmutableList.of(ImmutableList.of(new Object())));
+                    return wrapList(ImmutableList.of(ImmutableList.of(new Object())));
                 }), ignored -> {},
                 new WarningsManager(),
                 Optional.of(new ArrayBlockingQueue<>(100)));
@@ -93,7 +93,7 @@ class TestAsyncResultIterator
         AsyncResultIterator iterator = new AsyncResultIterator(
                 new MockStatementClient(() -> {
                     thread.compareAndSet(null, Thread.currentThread());
-                    return fromIterableRows(ImmutableList.of(ImmutableList.of(new Object())));
+                    return wrapList(ImmutableList.of(ImmutableList.of(new Object())));
                 }), ignored -> {},
                 new WarningsManager(),
                 Optional.of(queue));


### PR DESCRIPTION
Iterable<List<Object>> was an initial sin, as the assumption was that you can iterate over data multiple times, which isn't true anymore for spooled segments, which are downloaded and acknowledged once the data is fully read.

Two new classes are introduced: SpooledSegmentIterator which is responsible for loading, acknowledging spooled segments, closing of the input stream for the spooled segment. This encapsulates this logic now in a single place and makes this logic reusable for other use cases. This iterator is lazy, the segment is loaded on the first row read.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
