### PR TITLE
Remove unhelpful log from LokiSplitManager

### DIFF
--- a/plugin/trino-loki/pom.xml
+++ b/plugin/trino-loki/pom.xml
@@ -45,11 +45,6 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
-            <artifactId>log</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
         </dependency>
 
@@ -108,6 +103,12 @@
         <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_annotations</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
             <scope>runtime</scope>
         </dependency>
 

--- a/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiSplitManager.java
+++ b/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiSplitManager.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.loki;
 
 import com.google.common.collect.ImmutableList;
-import io.airlift.log.Logger;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorSplitManager;
@@ -30,8 +29,6 @@ import java.util.List;
 public class LokiSplitManager
         implements ConnectorSplitManager
 {
-    private static final Logger log = Logger.get(LokiSplitManager.class);
-
     @Override
     public ConnectorSplitSource getSplits(
             ConnectorTransactionHandle transaction,
@@ -43,8 +40,6 @@ public class LokiSplitManager
         final LokiTableHandle table = (LokiTableHandle) connectorTableHandle;
 
         List<ConnectorSplit> splits = ImmutableList.of(new LokiSplit(table.query(), table.start(), table.end(), table.step()));
-
-        log.debug("created %d splits", splits.size());
         return new FixedSplitSource(splits);
     }
 }


### PR DESCRIPTION
## Description

The log is redundant because the split size is always 1. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
