### PR TITLE
Remove the Deprecated marker for S3StorageClassFilter

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
@@ -1255,13 +1255,11 @@ public class HiveConfig
         return this;
     }
 
-    @Deprecated
     public S3StorageClassFilter getS3StorageClassFilter()
     {
         return s3StorageClassFilter;
     }
 
-    @Deprecated
     @Config("hive.s3.storage-class-filter")
     @ConfigDescription("Filter based on storage class of S3 object")
     public HiveConfig setS3StorageClassFilter(S3StorageClassFilter s3StorageClassFilter)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

```hive.s3.storage-class-filter``` is still being used to filter out glacier objects when listing s3 objects. Remove the annotation to correct it

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
