### PR TITLE
Increase waiting time before vacuum procedure test

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -1737,7 +1737,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
             assertThat(getAllDataFilesFromTableDirectory(tableName)).isEqualTo(union(initialFiles, updatedFiles));
 
             // vacuum with low retention period
-            MILLISECONDS.sleep(1_000 - timeSinceUpdate.elapsed(MILLISECONDS) + 1);
+            MILLISECONDS.sleep(2_000 - timeSinceUpdate.elapsed(MILLISECONDS) + 1);
             assertUpdate(sessionWithShortRetentionUnlocked, "CALL system.vacuum(schema_name => CURRENT_SCHEMA, table_name => '" + tableName + "', retention => '1s')");
             // table data shouldn't change
             assertThat(query("SELECT * FROM " + tableName))
@@ -1783,7 +1783,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
             assertThat(getAllDataFilesFromTableDirectory(tableName)).isEqualTo(union(initialFiles, updatedFiles));
 
             // vacuum with low retention period
-            MILLISECONDS.sleep(1_000 - timeSinceUpdate.elapsed(MILLISECONDS) + 1);
+            MILLISECONDS.sleep(2_000 - timeSinceUpdate.elapsed(MILLISECONDS) + 1);
             assertUpdate(sessionWithShortRetentionUnlocked, "CALL system.vacuum(schema_name => CURRENT_SCHEMA, table_name => '" + tableName + "', retention => '1s')");
             // table data shouldn't change
             assertThat(query("SELECT * FROM " + tableName))
@@ -1830,7 +1830,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
             assertThat(getAllDataFilesFromTableDirectory(tableName)).isEqualTo(union(initialFiles, updatedFiles));
 
             // vacuum with low retention period
-            MILLISECONDS.sleep(1_000 - timeSinceUpdate.elapsed(MILLISECONDS) + 1);
+            MILLISECONDS.sleep(2_000 - timeSinceUpdate.elapsed(MILLISECONDS) + 1);
             assertUpdate(sessionWithShortRetentionUnlocked, "CALL system.vacuum(CURRENT_SCHEMA, '" + tableName + "', '1s')");
             // table data shouldn't change
             assertQuery("SELECT * FROM " + tableName, "VALUES (101, TIMESTAMP '2024-12-13 11:00:00.000000'), (102, TIMESTAMP '2024-12-13 12:00:00.000000')");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Fixes https://github.com/trinodb/trino/issues/19461
Increase waiting time before vacuum procedure test

Vacuum procedure is relying on last modification time for files. Some storages, like ABFS report time with resolution of seconds.
In tests we wait at least 1001 ms, which in some cases may be not enough due to time truncate made by ABFS.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
