### PR TITLE
Add Trino 472 release notes

### DIFF
--- a/docs/src/main/sphinx/release.md
+++ b/docs/src/main/sphinx/release.md
@@ -6,6 +6,7 @@
 ```{toctree}
 :maxdepth: 1
 
+release/release-472
 release/release-471
 release/release-470
 release/release-469

--- a/docs/src/main/sphinx/release/release-472.md
+++ b/docs/src/main/sphinx/release/release-472.md
@@ -1,0 +1,60 @@
+# Release 472 (5 Mar 2025)
+
+## General
+
+* Color the server console output for improved readability. ({issue}`25090`)
+* {{breaking}} Rename HTTP client property prefixes from `workerInfo` and
+  `memoryManager` to `worker-info` and `memory-manager`. ({issue}`25099`)
+* Fix failure for queries with large numbers of expressions in the `SELECT` clause. ({issue}`25040`)
+* Improve performance of certain queries involving `ORDER BY ... LIMIT` with subqueries. ({issue}`25138`)
+* Fix incorrect results when passing an array that contains nulls to
+  `cosine_distance` and `cosine_similarity`. ({issue}`25195`)
+* Prevent improper use of `WITH SESSION` with non-`SELECT` queries. ({issue}`25112`)
+
+## JDBC driver
+
+* Provide a `javax.sql.DataSource` implementation. ({issue}`24985`)
+* Fix roles being cleared after invoking `SET SESSION AUTHORIZATION` or 
+  `RESET SESSION AUTHORIZATION`. ({issue}`25191`)
+
+## Docker image
+
+* Improve performance when using Snappy compression. ({issue}`25143`)
+* Fix initialization failure for the DuckDB connector. ({issue}`25143`)
+
+## BigQuery connector
+
+* Improve performance of listing tables when
+  `bigquery.case-insensitive-name-matching` is enabled. ({issue}`25222`)
+
+## Delta Lake connector
+
+* Improve support for highly concurrent table modifications. ({issue}`25141`)
+
+## Faker connector
+
+* Add support for the `row` type and generate empty values for `array`, `map`,
+  and `json` types. ({issue}`25120`)
+
+## Iceberg connector
+
+* Add the `$partition` hidden column. ({issue}`24301`)
+* Fix incorrect results when reading Iceberg tables after deletes were
+  performed. ({issue}`25151`)
+
+## Loki connector
+
+* Fix connection failures with Loki version higher than 3.2.0. ({issue}`25156`)
+
+## PostgreSQL connector
+
+* Improve performance for queries involving cast of
+  [integer types](integer-data-types). ({issue}`24950`)
+
+## SPI
+
+* Remove the deprecated `ConnectorMetadata.addColumn(ConnectorSession session,
+  ConnectorTableHandle tableHandle, ColumnMetadata column)` method. Use the
+  `ConnectorMetadata.addColumn(ConnectorSession session, ConnectorTableHandle
+  tableHandle, ColumnMetadata column, ColumnPosition position)` instead.
+  ({issue}`25163`)


### PR DESCRIPTION
## Description

Assemble the release notes for the upcoming Trino 472 release.

## Additional context and related issues

See https://github.com/trinodb/trino/pulls?q=is%3Apr+is%3Aclosed+milestone%3A472

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

## Verification for each pull request

Format: PR/issue number, ✅ / ❌ rn ✅ / ❌ docs
✅ rn - release note added and verified, or assessed to be not necessary, set to ❌ rn before completion
✅ docs - need for docs assessed and merged, or assessed to be not necessary, set to ❌ docs before completion

## 19 Feb 2025

* #25037 ✅ rn ✅ docs
* #25079 ✅ rn ✅ docs
* #25089 ✅ rn ✅ docs

## 20 Feb 2025

* #25090 ✅ rn ✅ docs
* #24984 ✅ rn ✅ docs
* #25092 ✅ rn ✅ docs
* #25095 ✅ rn ✅ docs
* #25087 ✅ rn ✅ docs
* #25099 ✅ rn ✅ docs

## 21 Feb 2025

* #25104 ✅ rn ✅ docs
* #25084 ✅ rn ✅ docs
* #25112 ✅ rn ✅ docs
* #25108 ✅ rn ✅ docs

## 22 Feb 2025

no PRs merged

## 23 Feb 2025

* #25118 ✅ rn ✅ docs
* #25115 ✅ rn ✅ docs
* #25111 ✅ rn ✅ docs
* #25119 ✅ rn ✅ docs

## 24 Feb 2025

* #25121 ✅ rn ✅ docs
* #25103 ✅ rn ✅ docs

## 25 Feb 2025

* #25131 ✅ rn ✅ docs
* #25040 ✅ rn ✅ docs
* #25133 ✅ rn ✅ docs
* #25134 ✅ rn ✅ docs
* #25137 ✅ rn ✅ docs
* #25143 ✅ rn ✅ docs
* #25098 ✅ rn ✅ docs
* #25147 ✅ rn ✅ docs
* #25150 ✅ rn ✅ docs

## 26 Feb 2025

* #25155 ✅ rn ✅ docs
* #25153 ✅ rn ✅ docs
* #25159 ✅ rn ✅ docs
* #25164 ✅ rn ✅ docs
* #24985 ✅ rn ✅ docs
* #25141 ✅ rn ✅ docs
* #25120 ✅ rn ✅ docs
* #25167 ✅ rn ✅ docs

## 27 Feb 2025

* #25109 ✅ rn ✅ docs
* #25180 ✅ rn ✅ docs
* #25171 ✅ rn ✅ docs
* #25182 ✅ rn ✅ docs
* #25168 ✅ rn ✅ docs
* #25177 ✅ rn ✅ docs
* #25163 ✅ rn ✅ docs
* #25173 ✅ rn ✅ docs

## 28 Feb 2025

* #25094 ✅ rn ✅ docs
* #25189 ✅ rn ✅ docs
* #25190 ✅ rn ✅ docs
* #25139 ✅ rn ✅ docs
* #25186 ✅ rn ✅ docs

## 1 Mar 2025

* #25056 ✅ rn ✅ docs
* #25194 ✅ rn ✅ docs

## 2 Mar 2025

* #25195 ✅ rn ✅ docs
* #25198 ✅ rn ✅ docs

## 3 Mar 2025

* #25197 ✅ rn ✅ docs
* #25191 ✅ rn ✅ docs
* #25175 ✅ rn ❌ docs
* #25196 ✅ rn ✅ docs
* #25144 ✅ rn ✅ docs
* #25172 ✅ rn ✅ docs
* #25210 ✅ rn ✅ docs
* #25212 ✅ rn ✅ docs

## 4 Mar 2025

* #25213 ✅ rn ✅ docs
* #25017 ✅ rn ✅ docs
* #25209 ✅ rn ✅ docs

## 5 Mar 2025

* #25203 ✅ rn ✅ docs
* #25216 ✅ rn ✅ docs
* #24982 ✅ rn ✅ docs
* #25218 ✅ rn ✅ docs 
* #25193 ✅ rn ✅ docs
* #25221 ✅ rn ✅ docs
* #25224 ✅ rn ✅ docs
* #25146 ✅ rn ✅ docs
* #25026 ✅ rn ✅ docs
* #25220 ✅ rn ✅ docs

