### PR TITLE
Add physical data scan tracking to resource groups

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/resourcegroups/ResourceUsage.java
+++ b/core/trino-main/src/main/java/io/trino/execution/resourcegroups/ResourceUsage.java
@@ -25,25 +25,29 @@ final class ResourceUsage
 {
     private final long cpuUsageMillis;
     private final long memoryUsageBytes;
+    private final long physicalInputDataUsageBytes;
 
-    public ResourceUsage(long cpuUsageMillis, long memoryUsageBytes)
+    public ResourceUsage(long cpuUsageMillis, long memoryUsageBytes, long physicalInputDataUsageBytes)
     {
         this.cpuUsageMillis = cpuUsageMillis;
         this.memoryUsageBytes = memoryUsageBytes;
+        this.physicalInputDataUsageBytes = physicalInputDataUsageBytes;
     }
 
     public ResourceUsage add(ResourceUsage other)
     {
         long newCpuUsageMillis = saturatedAdd(this.cpuUsageMillis, other.cpuUsageMillis);
         long newMemoryUsageBytes = saturatedAdd(this.memoryUsageBytes, other.memoryUsageBytes);
-        return new ResourceUsage(newCpuUsageMillis, newMemoryUsageBytes);
+        long newPhysicalInputDataUsageBytes = saturatedAdd(this.physicalInputDataUsageBytes, other.physicalInputDataUsageBytes);
+        return new ResourceUsage(newCpuUsageMillis, newMemoryUsageBytes, newPhysicalInputDataUsageBytes);
     }
 
     public ResourceUsage subtract(ResourceUsage other)
     {
         long newCpuUsageMillis = saturatedSubtract(this.cpuUsageMillis, other.cpuUsageMillis);
         long newMemoryUsageBytes = saturatedSubtract(this.memoryUsageBytes, other.memoryUsageBytes);
-        return new ResourceUsage(newCpuUsageMillis, newMemoryUsageBytes);
+        long newPhysicalInputDataUsageBytes = saturatedSubtract(this.physicalInputDataUsageBytes, other.physicalInputDataUsageBytes);
+        return new ResourceUsage(newCpuUsageMillis, newMemoryUsageBytes, newPhysicalInputDataUsageBytes);
     }
 
     public long getCpuUsageMillis()
@@ -54,6 +58,11 @@ final class ResourceUsage
     public long getMemoryUsageBytes()
     {
         return memoryUsageBytes;
+    }
+
+    public long getPhysicalInputDataUsageBytes()
+    {
+        return physicalInputDataUsageBytes;
     }
 
     @Override
@@ -68,12 +77,13 @@ final class ResourceUsage
 
         ResourceUsage otherUsage = (ResourceUsage) other;
         return cpuUsageMillis == otherUsage.cpuUsageMillis
-                && memoryUsageBytes == otherUsage.memoryUsageBytes;
+                && memoryUsageBytes == otherUsage.memoryUsageBytes
+                && physicalInputDataUsageBytes == otherUsage.physicalInputDataUsageBytes;
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(cpuUsageMillis, memoryUsageBytes);
+        return Objects.hash(cpuUsageMillis, memoryUsageBytes, physicalInputDataUsageBytes);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/ResourceGroupInfo.java
+++ b/core/trino-main/src/main/java/io/trino/server/ResourceGroupInfo.java
@@ -37,9 +37,11 @@ public record ResourceGroupInfo(
         DataSize softMemoryLimit,
         int softConcurrencyLimit,
         int hardConcurrencyLimit,
+        DataSize hardPhysicalDataScanLimit,
         int maxQueuedQueries,
         DataSize memoryUsage,
         Duration cpuUsage,
+        DataSize physicalInputDataUsage,
         int numQueuedQueries,
         int numRunningQueries,
         int numEligibleSubGroups,
@@ -54,7 +56,8 @@ public record ResourceGroupInfo(
         requireNonNull(softMemoryLimit, "softMemoryLimit is null");
         requireNonNull(memoryUsage, "memoryUsage is null");
         requireNonNull(cpuUsage, "cpuUsage is null");
-
+        requireNonNull(hardPhysicalDataScanLimit, "hardPhysicalDataScanLimit is null");
+        requireNonNull(physicalInputDataUsage, "physicalInputDataUsage is null");
         subGroups = subGroups.map(ImmutableList::copyOf);
         runningQueries = runningQueries.map(ImmutableList::copyOf);
     }

--- a/core/trino-main/src/test/java/io/trino/execution/MockManagedQueryExecution.java
+++ b/core/trino-main/src/test/java/io/trino/execution/MockManagedQueryExecution.java
@@ -54,10 +54,11 @@ public class MockManagedQueryExecution
 
     private DataSize memoryUsage;
     private Duration cpuUsage;
+    private DataSize physicalInputDataUsage;
     private QueryState state = QUEUED;
     private Throwable failureCause;
 
-    private MockManagedQueryExecution(String queryId, int priority, DataSize memoryUsage, Duration cpuUsage)
+    private MockManagedQueryExecution(String queryId, int priority, DataSize memoryUsage, Duration cpuUsage, DataSize physicalInputDataUsage)
     {
         requireNonNull(queryId, "queryId is null");
         this.session = testSessionBuilder()
@@ -67,6 +68,7 @@ public class MockManagedQueryExecution
 
         this.memoryUsage = requireNonNull(memoryUsage, "memoryUsage is null");
         this.cpuUsage = requireNonNull(cpuUsage, "cpuUsage is null");
+        this.physicalInputDataUsage = requireNonNull(physicalInputDataUsage, "physicalInputDataUsage is null");
     }
 
     public void consumeCpuTimeMillis(long cpuTimeDeltaMillis)
@@ -80,6 +82,13 @@ public class MockManagedQueryExecution
     {
         checkState(state == RUNNING, "cannot set memory usage in a non-running state");
         this.memoryUsage = memoryUsage;
+    }
+
+    public void consumePhysicalInputDataBytes(long physicalInputDataBytes)
+    {
+        checkState(state == RUNNING, "cannot set physical input data usage in a non-running state");
+        long newDataScan = physicalInputDataUsage.toBytes() + physicalInputDataBytes;
+        this.physicalInputDataUsage = DataSize.ofBytes(newDataScan);
     }
 
     public void complete()
@@ -134,7 +143,7 @@ public class MockManagedQueryExecution
                         DataSize.ofBytes(14),
                         15,
                         DataSize.ofBytes(13),
-                        DataSize.ofBytes(13),
+                        physicalInputDataUsage,
                         DataSize.ofBytes(13),
                         DataSize.ofBytes(13),
                         16.0,
@@ -225,7 +234,7 @@ public class MockManagedQueryExecution
                         false,
                         ImmutableSet.of(),
 
-                        DataSize.ofBytes(241),
+                        physicalInputDataUsage,
                         DataSize.ofBytes(0),
                         251,
                         0,
@@ -358,6 +367,7 @@ public class MockManagedQueryExecution
     {
         private DataSize memoryUsage = DataSize.ofBytes(0);
         private Duration cpuUsage = new Duration(0, MILLISECONDS);
+        private DataSize physicalInputDataUsage = DataSize.ofBytes(0);
         private int priority = 1;
         private String queryId = "query_id";
 
@@ -375,6 +385,12 @@ public class MockManagedQueryExecution
             return this;
         }
 
+        public MockManagedQueryExecutionBuilder withInitialPhysicalInputDataUsage(long physicalInputDataUsageBytes)
+        {
+            this.physicalInputDataUsage = DataSize.ofBytes(physicalInputDataUsageBytes);
+            return this;
+        }
+
         public MockManagedQueryExecutionBuilder withPriority(int priority)
         {
             this.priority = priority;
@@ -389,7 +405,7 @@ public class MockManagedQueryExecution
 
         public MockManagedQueryExecution build()
         {
-            return new MockManagedQueryExecution(queryId, priority, memoryUsage, cpuUsage);
+            return new MockManagedQueryExecution(queryId, priority, memoryUsage, cpuUsage, physicalInputDataUsage);
         }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/resourcegroups/TestResourceGroups.java
+++ b/core/trino-main/src/test/java/io/trino/execution/resourcegroups/TestResourceGroups.java
@@ -296,7 +296,7 @@ public class TestResourceGroups
         assertThat(query2.getState()).isEqualTo(RUNNING);
         assertThat(query3.getState()).isEqualTo(QUEUED);
 
-        root.generateCpuQuota(2);
+        root.generateQuotas(2);
         root.updateGroupsAndProcessQueuedQueries();
         assertThat(query2.getState()).isEqualTo(RUNNING);
         assertThat(query3.getState()).isEqualTo(RUNNING);
@@ -329,9 +329,39 @@ public class TestResourceGroups
         root.updateGroupsAndProcessQueuedQueries();
         assertThat(query2.getState()).isEqualTo(QUEUED);
 
-        root.generateCpuQuota(2);
+        root.generateQuotas(2);
         root.updateGroupsAndProcessQueuedQueries();
         assertThat(query2.getState()).isEqualTo(RUNNING);
+    }
+
+    @Test
+    @Timeout(10)
+    public void testPhysicalDataScanLimit()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        root.setMaxQueuedQueries(4);
+        root.setHardConcurrencyLimit(3);
+        root.setHardPhysicalDataScanLimitBytes(1);
+        root.setPhysicalDataScanQuotaGenerationBytesPerSecond(1);
+
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder().withInitialPhysicalInputDataUsage(3).build();
+        root.run(query1);
+        assertThat(query1.getState()).isEqualTo(RUNNING);
+        root.updateGroupsAndProcessQueuedQueries();
+
+        MockManagedQueryExecution query2 = new MockManagedQueryExecutionBuilder().build();
+        root.run(query2);
+        assertThat(query2.getState()).isEqualTo(QUEUED);
+
+        MockManagedQueryExecution query3 = new MockManagedQueryExecutionBuilder().build();
+        root.run(query3);
+        assertThat(query3.getState()).isEqualTo(QUEUED);
+
+        query1.complete();
+        root.generateQuotas(3);
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(query2.getState()).isEqualTo(RUNNING);
+        assertThat(query3.getState()).isEqualTo(RUNNING);
     }
 
     /**
@@ -367,7 +397,7 @@ public class TestResourceGroups
         assertThat(q2.getState()).isEqualTo(QUEUED);
 
         // Generating CPU quota before the query finishes. This assertion verifies CPU update during quota generation.
-        root.generateCpuQuota(2);
+        root.generateQuotas(2);
         Stream.of(root, child).forEach(group -> assertWithinCpuLimit(group, 2));
 
         // An incoming query starts running right away.
@@ -412,7 +442,7 @@ public class TestResourceGroups
         child.run(q2);
         assertThat(q2.getState()).isEqualTo(QUEUED);
 
-        root.generateCpuQuota(2);
+        root.generateQuotas(2);
         Stream.of(root, child).forEach(group -> assertWithinCpuLimit(group, 2));
         assertThat(q2.getState()).isEqualTo(QUEUED);
 
@@ -634,6 +664,163 @@ public class TestResourceGroups
         assertThat(q2.getState()).isEqualTo(RUNNING);
     }
 
+    @Test
+    @Timeout(10)
+    public void testPhysicalInputDataUsageUpdateForRunningQuery()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        InternalResourceGroup child = root.getOrCreateSubGroup("child");
+
+        Stream.of(root, child).forEach(group -> {
+            group.setHardConcurrencyLimit(100);
+            group.setMaxQueuedQueries(100);
+            group.setHardPhysicalDataScanLimitBytes(5);
+            group.setPhysicalDataScanQuotaGenerationBytesPerSecond(1);
+        });
+
+        MockManagedQueryExecution q1 = new MockManagedQueryExecutionBuilder().build();
+        child.run(q1);
+        assertThat(q1.getState()).isEqualTo(RUNNING);
+        q1.consumePhysicalInputDataBytes(6);
+
+        Stream.of(root, child).forEach(group -> assertWithinPhysicalDataScanLimit(group, 0));
+        root.updateGroupsAndProcessQueuedQueries();
+        Stream.of(root, child).forEach(group -> assertExceedsPhysicalDataScanLimit(group, 6));
+
+        // A new query gets queued since the current usage exceeds the limit.
+        MockManagedQueryExecution q2 = new MockManagedQueryExecutionBuilder().build();
+        child.run(q2);
+        assertThat(q2.getState()).isEqualTo(QUEUED);
+
+        // Generating data scan quota before the query finishes. This assertion verifies data scan update during quota generation.
+        root.generateQuotas(2);
+        Stream.of(root, child).forEach(group -> assertWithinPhysicalDataScanLimit(group, 4));
+
+        // A new incoming query q3 starts running right away.
+        MockManagedQueryExecution q3 = new MockManagedQueryExecutionBuilder().build();
+        child.run(q3);
+        assertThat(q3.getState()).isEqualTo(RUNNING);
+
+        // A queued query starts running only after invoking `updateGroupsAndProcessQueuedQueries`.
+        assertThat(q2.getState()).isEqualTo(QUEUED);
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(q2.getState()).isEqualTo(RUNNING);
+    }
+
+    @Test
+    @Timeout(10)
+    public void testPhysicalInputDataUsageUpdateAtQueryCompletion()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        InternalResourceGroup child = root.getOrCreateSubGroup("child");
+
+        Stream.of(root, child).forEach(group -> {
+            group.setHardConcurrencyLimit(100);
+            group.setMaxQueuedQueries(100);
+            group.setHardPhysicalDataScanLimitBytes(3);
+            group.setPhysicalDataScanQuotaGenerationBytesPerSecond(1);
+        });
+
+        MockManagedQueryExecution q1 = new MockManagedQueryExecutionBuilder().build();
+        child.run(q1);
+        assertThat(q1.getState()).isEqualTo(RUNNING);
+
+        q1.consumePhysicalInputDataBytes(4);
+        q1.complete();
+
+        // q1 is removed from runningQueries and usage is cached at this point.
+        Stream.of(root, child).forEach(group -> assertExceedsPhysicalDataScanLimit(group, 4));
+
+        // q2 gets queued since cached usage exceeds the limit.
+        MockManagedQueryExecution q2 = new MockManagedQueryExecutionBuilder().build();
+        child.run(q2);
+        assertThat(q2.getState()).isEqualTo(QUEUED);
+
+        root.generateQuotas(2);
+        Stream.of(root, child).forEach(group -> assertWithinPhysicalDataScanLimit(group, 2));
+        assertThat(q2.getState()).isEqualTo(QUEUED);
+
+        // q2 should run after groups are updated. Data scan usage should not be double counted.
+        root.updateGroupsAndProcessQueuedQueries();
+        Stream.of(root, child).forEach(group -> assertWithinPhysicalDataScanLimit(group, 2));
+        assertThat(q2.getState()).isEqualTo(RUNNING);
+    }
+
+    @Test
+    @Timeout(10)
+    public void testPhysicalInputDataUsageUpdateWhenParentGroupHasRunningQueries()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (_, _) -> {}, directExecutor());
+        root.setHardConcurrencyLimit(100);
+        root.setMaxQueuedQueries(100);
+        root.setHardPhysicalDataScanLimitBytes(3);
+        root.setPhysicalDataScanQuotaGenerationBytesPerSecond(1);
+
+        MockManagedQueryExecution q1 = new MockManagedQueryExecutionBuilder().build();
+        root.run(q1);
+        assertThat(q1.getState()).isEqualTo(RUNNING);
+        q1.consumePhysicalInputDataBytes(2);
+
+        InternalResourceGroup child = root.getOrCreateSubGroup("child");
+        child.setHardConcurrencyLimit(100);
+        child.setMaxQueuedQueries(100);
+        child.setHardPhysicalDataScanLimitBytes(3);
+        child.setPhysicalDataScanQuotaGenerationBytesPerSecond(1);
+
+        MockManagedQueryExecution q2 = new MockManagedQueryExecutionBuilder().build();
+        child.run(q2);
+        assertThat(q2.getState()).isEqualTo(RUNNING);
+        q2.consumePhysicalInputDataBytes(2);
+
+        root.updateGroupsAndProcessQueuedQueries();
+        assertExceedsPhysicalDataScanLimit(root, 4);
+        assertWithinPhysicalDataScanLimit(child, 2);
+
+        // q3 gets queued even though child is within data scan limit because root exceeds
+        MockManagedQueryExecution q3 = new MockManagedQueryExecutionBuilder().build();
+        child.run(q3);
+        assertThat(q3.getState()).isEqualTo(QUEUED);
+    }
+
+    @Test
+    @Timeout(10)
+    public void testPhysicalInputDataUsageUpdateForDisabledGroup()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (_, _) -> {}, directExecutor());
+        InternalResourceGroup child = root.getOrCreateSubGroup("child");
+
+        Stream.of(root, child).forEach(group -> {
+            group.setHardConcurrencyLimit(100);
+            group.setMaxQueuedQueries(100);
+            group.setHardPhysicalDataScanLimitBytes(3);
+            group.setPhysicalDataScanQuotaGenerationBytesPerSecond(1);
+        });
+
+        MockManagedQueryExecution q1 = new MockManagedQueryExecutionBuilder().build();
+        child.run(q1);
+        assertThat(q1.getState()).isEqualTo(RUNNING);
+        q1.consumePhysicalInputDataBytes(2);
+
+        Stream.of(root, child).forEach(group -> assertWithinPhysicalDataScanLimit(group, 0));
+        root.updateGroupsAndProcessQueuedQueries();
+        Stream.of(root, child).forEach(group -> assertWithinPhysicalDataScanLimit(group, 2));
+
+        child.setDisabled(true);
+
+        MockManagedQueryExecution q2 = new MockManagedQueryExecutionBuilder().build();
+        root.run(q2);
+        assertThat(q2.getState()).isEqualTo(RUNNING);
+        q2.consumePhysicalInputDataBytes(2);
+
+        root.updateGroupsAndProcessQueuedQueries();
+        assertWithinPhysicalDataScanLimit(child, 2);
+        assertExceedsPhysicalDataScanLimit(root, 4);
+
+        MockManagedQueryExecution q3 = new MockManagedQueryExecutionBuilder().build();
+        root.run(q3);
+        assertThat(q3.getState()).isEqualTo(QUEUED);
+    }
+
     /**
      * A test for correct CPU usage update aggregation and propagation in non-leaf nodes. It uses in a multi
      * level resource group tree, with non-leaf resource groups having more than one child.
@@ -699,7 +886,7 @@ public class TestResourceGroups
         assertThat(q5.getState()).isEqualTo(QUEUED);
 
         // Assert CPU usage update after quota regeneration
-        root.generateCpuQuota(4);
+        root.generateQuotas(4);
         assertWithinCpuLimit(root, 14);
         assertExceedsCpuLimit(rootChild1, 10);
         assertWithinCpuLimit(rootChild2, 0);
@@ -727,7 +914,7 @@ public class TestResourceGroups
         assertThat(q6.getState()).isEqualTo(QUEUED);
 
         // Assert usage after regeneration
-        root.generateCpuQuota(6);
+        root.generateQuotas(6);
         assertWithinCpuLimit(root, 11);
         assertExceedsCpuLimit(rootChild1, 7);
         assertWithinCpuLimit(rootChild2, 0);
@@ -742,7 +929,7 @@ public class TestResourceGroups
         assertThat(q6.getState()).isEqualTo(RUNNING);
 
         // q5 starts running after rootChild1's usage comes within the limit
-        root.generateCpuQuota(2);
+        root.generateQuotas(2);
         assertWithinCpuLimit(rootChild1, 5);
         root.updateGroupsAndProcessQueuedQueries();
         assertThat(q5.getState()).isEqualTo(RUNNING);
@@ -840,6 +1027,118 @@ public class TestResourceGroups
 
         // queued queries will start running after the update
         assertThat(q5.getState()).isEqualTo(QUEUED);
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(q5.getState()).isEqualTo(RUNNING);
+    }
+
+    /**
+     * A test for correct physical input data usage update aggregation and propagation in non-leaf nodes. It uses in a multi
+     * level resource group tree, with non-leaf resource groups having more than one child.
+     */
+    @Test
+    @Timeout(10)
+    public void testPhysicalInputDataUsageUpdateRecursively()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        InternalResourceGroup rootChild1 = root.getOrCreateSubGroup("rootChild1");
+        InternalResourceGroup rootChild2 = root.getOrCreateSubGroup("rootChild2");
+        InternalResourceGroup rootChild1Child1 = rootChild1.getOrCreateSubGroup("rootChild1Child1");
+        InternalResourceGroup rootChild1Child2 = rootChild1.getOrCreateSubGroup("rootChild1Child2");
+
+        // Set the same values in all the groups for some configurations
+        Stream.of(root, rootChild1, rootChild2, rootChild1Child1, rootChild1Child2).forEach(group -> {
+            group.setHardConcurrencyLimit(100);
+            group.setMaxQueuedQueries(100);
+            group.setPhysicalDataScanQuotaGenerationBytesPerSecond(1);
+        });
+
+        root.setHardPhysicalDataScanLimitBytes(12);
+        rootChild1.setHardPhysicalDataScanLimitBytes(4);
+
+        // Setting a higher limit for leaf nodes to make sure they are always in the limit
+        rootChild2.setHardPhysicalDataScanLimitBytes(100);
+        rootChild1Child1.setHardPhysicalDataScanLimitBytes(100);
+        rootChild1Child2.setHardPhysicalDataScanLimitBytes(100);
+
+        MockManagedQueryExecution q1 = new MockManagedQueryExecutionBuilder().build();
+        MockManagedQueryExecution q2 = new MockManagedQueryExecutionBuilder().build();
+        MockManagedQueryExecution q3 = new MockManagedQueryExecutionBuilder().build();
+
+        rootChild1Child1.run(q1);
+        rootChild1Child2.run(q2);
+        rootChild2.run(q3);
+
+        assertThat(q1.getState()).isEqualTo(RUNNING);
+        assertThat(q2.getState()).isEqualTo(RUNNING);
+        assertThat(q3.getState()).isEqualTo(RUNNING);
+
+        q1.consumePhysicalInputDataBytes(4);
+        q2.consumePhysicalInputDataBytes(5);
+        q3.consumePhysicalInputDataBytes(6);
+
+        // The cached memory usage gets updated for the tree
+        root.updateGroupsAndProcessQueuedQueries();
+        assertExceedsPhysicalDataScanLimit(root, 15);
+        assertExceedsPhysicalDataScanLimit(rootChild1, 9);
+        assertWithinPhysicalDataScanLimit(rootChild2, 6);
+        assertWithinPhysicalDataScanLimit(rootChild1Child1, 4);
+        assertWithinPhysicalDataScanLimit(rootChild1Child2, 5);
+
+        // q4 submitted in rootChild2 gets queued because root's data scan usage exceeds the limit
+        MockManagedQueryExecution q4 = new MockManagedQueryExecutionBuilder().build();
+        rootChild2.run(q4);
+        assertThat(q4.getState()).isEqualTo(QUEUED);
+
+        // q5 submitted in rootChild1Child1 gets queued because root's data scan usage exceeds the limit
+        MockManagedQueryExecution q5 = new MockManagedQueryExecutionBuilder().build();
+        rootChild1Child1.run(q5);
+        assertThat(q5.getState()).isEqualTo(QUEUED);
+
+        // Assert data scan usage update after quota regeneration
+        root.generateQuotas(4);
+        assertWithinPhysicalDataScanLimit(root, 11);
+        assertExceedsPhysicalDataScanLimit(rootChild1, 5);
+        assertWithinPhysicalDataScanLimit(rootChild2, 2);
+        assertWithinPhysicalDataScanLimit(rootChild1Child1, 0);
+        assertWithinPhysicalDataScanLimit(rootChild1Child2, 1);
+
+        root.updateGroupsAndProcessQueuedQueries();
+
+        // q4 starts running since usage in root and rootChild2 is within the limits
+        assertThat(q4.getState()).isEqualTo(RUNNING);
+        // q5 is still queued since usage in rootChild1 exceeds the limit.
+        assertThat(q5.getState()).isEqualTo(QUEUED);
+
+        // Query completion updates cached CPU usage of root, rootChild1 and rootChild1Child2.
+        q2.consumePhysicalInputDataBytes(3);
+        q2.complete();
+        assertExceedsPhysicalDataScanLimit(root, 14);
+        assertExceedsPhysicalDataScanLimit(rootChild1, 8);
+        assertWithinPhysicalDataScanLimit(rootChild1Child2, 4);
+
+        // q6 in rootChild2 gets queued because root's CPU usage exceeds the limit.
+        MockManagedQueryExecution q6 = new MockManagedQueryExecutionBuilder().build();
+        rootChild2.run(q6);
+        assertThat(q6.getState()).isEqualTo(QUEUED);
+
+        // Assert usage after regeneration
+        root.generateQuotas(3);
+        assertWithinPhysicalDataScanLimit(root, 11);
+        assertExceedsPhysicalDataScanLimit(rootChild1, 5);
+        assertWithinPhysicalDataScanLimit(rootChild2, 0);
+        assertWithinPhysicalDataScanLimit(rootChild1Child1, 0);
+        assertWithinPhysicalDataScanLimit(rootChild1Child2, 1);
+
+        root.updateGroupsAndProcessQueuedQueries();
+
+        // q5 is queued, because rootChild1's usage still exceeds the limit.
+        assertThat(q5.getState()).isEqualTo(QUEUED);
+        // q6 starts running, because usage in rootChild2 and root are within their limits.
+        assertThat(q6.getState()).isEqualTo(RUNNING);
+
+        // q5 starts running after rootChild1's usage comes within the limit
+        root.generateQuotas(2);
+        assertWithinPhysicalDataScanLimit(rootChild1, 3);
         root.updateGroupsAndProcessQueuedQueries();
         assertThat(q5.getState()).isEqualTo(RUNNING);
     }
@@ -1261,6 +1560,7 @@ public class TestResourceGroups
         assertThat(rootInfo.softMemoryLimit().toBytes()).isEqualTo(root.getSoftMemoryLimitBytes());
         assertThat(rootInfo.memoryUsage()).isEqualTo(DataSize.ofBytes(0));
         assertThat(rootInfo.cpuUsage().toMillis()).isEqualTo(0);
+        assertThat(rootInfo.physicalInputDataUsage()).isEqualTo(DataSize.ofBytes(0));
         List<ResourceGroupInfo> subGroups = rootInfo.subGroups().get();
         assertThat(subGroups).hasSize(2);
         assertGroupInfoEquals(subGroups.get(0), rootA.getInfo());
@@ -1268,6 +1568,7 @@ public class TestResourceGroups
         assertThat(subGroups.get(0).state()).isEqualTo(CAN_QUEUE);
         assertThat(subGroups.get(0).softMemoryLimit().toBytes()).isEqualTo(rootA.getSoftMemoryLimitBytes());
         assertThat(subGroups.get(0).hardConcurrencyLimit()).isEqualTo(rootA.getHardConcurrencyLimit());
+        assertThat(subGroups.get(0).hardPhysicalDataScanLimit().toBytes()).isEqualTo(rootA.getHardPhysicalDataScanLimitBytes());
         assertThat(subGroups.get(0).maxQueuedQueries()).isEqualTo(rootA.getMaxQueuedQueries());
         assertThat(subGroups.get(0).numEligibleSubGroups()).isEqualTo(2);
         assertThat(subGroups.get(0).numRunningQueries()).isEqualTo(0);
@@ -1277,6 +1578,7 @@ public class TestResourceGroups
         assertThat(subGroups.get(1).state()).isEqualTo(CAN_QUEUE);
         assertThat(subGroups.get(1).softMemoryLimit().toBytes()).isEqualTo(rootB.getSoftMemoryLimitBytes());
         assertThat(subGroups.get(1).hardConcurrencyLimit()).isEqualTo(rootB.getHardConcurrencyLimit());
+        assertThat(subGroups.get(1).hardPhysicalDataScanLimit().toBytes()).isEqualTo(rootB.getHardPhysicalDataScanLimitBytes());
         assertThat(subGroups.get(1).maxQueuedQueries()).isEqualTo(rootB.getMaxQueuedQueries());
         assertThat(subGroups.get(1).numEligibleSubGroups()).isEqualTo(0);
         assertThat(subGroups.get(1).numRunningQueries()).isEqualTo(1);
@@ -1610,7 +1912,9 @@ public class TestResourceGroups
                 actual.schedulingPolicy() == expected.schedulingPolicy() &&
                 Objects.equals(actual.softMemoryLimit(), expected.softMemoryLimit()) &&
                 Objects.equals(actual.memoryUsage(), expected.memoryUsage()) &&
-                Objects.equals(actual.cpuUsage(), expected.cpuUsage())).isTrue();
+                Objects.equals(actual.cpuUsage(), expected.cpuUsage()) &&
+                Objects.equals(actual.hardPhysicalDataScanLimit(), expected.hardPhysicalDataScanLimit()) &&
+                Objects.equals(actual.physicalInputDataUsage(), expected.physicalInputDataUsage())).isTrue();
     }
 
     private static void assertExceedsCpuLimit(InternalResourceGroup group, long expectedMillis)
@@ -1643,5 +1947,21 @@ public class TestResourceGroups
         assertThat(actualBytes).isEqualTo(expectedBytes);
         assertThat(actualBytes).isLessThanOrEqualTo(group.getSoftMemoryLimitBytes());
         assertThat(group.getMemoryUsageBytes()).isEqualTo(expectedBytes);
+    }
+
+    private static void assertExceedsPhysicalDataScanLimit(InternalResourceGroup group, long expectedBytes)
+    {
+        long actualBytes = group.getResourceUsageSnapshot().getPhysicalInputDataUsageBytes();
+        assertThat(actualBytes).isEqualTo(expectedBytes);
+        assertThat(actualBytes).isGreaterThan(group.getHardPhysicalDataScanLimitBytes());
+        assertThat(group.getPhysicalInputDataUsageBytes()).isEqualTo(expectedBytes);
+    }
+
+    private static void assertWithinPhysicalDataScanLimit(InternalResourceGroup group, long expectedBytes)
+    {
+        long actualBytes = group.getResourceUsageSnapshot().getPhysicalInputDataUsageBytes();
+        assertThat(actualBytes).isEqualTo(expectedBytes);
+        assertThat(actualBytes).isLessThanOrEqualTo(group.getHardPhysicalDataScanLimitBytes());
+        assertThat(group.getPhysicalInputDataUsageBytes()).isEqualTo(expectedBytes);
     }
 }

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -680,6 +680,30 @@
                                     <old>method io.trino.spi.Page io.trino.spi.connector.RecordPageSource::getNextPage()</old>
                                     <justification>Deprecated</justification>
                                 </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.addedToInterface</code>
+                                    <new>method long io.trino.spi.resourcegroups.ResourceGroup::getHardPhysicalDataScanLimitBytes()</new>
+                                    <justification>Add physical data scan tracking to resource groups</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.addedToInterface</code>
+                                    <new>method void io.trino.spi.resourcegroups.ResourceGroup::setHardPhysicalDataScanLimitBytes(long)</new>
+                                    <justification>Add physical data scan tracking to resource groups</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.addedToInterface</code>
+                                    <new>method long io.trino.spi.resourcegroups.ResourceGroup::getPhysicalDataScanQuotaGenerationBytesPerSecond()</new>
+                                    <justification>Add physical data scan tracking to resource groups</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.addedToInterface</code>
+                                    <new>method void io.trino.spi.resourcegroups.ResourceGroup::setPhysicalDataScanQuotaGenerationBytesPerSecond(long)</new>
+                                    <justification>Add physical data scan tracking to resource groups</justification>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/resourcegroups/ResourceGroup.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/resourcegroups/ResourceGroup.java
@@ -49,6 +49,21 @@ public interface ResourceGroup
      */
     void setCpuQuotaGenerationMillisPerSecond(long rate);
 
+    long getHardPhysicalDataScanLimitBytes();
+
+    /**
+     * Threshold on total physical data scan usage after which new queries
+     * will queue instead of starting.
+     */
+    void setHardPhysicalDataScanLimitBytes(long limit);
+
+    long getPhysicalDataScanQuotaGenerationBytesPerSecond();
+
+    /**
+     * Rate at which physical data scan quota regenerates.
+     */
+    void setPhysicalDataScanQuotaGenerationBytesPerSecond(long rate);
+
     int getSoftConcurrencyLimit();
 
     /**

--- a/docs/src/main/sphinx/admin/resource-groups-example.json
+++ b/docs/src/main/sphinx/admin/resource-groups-example.json
@@ -3,6 +3,7 @@
     {
       "name": "global",
       "softMemoryLimit": "80%",
+      "hardPhysicalDataScanLimit": "50TB",
       "hardConcurrencyLimit": 100,
       "maxQueued": 1000,
       "schedulingPolicy": "weighted",
@@ -34,7 +35,8 @@
                   "name": "${USER}",
                   "softMemoryLimit": "10%",
                   "hardConcurrencyLimit": 1,
-                  "maxQueued": 100
+                  "maxQueued": 100,
+                  "hardPhysicalDataScanLimit": "10GB"
                 }
               ]
             },
@@ -118,5 +120,6 @@
       "group": "global.adhoc.other.${USER}"
     }
   ],
-  "cpuQuotaPeriod": "1h"
+  "cpuQuotaPeriod": "1h",
+  "physicalDataScanQuotaPeriod": "1h"
 }

--- a/docs/src/main/sphinx/admin/resource-groups.md
+++ b/docs/src/main/sphinx/admin/resource-groups.md
@@ -113,6 +113,9 @@ are reflected automatically for incoming queries.
 - `hardCpuLimit` (optional): maximum amount of CPU time this
   group may use in a period.
 
+- `hardPhysicalDataScanLimit` (optional): maximum amount of data this
+  group can scan in a period before new queries become queued. Must be specified as an absolute value (i.e. `1GB`).
+
 - `schedulingPolicy` (optional): specifies how queued queries are selected to run,
   and how sub-groups become eligible to start their queries. May be one of three values:
 
@@ -213,6 +216,7 @@ Selectors are processed sequentially and the first one that matches will be used
 ## Global properties
 
 - `cpuQuotaPeriod` (optional): the period in which cpu quotas are enforced.
+- `physicalDataScanQuotaPeriod` (optional): the period in which physical data scan quotas are enforced.
 
 ## Providing selector properties
 
@@ -305,7 +309,7 @@ INSERT INTO resource_groups_global_properties (name, value) VALUES ('cpu_quota_p
 -- The parent-child relationship is indicated by the ID in 'parent' column.
 
 -- create a root group 'global' with NULL parent
-INSERT INTO resource_groups (name, soft_memory_limit, hard_concurrency_limit, max_queued, scheduling_policy, jmx_export, environment) VALUES ('global', '80%', 100, 1000, 'weighted', true, 'test_environment');
+INSERT INTO resource_groups (name, soft_memory_limit, hard_physical_data_scan_limit, hard_concurrency_limit, max_queued, scheduling_policy, jmx_export, environment) VALUES ('global', '80%', '50TB', 100, 1000, 'weighted', true, 'test_environment');
 
 -- get ID of 'global' group
 SELECT resource_group_id FROM resource_groups WHERE name = 'global';  -- 1
@@ -321,7 +325,7 @@ INSERT INTO resource_groups (name, soft_memory_limit, hard_concurrency_limit, ma
 -- get ID of 'other' group
 SELECT resource_group_id FROM resource_groups WHERE name = 'other';  -- 4
 -- create '${USER}' group with 'other' as parent.
-INSERT INTO resource_groups (name, soft_memory_limit, hard_concurrency_limit, max_queued, environment, parent) VALUES ('${USER}', '10%', 1, 100, 'test_environment', 4);
+INSERT INTO resource_groups (name, soft_memory_limit, hard_physical_data_scan_limit, hard_concurrency_limit, max_queued, environment, parent) VALUES ('${USER}', '10%', '10GB', 1, 100, 'test_environment', 4);
 
 -- create 'bi-${toolname}' group with 'adhoc' as parent
 INSERT INTO resource_groups (name, soft_memory_limit, hard_concurrency_limit, max_queued, scheduling_weight, scheduling_policy, environment, parent) VALUES ('bi-${toolname}', '10%', 10, 100, 10, 'weighted_fair', 'test_environment', 3);

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/FileResourceGroupConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/FileResourceGroupConfigurationManager.java
@@ -51,6 +51,7 @@ public class FileResourceGroupConfigurationManager
     private final List<ResourceGroupSpec> rootGroups;
     private final List<ResourceGroupSelector> selectors;
     private final Optional<Duration> cpuQuotaPeriod;
+    private final Optional<Duration> physicalDataScanQuotaPeriod;
 
     @Inject
     public FileResourceGroupConfigurationManager(LifeCycleManager lifeCycleManager, ClusterMemoryPoolManager memoryPoolManager, FileResourceGroupConfig config)
@@ -78,6 +79,7 @@ public class FileResourceGroupConfigurationManager
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.rootGroups = ImmutableList.copyOf(managerSpec.getRootGroups());
         this.cpuQuotaPeriod = managerSpec.getCpuQuotaPeriod();
+        this.physicalDataScanQuotaPeriod = managerSpec.getPhysicalDataScanQuotaPeriod();
         validateRootGroups(managerSpec);
         this.selectors = buildSelectors(managerSpec);
     }
@@ -117,6 +119,12 @@ public class FileResourceGroupConfigurationManager
     protected Optional<Duration> getCpuQuotaPeriod()
     {
         return cpuQuotaPeriod;
+    }
+
+    @Override
+    protected Optional<Duration> getPhysicalDataScanQuotaPeriod()
+    {
+        return physicalDataScanQuotaPeriod;
     }
 
     @Override

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/ManagerSpec.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/ManagerSpec.java
@@ -31,16 +31,19 @@ public class ManagerSpec
     private final List<ResourceGroupSpec> rootGroups;
     private final List<SelectorSpec> selectors;
     private final Optional<Duration> cpuQuotaPeriod;
+    private final Optional<Duration> physicalDataScanQuotaPeriod;
 
     @JsonCreator
     public ManagerSpec(
             @JsonProperty("rootGroups") List<ResourceGroupSpec> rootGroups,
             @JsonProperty("selectors") List<SelectorSpec> selectors,
-            @JsonProperty("cpuQuotaPeriod") Optional<Duration> cpuQuotaPeriod)
+            @JsonProperty("cpuQuotaPeriod") Optional<Duration> cpuQuotaPeriod,
+            @JsonProperty("physicalDataScanQuotaPeriod") Optional<Duration> physicalDataScanQuotaPeriod)
     {
         this.rootGroups = ImmutableList.copyOf(requireNonNull(rootGroups, "rootGroups is null"));
         this.selectors = ImmutableList.copyOf(requireNonNull(selectors, "selectors is null"));
         this.cpuQuotaPeriod = requireNonNull(cpuQuotaPeriod, "cpuQuotaPeriod is null");
+        this.physicalDataScanQuotaPeriod = requireNonNull(physicalDataScanQuotaPeriod, "physicalDataScanQuotaPeriod is null");
         Set<ResourceGroupNameTemplate> names = new HashSet<>();
         for (ResourceGroupSpec group : rootGroups) {
             checkArgument(!names.contains(group.getName()), "Duplicated root group: %s", group.getName());
@@ -61,5 +64,10 @@ public class ManagerSpec
     public Optional<Duration> getCpuQuotaPeriod()
     {
         return cpuQuotaPeriod;
+    }
+
+    public Optional<Duration> getPhysicalDataScanQuotaPeriod()
+    {
+        return physicalDataScanQuotaPeriod;
     }
 }

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/ResourceGroupSpec.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/ResourceGroupSpec.java
@@ -49,6 +49,7 @@ public class ResourceGroupSpec
     private final Optional<Boolean> jmxExport;
     private final Optional<Duration> softCpuLimit;
     private final Optional<Duration> hardCpuLimit;
+    private final Optional<DataSize> hardPhysicalDataScanLimit;
 
     @JsonCreator
     public ResourceGroupSpec(
@@ -63,7 +64,8 @@ public class ResourceGroupSpec
             @JsonProperty("subGroups") Optional<List<ResourceGroupSpec>> subGroups,
             @JsonProperty("jmxExport") Optional<Boolean> jmxExport,
             @JsonProperty("softCpuLimit") Optional<Duration> softCpuLimit,
-            @JsonProperty("hardCpuLimit") Optional<Duration> hardCpuLimit)
+            @JsonProperty("hardCpuLimit") Optional<Duration> hardCpuLimit,
+            @JsonProperty("hardPhysicalDataScanLimit") Optional<DataSize> hardPhysicalDataScanLimit)
     {
         this.softCpuLimit = requireNonNull(softCpuLimit, "softCpuLimit is null");
         this.hardCpuLimit = requireNonNull(hardCpuLimit, "hardCpuLimit is null");
@@ -72,6 +74,7 @@ public class ResourceGroupSpec
         checkArgument(maxQueued >= 0, "maxQueued is negative");
         this.maxQueued = maxQueued;
         this.softConcurrencyLimit = softConcurrencyLimit;
+        this.hardPhysicalDataScanLimit = requireNonNull(hardPhysicalDataScanLimit, "hardPhysicalDataScanLimit is null");
 
         checkArgument(hardConcurrencyLimit.isPresent() || maxRunning.isPresent(), "Missing required property: hardConcurrencyLimit");
         this.hardConcurrencyLimit = hardConcurrencyLimit.orElseGet(maxRunning::get);
@@ -167,6 +170,11 @@ public class ResourceGroupSpec
         return hardCpuLimit;
     }
 
+    public Optional<DataSize> getHardPhysicalDataScanLimit()
+    {
+        return hardPhysicalDataScanLimit;
+    }
+
     @Override
     public boolean equals(Object other)
     {
@@ -187,7 +195,8 @@ public class ResourceGroupSpec
                 subGroups.equals(that.subGroups) &&
                 jmxExport.equals(that.jmxExport) &&
                 softCpuLimit.equals(that.softCpuLimit) &&
-                hardCpuLimit.equals(that.hardCpuLimit));
+                hardCpuLimit.equals(that.hardCpuLimit) &&
+                hardPhysicalDataScanLimit.equals(that.hardPhysicalDataScanLimit));
     }
 
     // Subgroups not included, used to determine whether a group needs to be reconfigured
@@ -205,7 +214,8 @@ public class ResourceGroupSpec
                 schedulingWeight.equals(other.schedulingWeight) &&
                 jmxExport.equals(other.jmxExport) &&
                 softCpuLimit.equals(other.softCpuLimit) &&
-                hardCpuLimit.equals(other.hardCpuLimit));
+                hardCpuLimit.equals(other.hardCpuLimit) &&
+                hardPhysicalDataScanLimit.equals(other.hardPhysicalDataScanLimit));
     }
 
     @Override
@@ -222,7 +232,8 @@ public class ResourceGroupSpec
                 subGroups,
                 jmxExport,
                 softCpuLimit,
-                hardCpuLimit);
+                hardCpuLimit,
+                hardPhysicalDataScanLimit);
     }
 
     @Override
@@ -239,6 +250,7 @@ public class ResourceGroupSpec
                 .add("jmxExport", jmxExport)
                 .add("softCpuLimit", softCpuLimit)
                 .add("hardCpuLimit", hardCpuLimit)
+                .add("hardPhysicalDataScanLimit", hardPhysicalDataScanLimit)
                 .toString();
     }
 }

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/ResourceGroupGlobalProperties.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/ResourceGroupGlobalProperties.java
@@ -14,11 +14,7 @@
 package io.trino.plugin.resourcegroups.db;
 
 import io.airlift.units.Duration;
-import org.jdbi.v3.core.mapper.RowMapper;
-import org.jdbi.v3.core.statement.StatementContext;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -27,10 +23,12 @@ import static java.util.Objects.requireNonNull;
 public class ResourceGroupGlobalProperties
 {
     private final Optional<Duration> cpuQuotaPeriod;
+    private final Optional<Duration> physicalDataScanQuotaPeriod;
 
-    public ResourceGroupGlobalProperties(Optional<Duration> cpuQuotaPeriod)
+    private ResourceGroupGlobalProperties(Optional<Duration> cpuQuotaPeriod, Optional<Duration> physicalDataScanQuotaPeriod)
     {
         this.cpuQuotaPeriod = requireNonNull(cpuQuotaPeriod, "cpuQuotaPeriod is null");
+        this.physicalDataScanQuotaPeriod = requireNonNull(physicalDataScanQuotaPeriod, "physicalDataScanQuotaPeriod is null");
     }
 
     public Optional<Duration> getCpuQuotaPeriod()
@@ -38,15 +36,9 @@ public class ResourceGroupGlobalProperties
         return cpuQuotaPeriod;
     }
 
-    public static class Mapper
-            implements RowMapper<ResourceGroupGlobalProperties>
+    public Optional<Duration> getPhysicalDataScanQuotaPeriod()
     {
-        @Override
-        public ResourceGroupGlobalProperties map(ResultSet resultSet, StatementContext context)
-                throws SQLException
-        {
-            return new ResourceGroupGlobalProperties(Optional.ofNullable(resultSet.getString("value")).map(Duration::valueOf));
-        }
+        return physicalDataScanQuotaPeriod;
     }
 
     @Override
@@ -59,12 +51,40 @@ public class ResourceGroupGlobalProperties
         if (!(other instanceof ResourceGroupGlobalProperties that)) {
             return false;
         }
-        return cpuQuotaPeriod.equals(that.cpuQuotaPeriod);
+        return cpuQuotaPeriod.equals(that.cpuQuotaPeriod) && physicalDataScanQuotaPeriod.equals(that.physicalDataScanQuotaPeriod);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(cpuQuotaPeriod);
+        return Objects.hash(cpuQuotaPeriod, physicalDataScanQuotaPeriod);
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static class Builder
+    {
+        private Optional<Duration> cpuQuotaPeriod = Optional.empty();
+        private Optional<Duration> physicalDataScanQuotaPeriod = Optional.empty();
+
+        public Builder setCpuQuotaPeriod(Optional<Duration> cpuQuotaPeriod)
+        {
+            this.cpuQuotaPeriod = cpuQuotaPeriod;
+            return this;
+        }
+
+        public Builder setPhysicalDataScanQuotaPeriod(Optional<Duration> physicalDataScanQuotaPeriod)
+        {
+            this.physicalDataScanQuotaPeriod = physicalDataScanQuotaPeriod;
+            return this;
+        }
+
+        public ResourceGroupGlobalProperties build()
+        {
+            return new ResourceGroupGlobalProperties(cpuQuotaPeriod, physicalDataScanQuotaPeriod);
+        }
     }
 }

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/ResourceGroupGlobalPropertiesReducer.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/ResourceGroupGlobalPropertiesReducer.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.resourcegroups.db;
+
+import io.airlift.units.Duration;
+import org.jdbi.v3.core.result.RowReducer;
+import org.jdbi.v3.core.result.RowView;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public class ResourceGroupGlobalPropertiesReducer
+        implements RowReducer<ResourceGroupGlobalProperties.Builder, ResourceGroupGlobalProperties>
+{
+    @Override
+    public ResourceGroupGlobalProperties.Builder container()
+    {
+        return ResourceGroupGlobalProperties.builder();
+    }
+
+    @Override
+    public void accumulate(ResourceGroupGlobalProperties.Builder container, RowView rowView)
+    {
+        String name = rowView.getColumn("name", String.class);
+        Optional<Duration> value = Optional.ofNullable(rowView.getColumn("value", String.class)).map(Duration::valueOf);
+
+        switch (name) {
+            case "cpu_quota_period":
+                container.setCpuQuotaPeriod(value);
+                break;
+            case "physical_data_scan_quota_period":
+                container.setPhysicalDataScanQuotaPeriod(value);
+                break;
+            default:
+                throw new IllegalArgumentException("Unrecognized resource group global property: " + name);
+        }
+    }
+
+    @Override
+    public Stream<ResourceGroupGlobalProperties> stream(ResourceGroupGlobalProperties.Builder container)
+    {
+        return Stream.of(container.build());
+    }
+}

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/ResourceGroupSpecBuilder.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/ResourceGroupSpecBuilder.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.resourcegroups.db;
 
 import com.google.common.collect.ImmutableList;
+import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.plugin.resourcegroups.ResourceGroupNameTemplate;
 import io.trino.plugin.resourcegroups.ResourceGroupSpec;
@@ -39,6 +40,7 @@ public class ResourceGroupSpecBuilder
     private final Optional<Boolean> jmxExport;
     private final Optional<Duration> softCpuLimit;
     private final Optional<Duration> hardCpuLimit;
+    private final Optional<DataSize> hardPhysicalDataScanLimit;
     private final Optional<Long> parentId;
     private final ImmutableList.Builder<ResourceGroupSpec> subGroups = ImmutableList.builder();
 
@@ -54,6 +56,7 @@ public class ResourceGroupSpecBuilder
             Optional<Boolean> jmxExport,
             Optional<String> softCpuLimit,
             Optional<String> hardCpuLimit,
+            Optional<String> hardPhysicalDataScanLimit,
             Optional<Long> parentId)
     {
         this.id = id;
@@ -67,6 +70,7 @@ public class ResourceGroupSpecBuilder
         this.jmxExport = requireNonNull(jmxExport, "jmxExport is null");
         this.softCpuLimit = softCpuLimit.map(Duration::valueOf);
         this.hardCpuLimit = hardCpuLimit.map(Duration::valueOf);
+        this.hardPhysicalDataScanLimit = hardPhysicalDataScanLimit.map(DataSize::valueOf);
         this.parentId = parentId;
     }
 
@@ -114,7 +118,8 @@ public class ResourceGroupSpecBuilder
                 Optional.of(subGroups.build()),
                 jmxExport,
                 softCpuLimit,
-                hardCpuLimit);
+                hardCpuLimit,
+                hardPhysicalDataScanLimit);
     }
 
     public static class Mapper
@@ -144,6 +149,7 @@ public class ResourceGroupSpecBuilder
             }
             Optional<String> softCpuLimit = Optional.ofNullable(resultSet.getString("soft_cpu_limit"));
             Optional<String> hardCpuLimit = Optional.ofNullable(resultSet.getString("hard_cpu_limit"));
+            Optional<String> hardPhysicalDataScanLimit = Optional.ofNullable(resultSet.getString("hard_physical_data_scan_limit"));
             Optional<Long> parentId = Optional.of(resultSet.getLong("parent"));
             if (resultSet.wasNull()) {
                 parentId = Optional.empty();
@@ -160,6 +166,7 @@ public class ResourceGroupSpecBuilder
                     jmxExport,
                     softCpuLimit,
                     hardCpuLimit,
+                    hardPhysicalDataScanLimit,
                     parentId);
         }
     }

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/ResourceGroupsDao.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/ResourceGroupsDao.java
@@ -17,6 +17,7 @@ import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.statement.UseRowMapper;
+import org.jdbi.v3.sqlobject.statement.UseRowReducer;
 
 import java.util.List;
 
@@ -25,13 +26,13 @@ public interface ResourceGroupsDao
     @SqlUpdate("CREATE TABLE IF NOT EXISTS resource_groups_global_properties (\n" +
             "  name VARCHAR(128) NOT NULL PRIMARY KEY,\n" +
             "  value VARCHAR(512) NULL,\n" +
-            "  CHECK (name in ('cpu_quota_period'))\n" +
+            "  CHECK (name in ('cpu_quota_period', 'physical_data_scan_quota_period'))\n" +
             ")")
     void createResourceGroupsGlobalPropertiesTable();
 
-    @SqlQuery("SELECT value FROM resource_groups_global_properties WHERE name = 'cpu_quota_period'")
-    @UseRowMapper(ResourceGroupGlobalProperties.Mapper.class)
-    List<ResourceGroupGlobalProperties> getResourceGroupGlobalProperties();
+    @SqlQuery("SELECT name, value FROM resource_groups_global_properties WHERE name IN ('cpu_quota_period', 'physical_data_scan_quota_period')")
+    @UseRowReducer(ResourceGroupGlobalPropertiesReducer.class)
+    ResourceGroupGlobalProperties getResourceGroupGlobalProperties();
 
     @SqlUpdate("CREATE TABLE IF NOT EXISTS resource_groups (\n" +
             "  resource_group_id BIGINT NOT NULL AUTO_INCREMENT,\n" +
@@ -45,6 +46,7 @@ public interface ResourceGroupsDao
             "  jmx_export BOOLEAN NULL,\n" +
             "  soft_cpu_limit VARCHAR(128) NULL,\n" +
             "  hard_cpu_limit VARCHAR(128) NULL,\n" +
+            "  hard_physical_data_scan_limit VARCHAR(128) NULL,\n" +
             "  parent BIGINT NULL,\n" +
             "  environment VARCHAR(128) NULL,\n" +
             "  PRIMARY KEY (resource_group_id),\n" +
@@ -54,7 +56,7 @@ public interface ResourceGroupsDao
 
     @SqlQuery("SELECT resource_group_id, name, soft_memory_limit, max_queued, soft_concurrency_limit, " +
             "  hard_concurrency_limit, scheduling_policy, scheduling_weight, jmx_export, soft_cpu_limit, " +
-            "  hard_cpu_limit, parent\n" +
+            "  hard_cpu_limit, hard_physical_data_scan_limit, parent\n" +
             "FROM resource_groups\n" +
             "WHERE environment = :environment\n")
     @UseRowMapper(ResourceGroupSpecBuilder.Mapper.class)

--- a/plugin/trino-resource-group-managers/src/main/resources/db/migration/mysql/V9__add_physical_data_scan_to_resource_groups.sql
+++ b/plugin/trino-resource-group-managers/src/main/resources/db/migration/mysql/V9__add_physical_data_scan_to_resource_groups.sql
@@ -1,0 +1,25 @@
+ALTER TABLE resource_groups ADD COLUMN hard_physical_data_scan_limit VARCHAR(128);
+
+-- Find and drop the old constraint dynamically
+SET @constraint_name = (
+    SELECT tc.CONSTRAINT_NAME
+    FROM information_schema.TABLE_CONSTRAINTS AS tc
+    JOIN information_schema.CHECK_CONSTRAINTS AS cc
+      ON tc.CONSTRAINT_NAME = cc.CONSTRAINT_NAME
+      AND tc.CONSTRAINT_SCHEMA = cc.CONSTRAINT_SCHEMA
+    WHERE tc.CONSTRAINT_SCHEMA = DATABASE()
+      AND tc.TABLE_NAME = 'resource_groups_global_properties'
+      AND tc.CONSTRAINT_TYPE = 'CHECK'
+      AND cc.CHECK_CLAUSE LIKE '%cpu_quota_period%'
+);
+
+-- Drop the constraint if it exists otherwise run no-op SQL
+SET @sql = IF(@constraint_name IS NOT NULL,
+              CONCAT('ALTER TABLE resource_groups_global_properties DROP CHECK `', @constraint_name, '`'),
+              'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- Add the new CHECK constraint with an explicit and permanent name.
+ALTER TABLE resource_groups_global_properties ADD CONSTRAINT resource_groups_global_properties_name_check CHECK (name IN ('cpu_quota_period', 'physical_data_scan_quota_period'));

--- a/plugin/trino-resource-group-managers/src/main/resources/db/migration/oracle/V9__add_physical_data_scan_to_resource_groups.sql
+++ b/plugin/trino-resource-group-managers/src/main/resources/db/migration/oracle/V9__add_physical_data_scan_to_resource_groups.sql
@@ -1,0 +1,18 @@
+ALTER TABLE resource_groups ADD hard_physical_data_scan_limit VARCHAR(128);
+
+-- Find and drop the old constraint dynamically
+BEGIN
+    FOR c IN (
+       SELECT constraint_name
+       FROM user_constraints
+       WHERE table_name = 'RESOURCE_GROUPS_GLOBAL_PROPERTIES'
+         AND constraint_type = 'C'
+         AND search_condition_vc LIKE '%cpu_quota_period%'
+   ) LOOP
+      EXECUTE IMMEDIATE 'ALTER TABLE resource_groups_global_properties DROP CONSTRAINT ' || c.constraint_name;
+    END LOOP;
+END;
+/
+
+-- Add the new CHECK constraint with an explicit and permanent name.
+ALTER TABLE resource_groups_global_properties ADD CONSTRAINT resource_groups_global_properties_name_check CHECK (name IN ('cpu_quota_period', 'physical_data_scan_quota_period'));

--- a/plugin/trino-resource-group-managers/src/main/resources/db/migration/postgresql/V9__add_physical_data_scan_to_resource_groups.sql
+++ b/plugin/trino-resource-group-managers/src/main/resources/db/migration/postgresql/V9__add_physical_data_scan_to_resource_groups.sql
@@ -1,0 +1,20 @@
+ALTER TABLE resource_groups ADD COLUMN hard_physical_data_scan_limit VARCHAR(128);
+
+-- Find and drop the old constraint dynamically
+DO $$
+DECLARE
+    constraint_name_to_drop TEXT;
+BEGIN
+    SELECT conname
+    INTO constraint_name_to_drop
+    FROM pg_constraint
+    WHERE conrelid = 'resource_groups_global_properties'::regclass AND contype = 'c' AND pg_get_constraintdef(oid) LIKE '%cpu_quota_period%';
+
+    IF constraint_name_to_drop IS NOT NULL THEN
+            EXECUTE 'ALTER TABLE resource_groups_global_properties DROP CONSTRAINT ' || quote_ident(constraint_name_to_drop);
+    END IF;
+END;
+$$;
+
+-- Add the new CHECK constraint with an explicit and permanent name.
+ALTER TABLE resource_groups_global_properties ADD CONSTRAINT resource_groups_global_properties_name_check CHECK (name IN ('cpu_quota_period', 'physical_data_scan_quota_period'));

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestingResourceGroup.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestingResourceGroup.java
@@ -28,9 +28,11 @@ public class TestingResourceGroup
     private long softMemoryLimitBytes;
     private Duration softCpuLimit;
     private Duration hardCpuLimit;
-    private long quotaGenerationRate;
+    private long cpuQuotaGenerationRate;
     private int softConcurrencyLimit;
     private int hardConcurrencyLimit;
+    private long hardPhysicalDataScanLimitBytes;
+    private long physicalDataScanGenerationRate;
     private int maxQueued;
     private int schedulingWeight;
     private SchedulingPolicy policy;
@@ -87,13 +89,37 @@ public class TestingResourceGroup
     @Override
     public long getCpuQuotaGenerationMillisPerSecond()
     {
-        return quotaGenerationRate;
+        return cpuQuotaGenerationRate;
     }
 
     @Override
     public void setCpuQuotaGenerationMillisPerSecond(long rate)
     {
-        quotaGenerationRate = rate;
+        cpuQuotaGenerationRate = rate;
+    }
+
+    @Override
+    public long getHardPhysicalDataScanLimitBytes()
+    {
+        return hardPhysicalDataScanLimitBytes;
+    }
+
+    @Override
+    public void setHardPhysicalDataScanLimitBytes(long limit)
+    {
+        this.hardPhysicalDataScanLimitBytes = limit;
+    }
+
+    @Override
+    public long getPhysicalDataScanQuotaGenerationBytesPerSecond()
+    {
+        return physicalDataScanGenerationRate;
+    }
+
+    @Override
+    public void setPhysicalDataScanQuotaGenerationBytesPerSecond(long rate)
+    {
+        physicalDataScanGenerationRate = rate;
     }
 
     @Override

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestingResourceGroups.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestingResourceGroups.java
@@ -38,6 +38,7 @@ final class TestingResourceGroups
                 selectors.stream()
                         .map(SelectorSpecBuilder::build)
                         .collect(toImmutableList()),
+                Optional.empty(),
                 Optional.empty());
     }
 
@@ -54,6 +55,7 @@ final class TestingResourceGroups
                 10,
                 Optional.empty(),
                 Optional.of(10),
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/BaseTestDbResourceGroupsFlywayMigration.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/BaseTestDbResourceGroupsFlywayMigration.java
@@ -95,6 +95,25 @@ public abstract class BaseTestDbResourceGroupsFlywayMigration
         assertThat(tableExists("resource_groups_global_properties")).isFalse();
     }
 
+    @Test
+    public void testMigrationForConstraints()
+    {
+        DbResourceGroupConfig config = new DbResourceGroupConfig()
+                .setConfigDbUrl(container.getJdbcUrl())
+                .setConfigDbUser(container.getUsername())
+                .setConfigDbPassword(container.getPassword());
+        FlywayMigration.migrate(config);
+        String cpuInsert = "INSERT INTO resource_groups_global_properties VALUES ('cpu_quota_period', '1h')";
+        String dataInsert = "INSERT INTO resource_groups_global_properties VALUES ('physical_data_scan_quota_period', '1h')";
+        Handle handle = jdbi.open();
+        handle.execute(cpuInsert);
+        handle.execute(dataInsert);
+        handle.close();
+        verifyResourceGroupsSchema(2);
+
+        dropAllTables();
+    }
+
     protected void verifyResourceGroupsSchema(int expectedPropertiesCount)
     {
         verifyResultSetCount("SELECT name FROM resource_groups_global_properties", expectedPropertiesCount);

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/H2ResourceGroupsDao.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/H2ResourceGroupsDao.java
@@ -29,8 +29,8 @@ public interface H2ResourceGroupsDao
     void updateResourceGroupsGlobalProperties(@Bind("name") String name);
 
     @SqlUpdate("INSERT INTO resource_groups\n" +
-            "(resource_group_id, name, soft_memory_limit, max_queued, soft_concurrency_limit, hard_concurrency_limit, scheduling_policy, scheduling_weight, jmx_export, soft_cpu_limit, hard_cpu_limit, parent, environment)\n" +
-            "VALUES (:resource_group_id, :name, :soft_memory_limit, :max_queued, :soft_concurrency_limit, :hard_concurrency_limit, :scheduling_policy, :scheduling_weight, :jmx_export, :soft_cpu_limit, :hard_cpu_limit, :parent, :environment)")
+            "(resource_group_id, name, soft_memory_limit, max_queued, soft_concurrency_limit, hard_concurrency_limit, scheduling_policy, scheduling_weight, jmx_export, soft_cpu_limit, hard_cpu_limit, hard_physical_data_scan_limit, parent, environment)\n" +
+            "VALUES (:resource_group_id, :name, :soft_memory_limit, :max_queued, :soft_concurrency_limit, :hard_concurrency_limit, :scheduling_policy, :scheduling_weight, :jmx_export, :soft_cpu_limit, :hard_cpu_limit, :hard_physical_data_scan_limit, :parent, :environment)")
     void insertResourceGroup(
             @Bind("resource_group_id") long resourceGroupId,
             @Bind("name") String name,
@@ -43,6 +43,7 @@ public interface H2ResourceGroupsDao
             @Bind("jmx_export") Boolean jmxExport,
             @Bind("soft_cpu_limit") String softCpuLimit,
             @Bind("hard_cpu_limit") String hardCpuLimit,
+            @Bind("hard_physical_data_scan_limit") String hardPhysicalDataScanLimit,
             @Bind("parent") Long parent,
             @Bind("environment") String environment);
 
@@ -58,6 +59,7 @@ public interface H2ResourceGroupsDao
             ", jmx_export = :jmx_export\n" +
             ", soft_cpu_limit = :soft_cpu_limit\n" +
             ", hard_cpu_limit = :hard_cpu_limit\n" +
+            ", hard_physical_data_scan_limit = :hard_physical_data_scan_limit\n" +
             ", parent = :parent\n" +
             ", environment = :environment\n" +
             "WHERE resource_group_id = :resource_group_id")
@@ -73,6 +75,7 @@ public interface H2ResourceGroupsDao
             @Bind("jmx_export") Boolean jmxExport,
             @Bind("soft_cpu_limit") String softCpuLimit,
             @Bind("hard_cpu_limit") String hardCpuLimit,
+            @Bind("hard_physical_data_scan_limit") String hardPhysicalDataScanLimit,
             @Bind("parent") Long parent,
             @Bind("environment") String environment);
 

--- a/plugin/trino-resource-group-managers/src/test/resources/resource_groups_config.json
+++ b/plugin/trino-resource-group-managers/src/test/resources/resource_groups_config.json
@@ -7,6 +7,7 @@
       "maxQueued": 1000,
       "softCpuLimit": "1h",
       "hardCpuLimit": "1d",
+      "hardPhysicalDataScanLimit": "1TB",
       "schedulingPolicy": "weighted",
       "jmxExport": true,
       "subGroups": [
@@ -15,7 +16,8 @@
           "softMemoryLimit": "2MB",
           "hardConcurrencyLimit": 3,
           "maxQueued": 4,
-          "schedulingWeight": 5
+          "schedulingWeight": 5,
+          "hardPhysicalDataScanLimit": "10MB"
         },
         {
           "name": "sub_no_soft_memory_limit",
@@ -30,6 +32,7 @@
       "group": "global"
     }
   ],
-  "cpuQuotaPeriod": "1h"
+  "cpuQuotaPeriod": "1h",
+  "physicalDataScanQuotaPeriod": "1h"
 }
 

--- a/plugin/trino-resource-group-managers/src/test/resources/resource_groups_config_user_groups.json
+++ b/plugin/trino-resource-group-managers/src/test/resources/resource_groups_config_user_groups.json
@@ -7,6 +7,7 @@
       "maxQueued": 1000,
       "softCpuLimit": "1h",
       "hardCpuLimit": "1d",
+      "hardPhysicalDataScanLimit": "5MB",
       "schedulingPolicy": "weighted",
       "jmxExport": true,
       "subGroups": [
@@ -14,6 +15,7 @@
           "name": "sub",
           "softMemoryLimit": "2MB",
           "hardConcurrencyLimit": 3,
+          "hardPhysicalDataScanLimit": "1MB",
           "maxQueued": 4,
           "schedulingWeight": 5
         }
@@ -26,6 +28,7 @@
       "userGroup": "groupA"
     }
   ],
-  "cpuQuotaPeriod": "1h"
+  "cpuQuotaPeriod": "1h",
+  "physicalDataScanQuotaPeriod": "1h"
 }
 

--- a/testing/trino-tests/src/test/java/io/trino/execution/resourcegroups/db/H2TestUtil.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/resourcegroups/db/H2TestUtil.java
@@ -159,13 +159,14 @@ final class H2TestUtil
             throws InterruptedException
     {
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
-        dao.insertResourceGroup(1, "global", "1MB", 100, 1000, 1000, null, null, null, null, null, null, TEST_ENVIRONMENT);
-        dao.insertResourceGroup(2, "bi-${USER}", "1MB", 3, 2, 2, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
-        dao.insertResourceGroup(3, "user-${USER}", "1MB", 3, 3, 3, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
-        dao.insertResourceGroup(4, "adhoc-${USER}", "1MB", 3, 3, 3, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
-        dao.insertResourceGroup(5, "dashboard-${USER}", "1MB", 1, 1, 1, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
-        dao.insertResourceGroup(6, "no-queueing", "1MB", 0, 1, 1, null, null, null, null, null, null, TEST_ENVIRONMENT_2);
-        dao.insertResourceGroup(7, "explain", "1MB", 0, 1, 1, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.insertResourceGroupsGlobalProperties("physical_data_scan_quota_period", "1h");
+        dao.insertResourceGroup(1, "global", "1MB", 100, 1000, 1000, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(2, "bi-${USER}", "1MB", 3, 2, 2, null, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(3, "user-${USER}", "1MB", 3, 3, 3, null, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(4, "adhoc-${USER}", "1MB", 3, 3, 3, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(5, "dashboard-${USER}", "1MB", 1, 1, 1, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(6, "no-queueing", "1MB", 0, 1, 1, null, null, null, null, null, null, null, TEST_ENVIRONMENT_2);
+        dao.insertResourceGroup(7, "explain", "1MB", 0, 1, 1, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
         dao.insertSelector(2, 10_000, "user.*", null, null, null, "test", null, null, null);
         dao.insertSelector(4, 1_000, "user.*", null, null, null, "(?i).*adhoc.*", null, null, null);
         dao.insertSelector(5, 100, "user.*", null, null, null, "(?i).*dashboard.*", null, null, null);

--- a/testing/trino-tests/src/test/java/io/trino/execution/resourcegroups/db/TestQueuesDb.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/resourcegroups/db/TestQueuesDb.java
@@ -131,8 +131,8 @@ public class TestQueuesDb
         waitForQueryState(queryRunner, secondDashboardQuery, QUEUED);
         waitForRunningQueryCount(queryRunner, 1);
         // Update db to allow for 1 more running query in dashboard resource group
-        dao.updateResourceGroup(3, "user-${USER}", "1MB", 3, 4, 4, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
-        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 2, 2, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(3, "user-${USER}", "1MB", 3, 4, 4, null, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 2, 2, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
         waitForQueryState(queryRunner, secondDashboardQuery, RUNNING);
         QueryId thirdDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
         waitForQueryState(queryRunner, thirdDashboardQuery, QUEUED);
@@ -181,8 +181,8 @@ public class TestQueuesDb
         waitForQueryState(queryRunner, thirdDashboardQuery, FAILED);
 
         // Allow one more query to run and resubmit third query
-        dao.updateResourceGroup(3, "user-${USER}", "1MB", 3, 4, 4, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
-        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 2, 2, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(3, "user-${USER}", "1MB", 3, 4, 4, null, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 2, 2, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
 
         InternalResourceGroupManager<?> manager = queryRunner.getCoordinator().getResourceGroupManager().get();
         DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
@@ -194,7 +194,7 @@ public class TestQueuesDb
         waitForQueryState(queryRunner, thirdDashboardQuery, QUEUED);
 
         // Lower running queries in dashboard resource groups and reload the config
-        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 1, 1, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 1, 1, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
         dbConfigurationManager.load();
 
         // Cancel query and verify that third query is still queued
@@ -258,7 +258,7 @@ public class TestQueuesDb
         assertThat(resourceGroup.get().toString()).isEqualTo("global.user-user.dashboard-user");
 
         // create a new resource group that rejects all queries submitted to it
-        dao.insertResourceGroup(8, "reject-all-queries", "1MB", 0, 0, 0, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(8, "reject-all-queries", "1MB", 0, 0, 0, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
 
         // add a new selector that has a higher priority than the existing dashboard selector and that routes queries to the "reject-all-queries" resource group
         dao.insertSelector(8, 200, "user.*", null, null, null, "(?i).*dashboard.*", null, null, null);
@@ -302,7 +302,7 @@ public class TestQueuesDb
         assertThat(queryManager.getFullQueryInfo(firstQuery).getErrorCode()).isEqualTo(EXCEEDED_TIME_LIMIT.toErrorCode());
         assertThat(queryManager.getFullQueryInfo(firstQuery).getFailureInfo().getMessage()).contains("Query exceeded the maximum execution time limit of 1.00ms");
         // set max running queries to 0 for the dashboard resource group so that new queries get queued immediately
-        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, null, 0, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, null, 0, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
         dbConfigurationManager.load();
         QueryId secondQuery = createQuery(
                 queryRunner,
@@ -320,7 +320,7 @@ public class TestQueuesDb
         DispatchManager dispatchManager = queryRunner.getCoordinator().getDispatchManager();
         assertThat(dispatchManager.getQueryInfo(secondQuery).getState()).isEqualTo(QUEUED);
         // reconfigure the resource group to run the second query
-        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, null, 1, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, null, 1, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
         dbConfigurationManager.load();
         // cancel the first one and let the second one start
         dispatchManager.cancelQuery(firstQuery);
@@ -390,14 +390,14 @@ public class TestQueuesDb
         InternalResourceGroupManager<?> manager = queryRunner.getCoordinator().getResourceGroupManager().orElseThrow();
         DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
 
-        dao.updateResourceGroup(2, "bi-${USER}", "100%", 3, 2, 2, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(2, "bi-${USER}", "100%", 3, 2, 2, null, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
         dbConfigurationManager.load();
         assertThat(manager.tryGetResourceGroupInfo(new ResourceGroupId(new ResourceGroupId("global"), "bi-user"))
                 .orElseThrow(() -> new IllegalStateException("Resource group not found"))
                 .softMemoryLimit()
                 .toBytes()).isEqualTo(queryRunner.getCoordinator().getClusterMemoryManager().getClusterMemoryBytes());
 
-        dao.updateResourceGroup(2, "bi-${USER}", "123MB", 3, 2, 2, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(2, "bi-${USER}", "123MB", 3, 2, 2, null, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
         dbConfigurationManager.load();
 
         // wait for SqlQueryManager which enforce memory limits per second
@@ -416,10 +416,9 @@ public class TestQueuesDb
     {
         InternalResourceGroupManager<?> manager = queryRunner.getCoordinator().getResourceGroupManager().orElseThrow();
         DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
-
-        dao.insertResourceGroup(10, "queued", "80%", 10, null, 1, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(10, "queued", "80%", 10, null, 1, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
         dao.insertSelector(10, 1, null, null, null, null, null, null, "[\"queued\"]", null);
-        dao.insertResourceGroup(11, "running", "80%", 10, null, 2, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(11, "running", "80%", 10, null, 2, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
         dao.insertSelector(11, 1, null, null, null, null, null, null, "[\"running\"]", null);
         dbConfigurationManager.load();
 
@@ -432,10 +431,10 @@ public class TestQueuesDb
         waitForQueryState(queryRunner, firstQueryFromRunningGroup, RUNNING);
 
         dao.deleteSelectors(10);
-        dao.insertResourceGroup(12, "subgroup", "80%", 10, null, 1, null, null, null, null, null, 10L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(12, "subgroup", "80%", 10, null, 1, null, null, null, null, null, null, 10L, TEST_ENVIRONMENT);
         dao.insertSelector(12, 1, null, null, null, null, null, null, "[\"queued\"]", null);
         dao.deleteSelectors(11);
-        dao.insertResourceGroup(13, "subgroup", "80%", 10, null, 1, null, null, null, null, null, 11L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(13, "subgroup", "80%", 10, null, 1, null, null, null, null, null, null, 11L, TEST_ENVIRONMENT);
         dao.insertSelector(13, 1, null, null, null, null, null, null, "[\"running\"]", null);
         dbConfigurationManager.load();
 
@@ -457,11 +456,11 @@ public class TestQueuesDb
         InternalResourceGroupManager<?> manager = queryRunner.getCoordinator().getResourceGroupManager().orElseThrow();
         DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
 
-        dao.insertResourceGroup(10, "queued", "80%", 10, null, 3, null, null, null, null, null, null, TEST_ENVIRONMENT);
-        dao.insertResourceGroup(11, "subgroup", "80%", 10, null, 1, null, null, null, null, null, 10L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(10, "queued", "80%", 10, null, 3, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(11, "subgroup", "80%", 10, null, 1, null, null, null, null, null, null, 10L, TEST_ENVIRONMENT);
         dao.insertSelector(11, 1, null, null, null, null, null, null, "[\"queued\"]", null);
-        dao.insertResourceGroup(12, "running", "80%", 10, null, 3, null, null, null, null, null, null, TEST_ENVIRONMENT);
-        dao.insertResourceGroup(13, "subgroup", "80%", 10, null, 1, null, null, null, null, null, 12L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(12, "running", "80%", 10, null, 3, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(13, "subgroup", "80%", 10, null, 1, null, null, null, null, null, null, 12L, TEST_ENVIRONMENT);
         dao.insertSelector(13, 1, null, null, null, null, null, null, "[\"running\"]", null);
         dbConfigurationManager.load();
 
@@ -498,8 +497,7 @@ public class TestQueuesDb
     {
         InternalResourceGroupManager<?> manager = queryRunner.getCoordinator().getResourceGroupManager().orElseThrow();
         DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
-
-        dao.insertResourceGroup(10, "${USER}", "80%", 0, null, 0, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(10, "${USER}", "80%", 0, null, 0, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
         dao.insertSelector(10, 1, null, null, null, null, null, null, "[\"tag\"]", null);
         dbConfigurationManager.load();
 
@@ -507,13 +505,13 @@ public class TestQueuesDb
         waitForQueryState(queryRunner, firstQuery, FAILED);
         assertFailureMessage(firstQuery, "Too many queued queries for \"admin\"");
 
-        dao.updateResourceGroup(10, "admin", "80%", 1, null, 0, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(10, "admin", "80%", 1, null, 0, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
         dbConfigurationManager.load();
 
         QueryId secondQuery = createQuery(queryRunner, session("admin", "tag"), LONG_LASTING_QUERY);
         waitForQueryState(queryRunner, secondQuery, QUEUED);
 
-        dao.updateResourceGroup(10, "${USER}", "80%", 1, null, 2, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(10, "${USER}", "80%", 1, null, 2, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
         dbConfigurationManager.load();
 
         QueryId thirdQuery = createQuery(queryRunner, session("admin", "tag"), LONG_LASTING_QUERY);
@@ -529,7 +527,7 @@ public class TestQueuesDb
         InternalResourceGroupManager<?> manager = queryRunner.getCoordinator().getResourceGroupManager().orElseThrow();
         DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
 
-        dao.insertResourceGroup(10, "${USER}", "80%", 100, null, 100, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(10, "${USER}", "80%", 100, null, 100, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
         dao.insertSelector(10, 100, null, null, null, null, null, null, "[\"tag\"]", null);
         dbConfigurationManager.load();
 
@@ -537,14 +535,14 @@ public class TestQueuesDb
         QueryId firstQuery = createQuery(queryRunner, session("admin", "tag"), LONG_LASTING_QUERY);
         waitForQueryState(queryRunner, firstQuery, RUNNING);
 
-        dao.updateResourceGroup(10, "admin", "80%", 100, null, 100, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(10, "admin", "80%", 100, null, 100, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
         dbConfigurationManager.load();
 
         // associate the resource group with config 'admin'
         QueryId secondQuery = createQuery(queryRunner, session("admin", "tag"), LONG_LASTING_QUERY);
         waitForQueryState(queryRunner, secondQuery, RUNNING);
 
-        dao.insertResourceGroup(11, "${USER}", "80%", 0, null, 0, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(11, "${USER}", "80%", 0, null, 0, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
         dao.insertSelector(11, 101, null, null, null, null, null, null, "[\"tag\"]", null);
         dbConfigurationManager.load();
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

This PR adds support to track physical data scan usage in resource groups. This is an optional feature in resource groups and behaves similar to `cpuLimit`. This is a helpful feature for admins who need to 'throttle' their users from pulling too much data from file system. Quota based tracking will penalize users accordingly. 

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
 https://github.com/trinodb/trino/issues/25003

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Add physical data scan tracking to resource groups({issue}`25003`)
## SPI
*  Methods added to io.trino.spi.resourcegroups for tracking data scan usage({issue}`25003`)
```
