### PR TITLE
Remove bidirectional coupling from/to Block to/from BlockEncoding

### DIFF
--- a/core/trino-main/src/main/java/io/trino/block/BlockJsonSerde.java
+++ b/core/trino-main/src/main/java/io/trino/block/BlockJsonSerde.java
@@ -54,8 +54,7 @@ public final class BlockJsonSerde
         public void serialize(Block block, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
                 throws IOException
         {
-            //  Encoding name is length prefixed as are many block encodings
-            SliceOutput output = new DynamicSliceOutput(toIntExact(block.getSizeInBytes() + block.getEncodingName().length() + (2 * Integer.BYTES)));
+            SliceOutput output = new DynamicSliceOutput(toIntExact(blockEncodingSerde.estimatedWriteSize(block)));
             writeBlock(blockEncodingSerde, output, block);
             Slice slice = output.slice();
             jsonGenerator.writeBinary(Base64Variants.MIME_NO_LINEFEEDS, slice.byteArray(), slice.byteArrayOffset(), slice.length());

--- a/core/trino-main/src/main/java/io/trino/metadata/InternalBlockEncodingSerde.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/InternalBlockEncodingSerde.java
@@ -27,25 +27,28 @@ import org.assertj.core.util.VisibleForTesting;
 import java.util.Optional;
 import java.util.function.Function;
 
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
 public final class InternalBlockEncodingSerde
         implements BlockEncodingSerde
 {
-    private final Function<String, BlockEncoding> blockEncodings;
+    private final Function<String, BlockEncoding> nameToEncoding; // for deserialization
+    private final Function<Class<? extends Block>, BlockEncoding> blockToEncoding; // for serialization
     private final Function<TypeId, Type> types;
 
     @Inject
     public InternalBlockEncodingSerde(BlockEncodingManager blockEncodingManager, TypeManager typeManager)
     {
-        this(blockEncodingManager::getBlockEncoding, typeManager::getType);
+        this(blockEncodingManager::getBlockEncodingByName, blockEncodingManager::getBlockEncodingByBlockClass, typeManager::getType);
     }
 
     @VisibleForTesting
-    InternalBlockEncodingSerde(Function<String, BlockEncoding> blockEncodings, Function<TypeId, Type> types)
+    InternalBlockEncodingSerde(Function<String, BlockEncoding> nameToEncoding, Function<Class<? extends Block>, BlockEncoding> blockToEncoding, Function<TypeId, Type> types)
     {
-        this.blockEncodings = requireNonNull(blockEncodings, "blockEncodings is null");
+        this.nameToEncoding = requireNonNull(nameToEncoding, "nameToEncoding is null");
+        this.blockToEncoding = requireNonNull(blockToEncoding, "blockToEncoding is null");
         this.types = requireNonNull(types, "types is null");
     }
 
@@ -56,7 +59,7 @@ public final class InternalBlockEncodingSerde
         String encodingName = readLengthPrefixedString(input);
 
         // look up the encoding factory
-        BlockEncoding blockEncoding = blockEncodings.apply(encodingName);
+        BlockEncoding blockEncoding = nameToEncoding.apply(encodingName);
 
         // load read the encoding factory from the output stream
         return blockEncoding.readBlock(this, input);
@@ -66,11 +69,8 @@ public final class InternalBlockEncodingSerde
     public void writeBlock(SliceOutput output, Block block)
     {
         while (true) {
-            // get the encoding name
-            String encodingName = block.getEncodingName();
-
             // look up the BlockEncoding
-            BlockEncoding blockEncoding = blockEncodings.apply(encodingName);
+            BlockEncoding blockEncoding = blockToEncoding.apply(block.getClass());
 
             // see if a replacement block should be written instead
             Optional<Block> replacementBlock = blockEncoding.replacementBlockForWrite(block);
@@ -80,12 +80,30 @@ public final class InternalBlockEncodingSerde
             }
 
             // write the name to the output
-            writeLengthPrefixedString(output, encodingName);
+            writeLengthPrefixedString(output, blockEncoding.getName());
 
             // write the block to the output
             blockEncoding.writeBlock(this, output, block);
 
             break;
+        }
+    }
+
+    @Override
+    public long estimatedWriteSize(Block block)
+    {
+        while (true) {
+            BlockEncoding blockEncoding = blockToEncoding.apply(block.getClass());
+            // see if a replacement block should be written instead
+            Optional<Block> replacementBlock = blockEncoding.replacementBlockForWrite(block);
+            if (replacementBlock.isPresent()) {
+                block = replacementBlock.get();
+                continue;
+            }
+
+            // length of encoding name + encoding name + block size
+            // TODO: improve this estimate by adding estimatedWriteSize to BlockEncoding interface
+            return SIZE_OF_INT + blockEncoding.getName().length() + block.getSizeInBytes();
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutineHash.java
+++ b/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutineHash.java
@@ -234,7 +234,7 @@ public final class SqlRoutineHash
                 case Slice sliceValue -> hasher.putBytes(sliceValue.getBytes());
                 default -> {
                     Block block = literal.getBlockValue();
-                    SliceOutput output = new DynamicSliceOutput(toIntExact(block.getSizeInBytes() + block.getEncodingName().length() + (2 * Integer.BYTES)));
+                    SliceOutput output = new DynamicSliceOutput(toIntExact(blockEncodingSerde.estimatedWriteSize(block)));
                     blockEncodingSerde.writeBlock(output, block);
                     hasher.putBytes(output.slice().getBytes());
                 }

--- a/core/trino-main/src/test/java/io/trino/block/TestRunLengthEncodedBlock.java
+++ b/core/trino-main/src/test/java/io/trino/block/TestRunLengthEncodedBlock.java
@@ -19,7 +19,6 @@ import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.ByteArrayBlockBuilder;
 import io.trino.spi.block.IntArrayBlockBuilder;
 import io.trino.spi.block.LongArrayBlockBuilder;
-import io.trino.spi.block.RunLengthBlockEncoding;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.block.ShortArrayBlockBuilder;
 import io.trino.spi.block.VariableWidthBlock;
@@ -87,7 +86,6 @@ public class TestRunLengthEncodedBlock
     {
         LongArrayBlockBuilder blockBuilder = new LongArrayBlockBuilder(null, 100);
         populateNullValues(blockBuilder, 100);
-        assertThat(blockBuilder.build().getEncodingName()).isEqualTo(RunLengthBlockEncoding.NAME);
     }
 
     @Test
@@ -95,7 +93,6 @@ public class TestRunLengthEncodedBlock
     {
         IntArrayBlockBuilder blockBuilder = new IntArrayBlockBuilder(null, 100);
         populateNullValues(blockBuilder, 100);
-        assertThat(blockBuilder.build().getEncodingName()).isEqualTo(RunLengthBlockEncoding.NAME);
     }
 
     @Test
@@ -103,7 +100,6 @@ public class TestRunLengthEncodedBlock
     {
         ShortArrayBlockBuilder blockBuilder = new ShortArrayBlockBuilder(null, 100);
         populateNullValues(blockBuilder, 100);
-        assertThat(blockBuilder.build().getEncodingName()).isEqualTo(RunLengthBlockEncoding.NAME);
     }
 
     @Test
@@ -111,7 +107,6 @@ public class TestRunLengthEncodedBlock
     {
         ByteArrayBlockBuilder blockBuilder = new ByteArrayBlockBuilder(null, 100);
         populateNullValues(blockBuilder, 100);
-        assertThat(blockBuilder.build().getEncodingName()).isEqualTo(RunLengthBlockEncoding.NAME);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/metadata/TestInternalBlockEncodingSerde.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestInternalBlockEncodingSerde.java
@@ -20,6 +20,7 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.BlockEncoding;
 import io.trino.spi.block.BlockEncodingSerde;
+import io.trino.spi.block.VariableWidthBlock;
 import io.trino.spi.block.VariableWidthBlockEncoding;
 import io.trino.spi.type.TestingTypeManager;
 import io.trino.spi.type.Type;
@@ -35,7 +36,8 @@ public class TestInternalBlockEncodingSerde
 {
     private final TestingTypeManager testingTypeManager = new TestingTypeManager();
     private final Map<String, BlockEncoding> blockEncodings = ImmutableMap.of(VariableWidthBlockEncoding.NAME, new VariableWidthBlockEncoding());
-    private final BlockEncodingSerde blockEncodingSerde = new InternalBlockEncodingSerde(blockEncodings::get, testingTypeManager::getType);
+    private final Map<Class<? extends Block>, BlockEncoding> blockNames = ImmutableMap.of(VariableWidthBlock.class, new VariableWidthBlockEncoding());
+    private final BlockEncodingSerde blockEncodingSerde = new InternalBlockEncodingSerde(blockEncodings::get, blockNames::get, testingTypeManager::getType);
 
     @Test
     public void blockRoundTrip()

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -218,6 +218,96 @@
                                 </item>
                                 <!-- Backwards incompatible changes since the previous release -->
                                 <!-- Any exclusions below can be deleted after each release -->
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method java.lang.String io.trino.spi.block.ArrayBlock::getEncodingName()</old>
+                                    <justification>Removal of bidrectional coupling of Blocks and BlockEncodings</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method java.lang.String io.trino.spi.block.Block::getEncodingName()</old>
+                                    <justification>Removal of bidrectional coupling of Blocks and BlockEncodings</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.addedToInterface</code>
+                                    <new>method java.lang.Class&lt;? extends io.trino.spi.block.Block&gt; io.trino.spi.block.BlockEncoding::getBlockClass()</new>
+                                    <justification>Removal of bidrectional coupling of Blocks and BlockEncodings</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method java.lang.String io.trino.spi.block.ByteArrayBlock::getEncodingName()</old>
+                                    <justification>Removal of bidrectional coupling of Blocks and BlockEncodings</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method java.lang.String io.trino.spi.block.DictionaryBlock::getEncodingName()</old>
+                                    <justification>Removal of bidrectional coupling of Blocks and BlockEncodings</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method java.lang.String io.trino.spi.block.Fixed12Block::getEncodingName()</old>
+                                    <justification>Removal of bidrectional coupling of Blocks and BlockEncodings</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method java.lang.String io.trino.spi.block.Int128ArrayBlock::getEncodingName()</old>
+                                    <justification>Removal of bidrectional coupling of Blocks and BlockEncodings</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method java.lang.String io.trino.spi.block.IntArrayBlock::getEncodingName()</old>
+                                    <justification>Removal of bidrectional coupling of Blocks and BlockEncodings</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method java.lang.String io.trino.spi.block.LazyBlock::getEncodingName()</old>
+                                    <justification>Removal of bidrectional coupling of Blocks and BlockEncodings</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method java.lang.String io.trino.spi.block.LongArrayBlock::getEncodingName()</old>
+                                    <justification>Removal of bidrectional coupling of Blocks and BlockEncodings</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method java.lang.String io.trino.spi.block.MapBlock::getEncodingName()</old>
+                                    <justification>Removal of bidrectional coupling of Blocks and BlockEncodings</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method java.lang.String io.trino.spi.block.RowBlock::getEncodingName()</old>
+                                    <justification>Removal of bidrectional coupling of Blocks and BlockEncodings</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method java.lang.String io.trino.spi.block.RunLengthEncodedBlock::getEncodingName()</old>
+                                    <justification>Removal of bidrectional coupling of Blocks and BlockEncodings</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method java.lang.String io.trino.spi.block.ShortArrayBlock::getEncodingName()</old>
+                                    <justification>Removal of bidrectional coupling of Blocks and BlockEncodings</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method java.lang.String io.trino.spi.block.VariableWidthBlock::getEncodingName()</old>
+                                    <justification>Removal of bidrectional coupling of Blocks and BlockEncodings</justification>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -218,68 +218,6 @@
                                 </item>
                                 <!-- Backwards incompatible changes since the previous release -->
                                 <!-- Any exclusions below can be deleted after each release -->
-                                <item>
-                                    <ignore>true</ignore>
-                                    <code>java.method.removed</code>
-                                    <old>method java.lang.Iterable&lt;io.trino.spi.eventlistener.EventListener&gt; io.trino.spi.connector.Connector::getEventListeners()</old>
-                                    <justification>Remove connector event listeners</justification>
-                                </item>
-                                <item>
-                                    <ignore>true</ignore>
-                                    <code>java.annotation.removed</code>
-                                    <old>method byte[] io.trino.spi.type.SqlVarbinary::getBytes()</old>
-                                    <new>method byte[] io.trino.spi.type.SqlVarbinary::getBytes()</new>
-                                    <annotation>@com.fasterxml.jackson.annotation.JsonValue</annotation>
-                                    <justification>On-the-wire representation shouldn't rely on the Jackson format</justification>
-                                </item>
-                                <item>
-                                    <ignore>true</ignore>
-                                    <code>java.annotation.removed</code>
-                                    <old>method java.lang.String io.trino.spi.type.SqlDate::toString()</old>
-                                    <new>method java.lang.String io.trino.spi.type.SqlDate::toString()</new>
-                                    <annotation>@com.fasterxml.jackson.annotation.JsonValue</annotation>
-                                    <justification>On-the-wire representation shouldn't rely on the Jackson format</justification>
-                                </item>
-                                <item>
-                                    <ignore>true</ignore>
-                                    <code>java.annotation.removed</code>
-                                    <old>method java.lang.String io.trino.spi.type.SqlDecimal::toString()</old>
-                                    <new>method java.lang.String io.trino.spi.type.SqlDecimal::toString()</new>
-                                    <annotation>@com.fasterxml.jackson.annotation.JsonValue</annotation>
-                                    <justification>On-the-wire representation shouldn't rely on the Jackson format</justification>
-                                </item>
-                                <item>
-                                    <ignore>true</ignore>
-                                    <code>java.annotation.removed</code>
-                                    <old>method java.lang.String io.trino.spi.type.SqlTime::toString()</old>
-                                    <new>method java.lang.String io.trino.spi.type.SqlTime::toString()</new>
-                                    <annotation>@com.fasterxml.jackson.annotation.JsonValue</annotation>
-                                    <justification>On-the-wire representation shouldn't rely on the Jackson format</justification>
-                                </item>
-                                <item>
-                                    <ignore>true</ignore>
-                                    <code>java.annotation.removed</code>
-                                    <old>method java.lang.String io.trino.spi.type.SqlTimeWithTimeZone::toString()</old>
-                                    <new>method java.lang.String io.trino.spi.type.SqlTimeWithTimeZone::toString()</new>
-                                    <annotation>@com.fasterxml.jackson.annotation.JsonValue</annotation>
-                                    <justification>On-the-wire representation shouldn't rely on the Jackson format</justification>
-                                </item>
-                                <item>
-                                    <ignore>true</ignore>
-                                    <code>java.annotation.removed</code>
-                                    <old>method java.lang.String io.trino.spi.type.SqlTimestamp::toString()</old>
-                                    <new>method java.lang.String io.trino.spi.type.SqlTimestamp::toString()</new>
-                                    <annotation>@com.fasterxml.jackson.annotation.JsonValue</annotation>
-                                    <justification>On-the-wire representation shouldn't rely on the Jackson format</justification>
-                                </item>
-                                <item>
-                                    <ignore>true</ignore>
-                                    <code>java.annotation.removed</code>
-                                    <old>method java.lang.String io.trino.spi.type.SqlTimestampWithTimeZone::toString()</old>
-                                    <new>method java.lang.String io.trino.spi.type.SqlTimestampWithTimeZone::toString()</new>
-                                    <annotation>@com.fasterxml.jackson.annotation.JsonValue</annotation>
-                                    <justification>On-the-wire representation shouldn't rely on the Jackson format</justification>
-                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlock.java
@@ -193,12 +193,6 @@ public final class ArrayBlock
     }
 
     @Override
-    public String getEncodingName()
-    {
-        return ArrayBlockEncoding.NAME;
-    }
-
-    @Override
     public boolean mayHaveNull()
     {
         return valueIsNull != null;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlockEncoding.java
@@ -32,6 +32,12 @@ public class ArrayBlockEncoding
     }
 
     @Override
+    public Class<? extends Block> getBlockClass()
+    {
+        return ArrayBlock.class;
+    }
+
+    @Override
     public void writeBlock(BlockEncodingSerde blockEncodingSerde, SliceOutput sliceOutput, Block block)
     {
         ArrayBlock arrayBlock = (ArrayBlock) block;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Block.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Block.java
@@ -95,11 +95,6 @@ public sealed interface Block
     void retainedBytesForEachPart(ObjLongConsumer<Object> consumer);
 
     /**
-     * Get the encoding for this block.
-     */
-    String getEncodingName();
-
-    /**
      * Create a new block from the current block by keeping the same elements only with respect
      * to {@code positions} that starts at {@code offset} and has length of {@code length}. The
      * implementation may return a view over the data in this block or may return a copy, and the

--- a/core/trino-spi/src/main/java/io/trino/spi/block/BlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/BlockEncoding.java
@@ -25,6 +25,8 @@ public interface BlockEncoding
      */
     String getName();
 
+    Class<? extends Block> getBlockClass();
+
     /**
      * Read a block from the specified input.  The returned
      * block should begin at the specified position.

--- a/core/trino-spi/src/main/java/io/trino/spi/block/BlockEncodingSerde.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/BlockEncodingSerde.java
@@ -30,6 +30,14 @@ public interface BlockEncodingSerde
     void writeBlock(SliceOutput output, Block block);
 
     /**
+     * Estimate the size of the block when serialized to the on-the-wire representation.
+     */
+    default long estimatedWriteSize(Block block)
+    {
+        return block.getSizeInBytes();
+    }
+
+    /**
      * Reads a type from the input.
      */
     Type readType(SliceInput sliceInput);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlock.java
@@ -216,12 +216,6 @@ public final class ByteArrayBlock
     }
 
     @Override
-    public String getEncodingName()
-    {
-        return ByteArrayBlockEncoding.NAME;
-    }
-
-    @Override
     public ByteArrayBlock copyWithAppendedNull()
     {
         boolean[] newValueIsNull = copyIsNullAndAppendNull(valueIsNull, arrayOffset, positionCount);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlockEncoding.java
@@ -34,6 +34,12 @@ public class ByteArrayBlockEncoding
     }
 
     @Override
+    public Class<? extends Block> getBlockClass()
+    {
+        return ByteArrayBlock.class;
+    }
+
+    @Override
     public void writeBlock(BlockEncodingSerde blockEncodingSerde, SliceOutput sliceOutput, Block block)
     {
         ByteArrayBlock byteArrayBlock = (ByteArrayBlock) block;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
@@ -279,12 +279,6 @@ public final class DictionaryBlock
     }
 
     @Override
-    public String getEncodingName()
-    {
-        return DictionaryBlockEncoding.NAME;
-    }
-
-    @Override
     public Block copyPositions(int[] positions, int offset, int length)
     {
         checkArrayRange(positions, offset, length);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlockEncoding.java
@@ -30,6 +30,12 @@ public class DictionaryBlockEncoding
     }
 
     @Override
+    public Class<? extends Block> getBlockClass()
+    {
+        return DictionaryBlock.class;
+    }
+
+    @Override
     public void writeBlock(BlockEncodingSerde blockEncodingSerde, SliceOutput sliceOutput, Block block)
     {
         // The down casts here are safe because it is the block itself the provides this encoding implementation.

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Fixed12Block.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Fixed12Block.java
@@ -224,12 +224,6 @@ public final class Fixed12Block
     }
 
     @Override
-    public String getEncodingName()
-    {
-        return Fixed12BlockEncoding.NAME;
-    }
-
-    @Override
     public Fixed12Block copyWithAppendedNull()
     {
         boolean[] newValueIsNull = copyIsNullAndAppendNull(valueIsNull, positionOffset, positionCount);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Fixed12BlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Fixed12BlockEncoding.java
@@ -31,6 +31,12 @@ public class Fixed12BlockEncoding
     }
 
     @Override
+    public Class<? extends Block> getBlockClass()
+    {
+        return Fixed12Block.class;
+    }
+
+    @Override
     public void writeBlock(BlockEncodingSerde blockEncodingSerde, SliceOutput sliceOutput, Block block)
     {
         Fixed12Block fixed12Block = (Fixed12Block) block;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlock.java
@@ -216,12 +216,6 @@ public final class Int128ArrayBlock
     }
 
     @Override
-    public String getEncodingName()
-    {
-        return Int128ArrayBlockEncoding.NAME;
-    }
-
-    @Override
     public Int128ArrayBlock copyWithAppendedNull()
     {
         boolean[] newValueIsNull = copyIsNullAndAppendNull(valueIsNull, positionOffset, positionCount);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlockEncoding.java
@@ -31,6 +31,12 @@ public class Int128ArrayBlockEncoding
     }
 
     @Override
+    public Class<? extends Block> getBlockClass()
+    {
+        return Int128ArrayBlock.class;
+    }
+
+    @Override
     public void writeBlock(BlockEncodingSerde blockEncodingSerde, SliceOutput sliceOutput, Block block)
     {
         Int128ArrayBlock int128ArrayBlock = (Int128ArrayBlock) block;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlock.java
@@ -199,12 +199,6 @@ public final class IntArrayBlock
     }
 
     @Override
-    public String getEncodingName()
-    {
-        return IntArrayBlockEncoding.NAME;
-    }
-
-    @Override
     public IntArrayBlock copyWithAppendedNull()
     {
         boolean[] newValueIsNull = copyIsNullAndAppendNull(valueIsNull, arrayOffset, positionCount);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlockEncoding.java
@@ -33,6 +33,12 @@ public class IntArrayBlockEncoding
     }
 
     @Override
+    public Class<? extends Block> getBlockClass()
+    {
+        return IntArrayBlock.class;
+    }
+
+    @Override
     public void writeBlock(BlockEncodingSerde blockEncodingSerde, SliceOutput sliceOutput, Block block)
     {
         IntArrayBlock intArrayBlock = (IntArrayBlock) block;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LazyBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LazyBlock.java
@@ -114,12 +114,6 @@ public final class LazyBlock
     }
 
     @Override
-    public String getEncodingName()
-    {
-        return LazyBlockEncoding.NAME;
-    }
-
-    @Override
     public Block copyWithAppendedNull()
     {
         throw new UnsupportedOperationException("LazyBlock does not support newBlockWithAppendedNull()");

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LazyBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LazyBlockEncoding.java
@@ -30,6 +30,12 @@ public class LazyBlockEncoding
     }
 
     @Override
+    public Class<? extends Block> getBlockClass()
+    {
+        return LazyBlock.class;
+    }
+
+    @Override
     public Block readBlock(BlockEncodingSerde blockEncodingSerde, SliceInput input)
     {
         // We write the actual underlying block, so we will never need to read a lazy block

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlock.java
@@ -198,12 +198,6 @@ public final class LongArrayBlock
     }
 
     @Override
-    public String getEncodingName()
-    {
-        return LongArrayBlockEncoding.NAME;
-    }
-
-    @Override
     public LongArrayBlock copyWithAppendedNull()
     {
         boolean[] newValueIsNull = copyIsNullAndAppendNull(valueIsNull, arrayOffset, positionCount);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlockEncoding.java
@@ -33,6 +33,12 @@ public class LongArrayBlockEncoding
     }
 
     @Override
+    public Class<? extends Block> getBlockClass()
+    {
+        return LongArrayBlock.class;
+    }
+
+    @Override
     public void writeBlock(BlockEncodingSerde blockEncodingSerde, SliceOutput sliceOutput, Block block)
     {
         LongArrayBlock longArrayBlock = (LongArrayBlock) block;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/MapBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/MapBlock.java
@@ -345,12 +345,6 @@ public final class MapBlock
     }
 
     @Override
-    public String getEncodingName()
-    {
-        return MapBlockEncoding.NAME;
-    }
-
-    @Override
     public MapBlock copyPositions(int[] positions, int offset, int length)
     {
         checkArrayRange(positions, offset, length);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/MapBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/MapBlockEncoding.java
@@ -37,6 +37,12 @@ public class MapBlockEncoding
     }
 
     @Override
+    public Class<? extends Block> getBlockClass()
+    {
+        return MapBlock.class;
+    }
+
+    @Override
     public void writeBlock(BlockEncodingSerde blockEncodingSerde, SliceOutput sliceOutput, Block block)
     {
         MapBlock mapBlock = (MapBlock) block;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
@@ -255,12 +255,6 @@ public final class RowBlock
     }
 
     @Override
-    public String getEncodingName()
-    {
-        return RowBlockEncoding.NAME;
-    }
-
-    @Override
     public RowBlock copyPositions(int[] positions, int offset, int length)
     {
         checkArrayRange(positions, offset, length);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlockEncoding.java
@@ -31,6 +31,12 @@ public class RowBlockEncoding
     }
 
     @Override
+    public Class<? extends Block> getBlockClass()
+    {
+        return RowBlock.class;
+    }
+
+    @Override
     public void writeBlock(BlockEncodingSerde blockEncodingSerde, SliceOutput sliceOutput, Block block)
     {
         RowBlock rowBlock = (RowBlock) block;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthBlockEncoding.java
@@ -28,6 +28,12 @@ public class RunLengthBlockEncoding
     }
 
     @Override
+    public Class<? extends Block> getBlockClass()
+    {
+        return RunLengthEncodedBlock.class;
+    }
+
+    @Override
     public void writeBlock(BlockEncodingSerde blockEncodingSerde, SliceOutput sliceOutput, Block block)
     {
         RunLengthEncodedBlock rleBlock = (RunLengthEncodedBlock) block;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
@@ -138,12 +138,6 @@ public final class RunLengthEncodedBlock
     }
 
     @Override
-    public String getEncodingName()
-    {
-        return RunLengthBlockEncoding.NAME;
-    }
-
-    @Override
     public Block getPositions(int[] positions, int offset, int length)
     {
         checkArrayRange(positions, offset, length);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlock.java
@@ -198,12 +198,6 @@ public final class ShortArrayBlock
     }
 
     @Override
-    public String getEncodingName()
-    {
-        return ShortArrayBlockEncoding.NAME;
-    }
-
-    @Override
     public ShortArrayBlock copyWithAppendedNull()
     {
         boolean[] newValueIsNull = copyIsNullAndAppendNull(valueIsNull, arrayOffset, positionCount);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlockEncoding.java
@@ -33,6 +33,12 @@ public class ShortArrayBlockEncoding
     }
 
     @Override
+    public Class<? extends Block> getBlockClass()
+    {
+        return ShortArrayBlock.class;
+    }
+
+    @Override
     public void writeBlock(BlockEncodingSerde blockEncodingSerde, SliceOutput sliceOutput, Block block)
     {
         ShortArrayBlock shortArrayBlock = (ShortArrayBlock) block;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlock.java
@@ -282,12 +282,6 @@ public final class VariableWidthBlock
     }
 
     @Override
-    public String getEncodingName()
-    {
-        return VariableWidthBlockEncoding.NAME;
-    }
-
-    @Override
     public VariableWidthBlock copyWithAppendedNull()
     {
         boolean[] newValueIsNull = copyIsNullAndAppendNull(valueIsNull, arrayOffset, positionCount);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlockEncoding.java
@@ -36,6 +36,12 @@ public class VariableWidthBlockEncoding
     }
 
     @Override
+    public Class<? extends Block> getBlockClass()
+    {
+        return VariableWidthBlock.class;
+    }
+
+    @Override
     public void writeBlock(BlockEncodingSerde blockEncodingSerde, SliceOutput sliceOutput, Block block)
     {
         VariableWidthBlock variableWidthBlock = (VariableWidthBlock) block;

--- a/core/trino-spi/src/test/java/io/trino/spi/block/TestingBlockEncodingSerde.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/TestingBlockEncodingSerde.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
@@ -33,7 +34,8 @@ public final class TestingBlockEncodingSerde
         implements BlockEncodingSerde
 {
     private final Function<TypeId, Type> types;
-    private final ConcurrentMap<String, BlockEncoding> blockEncodings = new ConcurrentHashMap<>();
+    private final ConcurrentMap<Class<? extends Block>, BlockEncoding> blockEncodingsByClass = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, BlockEncoding> blockEncodingsByName = new ConcurrentHashMap<>();
 
     public TestingBlockEncodingSerde()
     {
@@ -61,7 +63,8 @@ public final class TestingBlockEncodingSerde
 
     private void addBlockEncoding(BlockEncoding blockEncoding)
     {
-        blockEncodings.put(blockEncoding.getName(), blockEncoding);
+        blockEncodingsByClass.put(blockEncoding.getBlockClass(), blockEncoding);
+        blockEncodingsByName.put(blockEncoding.getName(), blockEncoding);
     }
 
     @Override
@@ -71,7 +74,7 @@ public final class TestingBlockEncodingSerde
         String encodingName = readLengthPrefixedString(input);
 
         // look up the encoding factory
-        BlockEncoding blockEncoding = blockEncodings.get(encodingName);
+        BlockEncoding blockEncoding = blockEncodingsByName.get(encodingName);
         checkArgument(blockEncoding != null, "Unknown block encoding %s", encodingName);
 
         // load read the encoding factory from the output stream
@@ -82,11 +85,8 @@ public final class TestingBlockEncodingSerde
     public void writeBlock(SliceOutput output, Block block)
     {
         while (true) {
-            // get the encoding name
-            String encodingName = block.getEncodingName();
-
             // look up the encoding factory
-            BlockEncoding blockEncoding = blockEncodings.get(encodingName);
+            BlockEncoding blockEncoding = blockEncodingsByClass.get(block.getClass());
 
             // see if a replacement block should be written instead
             Optional<Block> replacementBlock = blockEncoding.replacementBlockForWrite(block);
@@ -96,12 +96,29 @@ public final class TestingBlockEncodingSerde
             }
 
             // write the name to the output
-            writeLengthPrefixedString(output, encodingName);
+            writeLengthPrefixedString(output, blockEncoding.getName());
 
             // write the block to the output
             blockEncoding.writeBlock(this, output, block);
 
             break;
+        }
+    }
+
+    @Override
+    public long estimatedWriteSize(Block block)
+    {
+        while (true) {
+            BlockEncoding blockEncoding = blockEncodingsByClass.get(block.getClass());
+            // see if a replacement block should be written instead
+            Optional<Block> replacementBlock = blockEncoding.replacementBlockForWrite(block);
+            if (replacementBlock.isPresent()) {
+                block = replacementBlock.get();
+                continue;
+            }
+            // length of encoding name + encoding name + block size
+            // TODO: improve this estimate by adding estimatedWriteSize to BlockEncoding interface
+            return SIZE_OF_INT + blockEncoding.getName().length() + block.getSizeInBytes();
         }
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBlockEncodingSerde.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBlockEncodingSerde.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateType.DATE;
@@ -60,7 +61,9 @@ public final class HiveBlockEncodingSerde
         implements BlockEncodingSerde
 {
     private static final List<Type> TYPES = ImmutableList.of(BOOLEAN, BIGINT, DOUBLE, INTEGER, VARCHAR, VARBINARY, TIMESTAMP_MILLIS, TIMESTAMP_TZ_MILLIS, DATE, HYPER_LOG_LOG);
-    private final ConcurrentMap<String, BlockEncoding> blockEncodings = new ConcurrentHashMap<>();
+
+    private final ConcurrentMap<String, BlockEncoding> blockEncodingsByName = new ConcurrentHashMap<>();
+    private final ConcurrentMap<Class<? extends Block>, BlockEncoding> blockEncodingsByClass = new ConcurrentHashMap<>();
 
     @Inject
     public HiveBlockEncodingSerde()
@@ -82,7 +85,8 @@ public final class HiveBlockEncodingSerde
 
     private void addBlockEncoding(BlockEncoding blockEncoding)
     {
-        blockEncodings.put(blockEncoding.getName(), blockEncoding);
+        blockEncodingsByClass.put(blockEncoding.getBlockClass(), blockEncoding);
+        blockEncodingsByName.put(blockEncoding.getName(), blockEncoding);
     }
 
     @Override
@@ -92,7 +96,7 @@ public final class HiveBlockEncodingSerde
         String encodingName = readLengthPrefixedString(input);
 
         // look up the encoding factory
-        BlockEncoding blockEncoding = blockEncodings.get(encodingName);
+        BlockEncoding blockEncoding = blockEncodingsByName.get(encodingName);
         checkArgument(blockEncoding != null, "Unknown block encoding %s", encodingName);
 
         // load read the encoding factory from the output stream
@@ -100,15 +104,29 @@ public final class HiveBlockEncodingSerde
     }
 
     @Override
+    public long estimatedWriteSize(Block block)
+    {
+        while (true) {
+            BlockEncoding blockEncoding = blockEncodingsByClass.get(block.getClass());
+            // see if a replacement block should be written instead
+            Optional<Block> replacementBlock = blockEncoding.replacementBlockForWrite(block);
+            if (replacementBlock.isPresent()) {
+                block = replacementBlock.get();
+                continue;
+            }
+            // length of encoding name + encoding name + block size
+            // TODO: improve this estimate by adding estimatedWriteSize to BlockEncoding interface
+            return SIZE_OF_INT + blockEncoding.getName().length() + block.getSizeInBytes();
+        }
+    }
+
+    @Override
     public void writeBlock(SliceOutput output, Block block)
     {
         while (true) {
-            // get the encoding name
-            String encodingName = block.getEncodingName();
-
             // look up the encoding factory
-            BlockEncoding blockEncoding = blockEncodings.get(encodingName);
-            checkArgument(blockEncoding != null, "Cannot write block %s with encoding %s", block, encodingName);
+            BlockEncoding blockEncoding = blockEncodingsByClass.get(block.getClass());
+            checkArgument(blockEncoding != null, "Cannot write block %s as no encoding was found", block);
 
             // see if a replacement block should be written instead
             Optional<Block> replacementBlock = blockEncoding.replacementBlockForWrite(block);
@@ -118,7 +136,7 @@ public final class HiveBlockEncodingSerde
             }
 
             // write the name to the output
-            writeLengthPrefixedString(output, encodingName);
+            writeLengthPrefixedString(output, blockEncoding.getName());
 
             // write the block to the output
             blockEncoding.writeBlock(this, output, block);


### PR DESCRIPTION
Right now these abstractions allow for a single encoding for a given block.

In the future we want multiple encoding for a given block to exist and be able
to apply them based on the block properties (size/number of nulls etc).


<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
