### PR TITLE
Reduce variable width flat size

### DIFF
--- a/core/trino-main/src/test/java/io/trino/operator/GroupByHashYieldAssertion.java
+++ b/core/trino-main/src/test/java/io/trino/operator/GroupByHashYieldAssertion.java
@@ -245,8 +245,7 @@ public final class GroupByHashYieldAssertion
                 Integer.BYTES + // groupId
                 Long.BYTES + // rawHash (optional, but present in this test)
                 Byte.BYTES + // field null
-                Integer.BYTES + // field variable length
-                Long.BYTES + // field first 8 bytes
+                Integer.BYTES + // field variable length (or short length and first 3 field bytes)
                 Integer.BYTES; // field variable offset (or 4 more field bytes)
         return (long) capacity * sizePerEntry;
     }

--- a/core/trino-spi/src/test/java/io/trino/spi/type/TestVarchars.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/type/TestVarchars.java
@@ -27,6 +27,20 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestVarchars
 {
     @Test
+    public void testShortLengthEncoding()
+    {
+        byte[] bytes = new byte[8];
+        for (int i = 0; i <= 256; i++) {
+            AbstractVariableWidthType.writeFlatVariableLength(i, bytes, 0);
+            assertThat(AbstractVariableWidthType.readFlatVariableLength(bytes, 0))
+                    .isEqualTo(i);
+        }
+        AbstractVariableWidthType.writeFlatVariableLength(Integer.MAX_VALUE, bytes, 0);
+        assertThat(AbstractVariableWidthType.readFlatVariableLength(bytes, 0))
+                .isEqualTo(Integer.MAX_VALUE);
+    }
+
+    @Test
     public void testTruncateToLength()
     {
         // Single byte code points


### PR DESCRIPTION
## Description
Reduces the width of variable width data types from 16 to 8 bytes when stored in FlatHash instances. This necessitates changing the short string optimization threshold from 12 down to 7 bytes.

[BenchmarkGroupByHash](https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/pettyjamesm/d35182de5682f4e8e107096c1bb4700b/raw/96600de9b7d874a9ab906ee192e86c0aee018765/baseline-varchar-size.json,https://gist.githubusercontent.com/pettyjamesm/d35182de5682f4e8e107096c1bb4700b/raw/96600de9b7d874a9ab906ee192e86c0aee018765/reduced-varchar-size.json) shows a significant improvement in `addPages` performance (particularly with multiple varchar columns) with essentially no change in `writeData` performance.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
