### PR TITLE
Fix duplicate key due to non-lowercase collections in MongoDB

### DIFF
--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
@@ -247,7 +247,9 @@ public class MongoSession
                 .collect(toSet()));
         builder.addAll(getTableMetadataNames(schemaName));
 
-        return builder.build();
+        return builder.build().stream()
+                .map(name -> name.toLowerCase(ENGLISH))
+                .collect(toImmutableSet());
     }
 
     public MongoTable getTable(SchemaTableName tableName)


### PR DESCRIPTION
## Description

The connector threw "Duplicate key {schema}.{table} (attempted merging values TABLE and TABLE)" error when tables exist with different cases like test and TEST. 

```
io.trino.testing.QueryFailedException: Error listing tables for catalog mongodb: Duplicate key test_db_fymzuxlc22.test_collection_a2p6hs64ml (attempted merging values TABLE and TABLE)

	at io.trino.testing.AbstractTestingTrinoClient.execute(AbstractTestingTrinoClient.java:138)
	at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:565)
	at io.trino.testing.DistributedQueryRunner.execute(DistributedQueryRunner.java:548)
	at io.trino.sql.query.QueryAssertions$QueryAssert.lambda$new$1(QueryAssertions.java:317)
	at com.google.common.base.Suppliers$NonSerializableMemoizingSupplier.get(Suppliers.java:200)
	at io.trino.sql.query.QueryAssertions$QueryAssert.result(QueryAssertions.java:436)
	at io.trino.sql.query.QueryAssertions$QueryAssert.matches(QueryAssertions.java:357)
	at io.trino.plugin.mongodb.TestMongoConnectorTest.testNonLowercaseCollection(TestMongoConnectorTest.java:170)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.concurrent.ForkJoinTask.doExec$$$capture(ForkJoinTask.java:507)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1458)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2034)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:189)
	Suppressed: java.lang.Exception: SQL: SELECT * FROM information_schema.tables WHERE table_catalog = 'mongodb' AND table_schema = 'test_db_fymzuxlc22'
		at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:572)
		... 12 more
```

## Release notes

```markdown
## MongoDB
* Fix failure when tables exist with different cases. ({issue}`issuenumber`)
```
