### PR TITLE
Fix pushdown when no partitionSpec exists and table is partitioned

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -567,7 +567,7 @@ public final class IcebergUtil
                 .collect(toImmutableList());
 
         if (partitionSpecs.isEmpty()) {
-            return false;
+            return canEnforceConstraintWithinPartitioningSpec(typeOperators, table.spec(), columnHandle, domain);
         }
 
         return partitionSpecs.stream().allMatch(spec -> canEnforceConstraintWithinPartitioningSpec(typeOperators, spec, columnHandle, domain));

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -301,6 +301,15 @@ public abstract class BaseIcebergConnectorTest
     }
 
     @Test
+    public void testDeleteOnV1TableWhenManifestFileIsNotExist()
+    {
+        try (TestTable table = newTrinoTable("test_delete_", "(a bigint, dt date) WITH (format_version = 1, partitioning = ARRAY['dt'])")) {
+            assertQuerySucceeds("DELETE FROM " + table.getName() + " WHERE dt = date '2025-02-17'");
+            assertQueryReturnsEmptyResult("SELECT * FROM " + table.getName());
+        }
+    }
+
+    @Test
     @Override
     public void testCharVarcharComparison()
     {
@@ -4122,6 +4131,20 @@ public abstract class BaseIcebergConnectorTest
             assertThat(query("SELECT * FROM " + testTable.getName() + " WHERE a = 10"))
                     .isNotFullyPushedDown(FilterNode.class);
             assertUpdate("INSERT INTO " + testTable.getName() + " VALUES 10", 1);
+            assertThat(query("SELECT * FROM " + testTable.getName() + " WHERE a = 10"))
+                    .isNotFullyPushedDown(FilterNode.class);
+        }
+    }
+
+    @Test
+    public void testPredicateOnDataColumnForPartitionedTableIsNotPushedDown()
+    {
+        try (TestTable testTable = newTrinoTable(
+                "test_predicate_on_data_column_for_partitioned_table_is_not_pushed_down",
+                "(a integer, dt date) WITH (partitioning = ARRAY['dt'])")) {
+            assertThat(query("SELECT * FROM " + testTable.getName() + " WHERE a = 10"))
+                    .isNotFullyPushedDown(FilterNode.class);
+            assertUpdate("INSERT INTO " + testTable.getName() + " VALUES (10, date '2025-02-18')", 1);
             assertThat(query("SELECT * FROM " + testTable.getName() + " WHERE a = 10"))
                     .isNotFullyPushedDown(FilterNode.class);
         }


### PR DESCRIPTION
### Description
After [fix](https://github.com/trinodb/trino/pull/21253) the method `canEnforceColumnConstraintInSpecs` always returns `false` if the table is empty and there is no `partitionSpec`. But if we try to delete from partition table and use partition in filter the method should return the `true`.

### Additional context and related issues
For example, if we runing query
```
delete from iceberg.dev_tmp.test_reading_iceberg where date_year = date '2022-02-15'
```
for the table
```
create table iceberg.dev_tmp.test_reading_iceberg  (
    launch_id	bigint,
	user_id	    bigint,
	badge_id	bigint,
	is_active	boolean,
	date_from	timestamp(6),
	date_to	    timestamp(6),
	date_year	date
)
with (
    format = 'ORC',
    partitioning = ARRAY['date_year'],
    sorted_by = ARRAY['user_id']
);
```
we will have the next plan
```
Trino version: 461
Output[columnNames = [rows]]
│   Layout: [rows:bigint]
│   Estimates: {rows: ? (?), cpu: 0, memory: 0B, network: 0B}
└─ TableCommit[target = iceberg:dev_tmp.test_reading_iceberg$data@8127773692020639562]
   │   Layout: [rows:bigint]
   └─ LocalExchange[partitioning = SINGLE]
      │   Layout: [partialrows:bigint, fragment:varbinary]
      │   Estimates: {rows: ? (?), cpu: 0, memory: 0B, network: 0B}
      └─ RemoteExchange[type = GATHER]
         │   Layout: [partialrows:bigint, fragment:varbinary]
         │   Estimates: {rows: ? (?), cpu: 0, memory: 0B, network: ?}
         └─ MergeWriter[table = iceberg:dev_tmp.test_reading_iceberg$data@8127773692020639562]
            │   Layout: [partialrows:bigint, fragment:varbinary]
            └─ LocalExchange[partitioning = MERGE [insert = HASH, update = iceberg:INSTANCE], arguments = [operation::tinyint, date_year::date, field::row(_file varchar, _pos bigint, partition_spec_id integer, partition_data varchar)]]
               │   Layout: [launch_id:bigint, is_active:boolean, date_from:timestamp(6), date_year:date, operation:tinyint, field:row(_file varchar, _pos bigint, partition_spec_id integer, partition_data varchar), insert_from_update:tinyint]
               │   Estimates: {rows: 0 (0B), cpu: 0, memory: 0B, network: 0B}
               └─ RemoteExchange[type = REPARTITION]
                  │   Layout: [launch_id:bigint, is_active:boolean, date_from:timestamp(6), date_year:date, operation:tinyint, field:row(_file varchar, _pos bigint, partition_spec_id integer, partition_data varchar), insert_from_update:tinyint]
                  │   Estimates: {rows: 0 (0B), cpu: 0, memory: 0B, network: 0B}
                  └─ ScanFilterProject[table = iceberg:dev_tmp.test_reading_iceberg$data@8127773692020639562, filterPredicate = (date_year = date '2022-02-15')]
                         Layout: [launch_id:bigint, is_active:boolean, date_from:timestamp(6), date_year:date, operation:tinyint, field:row(_file varchar, _pos bigint, partition_spec_id integer, partition_data varchar), insert_from_update:tinyint]
                         Estimates: {rows: 0 (0B), cpu: 0, memory: 0B, network: 0B}/{rows: 0 (0B), cpu: 0, memory: 0B, network: 0B}/{rows: 0 (0B), cpu: 0, memory: 0B, network: 0B}
                         launch_id := null::bigint
                         is_active := null::boolean
                         date_from := null::timestamp(6)
                         operation := tinyint '2'
                         insert_from_update := tinyint '0'
                         field := -2147483647:$row_id:row(_file varchar, _pos bigint, partition_spec_id integer, partition_data varchar)
                         date_year := 7:date_year:date
```

but it should be
```
Trino version: 461
Output[columnNames = [rows]]
│   Layout: [rows:bigint]
│   Estimates: {rows: ? (?), cpu: 0, memory: 0B, network: 0B}
└─ TableDelete[target = iceberg:dev_tmp.test_reading_iceberg$data@8950812331090170516 constraint on [date_year]]
       Layout: [rows:bigint]
```

### Release notes
(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
