### PR TITLE
Add arrow encoding to spooling

### DIFF
--- a/client/trino-cli/pom.xml
+++ b/client/trino-cli/pom.xml
@@ -200,7 +200,7 @@
                 <groupId>org.skife.maven</groupId>
                 <artifactId>really-executable-jar-maven-plugin</artifactId>
                 <configuration>
-                    <flags>-Xmx1G --enable-native-access=ALL-UNNAMED -XX:+IgnoreUnrecognizedVMOptions</flags>
+                    <flags>-Xmx1G --enable-native-access=ALL-UNNAMED -XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.nio=ALL-UNNAMED -Dorg.slf4j.simpleLogger.defaultLogLevel=error</flags>
                     <classifier>executable</classifier>
                 </configuration>
                 <executions>

--- a/client/trino-client/pom.xml
+++ b/client/trino-client/pom.xml
@@ -86,6 +86,28 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-memory-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-vector</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>org.gaul</groupId>
             <artifactId>modernizer-maven-annotations</artifactId>
             <optional>true</optional>
@@ -94,6 +116,24 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>aircompressor-v3</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-memory-netty</artifactId>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
             <scope>runtime</scope>
         </dependency>
 

--- a/client/trino-client/src/main/java/io/trino/client/spooling/encoding/AirliftCompressionCodecFactory.java
+++ b/client/trino-client/src/main/java/io/trino/client/spooling/encoding/AirliftCompressionCodecFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client.spooling.encoding;
+
+import org.apache.arrow.vector.compression.CompressionCodec;
+import org.apache.arrow.vector.compression.CompressionUtil;
+
+import static java.util.Objects.requireNonNull;
+
+public class AirliftCompressionCodecFactory
+        implements CompressionCodec.Factory
+{
+    @Override
+    public CompressionCodec createCodec(CompressionUtil.CodecType codecType)
+    {
+        if (requireNonNull(codecType) == CompressionUtil.CodecType.ZSTD) {
+            return new AirliftZstdCompressionCodec();
+        }
+        throw new IllegalStateException("Unsupported codec type: " + codecType);
+    }
+
+    @Override
+    public CompressionCodec createCodec(CompressionUtil.CodecType codecType, int compressionLevel)
+    {
+        if (requireNonNull(codecType) == CompressionUtil.CodecType.ZSTD) {
+            return new AirliftZstdCompressionCodec();
+        }
+        throw new IllegalStateException("Unsupported codec type: " + codecType);
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/spooling/encoding/AirliftZstdCompressionCodec.java
+++ b/client/trino-client/src/main/java/io/trino/client/spooling/encoding/AirliftZstdCompressionCodec.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client.spooling.encoding;
+
+import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.compression.AbstractCompressionCodec;
+import org.apache.arrow.vector.compression.CompressionUtil;
+
+import java.nio.ByteBuffer;
+
+import static io.trino.client.spooling.encoding.DecompressionUtils.decompressZstd;
+import static java.lang.Math.toIntExact;
+import static org.apache.arrow.vector.compression.CompressionUtil.CodecType.ZSTD;
+import static org.apache.arrow.vector.compression.CompressionUtil.SIZE_OF_UNCOMPRESSED_LENGTH;
+
+public class AirliftZstdCompressionCodec
+        extends AbstractCompressionCodec
+{
+    @Override
+    protected ArrowBuf doCompress(BufferAllocator allocator, ArrowBuf uncompressedBuffer)
+    {
+        throw new UnsupportedOperationException("Compression is not supported client-side");
+    }
+
+    @Override
+    protected ArrowBuf doDecompress(BufferAllocator allocator, ArrowBuf compressedBuffer)
+    {
+        int decompressedLength = toIntExact(readUncompressedLength(compressedBuffer));
+        ArrowBuf uncompressedBuffer = allocator.buffer(decompressedLength);
+
+        ByteBuffer inputBuffer = compressedBuffer.nioBuffer(SIZE_OF_UNCOMPRESSED_LENGTH, toIntExact(compressedBuffer.writerIndex() - SIZE_OF_UNCOMPRESSED_LENGTH));
+        ByteBuffer outputBuffer = uncompressedBuffer.nioBuffer(0, decompressedLength);
+
+        long uncompressedSize = decompressZstd(inputBuffer, outputBuffer);
+
+        if (uncompressedSize != decompressedLength) {
+            uncompressedBuffer.close();
+            throw new RuntimeException(
+                    "Expected != actual decompressed length: "
+                            + decompressedLength
+                            + " != "
+                            + uncompressedSize);
+        }
+        return uncompressedBuffer;
+    }
+
+    @Override
+    public CompressionUtil.CodecType getCodecType()
+    {
+        return ZSTD;
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/spooling/encoding/ArrowDecodingUtils.java
+++ b/client/trino-client/src/main/java/io/trino/client/spooling/encoding/ArrowDecodingUtils.java
@@ -1,0 +1,505 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client.spooling.encoding;
+
+import io.trino.client.ClientTypeSignature;
+import io.trino.client.Column;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.DateDayVector;
+import org.apache.arrow.vector.DecimalVector;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.FixedSizeBinaryVector;
+import org.apache.arrow.vector.IntervalDayVector;
+import org.apache.arrow.vector.TimeStampVector;
+import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.MapVector;
+import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.util.TransferPair;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
+import static io.trino.client.ClientStandardTypes.ARRAY;
+import static io.trino.client.ClientStandardTypes.BIGINT;
+import static io.trino.client.ClientStandardTypes.BOOLEAN;
+import static io.trino.client.ClientStandardTypes.CHAR;
+import static io.trino.client.ClientStandardTypes.DATE;
+import static io.trino.client.ClientStandardTypes.DECIMAL;
+import static io.trino.client.ClientStandardTypes.DOUBLE;
+import static io.trino.client.ClientStandardTypes.INTEGER;
+import static io.trino.client.ClientStandardTypes.INTERVAL_DAY_TO_SECOND;
+import static io.trino.client.ClientStandardTypes.MAP;
+import static io.trino.client.ClientStandardTypes.REAL;
+import static io.trino.client.ClientStandardTypes.SMALLINT;
+import static io.trino.client.ClientStandardTypes.TIMESTAMP;
+import static io.trino.client.ClientStandardTypes.TINYINT;
+import static io.trino.client.ClientStandardTypes.UUID;
+import static io.trino.client.ClientStandardTypes.VARCHAR;
+import static io.trino.client.IntervalDayTime.formatMillis;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableMap;
+import static java.util.Objects.requireNonNull;
+import static java.util.UUID.nameUUIDFromBytes;
+
+public class ArrowDecodingUtils
+{
+    // TODO: remove me once I'm not longer needed
+    private static final boolean DEBUG = false;
+
+    private ArrowDecodingUtils()
+    {
+    }
+
+    public static VectorTypeDecoder[] createVectorTypeDecoders(List<Column> columns, BufferAllocator allocator, List<FieldVector> vectors)
+    {
+        verify(!columns.isEmpty(), "Columns must not be empty");
+        VectorTypeDecoder[] decoders = new VectorTypeDecoder[columns.size()];
+        for (int i = 0; i < columns.size(); i++) {
+            TransferPair transferPair = vectors.get(i).getTransferPair(allocator);
+            transferPair.getTo().allocateNew();
+            transferPair.transfer();
+            decoders[i] = debugging(createVectorTypeDecoder(columns.get(i).getTypeSignature(), transferPair.getTo()));
+        }
+        return decoders;
+    }
+
+    private static VectorTypeDecoder createVectorTypeDecoder(ClientTypeSignature signature, ValueVector vector)
+    {
+        switch (signature.getRawType()) {
+            case BIGINT:
+                return new BigintDecoder(checkedCast(vector, BigIntVector.class));
+            case INTEGER:
+                return new PassThroughDecoder(vector);
+            case SMALLINT:
+                return new PassThroughDecoder(vector);
+            case TINYINT:
+                return new PassThroughDecoder(vector);
+            case DOUBLE:
+                return new PassThroughDecoder(vector);
+            case REAL:
+                return new PassThroughDecoder(vector);
+            case BOOLEAN:
+                return new PassThroughDecoder(vector);
+            case VARCHAR:
+            case CHAR:
+                return new VarcharDecoder(checkedCast(vector, VarCharVector.class));
+            case MAP:
+                return new MapDecoder(signature, checkedCast(vector, MapVector.class));
+            case ARRAY:
+                return new ArrayDecoder(signature, checkedCast(vector, ListVector.class));
+            case TIMESTAMP:
+                return new TimestampDecoder(checkedCast(vector, TimeStampVector.class));
+            case DATE:
+                return new DateDecoder(checkedCast(vector, DateDayVector.class));
+            case UUID:
+                return new UuidDecoder(checkedCast(vector, FixedSizeBinaryVector.class));
+            case DECIMAL:
+                return new DecimalDecoder(checkedCast(vector, DecimalVector.class));
+            case INTERVAL_DAY_TO_SECOND:
+                return new IntervalDayTimeDecoder(checkedCast(vector, IntervalDayVector.class));
+//            case ROW:
+//            case JSON:
+//            case TIME:
+//            case TIME_WITH_TIME_ZONE:
+//            case TIMESTAMP_WITH_TIME_ZONE:
+//            case INTERVAL_YEAR_TO_MONTH:
+//            case IPADDRESS:
+//            case GEOMETRY:
+//            case SPHERICAL_GEOGRAPHY:
+//            case COLOR:
+//            case KDB_TREE:
+//            case BING_TILE:
+//            case QDIGEST:
+//            case P4_HYPER_LOG_LOG:
+//            case HYPER_LOG_LOG:
+//            case SET_DIGEST:
+//            case VARBINARY:
+            default:
+                return new PassThroughDecoder(vector);
+        }
+    }
+
+    private static class PassThroughDecoder
+            implements VectorTypeDecoder
+    {
+        private final ValueVector vector;
+
+        public PassThroughDecoder(ValueVector vector)
+        {
+            this.vector = requireNonNull(vector, "vector is null");
+        }
+
+        @Override
+        public Object decode(int position)
+        {
+            if (vector.isNull(position)) {
+                return null;
+            }
+            return vector.getObject(position);
+        }
+
+        @Override
+        public void close()
+        {
+            vector.close();
+        }
+    }
+
+    private static class VarcharDecoder
+            implements VectorTypeDecoder
+    {
+        private final VarCharVector vector;
+
+        public VarcharDecoder(VarCharVector vector)
+        {
+            this.vector = requireNonNull(vector, "vector is null");
+        }
+
+        @Override
+        public Object decode(int position)
+        {
+            if (vector.isNull(position)) {
+                return null;
+            }
+            return vector.getObject(position).toString();
+        }
+
+        @Override
+        public void close()
+        {
+            vector.close();
+        }
+    }
+
+    private static class MapDecoder
+            implements VectorTypeDecoder
+    {
+        private final VectorTypeDecoder keyDecoder;
+        private final VectorTypeDecoder valueDecoder;
+        private final MapVector vector;
+
+        public MapDecoder(ClientTypeSignature signature, MapVector vector)
+        {
+            requireNonNull(signature, "signature is null");
+            this.vector = requireNonNull(vector, "vector is null");
+            StructVector structVector = (StructVector) vector.getDataVector();
+
+            checkArgument(signature.getRawType().equals(MAP), "not a map type signature: %s", signature);
+            this.keyDecoder = debugging(createVectorTypeDecoder(signature.getArgumentsAsTypeSignatures().get(0), structVector.getChild("key")));
+            this.valueDecoder = debugging(createVectorTypeDecoder(signature.getArgumentsAsTypeSignatures().get(1), structVector.getChild("value")));
+        }
+
+        @Override
+        public Object decode(int position)
+        {
+            if (vector.isNull(position)) {
+                return null;
+            }
+
+            if (vector.isEmpty(position)) {
+                return emptyMap();
+            }
+
+            Map<Object, Object> values = new HashMap<>();
+            for (int i = vector.getElementStartIndex(position); i < vector.getElementEndIndex(position); i++) {
+                values.put(keyDecoder.decode(i), valueDecoder.decode(i));
+            }
+            return unmodifiableMap(values);
+        }
+
+        @Override
+        public void close()
+                throws IOException
+        {
+            keyDecoder.close();
+            valueDecoder.close();
+            vector.close();
+        }
+    }
+
+    private static class ArrayDecoder
+            implements VectorTypeDecoder
+    {
+        private final VectorTypeDecoder valueDecoder;
+        private final ListVector vector;
+
+        public ArrayDecoder(ClientTypeSignature signature, ListVector vector)
+        {
+            requireNonNull(signature, "signature is null");
+            this.vector = requireNonNull(vector, "vector is null");
+            checkArgument(signature.getRawType().equals(ARRAY), "not an array type signature: %s", signature);
+            this.valueDecoder = debugging(createVectorTypeDecoder(signature.getArgumentsAsTypeSignatures().get(0), vector.getDataVector()));
+        }
+
+        @Override
+        public Object decode(int position)
+        {
+            if (vector.isNull(position)) {
+                return null;
+            }
+
+            if (vector.isEmpty(position)) {
+                return emptyList();
+            }
+
+            List<Object> values = new ArrayList<>();
+            for (int i = vector.getElementStartIndex(position); i < vector.getElementEndIndex(position); i++) {
+                values.add(valueDecoder.decode(i));
+            }
+            return unmodifiableList(values);
+        }
+
+        @Override
+        public void close()
+                throws IOException
+        {
+            valueDecoder.close();
+            vector.close();
+        }
+    }
+
+    private static class BigintDecoder
+            implements VectorTypeDecoder
+    {
+        private final BigIntVector vector;
+
+        public BigintDecoder(BigIntVector vector)
+        {
+            this.vector = requireNonNull(vector, "vector is null");
+        }
+
+        @Override
+        public Object decode(int position)
+        {
+            if (vector.isNull(position)) {
+                return null;
+            }
+            return vector.get(position);
+        }
+
+        @Override
+        public void close()
+        {
+            vector.close();
+        }
+    }
+
+    private static class DateDecoder
+            implements VectorTypeDecoder
+    {
+        private final DateDayVector vector;
+
+        public DateDecoder(DateDayVector vector)
+        {
+            this.vector = requireNonNull(vector, "vector is null");
+        }
+
+        @Override
+        public Object decode(int position)
+        {
+            if (vector.isNull(position)) {
+                return null;
+            }
+            return LocalDate.ofEpochDay(vector.get(position)).toString();
+        }
+
+        @Override
+        public void close()
+        {
+            vector.close();
+        }
+    }
+
+    private static class TimestampDecoder
+            implements VectorTypeDecoder
+    {
+        private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss");
+
+        private final TimeStampVector vector;
+
+        public TimestampDecoder(TimeStampVector vector)
+        {
+            this.vector = requireNonNull(vector, "vector is null");
+        }
+
+        @Override
+        public Object decode(int position)
+        {
+            if (vector.isNull(position)) {
+                return null;
+            }
+            return formatTimestamp((LocalDateTime) vector.getObject(position));
+        }
+
+        private static String formatTimestamp(LocalDateTime dateTime)
+        {
+            return TIMESTAMP_FORMATTER.format(dateTime);
+            // TODO: fix me
+//            if (precision > 0) {
+//                long scaledFraction = picoFraction / POWERS_OF_TEN[MAX_PRECISION - precision];
+//                builder.append('.');
+//                builder.setLength(builder.length() + precision);
+//                int index = builder.length() - 1;
+//
+//                // Append the fractional the decimal digits in reverse order
+//                // comparable to format("%0" + precision + "d", scaledFraction);
+//                for (int i = 0; i < precision; i++) {
+//                    long temp = scaledFraction / 10;
+//                    int digit = (int) (scaledFraction - (temp * 10));
+//                    scaledFraction = temp;
+//                    builder.setCharAt(index - i, (char) ('0' + digit));
+//                }
+//            }
+        }
+
+        @Override
+        public void close()
+        {
+            vector.close();
+        }
+    }
+
+    private static class DecimalDecoder
+            implements VectorTypeDecoder
+    {
+        private final DecimalVector vector;
+
+        public DecimalDecoder(DecimalVector vector)
+        {
+            this.vector = requireNonNull(vector, "vector is null");
+        }
+
+        @Override
+        public Object decode(int position)
+        {
+            if (vector.isNull(position)) {
+                return null;
+            }
+            // TODO: expect BigDecimal directly in the JDBC driver
+            return vector.getObject(position).toString();
+        }
+
+        @Override
+        public void close()
+        {
+            vector.close();
+        }
+    }
+
+    private static class UuidDecoder
+            implements VectorTypeDecoder
+    {
+        private final FixedSizeBinaryVector vector;
+
+        public UuidDecoder(FixedSizeBinaryVector vector)
+        {
+            this.vector = requireNonNull(vector, "vector is null");
+        }
+
+        @Override
+        public Object decode(int position)
+        {
+            if (vector.isNull(position)) {
+                return null;
+            }
+
+            // TODO: expect UUID directly in the JDBC driver
+            return nameUUIDFromBytes(vector.get(position)).toString();
+        }
+
+        @Override
+        public void close()
+        {
+            vector.close();
+        }
+    }
+
+    private static class IntervalDayTimeDecoder
+            implements VectorTypeDecoder
+    {
+        private final IntervalDayVector vector;
+
+        public IntervalDayTimeDecoder(IntervalDayVector vector)
+        {
+            this.vector = requireNonNull(vector, "vector is null");
+        }
+
+        @Override
+        public Object decode(int position)
+        {
+            if (vector.isNull(position)) {
+                return null;
+            }
+
+            Duration duration = vector.getObject(position);
+            return formatMillis(duration.toNanos() / 1_000_000);
+        }
+
+        @Override
+        public void close()
+        {
+            vector.close();
+        }
+    }
+
+    public interface VectorTypeDecoder
+            extends Closeable
+    {
+        Object decode(int position);
+    }
+
+    private static VectorTypeDecoder debugging(VectorTypeDecoder delegate)
+    {
+        if (!DEBUG) {
+            return delegate;
+        }
+        return new VectorTypeDecoder() {
+            @Override
+            public Object decode(int position)
+            {
+                Object object = delegate.decode(position);
+                System.out.println(delegate.getClass().getSimpleName() + "[" + position + "] = " + object);
+                return object;
+            }
+
+            @Override
+            public void close()
+                    throws IOException
+            {
+                delegate.close();
+            }
+        };
+    }
+
+    private static <T extends FieldVector> T checkedCast(ValueVector vector, Class<T> clazz)
+    {
+        checkArgument(clazz.isInstance(vector), "Expected %s, but got %s", clazz, vector.getClass());
+        return clazz.cast(vector);
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/spooling/encoding/ArrowQueryDataDecoder.java
+++ b/client/trino-client/src/main/java/io/trino/client/spooling/encoding/ArrowQueryDataDecoder.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client.spooling.encoding;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.client.CloseableIterator;
+import io.trino.client.Column;
+import io.trino.client.QueryDataDecoder;
+import io.trino.client.spooling.DataAttributes;
+import io.trino.client.spooling.encoding.ArrowDecodingUtils.VectorTypeDecoder;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.ipc.ArrowReader;
+import org.apache.arrow.vector.ipc.ArrowStreamReader;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static io.trino.client.spooling.encoding.ArrowDecodingUtils.createVectorTypeDecoders;
+import static java.util.Objects.requireNonNull;
+import static java.util.UUID.randomUUID;
+
+public class ArrowQueryDataDecoder
+        implements QueryDataDecoder
+{
+    private static final String ENCODING = "arrow";
+
+    private static final BufferAllocator ROOT_ALLOCATOR = new RootAllocator();
+    private final List<Column> columns;
+
+    public ArrowQueryDataDecoder(List<Column> columns)
+    {
+        this.columns = ImmutableList.copyOf(columns);
+    }
+
+    @Override
+    public CloseableIterator<List<Object>> decode(InputStream input, DataAttributes segmentAttributes)
+            throws IOException
+    {
+        BufferAllocator allocator = ROOT_ALLOCATOR.newChildAllocator(randomUUID().toString(), Integer.MAX_VALUE, Integer.MAX_VALUE);
+        ArrowStreamReader streamReader = new ArrowStreamReader(input, allocator, new AirliftCompressionCodecFactory());
+        return new ArrowRowIterator(allocator, streamReader, columns);
+    }
+
+    public static class ArrowRowIterator
+            implements CloseableIterator<List<Object>>
+    {
+        private final BufferAllocator allocator;
+        private final ArrowReader reader;
+        private final List<Column> columns;
+
+        private VectorTypeDecoder[] currentVectorDecoders;
+        private int currentRow;
+        private int currentMaxRows;
+
+        public ArrowRowIterator(BufferAllocator allocator, ArrowReader reader, List<Column> columns)
+                throws IOException
+        {
+            this.allocator = requireNonNull(allocator, "allocator is null");
+            this.reader = requireNonNull(reader, "reader is null");
+            this.columns = requireNonNull(columns, "columns is null");
+            this.currentMaxRows = reader.getVectorSchemaRoot().getRowCount();
+        }
+
+        private boolean advance()
+        {
+            clearVectors();
+            try {
+                if (reader.loadNextBatch()) {
+                    currentRow = 0;
+                    currentMaxRows = reader.getVectorSchemaRoot().getRowCount();
+                    currentVectorDecoders = createVectorTypeDecoders(columns, allocator, reader.getVectorSchemaRoot().getFieldVectors());
+                    return true;
+                }
+                return false;
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return currentRow < currentMaxRows || advance();
+        }
+
+        @Override
+        public List<Object> next()
+        {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+
+            ArrayList<Object> row = new ArrayList<>();
+            for (VectorTypeDecoder vectorDecoder : currentVectorDecoders) {
+                row.add(vectorDecoder.decode(currentRow));
+            }
+            currentRow++;
+            return row;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "ArrowRowIterator{reader=" + reader + '}';
+        }
+
+        @Override
+        public void close()
+                throws IOException
+        {
+            clearVectors();
+            reader.close();
+            allocator.close();
+        }
+
+        private void clearVectors()
+        {
+            if (currentVectorDecoders != null) {
+                for (VectorTypeDecoder vectorDecoder : currentVectorDecoders) {
+                    try {
+                        vectorDecoder.close();
+                    }
+                    catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                }
+            }
+        }
+    }
+
+    public static class Factory
+            implements QueryDataDecoder.Factory
+    {
+        @Override
+        public QueryDataDecoder create(List<Column> columns, DataAttributes queryAttributes)
+        {
+            return new ArrowQueryDataDecoder(columns);
+        }
+
+        @Override
+        public String encoding()
+        {
+            return ENCODING;
+        }
+    }
+
+    private static class ZstdArrowQueryDataDecoder
+            extends ArrowQueryDataDecoder
+    {
+        public ZstdArrowQueryDataDecoder(List<Column> columns)
+        {
+            super(columns);
+        }
+
+        @Override
+        public String encoding()
+        {
+            return super.encoding() + "+zstd";
+        }
+    }
+
+    // Arrow knows internally how to decode Zstd, so we don't need to do anything special here
+    public static class ZstdFactory
+            extends Factory
+    {
+        @Override
+        public QueryDataDecoder create(List<Column> columns, DataAttributes queryAttributes)
+        {
+            return new ZstdArrowQueryDataDecoder(columns);
+        }
+
+        @Override
+        public String encoding()
+        {
+            return super.encoding() + "+zstd";
+        }
+    }
+
+    @Override
+    public String encoding()
+    {
+        return ENCODING;
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/spooling/encoding/DecompressionUtils.java
+++ b/client/trino-client/src/main/java/io/trino/client/spooling/encoding/DecompressionUtils.java
@@ -19,6 +19,7 @@ import io.airlift.compress.zstd.ZstdDecompressor;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.nio.ByteBuffer;
 import java.util.Optional;
 
 public class DecompressionUtils
@@ -47,8 +48,14 @@ public class DecompressionUtils
             ZstdDecompressor decompressor = new ZstdDecompressor();
             return decompressor.decompress(input, 0, input.length, output, 0, output.length);
         }
-
         return decompressNative(ZSTD_DECOMPRESSOR_CONSTRUCTOR.get(), input, output);
+    }
+
+    public static int decompressZstd(ByteBuffer input, ByteBuffer output)
+    {
+        ZstdDecompressor decompressor = new ZstdDecompressor();
+        decompressor.decompress(input, output);
+        return output.position();
     }
 
     private static int decompressNative(MethodHandle constructor, byte[] input, byte[] output)

--- a/client/trino-client/src/main/java/io/trino/client/spooling/encoding/QueryDataDecoders.java
+++ b/client/trino-client/src/main/java/io/trino/client/spooling/encoding/QueryDataDecoders.java
@@ -24,14 +24,17 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.lang.String.format;
 import static java.util.function.Function.identity;
-import static java.util.stream.Collectors.joining;
 
 public class QueryDataDecoders
 {
     private static final List<Factory> decoders = ImmutableList.of(
             new JsonQueryDataDecoder.ZstdFactory(),
             new JsonQueryDataDecoder.Lz4Factory(),
-            new JsonQueryDataDecoder.Factory());
+            new JsonQueryDataDecoder.Factory(),
+            new ArrowQueryDataDecoder.Factory(),
+            new ArrowQueryDataDecoder.ZstdFactory());
+
+    private static final String preferredEncodings = "json+zstd,json+lz4,json";
 
     private static final Map<String, Factory> encodingMap = factoriesMap();
 
@@ -60,9 +63,7 @@ public class QueryDataDecoders
 
     public static String getPreferredEncodings()
     {
-        return decoders.stream()
-                .map(Factory::encoding)
-                .collect(joining(","));
+        return preferredEncodings;
     }
 
     private static Map<String, Factory> factoriesMap()

--- a/client/trino-jdbc/pom.xml
+++ b/client/trino-jdbc/pom.xml
@@ -454,12 +454,20 @@
                                     <shadedPattern>${shadeBase}.guava</shadedPattern>
                                 </relocation>
                                 <relocation>
+                                    <pattern>com.google.flatbuffers</pattern>
+                                    <shadedPattern>${shadeBase}.flatbuffers</shadedPattern>
+                                </relocation>
+                                <relocation>
                                     <pattern>com.google.thirdparty</pattern>
                                     <shadedPattern>${shadeBase}.guava</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>io.airlift</pattern>
                                     <shadedPattern>${shadeBase}.airlift</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.netty</pattern>
+                                    <shadedPattern>${shadeBase}.io.netty</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>jakarta.annotation</pattern>
@@ -480,6 +488,18 @@
                                 <relocation>
                                     <pattern>okio</pattern>
                                     <shadedPattern>${shadeBase}.okio</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.arrow</pattern>
+                                    <shadedPattern>${shadeBase}.org.apache.arrow</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons</pattern>
+                                    <shadedPattern>${shadeBase}.org.apache.commons</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.slf4j</pattern>
+                                    <shadedPattern>${shadeBase}.org.slf4j</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>dev.failsafe</pattern>
@@ -510,10 +530,15 @@
                                         <exclude>LICENSE</exclude>
                                         <exclude>META-INF/**.kotlin_module</exclude>
                                         <exclude>META-INF/versions/**</exclude>
+                                        <exclude>arrow-git.properties</exclude>
                                         <exclude>META-INF/NOTICE**</exclude>
+                                        <exclude>META-INF/io.netty.versions.properties</exclude>
+                                        <exclude>META-INF/services/org.slf4j.spi.SLF4JServiceProvider</exclude>
+                                        <exclude>META-INF/services/reactor.blockhound.integration.BlockHoundIntegration</exclude>
                                         <exclude>META-INF/*-NOTICE</exclude>
                                         <exclude>META-INF/*-LICENSE</exclude>
                                         <exclude>META-INF/LICENSE**</exclude>
+                                        <exclude>META-INF/DEPENDENCIES</exclude>
                                         <exclude>META-INF/io/opentelemetry/**</exclude>
                                         <exclude>io/opentelemetry/semconv/**</exclude>
                                         <exclude>META-INF/native-image/**</exclude>

--- a/core/trino-main/pom.xml
+++ b/core/trino-main/pom.xml
@@ -330,6 +330,16 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-memory-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-vector</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math3</artifactId>
         </dependency>
@@ -391,6 +401,12 @@
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna-platform</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-memory-netty</artifactId>
             <scope>runtime</scope>
         </dependency>
 

--- a/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResource.java
@@ -289,8 +289,7 @@ public class ExecutingStatementResource
             response.encoding("identity");
         }
 
-        queryDataEncoding
-                .ifPresent(encoding -> response.header(TRINO_HEADERS.responseQueryDataEncoding(), encoding));
+        queryDataEncoding.ifPresent(encoding -> response.header(TRINO_HEADERS.responseQueryDataEncoding(), encoding));
 
         return response.build();
     }

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/QueryDataEncoder.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/QueryDataEncoder.java
@@ -13,6 +13,7 @@
  */
 package io.trino.server.protocol.spooling;
 
+import com.google.common.collect.ImmutableList;
 import io.trino.Session;
 import io.trino.client.spooling.DataAttributes;
 import io.trino.server.protocol.OutputColumn;
@@ -30,6 +31,11 @@ public interface QueryDataEncoder
         QueryDataEncoder create(Session session, List<OutputColumn> columns);
 
         String encoding();
+
+        default List<OutputColumn> unsupported(List<OutputColumn> columns)
+        {
+            return ImmutableList.of();
+        }
     }
 
     DataAttributes encodeTo(OutputStream output, List<Page> pages)

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/QueryDataEncodingConfig.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/QueryDataEncodingConfig.java
@@ -26,6 +26,8 @@ public class QueryDataEncodingConfig
     private boolean jsonEnabled = true;
     private boolean jsonZstdEnabled = true;
     private boolean jsonLz4Enabled = true;
+    private boolean arrowIpcEnabled;
+    private boolean arrowIpcZstdEnabled;
     private DataSize compressionThreshold = DataSize.of(8, KILOBYTE);
 
     public boolean isJsonEnabled()
@@ -64,6 +66,32 @@ public class QueryDataEncodingConfig
     public QueryDataEncodingConfig setJsonLz4Enabled(boolean jsonLz4Enabled)
     {
         this.jsonLz4Enabled = jsonLz4Enabled;
+        return this;
+    }
+
+    public boolean isArrowIpcEnabled()
+    {
+        return arrowIpcEnabled;
+    }
+
+    @Config("protocol.spooling.encoding.arrow.enabled")
+    @ConfigDescription("Enable uncompressed Arrow spooled encoding")
+    public QueryDataEncodingConfig setArrowIpcEnabled(boolean arrowIpcEnabled)
+    {
+        this.arrowIpcEnabled = arrowIpcEnabled;
+        return this;
+    }
+
+    public boolean isArrowIpcZstdEnabled()
+    {
+        return arrowIpcZstdEnabled;
+    }
+
+    @Config("protocol.spooling.encoding.arrow+zstd.enabled")
+    @ConfigDescription("Enable Zstd compressed Arrow spooled encoding")
+    public QueryDataEncodingConfig setArrowIpcZstdEnabled(boolean arrowIpcZstdEnabled)
+    {
+        this.arrowIpcZstdEnabled = arrowIpcZstdEnabled;
         return this;
     }
 

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/ArrowCompressionFactory.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/ArrowCompressionFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding;
+
+import org.apache.arrow.vector.compression.CompressionCodec;
+import org.apache.arrow.vector.compression.CompressionUtil;
+
+import static java.util.Objects.requireNonNull;
+
+public class ArrowCompressionFactory
+        implements CompressionCodec.Factory
+{
+    @Override
+    public CompressionCodec createCodec(CompressionUtil.CodecType codecType)
+    {
+        if (requireNonNull(codecType) == CompressionUtil.CodecType.ZSTD) {
+            return new ZstdCompressionCodec();
+        }
+        throw new IllegalArgumentException("Compression type not supported: " + codecType);
+    }
+
+    @Override
+    public CompressionCodec createCodec(CompressionUtil.CodecType codecType, int compressionLevel)
+    {
+        if (requireNonNull(codecType) == CompressionUtil.CodecType.ZSTD) {
+            return new ZstdCompressionCodec();
+        }
+        throw new IllegalArgumentException("Compression type not supported: " + codecType);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/ArrowQueryDataEncoder.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/ArrowQueryDataEncoder.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding;
+
+import com.google.inject.Inject;
+import io.trino.Session;
+import io.trino.client.spooling.DataAttributes;
+import io.trino.server.protocol.OutputColumn;
+import io.trino.server.protocol.spooling.QueryDataEncoder;
+import io.trino.server.protocol.spooling.encoding.arrow.PageWriter;
+import io.trino.server.protocol.spooling.encoding.arrow.TrinoToArrowTypeConverter;
+import io.trino.spi.Page;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.compression.CompressionCodec;
+import org.apache.arrow.vector.compression.CompressionUtil;
+import org.apache.arrow.vector.compression.NoCompressionCodec;
+import org.apache.arrow.vector.ipc.ArrowStreamWriter;
+import org.apache.arrow.vector.ipc.message.IpcOption;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.channels.Channels;
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.client.spooling.DataAttribute.SEGMENT_SIZE;
+import static io.trino.server.protocol.spooling.encoding.arrow.TrinoToArrowTypeConverter.toArrowField;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+
+public class ArrowQueryDataEncoder
+        implements QueryDataEncoder
+{
+    private static final String ENCODING = "arrow";
+
+    private final List<Field> fields;
+    private final List<OutputColumn> columns;
+    private final CompressionCodec.Factory compressionFactory;
+    private final CompressionUtil.CodecType codecType;
+    private final BufferAllocator allocator;
+
+    public ArrowQueryDataEncoder(
+            BufferAllocator allocator,
+            CompressionCodec.Factory compressionFactory,
+            CompressionUtil.CodecType codecType,
+            List<OutputColumn> columns)
+    {
+        this.fields = columns.stream()
+                .map(column -> toArrowField(column.columnName(), column.type(), true))
+                .collect(toImmutableList());
+        this.columns = requireNonNull(columns, "columns is null");
+
+        this.compressionFactory = requireNonNull(compressionFactory, "compressionFactory is null");
+        this.allocator = requireNonNull(allocator, "allocator is null");
+        this.codecType = requireNonNull(codecType, "codecType is null");
+    }
+
+    @Override
+    public DataAttributes encodeTo(OutputStream output, List<Page> pages)
+            throws IOException
+    {
+        try (VectorSchemaRoot schema = VectorSchemaRoot.create(new Schema(fields), allocator)) {
+            ArrowStreamWriter streamWriter = new ArrowStreamWriter(schema, null, Channels.newChannel(output), IpcOption.DEFAULT, compressionFactory, codecType);
+            try (PageWriter arrowPageWriter = new PageWriter(streamWriter, schema, columns)) {
+                return DataAttributes.builder()
+                        .set(SEGMENT_SIZE, toIntExact(arrowPageWriter.writePages(pages)))
+                        .build();
+            }
+        }
+    }
+
+    @Override
+    public String encoding()
+    {
+        return switch (codecType) {
+            case NO_COMPRESSION -> ENCODING;
+            case ZSTD -> ENCODING + "+zstd";
+            default -> throw new IllegalArgumentException("Unsupported codec type: " + codecType);
+        };
+    }
+
+    public static class Factory
+            implements QueryDataEncoder.Factory
+    {
+        private final BufferAllocator allocator;
+
+        @Inject
+        public Factory(BufferAllocator rootAllocator)
+        {
+            this.allocator = requireNonNull(rootAllocator, "allocator is null");
+        }
+
+        @Override
+        public List<OutputColumn> unsupported(List<OutputColumn> columns)
+        {
+            return TrinoToArrowTypeConverter.unsupported(columns);
+        }
+
+        @Override
+        public QueryDataEncoder create(Session session, List<OutputColumn> columns)
+        {
+            return new ArrowQueryDataEncoder(
+                    allocator.newChildAllocator(session.getQueryId().toString(), Integer.MAX_VALUE, Integer.MAX_VALUE),
+                    NoCompressionCodec.Factory.INSTANCE,
+                    CompressionUtil.CodecType.NO_COMPRESSION,
+                    columns);
+        }
+
+        @Override
+        public String encoding()
+        {
+            return ENCODING;
+        }
+    }
+
+    public static class ZstdFactory
+            implements QueryDataEncoder.Factory
+    {
+        private final BufferAllocator allocator;
+        private final CompressionCodec.Factory compressionFactory;
+
+        @Inject
+        public ZstdFactory(BufferAllocator rootAllocator, CompressionCodec.Factory compressionFactory)
+        {
+            this.allocator = requireNonNull(rootAllocator, "allocator is null");
+            this.compressionFactory = requireNonNull(compressionFactory, "compressionFactory is null");
+        }
+
+        @Override
+        public QueryDataEncoder create(Session session, List<OutputColumn> columns)
+        {
+            return new ArrowQueryDataEncoder(
+                    allocator.newChildAllocator(session.getQueryId().toString(), Integer.MAX_VALUE, Integer.MAX_VALUE),
+                    compressionFactory,
+                    CompressionUtil.CodecType.ZSTD,
+                    columns);
+        }
+
+        @Override
+        public List<OutputColumn> unsupported(List<OutputColumn> columns)
+        {
+            return TrinoToArrowTypeConverter.unsupported(columns);
+        }
+
+        @Override
+        public String encoding()
+        {
+            return ENCODING + "+zstd";
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/ZstdCompressionCodec.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/ZstdCompressionCodec.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding;
+
+import io.airlift.compress.v3.zstd.ZstdCompressor;
+import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.compression.AbstractCompressionCodec;
+import org.apache.arrow.vector.compression.CompressionUtil;
+
+import java.lang.foreign.MemorySegment;
+
+import static java.lang.Math.toIntExact;
+import static org.apache.arrow.vector.compression.CompressionUtil.CodecType.ZSTD;
+
+public class ZstdCompressionCodec
+        extends AbstractCompressionCodec
+{
+    @Override
+    protected ArrowBuf doCompress(BufferAllocator allocator, ArrowBuf uncompressedBuffer)
+    {
+        ZstdCompressor compressor = ZstdCompressor.create();
+        long dstSize = 8L + compressor.maxCompressedLength(toIntExact(uncompressedBuffer.writerIndex()));
+        ArrowBuf compressedBuffer = allocator.buffer(dstSize);
+
+        try {
+            long written = compressor.compress(
+                    MemorySegment.ofAddress(uncompressedBuffer.memoryAddress()).reinterpret(uncompressedBuffer.writerIndex()),
+                    MemorySegment.ofAddress(compressedBuffer.memoryAddress() + 8L).reinterpret(dstSize));
+            compressedBuffer.writerIndex(8L + written);
+            return compressedBuffer;
+        }
+        catch (Exception e) {
+            compressedBuffer.close();
+            throw new RuntimeException("Error compressing to ZSTD", e);
+        }
+    }
+
+    @Override
+    protected ArrowBuf doDecompress(BufferAllocator allocator, ArrowBuf compressedBuffer)
+    {
+        throw new UnsupportedOperationException("Decompression is not supported server-side");
+    }
+
+    @Override
+    public CompressionUtil.CodecType getCodecType()
+    {
+        return ZSTD;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/ArrayWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/ArrayWriter.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.trino.spi.block.ArrayBlock;
+import io.trino.spi.block.Block;
+import io.trino.spi.type.ArrayType;
+import org.apache.arrow.vector.complex.ListVector;
+
+import static io.trino.server.protocol.spooling.encoding.arrow.VectorWriters.writerForVector;
+import static java.util.Objects.requireNonNull;
+
+public final class ArrayWriter
+        implements ArrowWriter
+{
+    private final ListVector vector;
+    private final ArrayType type;
+
+    public ArrayWriter(ListVector vector, ArrayType type)
+    {
+        this.vector = requireNonNull(vector, "vector is null");
+        this.type = requireNonNull(type, "type is null");
+    }
+
+    @Override
+    public void write(Block block)
+    {
+        vector.setInitialCapacity(block.getPositionCount());
+        vector.allocateNew();
+
+        if (block instanceof ArrayBlock arrayBlock) {
+            Block dataBlock = arrayBlock.getElementsBlock();
+            ArrowWriter elementWriter = writerForVector(vector.getDataVector(), type.getElementType());
+            for (int position = 0; position < block.getPositionCount(); position++) {
+                if (block.isNull(position)) {
+                    vector.setNull(position);
+                    continue;
+                }
+                Block elementBlock = arrayBlock.getArray(position);
+                vector.startNewValue(position);
+                vector.endValue(position, elementBlock.getPositionCount());
+            }
+            elementWriter.write(dataBlock);
+            vector.setValueCount(block.getPositionCount());
+        }
+        else {
+            throw new UnsupportedOperationException("ArrayBlock is expected but got " + block.getClass().getSimpleName());
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/ArrowWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/ArrowWriter.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.trino.spi.block.Block;
+
+public sealed interface ArrowWriter
+        permits
+        PrimitiveWriter,
+        ArrayWriter,
+        MapWriter,
+        RowWriter
+        // No extension types yet
+{
+    void write(Block block);
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/BigintWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/BigintWriter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.trino.spi.block.Block;
+import org.apache.arrow.vector.BigIntVector;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+
+public final class BigintWriter
+        extends FixedWidthWriter<BigIntVector>
+{
+    public BigintWriter(BigIntVector vector)
+    {
+        super(vector);
+    }
+
+    @Override
+    protected void setNull(int position)
+    {
+        vector.setNull(position);
+    }
+
+    @Override
+    protected void writeValue(Block block, int position)
+    {
+        vector.set(position, BIGINT.getLong(block, position));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/BooleanWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/BooleanWriter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.trino.spi.block.Block;
+import org.apache.arrow.vector.BitVector;
+
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+
+public final class BooleanWriter
+        extends FixedWidthWriter<BitVector>
+{
+    public BooleanWriter(BitVector vector)
+    {
+        super(vector);
+    }
+
+    @Override
+    protected void setNull(int position)
+    {
+        vector.setNull(position);
+    }
+
+    @Override
+    protected void writeValue(Block block, int position)
+    {
+        vector.set(position, BOOLEAN.getBoolean(block, position) ? 1 : 0);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/CharWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/CharWriter.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.block.Block;
+import io.trino.spi.type.CharType;
+import org.apache.arrow.vector.VarCharVector;
+
+import static io.trino.spi.type.Chars.padSpaces;
+import static java.util.Objects.requireNonNull;
+
+public final class CharWriter
+        extends VariableWidthWriter<VarCharVector>
+{
+    private final CharType type;
+
+    public CharWriter(VarCharVector vector, CharType type)
+    {
+        super(vector);
+        this.type = requireNonNull(type, "type is null");
+    }
+
+    @Override
+    protected void setNull(int position)
+    {
+        vector.setNull(position);
+    }
+
+    @Override
+    protected void writeValue(Block block, int position)
+    {
+        // TODO: find a way to avoid the copy
+        Slice slice = padSpaces(type.getSlice(block, position), type.getLength());
+        vector.setSafe(position, slice.byteArray(), slice.byteArrayOffset(), slice.length());
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/DateWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/DateWriter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.trino.spi.block.Block;
+import org.apache.arrow.vector.DateDayVector;
+
+import static io.trino.spi.type.DateType.DATE;
+
+public final class DateWriter
+        extends FixedWidthWriter<DateDayVector>
+{
+    public DateWriter(DateDayVector vector)
+    {
+        super(vector);
+    }
+
+    @Override
+    protected void setNull(int position)
+    {
+        vector.setNull(position);
+    }
+
+    @Override
+    protected void writeValue(Block block, int position)
+    {
+        vector.set(position, DATE.getInt(block, position));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/DecimalWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/DecimalWriter.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.trino.spi.block.Block;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Int128;
+import org.apache.arrow.vector.DecimalVector;
+
+import static java.util.Objects.requireNonNull;
+
+public final class DecimalWriter
+        extends FixedWidthWriter<DecimalVector>
+{
+    private final DecimalType type;
+
+    public DecimalWriter(DecimalVector vector, DecimalType type)
+    {
+        super(vector);
+        this.type = requireNonNull(type, "type is null");
+    }
+
+    @Override
+    protected void setNull(int position)
+    {
+        vector.setNull(position);
+    }
+
+    @Override
+    protected void writeValue(Block block, int position)
+    {
+        if (type.isShort()) {
+            vector.set(position, type.getLong(block, position));
+        }
+        else {
+            Int128 decimal = (Int128) type.getObject(block, position);
+            vector.setBigEndianSafe(position, decimal.toBigEndianBytes());
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/DoubleWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/DoubleWriter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.trino.spi.block.Block;
+import org.apache.arrow.vector.Float8Vector;
+
+import static io.trino.spi.type.DoubleType.DOUBLE;
+
+public final class DoubleWriter
+        extends FixedWidthWriter<Float8Vector>
+{
+    public DoubleWriter(Float8Vector vector)
+    {
+        super(vector);
+    }
+
+    @Override
+    protected void setNull(int position)
+    {
+        vector.setNull(position);
+    }
+
+    @Override
+    protected void writeValue(Block block, int position)
+    {
+        vector.set(position, DOUBLE.getDouble(block, position));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/FixedWidthWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/FixedWidthWriter.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.trino.spi.block.Block;
+import org.apache.arrow.vector.FixedWidthVector;
+
+public abstract sealed class FixedWidthWriter<V extends FixedWidthVector>
+        extends PrimitiveWriter<V> permits
+        BigintWriter,
+        BooleanWriter,
+        DateWriter,
+        DecimalWriter,
+        DoubleWriter,
+        IntegerWriter,
+        IntervalDayWriter,
+        RealWriter,
+        SmallIntWriter,
+        TimeSecWriter,
+        TimeMilliWriter,
+        TimeMicroWriter,
+        TimeNanoWriter,
+        TimestampSecWriter,
+        TimestampMilliWriter,
+        TimestampMicroWriter,
+        TimestampNanoWriter,
+        TinyIntWriter,
+        UuidWriter
+{
+    protected FixedWidthWriter(V vector)
+    {
+        super(vector);
+    }
+
+    @Override
+    protected void initialize(Block block)
+    {
+        vector.allocateNew(block.getPositionCount());
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/IntegerWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/IntegerWriter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.trino.spi.block.Block;
+import org.apache.arrow.vector.IntVector;
+
+import static io.trino.spi.type.IntegerType.INTEGER;
+
+public final class IntegerWriter
+        extends FixedWidthWriter<IntVector>
+{
+    public IntegerWriter(IntVector vector)
+    {
+        super(vector);
+    }
+
+    @Override
+    protected void setNull(int position)
+    {
+        vector.setNull(position);
+    }
+
+    @Override
+    protected void writeValue(Block block, int position)
+    {
+        vector.set(position, INTEGER.getInt(block, position));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/IntervalDayWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/IntervalDayWriter.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.trino.spi.block.Block;
+import io.trino.type.IntervalDayTimeType;
+import org.apache.arrow.vector.IntervalDayVector;
+
+import static java.lang.Math.toIntExact;
+
+public final class IntervalDayWriter
+        extends FixedWidthWriter<IntervalDayVector>
+{
+    private static final int MILLIS_IN_DAY = 24 * 60 * 60 * 1000;
+
+    public IntervalDayWriter(IntervalDayVector vector)
+    {
+        super(vector);
+    }
+
+    @Override
+    protected void setNull(int position)
+    {
+        vector.setNull(position);
+    }
+
+    @Override
+    protected void writeValue(Block block, int position)
+    {
+        long intervalDayTime = IntervalDayTimeType.INTERVAL_DAY_TIME.getLong(block, position);
+        int days = toIntExact(intervalDayTime / MILLIS_IN_DAY);
+        int millis = toIntExact((intervalDayTime % MILLIS_IN_DAY) / 1000000);
+        vector.set(position, days, millis);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/MapWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/MapWriter.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.trino.spi.block.Block;
+import io.trino.spi.block.ColumnarMap;
+import io.trino.spi.type.MapType;
+import org.apache.arrow.vector.complex.MapVector;
+import org.apache.arrow.vector.complex.StructVector;
+
+import static io.trino.server.protocol.spooling.encoding.arrow.VectorWriters.writerForVector;
+import static java.util.Objects.requireNonNull;
+
+public final class MapWriter
+        implements ArrowWriter
+{
+    private final MapVector vector;
+    private final ArrowWriter keyWriter;
+    private final ArrowWriter valueWriter;
+
+    public MapWriter(MapVector vector, MapType type)
+    {
+        this.vector = requireNonNull(vector, "vector is null");
+        if (vector.getDataVector() instanceof StructVector structVector) {
+            this.keyWriter = writerForVector(structVector.getChild("key"), type.getKeyType());
+            this.valueWriter = writerForVector(structVector.getChild("value"), type.getValueType());
+        }
+        else {
+            throw new UnsupportedOperationException("Unsupported data vector: " + vector.getDataVector().getClass());
+        }
+    }
+
+    @Override
+    public void write(Block block)
+    {
+        ColumnarMap mapBlock = ColumnarMap.toColumnarMap(block);
+        Block keyBlock = mapBlock.getKeysBlock();
+        Block valueBlock = mapBlock.getValuesBlock();
+        vector.setInitialTotalCapacity(mapBlock.getPositionCount(), mapBlock.getValuesBlock().getPositionCount());
+        vector.allocateNew();
+        for (int position = 0; position < block.getPositionCount(); position++) {
+            if (block.isNull(position)) {
+                vector.setNull(position);
+                continue;
+            }
+
+            vector.startNewValue(position);
+            int entries = mapBlock.getEntryCount(position);
+            vector.endValue(position, entries);
+        }
+        keyWriter.write(keyBlock);
+        valueWriter.write(valueBlock);
+        vector.setValueCount(block.getPositionCount());
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/NullWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/NullWriter.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.trino.spi.block.Block;
+import org.apache.arrow.vector.NullVector;
+
+public final class NullWriter
+        extends PrimitiveWriter<NullVector>
+{
+    public NullWriter(NullVector vector)
+    {
+        super(vector);
+    }
+
+    @Override
+    protected void initialize(Block block)
+    {
+        vector.allocateNew();
+    }
+
+    @Override
+    protected void setNull(int position)
+    {
+        vector.setNull(position);
+    }
+
+    @Override
+    protected void writeValue(Block block, int position)
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/PageWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/PageWriter.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.server.protocol.OutputColumn;
+import io.trino.spi.Page;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowStreamWriter;
+
+import java.io.IOException;
+import java.util.List;
+
+import static io.trino.server.protocol.spooling.encoding.arrow.VectorWriters.writerForVector;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+
+public class PageWriter
+        implements AutoCloseable
+{
+    private final VectorSchemaRoot schema;
+    private final ArrowStreamWriter streamWriter;
+    private final List<OutputColumn> columns;
+
+    public PageWriter(ArrowStreamWriter streamWriter, VectorSchemaRoot schema, List<OutputColumn> columns)
+    {
+        this.streamWriter = requireNonNull(streamWriter, "streamWriter is null");
+        this.schema = requireNonNull(schema, "schema is null");
+        this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
+    }
+
+    public int writePages(List<Page> pages)
+            throws IOException
+    {
+        for (Page page : pages) {
+            schema.setRowCount(page.getPositionCount());
+            for (int i = 0; i < columns.size(); i++) {
+                schema.getVector(i).allocateNew();
+                writerForVector(schema.getVector(i), columns.get(i).type())
+                        .write(page.getBlock(columns.get(i).sourcePageChannel()));
+            }
+            streamWriter.writeBatch();
+        }
+        return toIntExact(streamWriter.bytesWritten());
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        streamWriter.close();
+        schema.close();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/PrimitiveWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/PrimitiveWriter.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.trino.spi.block.Block;
+import org.apache.arrow.vector.ValueVector;
+
+import static java.util.Objects.requireNonNull;
+
+public abstract sealed class PrimitiveWriter<V extends ValueVector>
+        implements ArrowWriter
+        permits FixedWidthWriter, NullWriter, VariableWidthWriter
+{
+    protected final V vector;
+
+    protected PrimitiveWriter(V vector)
+    {
+        this.vector = requireNonNull(vector, "vector is null");
+    }
+
+    @Override
+    public void write(Block block)
+    {
+        initialize(block);
+        vector.setValueCount(block.getPositionCount());
+
+        for (int position = 0; position < block.getPositionCount(); position++) {
+            if (block.isNull(position)) {
+                setNull(position);
+            }
+        }
+
+        for (int position = 0; position < block.getPositionCount(); position++) {
+            if (!block.isNull(position)) {
+                writeValue(block, position);
+            }
+        }
+    }
+
+    protected abstract void initialize(Block block);
+
+    protected abstract void setNull(int position);
+
+    protected abstract void writeValue(Block block, int position);
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/RealWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/RealWriter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.trino.spi.block.Block;
+import org.apache.arrow.vector.Float4Vector;
+
+import static io.trino.spi.type.RealType.REAL;
+
+public final class RealWriter
+        extends FixedWidthWriter<Float4Vector>
+{
+    public RealWriter(Float4Vector vector)
+    {
+        super(vector);
+    }
+
+    @Override
+    protected void setNull(int position)
+    {
+        vector.setNull(position);
+    }
+
+    @Override
+    protected void writeValue(Block block, int position)
+    {
+        vector.set(position, REAL.getFloat(block, position));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/RowWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/RowWriter.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.trino.spi.block.Block;
+import io.trino.spi.block.RowBlock;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.complex.StructVector;
+
+import java.util.List;
+
+import static io.trino.server.protocol.spooling.encoding.arrow.VectorWriters.writerForVector;
+import static java.util.Objects.requireNonNull;
+
+public final class RowWriter
+        implements ArrowWriter
+{
+    private final RowType type;
+    private final StructVector vector;
+
+    public RowWriter(StructVector vector, RowType rowType)
+    {
+        this.vector = requireNonNull(vector, "vector is null");
+        this.type = requireNonNull(rowType, "rowType is null");
+    }
+
+    @Override
+    public void write(Block block)
+    {
+        vector.setInitialCapacity(block.getPositionCount());
+        vector.allocateNew();
+        List<Block> fields = RowBlock.getRowFieldsFromBlock(block);
+        List<FieldVector> children = vector.getChildrenFromFields();
+        for (int i = 0; i < children.size(); i++) {
+            Type childType = type.getFields().get(i).getType();
+            Block childBlock = fields.get(i);
+            ArrowWriter columnWriter = writerForVector(children.get(i), childType);
+            columnWriter.write(childBlock);
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/SmallIntWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/SmallIntWriter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.trino.spi.block.Block;
+import org.apache.arrow.vector.SmallIntVector;
+
+import static io.trino.spi.type.SmallintType.SMALLINT;
+
+public final class SmallIntWriter
+        extends FixedWidthWriter<SmallIntVector>
+{
+    public SmallIntWriter(SmallIntVector vector)
+    {
+        super(vector);
+    }
+
+    @Override
+    protected void setNull(int position)
+    {
+        vector.setNull(position);
+    }
+
+    @Override
+    protected void writeValue(Block block, int position)
+    {
+        vector.set(position, SMALLINT.getShort(block, position));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/TimeMicroWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/TimeMicroWriter.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.trino.spi.block.Block;
+import org.apache.arrow.vector.TimeMicroVector;
+
+import static io.trino.spi.type.TimeType.TIME_MICROS;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
+
+public final class TimeMicroWriter
+        extends FixedWidthWriter<TimeMicroVector>
+{
+    public TimeMicroWriter(TimeMicroVector vector)
+    {
+        super(vector);
+    }
+
+    @Override
+    protected void setNull(int position)
+    {
+        vector.setNull(position);
+    }
+
+    @Override
+    protected void writeValue(Block block, int position)
+    {
+        vector.set(position, TIME_MICROS.getLong(block, position) / PICOSECONDS_PER_MICROSECOND);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/TimeMilliWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/TimeMilliWriter.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.trino.spi.block.Block;
+import org.apache.arrow.vector.TimeMilliVector;
+
+import static io.trino.spi.type.TimeType.TIME_MILLIS;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MILLISECOND;
+
+public final class TimeMilliWriter
+        extends FixedWidthWriter<TimeMilliVector>
+{
+    public TimeMilliWriter(TimeMilliVector vector)
+    {
+        super(vector);
+    }
+
+    @Override
+    protected void setNull(int position)
+    {
+        vector.setNull(position);
+    }
+
+    @Override
+    protected void writeValue(Block block, int position)
+    {
+        vector.set(position, (int) (TIME_MILLIS.getLong(block, position) / PICOSECONDS_PER_MILLISECOND));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/TimeNanoWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/TimeNanoWriter.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.trino.spi.block.Block;
+import org.apache.arrow.vector.TimeNanoVector;
+
+import static io.trino.spi.type.TimeType.TIME_NANOS;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
+
+public final class TimeNanoWriter
+        extends FixedWidthWriter<TimeNanoVector>
+{
+    public TimeNanoWriter(TimeNanoVector vector)
+    {
+        super(vector);
+    }
+
+    @Override
+    protected void setNull(int position)
+    {
+        vector.setNull(position);
+    }
+
+    @Override
+    protected void writeValue(Block block, int position)
+    {
+        vector.set(position, TIME_NANOS.getLong(block, position) / PICOSECONDS_PER_NANOSECOND);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/TimeSecWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/TimeSecWriter.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.trino.spi.block.Block;
+import org.apache.arrow.vector.TimeSecVector;
+
+import static io.trino.spi.type.TimeType.TIME_SECONDS;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_SECOND;
+
+public final class TimeSecWriter
+        extends FixedWidthWriter<TimeSecVector>
+{
+    public TimeSecWriter(TimeSecVector vector)
+    {
+        super(vector);
+    }
+
+    @Override
+    protected void setNull(int position)
+    {
+        vector.setNull(position);
+    }
+
+    @Override
+    protected void writeValue(Block block, int position)
+    {
+        vector.set(position, (int) (TIME_SECONDS.getLong(block, position) / PICOSECONDS_PER_SECOND));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/TimestampMicroWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/TimestampMicroWriter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.trino.spi.block.Block;
+import org.apache.arrow.vector.TimeStampMicroVector;
+
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+
+public final class TimestampMicroWriter
+        extends FixedWidthWriter<TimeStampMicroVector>
+{
+    public TimestampMicroWriter(TimeStampMicroVector vector)
+    {
+        super(vector);
+    }
+
+    @Override
+    protected void setNull(int position)
+    {
+        vector.setNull(position);
+    }
+
+    @Override
+    protected void writeValue(Block block, int position)
+    {
+        vector.set(position, TIMESTAMP_MICROS.getLong(block, position));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/TimestampMilliWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/TimestampMilliWriter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.trino.spi.block.Block;
+import org.apache.arrow.vector.TimeStampMilliVector;
+
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+
+public final class TimestampMilliWriter
+        extends FixedWidthWriter<TimeStampMilliVector>
+{
+    public TimestampMilliWriter(TimeStampMilliVector vector)
+    {
+        super(vector);
+    }
+
+    @Override
+    protected void setNull(int position)
+    {
+        vector.setNull(position);
+    }
+
+    @Override
+    protected void writeValue(Block block, int position)
+    {
+        vector.set(position, TIMESTAMP_MILLIS.getLong(block, position) / 1_000);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/TimestampNanoWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/TimestampNanoWriter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.trino.spi.block.Block;
+import org.apache.arrow.vector.TimeStampNanoVector;
+
+import static io.trino.spi.type.TimestampType.TIMESTAMP_NANOS;
+
+public final class TimestampNanoWriter
+        extends FixedWidthWriter<TimeStampNanoVector>
+{
+    public TimestampNanoWriter(TimeStampNanoVector vector)
+    {
+        super(vector);
+    }
+
+    @Override
+    protected void setNull(int position)
+    {
+        vector.setNull(position);
+    }
+
+    @Override
+    protected void writeValue(Block block, int position)
+    {
+        vector.set(position, TIMESTAMP_NANOS.getLong(block, position));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/TimestampSecWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/TimestampSecWriter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.trino.spi.block.Block;
+import org.apache.arrow.vector.TimeStampSecVector;
+
+import static io.trino.spi.type.TimestampType.TIMESTAMP_SECONDS;
+
+public final class TimestampSecWriter
+        extends FixedWidthWriter<TimeStampSecVector>
+{
+    public TimestampSecWriter(TimeStampSecVector vector)
+    {
+        super(vector);
+    }
+
+    @Override
+    protected void setNull(int position)
+    {
+        vector.setNull(position);
+    }
+
+    @Override
+    protected void writeValue(Block block, int position)
+    {
+        vector.set(position, TIMESTAMP_SECONDS.getLong(block, position) / 1_000_000);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/TinyIntWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/TinyIntWriter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.trino.spi.block.Block;
+import org.apache.arrow.vector.TinyIntVector;
+
+import static io.trino.spi.type.TinyintType.TINYINT;
+
+public final class TinyIntWriter
+        extends FixedWidthWriter<TinyIntVector>
+{
+    public TinyIntWriter(TinyIntVector vector)
+    {
+        super(vector);
+    }
+
+    @Override
+    protected void setNull(int position)
+    {
+        vector.setNull(position);
+    }
+
+    @Override
+    protected void writeValue(Block block, int position)
+    {
+        vector.set(position, TINYINT.getByte(block, position));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/TrinoToArrowTypeConverter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/TrinoToArrowTypeConverter.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.server.protocol.OutputColumn;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.BigintType;
+import io.trino.spi.type.BooleanType;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.DateType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.DoubleType;
+import io.trino.spi.type.HyperLogLogType;
+import io.trino.spi.type.IntegerType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RealType;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.SmallintType;
+import io.trino.spi.type.TimeType;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.TinyintType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.UuidType;
+import io.trino.spi.type.VarbinaryType;
+import io.trino.spi.type.VarcharType;
+import io.trino.type.IntervalDayTimeType;
+import io.trino.type.UnknownType;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static org.apache.arrow.vector.types.DateUnit.DAY;
+import static org.apache.arrow.vector.types.FloatingPointPrecision.DOUBLE;
+import static org.apache.arrow.vector.types.FloatingPointPrecision.SINGLE;
+import static org.apache.arrow.vector.types.IntervalUnit.DAY_TIME;
+import static org.apache.arrow.vector.types.TimeUnit.MICROSECOND;
+import static org.apache.arrow.vector.types.TimeUnit.MILLISECOND;
+import static org.apache.arrow.vector.types.TimeUnit.NANOSECOND;
+import static org.apache.arrow.vector.types.TimeUnit.SECOND;
+import static org.apache.arrow.vector.types.pojo.FieldType.notNullable;
+import static org.apache.arrow.vector.types.pojo.FieldType.nullable;
+
+public final class TrinoToArrowTypeConverter
+{
+    private TrinoToArrowTypeConverter() {}
+
+    public static Field toArrowField(String name, Type type, boolean nullable)
+    {
+        return switch (type) {
+            case ArrayType t -> new Field(name, new FieldType(true, new ArrowType.List(), null), List.of(
+                    new Field("element", new FieldType(true, toArrowField(t.getElementType()), null), null)));
+            case MapType mapType -> {
+                Field entries = new Field("entries",
+                        notNullable(ArrowType.Struct.INSTANCE),
+                        List.of(toArrowField("key", mapType.getKeyType(), false), toArrowField("value", mapType.getValueType(), nullable)));
+                yield new Field(name, nullable(new ArrowType.Map(false)), List.of(entries));
+            }
+            case RowType rowType -> {
+                List<Field> children = rowType.getFields().stream()
+                        .map(field -> toArrowField(field.getName().orElse(""), field.getType(), nullable))
+                        .collect(toImmutableList());
+                yield new Field(name, nullable(ArrowType.Struct.INSTANCE), children);
+            }
+            default -> new Field(name, nullableField(toArrowField(type), nullable), null);
+        };
+    }
+
+    private static ArrowType toArrowField(Type type)
+    {
+        return switch (type) {
+            case BooleanType _ -> new ArrowType.Bool();
+            case TinyintType _ -> new ArrowType.Int(8, true);
+            case SmallintType _ -> new ArrowType.Int(16, true);
+            case IntegerType _ -> new ArrowType.Int(32, true);
+            case BigintType _ -> new ArrowType.Int(64, true);
+            case RealType _ -> new ArrowType.FloatingPoint(SINGLE);
+            case DoubleType _ -> new ArrowType.FloatingPoint(DOUBLE);
+            case VarcharType _, CharType _ -> new ArrowType.Utf8();
+            case VarbinaryType _ -> new ArrowType.Binary();
+            case DateType _ -> new ArrowType.Date(DAY);
+            case TimeType time -> switch (time.getPrecision()) {
+                case 0 -> new ArrowType.Time(SECOND, 32);
+                case 3 -> new ArrowType.Time(MILLISECOND, 32);
+                case 6 -> new ArrowType.Time(MICROSECOND, 64);
+                case 9 -> new ArrowType.Time(NANOSECOND, 64);
+                default -> throw new UnsupportedOperationException("Unsupported timestamp precision: " + time.getPrecision());
+            };
+            case TimestampType timestamp -> switch (timestamp.getPrecision()) {
+                case 0 -> new ArrowType.Timestamp(SECOND, null);
+                case 3 -> new ArrowType.Timestamp(MILLISECOND, null);
+                case 6 -> new ArrowType.Timestamp(MICROSECOND, null);
+                case 9 -> new ArrowType.Timestamp(NANOSECOND, null);
+                default -> throw new UnsupportedOperationException("Unsupported timestamp precision: " + timestamp.getPrecision());
+            };
+            case DecimalType decimal -> new ArrowType.Decimal(decimal.getPrecision(), decimal.getScale(), 128);
+            case UuidType _ -> new ArrowType.FixedSizeBinary(16);
+            case HyperLogLogType _ -> new ArrowType.Binary();
+            case ArrayType _ -> new ArrowType.List();
+            case MapType _ -> new ArrowType.Map(false);
+            case RowType _ -> new ArrowType.Struct();
+            case IntervalDayTimeType _ -> new ArrowType.Interval(DAY_TIME);
+            case UnknownType _ -> new ArrowType.Null();
+            default -> throw new UnsupportedOperationException("Unsupported type: " + type);
+        };
+    }
+
+    private static FieldType nullableField(ArrowType type, boolean nullable)
+    {
+        if (nullable) {
+            return nullable(type);
+        }
+        return notNullable(type);
+    }
+
+    public static List<OutputColumn> unsupported(List<OutputColumn> columns)
+    {
+        ImmutableList.Builder<OutputColumn> builder = ImmutableList.builder();
+        for (OutputColumn column : columns) {
+            try {
+                toArrowField(column.columnName(), column.type(), false);
+            }
+            catch (UnsupportedOperationException e) {
+                builder.add(column);
+            }
+        }
+        return builder.build();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/UuidWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/UuidWriter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.trino.spi.block.Block;
+import org.apache.arrow.vector.FixedSizeBinaryVector;
+
+import static io.trino.spi.type.UuidType.UUID;
+
+public final class UuidWriter
+        extends FixedWidthWriter<FixedSizeBinaryVector>
+{
+    public UuidWriter(FixedSizeBinaryVector vector)
+    {
+        super(vector);
+    }
+
+    @Override
+    protected void setNull(int position)
+    {
+        vector.setNull(position);
+    }
+
+    @Override
+    protected void writeValue(Block block, int position)
+    {
+        vector.set(position, UUID.getSlice(block, position).getBytes());
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/VarbinaryWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/VarbinaryWriter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.trino.spi.block.Block;
+import org.apache.arrow.vector.VarBinaryVector;
+
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+
+public final class VarbinaryWriter
+        extends VariableWidthWriter<VarBinaryVector>
+{
+    public VarbinaryWriter(VarBinaryVector vector)
+    {
+        super(vector);
+    }
+
+    @Override
+    protected void setNull(int position)
+    {
+        vector.setNull(position);
+    }
+
+    @Override
+    protected void writeValue(Block block, int position)
+    {
+        vector.setSafe(position, VARBINARY.getSlice(block, position).getBytes());
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/VarcharWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/VarcharWriter.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.block.Block;
+import org.apache.arrow.vector.VarCharVector;
+
+import static io.trino.spi.type.VarcharType.VARCHAR;
+
+public final class VarcharWriter
+        extends VariableWidthWriter<VarCharVector>
+{
+    public VarcharWriter(VarCharVector vector)
+    {
+        super(vector);
+    }
+
+    @Override
+    protected void setNull(int position)
+    {
+        vector.setNull(position);
+    }
+
+    @Override
+    protected void writeValue(Block block, int position)
+    {
+        Slice slice = VARCHAR.getSlice(block, position);
+        vector.setSafe(position, slice.byteArray(), slice.byteArrayOffset(), slice.length());
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/VariableWidthWriter.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/VariableWidthWriter.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.trino.spi.block.Block;
+import org.apache.arrow.vector.VariableWidthVector;
+
+public abstract sealed class VariableWidthWriter<V extends VariableWidthVector>
+        extends PrimitiveWriter<V> permits
+        CharWriter,
+        VarbinaryWriter,
+        VarcharWriter
+{
+    protected VariableWidthWriter(V vector)
+    {
+        super(vector);
+    }
+
+    @Override
+    protected void initialize(Block block)
+    {
+        vector.allocateNew(block.getSizeInBytes(), block.getPositionCount());
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/VectorWriters.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/arrow/VectorWriters.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling.encoding.arrow;
+
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.DateDayVector;
+import org.apache.arrow.vector.DecimalVector;
+import org.apache.arrow.vector.FixedSizeBinaryVector;
+import org.apache.arrow.vector.Float4Vector;
+import org.apache.arrow.vector.Float8Vector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.IntervalDayVector;
+import org.apache.arrow.vector.NullVector;
+import org.apache.arrow.vector.SmallIntVector;
+import org.apache.arrow.vector.TimeMicroVector;
+import org.apache.arrow.vector.TimeMilliVector;
+import org.apache.arrow.vector.TimeNanoVector;
+import org.apache.arrow.vector.TimeSecVector;
+import org.apache.arrow.vector.TimeStampMicroVector;
+import org.apache.arrow.vector.TimeStampMilliVector;
+import org.apache.arrow.vector.TimeStampNanoVector;
+import org.apache.arrow.vector.TimeStampSecVector;
+import org.apache.arrow.vector.TinyIntVector;
+import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.VarBinaryVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.MapVector;
+import org.apache.arrow.vector.complex.StructVector;
+
+public final class VectorWriters
+{
+    private VectorWriters() {}
+
+    public static ArrowWriter writerForVector(ValueVector valueVector, Type type)
+    {
+        return switch (valueVector) {
+            case BitVector vector -> new BooleanWriter(vector);
+            case TinyIntVector vector -> new TinyIntWriter(vector);
+            case SmallIntVector vector -> new SmallIntWriter(vector);
+            case IntVector vector -> new IntegerWriter(vector);
+            case BigIntVector vector -> new BigintWriter(vector);
+            case Float4Vector vector -> new RealWriter(vector);
+            case Float8Vector vector -> new DoubleWriter(vector);
+            case VarCharVector vector -> type instanceof CharType charType ? new CharWriter(vector, charType) : new VarcharWriter(vector);
+            case VarBinaryVector vector -> new VarbinaryWriter(vector);
+            case DateDayVector vector -> new DateWriter(vector);
+            case DecimalVector vector -> new DecimalWriter(vector, (DecimalType) type);
+            case IntervalDayVector vector -> new IntervalDayWriter(vector);
+            case FixedSizeBinaryVector vector -> new UuidWriter(vector);
+            case TimeSecVector vector -> new TimeSecWriter(vector);
+            case TimeMilliVector vector -> new TimeMilliWriter(vector);
+            case TimeMicroVector vector -> new TimeMicroWriter(vector);
+            case TimeNanoVector vector -> new TimeNanoWriter(vector);
+            case TimeStampSecVector vector -> new TimestampSecWriter(vector);
+            case TimeStampMilliVector vector -> new TimestampMilliWriter(vector);
+            case TimeStampMicroVector vector -> new TimestampMicroWriter(vector);
+            case TimeStampNanoVector vector -> new TimestampNanoWriter(vector);
+            case MapVector vector -> new MapWriter(vector, (MapType) type);
+            case ListVector vector -> new ArrayWriter(vector, (ArrayType) type);
+            case StructVector vector -> new RowWriter(vector, (RowType) type);
+            case NullVector vector -> new NullWriter(vector);
+            default -> throw new UnsupportedOperationException("Unsupported vector type: " + valueVector.getClass().getName());
+        };
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/server/protocol/spooling/TestQueryDataEncodingConfig.java
+++ b/core/trino-main/src/test/java/io/trino/server/protocol/spooling/TestQueryDataEncodingConfig.java
@@ -34,6 +34,8 @@ class TestQueryDataEncodingConfig
                 .setJsonEnabled(true)
                 .setJsonLz4Enabled(true)
                 .setJsonZstdEnabled(true)
+                .setArrowIpcEnabled(false)
+                .setArrowIpcZstdEnabled(false)
                 .setCompressionThreshold(DataSize.of(8, KILOBYTE)));
     }
 
@@ -44,6 +46,8 @@ class TestQueryDataEncodingConfig
                 .put("protocol.spooling.encoding.json.enabled", "false")
                 .put("protocol.spooling.encoding.json+lz4.enabled", "false")
                 .put("protocol.spooling.encoding.json+zstd.enabled", "false")
+                .put("protocol.spooling.encoding.arrow.enabled", "true")
+                .put("protocol.spooling.encoding.arrow+zstd.enabled", "true")
                 .put("protocol.spooling.encoding.compression.threshold", "1MB")
                 .buildOrThrow();
 
@@ -51,6 +55,8 @@ class TestQueryDataEncodingConfig
                 .setJsonEnabled(false)
                 .setJsonLz4Enabled(false)
                 .setJsonZstdEnabled(false)
+                .setArrowIpcEnabled(true)
+                .setArrowIpcZstdEnabled(true)
                 .setCompressionThreshold(DataSize.of(1, MEGABYTE));
 
         assertFullMapping(properties, expected);

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,6 @@
     <url>https://trino.io</url>
 
     <inceptionYear>2012</inceptionYear>
-
     <licenses>
         <license>
             <name>Apache License 2.0</name>
@@ -178,6 +177,8 @@
             ${extraJavaVectorArgs}
             <!-- # https://bugs.openjdk.org/browse/JDK-8327134 -->
             -Djava.security.manager=allow
+            <!-- for arrow-memory -->
+            --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED
         </air.test.jvm.additional-arguments.default>
         <air.test.jvm.additional-arguments>${air.test.jvm.additional-arguments.default}</air.test.jvm.additional-arguments>
 
@@ -2634,6 +2635,41 @@
                                 </conflictingDependencies>
                                 <resources>
                                     <resource>mime.types</resource>
+                                </resources>
+                            </exception>
+                            <exception>
+                                <conflictingDependencies>
+                                    <dependency>
+                                        <groupId>org.apache.arrow</groupId>
+                                        <artifactId>arrow-compression</artifactId>
+                                    </dependency>
+                                    <dependency>
+                                        <groupId>org.apache.arrow</groupId>
+                                        <artifactId>arrow-format</artifactId>
+                                    </dependency>
+                                    <dependency>
+                                        <groupId>org.apache.arrow</groupId>
+                                        <artifactId>arrow-memory-core</artifactId>
+                                    </dependency>
+                                    <dependency>
+                                        <groupId>org.apache.arrow</groupId>
+                                        <artifactId>arrow-memory-netty</artifactId>
+                                    </dependency>
+                                    <dependency>
+                                        <groupId>org.apache.arrow</groupId>
+                                        <artifactId>arrow-memory-netty-buffer-patch</artifactId>
+                                    </dependency>
+                                    <dependency>
+                                        <groupId>org.apache.arrow</groupId>
+                                        <artifactId>arrow-memory-unsafe</artifactId>
+                                    </dependency>
+                                    <dependency>
+                                        <groupId>org.apache.arrow</groupId>
+                                        <artifactId>arrow-vector</artifactId>
+                                    </dependency>
+                                </conflictingDependencies>
+                                <resources>
+                                    <resource>arrow-git.properties</resource>
                                 </resources>
                             </exception>
                             <exception>

--- a/testing/trino-testing/src/main/java/io/trino/testing/LocalSpoolingManager.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/LocalSpoolingManager.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.DoNotCall;
 import io.airlift.json.JsonCodec;
+import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
 import io.trino.spi.Plugin;
 import io.trino.spi.spool.SpooledLocation;
@@ -54,6 +55,8 @@ import static java.util.Objects.requireNonNull;
 public class LocalSpoolingManager
         implements SpoolingManager
 {
+    private static final Logger log = Logger.get(LocalSpoolingManager.class);
+
     private static final JsonCodec<LocalSpooledSegmentHandle> HANDLE_CODEC = jsonCodec(LocalSpooledSegmentHandle.class);
     private final Path rootPath;
     private final AtomicLong segmentId = new AtomicLong();
@@ -62,6 +65,7 @@ public class LocalSpoolingManager
     {
         try {
             this.rootPath = Files.createTempDirectory("spooling");
+            log.info("Spooling files in " + rootPath);
         }
         catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/testing/trino-tests/pom.xml
+++ b/testing/trino-tests/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>trino-tests</artifactId>
     <description>Trino - Tests</description>
 
+    <properties>
+        <air.test.jvm.additional-arguments>${air.test.jvm.additional-arguments.default} --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED</air.test.jvm.additional-arguments>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.jetbrains</groupId>

--- a/testing/trino-tests/src/test/java/io/trino/server/protocol/TestArrowSpooledDistributedQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/server/protocol/TestArrowSpooledDistributedQueries.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+public class TestArrowSpooledDistributedQueries
+        extends AbstractSpooledQueryDataDistributedQueries
+{
+    @Override
+    protected Map<String, String> spoolingConfig()
+    {
+        return ImmutableMap.of("protocol.spooling.encoding.arrow+zstd.enabled", "true");
+    }
+
+    @Test
+    @Override
+    public void testTimestampWithTimeZoneLiterals()
+    {
+        assertThatThrownBy(super::testTimestampWithTimeZoneLiterals)
+                .hasMessageContaining("Output columns [OutputColumn[sourcePageChannel=0, columnName=_col0, type=timestamp(0) with time zone]] are not supported for spooling encoding '%s'".formatted(encoding()));
+    }
+
+    @Test
+    @Override
+    public void testSelectLargeInterval()
+    {
+        assertThatThrownBy(super::testSelectLargeInterval)
+                .hasMessageContaining("Output columns [OutputColumn[sourcePageChannel=0, columnName=_col0, type=interval year to month]] are not supported for spooling encoding '%s'".formatted(encoding()));
+    }
+
+    @Test
+    @Override
+    public void testTimeLiterals()
+    {
+        assertThatThrownBy(super::testTimeLiterals)
+                .hasMessageContaining("class java.lang.Integer cannot be cast to class java.lang.String");
+    }
+
+    @Test
+    @Override
+    public void testTimestampLiterals()
+    {
+        assertThatThrownBy(super::testTimestampLiterals)
+                .hasMessageContaining("expected: 1960-01-22T03:04:05.123 (java.time.LocalDateTime)");
+    }
+
+    @Test
+    @Override
+    public void testIn()
+    {
+        assertThatThrownBy(super::testIn)
+                .hasMessageContaining("Output columns [OutputColumn[sourcePageChannel=0, columnName=x, type=timestamp(0) with time zone]] are not supported for spooling encoding '%s'".formatted(encoding()));
+    }
+
+    @Test
+    @Override
+    public void testTimeWithTimeZoneLiterals()
+    {
+        assertThatThrownBy(super::testTimeWithTimeZoneLiterals)
+                .hasMessageContaining("Output columns [OutputColumn[sourcePageChannel=0, columnName=_col0, type=time(3) with time zone]] are not supported for spooling encoding '%s'".formatted(encoding()));
+    }
+
+    @Test
+    @Override
+    public void testAtTimeZone()
+    {
+        assertThatThrownBy(super::testAtTimeZone)
+                .hasMessageContaining("Output columns [OutputColumn[sourcePageChannel=0, columnName=_col0, type=timestamp(0) with time zone]] are not supported for spooling encoding '%s'".formatted(encoding()));
+    }
+
+    @Test
+    @Override
+    public void testTransactionsTable()
+    {
+        assertThatThrownBy(super::testTransactionsTable)
+                .hasMessageContaining("Output columns [OutputColumn[sourcePageChannel=4, columnName=create_time, type=timestamp(3) with time zone]] are not supported for spooling encoding '%s'".formatted(encoding()));
+    }
+
+    @Test
+    @Override
+    public void testValuesWithTimestamp()
+    {
+        assertThatThrownBy(super::testValuesWithTimestamp)
+                .hasMessageContaining("Output columns [OutputColumn[sourcePageChannel=0, columnName=_col0, type=timestamp(3) with time zone], OutputColumn[sourcePageChannel=1, columnName=_col1, type=timestamp(3) with time zone]] are not supported for spooling encoding '%s'".formatted(encoding()));
+    }
+
+    @Override
+    protected String encoding()
+    {
+        return "arrow+zstd";
+    }
+}

--- a/testing/trino-tests/src/test/java/io/trino/tests/tpch/TpchQueryRunner.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/tpch/TpchQueryRunner.java
@@ -80,8 +80,11 @@ public final class TpchQueryRunner
                 .setExtraProperties(ImmutableMap.<String, String>builder()
                         .put("sql.default-catalog", "tpch")
                         .put("sql.default-schema", "tiny")
+                        .put("protocol.spooling.encoding.arrow+zstd.enabled", "true")
+                        .put("protocol.spooling.encoding.arrow.enabled", "true")
                         .buildOrThrow())
-                .withProtocolSpooling("json+zstd")
+                .withProtocolSpooling("arrow+zstd")
+                .withTracing()
                 .build();
         Logger log = Logger.get(TpchQueryRunner.class);
         log.info("======== SERVER STARTED ========");


### PR DESCRIPTION
Just a working prototype without all of the types covered

TODO:

- [ ] add support for interval type (encode/decode)
- [ ] add support for date time type (encode/decode)
- [ ] add support for timestamp type (encode/decode)
- [ ] add support for timestamp with tz type (encode/decode)
- [ ] add support for time type (encode/decode)
- [ ] add support for time with tz type (encode/decode)
- [ ] coalesce small pages to bigger arrow batches (configurable?)
- [ ] optimize decoding in the client
- [ ] test every type with NULL, map key, map value, list 