### PR TITLE
Showcase support for reading wildcard tables in Elasticsearch & OpenSearch

### DIFF
--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
@@ -2535,6 +2535,55 @@ public abstract class BaseElasticsearchConnectorTest
         deleteIndex(tableName);
     }
 
+    @Test
+    public void testWildcardTableSameSchema()
+            throws IOException
+    {
+        String suffix = randomNameSuffix();
+        String firstIndex = format("test_wildcard_%s_1", suffix);
+        String secondIndex = format("test_wildcard_%s_2", suffix);
+        String wildcardTable = format("test_wildcard_%s_*", suffix);
+
+        String mappings =
+                """
+                {
+                    "properties": {
+                      "long_column":      { "type": "long" },
+                      "text_column":      { "type": "text" }
+                    }
+                }
+                """;
+
+        createIndex(firstIndex, mappings);
+        index(firstIndex, ImmutableMap.<String, Object>builder()
+                .put("long_column", 1L)
+                .put("text_column", "Trino")
+                .buildOrThrow());
+        createIndex(secondIndex, mappings);
+        index(secondIndex, ImmutableMap.<String, Object>builder()
+                .put("long_column", 2L)
+                .put("text_column", "rocks")
+                .buildOrThrow());
+
+        try {
+            assertThat(query("DESCRIBE \"" + wildcardTable + "\""))
+                    .skippingTypesCheck()
+                    .matches( "VALUES ('long_column', 'bigint', '', ''), ('text_column', 'varchar', '', '')");
+            assertThat(query("SELECT * FROM \"" + wildcardTable + "\""))
+                    .matches("VALUES (BIGINT '1', VARCHAR 'Trino'), (BIGINT '2', VARCHAR 'rocks')");
+
+            // Unsupported operations
+            assertQueryFails("DROP TABLE \"" + wildcardTable + "\"", "This connector does not support dropping tables");
+            assertQueryFails("INSERT INTO \"" + wildcardTable + "\" VALUES (3, 'SQL')", "This connector does not support inserts");
+            assertQueryFails("ALTER TABLE \"" + wildcardTable + "\" ADD COLUMN new_column INT", "This connector does not support adding columns");
+            assertQueryFails("ALTER TABLE \"" + wildcardTable + "\" RENAME TO new_wildcard_table", "This connector does not support renaming tables");
+        }
+        finally {
+            deleteIndex(firstIndex);
+            deleteIndex(secondIndex);
+        }
+    }
+
     protected void assertTableDoesNotExist(String name)
     {
         String catalogName = getSession().getCatalog().orElseThrow();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

This contribution documents in the code that the `trino-elasticsearch` connector supports
querying wildcard tables through the `trino-elasticsearch` connector.

```
SELECT * from elasticsearch."default"."heartbeat-*"
```


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Test was inspired from https://github.com/trinodb/trino/pull/12428 `trino-bigquery` effort.

Querying wildcard tables is a feature supported by ES to allow searching multiple indexes at the same time (a common pattern where people shard their data sets across indexes for retention, etc): https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multiple-indices.html

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
