### PR TITLE
Suggest valid session property names

### DIFF
--- a/core/trino-main/pom.xml
+++ b/core/trino-main/pom.xml
@@ -330,6 +330,12 @@
         </dependency>
 
         <dependency>
+            <groupId>me.xdrop</groupId>
+            <artifactId>fuzzywuzzy</artifactId>
+            <version>1.4.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math3</artifactId>
         </dependency>

--- a/core/trino-main/src/main/java/io/trino/execution/SessionPropertyEvaluator.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SessionPropertyEvaluator.java
@@ -28,11 +28,15 @@ import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.NodeRef;
 import io.trino.sql.tree.Parameter;
 import io.trino.sql.tree.QualifiedName;
+import me.xdrop.fuzzywuzzy.FuzzySearch;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.SystemSessionProperties.TIME_ZONE_ID;
 import static io.trino.metadata.MetadataUtil.getRequiredCatalogHandle;
 import static io.trino.metadata.SessionPropertyManager.evaluatePropertyValue;
@@ -40,6 +44,7 @@ import static io.trino.metadata.SessionPropertyManager.serializeSessionProperty;
 import static io.trino.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
 import static java.lang.String.format;
+import static java.util.Comparator.comparingInt;
 import static java.util.Objects.requireNonNull;
 
 public class SessionPropertyEvaluator
@@ -63,7 +68,7 @@ public class SessionPropertyEvaluator
         List<String> nameParts = name.getParts();
         if (nameParts.size() == 1) {
             PropertyMetadata<?> systemPropertyMetadata = sessionPropertyManager.getSystemSessionPropertyMetadata(nameParts.getFirst())
-                    .orElseThrow(() -> semanticException(INVALID_SESSION_PROPERTY, expression, "Session property '%s' does not exist", name));
+                    .orElseThrow(() -> semanticException(INVALID_SESSION_PROPERTY, expression, "Session property '%s' does not exist%s", name, suggest(name, sessionPropertyManager.getSystemSessionPropertiesMetadata())));
 
             return evaluate(session, name, expression, parameters, systemPropertyMetadata);
         }
@@ -73,7 +78,7 @@ public class SessionPropertyEvaluator
 
             CatalogHandle catalogHandle = getRequiredCatalogHandle(plannerContext.getMetadata(), session, expression, catalogName);
             PropertyMetadata<?> connectorPropertyMetadata = sessionPropertyManager.getConnectorSessionPropertyMetadata(catalogHandle, propertyName)
-                    .orElseThrow(() -> semanticException(INVALID_SESSION_PROPERTY, expression, "Session property '%s' does not exist", name));
+                    .orElseThrow(() -> semanticException(INVALID_SESSION_PROPERTY, expression, "Session property '%s' does not exist%s", name, suggest(name, sessionPropertyManager.getConnectionSessionPropertiesMetadata(catalogHandle))));
 
             return evaluate(session, name, expression, parameters, connectorPropertyMetadata);
         }
@@ -109,5 +114,49 @@ public class SessionPropertyEvaluator
         }
 
         return value;
+    }
+
+    public static List<PropertyMetadata<?>> findSimilar(String propertyName, Set<PropertyMetadata<?>> candidates, int count)
+    {
+        return candidates.stream()
+                .filter(property -> !property.isHidden())
+                .map(candidate -> new Match(candidate, FuzzySearch.ratio(candidate.getName(), propertyName)))
+                .filter(match -> match.ratio() > 75)
+                .sorted(comparingInt(Match::ratio).reversed())
+                .limit(count)
+                .map(Match::metadata)
+                .collect(toImmutableList());
+    }
+
+    private record Match(PropertyMetadata<?> metadata, int ratio)
+    {
+        public Match
+        {
+            requireNonNull(metadata, "metadata is null");
+            verify(ratio >= 0 && ratio < 100, "ratio must be in the [0, 100) range");
+        }
+    }
+
+    private static String suggest(QualifiedName propertyName, Set<PropertyMetadata<?>> knownProperties)
+    {
+        List<PropertyMetadata<?>> suggestions = findSimilar(propertyName.getSuffix(), knownProperties, 3);
+        if (suggestions.isEmpty()) {
+            return "";
+        }
+
+        return ". Did you mean to use " + switch (suggestions.size()) {
+            case 3 -> "'" + formatSuggestion(propertyName, suggestions.get(0)) + "', '" + formatSuggestion(propertyName, suggestions.get(1)) + "' or '" + formatSuggestion(propertyName, suggestions.get(2)) + "'?";
+            case 2 -> "'" + formatSuggestion(propertyName, suggestions.get(0)) + "' or '" + formatSuggestion(propertyName, suggestions.get(1)) + "'?";
+            default -> "'" + formatSuggestion(propertyName, suggestions.get(0)) + "'?";
+        };
+    }
+
+    private static String formatSuggestion(QualifiedName name, PropertyMetadata<?> suggestion)
+    {
+        if (name.getParts().size() == 2) {
+            return name.getParts().getFirst() + "." + suggestion.getName();
+        }
+
+        return suggestion.getName();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/SessionPropertyManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SessionPropertyManager.java
@@ -105,12 +105,23 @@ public final class SessionPropertyManager
         return Optional.ofNullable(systemSessionProperties.get(name));
     }
 
+    public Set<PropertyMetadata<?>> getSystemSessionPropertiesMetadata()
+    {
+        return ImmutableSet.copyOf(systemSessionProperties.values());
+    }
+
     public Optional<PropertyMetadata<?>> getConnectorSessionPropertyMetadata(CatalogHandle catalogHandle, String propertyName)
     {
         requireNonNull(catalogHandle, "catalogHandle is null");
         requireNonNull(propertyName, "propertyName is null");
         Map<String, PropertyMetadata<?>> properties = connectorSessionProperties.getService(catalogHandle);
         return Optional.ofNullable(properties.get(propertyName));
+    }
+
+    public Set<PropertyMetadata<?>> getConnectionSessionPropertiesMetadata(CatalogHandle catalogHandle)
+    {
+        requireNonNull(catalogHandle, "catalogHandle is null");
+        return ImmutableSet.copyOf(connectorSessionProperties.getService(catalogHandle).values());
     }
 
     public List<SessionPropertyValue> getAllSessionProperties(Session session, List<CatalogInfo> catalogInfos)

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -81,6 +81,7 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public abstract class AbstractTestEngineOnlyQueries
         extends AbstractTestQueryFramework
@@ -5410,6 +5411,12 @@ public abstract class AbstractTestEngineOnlyQueries
         result = computeActual(format("SET SESSION %s.connector_double = 11.1", TESTING_CATALOG));
         assertNoRelationalResult(result);
         assertThat(result.getSetSessionProperties()).isEqualTo(ImmutableMap.of(TESTING_CATALOG + ".connector_double", "11.1"));
+
+        assertThatThrownBy(() -> computeActual(format("SET SESSION %s.connector_l = 1", TESTING_CATALOG)))
+                .hasMessage("line 1:43: Session property 'testing_catalog.connector_l' does not exist. Did you mean to use 'testing_catalog.connector_long', 'testing_catalog.connector_double' or 'testing_catalog.connector_boolean'?");
+
+        assertThatThrownBy(() -> computeActual("SET SESSION task_writer_count = 1"))
+                .hasMessage("line 1:33: Session property 'task_writer_count' does not exist. Did you mean to use 'task_max_writer_count' or 'task_min_writer_count'?");
     }
 
     @Test


### PR DESCRIPTION
Requires a small new dependency that does levenstein distance on strings. This dependency is already used in Airlift's bootstrap so net dependency addition is zero.

We already have the same mechanism for configuration properties.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Suggest valid session property names ({issue}`issuenumber`)
```
