### PR TITLE
Fix Ranger plugin initialization

### DIFF
--- a/plugin/trino-ranger/src/main/java/io/trino/plugin/ranger/RangerSystemAccessControl.java
+++ b/plugin/trino-ranger/src/main/java/io/trino/plugin/ranger/RangerSystemAccessControl.java
@@ -149,11 +149,7 @@ public class RangerSystemAccessControl
         }
 
         UserGroupInformation.setConfiguration(hadoopConf);
-        RangerPluginConfig pluginConfig = new RangerPluginConfig(RANGER_TRINO_SERVICETYPE, config.getServiceName(), RANGER_TRINO_APPID, null, null, null);
-
-        for (File configPath : config.getPluginConfigResource()) {
-            pluginConfig.addResourceIfReadable(configPath.getAbsolutePath());
-        }
+        RangerPluginConfig pluginConfig = new RangerPluginConfig(RANGER_TRINO_SERVICETYPE, config.getServiceName(), RANGER_TRINO_APPID, null, null, config.getPluginConfigResource(), null);
 
         rangerPlugin = new RangerBasePlugin(pluginConfig);
         rangerPlugin.init();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
This fix addresses the issue reported in #24887. 



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Currently Ranger plugin configuration is intilizated with default configurations, followed by loading configurations from files specified in `access-control.properties`. Few configurations used by Ranger plugin are not overrideable after initialization, hence the configurations in files specified in `access-control.proerties` are not effective.

To address this issue, Apache Ranger 2.6.0 enhanced plugin initialization to load configurations from list of files specified in the constructor.  


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
