### PR TITLE
Support write operations for S3 Tables in Iceberg

### DIFF
--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/Location.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/Location.java
@@ -23,6 +23,7 @@ import java.util.OptionalInt;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Iterables.getLast;
+import static io.trino.filesystem.Locations.isS3Tables;
 import static java.lang.Integer.parseInt;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Predicate.not;
@@ -92,7 +93,10 @@ public final class Location
                 }
             }
 
-            checkArgument((userInfo.isEmpty() && host.isEmpty() && port.isEmpty()) || authoritySplit.size() == 2, "Path missing in file system location: %s", location);
+            if (!isS3Tables(location)) {
+                // S3 Tables create tables under the bucket like 's3://e97725d9-dbfb-4334-784sox7edps35ncq16arh546frqa1use2b--table-s3'
+                checkArgument((userInfo.isEmpty() && host.isEmpty() && port.isEmpty()) || authoritySplit.size() == 2, "Path missing in file system location: %s", location);
+            }
             String path = (authoritySplit.size() == 2) ? authoritySplit.get(1) : "";
 
             return new Location(location, Optional.of(scheme), userInfo, host, port, path);

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/Locations.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/Locations.java
@@ -13,8 +13,12 @@
  */
 package io.trino.filesystem;
 
+import java.util.regex.Pattern;
+
 public final class Locations
 {
+    private static final Pattern S3_TABLES = Pattern.compile("s3://(?!.*/).*--table-s3");
+
     private Locations() {}
 
     /**
@@ -36,5 +40,10 @@ public final class Locations
     {
         return leftLocation.equals(rightLocation) ||
                 leftLocation.removeOneTrailingSlash().equals(rightLocation.removeOneTrailingSlash());
+    }
+
+    public static boolean isS3Tables(String location)
+    {
+        return S3_TABLES.matcher(location).matches();
     }
 }

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/TestLocations.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/TestLocations.java
@@ -79,4 +79,17 @@ public class TestLocations
         assertThat(areDirectoryLocationsEquivalent(Location.of(rightLocation), Location.of(leftLocation))).as("equivalence of '%s' in relation to '%s'", rightLocation, leftLocation)
                 .isEqualTo(equivalent);
     }
+
+    @Test
+    void testIsS3Tables()
+    {
+        assertThat(Locations.isS3Tables("s3://e97725d9-dbfb-4334-784sox7edps35ncq16arh546frqa1use2b--table-s3")).isTrue();
+        assertThat(Locations.isS3Tables("s3://75fed916-b871-4909-mx9t6iohbseks57q16e5y6nf1c8gguse2b--table-s3")).isTrue();
+
+        assertThat(Locations.isS3Tables("s3://e97725d9-dbfb-4334-784sox7edps35ncq16arh546frqa1use2b--table-s3/")).isFalse();
+        assertThat(Locations.isS3Tables("s3://75fed916-b871-4909-mx9t6iohbseks57q16e5y6nf1c8gguse2b--table-s3/")).isFalse();
+        assertThat(Locations.isS3Tables("s3://75fed916-b871-4909/mx9t6iohbseks57q16e5y6nf1c8gguse2b--table-s3")).isFalse();
+        assertThat(Locations.isS3Tables("s3://test-bucket")).isFalse();
+        assertThat(Locations.isS3Tables("s3://test-bucket/default")).isFalse();
+    }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -853,7 +853,7 @@ public final class IcebergUtil
         if (replace) {
             return catalog.newCreateOrReplaceTableTransaction(session, schemaTableName, schema, partitionSpec, sortOrder, tableLocation, createTableProperties(tableMetadata, allowedExtraProperties));
         }
-        return catalog.newCreateTableTransaction(session, schemaTableName, schema, partitionSpec, sortOrder, tableLocation, createTableProperties(tableMetadata, allowedExtraProperties));
+        return catalog.newCreateTableTransaction(session, schemaTableName, schema, partitionSpec, sortOrder, Optional.ofNullable(tableLocation), createTableProperties(tableMetadata, allowedExtraProperties));
     }
 
     public static Map<String, String> createTableProperties(ConnectorTableMetadata tableMetadata, Predicate<String> allowedExtraProperties)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
@@ -218,18 +218,18 @@ public abstract class AbstractTrinoCatalog
             Schema schema,
             PartitionSpec partitionSpec,
             SortOrder sortOrder,
-            String location,
+            Optional<String> location,
             Map<String, String> properties,
             Optional<String> owner)
     {
-        TableMetadata metadata = newTableMetadata(schema, partitionSpec, sortOrder, location, properties);
+        TableMetadata metadata = newTableMetadata(schema, partitionSpec, sortOrder, location.orElse(null), properties);
         TableOperations ops = tableOperationsProvider.createTableOperations(
                 this,
                 session,
                 schemaTableName.getSchemaName(),
                 schemaTableName.getTableName(),
                 owner,
-                Optional.of(location));
+                location);
         return createTableTransaction(schemaTableName.toString(), ops, metadata);
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/TrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/TrinoCatalog.java
@@ -25,6 +25,7 @@ import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.security.TrinoPrincipal;
+import jakarta.annotation.Nullable;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -116,7 +117,7 @@ public interface TrinoCatalog
             Schema schema,
             PartitionSpec partitionSpec,
             SortOrder sortOrder,
-            String location,
+            Optional<String> location,
             Map<String, String> properties);
 
     Transaction newCreateOrReplaceTableTransaction(
@@ -159,6 +160,7 @@ public interface TrinoCatalog
 
     void updateViewColumnComment(ConnectorSession session, SchemaTableName schemaViewName, String columnName, Optional<String> comment);
 
+    @Nullable
     String defaultTableLocation(ConnectorSession session, SchemaTableName schemaTableName);
 
     void setTablePrincipal(ConnectorSession session, SchemaTableName schemaTableName, TrinoPrincipal principal);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -749,7 +749,7 @@ public class TrinoGlueCatalog
             Schema schema,
             PartitionSpec partitionSpec,
             SortOrder sortOrder,
-            String location,
+            Optional<String> location,
             Map<String, String> properties)
     {
         return newCreateTableTransaction(

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
@@ -293,7 +293,7 @@ public class TrinoHiveCatalog
             Schema schema,
             PartitionSpec partitionSpec,
             SortOrder sortOrder,
-            String location,
+            Optional<String> location,
             Map<String, String> properties)
     {
         return newCreateTableTransaction(

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
@@ -283,7 +283,7 @@ public class TrinoJdbcCatalog
             Schema schema,
             PartitionSpec partitionSpec,
             SortOrder sortOrder,
-            String location,
+            Optional<String> location,
             Map<String, String> properties)
     {
         return newCreateTableTransaction(

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/TrinoNessieCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/TrinoNessieCatalog.java
@@ -272,7 +272,7 @@ public class TrinoNessieCatalog
             Schema schema,
             PartitionSpec partitionSpec,
             SortOrder sortOrder,
-            String location,
+            Optional<String> location,
             Map<String, String> properties)
     {
         return newCreateTableTransaction(

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/SigV4AwsProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/SigV4AwsProperties.java
@@ -16,12 +16,9 @@ package io.trino.plugin.iceberg.catalog.rest;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.trino.filesystem.s3.S3FileSystemConfig;
-import io.trino.plugin.iceberg.IcebergSecurityConfig;
 
 import java.util.Map;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static io.trino.plugin.iceberg.IcebergSecurityConfig.IcebergSecurity.READ_ONLY;
 import static java.util.Objects.requireNonNull;
 
 public class SigV4AwsProperties
@@ -30,10 +27,8 @@ public class SigV4AwsProperties
     private final Map<String, String> properties;
 
     @Inject
-    public SigV4AwsProperties(IcebergSecurityConfig securityConfig, IcebergRestCatalogSigV4Config sigV4Config, S3FileSystemConfig s3Config)
+    public SigV4AwsProperties(IcebergRestCatalogSigV4Config sigV4Config, S3FileSystemConfig s3Config)
     {
-        // TODO https://github.com/trinodb/trino/issues/24916 Allow write operations with SigV4
-        checkArgument(securityConfig.getSecuritySystem() == READ_ONLY, "Read-only security system is required");
         this.properties = ImmutableMap.<String, String>builder()
                 .put("rest.sigv4-enabled", "true")
                 .put("rest.signing-name", sigV4Config.getSigningName())

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -52,6 +52,7 @@ import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.Transaction;
+import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.SessionCatalog.SessionContext;
@@ -83,7 +84,6 @@ import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.cache.CacheUtils.uncheckedCacheGet;
 import static io.trino.filesystem.Locations.appendPath;
@@ -386,16 +386,19 @@ public class TrinoRestCatalog
             Schema schema,
             PartitionSpec partitionSpec,
             SortOrder sortOrder,
-            String location,
+            Optional<String> location,
             Map<String, String> properties)
     {
         try {
-            return restSessionCatalog.buildTable(convert(session), toRemoteTable(session, schemaTableName, true), schema)
+            Catalog.TableBuilder tableBuilder = restSessionCatalog.buildTable(convert(session), toRemoteTable(session, schemaTableName, true), schema)
                     .withPartitionSpec(partitionSpec)
                     .withSortOrder(sortOrder)
-                    .withLocation(location)
-                    .withProperties(properties)
-                    .createTransaction();
+                    .withProperties(properties);
+            if (location.isEmpty()) {
+                // TODO Replace with createTransaction once S3 Tables supports stage-create option
+                return tableBuilder.create().newTransaction();
+            }
+            return tableBuilder.withLocation(location.get()).createTransaction();
         }
         catch (RESTException e) {
             throw new TrinoException(ICEBERG_CATALOG_ERROR, "Failed to create transaction", e);
@@ -565,7 +568,11 @@ public class TrinoRestCatalog
 
         Map<String, Object> properties = loadNamespaceMetadata(session, schemaTableName.getSchemaName());
         String databaseLocation = (String) properties.get(IcebergSchemaProperties.LOCATION_PROPERTY);
-        checkArgument(databaseLocation != null, "location must be set for %s", schemaTableName.getSchemaName());
+        if (databaseLocation == null) {
+            // Iceberg REST catalog doesn't require location property.
+            // S3 Tables doesn't return the property.
+            return null;
+        }
 
         return appendPath(databaseLocation, tableName);
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/snowflake/TrinoSnowflakeCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/snowflake/TrinoSnowflakeCatalog.java
@@ -213,7 +213,7 @@ public class TrinoSnowflakeCatalog
             Schema schema,
             PartitionSpec partitionSpec,
             SortOrder sortOrder,
-            String location,
+            Optional<String> location,
             Map<String, String> properties)
     {
         throw new TrinoException(NOT_SUPPORTED, "Snowflake managed Iceberg tables do not support modifications");

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrateProcedure.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrateProcedure.java
@@ -231,7 +231,7 @@ public class MigrateProcedure
                     schema,
                     parsePartitionFields(schema, toPartitionFields(hiveTable)),
                     unsorted(),
-                    location,
+                    Optional.of(location),
                     properties);
 
             List<DataFile> dataFiles = dataFilesBuilder.build();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/BaseTrinoCatalogTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/BaseTrinoCatalogTest.java
@@ -168,7 +168,7 @@ public abstract class BaseTrinoCatalogTest
                             new Schema(Types.NestedField.of(1, true, "col1", Types.LongType.get())),
                             PartitionSpec.unpartitioned(),
                             SortOrder.unsorted(),
-                            tableLocation,
+                            Optional.of(tableLocation),
                             tableProperties)
                     .commitTransaction();
             assertThat(catalog.listTables(SESSION, Optional.of(namespace))).contains(new TableInfo(schemaTableName, TABLE));
@@ -228,7 +228,7 @@ public abstract class BaseTrinoCatalogTest
                             tableSchema,
                             PartitionSpec.unpartitioned(),
                             sortOrder,
-                            tableLocation,
+                            Optional.of(tableLocation),
                             ImmutableMap.of())
                     .commitTransaction();
             assertThat(catalog.listTables(SESSION, Optional.of(namespace))).contains(new TableInfo(schemaTableName, TABLE));
@@ -283,7 +283,7 @@ public abstract class BaseTrinoCatalogTest
                             new Schema(Types.NestedField.of(1, true, "col1", Types.LongType.get())),
                             PartitionSpec.unpartitioned(),
                             SortOrder.unsorted(),
-                            arbitraryTableLocation(catalog, SESSION, sourceSchemaTableName),
+                            Optional.of(arbitraryTableLocation(catalog, SESSION, sourceSchemaTableName)),
                             ImmutableMap.of())
                     .commitTransaction();
             assertThat(catalog.listTables(SESSION, Optional.of(namespace))).contains(new TableInfo(sourceSchemaTableName, TABLE));
@@ -434,7 +434,7 @@ public abstract class BaseTrinoCatalogTest
                             new Schema(Types.NestedField.of(1, true, "col1", Types.LongType.get())),
                             PartitionSpec.unpartitioned(),
                             SortOrder.unsorted(),
-                            arbitraryTableLocation(catalog, SESSION, table1),
+                            Optional.of(arbitraryTableLocation(catalog, SESSION, table1)),
                             ImmutableMap.of())
                     .commitTransaction();
             closer.register(() -> catalog.dropTable(SESSION, table1));
@@ -445,7 +445,7 @@ public abstract class BaseTrinoCatalogTest
                             new Schema(Types.NestedField.of(1, true, "col1", Types.LongType.get())),
                             PartitionSpec.unpartitioned(),
                             SortOrder.unsorted(),
-                            arbitraryTableLocation(catalog, SESSION, table2),
+                            Optional.of(arbitraryTableLocation(catalog, SESSION, table2)),
                             ImmutableMap.of())
                     .commitTransaction();
             closer.register(() -> catalog.dropTable(SESSION, table2));

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/hms/TestTrinoHiveCatalogWithHiveMetastore.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/hms/TestTrinoHiveCatalogWithHiveMetastore.java
@@ -270,7 +270,7 @@ public class TestTrinoHiveCatalogWithHiveMetastore
                         new Schema(Types.NestedField.of(1, true, "col1", Types.LongType.get())),
                         PartitionSpec.unpartitioned(),
                         SortOrder.unsorted(),
-                        arbitraryTableLocation(catalog, SESSION, lowerCaseTableTypeTable),
+                        Optional.of(arbitraryTableLocation(catalog, SESSION, lowerCaseTableTypeTable)),
                         ImmutableMap.of())
                 .commitTransaction();
 

--- a/plugin/trino-iceberg/src/test/java/org/apache/iceberg/snowflake/TestTrinoSnowflakeCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/org/apache/iceberg/snowflake/TestTrinoSnowflakeCatalog.java
@@ -254,7 +254,7 @@ public class TestTrinoSnowflakeCatalog
                                 new Schema(Types.NestedField.of(1, true, "col1", Types.LongType.get())),
                                 PartitionSpec.unpartitioned(),
                                 SortOrder.unsorted(),
-                                tableLocation,
+                                Optional.of(tableLocation),
                                 tableProperties)
                         .commitTransaction())
                 .hasMessageContaining("Snowflake managed Iceberg tables do not support modifications");
@@ -293,7 +293,7 @@ public class TestTrinoSnowflakeCatalog
                                 tableSchema,
                                 PartitionSpec.unpartitioned(),
                                 sortOrder,
-                                tableLocation,
+                                Optional.of(tableLocation),
                                 ImmutableMap.of())
                         .commitTransaction())
                 .hasMessageContaining("Snowflake managed Iceberg tables do not support modifications");


### PR DESCRIPTION
## Description

`Location` class requires a small change because it doesn't allow S3 Tables path, e.g. `s3://{random}--table-s3'`. 

Fixes #24916

cc: @jamesbornholt

## Release notes

```markdown
## Iceberg
* Fix some things. ({issue}`issuenumber`)
```
