### PR TITLE
Fix Hive-to-Iceberg table migration errors caused by special characters.

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/procedure/TestIcebergAddFilesProcedure.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/procedure/TestIcebergAddFilesProcedure.java
@@ -265,6 +265,22 @@ final class TestIcebergAddFilesProcedure
     }
 
     @Test
+    void testAddFilesSpecialCharPartitionColumnDefinitions()
+    {
+        String hiveTableName = "test_add_files_" + randomNameSuffix();
+        String icebergTableName = "test_add_files_" + randomNameSuffix();
+
+        assertUpdate("CREATE TABLE hive.tpch." + hiveTableName + " WITH (partitioned_by = ARRAY['special@col']) AS SELECT 1 x, 10 \"special@col\"", 1);
+        assertUpdate("CREATE TABLE iceberg.tpch." + icebergTableName + " WITH (partitioning = ARRAY['\"special@col\"']) AS SELECT 2 x, 20 \"special@col\"", 1);
+
+        assertUpdate("ALTER TABLE " + icebergTableName + " EXECUTE add_files_from_table('tpch', '" + hiveTableName + "', map(ARRAY['special@col'], ARRAY['10']))");
+        assertQuery("SELECT * FROM iceberg.tpch." + icebergTableName, "VALUES (1, 10), (2, 20)");
+
+        assertUpdate("DROP TABLE hive.tpch." + hiveTableName);
+        assertUpdate("DROP TABLE iceberg.tpch." + icebergTableName);
+    }
+
+    @Test
     void testAddFilesFromNonPartitionTable()
     {
         String hiveTableName = "test_add_files_" + randomNameSuffix();


### PR DESCRIPTION
## Description

This PR fixes a bug where `iceberg.system.migrate` fails when a Hive table's partition key contains special characters (e.g., `@`). The failure happens because the migration process incorrectly applies Iceberg’s partition parsing rules to Hive tables, leading to an `Invalid partition field declaration` error.

## Error Example:

When running:
```sql
CREATE TABLE hive.tpch.test_migrate_partitioned_table
WITH (partitioned_by = ARRAY['special@col'])
AS SELECT 1 AS id, 'special1' AS "special@col";

CALL iceberg.system.migrate('tpch', 'test_migrate_partitioned_table')
```

If the Hive table has a partition key with special characters, the migration fails with:
```sql
io.trino.spi.TrinoException: Unable to parse partitioning value: Invalid partition field declaration: special@col
```

## Release notes

```md
## Iceberg connector

* Fix failure when executing `migrate` procedure on tables partitioned by special character names. ({issue}`25228`)
```