### PR TITLE
Allow querying Faker tables with some unsupported data types

### DIFF
--- a/docs/src/main/sphinx/connector/faker.md
+++ b/docs/src/main/sphinx/connector/faker.md
@@ -201,6 +201,7 @@ Faker supports the following non-character types:
 - `TIMESTAMP WITH TIME ZONE` and `TIMESTAMP(P) WITH TIME ZONE`
 - `TIME` and `TIME(P)`
 - `TIME WITH TIME ZONE` and `TIME(P) WITH TIME ZONE`
+- `ROW`
 - `IPADDRESS`
 - `UUID`
 
@@ -212,7 +213,7 @@ their data range, set the `min` and `max` column properties - see
 
 Faker does not support the following data types:
 
-- Structural types `ARRAY`, `MAP`, and `ROW`
+- Structural types `ARRAY` and `MAP`
 - `JSON`
 - Geometry
 - HyperLogLog and all digest types

--- a/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerQueries.java
+++ b/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerQueries.java
@@ -612,4 +612,20 @@ final class TestFakerQueries
             assertThat(createTable).containsPattern("comment varchar\\(79\\)");
         }
     }
+
+    @Test
+    void testCreateTableAsSelectBoolean()
+    {
+        String source = """
+                        SELECT
+                          sequential_number % 2 = 0 AS boolean,
+                          ARRAY[true, false, sequential_number % 2 = 0] AS boolean_array
+                        FROM TABLE(sequence(start => 0, stop => 1000, step => 1))
+                        """;
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "booleans", "AS " + source)) {
+            String createTable = (String) computeScalar("SHOW CREATE TABLE " + table.getName());
+            assertThat(createTable).containsPattern("boolean boolean WITH \\(null_probability = 0E0\\)");
+            assertThat(createTable).containsPattern("boolean_array array\\(boolean\\) WITH \\(null_probability = 0E0\\)");
+        }
+    }
 }

--- a/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerQueries.java
+++ b/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerQueries.java
@@ -127,6 +127,12 @@ final class TestFakerQueries
                 .add(new TestDataType("rnd_nchar", "char(1000)", "count(distinct rnd_nchar)", "1000"))
                 .add(new TestDataType("rnd_ipaddress", "ipaddress", "count(distinct rnd_ipaddress)", "1000"))
                 .add(new TestDataType("rnd_uuid", "uuid", "count(distinct rnd_uuid)", "1000"))
+                .add(new TestDataType("rnd_array_int", "array(integer)", "count(distinct rnd_array_int)", "1"))
+                .add(new TestDataType("rnd_array_varchar", "array(varchar)", "count(distinct rnd_array_varchar)", "1"))
+                .add(new TestDataType("rnd_map_int", "map(integer, integer)", "count(distinct rnd_map_int)", "1"))
+                .add(new TestDataType("rnd_map_varchar", "map(varchar, varchar)", "count(distinct rnd_map_varchar)", "1"))
+                .add(new TestDataType("rnd_row", "row(integer, varchar)", "count(distinct rnd_row)", "1000"))
+                .add(new TestDataType("rnd_json", "json", "count(distinct rnd_json)", "1"))
                 .build();
 
         for (TestDataType testCase : testCases) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Arrays, maps, and JSON are common data types, so instead of throwing
exceptions when reading from tables with columns of these types, return
empty arrays, maps, and JSON objects.
    
Rows can be fully supported, by using existing generators.

When running CTAS queries, exclude more types when trying to generate
random values for dictionary columns to avoid failures.

All these changes simplify copying existing schemas, without the need for excluding columns. For example, instead of running this query:
```sql
create table faker.default.unique_pulls as
select * from table(exclude_columns(input => table(trinocicd.v2.unique_pulls), columns => descriptor(label_ids, label_names, requested_reviewer_ids, requested_reviewer_logins)));
```

It's now possible to just run:
```sql
create table faker.default.unique_pulls as
select * from trinocicd.v2.unique_pulls;
```

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Faker
* Add support for the `ROW` type and generate empty values for `ARRAY`, `MAP`, and `JSON` types. ({issue}`issuenumber`)
```
