### PR TITLE
Add libstdc++ to the docker image

### DIFF
--- a/core/docker/Dockerfile
+++ b/core/docker/Dockerfile
@@ -37,6 +37,7 @@ RUN \
     yum update -y && \
     yum install --installroot /tmp/overlay --setopt install_weak_deps=false --nodocs -y \
       less \
+      libstdc++ `# required by snappy and duckdb` \
       curl-minimal grep `# required by health-check` \
       zlib `#required by java` \
       shadow-utils `# required by useradd` \


### PR DESCRIPTION
This is required by both Snappy native compression and Duckdb connector.

Fixes https://github.com/trinodb/trino/issues/25126

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
