### PR TITLE
Fix example SQL UDF in SET docs

### DIFF
--- a/docs/src/main/sphinx/udf/sql/set.md
+++ b/docs/src/main/sphinx/udf/sql/set.md
@@ -23,9 +23,9 @@ multiple times to different values:
 
 ```sql
 FUNCTION one()
-  RETURNS bigint
+  RETURNS int
   BEGIN
-    DECLARE counter tinyint DEFAULT 1;
+    DECLARE counter int DEFAULT 1;
     SET counter = 0;
     SET counter = counter + 2;
     SET counter = counter / counter;


### PR DESCRIPTION
## Description

Discovered by @wendigo .. looks like coercion is not supported. Not sure how this statement got into the docs in the first place .. I recall testing them all. This removes the coercion since it doesnt add any value to the example anyway.

Potentially @electrum could add support for coercion as a follow up.

## Additional context and related issues

na

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
