### PR TITLE
Bump loki-client-java to 0.0.4

### DIFF
--- a/docs/src/main/sphinx/connector/loki.md
+++ b/docs/src/main/sphinx/connector/loki.md
@@ -12,7 +12,7 @@ catalog with the Loki connector to run SQL queries against Loki.
 
 To connect to Loki, you need:
 
-- Loki 3.1.0 or higher.
+- Loki 3.2.0 or higher.
 - Network access from the Trino coordinator and workers to Loki. Port 3100 is
   the default port.
 

--- a/plugin/trino-loki/pom.xml
+++ b/plugin/trino-loki/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>io.github.jeschkies</groupId>
             <artifactId>loki-client</artifactId>
-            <version>0.0.3</version>
+            <version>0.0.4</version>
         </dependency>
 
         <dependency>

--- a/plugin/trino-loki/src/test/java/io/trino/plugin/loki/TestingLokiServer.java
+++ b/plugin/trino-loki/src/test/java/io/trino/plugin/loki/TestingLokiServer.java
@@ -26,7 +26,7 @@ public class TestingLokiServer
         implements Closeable
 {
     private static final int LOKI_PORT = 3100;
-    private static final String DEFAULT_VERSION = "3.1.0";
+    private static final String DEFAULT_VERSION = "3.2.0";
 
     private final GenericContainer<?> loki;
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Loki 3.2.0 introduced a breaking change. Using log queries in instant queries was not allowed anymore. This broke the code checking for the expected result type. It was fixed in the loki-client-java library.

Closes #25156

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

```markdown
## Loki
* Fix failure when connecting to Loki server version > 3.2.0. ({issue}`25156`)
```
