### PR TITLE
Reimplement FlatHash to reduce memory usage

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionManager.java
@@ -255,8 +255,9 @@ public class FunctionManager
                 case FLAT:
                     verifyFunctionSignature(parameterType.equals(byte[].class) &&
                                     methodType.parameterType(parameterIndex + 1).equals(int.class) &&
-                                    methodType.parameterType(parameterIndex + 2).equals(byte[].class),
-                            "Expected FLAT argument types to be byte[], int, byte[]");
+                                    methodType.parameterType(parameterIndex + 2).equals(byte[].class) &&
+                                    methodType.parameterType(parameterIndex + 3).equals(int.class),
+                            "Expected FLAT argument types to be byte[], int, byte[], int");
                     break;
                 case IN_OUT:
                     verifyFunctionSignature(parameterType.equals(InOut.class), "Expected IN_OUT argument type to be InOut");

--- a/core/trino-main/src/main/java/io/trino/operator/DistinctLimitOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DistinctLimitOperator.java
@@ -137,6 +137,7 @@ public class DistinctLimitOperator
                 operatorContext.getSession(),
                 distinctTypes,
                 hashChannel.isPresent(),
+                false,
                 toIntExact(min(limit, 10_000)),
                 hashStrategyCompiler,
                 this::updateMemoryReservation);

--- a/core/trino-main/src/main/java/io/trino/operator/FlatGroupByHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/FlatGroupByHash.java
@@ -128,11 +128,6 @@ public class FlatGroupByHash
         currentHashes = other.currentHashes == null ? null : Arrays.copyOf(other.currentHashes, other.currentHashes.length);
     }
 
-    public int getPhysicalPosition(int groupId)
-    {
-        return flatHash.getPhysicalPosition(groupId);
-    }
-
     @Override
     public long getRawHash(int groupId)
     {

--- a/core/trino-main/src/main/java/io/trino/operator/FlatGroupByHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/FlatGroupByHash.java
@@ -35,6 +35,7 @@ import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.operator.FlatHash.sumExact;
 import static java.lang.Math.min;
 import static java.lang.Math.multiplyExact;
+import static java.util.Objects.requireNonNull;
 
 // This implementation assumes arrays used in the hash are always a power of 2
 public class FlatGroupByHash
@@ -45,9 +46,31 @@ public class FlatGroupByHash
     // Max (page value count / cumulative dictionary size) to trigger the low cardinality case
     private static final double SMALL_DICTIONARIES_MAX_CARDINALITY_RATIO = 0.25;
 
+    public enum HashMode {
+        // Hash values are pre-computed as input, and emitted as output
+        PRECOMPUTED,
+        // Hash values are computed by the FlatGroupByHash instance and stored along with the entry
+        CACHED,
+        // Hash values are re-computed for each access on demand
+        ON_DEMAND;
+
+        public boolean isHashPrecomputed()
+        {
+            return this == PRECOMPUTED;
+        }
+
+        public boolean isHashCached()
+        {
+            return switch (this) {
+                case PRECOMPUTED, CACHED -> true;
+                case ON_DEMAND -> false;
+            };
+        }
+    }
+
+    private final HashMode hashMode;
     private final FlatHash flatHash;
     private final int groupByChannelCount;
-    private final boolean hasPrecomputedHash;
 
     private final boolean processDictionary;
 
@@ -63,19 +86,19 @@ public class FlatGroupByHash
 
     public FlatGroupByHash(
             List<Type> hashTypes,
-            boolean hasPrecomputedHash,
+            HashMode hashMode,
             int expectedSize,
             boolean processDictionary,
             FlatHashStrategyCompiler hashStrategyCompiler,
             UpdateMemory checkMemoryReservation)
     {
-        this.flatHash = new FlatHash(hashStrategyCompiler.getFlatHashStrategy(hashTypes), hasPrecomputedHash, expectedSize, checkMemoryReservation);
+        this.hashMode = requireNonNull(hashMode, "hashMode is null");
+        this.flatHash = new FlatHash(hashStrategyCompiler.getFlatHashStrategy(hashTypes), hashMode, expectedSize, checkMemoryReservation);
         this.groupByChannelCount = hashTypes.size();
-        this.hasPrecomputedHash = hasPrecomputedHash;
 
         checkArgument(expectedSize > 0, "expectedSize must be greater than zero");
 
-        int totalChannels = hashTypes.size() + (hasPrecomputedHash ? 1 : 0);
+        int totalChannels = hashTypes.size() + (hashMode.isHashPrecomputed() ? 1 : 0);
         this.currentBlocks = new Block[totalChannels];
         this.currentBlockBuilders = new BlockBuilder[totalChannels];
 
@@ -86,7 +109,7 @@ public class FlatGroupByHash
     {
         this.flatHash = other.flatHash.copy();
         groupByChannelCount = other.groupByChannelCount;
-        hasPrecomputedHash = other.hasPrecomputedHash;
+        hashMode = other.hashMode;
         processDictionary = other.processDictionary;
         dictionaryLookBack = other.dictionaryLookBack == null ? null : other.dictionaryLookBack.copy();
         currentPageSizeInBytes = other.currentPageSizeInBytes;
@@ -238,7 +261,7 @@ public class FlatGroupByHash
             return false;
         }
 
-        if (!hasPrecomputedHash) {
+        if (!hashMode.isHashPrecomputed()) {
             return true;
         }
 

--- a/core/trino-main/src/main/java/io/trino/operator/FlatHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/FlatHash.java
@@ -23,19 +23,13 @@ import java.util.Arrays;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Throwables.throwIfUnchecked;
-import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static io.airlift.slice.SizeOf.sizeOfByteArray;
-import static io.airlift.slice.SizeOf.sizeOfIntArray;
-import static io.airlift.slice.SizeOf.sizeOfObjectArray;
-import static io.trino.operator.AppendOnlyVariableWidthData.POINTER_SIZE;
 import static io.trino.operator.AppendOnlyVariableWidthData.getChunkOffset;
 import static io.trino.spi.StandardErrorCode.GENERIC_INSUFFICIENT_RESOURCES;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static java.lang.Math.addExact;
 import static java.lang.Math.max;
-import static java.lang.Math.min;
 import static java.lang.Math.multiplyExact;
 import static java.lang.Math.toIntExact;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
@@ -53,102 +47,100 @@ public final class FlatHash
         return max(toIntExact(1L << (64 - Long.numberOfLeadingZeros(capacity - 1))), 16);
     }
 
+    private static int calculateMaxFill(int capacity)
+    {
+        return toIntExact(capacity * 15L / 16);
+    }
+
     private static final int RECORDS_PER_GROUP_SHIFT = 10;
     private static final int RECORDS_PER_GROUP = 1 << RECORDS_PER_GROUP_SHIFT;
     private static final int RECORDS_PER_GROUP_MASK = RECORDS_PER_GROUP - 1;
 
     private static final int VECTOR_LENGTH = Long.BYTES;
     private static final VarHandle LONG_HANDLE = MethodHandles.byteArrayViewVarHandle(long[].class, LITTLE_ENDIAN);
-    private static final VarHandle INT_HANDLE = MethodHandles.byteArrayViewVarHandle(int[].class, LITTLE_ENDIAN);
 
     private final FlatHashStrategy flatHashStrategy;
+    private final AppendOnlyVariableWidthData variableWidthData;
+    private final UpdateMemory checkMemoryReservation;
+
     private final boolean hasPrecomputedHash;
     private final boolean cacheHashValue;
-
-    private final int recordSize;
-    private final int recordGroupIdOffset;
-    private final int recordHashOffset;
-    private final int recordValueOffset;
-
-    private int capacity;
-    private int mask;
+    private final int fixedRecordSize;
+    private final int variableWidthOffset;
+    private final int fixedValueOffset;
 
     private byte[] control;
-    private byte[][] recordGroups;
-    private final AppendOnlyVariableWidthData variableWidthData;
+    private int[] groupIdsByHash;
+    private byte[][] fixedSizeRecords;
 
-    // position of each group in the hash table
-    private int[] groupRecordIndex;
-
-    // reserve enough memory before rehash
-    private final UpdateMemory checkMemoryReservation;
-    private long fixedSizeEstimate;
-    private long rehashMemoryReservation;
-
+    private long fixedRecordGroupsRetainedSize;
+    private long temporaryRehashRetainedSize;
+    private int capacity;
+    private int mask;
     private int nextGroupId;
     private int maxFill;
 
     public FlatHash(FlatHashStrategy flatHashStrategy, FlatGroupByHash.HashMode hashMode, int expectedSize, UpdateMemory checkMemoryReservation)
     {
-        this.flatHashStrategy = flatHashStrategy;
+        this.flatHashStrategy = requireNonNull(flatHashStrategy, "flatHashStrategy is null");
+        this.checkMemoryReservation = requireNonNull(checkMemoryReservation, "checkMemoryReservation is null");
+        boolean hasVariableData = flatHashStrategy.isAnyVariableWidth();
+        this.variableWidthData = hasVariableData ? new AppendOnlyVariableWidthData() : null;
         requireNonNull(hashMode, "hashMode is null");
         this.hasPrecomputedHash = hashMode.isHashPrecomputed();
         this.cacheHashValue = hashMode.isHashCached();
-        this.checkMemoryReservation = checkMemoryReservation;
-
-        capacity = max(VECTOR_LENGTH, computeCapacity(expectedSize, DEFAULT_LOAD_FACTOR));
-        maxFill = calculateMaxFill(capacity);
-        mask = capacity - 1;
-        control = new byte[capacity + VECTOR_LENGTH];
-
-        groupRecordIndex = new int[maxFill];
 
         // the record is laid out as follows:
-        // 1. optional variable width pointer
-        // 2. groupId (int)
+        // 1. optional raw hash (long)
+        // 2. optional variable width pointer (int chunkIndex, int chunkOffset)
         // 3. fixed data for each type
-        boolean variableWidth = flatHashStrategy.isAnyVariableWidth();
-        variableWidthData = variableWidth ? new AppendOnlyVariableWidthData() : null;
-        recordGroupIdOffset = (variableWidth ? POINTER_SIZE : 0);
-        recordHashOffset = recordGroupIdOffset + Integer.BYTES;
-        recordValueOffset = recordHashOffset + (cacheHashValue ? Long.BYTES : 0);
-        recordSize = recordValueOffset + flatHashStrategy.getTotalFlatFixedLength();
+        this.variableWidthOffset = cacheHashValue ? Long.BYTES : 0;
+        this.fixedValueOffset = variableWidthOffset + (hasVariableData ? AppendOnlyVariableWidthData.POINTER_SIZE : 0);
+        this.fixedRecordSize = fixedValueOffset + flatHashStrategy.getTotalFlatFixedLength();
 
-        recordGroups = createRecordGroups(capacity, recordSize);
-        fixedSizeEstimate = computeFixedSizeEstimate(capacity, recordSize);
+        this.capacity = max(VECTOR_LENGTH, computeCapacity(expectedSize, DEFAULT_LOAD_FACTOR));
+        this.mask = capacity - 1;
+        this.maxFill = calculateMaxFill(capacity);
+
+        int groupsRequired = recordGroupsRequiredForCapacity(capacity);
+        this.control = new byte[capacity + VECTOR_LENGTH];
+        this.groupIdsByHash = new int[capacity];
+        Arrays.fill(groupIdsByHash, -1);
+        this.fixedSizeRecords = new byte[groupsRequired][];
     }
 
-    private FlatHash(FlatHash other)
+    public FlatHash(FlatHash other)
     {
-        flatHashStrategy = other.flatHashStrategy;
-        hasPrecomputedHash = other.hasPrecomputedHash;
-        cacheHashValue = other.cacheHashValue;
-
-        recordSize = other.recordSize;
-        recordGroupIdOffset = other.recordGroupIdOffset;
-        recordHashOffset = other.recordHashOffset;
-        recordValueOffset = other.recordValueOffset;
-        capacity = other.capacity;
-        mask = other.mask;
-        control = Arrays.copyOf(other.control, other.control.length);
-        recordGroups = Arrays.stream(other.recordGroups)
-                .map(records -> records == null ? null : Arrays.copyOf(records, records.length))
+        this.flatHashStrategy = other.flatHashStrategy;
+        this.checkMemoryReservation = other.checkMemoryReservation;
+        this.variableWidthData = other.variableWidthData == null ? null : new AppendOnlyVariableWidthData(other.variableWidthData);
+        this.hasPrecomputedHash = other.hasPrecomputedHash;
+        this.cacheHashValue = other.cacheHashValue;
+        this.fixedRecordSize = other.fixedRecordSize;
+        this.variableWidthOffset = other.variableWidthOffset;
+        this.fixedValueOffset = other.fixedValueOffset;
+        this.fixedRecordGroupsRetainedSize = other.fixedRecordGroupsRetainedSize;
+        this.capacity = other.capacity;
+        this.mask = other.mask;
+        this.nextGroupId = other.nextGroupId;
+        this.maxFill = other.maxFill;
+        this.control = Arrays.copyOf(other.control, other.control.length);
+        this.groupIdsByHash = Arrays.copyOf(other.groupIdsByHash, other.groupIdsByHash.length);
+        this.fixedSizeRecords = Arrays.stream(other.fixedSizeRecords)
+                .map(fixedSizeRecords -> fixedSizeRecords == null ? null : Arrays.copyOf(fixedSizeRecords, fixedSizeRecords.length))
                 .toArray(byte[][]::new);
-        variableWidthData = other.variableWidthData == null ? null : new AppendOnlyVariableWidthData(other.variableWidthData);
-        groupRecordIndex = Arrays.copyOf(other.groupRecordIndex, other.groupRecordIndex.length);
-        checkMemoryReservation = other.checkMemoryReservation;
-        fixedSizeEstimate = other.fixedSizeEstimate;
-        rehashMemoryReservation = other.rehashMemoryReservation;
-        nextGroupId = other.nextGroupId;
-        maxFill = other.maxFill;
     }
 
     public long getEstimatedSize()
     {
         return sumExact(
-                fixedSizeEstimate,
-                (variableWidthData == null ? 0 : variableWidthData.getRetainedSizeBytes()),
-                rehashMemoryReservation);
+                INSTANCE_SIZE,
+                fixedRecordGroupsRetainedSize,
+                temporaryRehashRetainedSize,
+                sizeOf(control),
+                sizeOf(groupIdsByHash),
+                sizeOf(fixedSizeRecords),
+                variableWidthData == null ? 0 : variableWidthData.getRetainedSizeBytes());
     }
 
     public int size()
@@ -163,36 +155,52 @@ public final class FlatHash
 
     public long hashPosition(int groupId)
     {
-        // for spilling
-        checkArgument(groupId < nextGroupId, "groupId out of range");
-
-        int index = groupRecordIndex[groupId];
-        byte[] records = getRecords(index);
-        if (cacheHashValue) {
-            return (long) LONG_HANDLE.get(records, getRecordOffset(index) + recordHashOffset);
+        if (groupId < 0) {
+            throw new IllegalArgumentException("groupId is negative");
         }
-        else {
-            return valueHashCode(records, index);
+        byte[] fixedSizeRecords = getFixedSizeRecords(groupId);
+        int fixedRecordOffset = getFixedRecordOffset(groupId);
+        if (cacheHashValue) {
+            return (long) LONG_HANDLE.get(fixedSizeRecords, fixedRecordOffset);
+        }
+        byte[] variableWidthChunk = null;
+        int variableChunkOffset = 0;
+        if (variableWidthData != null) {
+            variableWidthChunk = variableWidthData.getChunk(fixedSizeRecords, fixedRecordOffset + variableWidthOffset);
+            variableChunkOffset = getChunkOffset(fixedSizeRecords, fixedRecordOffset + variableWidthOffset);
+        }
+        try {
+            return flatHashStrategy.hash(fixedSizeRecords, fixedRecordOffset + fixedValueOffset, variableWidthChunk, variableChunkOffset);
+        }
+        catch (Throwable throwable) {
+            throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
         }
     }
 
     public void appendTo(int groupId, BlockBuilder[] blockBuilders)
     {
         checkArgument(groupId < nextGroupId, "groupId out of range");
-        int index = groupRecordIndex[groupId];
-        byte[] records = getRecords(index);
-        int recordOffset = getRecordOffset(index);
+
+        byte[] fixedSizeRecords = getFixedSizeRecords(groupId);
+        int recordOffset = getFixedRecordOffset(groupId);
 
         byte[] variableWidthChunk = null;
-        int variableWidthOffset = 0;
+        int variableChunkOffset = 0;
         if (variableWidthData != null) {
-            variableWidthChunk = variableWidthData.getChunk(records, recordOffset);
-            variableWidthOffset = getChunkOffset(records, recordOffset);
+            variableWidthChunk = variableWidthData.getChunk(fixedSizeRecords, recordOffset + variableWidthOffset);
+            variableChunkOffset = getChunkOffset(fixedSizeRecords, recordOffset + variableWidthOffset);
         }
 
-        flatHashStrategy.readFlat(records, recordOffset + recordValueOffset, variableWidthChunk, variableWidthOffset, blockBuilders);
+        flatHashStrategy.readFlat(
+                fixedSizeRecords,
+                recordOffset + fixedValueOffset,
+                variableWidthChunk,
+                variableChunkOffset,
+                blockBuilders);
+
         if (hasPrecomputedHash) {
-            BIGINT.writeLong(blockBuilders[blockBuilders.length - 1], (long) LONG_HANDLE.get(records, recordOffset + recordHashOffset));
+            BIGINT.writeLong(blockBuilders[blockBuilders.length - 1], (long) LONG_HANDLE.get(fixedSizeRecords, recordOffset));
         }
     }
 
@@ -208,22 +216,23 @@ public final class FlatHash
 
     public void computeHashes(Block[] blocks, long[] hashes, int offset, int length)
     {
-        if (hasPrecomputedHash) {
-            Block hashBlock = blocks[blocks.length - 1];
-            for (int i = 0; i < length; i++) {
-                hashes[i] = BIGINT.getLong(hashBlock, offset + i);
-            }
-        }
-        else {
-            flatHashStrategy.hashBlocksBatched(blocks, hashes, offset, length);
-        }
+        flatHashStrategy.hashBlocksBatched(blocks, hashes, offset, length);
+    }
+
+    public int putIfAbsent(Block[] blocks, int position)
+    {
+        return putIfAbsent(blocks, position, flatHashStrategy.hash(blocks, position));
     }
 
     public int putIfAbsent(Block[] blocks, int position, long hash)
     {
         int index = getIndex(blocks, position, hash);
         if (index >= 0) {
-            return (int) INT_HANDLE.get(getRecords(index), getRecordOffset(index) + recordGroupIdOffset);
+            int groupId = groupIdsByHash[index];
+            if (groupId < 0) {
+                throw new IllegalStateException("groupId out of range");
+            }
+            return groupId;
         }
 
         index = -index - 1;
@@ -234,23 +243,10 @@ public final class FlatHash
         return groupId;
     }
 
-    public int putIfAbsent(Block[] blocks, int position)
-    {
-        long hash;
-        if (hasPrecomputedHash) {
-            hash = BIGINT.getLong(blocks[blocks.length - 1], position);
-        }
-        else {
-            hash = flatHashStrategy.hash(blocks, position);
-        }
-
-        return putIfAbsent(blocks, position, hash);
-    }
-
     private int getIndex(Block[] blocks, int position, long hash)
     {
         byte hashPrefix = (byte) (hash & 0x7F | 0x80);
-        int bucket = bucket((int) (hash >> 7));
+        int bucket = bucket((int) hash >> 7);
 
         int step = 1;
         long repeated = repeat(hashPrefix);
@@ -278,7 +274,8 @@ public final class FlatHash
         long controlMatches = match(controlVector, repeated);
         while (controlMatches != 0) {
             int index = bucket(vectorStartBucket + (Long.numberOfTrailingZeros(controlMatches) >>> 3));
-            if (valueIdentical(index, blocks, position, hash)) {
+            int groupId = groupIdsByHash[index];
+            if (valueIdentical(groupId, blocks, position, hash)) {
                 return index;
             }
 
@@ -300,26 +297,41 @@ public final class FlatHash
     private int addNewGroup(int index, Block[] blocks, int position, long hash)
     {
         setControl(index, (byte) (hash & 0x7F | 0x80));
-
-        byte[] records = getRecords(index);
-        int recordOffset = getRecordOffset(index);
-
         int groupId = nextGroupId++;
-        INT_HANDLE.set(records, recordOffset + recordGroupIdOffset, groupId);
-        groupRecordIndex[groupId] = index;
+        groupIdsByHash[index] = groupId;
+        int recordGroupIndex = recordGroupIndexForGroupId(groupId);
+        int fixedRecordOffset = getFixedRecordOffset(groupId);
+        byte[] fixedSizeRecords = this.fixedSizeRecords[recordGroupIndex];
+        if (fixedRecordOffset == 0) {
+            if (fixedSizeRecords != null) {
+                throw new IllegalStateException("fixedSizeRecords already exists");
+            }
+            // new record batch start, populate the record batch fields
+            fixedSizeRecords = new byte[multiplyExact(RECORDS_PER_GROUP, fixedRecordSize)];
+            this.fixedSizeRecords[recordGroupIndex] = fixedSizeRecords;
+            fixedRecordGroupsRetainedSize = addExact(fixedRecordGroupsRetainedSize, sizeOf(fixedSizeRecords));
+        }
 
         if (cacheHashValue) {
-            LONG_HANDLE.set(records, recordOffset + recordHashOffset, hash);
+            LONG_HANDLE.set(fixedSizeRecords, fixedRecordOffset, hash);
         }
 
         byte[] variableWidthChunk = null;
         int variableWidthChunkOffset = 0;
         if (variableWidthData != null) {
             int variableWidthSize = flatHashStrategy.getTotalVariableWidth(blocks, position);
-            variableWidthChunk = variableWidthData.allocate(records, recordOffset, variableWidthSize);
-            variableWidthChunkOffset = getChunkOffset(records, recordOffset);
+            variableWidthChunk = variableWidthData.allocate(fixedSizeRecords, fixedRecordOffset + variableWidthOffset, variableWidthSize);
+            variableWidthChunkOffset = getChunkOffset(fixedSizeRecords, fixedRecordOffset + variableWidthOffset);
         }
-        flatHashStrategy.writeFlat(blocks, position, records, recordOffset + recordValueOffset, variableWidthChunk, variableWidthChunkOffset);
+
+        flatHashStrategy.writeFlat(
+                blocks,
+                position,
+                fixedSizeRecords,
+                fixedRecordOffset + fixedValueOffset,
+                variableWidthChunk,
+                variableWidthChunkOffset);
+
         return groupId;
     }
 
@@ -344,14 +356,7 @@ public final class FlatHash
     private boolean tryRehash(int minimumRequiredCapacity)
     {
         int newCapacity = computeNewCapacity(minimumRequiredCapacity);
-
-        // update the fixed size estimate to the new size as we will need this much memory after the rehash
-        fixedSizeEstimate = computeFixedSizeEstimate(newCapacity, recordSize);
-
-        // the rehash incrementally allocates the new records as needed, so as new memory is added old memory is released
-        // while the rehash is in progress, the old control array is retained, and one additional record group is retained
-        rehashMemoryReservation = sumExact(sizeOf(control), sizeOf(recordGroups[0]));
-        verify(rehashMemoryReservation >= 0, "rehashMemoryReservation is negative");
+        temporaryRehashRetainedSize = multiplyExact((long) newCapacity, Integer.BYTES + Byte.BYTES);
         if (!checkMemoryReservation.update()) {
             return false;
         }
@@ -362,89 +367,92 @@ public final class FlatHash
 
     private void rehash(int minimumRequiredCapacity)
     {
-        int oldCapacity = capacity;
-        byte[] oldControl = control;
-        byte[][] oldRecordGroups = recordGroups;
-
         capacity = computeNewCapacity(minimumRequiredCapacity);
         maxFill = calculateMaxFill(capacity);
         mask = capacity - 1;
 
+        // Resize the record groups top level array to accommodate the new record groups
+        fixedSizeRecords = Arrays.copyOf(fixedSizeRecords, recordGroupsRequiredForCapacity(capacity));
+
+        // Construct the new hash table
         control = new byte[capacity + VECTOR_LENGTH];
+        groupIdsByHash = new int[capacity];
+        Arrays.fill(groupIdsByHash, -1);
 
-        // we incrementally allocate the record groups to smooth out memory allocation
-        if (capacity <= RECORDS_PER_GROUP) {
-            recordGroups = new byte[][] {new byte[multiplyExact(capacity, recordSize)]};
-        }
-        else {
-            recordGroups = new byte[(capacity + 1) >> RECORDS_PER_GROUP_SHIFT][];
-        }
+        for (int groupId = 0; groupId < nextGroupId; groupId++) {
+            long hash = hashPosition(groupId);
 
-        groupRecordIndex = new int[maxFill];
+            byte hashPrefix = (byte) (hash & 0x7F | 0x80);
+            int bucket = bucket((int) (hash >> 7));
 
-        for (int oldRecordGroupIndex = 0; oldRecordGroupIndex < oldRecordGroups.length; oldRecordGroupIndex++) {
-            byte[] oldRecords = oldRecordGroups[oldRecordGroupIndex];
-            oldRecordGroups[oldRecordGroupIndex] = null;
-            for (int indexInRecordGroup = 0; indexInRecordGroup < min(RECORDS_PER_GROUP, oldCapacity); indexInRecordGroup++) {
-                int oldIndex = (oldRecordGroupIndex << RECORDS_PER_GROUP_SHIFT) + indexInRecordGroup;
-                if (oldControl[oldIndex] == 0) {
-                    continue;
-                }
-
-                long hash;
-                if (cacheHashValue) {
-                    hash = (long) LONG_HANDLE.get(oldRecords, getRecordOffset(oldIndex) + recordHashOffset);
-                }
-                else {
-                    hash = valueHashCode(oldRecords, oldIndex);
-                }
-
-                byte hashPrefix = (byte) (hash & 0x7F | 0x80);
-                int bucket = bucket((int) (hash >> 7));
-
-                // getIndex is not used here because values in a rehash are always distinct
-                int step = 1;
-                while (true) {
-                    final long controlVector = (long) LONG_HANDLE.get(control, bucket);
-                    // values are already distinct, so just find the first empty slot
-                    int emptyIndex = findEmptyInVector(controlVector, bucket);
-                    if (emptyIndex >= 0) {
-                        setControl(emptyIndex, hashPrefix);
-
-                        int newRecordGroupIndex = emptyIndex >> RECORDS_PER_GROUP_SHIFT;
-                        byte[] records = recordGroups[newRecordGroupIndex];
-                        if (records == null) {
-                            records = new byte[multiplyExact(RECORDS_PER_GROUP, recordSize)];
-                            recordGroups[newRecordGroupIndex] = records;
-                        }
-                        int recordOffset = getRecordOffset(emptyIndex);
-                        int oldRecordOffset = getRecordOffset(oldIndex);
-                        System.arraycopy(oldRecords, oldRecordOffset, records, recordOffset, recordSize);
-
-                        int groupId = (int) INT_HANDLE.get(records, recordOffset + recordGroupIdOffset);
-                        groupRecordIndex[groupId] = emptyIndex;
-
-                        break;
+            // getIndex is not used here because values in a rehash are always distinct
+            int step = 1;
+            while (true) {
+                final long controlVector = (long) LONG_HANDLE.get(control, bucket);
+                // values are already distinct, so just find the first empty slot
+                int emptyIndex = findEmptyInVector(controlVector, bucket);
+                if (emptyIndex >= 0) {
+                    setControl(emptyIndex, hashPrefix);
+                    if (groupIdsByHash[emptyIndex] != -1) {
+                        throw new IllegalStateException("groupId mapping already exists at index");
                     }
-
-                    bucket = bucket(bucket + step);
-                    step += VECTOR_LENGTH;
+                    groupIdsByHash[emptyIndex] = groupId;
+                    break;
                 }
-            }
-        }
-
-        // add any completely empty record groups
-        // the odds of needing this are exceedingly low, but it is technically possible
-        for (int i = 0; i < recordGroups.length; i++) {
-            if (recordGroups[i] == null) {
-                recordGroups[i] = new byte[multiplyExact(RECORDS_PER_GROUP, recordSize)];
+                bucket = bucket(bucket + step);
+                step += VECTOR_LENGTH;
             }
         }
 
         // release temporary memory reservation
-        rehashMemoryReservation = 0;
-        fixedSizeEstimate = computeFixedSizeEstimate(capacity, recordSize);
+        temporaryRehashRetainedSize = 0;
         checkMemoryReservation.update();
+    }
+
+    private int bucket(int hash)
+    {
+        return hash & mask;
+    }
+
+    private static int recordGroupIndexForGroupId(int groupId)
+    {
+        return groupId >> RECORDS_PER_GROUP_SHIFT;
+    }
+
+    private byte[] getFixedSizeRecords(int groupId)
+    {
+        return fixedSizeRecords[recordGroupIndexForGroupId(groupId)];
+    }
+
+    private int getFixedRecordOffset(int groupId)
+    {
+        return (groupId & RECORDS_PER_GROUP_MASK) * fixedRecordSize;
+    }
+
+    private boolean valueIdentical(int groupId, Block[] rightBlocks, int rightPosition, long rightHash)
+    {
+        checkArgument(groupId >= 0, "groupId is negative");
+        byte[] fixedSizeRecords = getFixedSizeRecords(groupId);
+        int fixedRecordsOffset = getFixedRecordOffset(groupId);
+
+        if (cacheHashValue && rightHash != (long) LONG_HANDLE.get(fixedSizeRecords, fixedRecordsOffset)) {
+            return false;
+        }
+
+        byte[] variableWidthChunk = null;
+        int variableWidthChunkOffset = 0;
+        if (variableWidthData != null) {
+            variableWidthChunk = variableWidthData.getChunk(fixedSizeRecords, fixedRecordsOffset + variableWidthOffset);
+            variableWidthChunkOffset = getChunkOffset(fixedSizeRecords, fixedRecordsOffset + variableWidthOffset);
+        }
+
+        return flatHashStrategy.valueIdentical(
+                fixedSizeRecords,
+                fixedRecordsOffset + fixedValueOffset,
+                variableWidthChunk,
+                variableWidthChunkOffset,
+                rightBlocks,
+                rightPosition);
     }
 
     private int computeNewCapacity(int minimumRequiredCapacity)
@@ -460,69 +468,6 @@ public final class FlatHash
         return toIntExact(newCapacityLong);
     }
 
-    private int bucket(int hash)
-    {
-        return hash & mask;
-    }
-
-    private byte[] getRecords(int index)
-    {
-        return recordGroups[index >> RECORDS_PER_GROUP_SHIFT];
-    }
-
-    private int getRecordOffset(int index)
-    {
-        return (index & RECORDS_PER_GROUP_MASK) * recordSize;
-    }
-
-    private long valueHashCode(byte[] records, int index)
-    {
-        int recordOffset = getRecordOffset(index);
-
-        try {
-            byte[] variableWidthChunk = null;
-            int variableWidthOffset = 0;
-            if (variableWidthData != null) {
-                variableWidthChunk = variableWidthData.getChunk(records, recordOffset);
-                variableWidthOffset = getChunkOffset(records, recordOffset);
-            }
-
-            return flatHashStrategy.hash(records, recordOffset + recordValueOffset, variableWidthChunk, variableWidthOffset);
-        }
-        catch (Throwable throwable) {
-            throwIfUnchecked(throwable);
-            throw new RuntimeException(throwable);
-        }
-    }
-
-    private boolean valueIdentical(int leftIndex, Block[] rightBlocks, int rightPosition, long rightHash)
-    {
-        byte[] leftRecords = getRecords(leftIndex);
-        int leftRecordOffset = getRecordOffset(leftIndex);
-
-        if (cacheHashValue) {
-            long leftHash = (long) LONG_HANDLE.get(leftRecords, leftRecordOffset + recordHashOffset);
-            if (leftHash != rightHash) {
-                return false;
-            }
-        }
-
-        byte[] leftVariableWidthChunk = null;
-        int leftVariableWidthOffset = 0;
-        if (variableWidthData != null) {
-            leftVariableWidthChunk = variableWidthData.getChunk(leftRecords, leftRecordOffset);
-            leftVariableWidthOffset = getChunkOffset(leftRecords, leftRecordOffset);
-        }
-
-        return flatHashStrategy.valueIdentical(
-                leftRecords,
-                leftRecordOffset + recordValueOffset,
-                leftVariableWidthChunk,
-                leftVariableWidthOffset,
-                rightBlocks,
-                rightPosition);
-    }
-
     private static long repeat(byte value)
     {
         return ((value & 0xFF) * 0x01_01_01_01_01_01_01_01L);
@@ -535,47 +480,10 @@ public final class FlatHash
         return (comparison - 0x01_01_01_01_01_01_01_01L) & ~comparison & 0x80_80_80_80_80_80_80_80L;
     }
 
-    public int getPhysicalPosition(int groupId)
+    private static int recordGroupsRequiredForCapacity(int capacity)
     {
-        return groupRecordIndex[groupId];
-    }
-
-    private static int calculateMaxFill(int capacity)
-    {
-        return toIntExact(capacity * 15L / 16);
-    }
-
-    private static byte[][] createRecordGroups(int capacity, int recordSize)
-    {
-        if (capacity <= RECORDS_PER_GROUP) {
-            return new byte[][] {new byte[multiplyExact(capacity, recordSize)]};
-        }
-
-        byte[][] groups = new byte[(capacity + 1) >> RECORDS_PER_GROUP_SHIFT][];
-        for (int i = 0; i < groups.length; i++) {
-            groups[i] = new byte[multiplyExact(RECORDS_PER_GROUP, recordSize)];
-        }
-        return groups;
-    }
-
-    private static long computeRecordGroupsSize(int capacity, int recordSize)
-    {
-        if (capacity <= RECORDS_PER_GROUP) {
-            return sizeOfObjectArray(1) + sizeOfByteArray(multiplyExact(capacity, recordSize));
-        }
-
-        int groupCount = addExact(capacity, 1) >> RECORDS_PER_GROUP_SHIFT;
-        return sizeOfObjectArray(groupCount) +
-                multiplyExact(groupCount, sizeOfByteArray(multiplyExact(RECORDS_PER_GROUP, recordSize)));
-    }
-
-    private static long computeFixedSizeEstimate(int capacity, int recordSize)
-    {
-        return sumExact(
-                INSTANCE_SIZE,
-                sizeOfByteArray(capacity + VECTOR_LENGTH),
-                computeRecordGroupsSize(capacity, recordSize),
-                sizeOfIntArray(capacity));
+        checkArgument(capacity > 0, "capacity must be positive");
+        return max(1, (capacity + 1) >> RECORDS_PER_GROUP_SHIFT);
     }
 
     public static long sumExact(long... values)

--- a/core/trino-main/src/main/java/io/trino/operator/FlatHashStrategy.java
+++ b/core/trino-main/src/main/java/io/trino/operator/FlatHashStrategy.java
@@ -24,7 +24,7 @@ public interface FlatHashStrategy
 
     int getTotalVariableWidth(Block[] blocks, int position);
 
-    void readFlat(byte[] fixedChunk, int fixedOffset, byte[] variableChunk, BlockBuilder[] blockBuilders);
+    void readFlat(byte[] fixedChunk, int fixedOffset, byte[] variableChunk, int variableOffset, BlockBuilder[] blockBuilders);
 
     void writeFlat(Block[] blocks, int position, byte[] fixedChunk, int fixedOffset, byte[] variableChunk, int variableOffset);
 
@@ -32,12 +32,13 @@ public interface FlatHashStrategy
             byte[] leftFixedChunk,
             int leftFixedOffset,
             byte[] leftVariableChunk,
+            int leftVariableOffset,
             Block[] rightBlocks,
             int rightPosition);
 
     long hash(Block[] blocks, int position);
 
-    long hash(byte[] fixedChunk, int fixedOffset, byte[] variableChunk);
+    long hash(byte[] fixedChunk, int fixedOffset, byte[] variableChunk, int variableOffset);
 
     void hashBlocksBatched(Block[] blocks, long[] hashes, int offset, int length);
 }

--- a/core/trino-main/src/main/java/io/trino/operator/FlatSet.java
+++ b/core/trino-main/src/main/java/io/trino/operator/FlatSet.java
@@ -26,6 +26,7 @@ import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.operator.VariableWidthData.EMPTY_CHUNK;
 import static io.trino.operator.VariableWidthData.POINTER_SIZE;
+import static io.trino.operator.VariableWidthData.getChunkOffset;
 import static io.trino.spi.StandardErrorCode.GENERIC_INSUFFICIENT_RESOURCES;
 import static java.lang.Math.multiplyExact;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
@@ -239,7 +240,7 @@ final class FlatSet
         if (variableWidthData != null) {
             int variableWidthLength = type.getFlatVariableWidthSize(block, position);
             variableWidthChunk = variableWidthData.allocate(records, recordOffset, variableWidthLength);
-            variableWidthChunkOffset = VariableWidthData.getChunkOffset(records, recordOffset);
+            variableWidthChunkOffset = getChunkOffset(records, recordOffset);
         }
 
         try {
@@ -329,14 +330,17 @@ final class FlatSet
 
         try {
             byte[] variableWidthChunk = EMPTY_CHUNK;
+            int variableWidthChunkOffset = 0;
             if (variableWidthData != null) {
                 variableWidthChunk = variableWidthData.getChunk(records, recordOffset);
+                variableWidthChunkOffset = getChunkOffset(records, recordOffset);
             }
 
             return (long) hashFlat.invokeExact(
                     records,
                     recordOffset + recordValueOffset,
-                    variableWidthChunk);
+                    variableWidthChunk,
+                    variableWidthChunkOffset);
         }
         catch (Throwable throwable) {
             Throwables.throwIfUnchecked(throwable);
@@ -361,8 +365,10 @@ final class FlatSet
         int leftRecordOffset = getRecordOffset(leftPosition);
 
         byte[] leftVariableWidthChunk = EMPTY_CHUNK;
+        int leftVariableWidthChunkOffset = 0;
         if (variableWidthData != null) {
             leftVariableWidthChunk = variableWidthData.getChunk(leftRecords, leftRecordOffset);
+            leftVariableWidthChunkOffset = getChunkOffset(leftRecords, leftRecordOffset);
         }
 
         try {
@@ -370,6 +376,7 @@ final class FlatSet
                     leftRecords,
                     leftRecordOffset + recordValueOffset,
                     leftVariableWidthChunk,
+                    leftVariableWidthChunkOffset,
                     right,
                     rightPosition);
         }

--- a/core/trino-main/src/main/java/io/trino/operator/GroupByHashPageIndexer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupByHashPageIndexer.java
@@ -30,7 +30,7 @@ public class GroupByHashPageIndexer
 
     public GroupByHashPageIndexer(List<Type> hashTypes, FlatHashStrategyCompiler hashStrategyCompiler)
     {
-        this(GroupByHash.createGroupByHash(hashTypes, false, 20, false, hashStrategyCompiler, NOOP));
+        this(GroupByHash.createGroupByHash(hashTypes, false, false, 20, false, hashStrategyCompiler, NOOP));
     }
 
     public GroupByHashPageIndexer(GroupByHash hash)

--- a/core/trino-main/src/main/java/io/trino/operator/JoinDomainBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/JoinDomainBuilder.java
@@ -517,14 +517,17 @@ public class JoinDomainBuilder
 
         try {
             byte[] variableWidthChunk = EMPTY_CHUNK;
+            int variableChunkOffset = 0;
             if (distinctVariableWidthData != null) {
                 variableWidthChunk = distinctVariableWidthData.getChunk(distinctRecords, recordOffset);
+                variableChunkOffset = VariableWidthData.getChunkOffset(distinctRecords, recordOffset);
             }
 
             return (Object) readFlat.invokeExact(
                     distinctRecords,
                     recordOffset + distinctRecordValueOffset,
-                    variableWidthChunk);
+                    variableWidthChunk,
+                    variableChunkOffset);
         }
         catch (Throwable throwable) {
             Throwables.throwIfUnchecked(throwable);
@@ -543,14 +546,17 @@ public class JoinDomainBuilder
 
         try {
             byte[] variableWidthChunk = EMPTY_CHUNK;
+            int variableWidthOffset = 0;
             if (distinctVariableWidthData != null) {
                 variableWidthChunk = distinctVariableWidthData.getChunk(values, recordOffset);
+                variableWidthOffset = VariableWidthData.getChunkOffset(values, recordOffset);
             }
 
             return (long) hashFlat.invokeExact(
                     values,
                     recordOffset + distinctRecordValueOffset,
-                    variableWidthChunk);
+                    variableWidthChunk,
+                    variableWidthOffset);
         }
         catch (Throwable throwable) {
             Throwables.throwIfUnchecked(throwable);
@@ -574,8 +580,10 @@ public class JoinDomainBuilder
         byte[] leftFixedRecordChunk = distinctRecords;
         int leftRecordOffset = getRecordOffset(leftPosition);
         byte[] leftVariableWidthChunk = EMPTY_CHUNK;
+        int leftVariableWidthOffset = 0;
         if (distinctVariableWidthData != null) {
             leftVariableWidthChunk = distinctVariableWidthData.getChunk(leftFixedRecordChunk, leftRecordOffset);
+            leftVariableWidthOffset = VariableWidthData.getChunkOffset(leftFixedRecordChunk, leftRecordOffset);
         }
 
         try {
@@ -583,6 +591,7 @@ public class JoinDomainBuilder
                     leftFixedRecordChunk,
                     leftRecordOffset + distinctRecordValueOffset,
                     leftVariableWidthChunk,
+                    leftVariableWidthOffset,
                     right,
                     rightPosition);
         }
@@ -597,15 +606,19 @@ public class JoinDomainBuilder
         byte[] leftFixedRecordChunk = distinctRecords;
         int leftRecordOffset = getRecordOffset(leftPosition);
         byte[] leftVariableWidthChunk = EMPTY_CHUNK;
+        int leftVariableWidthOffset = 0;
         if (distinctVariableWidthData != null) {
             leftVariableWidthChunk = distinctVariableWidthData.getChunk(leftFixedRecordChunk, leftRecordOffset);
+            leftVariableWidthOffset = VariableWidthData.getChunkOffset(leftFixedRecordChunk, leftRecordOffset);
         }
 
         byte[] rightFixedRecordChunk = rightValues;
         int rightRecordOffset = getRecordOffset(rightPosition);
         byte[] rightVariableWidthChunk = EMPTY_CHUNK;
+        int rightVariableWidthOffset = 0;
         if (rightVariableWidthData != null) {
             rightVariableWidthChunk = rightVariableWidthData.getChunk(rightFixedRecordChunk, rightRecordOffset);
+            rightVariableWidthOffset = VariableWidthData.getChunkOffset(rightFixedRecordChunk, rightRecordOffset);
         }
 
         try {
@@ -613,9 +626,11 @@ public class JoinDomainBuilder
                     leftFixedRecordChunk,
                     leftRecordOffset + distinctRecordValueOffset,
                     leftVariableWidthChunk,
+                    leftVariableWidthOffset,
                     rightFixedRecordChunk,
                     rightRecordOffset + distinctRecordValueOffset,
-                    rightVariableWidthChunk);
+                    rightVariableWidthChunk,
+                    rightVariableWidthOffset);
         }
         catch (Throwable throwable) {
             Throwables.throwIfUnchecked(throwable);
@@ -645,9 +660,13 @@ public class JoinDomainBuilder
 
         byte[] leftVariableWidthChunk = EMPTY_CHUNK;
         byte[] rightVariableWidthChunk = EMPTY_CHUNK;
+        int leftVariableWidthOffset = 0;
+        int rightVariableWidthOffset = 0;
         if (distinctVariableWidthData != null) {
             leftVariableWidthChunk = distinctVariableWidthData.getChunk(distinctRecords, leftRecordOffset);
             rightVariableWidthChunk = distinctVariableWidthData.getChunk(distinctRecords, rightRecordOffset);
+            leftVariableWidthOffset = VariableWidthData.getChunkOffset(distinctRecords, leftRecordOffset);
+            rightVariableWidthOffset = VariableWidthData.getChunkOffset(distinctRecords, rightRecordOffset);
         }
 
         try {
@@ -655,9 +674,11 @@ public class JoinDomainBuilder
                     distinctRecords,
                     leftRecordOffset + distinctRecordValueOffset,
                     leftVariableWidthChunk,
+                    leftVariableWidthOffset,
                     distinctRecords,
                     rightRecordOffset + distinctRecordValueOffset,
-                    rightVariableWidthChunk);
+                    rightVariableWidthChunk,
+                    rightVariableWidthOffset);
         }
         catch (Throwable throwable) {
             Throwables.throwIfUnchecked(throwable);

--- a/core/trino-main/src/main/java/io/trino/operator/MarkDistinctHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/MarkDistinctHash.java
@@ -33,7 +33,7 @@ public class MarkDistinctHash
 
     public MarkDistinctHash(Session session, List<Type> types, boolean hasPrecomputedHash, FlatHashStrategyCompiler hashStrategyCompiler, UpdateMemory updateMemory)
     {
-        this.groupByHash = createGroupByHash(session, types, hasPrecomputedHash, 10_000, hashStrategyCompiler, updateMemory);
+        this.groupByHash = createGroupByHash(session, types, hasPrecomputedHash, false, 10_000, hashStrategyCompiler, updateMemory);
     }
 
     private MarkDistinctHash(MarkDistinctHash other)

--- a/core/trino-main/src/main/java/io/trino/operator/RowNumberOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/RowNumberOperator.java
@@ -185,6 +185,7 @@ public class RowNumberOperator
                     operatorContext.getSession(),
                     partitionTypes,
                     hashChannel.isPresent(),
+                    false,
                     expectedPositions,
                     hashStrategyCompiler,
                     this::updateMemoryReservation));

--- a/core/trino-main/src/main/java/io/trino/operator/TopNRankingOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TopNRankingOperator.java
@@ -251,6 +251,7 @@ public class TopNRankingOperator
                 session,
                 partitionTypes,
                 hasPrecomputedHash,
+                false,
                 expectedPositions,
                 hashStrategyCompiler,
                 updateMemory);

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/arrayagg/FlatArrayBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/arrayagg/FlatArrayBuilder.java
@@ -241,8 +241,10 @@ public class FlatArrayBuilder
         }
 
         byte[] variableWidthChunk = EMPTY_CHUNK;
+        int variableWidthChunkOffset = 0;
         if (variableWidthData != null) {
             variableWidthChunk = variableWidthData.getChunk(records, recordOffset);
+            variableWidthChunkOffset = getChunkOffset(records, recordOffset);
         }
 
         try {
@@ -250,6 +252,7 @@ public class FlatArrayBuilder
                     records,
                     recordOffset + recordValueOffset,
                     variableWidthChunk,
+                    variableWidthChunkOffset,
                     blockBuilder);
         }
         catch (Throwable throwable) {

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
@@ -124,6 +124,7 @@ public class InMemoryHashAggregationBuilder
                 operatorContext.getSession(),
                 groupByTypes,
                 hashChannel.isPresent(),
+                false,
                 expectedGroups,
                 hashStrategyCompiler,
                 updateMemory);

--- a/core/trino-main/src/main/java/io/trino/operator/index/UnloadedIndexKeyRecordSet.java
+++ b/core/trino-main/src/main/java/io/trino/operator/index/UnloadedIndexKeyRecordSet.java
@@ -66,7 +66,7 @@ public class UnloadedIndexKeyRecordSet
         }
 
         ImmutableList.Builder<PageAndPositions> builder = ImmutableList.builder();
-        GroupByHash groupByHash = createGroupByHash(session, distinctChannelTypes, false, 10_000, hashStrategyCompiler, NOOP);
+        GroupByHash groupByHash = createGroupByHash(session, distinctChannelTypes, false, false, 10_000, hashStrategyCompiler, NOOP);
         for (UpdateRequest request : requests) {
             Page page = request.getPage();
 

--- a/core/trino-main/src/main/java/io/trino/type/FunctionType.java
+++ b/core/trino-main/src/main/java/io/trino/type/FunctionType.java
@@ -225,7 +225,7 @@ public class FunctionType
     }
 
     @Override
-    public int relocateFlatVariableWidthOffsets(byte[] fixedSizeSlice, int fixedSizeOffset, byte[] variableSizeSlice, int variableSizeOffset)
+    public int getFlatVariableWidthLength(byte[] fixedSizeSlice, int fixedSizeOffset)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-main/src/main/java/io/trino/type/IpAddressType.java
+++ b/core/trino-main/src/main/java/io/trino/type/IpAddressType.java
@@ -28,6 +28,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 import io.trino.spi.type.AbstractType;
@@ -186,7 +187,8 @@ public class IpAddressType
     private static Slice readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return Slices.wrappedBuffer(fixedSizeSlice, fixedSizeOffset, INT128_BYTES);
     }
@@ -196,6 +198,7 @@ public class IpAddressType
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
             @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset,
             BlockBuilder blockBuilder)
     {
         ((Int128ArrayBlockBuilder) blockBuilder).writeInt128(

--- a/core/trino-main/src/main/java/io/trino/type/UnknownType.java
+++ b/core/trino-main/src/main/java/io/trino/type/UnknownType.java
@@ -22,6 +22,7 @@ import io.trino.spi.block.PageBuilderStatus;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 import io.trino.spi.type.AbstractType;
@@ -143,7 +144,8 @@ public final class UnknownType
     private static boolean readFlat(
             @FlatFixed byte[] unusedFixedSizeSlice,
             @FlatFixedOffset int unusedFixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         throw new AssertionError("value of unknown type should all be NULL");
     }

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupByHash.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupByHash.java
@@ -43,9 +43,7 @@ import org.openjdk.jmh.runner.RunnerException;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -267,14 +265,10 @@ public class BenchmarkGroupByHash
             prefilledHash = new FlatGroupByHash(data.getTypes(), data.getFlatGroupByHashMode(), EXPECTED_SIZE, false, new FlatHashStrategyCompiler(new TypeOperators()), NOOP);
             addInputPagesToHash(prefilledHash, data.getPages());
 
-            Integer[] groupIds = new Integer[prefilledHash.getGroupCount()];
-            for (int i = 0; i < groupIds.length; i++) {
-                groupIds[i] = i;
+            groupIdsByPhysicalOrder = new int[prefilledHash.getGroupCount()];
+            for (int i = 0; i < groupIdsByPhysicalOrder.length; i++) {
+                groupIdsByPhysicalOrder[i] = i;
             }
-            if (prefilledHash instanceof FlatGroupByHash flatGroupByHash) {
-                Arrays.sort(groupIds, Comparator.comparing(flatGroupByHash::getPhysicalPosition));
-            }
-            groupIdsByPhysicalOrder = Arrays.stream(groupIds).mapToInt(Integer::intValue).toArray();
 
             outputTypes = new ArrayList<>(data.getTypes());
             if (data.isHashPrecomputed()) {

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupByHashOnSimulatedData.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupByHashOnSimulatedData.java
@@ -88,6 +88,7 @@ public class BenchmarkGroupByHashOnSimulatedData
         GroupByHash groupByHash = GroupByHash.createGroupByHash(
                 data.getTypes(),
                 false,
+                false,
                 EXPECTED_GROUP_COUNT,
                 false,
                 hashStrategyCompiler,

--- a/core/trino-main/src/test/java/io/trino/operator/GroupByHashYieldAssertion.java
+++ b/core/trino-main/src/test/java/io/trino/operator/GroupByHashYieldAssertion.java
@@ -174,15 +174,8 @@ public final class GroupByHashYieldAssertion
                 // Hash table capacity should not have changed, because memory must be allocated first
                 assertThat(oldCapacity).isEqualTo((long) getHashCapacity.apply(operator));
 
-                long expectedHashBytes;
-                if (hashKeyType == BIGINT) {
-                    // The increase in hash memory should be twice the current capacity.
-                    expectedHashBytes = getHashTableSizeInBytes(hashKeyType, oldCapacity * 2);
-                }
-                else {
-                    // Flat hash uses an incremental rehash, so as new memory is allocated old memory is freed
-                    expectedHashBytes = getHashTableSizeInBytes(hashKeyType, oldCapacity) + oldCapacity;
-                }
+                // The increase in hash memory should be twice the current capacity.
+                long expectedHashBytes = getHashTableSizeInBytes(hashKeyType, oldCapacity * 2);
                 assertThat(actualHashIncreased).isBetween(expectedHashBytes, expectedHashBytes + additionalMemoryInBytes);
 
                 // Output should be blocked as well
@@ -239,12 +232,7 @@ public final class GroupByHashYieldAssertion
 
         @SuppressWarnings("OverlyComplexArithmeticExpression")
         int sizePerEntry = Byte.BYTES + // control byte
-                Integer.BYTES + // groupId to hashPosition
-                AppendOnlyVariableWidthData.POINTER_SIZE + // variable width pointer
-                Integer.BYTES + // groupId
-                Long.BYTES + // rawHash (optional, but present in this test)
-                Byte.BYTES + // field null
-                Integer.BYTES; // field variable length
+                Integer.BYTES; // hashPosition to groupId
         return (long) capacity * sizePerEntry;
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/GroupByHashYieldAssertion.java
+++ b/core/trino-main/src/test/java/io/trino/operator/GroupByHashYieldAssertion.java
@@ -240,7 +240,7 @@ public final class GroupByHashYieldAssertion
         @SuppressWarnings("OverlyComplexArithmeticExpression")
         int sizePerEntry = Byte.BYTES + // control byte
                 Integer.BYTES + // groupId to hashPosition
-                VariableWidthData.POINTER_SIZE + // variable width pointer
+                AppendOnlyVariableWidthData.POINTER_SIZE + // variable width pointer
                 Integer.BYTES + // groupId
                 Long.BYTES + // rawHash (optional, but present in this test)
                 Byte.BYTES + // field null

--- a/core/trino-main/src/test/java/io/trino/operator/TestFlatHashStrategy.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestFlatHashStrategy.java
@@ -87,12 +87,12 @@ class TestFlatHashStrategy
                 assertThat(fixedChunk).startsWith(new byte[FIXED_CHUNK_OFFSET]);
                 assertThat(variableChunk).startsWith(new byte[VARIABLE_CHUNK_OFFSET]);
 
-                assertThat(flatHashStrategy.hash(fixedChunk, FIXED_CHUNK_OFFSET, variableChunk)).isEqualTo(manualHash(types, blocks, position));
-                assertThat(flatHashStrategy.valueIdentical(fixedChunk, FIXED_CHUNK_OFFSET, variableChunk, blocks, position)).isTrue();
-                assertThat(flatHashStrategy.valueIdentical(fixedChunk, FIXED_CHUNK_OFFSET, variableChunk, blocks, 3)).isFalse();
+                assertThat(flatHashStrategy.hash(fixedChunk, FIXED_CHUNK_OFFSET, variableChunk, VARIABLE_CHUNK_OFFSET)).isEqualTo(manualHash(types, blocks, position));
+                assertThat(flatHashStrategy.valueIdentical(fixedChunk, FIXED_CHUNK_OFFSET, variableChunk, VARIABLE_CHUNK_OFFSET, blocks, position)).isTrue();
+                assertThat(flatHashStrategy.valueIdentical(fixedChunk, FIXED_CHUNK_OFFSET, variableChunk, VARIABLE_CHUNK_OFFSET, blocks, 3)).isFalse();
 
                 BlockBuilder[] blockBuilders = types.stream().map(type -> type.createBlockBuilder(null, 1)).toArray(BlockBuilder[]::new);
-                flatHashStrategy.readFlat(fixedChunk, FIXED_CHUNK_OFFSET, variableChunk, blockBuilders);
+                flatHashStrategy.readFlat(fixedChunk, FIXED_CHUNK_OFFSET, variableChunk, VARIABLE_CHUNK_OFFSET, blockBuilders);
                 List<Block> output = Arrays.stream(blockBuilders).map(BlockBuilder::build).toList();
                 Page actualPage = new Page(output.toArray(Block[]::new));
                 Page expectedPage = new Page(blocks).getSingleValuePage(position);

--- a/core/trino-main/src/test/java/io/trino/operator/TestGroupByHash.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestGroupByHash.java
@@ -70,7 +70,7 @@ public class TestGroupByHash
                 case BIGINT -> new BigintGroupByHash(true, expectedSize, updateMemory);
                 case FLAT -> new FlatGroupByHash(
                         ImmutableList.of(BigintType.BIGINT),
-                        true,
+                        FlatGroupByHash.HashMode.PRECOMPUTED,
                         expectedSize,
                         true,
                         new FlatHashStrategyCompiler(new TypeOperators()),
@@ -301,7 +301,7 @@ public class TestGroupByHash
 
         // Create GroupByHash with tiny size
         AtomicInteger rehashCount = new AtomicInteger();
-        GroupByHash groupByHash = createGroupByHash(ImmutableList.of(type), true, 1, false, new FlatHashStrategyCompiler(new TypeOperators()), () -> {
+        GroupByHash groupByHash = createGroupByHash(ImmutableList.of(type), true, false, 1, false, new FlatHashStrategyCompiler(new TypeOperators()), () -> {
             rehashCount.incrementAndGet();
             return true;
         });
@@ -322,7 +322,7 @@ public class TestGroupByHash
 
         // Create GroupByHash with tiny size
         AtomicInteger rehashCount = new AtomicInteger();
-        GroupByHash groupByHash = createGroupByHash(ImmutableList.of(type), true, 1, false, new FlatHashStrategyCompiler(new TypeOperators()), () -> {
+        GroupByHash groupByHash = createGroupByHash(ImmutableList.of(type), true, false, 1, false, new FlatHashStrategyCompiler(new TypeOperators()), () -> {
             rehashCount.incrementAndGet();
             return true;
         });
@@ -357,7 +357,7 @@ public class TestGroupByHash
         int yields = 0;
 
         // test addPage
-        GroupByHash groupByHash = createGroupByHash(ImmutableList.of(type), true, 1, false, new FlatHashStrategyCompiler(new TypeOperators()), updateMemory);
+        GroupByHash groupByHash = createGroupByHash(ImmutableList.of(type), true, false, 1, false, new FlatHashStrategyCompiler(new TypeOperators()), updateMemory);
         boolean finish = false;
         Work<?> addPageWork = groupByHash.addPage(page);
         while (!finish) {
@@ -383,7 +383,7 @@ public class TestGroupByHash
         currentQuota.set(0);
         allowedQuota.set(6);
         yields = 0;
-        groupByHash = createGroupByHash(ImmutableList.of(type), true, 1, false, new FlatHashStrategyCompiler(new TypeOperators()), updateMemory);
+        groupByHash = createGroupByHash(ImmutableList.of(type), true, false, 1, false, new FlatHashStrategyCompiler(new TypeOperators()), updateMemory);
 
         finish = false;
         Work<int[]> getGroupIdsWork = groupByHash.getGroupIds(page);
@@ -491,6 +491,7 @@ public class TestGroupByHash
                 TEST_SESSION,
                 ImmutableList.of(BIGINT, BIGINT),
                 false,
+                false,
                 100,
                 new FlatHashStrategyCompiler(new TypeOperators()),
                 NOOP);
@@ -519,6 +520,7 @@ public class TestGroupByHash
                 TEST_SESSION,
                 ImmutableList.of(BIGINT, BIGINT, BIGINT, BIGINT, BIGINT),
                 false,
+                false,
                 100,
                 new FlatHashStrategyCompiler(new TypeOperators()),
                 NOOP);
@@ -526,6 +528,7 @@ public class TestGroupByHash
         GroupByHash lowCardinalityGroupByHash = createGroupByHash(
                 TEST_SESSION,
                 ImmutableList.of(BIGINT, BIGINT, BIGINT, BIGINT),
+                false,
                 false,
                 100,
                 new FlatHashStrategyCompiler(new TypeOperators()),
@@ -559,6 +562,7 @@ public class TestGroupByHash
         GroupByHash groupByHash = createGroupByHash(
                 TEST_SESSION,
                 ImmutableList.of(BIGINT, BIGINT),
+                false,
                 false,
                 100,
                 new FlatHashStrategyCompiler(new TypeOperators()),
@@ -626,7 +630,7 @@ public class TestGroupByHash
 
     private static void assertGroupByHashWork(Page page, List<Type> types, Class<?> clazz)
     {
-        GroupByHash groupByHash = createGroupByHash(types, false, 100, true, new FlatHashStrategyCompiler(new TypeOperators()), NOOP);
+        GroupByHash groupByHash = createGroupByHash(types, false, false, 100, true, new FlatHashStrategyCompiler(new TypeOperators()), NOOP);
         Work<int[]> work = groupByHash.getGroupIds(page);
         // Compare by name since classes are private
         assertThat(work).isInstanceOf(clazz);

--- a/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRankBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRankBuilder.java
@@ -259,6 +259,7 @@ public class TestGroupedTopNRankBuilder
         return GroupByHash.createGroupByHash(
                 ImmutableList.of(partitionType),
                 false,
+                false,
                 1,
                 false,
                 new FlatHashStrategyCompiler(typeOperators),

--- a/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRowNumberBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRowNumberBuilder.java
@@ -238,6 +238,7 @@ public class TestGroupedTopNRowNumberBuilder
         return GroupByHash.createGroupByHash(
                 partitionTypes,
                 false,
+                false,
                 1,
                 false,
                 new FlatHashStrategyCompiler(new TypeOperators()),

--- a/core/trino-main/src/test/java/io/trino/type/AbstractTestType.java
+++ b/core/trino-main/src/test/java/io/trino/type/AbstractTestType.java
@@ -224,9 +224,10 @@ public abstract class AbstractTestType
         int variableOffset = 0;
         for (int i = 0; i < expectedStackValues.size(); i++) {
             writeFlatMethod.invoke(expectedStackValues.get(i), fixed, i * flatFixedSize, variable, variableOffset);
+            assertThat(type.getFlatVariableWidthLength(fixed, i * flatFixedSize)).isEqualTo(variableLengths[i]);
             variableOffset += variableLengths[i];
         }
-        assertFlat(fixed, 0, variable);
+        assertFlat(fixed, 0, variable, 0);
 
         Arrays.fill(fixed, (byte) 0);
         Arrays.fill(variable, (byte) 0);
@@ -235,7 +236,7 @@ public abstract class AbstractTestType
             writeBlockToFlatMethod.invokeExact(testBlock, i, fixed, i * flatFixedSize, variable, variableOffset);
             variableOffset += variableLengths[i];
         }
-        assertFlat(fixed, 0, variable);
+        assertFlat(fixed, 0, variable, 0);
 
         // test relocation
         byte[] newFixed = new byte[fixed.length + 73];
@@ -245,16 +246,14 @@ public abstract class AbstractTestType
         Arrays.fill(fixed, (byte) 0);
         Arrays.fill(variable, (byte) 0);
 
-        variableOffset = 101;
         for (int i = 0; i < expectedStackValues.size(); i++) {
-            int variableSize = type.relocateFlatVariableWidthOffsets(newFixed, 73 + i * flatFixedSize, newVariable, variableOffset);
-            variableOffset += variableSize;
+            int variableSize = type.getFlatVariableWidthLength(newFixed, 73 + i * flatFixedSize);
             assertThat(variableSize).isEqualTo(variableLengths[i]);
         }
-        assertFlat(newFixed, 73, newVariable);
+        assertFlat(newFixed, 73, newVariable, 101);
     }
 
-    private void assertFlat(byte[] fixed, int fixedOffset, byte[] variable)
+    private void assertFlat(byte[] fixed, int fixedOffset, byte[] variable, int variableOffset)
             throws Throwable
     {
         int flatFixedSize = type.getFlatFixedSize();
@@ -262,47 +261,51 @@ public abstract class AbstractTestType
             Object expectedStackValue = expectedStackValues.get(i);
             int elementFixedOffset = fixedOffset + (i * flatFixedSize);
             if (type.getJavaType() == boolean.class) {
-                assertThat((boolean) readFlatMethod.invokeExact(fixed, elementFixedOffset, variable)).isEqualTo(expectedStackValue);
+                assertThat((boolean) readFlatMethod.invokeExact(fixed, elementFixedOffset, variable, variableOffset)).isEqualTo(expectedStackValue);
             }
             else if (type.getJavaType() == long.class) {
-                assertThat((long) readFlatMethod.invokeExact(fixed, elementFixedOffset, variable)).isEqualTo(expectedStackValue);
+                assertThat((long) readFlatMethod.invokeExact(fixed, elementFixedOffset, variable, variableOffset)).isEqualTo(expectedStackValue);
             }
             else if (type.getJavaType() == double.class) {
-                assertThat((double) readFlatMethod.invokeExact(fixed, elementFixedOffset, variable)).isEqualTo(expectedStackValue);
+                assertThat((double) readFlatMethod.invokeExact(fixed, elementFixedOffset, variable, variableOffset)).isEqualTo(expectedStackValue);
             }
             else if (type.getJavaType() == Slice.class) {
-                assertThat((Slice) readFlatMethod.invokeExact(fixed, elementFixedOffset, variable)).isEqualTo(expectedStackValue);
+                assertThat((Slice) readFlatMethod.invokeExact(fixed, elementFixedOffset, variable, variableOffset)).isEqualTo(expectedStackValue);
             }
             else if (type.getJavaType() == Block.class) {
-                assertBlockEquals((Block) readFlatMethod.invokeExact(fixed, elementFixedOffset, variable), (Block) expectedStackValue);
+                assertBlockEquals((Block) readFlatMethod.invokeExact(fixed, elementFixedOffset, variable, variableOffset), (Block) expectedStackValue);
             }
             else if (stackStackEqualOperator != null) {
-                assertThat((Boolean) stackStackEqualOperator.invoke(readFlatMethod.invoke(fixed, elementFixedOffset, variable), expectedStackValue)).isTrue();
+                assertThat((Boolean) stackStackEqualOperator.invoke(readFlatMethod.invoke(fixed, elementFixedOffset, variable, variableOffset), expectedStackValue)).isTrue();
             }
             else {
-                assertThat(readFlatMethod.invoke(fixed, elementFixedOffset, variable)).isEqualTo(expectedStackValue);
+                assertThat(readFlatMethod.invoke(fixed, elementFixedOffset, variable, variableOffset)).isEqualTo(expectedStackValue);
             }
 
             BlockBuilder blockBuilder = type.createBlockBuilder(null, 1);
-            writeFlatToBlockMethod.invokeExact(fixed, elementFixedOffset, variable, blockBuilder);
+            writeFlatToBlockMethod.invokeExact(fixed, elementFixedOffset, variable, variableOffset, blockBuilder);
             assertPositionEquals(testBlock, i, expectedStackValue, expectedObjectValues.get(i));
 
             if (type.isComparable()) {
-                assertThat((Boolean) flatFlatEqualOperator.invokeExact(fixed, elementFixedOffset, variable, fixed, elementFixedOffset, variable)).isTrue();
-                assertThat((Boolean) flatBlockPositionEqualOperator.invokeExact(fixed, elementFixedOffset, variable, testBlock, i)).isTrue();
-                assertThat((Boolean) blockPositionFlatEqualOperator.invokeExact(testBlock, i, fixed, elementFixedOffset, variable)).isTrue();
+                assertThat((Boolean) flatFlatEqualOperator.invokeExact(fixed, elementFixedOffset, variable, variableOffset, fixed, elementFixedOffset, variable, variableOffset)).isTrue();
+                assertThat((Boolean) flatBlockPositionEqualOperator.invokeExact(fixed, elementFixedOffset, variable, variableOffset, testBlock, i)).isTrue();
+                assertThat((Boolean) blockPositionFlatEqualOperator.invokeExact(testBlock, i, fixed, elementFixedOffset, variable, variableOffset)).isTrue();
 
-                assertThat((long) flatHashCodeOperator.invokeExact(fixed, elementFixedOffset, variable)).isEqualTo(hashCodeOperator.hashCodeNullSafe(testBlock, i));
+                assertThat((long) flatHashCodeOperator.invokeExact(fixed, elementFixedOffset, variable, variableOffset)).isEqualTo(hashCodeOperator.hashCodeNullSafe(testBlock, i));
 
-                assertThat((long) flatXxHash64Operator.invokeExact(fixed, elementFixedOffset, variable)).isEqualTo(xxHash64Operator.xxHash64(testBlock, i));
+                assertThat((long) flatXxHash64Operator.invokeExact(fixed, elementFixedOffset, variable, variableOffset)).isEqualTo(xxHash64Operator.xxHash64(testBlock, i));
 
-                assertThat((boolean) flatFlatIdenticalOperator.invokeExact(fixed, elementFixedOffset, variable, fixed, elementFixedOffset, variable)).isTrue();
-                assertThat((boolean) flatBlockPositionIdenticalOperator.invokeExact(fixed, elementFixedOffset, variable, testBlock, i)).isTrue();
-                assertThat((boolean) blockPositionFlatIdenticalOperator.invokeExact(testBlock, i, fixed, elementFixedOffset, variable)).isTrue();
+                assertThat((boolean) flatFlatIdenticalOperator.invokeExact(fixed, elementFixedOffset, variable, variableOffset, fixed, elementFixedOffset, variable, variableOffset)).isTrue();
+                assertThat((boolean) flatBlockPositionIdenticalOperator.invokeExact(fixed, elementFixedOffset, variable, variableOffset, testBlock, i)).isTrue();
+                assertThat((boolean) blockPositionFlatIdenticalOperator.invokeExact(testBlock, i, fixed, elementFixedOffset, variable, variableOffset)).isTrue();
 
                 ValueBlock nullValue = type.createBlockBuilder(null, 1).appendNull().buildValueBlock();
-                assertThat((boolean) flatBlockPositionIdenticalOperator.invokeExact(fixed, elementFixedOffset, variable, nullValue, 0)).isFalse();
-                assertThat((boolean) blockPositionFlatIdenticalOperator.invokeExact(nullValue, 0, fixed, elementFixedOffset, variable)).isFalse();
+                assertThat((boolean) flatBlockPositionIdenticalOperator.invokeExact(fixed, elementFixedOffset, variable, variableOffset, nullValue, 0)).isFalse();
+                assertThat((boolean) blockPositionFlatIdenticalOperator.invokeExact(nullValue, 0, fixed, elementFixedOffset, variable, variableOffset)).isFalse();
+            }
+            // advance offset
+            if (type.isFlatVariableWidth()) {
+                variableOffset += type.getFlatVariableWidthLength(fixed, elementFixedOffset);
             }
         }
     }

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -314,6 +314,48 @@
                                     <old>method long io.trino.spi.connector.Connector::getInitialMemoryRequirement()</old>
                                     <justification>Remove unused connector method</justification>
                                 </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.addedToInterface</code>
+                                    <new>method int io.trino.spi.type.Type::getFlatVariableWidthLength(byte[], int)</new>
+                                    <justification>New interface method required for new flat variable width data layouts</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method int io.trino.spi.type.Type::relocateFlatVariableWidthOffsets(byte[], int, byte[], int)</old>
+                                    <justification>Remove flat offsets relocation method since offsets are no longer stored in flat representations</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method int io.trino.spi.type.AbstractVariableWidthType::relocateFlatVariableWidthOffsets(byte[], int, byte[], int)</old>
+                                    <justification>Remove flat offsets relocation method since offsets are no longer stored in flat representations</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method int io.trino.spi.type.ArrayType::relocateFlatVariableWidthOffsets(byte[], int, byte[], int)</old>
+                                    <justification>Remove flat offsets relocation method since offsets are no longer stored in flat representations</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method int io.trino.spi.type.FixedWidthType::relocateFlatVariableWidthOffsets(byte[], int, byte[], int)</old>
+                                    <justification>Remove flat offsets relocation method since offsets are no longer stored in flat representations</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method int io.trino.spi.type.MapType::relocateFlatVariableWidthOffsets(byte[], int, byte[], int)</old>
+                                    <justification>Remove flat offsets relocation method since offsets are no longer stored in flat representations</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method int io.trino.spi.type.RowType::relocateFlatVariableWidthOffsets(byte[], int, byte[], int)</old>
+                                    <justification>Remove flat offsets relocation method since offsets are no longer stored in flat representations</justification>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/function/FlatVariableOffset.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/FlatVariableOffset.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.function;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface FlatVariableOffset
+{
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/function/InvocationConvention.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/InvocationConvention.java
@@ -138,7 +138,7 @@ public class InvocationConvention
         /**
          * Argument is passed as a flat slice. The sql value may not be null.
          */
-        FLAT(false, 3),
+        FLAT(false, 4),
         /**
          * Argument is passed in an InOut. The sql value may be null.
          */

--- a/core/trino-spi/src/main/java/io/trino/spi/type/AbstractIntType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/AbstractIntType.java
@@ -25,6 +25,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -166,7 +167,8 @@ public abstract class AbstractIntType
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return (int) INT_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/AbstractLongType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/AbstractLongType.java
@@ -24,6 +24,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -144,7 +145,8 @@ public abstract class AbstractLongType
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return (long) LONG_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/BooleanType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/BooleanType.java
@@ -25,6 +25,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -178,7 +179,8 @@ public final class BooleanType
     private static boolean readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return fixedSizeSlice[fixedSizeOffset] != 0;
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/DoubleType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/DoubleType.java
@@ -25,6 +25,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.IsNull;
 import io.trino.spi.function.ScalarOperator;
@@ -178,7 +179,8 @@ public final class DoubleType
     private static double readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return (double) DOUBLE_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/FixedWidthType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/FixedWidthType.java
@@ -54,7 +54,7 @@ public interface FixedWidthType
     }
 
     @Override
-    default int relocateFlatVariableWidthOffsets(byte[] fixedSizeSlice, int fixedSizeOffset, byte[] variableSizeSlice, int variableSizeOffset)
+    default int getFlatVariableWidthLength(byte[] fixedSizeSlice, int fixedSizeOffset)
     {
         return 0;
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/LongDecimalType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/LongDecimalType.java
@@ -25,6 +25,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -141,7 +142,8 @@ final class LongDecimalType
     private static Int128 readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return Int128.valueOf(
                 (long) LONG_HANDLE.get(fixedSizeSlice, fixedSizeOffset),
@@ -153,6 +155,7 @@ final class LongDecimalType
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
             @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset,
             BlockBuilder blockBuilder)
     {
         ((Int128ArrayBlockBuilder) blockBuilder).writeInt128(

--- a/core/trino-spi/src/main/java/io/trino/spi/type/LongTimeWithTimeZoneType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/LongTimeWithTimeZoneType.java
@@ -25,6 +25,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -159,7 +160,8 @@ final class LongTimeWithTimeZoneType
     private static LongTimeWithTimeZone readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return new LongTimeWithTimeZone(
                 (long) LONG_HANDLE.get(fixedSizeSlice, fixedSizeOffset),
@@ -171,6 +173,7 @@ final class LongTimeWithTimeZoneType
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
             @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset,
             BlockBuilder blockBuilder)
     {
         write(blockBuilder,

--- a/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestampType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestampType.java
@@ -25,6 +25,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -177,7 +178,8 @@ final class LongTimestampType
     private static LongTimestamp readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return new LongTimestamp(
                 (long) LONG_HANDLE.get(fixedSizeSlice, fixedSizeOffset),
@@ -189,6 +191,7 @@ final class LongTimestampType
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
             @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset,
             BlockBuilder blockBuilder)
     {
         write(blockBuilder,

--- a/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestampWithTimeZoneType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestampWithTimeZoneType.java
@@ -25,6 +25,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -220,7 +221,8 @@ final class LongTimestampWithTimeZoneType
     private static LongTimestampWithTimeZone readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         long packedEpochMillis = (long) LONG_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
         int picosOfMilli = (int) INT_HANDLE.get(fixedSizeSlice, fixedSizeOffset + Long.BYTES);
@@ -232,6 +234,7 @@ final class LongTimestampWithTimeZoneType
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
             @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset,
             BlockBuilder blockBuilder)
     {
         write(blockBuilder,

--- a/core/trino-spi/src/main/java/io/trino/spi/type/RealType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/RealType.java
@@ -20,6 +20,7 @@ import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.IsNull;
 import io.trino.spi.function.ScalarOperator;
@@ -121,7 +122,8 @@ public final class RealType
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return (int) INT_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/ShortDecimalType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ShortDecimalType.java
@@ -25,6 +25,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -197,7 +198,8 @@ final class ShortDecimalType
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return (long) LONG_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimeWithTimeZoneType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimeWithTimeZoneType.java
@@ -25,6 +25,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -148,7 +149,8 @@ final class ShortTimeWithTimeZoneType
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return (long) LONG_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimestampType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimestampType.java
@@ -25,6 +25,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -183,7 +184,8 @@ final class ShortTimestampType
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return (long) LONG_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimestampWithTimeZoneType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimestampWithTimeZoneType.java
@@ -25,6 +25,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -148,7 +149,8 @@ final class ShortTimestampWithTimeZoneType
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return (long) LONG_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/SmallintType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/SmallintType.java
@@ -26,6 +26,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -229,7 +230,8 @@ public final class SmallintType
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return (short) SHORT_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TimeType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TimeType.java
@@ -19,6 +19,7 @@ import io.trino.spi.block.Block;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -135,7 +136,8 @@ public final class TimeType
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return (long) LONG_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TinyintType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TinyintType.java
@@ -26,6 +26,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -224,7 +225,8 @@ public final class TinyintType
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return fixedSizeSlice[fixedSizeOffset];
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/Type.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/Type.java
@@ -247,14 +247,9 @@ public interface Type
     int getFlatVariableWidthSize(Block block, int position);
 
     /**
-     * Update the variable width offsets recorded in the value.
-     * This method is called after the value has been moved to a new location, and therefore the offsets
-     * need to be updated.
-     * Returns the length of the variable width data, so container types can update their offsets.
-     *
-     * @return the length of the variable width data
+     * Returns the variable width size of the value already written at the specified position within a flat buffer
      */
-    int relocateFlatVariableWidthOffsets(byte[] fixedSizeSlice, int fixedSizeOffset, byte[] variableSizeSlice, int variableSizeOffset);
+    int getFlatVariableWidthLength(byte[] fixedSizeSlice, int fixedSizeOffset);
 
     final class Range
     {

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperatorDeclaration.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperatorDeclaration.java
@@ -22,6 +22,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.InvocationConvention;
 import io.trino.spi.function.InvocationConvention.InvocationArgumentConvention;
@@ -476,8 +477,9 @@ public final class TypeOperatorDeclaration
                     case FLAT:
                         checkArgument(parameterType.equals(byte[].class) &&
                                         methodType.parameterType(parameterIndex + 1).equals(int.class) &&
-                                        methodType.parameterType(parameterIndex + 2).equals(byte[].class),
-                                "Expected FLAT argument to have parameters byte[], int, and byte[]");
+                                        methodType.parameterType(parameterIndex + 2).equals(byte[].class) &&
+                                        methodType.parameterType(parameterIndex + 3).equals(int.class),
+                                "Expected FLAT argument to have parameters byte[], int, byte[], and int");
                         break;
                     case FUNCTION:
                         throw new IllegalArgumentException("Function argument convention is not supported in type operators");
@@ -605,12 +607,14 @@ public final class TypeOperatorDeclaration
                 }
             }
             else if (isAnnotationPresent(parameterAnnotations.get(0), FlatFixed.class)) {
-                if (parameterTypes.size() > 2 &&
+                if (parameterTypes.size() > 3 &&
                         isAnnotationPresent(parameterAnnotations.get(1), FlatFixedOffset.class) &&
                         isAnnotationPresent(parameterAnnotations.get(2), FlatVariableWidth.class) &&
+                        isAnnotationPresent(parameterAnnotations.get(3), FlatVariableOffset.class) &&
                         parameterTypes.get(0).equals(byte[].class) &&
                         parameterTypes.get(1).equals(int.class) &&
-                        parameterTypes.get(2).equals(byte[].class)) {
+                        parameterTypes.get(2).equals(byte[].class) &&
+                        parameterTypes.get(3).equals(int.class)) {
                     return FLAT;
                 }
             }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/UuidType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/UuidType.java
@@ -27,6 +27,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -196,7 +197,8 @@ public class UuidType
     private static Slice readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return wrappedBuffer(fixedSizeSlice, fixedSizeOffset, INT128_BYTES);
     }
@@ -217,6 +219,7 @@ public class UuidType
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
             @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset,
             BlockBuilder blockBuilder)
     {
         ((Int128ArrayBlockBuilder) blockBuilder).writeInt128(

--- a/core/trino-spi/src/test/java/io/trino/spi/function/TestScalarFunctionAdapter.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/function/TestScalarFunctionAdapter.java
@@ -554,6 +554,7 @@ public class TestScalarFunctionAdapter
                     callArguments.add(fixedSlice);
                     callArguments.add(0);
                     callArguments.add(variableSlice);
+                    callArguments.add(0);
                 }
                 case IN_OUT -> callArguments.add(new TestingInOut(argumentType, testValue));
                 default -> throw new IllegalArgumentException("Unsupported argument convention: " + argumentConvention);

--- a/core/trino-spi/src/test/java/io/trino/spi/type/TestTypeOperators.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/type/TestTypeOperators.java
@@ -102,6 +102,7 @@ class TestTypeOperators
                 callArguments.add(fixedSlice);
                 callArguments.add(0);
                 callArguments.add(new byte[0]);
+                callArguments.add(0);
             }
             default -> throw new UnsupportedOperationException();
         }

--- a/core/trino-spi/src/test/java/io/trino/spi/type/TestVarchars.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/type/TestVarchars.java
@@ -27,6 +27,20 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestVarchars
 {
     @Test
+    public void testShortLengthEncoding()
+    {
+        byte[] bytes = new byte[8];
+        for (int i = 0; i <= 256; i++) {
+            AbstractVariableWidthType.writeFlatVariableLength(i, bytes, 0);
+            assertThat(AbstractVariableWidthType.readVariableWidthLength(bytes, 0))
+                    .isEqualTo(i);
+        }
+        AbstractVariableWidthType.writeFlatVariableLength(Integer.MAX_VALUE, bytes, 0);
+        assertThat(AbstractVariableWidthType.readVariableWidthLength(bytes, 0))
+                .isEqualTo(Integer.MAX_VALUE);
+    }
+
+    @Test
     public void testTruncateToLength()
     {
         // Single byte code points


### PR DESCRIPTION
## Description
Reimplements `FlatHash` and the "flat" memory layout encoding scheme for variable width data to reduce memory consumption. The memory reduction comes from several different changes that are discussed in more detail below, and charts demonstrating the memory consumption for a two varchar aggregation can be found [in this gist](https://gist.github.com/pettyjamesm/31c45ae3716ade5a838283f90c1609c1).

All `DISTINCT` and `GROUP BY` queries should experience a significant reduction in memory usage. The extent of the improvement will depend on the number of columns, the types involved, and the length of values present in any variable width fields- but typical cases can expect to see a 50% reduction in memory used and some more extreme cases will see even larger improvements.

### Remove offsets from flat representation
When variable width types encode their data into a "flat" representation, they store information into the "fixed size" region of the layout to indicate how much variable width data is stored for that field. Previously, this was done by storing an "offset" (int) index into the variable width data array along with a length (int). This was in addition to a row level "pointer" into the variable width chunk and starting offset for the whole row.

This meant that each variable width column (e.g.: `varchar`) would require at minimum 8 bytes of fixed width data (`(int offset, int length)`) to store. However, in practice 16 bytes were stored for each varchar column in order to allow directly embedding "short strings" into the fixed width portion of the table so long as they were less than 12 bytes long.

This first change removes the offset field entirely as well as the "extra" bytes associated with short string optimization, which allows variable width data types to require only a single `int length` field in the fixed width data portion. This has two important implications:
1. Each variable width field now only requires 4 bytes instead of 16 bytes of "fixed" size data
2. When variable width data "compaction" occurs, the fixed width fields no longer need a "relocation" step to update their offsets. This significantly reduces the amount of work required to maintain heap structures used by things like `max_n` aggregations. 

### Reduce VariableWidthData expansion factor
As variable width data is inserted into a flat structure, "chunks" are allocated of increasingly larger sizes up until the per-chunk size reaches 8MB at which point all subsequent chunks are sized at exactly 8MB. Previously, each chunk was 2x as large as the previously allocated chunk. By reducing this growth rate to 1.5, the memory consumption associated with those chunk allocations grows slightly slower until it reaches the 8MB allocation size which can reduce the memory required for smaller aggregations.

### Add reduced size VariableWidthData
For each row in a "flat" structure that contains some variable width data, a "pointer" is stored from the fixed size section into a corresponding variable sized section that stores the variable width data. The structure of that pointer is `(int chunkIndex, int chunkOffset, int rowVariableWidthLength)` which is 12 bytes in total.

However, the row-level variable width length field is not necessary for all structures. Some structures need to know the entire row's variable width length in order to perform "compaction", but other structures are actually append-only and will never compact after insertion. In particular, `FlatHash` used in `GROUP BY` aggregations never removes an entry from the table once inserted.

This change introduces a parallel implementation of those pointers that stores only 8 bytes per row instead of 12 by removing the unnecessary length argument.

### Reimplement FlatGroupByHash to reduce memory usage
Previously, the `FlatHash` structure used in `GROUP BY` aggregations would insert the whole "fixed" size portion of data inside of the hash table. This has a few implications- but in particular it meant that each slot in the hash table itself was particularly "wide". The hash table logic fundamentally requires that the table itself double in size when growing, but immediately after growing most of the slots in the table are "empty". This means that "wide" hash tables pay a high memory cost for the currently empty slots in the table.

The new implementation stores only a single `int` in the table slot itself which points off to a separate structure for the fixed width portion of each entry. This extra indirection greatly reduces the amount of memory waste from empty table slots and avoids the need to relocate each table entry during rehashes. In some cases this extra indirection will come with a small performance penalty, while in others the ability to keep more of the hash table in CPU caches actually improves performance compared to the previous implementation.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Significantly reduce the amount of memory required for DISTINCT and GROUP BY operations ({issue}`25127`)
```
