### PR TITLE
Add system.iceberg_tables system table

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -1532,6 +1532,51 @@ FROM example.web.page_views
 WHERE "$file_modified_time" = CAST('2022-07-01 01:02:03.456 UTC' AS TIMESTAMP WITH TIME ZONE)
 ```
 
+(iceberg-system-tables)=
+#### System tables
+
+The connector exposes metadata tables in the system schema.
+
+##### `iceberg_tables` table
+
+The `iceberg_tables` table allows listing only Iceberg tables from a given catalog.
+The `SHOW TABLES` statement, `information_schema.tables`, and `jdbc.tables` will all
+return all tables that exist in the underlying metastore, even if the table cannot
+be handled in any way by the iceberg connector. This can happen if other connectors
+like Hive or Delta Lake, use the same metastore, catalog, and schema to store its tables.
+
+The table includes following columns:
+
+:::{list-table} iceberg_tables columns
+:widths: 30, 30, 40
+:header-rows: 1
+
+* - Name
+  - Type
+  - Description
+* - `table_schema`
+  - `VARCHAR`
+  - The name of the schema the table is in.
+* - `table_name`
+  - `VARCHAR`
+  - The name of the table.
+:::
+ 
+The following query lists Iceberg tables from all schemas in the `example` catalog.
+
+```sql
+SELECT * FROM example.system.iceberg_tables;
+```
+
+```text
+ table_schema | table_name  |
+--------------+-------------+
+ tpcds        | store_sales |
+ tpch         | nation      |
+ tpch         | region      |
+ tpch         | orders      |       
+```
+
 #### DROP TABLE
 
 The Iceberg connector supports dropping a table by using the

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConnector.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConnector.java
@@ -32,6 +32,7 @@ import io.trino.spi.connector.ConnectorPageSourceProviderFactory;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.SystemTable;
 import io.trino.spi.connector.TableProcedureMetadata;
 import io.trino.spi.function.FunctionProvider;
 import io.trino.spi.function.table.ConnectorTableFunction;
@@ -71,6 +72,7 @@ public class IcebergConnector
     private final Set<TableProcedureMetadata> tableProcedures;
     private final Set<ConnectorTableFunction> tableFunctions;
     private final FunctionProvider functionProvider;
+    private final Set<SystemTable> systemTables;
 
     @Inject
     public IcebergConnector(
@@ -90,7 +92,8 @@ public class IcebergConnector
             Set<Procedure> procedures,
             Set<TableProcedureMetadata> tableProcedures,
             Set<ConnectorTableFunction> tableFunctions,
-            FunctionProvider functionProvider)
+            FunctionProvider functionProvider,
+            Set<SystemTable> systemTables)
     {
         this.injector = requireNonNull(injector, "injector is null");
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
@@ -111,6 +114,7 @@ public class IcebergConnector
         this.tableProcedures = ImmutableSet.copyOf(requireNonNull(tableProcedures, "tableProcedures is null"));
         this.tableFunctions = ImmutableSet.copyOf(requireNonNull(tableFunctions, "tableFunctions is null"));
         this.functionProvider = requireNonNull(functionProvider, "functionProvider is null");
+        this.systemTables = ImmutableSet.copyOf(systemTables);
     }
 
     @Override
@@ -174,6 +178,12 @@ public class IcebergConnector
     public Optional<FunctionProvider> getFunctionProvider()
     {
         return Optional.of(functionProvider);
+    }
+
+    @Override
+    public Set<SystemTable> getSystemTables()
+    {
+        return systemTables;
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
@@ -49,10 +49,12 @@ import io.trino.plugin.iceberg.procedure.RemoveOrphanFilesTableProcedure;
 import io.trino.plugin.iceberg.procedure.RollbackToSnapshotProcedure;
 import io.trino.plugin.iceberg.procedure.RollbackToSnapshotTableProcedure;
 import io.trino.plugin.iceberg.procedure.UnregisterTableProcedure;
+import io.trino.plugin.iceberg.system.IcebergTablesSystemTable;
 import io.trino.spi.connector.ConnectorNodePartitioningProvider;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorPageSourceProviderFactory;
 import io.trino.spi.connector.ConnectorSplitManager;
+import io.trino.spi.connector.SystemTable;
 import io.trino.spi.connector.TableProcedureMetadata;
 import io.trino.spi.function.FunctionProvider;
 import io.trino.spi.function.table.ConnectorTableFunction;
@@ -128,6 +130,11 @@ public class IcebergModule
         newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(TableChangesFunctionProvider.class).in(Scopes.SINGLETON);
         binder.bind(FunctionProvider.class).to(IcebergFunctionProvider.class).in(Scopes.SINGLETON);
         binder.bind(TableChangesFunctionProcessorProviderFactory.class).in(Scopes.SINGLETON);
+
+        newSetBinder(binder, SystemTable.class)
+                .addBinding()
+                .to(IcebergTablesSystemTable.class)
+                .in(Scopes.SINGLETON);
 
         newOptionalBinder(binder, IcebergFileSystemFactory.class).setDefault().to(DefaultIcebergFileSystemFactory.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, CacheKeyProvider.class).setBinding().to(IcebergCacheKeyProvider.class).in(Scopes.SINGLETON);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/IcebergTablesSystemTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/IcebergTablesSystemTable.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.system;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
+import io.airlift.slice.Slice;
+import io.trino.plugin.iceberg.catalog.TrinoCatalog;
+import io.trino.plugin.iceberg.catalog.TrinoCatalogFactory;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorAccessControl;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.InMemoryRecordSet;
+import io.trino.spi.connector.InMemoryRecordSet.Builder;
+import io.trino.spi.connector.RecordCursor;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.SystemTable;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.TupleDomain;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.util.Objects.requireNonNull;
+
+public class IcebergTablesSystemTable
+        implements SystemTable
+{
+    private static final SchemaTableName NAME = new SchemaTableName("system", "iceberg_tables");
+
+    private static final ConnectorTableMetadata METADATA = new ConnectorTableMetadata(
+            NAME,
+            ImmutableList.<ColumnMetadata>builder()
+                    .add(new ColumnMetadata("table_schema", VARCHAR))
+                    .add(new ColumnMetadata("table_name", VARCHAR))
+                    .build());
+
+    private final TrinoCatalogFactory catalogFactory;
+
+    @Inject
+    public IcebergTablesSystemTable(TrinoCatalogFactory catalogFactory)
+    {
+        this.catalogFactory = requireNonNull(catalogFactory, "catalogFactory is null");
+    }
+
+    @Override
+    public Distribution getDistribution()
+    {
+        return Distribution.SINGLE_COORDINATOR;
+    }
+
+    @Override
+    public ConnectorTableMetadata getTableMetadata()
+    {
+        return METADATA;
+    }
+
+    @Override
+    public RecordCursor cursor(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession connectorSession,
+            TupleDomain<Integer> constraint,
+            Set<Integer> requiredColumns,
+            ConnectorSplit split,
+            ConnectorAccessControl accessControl)
+    {
+        Builder result = InMemoryRecordSet.builder(METADATA);
+
+        Domain schemaDomain = constraint.getDomain(0, VARCHAR);
+
+        Optional<String> schemaFilter = tryGetSingleVarcharValue(schemaDomain);
+
+        TrinoCatalog catalog = catalogFactory.create(connectorSession.getIdentity());
+        List<SchemaTableName> icebergTables = catalog.listIcebergTables(connectorSession, schemaFilter);
+        Set<SchemaTableName> accessibleIcebergTables = accessControl.filterTables(null, ImmutableSet.copyOf(icebergTables));
+        for (SchemaTableName table : accessibleIcebergTables) {
+            result.addRow(table.getSchemaName(), table.getTableName());
+        }
+        return result.build().cursor();
+    }
+
+    private static <T> Optional<String> tryGetSingleVarcharValue(Domain domain)
+    {
+        if (!domain.isSingleValue()) {
+            return Optional.empty();
+        }
+        Object value = domain.getSingleValue();
+        return Optional.of(((Slice) value).toStringUtf8());
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMinioConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMinioConnectorSmokeTest.java
@@ -13,10 +13,14 @@
  */
 package io.trino.plugin.iceberg;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.minio.messages.Event;
 import io.trino.Session;
+import io.trino.metastore.Column;
 import io.trino.metastore.HiveMetastore;
+import io.trino.metastore.HiveType;
+import io.trino.metastore.Table;
 import io.trino.plugin.hive.containers.Hive3MinioDataLake;
 import io.trino.plugin.hive.metastore.thrift.BridgingHiveMetastore;
 import io.trino.testing.QueryRunner;
@@ -28,18 +32,25 @@ import org.junit.jupiter.api.parallel.Execution;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.trino.metastore.PrincipalPrivileges.NO_PRIVILEGES;
+import static io.trino.plugin.hive.TableType.EXTERNAL_TABLE;
 import static io.trino.plugin.hive.TestingThriftHiveMetastoreBuilder.testingThriftHiveMetastoreBuilder;
+import static io.trino.plugin.iceberg.IcebergTestUtils.getHiveMetastore;
+import static io.trino.plugin.iceberg.catalog.AbstractIcebergTableOperations.ICEBERG_METASTORE_STORAGE_FORMAT;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
 import static io.trino.testing.containers.Minio.MINIO_REGION;
 import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
+import static org.apache.iceberg.BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE;
+import static org.apache.iceberg.BaseMetastoreTableOperations.TABLE_TYPE_PROP;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
@@ -231,6 +242,25 @@ public abstract class BaseIcebergMinioConnectorSmokeTest
         assertUpdate("INSERT INTO " + tableName + " VALUES " + values, 12);
         assertQuery("SELECT * FROM " + tableName, "VALUES " + values);
         assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Override
+    protected AutoCloseable createSparkIcebergTable(String schema)
+    {
+        HiveMetastore metastore = getHiveMetastore(getQueryRunner());
+        // simulate iceberg table created by spark with lowercase table type
+        Table lowerCaseTableType = io.trino.metastore.Table.builder()
+                .setDatabaseName(schema)
+                .setTableName("lowercase_type_" + randomNameSuffix())
+                .setOwner(Optional.empty())
+                .setDataColumns(ImmutableList.of(new Column("id", HiveType.HIVE_STRING, Optional.empty(), ImmutableMap.of())))
+                .setTableType(EXTERNAL_TABLE.name())
+                .withStorage(storage -> storage.setStorageFormat(ICEBERG_METASTORE_STORAGE_FORMAT))
+                .setParameter("EXTERNAL", "TRUE")
+                .setParameter(TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE.toLowerCase(ENGLISH))
+                .build();
+        metastore.createTable(lowerCaseTableType, NO_PRIVILEGES);
+        return () -> metastore.dropTable(lowerCaseTableType.getDatabaseName(), lowerCaseTableType.getTableName(), true);
     }
 
     private String onMetastore(@Language("SQL") String sql)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseSharedMetastoreTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseSharedMetastoreTest.java
@@ -153,6 +153,13 @@ public abstract class BaseSharedMetastoreTest
     }
 
     @Test
+    public void testIcebergTablesSystemTable()
+    {
+        assertQuery("SELECT * FROM iceberg.system.iceberg_tables WHERE table_schema = '%s'".formatted(tpchSchema), "VALUES ('%s', 'nation')".formatted(tpchSchema));
+        assertQuery("SELECT * FROM iceberg_with_redirections.system.iceberg_tables WHERE table_schema = '%s'".formatted(tpchSchema), "VALUES ('%s', 'nation')".formatted(tpchSchema));
+    }
+
+    @Test
     public void testTimeTravelWithRedirection()
             throws InterruptedException
     {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogCaseInsensitiveMapping.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogCaseInsensitiveMapping.java
@@ -93,7 +93,8 @@ final class TestIcebergRestCatalogCaseInsensitiveMapping
                 .containsExactlyInAnyOrder(
                         "information_schema",
                         "tpch",
-                        LOWERCASE_SCHEMA);
+                        LOWERCASE_SCHEMA,
+                        "system");
 
         assertThat(computeActual("SHOW SCHEMAS LIKE 'level%'").getOnlyColumnAsSet())
                 .containsExactlyInAnyOrder(
@@ -103,6 +104,7 @@ final class TestIcebergRestCatalogCaseInsensitiveMapping
                         """
                         VALUES
                         ('iceberg', 'information_schema'),
+                        ('iceberg', 'system'),
                         ('iceberg', '%s'),
                         ('iceberg', 'tpch')
                         """.formatted(LOWERCASE_SCHEMA));
@@ -149,7 +151,7 @@ final class TestIcebergRestCatalogCaseInsensitiveMapping
         // Query information_schema and list objects
         assertThat(computeActual("SHOW TABLES IN " + SCHEMA).getOnlyColumnAsSet()).contains(lowercaseTableName1, lowercaseTableName2);
         assertThat(computeActual("SHOW TABLES IN " + SCHEMA + " LIKE 'mixed_case_table%'").getOnlyColumnAsSet()).isEqualTo(Set.of(lowercaseTableName1, lowercaseTableName2));
-        assertQuery("SELECT * FROM information_schema.tables WHERE table_schema != 'information_schema' AND table_type = 'BASE TABLE'",
+        assertQuery("SELECT * FROM information_schema.tables WHERE table_schema NOT IN ('information_schema', 'system') AND table_type = 'BASE TABLE'",
                         """
                         VALUES
                         ('iceberg', '%1$s', '%2$s', 'BASE TABLE'),

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergUnityRestCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergUnityRestCatalogConnectorSmokeTest.java
@@ -38,6 +38,7 @@ final class TestIcebergUnityRestCatalogConnectorSmokeTest
         extends BaseIcebergConnectorSmokeTest
 {
     private final Path warehouseLocation;
+    private UnityCatalogContainer unityCatalog;
 
     public TestIcebergUnityRestCatalogConnectorSmokeTest()
             throws IOException
@@ -62,7 +63,7 @@ final class TestIcebergUnityRestCatalogConnectorSmokeTest
             throws Exception
     {
         closeAfterClass(() -> deleteRecursively(warehouseLocation, ALLOW_INSECURE));
-        UnityCatalogContainer unityCatalog = closeAfterClass(new UnityCatalogContainer("unity", "tpch"));
+        unityCatalog = closeAfterClass(new UnityCatalogContainer("unity", "tpch"));
 
         DistributedQueryRunner queryRunner = IcebergQueryRunner.builder()
                 .setBaseDataDir(Optional.of(warehouseLocation))
@@ -81,6 +82,25 @@ final class TestIcebergUnityRestCatalogConnectorSmokeTest
     }
 
     @Override
+    protected void createSchema(String schemaName)
+    {
+        unityCatalog.createSchema(schemaName);
+    }
+
+    @Override
+    protected void dropSchema(String schema)
+    {
+        unityCatalog.dropSchema(schema);
+    }
+
+    @Override
+    protected AutoCloseable createTable(String schema, String tableName, String tableDefinition)
+    {
+        unityCatalog.createTable(schema, tableName, tableDefinition);
+        return () -> unityCatalog.dropTable(schema, tableName);
+    }
+
+    @Override
     protected void dropTableFromMetastore(String tableName)
     {
         throw new UnsupportedOperationException();
@@ -95,7 +115,7 @@ final class TestIcebergUnityRestCatalogConnectorSmokeTest
     @Override
     protected String schemaPath()
     {
-        return format("%s/%s", warehouseLocation, getSession().getSchema());
+        return format("%s/%s", warehouseLocation, getSession().getSchema().orElseThrow());
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/snowflake/TestIcebergSnowflakeCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/snowflake/TestIcebergSnowflakeCatalogConnectorSmokeTest.java
@@ -684,6 +684,14 @@ public class TestIcebergSnowflakeCatalogConnectorSmokeTest
                 .hasRootCauseMessage("SQL compilation error:\ninvalid parameter 'table ? is not a Snowflake iceberg table'");
     }
 
+    @Test
+    @Override
+    public void testIcebergTablesSystemTable()
+    {
+        assertThat(query("SELECT * FROM iceberg.system.iceberg_tables WHERE table_schema = '%s'".formatted(SNOWFLAKE_TEST_SCHEMA.toLowerCase(ENGLISH))))
+                .matches("SELECT table_schema, table_name FROM iceberg.information_schema.tables WHERE table_schema='%s'".formatted(SNOWFLAKE_TEST_SCHEMA.toLowerCase(ENGLISH)));
+    }
+
     @Override
     protected boolean isFileSorted(Location path, String sortColumnName)
     {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/snowflake/TestIcebergSnowflakeCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/snowflake/TestIcebergSnowflakeCatalogConnectorSmokeTest.java
@@ -122,6 +122,34 @@ public class TestIcebergSnowflakeCatalogConnectorSmokeTest
     }
 
     @Override
+    protected void createSchema(String schemaName)
+            throws SQLException
+    {
+        server.execute(schemaName, "CREATE SCHEMA " + schemaName);
+    }
+
+    @Override
+    protected void dropSchema(String schema)
+            throws SQLException
+    {
+        server.execute(schema, "DROP SCHEMA " + schema);
+    }
+
+    @Override
+    protected AutoCloseable createTable(String schema, String tableName, String tableDefinition)
+            throws SQLException
+    {
+        server.execute(schema,
+                """
+                CREATE OR REPLACE ICEBERG TABLE %s %s
+                 EXTERNAL_VOLUME = '%s'
+                 CATALOG = 'SNOWFLAKE'
+                 BASE_LOCATION = '%s/'
+                """.formatted(tableName, tableDefinition, SNOWFLAKE_S3_EXTERNAL_VOLUME, tableName));
+        return () -> server.execute(schema, "DROP TABLE %s".formatted(tableName));
+    }
+
+    @Override
     protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
     {
         return switch (connectorBehavior) {
@@ -682,14 +710,6 @@ public class TestIcebergSnowflakeCatalogConnectorSmokeTest
         assertThatThrownBy(() -> assertQuery("SELECT count(*) FROM " + snowflakeNativeTableName))
                 .hasCauseInstanceOf(QueryFailedException.class)
                 .hasRootCauseMessage("SQL compilation error:\ninvalid parameter 'table ? is not a Snowflake iceberg table'");
-    }
-
-    @Test
-    @Override
-    public void testIcebergTablesSystemTable()
-    {
-        assertThat(query("SELECT * FROM iceberg.system.iceberg_tables WHERE table_schema = '%s'".formatted(SNOWFLAKE_TEST_SCHEMA.toLowerCase(ENGLISH))))
-                .matches("SELECT table_schema, table_name FROM iceberg.information_schema.tables WHERE table_schema='%s'".formatted(SNOWFLAKE_TEST_SCHEMA.toLowerCase(ENGLISH)));
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/containers/UnityCatalogContainer.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/containers/UnityCatalogContainer.java
@@ -30,16 +30,17 @@ import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 
+import static com.google.common.base.Verify.verify;
 import static io.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
-import static io.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
 import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
 import static io.trino.testing.TestingProperties.getDockerImagesVersion;
 import static java.lang.String.format;
@@ -56,10 +57,11 @@ public class UnityCatalogContainer
     private final String schemaName;
     private final PostgreSQLContainer<?> postgreSql;
     private final GenericContainer<?> unityCatalog;
+    private final QueryRunner queryRunner;
     private final AutoCloseableCloser closer = AutoCloseableCloser.create();
 
     public UnityCatalogContainer(String catalogName, String schemaName)
-            throws IOException
+            throws Exception
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.schemaName = requireNonNull(schemaName, "schema is null");
@@ -95,7 +97,15 @@ public class UnityCatalogContainer
         closer.register(unityCatalog);
 
         createCatalog();
-        createSchema();
+        createSchema(schemaName);
+
+        File metastoreDir = createTempDirectory("iceberg_query_runner").toFile();
+        metastoreDir.deleteOnExit();
+
+        // QueryRunner used to create tables
+        queryRunner = IcebergQueryRunner.builder()
+                .addIcebergProperty("hive.metastore.catalog.dir", metastoreDir.toURI().toString())
+                .build();
     }
 
     public String uri()
@@ -112,10 +122,10 @@ public class UnityCatalogContainer
                 .setHeader("Content-Type", "application/json")
                 .setBodyGenerator(createStaticBodyGenerator(body, UTF_8))
                 .build();
-        HTTP_CLIENT.execute(request, createStatusResponseHandler());
+        execute(request);
     }
 
-    private void createSchema()
+    public void createSchema(String schemaName)
     {
         @Language("JSON")
         String body = "{\"name\": \"" + schemaName + "\", \"catalog_name\": \"" + catalogName + "\"}";
@@ -127,28 +137,27 @@ public class UnityCatalogContainer
         execute(request);
     }
 
-    public void copyTpchTables(Iterable<TpchTable<?>> tpchTables)
-            throws Exception
+    public void dropSchema(String schema)
     {
-        File metastoreDir = createTempDirectory("iceberg_query_runner").toFile();
-        metastoreDir.deleteOnExit();
-
-        QueryRunner queryRunner = IcebergQueryRunner.builder()
-                .addIcebergProperty("hive.metastore.catalog.dir", metastoreDir.toURI().toString())
+        Request request = Request.Builder.prepareDelete()
+                .setUri(URI.create(uri() + "/schemas/%s.%s?catalog_name=%s".formatted(catalogName, schema, schema)))
                 .build();
-
-        for (TpchTable<?> table : tpchTables) {
-            String tableName = table.getTableName();
-            queryRunner.execute("CREATE TABLE iceberg.tpch." + tableName + " AS SELECT * FROM tpch.tiny." + tableName);
-            String metadataFilePath = (String) queryRunner.execute("SELECT file FROM \"" + tableName + "$metadata_log_entries\" ORDER BY file LIMIT 1").getOnlyValue();
-            createTable(tableName, metadataFilePath);
-        }
-        unityCatalog.copyFileToContainer(MountableFile.forHostPath(metastoreDir.getPath()), metastoreDir.getPath());
-        queryRunner.close();
+        execute(request);
     }
 
-    private void createTable(String tableName, String metadataFilePath)
+    public void copyTpchTables(Iterable<TpchTable<?>> tpchTables)
     {
+        for (TpchTable<?> table : tpchTables) {
+            String tableName = table.getTableName();
+            createTable(schemaName, tableName, "AS SELECT * FROM tpch.tiny." + tableName);
+        }
+    }
+
+    public void createTable(String schemaName, String tableName, String tableDefinition)
+    {
+        queryRunner.execute("CREATE TABLE iceberg.tpch." + tableName + " " + tableDefinition);
+        String metadataFilePath = (String) queryRunner.execute("SELECT file FROM \"" + tableName + "$metadata_log_entries\" ORDER BY file LIMIT 1").getOnlyValue();
+
         @Language("JSON")
         String body = "{" +
                 "\"catalog_name\": \"" + catalogName + "\"," +
@@ -169,6 +178,22 @@ public class UnityCatalogContainer
         execute("UPDATE uc_tables " +
                 "SET uniform_iceberg_metadata_location = '" + metadataFilePath + "'" +
                 "WHERE name = '" + tableName + "'");
+
+        Path absoluteMetadataFilePath = Paths.get(URI.create(metadataFilePath));
+        Path metadataDirectory = absoluteMetadataFilePath.getParent();
+        verify(metadataDirectory.endsWith("metadata"));
+        File tableDirectory = metadataDirectory.getParent().toFile();
+        unityCatalog.copyFileToContainer(MountableFile.forHostPath(tableDirectory.getAbsolutePath()), tableDirectory.getPath());
+    }
+
+    public void dropTable(String schema, String tableName)
+    {
+        Request request = Request.Builder.prepareDelete()
+                .setUri(URI.create(uri() + "/tables/%s.%s.%s?catalog_name=%s&schema_name=%s".formatted(catalogName, schema, tableName, catalogName, schema)))
+                .build();
+        execute(request);
+        // cleanup queryRunner table created during `createTable` call
+        queryRunner.execute("DROP TABLE iceberg.tpch.%s".formatted(tableName));
     }
 
     public void execute(@Language("SQL") String sql)
@@ -187,6 +212,7 @@ public class UnityCatalogContainer
     public void close()
             throws Exception
     {
+        queryRunner.close();
         closer.close();
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Add the ability to list only iceberg tables from the iceberg catalog. Before this change, there was no way to list only iceberg tables. The SHOW TABLES statement, information_schema.tables, and jdbc.tables will all return all tables that exist in the underlying metastore, even if the table cannot be handled in any way by the iceberg connector. This can happen if other connectors like hive or delta, use the same metastore, catalog, and schema to store its tables. The function accepts an optional parameter with the schema name. Sample statements:
`SELECT * FROM iceberg.system.iceberg_tables;`
`SELECT * FROM iceberg.system.iceberg_tables WHERE table_schema = 'test';`


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
https://github.com/trinodb/trino/pull/24469 added this functionality as a table function but it was reverted as the system table is a better fit
https://github.com/trinodb/trino/pull/24726 added access control support for the system tables
https://github.com/trinodb/trino/pull/11617 removed the non-iceberg table filter from TrinoHiveCatalog


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X ) Release notes are required, with the following suggested text:

```markdown
## Iceberg connector
* Add `system.iceberg_tables` system table to allow listing only iceberg tables
```
