### PR TITLE
Limit BigQuery off heap memory to split context

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryArrowConfig.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryArrowConfig.java
@@ -17,9 +17,11 @@ import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.units.DataSize;
 
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+
 public class BigQueryArrowConfig
 {
-    private DataSize maxAllocation = DataSize.ofBytes(Integer.MAX_VALUE);
+    private DataSize maxAllocation = DataSize.of(100, MEGABYTE);
 
     public DataSize getMaxAllocation()
     {

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryArrowConfig.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryArrowConfig.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
-import static io.airlift.units.DataSize.Unit.GIGABYTE;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
 class TestBigQueryArrowConfig
 {
@@ -30,18 +30,18 @@ class TestBigQueryArrowConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(BigQueryArrowConfig.class)
-                .setMaxAllocation(DataSize.ofBytes(Integer.MAX_VALUE)));
+                .setMaxAllocation(DataSize.of(100, MEGABYTE)));
     }
 
     @Test
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
-                .put("bigquery.arrow-serialization.max-allocation", "1GB")
+                .put("bigquery.arrow-serialization.max-allocation", "10MB")
                 .buildOrThrow();
 
         BigQueryArrowConfig expected = new BigQueryArrowConfig()
-                .setMaxAllocation(DataSize.of(1, GIGABYTE));
+                .setMaxAllocation(DataSize.of(10, MEGABYTE));
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
…g off heap memory staling

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
In BigQuery connector, allocate and release off heap memory every getNextPage call to be more multi catalog friendly. 


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
