### PR TITLE
Fix setup failure in TestDeltaLakeGlueMetastore

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaLakeGlueMetastore.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaLakeGlueMetastore.java
@@ -35,6 +35,7 @@ import io.trino.plugin.base.session.SessionPropertiesProvider;
 import io.trino.plugin.deltalake.DeltaLakeMetadata;
 import io.trino.plugin.deltalake.DeltaLakeMetadataFactory;
 import io.trino.plugin.deltalake.DeltaLakeModule;
+import io.trino.plugin.deltalake.DeltaLakeSecurityModule;
 import io.trino.plugin.deltalake.metastore.DeltaLakeMetastoreModule;
 import io.trino.plugin.hive.NodeVersion;
 import io.trino.spi.NodeManager;
@@ -128,6 +129,7 @@ public class TestDeltaLakeGlueMetastore
                 // connector modules
                 new DeltaLakeMetastoreModule(),
                 new DeltaLakeModule(),
+                new DeltaLakeSecurityModule(),
                 // test setup
                 new FileSystemModule("test", context.getNodeManager(), context.getOpenTelemetry(), false));
 


### PR DESCRIPTION
## Description

https://github.com/trinodb/trino/actions/runs/13380158557/job/37367214390
```
Error:    TestDeltaLakeGlueMetastore.setUp:137 » Creation Unable to create injector, see the following errors:

1) [Guice/JitDisabled]: Explicit bindings are required and Boolean annotated with @UsingSystemSecurity() is not explicitly bound.
  at DeltaLakeMetadataFactory.<init>(Unknown Source)
      \_ for 13th parameter useSystemSecurity
  at java.base/DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
