### PR TITLE
Remove Connector.getInitialMemoryRequirement()

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/DefaultCatalogFactory.java
+++ b/core/trino-main/src/main/java/io/trino/connector/DefaultCatalogFactory.java
@@ -25,7 +25,6 @@ import io.trino.connector.system.StaticSystemTablesProvider;
 import io.trino.connector.system.SystemConnector;
 import io.trino.connector.system.SystemTablesProvider;
 import io.trino.execution.scheduler.NodeSchedulerConfig;
-import io.trino.memory.LocalMemoryManager;
 import io.trino.metadata.InternalNodeManager;
 import io.trino.metadata.Metadata;
 import io.trino.security.AccessControl;
@@ -73,7 +72,6 @@ public class DefaultCatalogFactory
     private final int maxPrefetchedInformationSchemaPrefixes;
 
     private final ConcurrentMap<ConnectorName, ConnectorFactory> connectorFactories = new ConcurrentHashMap<>();
-    private final LocalMemoryManager localMemoryManager;
     private final SecretsResolver secretsResolver;
 
     @Inject
@@ -90,7 +88,6 @@ public class DefaultCatalogFactory
             TypeManager typeManager,
             NodeSchedulerConfig nodeSchedulerConfig,
             OptimizerConfig optimizerConfig,
-            LocalMemoryManager localMemoryManager,
             SecretsResolver secretsResolver)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
@@ -105,7 +102,6 @@ public class DefaultCatalogFactory
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.schedulerIncludeCoordinator = nodeSchedulerConfig.isIncludeCoordinator();
         this.maxPrefetchedInformationSchemaPrefixes = optimizerConfig.getMaxPrefetchedInformationSchemaPrefixes();
-        this.localMemoryManager = requireNonNull(localMemoryManager, "localMemoryManager is null");
         this.secretsResolver = requireNonNull(secretsResolver, "secretsResolver is null");
     }
 
@@ -188,7 +184,6 @@ public class DefaultCatalogFactory
                 catalogConnector,
                 informationSchemaConnector,
                 systemConnector,
-                localMemoryManager,
                 catalogProperties);
     }
 

--- a/core/trino-main/src/main/java/io/trino/memory/MemoryPool.java
+++ b/core/trino-main/src/main/java/io/trino/memory/MemoryPool.java
@@ -71,9 +71,6 @@ public class MemoryPool
     @GuardedBy("this")
     private final Map<TaskId, Long> taskRevocableMemoryReservations = new HashMap<>();
 
-    @GuardedBy("this")
-    private long connectorsReservedBytes;
-
     private final List<MemoryPoolListener> listeners = new CopyOnWriteArrayList<>();
 
     public MemoryPool(DataSize size)
@@ -210,20 +207,6 @@ public class MemoryPool
         return true;
     }
 
-    public boolean tryReserveConnectorMemory(long bytes)
-    {
-        checkArgument(bytes >= 0, "'%s' is negative", bytes);
-        synchronized (this) {
-            if (getFreeBytes() - bytes < 0) {
-                return false;
-            }
-            connectorsReservedBytes += bytes;
-            reservedBytes += bytes;
-        }
-        onMemoryReserved();
-        return true;
-    }
-
     public boolean tryReserveRevocable(long bytes)
     {
         checkArgument(bytes >= 0, "'%s' is negative", bytes);
@@ -338,24 +321,6 @@ public class MemoryPool
         }
     }
 
-    public synchronized void freeConnectorMemory(long bytes)
-    {
-        checkArgument(bytes >= 0, "'%s' is negative", bytes);
-        checkArgument(reservedBytes >= bytes, "tried to free more memory than is reserved");
-        checkArgument(connectorsReservedBytes >= bytes, "tried to free more memory for the connectors than is reserved");
-        if (bytes == 0) {
-            // Freeing zero bytes is a no-op
-            return;
-        }
-
-        connectorsReservedBytes -= bytes;
-        reservedBytes -= bytes;
-        if (getFreeBytes() > 0 && future != null) {
-            future.set(null);
-            future = null;
-        }
-    }
-
     /**
      * Returns the number of free bytes. This value may be negative, which indicates that the pool is over-committed.
      */
@@ -381,12 +346,6 @@ public class MemoryPool
     public synchronized long getReservedRevocableBytes()
     {
         return reservedRevocableBytes;
-    }
-
-    @Managed
-    public synchronized long getConnectorsReservedBytes()
-    {
-        return connectorsReservedBytes;
     }
 
     long getQueryMemoryReservation(QueryId queryId)

--- a/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
+++ b/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
@@ -75,7 +75,6 @@ import io.trino.execution.scheduler.NodeScheduler;
 import io.trino.execution.scheduler.NodeSchedulerConfig;
 import io.trino.execution.scheduler.UniformNodeSelectorFactory;
 import io.trino.execution.warnings.WarningCollector;
-import io.trino.memory.LocalMemoryManager;
 import io.trino.memory.MemoryManagerConfig;
 import io.trino.memory.NodeMemoryConfig;
 import io.trino.metadata.AnalyzePropertyManager;
@@ -396,7 +395,6 @@ public class PlanTester
                 typeManager,
                 nodeSchedulerConfig,
                 optimizerConfig,
-                new LocalMemoryManager(new NodeMemoryConfig()),
                 secretsResolver));
         this.splitManager = new SplitManager(createSplitManagerProvider(catalogManager), tracer, new QueryManagerConfig());
         this.pageSourceManager = new PageSourceManager(createPageSourceProviderFactory(catalogManager));

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskManagerRaceWithCatalogPrune.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskManagerRaceWithCatalogPrune.java
@@ -131,7 +131,6 @@ public class TestSqlTaskManagerRaceWithCatalogPrune
                     noOpConnectorService,
                     noOpConnectorService,
                     noOpConnectorService,
-                    new LocalMemoryManager(new NodeMemoryConfig()),
                     Optional.of(catalogProperties));
         }
 

--- a/core/trino-main/src/test/java/io/trino/memory/TestMemoryPools.java
+++ b/core/trino-main/src/test/java/io/trino/memory/TestMemoryPools.java
@@ -304,25 +304,6 @@ class TestMemoryPools
     }
 
     @Test
-    void testGlobalAllocations()
-    {
-        MemoryPool testPool = new MemoryPool(DataSize.ofBytes(1000));
-
-        assertThat(testPool.tryReserveConnectorMemory(999)).isTrue();
-        assertThat(testPool.tryReserveConnectorMemory(2)).isFalse();
-        assertThat(testPool.getReservedBytes()).isEqualTo(999);
-        assertThat(testPool.getConnectorsReservedBytes()).isEqualTo(999);
-        assertThat(testPool.getReservedRevocableBytes()).isEqualTo(0);
-        assertThat(testPool.getTaskMemoryReservations()).isEmpty();
-        assertThat(testPool.getQueryMemoryReservations()).isEmpty();
-        assertThat(testPool.getTaggedMemoryAllocations()).isEmpty();
-
-        testPool.freeConnectorMemory(999);
-        assertThat(testPool.getReservedBytes()).isEqualTo(0);
-        assertThat(testPool.getConnectorsReservedBytes()).isEqualTo(0);
-    }
-
-    @Test
     void testGlobalRevocableAllocations()
     {
         MemoryPool testPool = new MemoryPool(DataSize.ofBytes(1000));

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -308,6 +308,12 @@
                                     <old>method java.lang.String io.trino.spi.block.VariableWidthBlock::getEncodingName()</old>
                                     <justification>Removal of bidrectional coupling of Blocks and BlockEncodings</justification>
                                 </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method long io.trino.spi.connector.Connector::getInitialMemoryRequirement()</old>
+                                    <justification>Remove unused connector method</justification>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/Connector.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/Connector.java
@@ -147,18 +147,6 @@ public interface Connector
     }
 
     /**
-     * Retrieves the initial memory requirement for the connector.
-     * <p>
-     * The memory allocation is per catalog and is freed when the catalog is shut down.
-     *
-     * @return the initial memory requirement in bytes.
-     */
-    default long getInitialMemoryRequirement()
-    {
-        return 0;
-    }
-
-    /**
      * @return the set of table functions provided by this connector
      */
     default Set<ConnectorTableFunction> getTableFunctions()


### PR DESCRIPTION
## Description

This functionality is not used by any connector in Trino, nor is it tested. This functionality should be replaced with a memory reservation API that is passed into the connector. We could then have the memory connector declare its used memory, the Hive connector could report memory used for caches, etc.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## SPI
* Remove `Connector.getInitialMemoryRequirement()`. ({issue}`25055`)
```
