### PR TITLE
Allow dynamically enabling and disabling tracing

### DIFF
--- a/core/trino-main/pom.xml
+++ b/core/trino-main/pom.xml
@@ -226,6 +226,11 @@
 
         <dependency>
             <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk-testing</artifactId>
         </dependency>
 

--- a/core/trino-main/src/main/java/io/trino/server/Server.java
+++ b/core/trino-main/src/main/java/io/trino/server/Server.java
@@ -61,6 +61,7 @@ import io.trino.server.security.HeaderAuthenticatorManager;
 import io.trino.server.security.PasswordAuthenticatorManager;
 import io.trino.server.security.ServerSecurityModule;
 import io.trino.server.security.oauth2.OAuth2Client;
+import io.trino.server.tracing.DynamicTracingModule;
 import io.trino.spi.connector.CatalogHandle;
 import io.trino.transaction.TransactionManagerModule;
 import io.trino.util.EmbedVersion;
@@ -116,6 +117,7 @@ public class Server
                 new JmxOpenMetricsModule(),
                 new LogJmxModule(),
                 new TracingModule("trino", trinoVersion),
+                new DynamicTracingModule(),
                 new ServerSecurityModule(),
                 new AccessControlModule(),
                 new EventListenerModule(),

--- a/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
+++ b/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
@@ -88,6 +88,7 @@ import io.trino.server.StartupStatus;
 import io.trino.server.protocol.spooling.SpoolingManagerRegistry;
 import io.trino.server.security.CertificateAuthenticatorManager;
 import io.trino.server.security.ServerSecurityModule;
+import io.trino.server.tracing.DynamicTracingModule;
 import io.trino.spi.ErrorType;
 import io.trino.spi.Plugin;
 import io.trino.spi.QueryId;
@@ -304,6 +305,7 @@ public class TestingTrinoServer
                 .add(new TestingJmxModule())
                 .add(new JmxOpenMetricsModule())
                 .add(new TracingModule("trino", VERSION))
+                .add(new DynamicTracingModule())
                 .add(new ServerSecurityModule())
                 .add(new CatalogManagerModule())
                 .add(new TransactionManagerModule())

--- a/core/trino-main/src/main/java/io/trino/server/tracing/CoordinatorDynamicTracingController.java
+++ b/core/trino-main/src/main/java/io/trino/server/tracing/CoordinatorDynamicTracingController.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.tracing;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import io.airlift.http.client.FullJsonResponseHandler.JsonResponse;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.HttpUriBuilder;
+import io.airlift.http.client.Request;
+import io.airlift.json.JsonCodec;
+import io.airlift.log.Logger;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.trino.metadata.InternalNode;
+import io.trino.metadata.InternalNodeManager;
+import io.trino.metadata.InternalNodeManager.NodesSnapshot;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.airlift.http.client.FullJsonResponseHandler.createFullJsonResponseHandler;
+import static java.util.Objects.requireNonNull;
+
+public class CoordinatorDynamicTracingController
+        extends WorkerDynamicTracingController
+{
+    private static final Logger log = Logger.get(CoordinatorDynamicTracingController.class);
+
+    private final HttpClient httpClient;
+    private final InternalNodeManager nodeManager;
+    private final JsonCodec<TracingStatus> tracingStatusJsonCodec;
+
+    @Inject
+    public CoordinatorDynamicTracingController(
+            SdkTracerProvider tracerProvider,
+            DynamicTracingConfig config,
+            @ForDynamicTracing HttpClient httpClient,
+            InternalNodeManager nodeManager,
+            JsonCodec<TracingStatus> tracingStatusJsonCodec)
+    {
+        super(tracerProvider, config);
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
+        this.tracingStatusJsonCodec = requireNonNull(tracingStatusJsonCodec, "tracingStatusJsonCodec is null");
+    }
+
+    @Override
+    public TracingStatus enableExport()
+    {
+        ImmutableList.Builder<String> errorsBuilder = ImmutableList.builder();
+        NodesSnapshot activeNodesSnapshot = nodeManager.getActiveNodesSnapshot();
+        for (InternalNode node : activeNodesSnapshot.getAllNodes()) {
+            if (node.equals(nodeManager.getCurrentNode())) {
+                continue;
+            }
+            try {
+                TracingStatus status = sendRequest(node, "v1/tracing");
+                if (!status.enabled()) {
+                    sendRequest(node, "v1/tracing/enable");
+                    log.info("Enabled exporting OpenTelemetry traces on node %s with status %s", node.getNodeIdentifier(), status);
+                }
+            }
+            catch (Exception e) {
+                errorsBuilder.add("Node " + node.getNodeIdentifier() + " failed to enable export: " + e.getMessage());
+            }
+        }
+
+        List<String> errors = errorsBuilder.build();
+        TracingStatus status = super.enableExport();
+
+        if (!errors.isEmpty()) {
+            return new TracingStatus(
+                    status.enabled(),
+                    status.since(),
+                    Optional.of("Encountered errors enabling export on worker nodes: " + Joiner.on(", ").join(errors)));
+        }
+
+        return status;
+    }
+
+    @Override
+    public TracingStatus disableExport()
+    {
+        ImmutableList.Builder<String> errorsBuilder = ImmutableList.builder();
+        NodesSnapshot activeNodesSnapshot = nodeManager.getActiveNodesSnapshot();
+        for (InternalNode node : activeNodesSnapshot.getAllNodes()) {
+            if (node.equals(nodeManager.getCurrentNode())) {
+                continue;
+            }
+            try {
+                TracingStatus status = sendRequest(node, "v1/tracing");
+                if (status.enabled()) {
+                    sendRequest(node, "v1/tracing/disable");
+                    log.info("Disabled exporting OpenTelemetry traces on node %s with status %s", node.getNodeIdentifier(), status);
+                }
+            }
+            catch (Exception e) {
+                errorsBuilder.add("Node " + node.getNodeIdentifier() + " failed to disable export: " + e.getMessage());
+            }
+        }
+
+        TracingStatus status = super.disableExport();
+        List<String> errors = errorsBuilder.build();
+        if (!errors.isEmpty()) {
+            return new TracingStatus(
+                    status.enabled(),
+                    status.since(),
+                    Optional.of("Encountered errors disabling export on worker nodes: " + Joiner.on(", ").join(errors)));
+        }
+
+        return status;
+    }
+
+    @Override
+    public TracingStatus getStatus()
+    {
+        return super.getStatus();
+    }
+
+    public NodesTracingStatus getNodesStatus()
+    {
+        NodesSnapshot activeNodesSnapshot = nodeManager.getActiveNodesSnapshot();
+        ImmutableMap.Builder<String, TracingStatus> nodes = ImmutableMap.builder();
+        for (InternalNode node : activeNodesSnapshot.getAllNodes()) {
+            if (node.equals(nodeManager.getCurrentNode())) {
+                nodes.put(node.getNodeIdentifier(), getStatus());
+                continue;
+            }
+            try {
+                nodes.put(node.getNodeIdentifier(), sendRequest(node, "v1/tracing"));
+            }
+            catch (Exception e) {
+                nodes.put(node.getNodeIdentifier(), new TracingStatus(false, null, Optional.of(e.getMessage())));
+            }
+        }
+        return new NodesTracingStatus(nodes.buildOrThrow());
+    }
+
+    public record NodesTracingStatus(Map<String, TracingStatus> nodes)
+    {
+        public NodesTracingStatus {
+            nodes = ImmutableMap.copyOf(nodes);
+        }
+    }
+
+    private TracingStatus sendRequest(InternalNode node, String endpoint)
+    {
+        Request request = Request.builder()
+                .setMethod("GET")
+                .setUri(HttpUriBuilder.uriBuilderFrom(node.getInternalUri())
+                        .appendPath(endpoint)
+                        .build())
+                .build();
+        JsonResponse<TracingStatus> execute = httpClient.execute(request, createFullJsonResponseHandler(tracingStatusJsonCodec));
+        if (execute.getStatusCode() != 200) {
+            throw new IllegalStateException("Expected status code 200 but got " + execute.getStatusCode());
+        }
+        return execute.getValue();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/tracing/CoordinatorDynamicTracingResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/tracing/CoordinatorDynamicTracingResource.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.tracing;
+
+import com.google.inject.Inject;
+import io.trino.server.security.ResourceSecurity;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+
+import static io.trino.server.security.ResourceSecurity.AccessType.MANAGEMENT_READ;
+import static io.trino.server.security.ResourceSecurity.AccessType.MANAGEMENT_WRITE;
+import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static java.util.Objects.requireNonNull;
+
+@Path("/v1/tracing")
+@Produces("application/json")
+public class CoordinatorDynamicTracingResource
+{
+    private final CoordinatorDynamicTracingController controller;
+
+    @Inject
+    public CoordinatorDynamicTracingResource(CoordinatorDynamicTracingController controller)
+    {
+        this.controller = requireNonNull(controller, "controller is null");
+    }
+
+    @GET
+    @ResourceSecurity(MANAGEMENT_READ)
+    public Response getStatus()
+    {
+        return Response.ok(controller.getNodesStatus()).build();
+    }
+
+    @GET
+    @Path("/enable")
+    @ResourceSecurity(MANAGEMENT_WRITE)
+    public Response enable()
+    {
+        TracingStatus tracingStatus = controller.enableExport();
+        if (tracingStatus.error().isPresent()) {
+            return Response.status(INTERNAL_SERVER_ERROR).entity(tracingStatus).build();
+        }
+
+        return Response.ok(controller.getNodesStatus()).build();
+    }
+
+    @GET
+    @Path("/disable")
+    @ResourceSecurity(MANAGEMENT_WRITE)
+    public Response disable()
+    {
+        TracingStatus tracingStatus = controller.disableExport();
+        if (tracingStatus.error().isPresent()) {
+            return Response.status(INTERNAL_SERVER_ERROR).entity(tracingStatus).build();
+        }
+
+        return Response.ok(controller.getNodesStatus()).build();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/tracing/DynamicTracingConfig.java
+++ b/core/trino-main/src/main/java/io/trino/server/tracing/DynamicTracingConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.tracing;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+
+public class DynamicTracingConfig
+{
+    private boolean exportEnabled = true;
+
+    public boolean isExportEnabled()
+    {
+        return exportEnabled;
+    }
+
+    @ConfigDescription("Enable exporting traces after server has started")
+    @Config("tracing.export-enabled")
+    public DynamicTracingConfig setExportEnabled(boolean exportEnabled)
+    {
+        this.exportEnabled = exportEnabled;
+        return this;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/tracing/DynamicTracingController.java
+++ b/core/trino-main/src/main/java/io/trino/server/tracing/DynamicTracingController.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.tracing;
+
+public interface DynamicTracingController
+{
+    TracingStatus enableExport();
+
+    TracingStatus disableExport();
+
+    TracingStatus getStatus();
+}

--- a/core/trino-main/src/main/java/io/trino/server/tracing/DynamicTracingModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/tracing/DynamicTracingModule.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.tracing;
+
+import com.google.inject.Binder;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.airlift.tracing.TracingEnabledConfig;
+import io.trino.server.ServerConfig;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
+import static io.airlift.json.JsonCodecBinder.jsonCodecBinder;
+import static io.trino.server.InternalCommunicationHttpClientModule.internalHttpClientModule;
+
+public class DynamicTracingModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        if (!buildConfigObject(TracingEnabledConfig.class).isEnabled()) {
+            return;
+        }
+
+        if (buildConfigObject(ServerConfig.class).isCoordinator()) {
+            jaxrsBinder(binder).bind(CoordinatorDynamicTracingResource.class);
+            jsonCodecBinder(binder).bindJsonCodec(TracingStatus.class);
+            install(internalHttpClientModule("dynamic-tracing", ForDynamicTracing.class)
+                    .build());
+            binder.bind(CoordinatorDynamicTracingController.class).asEagerSingleton();
+        }
+        else {
+            jaxrsBinder(binder).bind(WorkerDynamicTracingResource.class);
+            binder.bind(DynamicTracingController.class).to(WorkerDynamicTracingController.class).asEagerSingleton();
+        }
+
+        configBinder(binder).bindConfig(DynamicTracingConfig.class);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/tracing/ForDynamicTracing.java
+++ b/core/trino-main/src/main/java/io/trino/server/tracing/ForDynamicTracing.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.tracing;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@BindingAnnotation
+public @interface ForDynamicTracing
+{
+}

--- a/core/trino-main/src/main/java/io/trino/server/tracing/TracingStatus.java
+++ b/core/trino-main/src/main/java/io/trino/server/tracing/TracingStatus.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.tracing;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record TracingStatus(@JsonProperty("enabled") boolean enabled, Instant since, Optional<String> error)
+{
+    public TracingStatus(boolean enabled, Instant since)
+    {
+        this(enabled, since, Optional.empty());
+    }
+
+    public TracingStatus
+    {
+        requireNonNull(since, "since is null");
+        since = since.truncatedTo(ChronoUnit.SECONDS);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/tracing/WorkerDynamicTracingController.java
+++ b/core/trino-main/src/main/java/io/trino/server/tracing/WorkerDynamicTracingController.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.tracing;
+
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+import io.opentelemetry.sdk.internal.ScopeConfigurator;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.internal.SdkTracerProviderUtil;
+import io.opentelemetry.sdk.trace.internal.TracerConfig;
+
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Objects.requireNonNull;
+
+public class WorkerDynamicTracingController
+        implements DynamicTracingController
+{
+    private static final Logger log = Logger.get(WorkerDynamicTracingController.class);
+
+    private final AtomicBoolean exportEnabled;
+    private final SdkTracerProvider tracerProvider;
+    private static final AtomicReference<Instant> since = new AtomicReference<>(Instant.now());
+
+    @Inject
+    public WorkerDynamicTracingController(SdkTracerProvider tracerProvider, DynamicTracingConfig config)
+    {
+        this.tracerProvider = requireNonNull(tracerProvider, "tracerProvider is null");
+        this.exportEnabled = new AtomicBoolean(requireNonNull(config, "config is null").isExportEnabled());
+
+        log.info("Exporting OpenTelemetry traces is now %s", exportEnabled.get() ? "enabled" : "disabled");
+    }
+
+    @Override
+    public TracingStatus enableExport()
+    {
+        if (exportEnabled.compareAndSet(false, true)) {
+            since.set(Instant.now());
+            log.info("Enabling exporting OpenTelemetry traces");
+            SdkTracerProviderUtil.setTracerConfigurator(tracerProvider, setExportEnabled(true));
+        }
+        return new TracingStatus(exportEnabled.get(), since.get());
+    }
+
+    @Override
+    public TracingStatus disableExport()
+    {
+        if (exportEnabled.compareAndSet(true, false)) {
+            since.set(Instant.now());
+            log.info("Disabling exporting OpenTelemetry traces");
+            SdkTracerProviderUtil.setTracerConfigurator(tracerProvider, setExportEnabled(false));
+        }
+        return new TracingStatus(exportEnabled.get(), since.get());
+    }
+
+    @Override
+    public TracingStatus getStatus()
+    {
+        return new TracingStatus(exportEnabled.get(), since.get());
+    }
+
+    static ScopeConfigurator<TracerConfig> setExportEnabled(boolean enabled)
+    {
+        since.set(Instant.now());
+        return _ -> enabled ? TracerConfig.enabled() : TracerConfig.disabled();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/tracing/WorkerDynamicTracingResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/tracing/WorkerDynamicTracingResource.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.tracing;
+
+import com.google.inject.Inject;
+import io.trino.server.security.ResourceSecurity;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+
+import static io.trino.server.security.ResourceSecurity.AccessType.INTERNAL_ONLY;
+import static java.util.Objects.requireNonNull;
+
+@Path("/v1/tracing")
+@Produces("application/json")
+public class WorkerDynamicTracingResource
+{
+    private DynamicTracingController controller;
+
+    @Inject
+    public WorkerDynamicTracingResource(DynamicTracingController controller)
+    {
+        this.controller = requireNonNull(controller, "controller is null");
+    }
+
+    @GET
+    @ResourceSecurity(INTERNAL_ONLY)
+    public Response getStatus()
+    {
+        return Response.ok(controller.getStatus()).build();
+    }
+
+    @GET
+    @Path("/enable")
+    @ResourceSecurity(INTERNAL_ONLY)
+    public Response enable()
+    {
+        return Response.ok(controller.enableExport()).build();
+    }
+
+    @GET
+    @Path("/disable")
+    @ResourceSecurity(INTERNAL_ONLY)
+    public Response disable()
+    {
+        return Response.ok(controller.disableExport()).build();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
         <air.test.jvm.additional-arguments>${air.test.jvm.additional-arguments.default}</air.test.jvm.additional-arguments>
 
         <!-- keep dependency properties sorted -->
-        <dep.airlift.version>303</dep.airlift.version>
+        <dep.airlift.version>304</dep.airlift.version>
         <dep.alluxio.version>2.9.6</dep.alluxio.version>
         <dep.antlr.version>4.13.2</dep.antlr.version>
         <dep.avro.version>1.12.0</dep.avro.version>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

When tracing is dynamically disabled, NOOP_TRACER is used (as if the tracing wasn't configured at all):

<img width="533" alt="Screenshot 2025-02-11 at 14 52 09" src="https://github.com/user-attachments/assets/9cdc1f84-4774-46e4-ad3c-3b4f7476b3b7" />

