### PR TITLE
Make data iterators closeable

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/CloseableIterator.java
+++ b/client/trino-client/src/main/java/io/trino/client/CloseableIterator.java
@@ -42,6 +42,15 @@ public interface CloseableIterator<T>
             {
                 return iterator.next();
             }
+
+            @Override
+            public String toString()
+            {
+                return "CloseableIterator{iterator=" + iterator + '}';
+            }
         };
     }
+
+    @Override
+    String toString();
 }

--- a/client/trino-client/src/main/java/io/trino/client/CloseableIterator.java
+++ b/client/trino-client/src/main/java/io/trino/client/CloseableIterator.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client;
+
+import java.io.Closeable;
+import java.util.Iterator;
+
+/*
+ * A CloseableIterator is an Iterator that must be closed to release resources.
+ */
+public interface CloseableIterator<T>
+        extends Iterator<T>, Closeable
+{
+    static <T> CloseableIterator<T> closeable(Iterator<T> iterator)
+    {
+        return new CloseableIterator<T>()
+        {
+            @Override
+            public void close()
+            {
+            }
+
+            @Override
+            public boolean hasNext()
+            {
+                return iterator.hasNext();
+            }
+
+            @Override
+            public T next()
+            {
+                return iterator.next();
+            }
+        };
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/JsonIterators.java
+++ b/client/trino-client/src/main/java/io/trino/client/JsonIterators.java
@@ -39,13 +39,13 @@ import static io.trino.client.JsonDecodingUtils.createTypeDecoders;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
-public final class JsonResultRows
+public final class JsonIterators
 {
     private static final JsonFactory JSON_FACTORY = createJsonFactory();
 
-    private JsonResultRows() {}
+    private JsonIterators() {}
 
-    private static class RowWiseIterator
+    private static class JsonIterator
             extends AbstractIterator<List<Object>>
             implements CloseableIterator<List<Object>>
     {
@@ -54,7 +54,7 @@ public final class JsonResultRows
         private final JsonParser parser;
         private final TypeDecoder[] decoders;
 
-        public RowWiseIterator(JsonParser parser, TypeDecoder[] decoders)
+        public JsonIterator(JsonParser parser, TypeDecoder[] decoders)
                 throws IOException
         {
             requireNonNull(decoders, "decoders is null");
@@ -78,7 +78,7 @@ public final class JsonResultRows
             }
         }
 
-        public RowWiseIterator(InputStream stream, TypeDecoder[] decoders)
+        public JsonIterator(InputStream stream, TypeDecoder[] decoders)
                 throws IOException
         {
             this(JSON_FACTORY.createParser(requireNonNull(stream, "stream is null")), decoders);
@@ -141,13 +141,13 @@ public final class JsonResultRows
     public static CloseableIterator<List<Object>> forJsonParser(JsonParser parser, List<Column> columns)
             throws IOException
     {
-        return new RowWiseIterator(parser, createTypeDecoders(columns));
+        return new JsonIterator(parser, createTypeDecoders(columns));
     }
 
     public static CloseableIterator<List<Object>> forInputStream(InputStream stream, TypeDecoder[] decoders)
             throws IOException
     {
-        return new RowWiseIterator(stream, decoders);
+        return new JsonIterator(stream, decoders);
     }
 
     @SuppressModernizer // There is no JsonFactory in the client module

--- a/client/trino-client/src/main/java/io/trino/client/JsonResultRows.java
+++ b/client/trino-client/src/main/java/io/trino/client/JsonResultRows.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 import static com.fasterxml.jackson.core.JsonParser.Feature.AUTO_CLOSE_SOURCE;
@@ -48,6 +47,7 @@ public final class JsonResultRows
 
     private static class RowWiseIterator
             extends AbstractIterator<List<Object>>
+            implements CloseableIterator<List<Object>>
     {
         private final Closer closer = Closer.create();
         private boolean closed;
@@ -129,7 +129,8 @@ public final class JsonResultRows
             }
         }
 
-        private void close()
+        @Override
+        public void close()
                 throws IOException
         {
             this.closed = true;
@@ -137,13 +138,13 @@ public final class JsonResultRows
         }
     }
 
-    public static Iterator<List<Object>> forJsonParser(JsonParser parser, List<Column> columns)
+    public static CloseableIterator<List<Object>> forJsonParser(JsonParser parser, List<Column> columns)
             throws IOException
     {
         return new RowWiseIterator(parser, createTypeDecoders(columns));
     }
 
-    public static Iterator<List<Object>> forInputStream(InputStream stream, TypeDecoder[] decoders)
+    public static CloseableIterator<List<Object>> forInputStream(InputStream stream, TypeDecoder[] decoders)
             throws IOException
     {
         return new RowWiseIterator(stream, decoders);

--- a/client/trino-client/src/main/java/io/trino/client/QueryDataDecoder.java
+++ b/client/trino-client/src/main/java/io/trino/client/QueryDataDecoder.java
@@ -17,7 +17,6 @@ import io.trino.client.spooling.DataAttributes;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Iterator;
 import java.util.List;
 
 public interface QueryDataDecoder
@@ -40,7 +39,7 @@ public interface QueryDataDecoder
      *
      * @throws IOException if an I/O error occurs
      */
-    Iterator<List<Object>> decode(InputStream input, DataAttributes segmentAttributes)
+    CloseableIterator<List<Object>> decode(InputStream input, DataAttributes segmentAttributes)
             throws IOException;
 
     String encoding();

--- a/client/trino-client/src/main/java/io/trino/client/ResultRows.java
+++ b/client/trino-client/src/main/java/io/trino/client/ResultRows.java
@@ -43,6 +43,12 @@ public interface ResultRows
         {
             return emptyIterator();
         }
+
+        @Override
+        public String toString()
+        {
+            return "EmptyResultRows{}";
+        }
     };
 
     static ResultRows wrapList(List<List<Object>> values)
@@ -55,6 +61,12 @@ public interface ResultRows
             public Iterator<List<Object>> iterator()
             {
                 return values.iterator();
+            }
+
+            @Override
+            public String toString()
+            {
+                return "ResultRows{values=" + values + "}";
             }
         };
     }
@@ -73,6 +85,12 @@ public interface ResultRows
             public Iterator<List<Object>> iterator()
             {
                 return iterator;
+            }
+
+            @Override
+            public String toString()
+            {
+                return "ResultRows{iterator=" + iterator + "}";
             }
         };
     }

--- a/client/trino-client/src/main/java/io/trino/client/ResultRows.java
+++ b/client/trino-client/src/main/java/io/trino/client/ResultRows.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 
+import static com.google.common.base.Verify.verify;
 import static java.util.Collections.emptyIterator;
 
 /**
@@ -74,6 +75,8 @@ public interface ResultRows
     static ResultRows wrapIterator(CloseableIterator<List<Object>> iterator)
     {
         return new ResultRows() {
+            private volatile boolean fetched;
+
             @Override
             public void close()
                     throws IOException
@@ -84,6 +87,8 @@ public interface ResultRows
             @Override
             public Iterator<List<Object>> iterator()
             {
+                verify(!fetched, "Iterator already fetched");
+                fetched = true;
                 return iterator;
             }
 

--- a/client/trino-client/src/main/java/io/trino/client/ResultRows.java
+++ b/client/trino-client/src/main/java/io/trino/client/ResultRows.java
@@ -52,26 +52,6 @@ public interface ResultRows
         }
     };
 
-    static ResultRows wrapList(List<List<Object>> values)
-    {
-        return new ResultRows() {
-            @Override
-            public void close() {}
-
-            @Override
-            public Iterator<List<Object>> iterator()
-            {
-                return values.iterator();
-            }
-
-            @Override
-            public String toString()
-            {
-                return "ResultRows{values=" + values + "}";
-            }
-        };
-    }
-
     static ResultRows wrapIterator(CloseableIterator<List<Object>> iterator)
     {
         return new ResultRows() {

--- a/client/trino-client/src/main/java/io/trino/client/ResultRows.java
+++ b/client/trino-client/src/main/java/io/trino/client/ResultRows.java
@@ -23,6 +23,8 @@ import static java.util.Collections.emptyIterator;
 
 /**
  * Allows iterating over decoded result data in row-wise manner.
+ *
+ * Iterator can be acquired only once, and it should be closed after use.
  */
 public interface ResultRows
         extends Iterable<List<Object>>, Closeable

--- a/client/trino-client/src/main/java/io/trino/client/ResultRowsDecoder.java
+++ b/client/trino-client/src/main/java/io/trino/client/ResultRowsDecoder.java
@@ -15,23 +15,20 @@ package io.trino.client;
 
 import io.trino.client.spooling.DataAttributes;
 import io.trino.client.spooling.EncodedQueryData;
-import io.trino.client.spooling.InlineSegment;
-import io.trino.client.spooling.Segment;
 import io.trino.client.spooling.SegmentLoader;
-import io.trino.client.spooling.SpooledSegment;
+import io.trino.client.spooling.SegmentsIterator;
 import io.trino.client.spooling.encoding.QueryDataDecoders;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
-import static com.google.common.collect.Iterators.concat;
-import static com.google.common.collect.Iterators.transform;
+import static io.trino.client.CloseableIterator.closeable;
 import static io.trino.client.ResultRows.NULL_ROWS;
+import static io.trino.client.ResultRows.wrapIterator;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -88,7 +85,7 @@ public class ResultRowsDecoder
                 return NULL_ROWS; // for backward compatibility instead of null
             }
             // RawQueryData is always typed
-            return () -> rawData.getIterable().iterator();
+            return wrapIterator(closeable(rawData.getIterable().iterator()));
         }
 
         if (data instanceof JsonQueryData) {
@@ -96,36 +93,21 @@ public class ResultRowsDecoder
             if (jsonData.isNull()) {
                 return NULL_ROWS;
             }
-            return () -> {
-                try {
-                    return JsonIterators.forJsonParser(jsonData.getJsonParser(), columns);
-                }
-                catch (IOException e) {
-                    throw new UncheckedIOException(e);
-                }
-            };
+            try {
+                return wrapIterator(JsonIterators.forJsonParser(jsonData.getJsonParser(), columns));
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
         }
 
         if (data instanceof EncodedQueryData) {
             EncodedQueryData encodedData = (EncodedQueryData) data;
             setEncoding(columns, encodedData.getEncoding());
-            return () -> concat(transform(encodedData.getSegments().iterator(), this::segmentToRows));
+            return wrapIterator(new SegmentsIterator(loader, decoder, encodedData.getSegments()));
         }
 
         throw new UnsupportedOperationException("Unsupported data type: " + data.getClass().getName());
-    }
-
-    private Iterator<List<Object>> segmentToRows(Segment segment)
-    {
-        if (segment instanceof InlineSegment) {
-            return ((InlineSegment) segment).toIterator(decoder);
-        }
-
-        if (segment instanceof SpooledSegment) {
-            return ((SpooledSegment) segment).toIterator(loader, decoder);
-        }
-
-        throw new UnsupportedOperationException("Unsupported segment type: " + segment.getClass().getName());
     }
 
     public Optional<String> getEncoding()

--- a/client/trino-client/src/main/java/io/trino/client/ResultRowsDecoder.java
+++ b/client/trino-client/src/main/java/io/trino/client/ResultRowsDecoder.java
@@ -98,7 +98,7 @@ public class ResultRowsDecoder
             }
             return () -> {
                 try {
-                    return JsonResultRows.forJsonParser(jsonData.getJsonParser(), columns);
+                    return JsonIterators.forJsonParser(jsonData.getJsonParser(), columns);
                 }
                 catch (IOException e) {
                     throw new UncheckedIOException(e);

--- a/client/trino-client/src/main/java/io/trino/client/StatementClientV1.java
+++ b/client/trino-client/src/main/java/io/trino/client/StatementClientV1.java
@@ -31,6 +31,7 @@ import okhttp3.RequestBody;
 
 import java.io.IOException;
 import java.io.InterruptedIOException;
+import java.io.UncheckedIOException;
 import java.net.ProtocolException;
 import java.net.SocketTimeoutException;
 import java.net.URI;
@@ -559,6 +560,15 @@ class StatementClientV1
             if (uri != null) {
                 httpDelete(uri);
             }
+        }
+
+        // Close rows - this will close the underlying iterators,
+        // releasing all resources and pruning remote segments
+        try {
+            currentRows.get().close();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/client/trino-client/src/main/java/io/trino/client/spooling/InlineSegment.java
+++ b/client/trino-client/src/main/java/io/trino/client/spooling/InlineSegment.java
@@ -15,10 +15,7 @@ package io.trino.client.spooling;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.trino.client.QueryDataDecoder;
 
-import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 
 import static java.lang.String.format;
@@ -50,10 +47,5 @@ public final class InlineSegment
     public String toString()
     {
         return format("InlineSegment{offset=%d, rows=%d, size=%d}", getOffset(), getRowsCount(), getSegmentSize());
-    }
-
-    public Iterator<List<Object>> toIterator(QueryDataDecoder decoder)
-    {
-        return new InlineSegmentIterator(this, decoder);
     }
 }

--- a/client/trino-client/src/main/java/io/trino/client/spooling/InlineSegmentIterator.java
+++ b/client/trino-client/src/main/java/io/trino/client/spooling/InlineSegmentIterator.java
@@ -14,12 +14,12 @@
 package io.trino.client.spooling;
 
 import com.google.common.collect.AbstractIterator;
+import io.trino.client.CloseableIterator;
 import io.trino.client.QueryDataDecoder;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.Iterator;
 import java.util.List;
 
 import static java.util.Objects.requireNonNull;
@@ -27,10 +27,11 @@ import static java.util.Objects.requireNonNull;
 // Accessible through the InlineSegment.toIterator
 class InlineSegmentIterator
         extends AbstractIterator<List<Object>>
+        implements CloseableIterator<List<Object>>
 {
     private InlineSegment segment;
     private final QueryDataDecoder decoder;
-    private Iterator<List<Object>> iterator;
+    private CloseableIterator<List<Object>> iterator;
 
     public InlineSegmentIterator(InlineSegment segment, QueryDataDecoder decoder)
     {
@@ -55,5 +56,14 @@ class InlineSegmentIterator
             return iterator.next();
         }
         return endOfData();
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        if (iterator != null) {
+            iterator.close();
+        }
     }
 }

--- a/client/trino-client/src/main/java/io/trino/client/spooling/SegmentsIterator.java
+++ b/client/trino-client/src/main/java/io/trino/client/spooling/SegmentsIterator.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client.spooling;
+
+import com.google.common.collect.AbstractIterator;
+import io.trino.client.CloseableIterator;
+import io.trino.client.QueryDataDecoder;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+
+import static com.google.common.base.Verify.verify;
+import static java.util.Objects.requireNonNull;
+
+public class SegmentsIterator
+        extends AbstractIterator<List<Object>>
+        implements CloseableIterator<List<Object>>
+{
+    private final SegmentLoader loader;
+    private final QueryDataDecoder decoder;
+    private final Deque<Segment> remainingSegments;
+    private CloseableIterator<List<Object>> currentIterator;
+
+    public SegmentsIterator(SegmentLoader loader, QueryDataDecoder decoder, List<Segment> segments)
+    {
+        verify(!segments.isEmpty(), "Expected at least a single segment to iterate over");
+        this.loader = requireNonNull(loader, "loader is null");
+        this.decoder = requireNonNull(decoder, "decoder is null");
+        this.remainingSegments = new ArrayDeque<>(segments);
+        this.currentIterator = iterate(this.remainingSegments.removeFirst());
+    }
+
+    @Override
+    protected List<Object> computeNext()
+    {
+        if (currentIterator.hasNext()) {
+            return currentIterator.next();
+        }
+
+        // Current iterator exhausted, move to next one
+        if (moveToNextIterator()) {
+            verify(currentIterator.hasNext(), "New current iterator is empty");
+            return currentIterator.next();
+        }
+
+        return endOfData();
+    }
+
+    private boolean moveToNextIterator()
+    {
+        if (!remainingSegments.isEmpty()) {
+            Segment segment = remainingSegments.removeFirst();
+            currentIterator = iterate(segment);
+            return true;
+        }
+        else {
+            return false;
+        }
+    }
+
+    private CloseableIterator<List<Object>> iterate(Segment segment)
+    {
+        if (segment instanceof InlineSegment) {
+            return new InlineSegmentIterator((InlineSegment) segment, decoder);
+        }
+
+        if (segment instanceof SpooledSegment) {
+            return new SpooledSegmentIterator((SpooledSegment) segment, loader, decoder);
+        }
+
+        throw new UnsupportedOperationException("Unsupported segment type: " + segment.getClass().getName());
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        IOException exception = new IOException("Could not close all segments");
+        if (currentIterator != null) {
+            try {
+                currentIterator.close();
+            }
+            catch (IOException e) {
+                exception.addSuppressed(e);
+            }
+        }
+
+        for (Segment segment : remainingSegments) {
+            try {
+                iterate(segment).close();
+            }
+            catch (IOException e) {
+                exception.addSuppressed(e);
+            }
+        }
+
+        if (exception.getSuppressed().length > 0) {
+            throw exception;
+        }
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/spooling/SegmentsIterator.java
+++ b/client/trino-client/src/main/java/io/trino/client/spooling/SegmentsIterator.java
@@ -111,4 +111,10 @@ public class SegmentsIterator
             throw exception;
         }
     }
+
+    @Override
+    public String toString()
+    {
+        return "SegmentsIterator{currentIterator=" + currentIterator + ", remainingSegments=" + remainingSegments + "}";
+    }
 }

--- a/client/trino-client/src/main/java/io/trino/client/spooling/SpooledSegment.java
+++ b/client/trino-client/src/main/java/io/trino/client/spooling/SpooledSegment.java
@@ -17,10 +17,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
-import io.trino.client.QueryDataDecoder;
 
 import java.net.URI;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -76,10 +74,5 @@ public final class SpooledSegment
     public String toString()
     {
         return format("SpooledSegment{offset=%d, rows=%d, size=%d, headers=%s}", getOffset(), getRowsCount(), getSegmentSize(), headers.keySet());
-    }
-
-    public Iterator<List<Object>> toIterator(SegmentLoader loader, QueryDataDecoder decoder)
-    {
-        return new SpooledSegmentIterator(this, loader, decoder);
     }
 }

--- a/client/trino-client/src/main/java/io/trino/client/spooling/SpooledSegmentIterator.java
+++ b/client/trino-client/src/main/java/io/trino/client/spooling/SpooledSegmentIterator.java
@@ -127,4 +127,10 @@ class SpooledSegmentIterator
             unload();
         }
     }
+
+    @Override
+    public String toString()
+    {
+        return "SpooledSegmentIterator{segment=" + segment + "}";
+    }
 }

--- a/client/trino-client/src/main/java/io/trino/client/spooling/encoding/CompressedQueryDataDecoder.java
+++ b/client/trino-client/src/main/java/io/trino/client/spooling/encoding/CompressedQueryDataDecoder.java
@@ -14,6 +14,7 @@
 package io.trino.client.spooling.encoding;
 
 import com.google.common.io.ByteStreams;
+import io.trino.client.CloseableIterator;
 import io.trino.client.QueryDataDecoder;
 import io.trino.client.spooling.DataAttribute;
 import io.trino.client.spooling.DataAttributes;
@@ -21,7 +22,6 @@ import io.trino.client.spooling.DataAttributes;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
@@ -42,7 +42,7 @@ public abstract class CompressedQueryDataDecoder
             throws IOException;
 
     @Override
-    public Iterator<List<Object>> decode(InputStream stream, DataAttributes metadata)
+    public CloseableIterator<List<Object>> decode(InputStream stream, DataAttributes metadata)
             throws IOException
     {
         Optional<Integer> expectedDecompressedSize = metadata.getOptional(DataAttribute.UNCOMPRESSED_SIZE, Integer.class);

--- a/client/trino-client/src/main/java/io/trino/client/spooling/encoding/JsonQueryDataDecoder.java
+++ b/client/trino-client/src/main/java/io/trino/client/spooling/encoding/JsonQueryDataDecoder.java
@@ -13,6 +13,7 @@
  */
 package io.trino.client.spooling.encoding;
 
+import io.trino.client.CloseableIterator;
 import io.trino.client.Column;
 import io.trino.client.JsonDecodingUtils.TypeDecoder;
 import io.trino.client.JsonResultRows;
@@ -21,7 +22,6 @@ import io.trino.client.spooling.DataAttributes;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Iterator;
 import java.util.List;
 
 import static io.trino.client.JsonDecodingUtils.createTypeDecoders;
@@ -38,7 +38,7 @@ public class JsonQueryDataDecoder
     }
 
     @Override
-    public Iterator<List<Object>> decode(InputStream stream, DataAttributes queryAttributes)
+    public CloseableIterator<List<Object>> decode(InputStream stream, DataAttributes queryAttributes)
             throws IOException
     {
         return JsonResultRows.forInputStream(stream, decoders);

--- a/client/trino-client/src/main/java/io/trino/client/spooling/encoding/JsonQueryDataDecoder.java
+++ b/client/trino-client/src/main/java/io/trino/client/spooling/encoding/JsonQueryDataDecoder.java
@@ -16,7 +16,7 @@ package io.trino.client.spooling.encoding;
 import io.trino.client.CloseableIterator;
 import io.trino.client.Column;
 import io.trino.client.JsonDecodingUtils.TypeDecoder;
-import io.trino.client.JsonResultRows;
+import io.trino.client.JsonIterators;
 import io.trino.client.QueryDataDecoder;
 import io.trino.client.spooling.DataAttributes;
 
@@ -41,7 +41,7 @@ public class JsonQueryDataDecoder
     public CloseableIterator<List<Object>> decode(InputStream stream, DataAttributes queryAttributes)
             throws IOException
     {
-        return JsonResultRows.forInputStream(stream, decoders);
+        return JsonIterators.forInputStream(stream, decoders);
     }
 
     @Override

--- a/client/trino-client/src/test/java/io/trino/client/TestResultRowsDecoder.java
+++ b/client/trino-client/src/test/java/io/trino/client/TestResultRowsDecoder.java
@@ -35,7 +35,7 @@ import java.util.OptionalDouble;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
-import static io.trino.client.JsonResultRows.createJsonFactory;
+import static io.trino.client.JsonIterators.createJsonFactory;
 import static io.trino.client.spooling.Segment.inlined;
 import static io.trino.client.spooling.Segment.spooled;
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/client/trino-client/src/test/java/io/trino/client/spooling/encoding/TestCompressedQueryDataDecoder.java
+++ b/client/trino-client/src/test/java/io/trino/client/spooling/encoding/TestCompressedQueryDataDecoder.java
@@ -15,6 +15,7 @@ package io.trino.client.spooling.encoding;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteStreams;
+import io.trino.client.CloseableIterator;
 import io.trino.client.QueryDataDecoder;
 import io.trino.client.spooling.DataAttributes;
 import org.junit.jupiter.api.Test;
@@ -23,10 +24,10 @@ import java.io.ByteArrayInputStream;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static io.trino.client.CloseableIterator.closeable;
 import static io.trino.client.spooling.DataAttribute.SEGMENT_SIZE;
 import static io.trino.client.spooling.DataAttribute.UNCOMPRESSED_SIZE;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -53,12 +54,12 @@ class TestCompressedQueryDataDecoder
 
         QueryDataDecoder decoder = new TestQueryDataDecoder(new QueryDataDecoder() {
             @Override
-            public Iterator<List<Object>> decode(InputStream input, DataAttributes segmentAttributes)
+            public CloseableIterator<List<Object>> decode(InputStream input, DataAttributes segmentAttributes)
                     throws IOException
             {
                 assertThat(new String(ByteStreams.toByteArray(input), UTF_8))
                         .isEqualTo("decompressed");
-                return SAMPLE_VALUES.iterator();
+                return closeable(SAMPLE_VALUES.iterator());
             }
 
             @Override
@@ -96,13 +97,13 @@ class TestCompressedQueryDataDecoder
 
         QueryDataDecoder decoder = new TestQueryDataDecoder(new QueryDataDecoder() {
             @Override
-            public Iterator<List<Object>> decode(InputStream input, DataAttributes segmentAttributes)
+            public CloseableIterator<List<Object>> decode(InputStream input, DataAttributes segmentAttributes)
                     throws IOException
             {
                 assertThat(new String(ByteStreams.toByteArray(input), UTF_8))
                         .isEqualTo("not compressed");
                 input.close(); // Closes input stream according to the contract
-                return SAMPLE_VALUES.iterator();
+                return closeable(SAMPLE_VALUES.iterator());
             }
 
             @Override

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestAsyncResultIterator.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestAsyncResultIterator.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Timeout;
 
 import java.net.URI;
 import java.time.ZoneId;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -41,7 +42,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
-import static io.trino.client.ResultRows.wrapList;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -64,7 +64,7 @@ class TestAsyncResultIterator
                     catch (InterruptedException e) {
                         interruptedButSwallowedLatch.countDown();
                     }
-                    return wrapList(ImmutableList.of(ImmutableList.of(new Object())));
+                    return fromList(ImmutableList.of(ImmutableList.of(new Object())));
                 }), ignored -> {},
                 new WarningsManager(),
                 Optional.of(new ArrayBlockingQueue<>(100)));
@@ -93,7 +93,7 @@ class TestAsyncResultIterator
         AsyncResultIterator iterator = new AsyncResultIterator(
                 new MockStatementClient(() -> {
                     thread.compareAndSet(null, Thread.currentThread());
-                    return wrapList(ImmutableList.of(ImmutableList.of(new Object())));
+                    return fromList(ImmutableList.of(ImmutableList.of(new Object())));
                 }), ignored -> {},
                 new WarningsManager(),
                 Optional.of(queue));
@@ -368,6 +368,26 @@ class TestAsyncResultIterator
             public Long getUpdateCount()
             {
                 throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    static ResultRows fromList(List<List<Object>> values)
+    {
+        return new ResultRows() {
+            @Override
+            public void close() {}
+
+            @Override
+            public Iterator<List<Object>> iterator()
+            {
+                return values.iterator();
+            }
+
+            @Override
+            public String toString()
+            {
+                return "ResultRows{values=" + values + "}";
             }
         };
     }

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/JsonQueryDataEncoder.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/JsonQueryDataEncoder.java
@@ -42,6 +42,7 @@ import static java.util.Objects.requireNonNull;
 public class JsonQueryDataEncoder
         implements QueryDataEncoder
 {
+    private static final JsonFactory JSON_FACTORY = jsonFactory();
     private static final String ENCODING = "json";
     private final Session session;
     private final TypeEncoder[] typeEncoders;
@@ -60,9 +61,8 @@ public class JsonQueryDataEncoder
     public DataAttributes encodeTo(OutputStream output, List<Page> pages)
             throws IOException
     {
-        JsonFactory jsonFactory = jsonFactory();
         ConnectorSession connectorSession = session.toConnectorSession();
-        try (CountingOutputStream wrapper = new CountingOutputStream(output); JsonGenerator generator = jsonFactory.createGenerator(wrapper)) {
+        try (CountingOutputStream wrapper = new CountingOutputStream(output); JsonGenerator generator = JSON_FACTORY.createGenerator(wrapper)) {
             writePagesToJsonGenerator(connectorSession, e -> { throw e; }, generator, typeEncoders, sourcePageChannels, pages);
             return DataAttributes.builder()
                     .set(SEGMENT_SIZE, toIntExact(wrapper.getCount()))


### PR DESCRIPTION
This PR streamlines the release of resources related to the spooling segments and is a preparation for the introduction of the preliminary Arrow encoding support.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
Just an internal refactor being a preparation for something else ;)
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
