### PR TITLE
Propagate correct partition count for insert stages

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchange.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchange.java
@@ -287,9 +287,9 @@ public class LocalExchange
     {
         if (partitioning.getConnectorHandle() instanceof MergePartitioningHandle) {
             // TODO: can we always use this code path?
-            return nodePartitioningManager.getNodePartitioningMap(session, partitioning).getBucketToPartition().length;
+            return nodePartitioningManager.getNodePartitioningMap(session, partitioning, 1000).getBucketToPartition().length;
         }
-        return nodePartitioningManager.getBucketNodeMap(session, partitioning).getBucketCount();
+        return nodePartitioningManager.getBucketCount(session, partitioning);
     }
 
     private static boolean isSystemPartitioning(PartitioningHandle partitioning)

--- a/core/trino-main/src/main/java/io/trino/operator/output/SkewedPartitionRebalancer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/SkewedPartitionRebalancer.java
@@ -147,7 +147,7 @@ public class SkewedPartitionRebalancer
         // compared to only a single hive bucket reaching the min limit.
         int bucketCount = (handle.getConnectorHandle() instanceof SystemPartitioningHandle)
                 ? SCALE_WRITERS_PARTITION_COUNT
-                : nodePartitioningManager.getBucketNodeMap(session, handle).getBucketCount();
+                : nodePartitioningManager.getBucketCount(session, handle);
         return nodePartitioningManager.getPartitionFunction(
                 session,
                 scheme,

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -1440,11 +1440,11 @@ public abstract class BaseIcebergConnectorTest
         // Insert "large" number of rows, supposedly topping over iceberg.writer-sort-buffer-size so that temporary files are utilized by the sorting writer.
         assertUpdate(
                 """
-                INSERT INTO %s
-                SELECT v.*
-                FROM (VALUES %s, %s, %s) v
-                CROSS JOIN UNNEST (sequence(1, 10_000)) a(i)
-                """.formatted(tableName, values, highValues, lowValues), 30000);
+                        INSERT INTO %s
+                        SELECT v.*
+                        FROM (VALUES %s, %s, %s) v
+                        CROSS JOIN UNNEST (sequence(1, 10_000)) a(i)
+                        """.formatted(tableName, values, highValues, lowValues), 30000);
 
         assertUpdate("DROP TABLE " + tableName);
     }
@@ -8187,35 +8187,35 @@ public abstract class BaseIcebergConnectorTest
                 TestTable dimensionTable = newTrinoTable("dimension_table", "(date date, following_holiday boolean, year int)")) {
             assertUpdate(
                     """
-                    INSERT INTO %s
-                    VALUES
-                        (DATE '2023-01-01' , false, 2023),
-                        (DATE '2023-01-02' , true, 2023),
-                        (DATE '2023-01-03' , false, 2023)""".formatted(dimensionTable.getName()), 3);
+                            INSERT INTO %s
+                            VALUES
+                                (DATE '2023-01-01' , false, 2023),
+                                (DATE '2023-01-02' , true, 2023),
+                                (DATE '2023-01-03' , false, 2023)""".formatted(dimensionTable.getName()), 3);
             assertUpdate(
                     """
-                    INSERT INTO %s
-                    VALUES
-                        (DATE '2023-01-02' , '#2023#1', DECIMAL '122.12'),
-                        (DATE '2023-01-02' , '#2023#2', DECIMAL '124.12'),
-                        (DATE '2023-01-02' , '#2023#3', DECIMAL '99.99'),
-                        (DATE '2023-01-02' , '#2023#4', DECIMAL '95.12'),
-                        (DATE '2023-01-03' , '#2023#5', DECIMAL '199.12'),
-                        (DATE '2023-01-04' , '#2023#6', DECIMAL '99.55'),
-                        (DATE '2023-01-05' , '#2023#7', DECIMAL '50.11'),
-                        (DATE '2023-01-05' , '#2023#8', DECIMAL '60.20'),
-                        (DATE '2023-01-05' , '#2023#9', DECIMAL '70.75'),
-                        (DATE '2023-01-05' , '#2023#10', DECIMAL '80.12')""".formatted(salesTable.getName()), 10);
+                            INSERT INTO %s
+                            VALUES
+                                (DATE '2023-01-02' , '#2023#1', DECIMAL '122.12'),
+                                (DATE '2023-01-02' , '#2023#2', DECIMAL '124.12'),
+                                (DATE '2023-01-02' , '#2023#3', DECIMAL '99.99'),
+                                (DATE '2023-01-02' , '#2023#4', DECIMAL '95.12'),
+                                (DATE '2023-01-03' , '#2023#5', DECIMAL '199.12'),
+                                (DATE '2023-01-04' , '#2023#6', DECIMAL '99.55'),
+                                (DATE '2023-01-05' , '#2023#7', DECIMAL '50.11'),
+                                (DATE '2023-01-05' , '#2023#8', DECIMAL '60.20'),
+                                (DATE '2023-01-05' , '#2023#9', DECIMAL '70.75'),
+                                (DATE '2023-01-05' , '#2023#10', DECIMAL '80.12')""".formatted(salesTable.getName()), 10);
 
             String selectQuery =
                     """
-                    SELECT receipt_id
-                    FROM %s s
-                    JOIN %s d
-                        ON  s.date = d.date
-                    WHERE
-                        d.following_holiday = true AND
-                        d.date BETWEEN DATE '2023-01-01' AND DATE '2024-01-01'""".formatted(salesTable.getName(), dimensionTable.getName());
+                            SELECT receipt_id
+                            FROM %s s
+                            JOIN %s d
+                                ON  s.date = d.date
+                            WHERE
+                                d.following_holiday = true AND
+                                d.date BETWEEN DATE '2023-01-01' AND DATE '2024-01-01'""".formatted(salesTable.getName(), dimensionTable.getName());
             MaterializedResultWithPlan result = getDistributedQueryRunner().executeWithPlan(
                     Session.builder(getSession())
                             .setCatalogSessionProperty(catalog, DYNAMIC_FILTERING_WAIT_TIMEOUT, "10s")
@@ -8619,7 +8619,8 @@ public abstract class BaseIcebergConnectorTest
         }
     }
 
-    @Test // regression test for https://github.com/trinodb/trino/issues/22922
+    // regression test for https://github.com/trinodb/trino/issues/22922
+    @Test
     void testArrayElementChange()
     {
         try (TestTable table = newTrinoTable(

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/iceberg/TestIcebergParquetFaultTolerantExecutionConnectorTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/iceberg/TestIcebergParquetFaultTolerantExecutionConnectorTest.java
@@ -78,6 +78,13 @@ public class TestIcebergParquetFaultTolerantExecutionConnectorTest
         abort("We always get 3 partitions with FTE");
     }
 
+    @Test
+    @Override
+    public void testMaxWriterTaskCount()
+    {
+        abort("Max writer task count is not supported with FTE");
+    }
+
     @Override
     protected boolean isFileSorted(String path, String sortColumnName)
     {


### PR DESCRIPTION
Previously optional partition count was passed to NodePartitioningManager. When partition count was unspecified, then maxHashPartitionCount was used. However, maxHashPartitionCount should only apply to intermediate stages, rather than insert stages. Insert stages are controlled via maxWriterTaskCount.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Make engine honor `task.max-writer-count` for Iceberg partitioned writes. ({issue}`issuenumber`)
```
