### PR TITLE
Disable strong integrity checks for S3 FS 

### DIFF
--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystem.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystem.java
@@ -24,6 +24,8 @@ import io.trino.filesystem.TrinoInputFile;
 import io.trino.filesystem.TrinoOutputFile;
 import io.trino.filesystem.UriLocation;
 import io.trino.filesystem.encryption.EncryptionKey;
+import software.amazon.awssdk.auth.signer.AwsS3V4Signer;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CommonPrefix;
@@ -196,6 +198,7 @@ final class S3FileSystem
                         .overrideConfiguration(context::applyCredentialProviderOverride)
                         .requestPayer(requestPayer)
                         .bucket(bucket)
+                        .overrideConfiguration(disableStrongIntegrityChecksums())
                         .delete(builder -> builder.objects(objects).quiet(true))
                         .build();
 
@@ -387,5 +390,15 @@ final class S3FileSystem
     private static void validateS3Location(Location location)
     {
         new S3Location(location);
+    }
+
+    // TODO (https://github.com/trinodb/trino/issues/24955):
+    // remove me once all of the S3-compatible storage support strong integrity checks
+    @SuppressWarnings("deprecation")
+    static AwsRequestOverrideConfiguration disableStrongIntegrityChecksums()
+    {
+        return AwsRequestOverrideConfiguration.builder()
+            .signer(AwsS3V4Signer.create())
+            .build();
     }
 }

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/AbstractTestS3FileSystem.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/AbstractTestS3FileSystem.java
@@ -41,6 +41,7 @@ import java.util.List;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.filesystem.encryption.EncryptionKey.randomAes256;
+import static io.trino.filesystem.s3.S3FileSystem.disableStrongIntegrityChecksums;
 import static io.trino.filesystem.s3.S3SseCUtils.encoded;
 import static io.trino.filesystem.s3.S3SseCUtils.md5Checksum;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -156,6 +157,7 @@ public abstract class AbstractTestS3FileSystem
                             builder.sseCustomerKeyMD5(md5Checksum(randomEncryptionKey));
                         }
                     })
+                    .overrideConfiguration(disableStrongIntegrityChecksums())
                     .build();
 
             s3Client.putObject(putObjectRequest, RequestBody.fromBytes(contents.clone()));
@@ -271,7 +273,9 @@ public abstract class AbstractTestS3FileSystem
 
         public void create()
         {
-            s3Client.putObject(request -> request.bucket(bucket()).key(path), RequestBody.empty());
+            s3Client.putObject(request -> request
+                    .overrideConfiguration(disableStrongIntegrityChecksums())
+                    .bucket(bucket()).key(path), RequestBody.empty());
         }
 
         @Override

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemAwsS3.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemAwsS3.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.util.List;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.filesystem.s3.S3FileSystem.disableStrongIntegrityChecksums;
 import static io.trino.testing.SystemEnvironmentUtils.requireEnv;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -46,6 +47,7 @@ public class TestS3FileSystemAwsS3
         accessKey = requireEnv("AWS_ACCESS_KEY_ID");
         secretKey = requireEnv("AWS_SECRET_ACCESS_KEY");
         region = requireEnv("AWS_REGION");
+
         bucket = requireEnv("EMPTY_S3_BUCKET");
     }
 
@@ -86,6 +88,7 @@ public class TestS3FileSystemAwsS3
                     .bucket(bucket())
                     .key(key)
                     .storageClass(storageClass.toString())
+                    .overrideConfiguration(disableStrongIntegrityChecksums())
                     .build();
             s3Client.putObject(
                     putObjectRequestBuilder,

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/s3/S3FileSystemExchangeStorage.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/s3/S3FileSystemExchangeStorage.java
@@ -53,6 +53,8 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.signer.AwsS3V4Signer;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
@@ -376,6 +378,7 @@ public class S3FileSystemExchangeStorage
             DeleteObjectsRequest request = DeleteObjectsRequest.builder()
                     .bucket(bucketName)
                     .delete(Delete.builder().objects(list.stream().map(key -> ObjectIdentifier.builder().key(key).build()).collect(toImmutableList())).build())
+                    .overrideConfiguration(disableStrongIntegrityChecksums())
                     .build();
             return toListenableFuture(s3AsyncClient.deleteObjects(request));
         }).collect(toImmutableList())));
@@ -905,5 +908,15 @@ public class S3FileSystemExchangeStorage
                     .build();
             return stats.getAbortMultipartUpload().record(toListenableFuture(s3AsyncClient.abortMultipartUpload(abortMultipartUploadRequest)));
         }
+    }
+
+    // TODO (https://github.com/trinodb/trino/issues/24955):
+    // remove me once all of the S3-compatible storage support strong integrity checks
+    @SuppressWarnings("deprecation")
+    static AwsRequestOverrideConfiguration disableStrongIntegrityChecksums()
+    {
+        return AwsRequestOverrideConfiguration.builder()
+                .signer(AwsS3V4Signer.create())
+                .build();
     }
 }

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/Minio.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/Minio.java
@@ -41,7 +41,7 @@ public class Minio
 {
     private static final Logger log = Logger.get(Minio.class);
 
-    public static final String DEFAULT_IMAGE = "minio/minio:RELEASE.2025-01-20T14-49-07Z";
+    public static final String DEFAULT_IMAGE = "minio/minio:RELEASE.2024-12-18T13-15-44Z";
     public static final String DEFAULT_HOST_NAME = "minio";
 
     public static final int MINIO_API_PORT = 4566;


### PR DESCRIPTION
Some of the S3-compatible storage solutions are not yet compatible with it (pre-2025 Minio, Vast, Dell ECS).

These changes allow to use new SDK against not-fully-compliant-S3-compatible solutions.

Release notes: increase compatibility with S3-compatible storage solutions.