### PR TITLE
Fix UNION lineage information missing in column analysis

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -3335,7 +3335,6 @@ public class TestAnalyzer
 
         Field firstField = visibleFields.getFirst();
         Set<Analysis.SourceColumn> firstFieldSources = analysis.getSourceColumns(firstField);
-        ImmutableList<Analysis.SourceColumn> sourceColumns = ImmutableList.copyOf(firstFieldSources);
         assertThat(firstField.getName()).isEqualTo(Optional.of("c"));
         assertThat(firstFieldSources.size()).isEqualTo(3);
         assertThat(firstFieldSources.stream()


### PR DESCRIPTION
## Description
This PR addresses the lineage collection issue with UNION/UNION ALL operations identified in #25148.

## Additional context and related issues
Fix #25148 

## Release notes
(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
