### PR TITLE
Fix VariableWidthData#getRetainedSize() estimate

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/VariableWidthData.java
+++ b/core/trino-main/src/main/java/io/trino/operator/VariableWidthData.java
@@ -15,11 +15,11 @@ package io.trino.operator;
 
 import com.google.common.primitives.Ints;
 import io.airlift.slice.SizeOf;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -28,7 +28,6 @@ import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static io.airlift.slice.SizeOf.sizeOfObjectArray;
 import static io.trino.operator.FlatHash.sumExact;
 import static java.lang.Math.addExact;
 import static java.lang.Math.clamp;
@@ -48,7 +47,7 @@ public final class VariableWidthData
     private static final VarHandle INT_HANDLE = MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.LITTLE_ENDIAN);
     public static final byte[] EMPTY_CHUNK = new byte[0];
 
-    private final List<byte[]> chunks = new ArrayList<>();
+    private final ObjectArrayList<byte[]> chunks = new ObjectArrayList<>();
     private int openChunkOffset;
 
     private long chunksRetainedSizeInBytes;
@@ -85,7 +84,7 @@ public final class VariableWidthData
         return sumExact(
                 INSTANCE_SIZE,
                 chunksRetainedSizeInBytes,
-                sizeOfObjectArray(chunks.size()));
+                sizeOf(chunks.elements()));
     }
 
     public List<byte[]> getAllChunks()


### PR DESCRIPTION
## Description
Previously, `VariableWidthData` would underestimate the retained size by using `ArrayList#size()` instead of the underlying array capacity.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
