### PR TITLE
Allow client to retry on the EOF while writing

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
@@ -648,7 +648,7 @@ class Query
             queryManager.failQuery(queryId, exception);
         }
         catch (RuntimeException e) {
-            log.debug(e, "Could not fail query");
+            log.warn(e, "Could not fail query");
         }
 
         if (typeSerializationException.isEmpty()) {


### PR DESCRIPTION
The EOF that happened during serialization means that the client disconnected while QueryResults was serialized. This is a class of error that can be retried by the client application, as the last QueryResults is cached.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
