### PR TITLE
Feature/support column properties with jdbc connector

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ColumnPropertiesProvider.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ColumnPropertiesProvider.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import io.trino.spi.session.PropertyMetadata;
+
+import java.util.List;
+
+public interface ColumnPropertiesProvider
+{
+    List<PropertyMetadata<?>> getColumnProperties();
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcColumnHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcColumnHandle.java
@@ -172,7 +172,7 @@ public class JdbcColumnHandle
 
         public Builder() {}
 
-        private Builder(JdbcColumnHandle handle)
+        public Builder(JdbcColumnHandle handle)
         {
             this.columnName = handle.getColumnName();
             this.jdbcTypeHandle = handle.getJdbcTypeHandle();

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcColumnHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcColumnHandle.java
@@ -30,7 +30,7 @@ import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.util.Objects.requireNonNull;
 
-public final class JdbcColumnHandle
+public class JdbcColumnHandle
         implements ColumnHandle
 {
     private static final int INSTANCE_SIZE = instanceSize(JdbcColumnHandle.class);
@@ -162,7 +162,7 @@ public final class JdbcColumnHandle
         return new Builder(handle);
     }
 
-    public static final class Builder
+    public static class Builder
     {
         private String columnName;
         private JdbcTypeHandle jdbcTypeHandle;

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcConnector.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcConnector.java
@@ -53,6 +53,7 @@ public class JdbcConnector
     private final Set<ConnectorTableFunction> connectorTableFunctions;
     private final List<PropertyMetadata<?>> sessionProperties;
     private final List<PropertyMetadata<?>> tableProperties;
+    private final List<PropertyMetadata<?>> columnProperties;
     private final JdbcTransactionManager transactionManager;
 
     @Inject
@@ -66,6 +67,7 @@ public class JdbcConnector
             Set<ConnectorTableFunction> connectorTableFunctions,
             Set<SessionPropertiesProvider> sessionProperties,
             Set<TablePropertiesProvider> tableProperties,
+            Set<ColumnPropertiesProvider> columnProperties,
             JdbcTransactionManager transactionManager)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
@@ -80,6 +82,9 @@ public class JdbcConnector
                 .collect(toImmutableList());
         this.tableProperties = tableProperties.stream()
                 .flatMap(tablePropertiesProvider -> tablePropertiesProvider.getTableProperties().stream())
+                .collect(toImmutableList());
+        this.columnProperties = columnProperties.stream()
+                .flatMap(columnPropertiesProvider -> columnPropertiesProvider.getColumnProperties().stream())
                 .collect(toImmutableList());
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
     }
@@ -154,6 +159,12 @@ public class JdbcConnector
     public List<PropertyMetadata<?>> getTableProperties()
     {
         return tableProperties;
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getColumnProperties()
+    {
+        return columnProperties;
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcModule.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcModule.java
@@ -64,6 +64,7 @@ public class JdbcModule
 
         procedureBinder(binder);
         tablePropertiesProviderBinder(binder);
+        columnPropertiesProviderBinder(binder);
 
         newOptionalBinder(binder, JdbcMetadataFactory.class).setDefault().to(DefaultJdbcMetadataFactory.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, IdentityCacheMapping.class).setDefault().to(SingletonIdentityCacheMapping.class).in(Scopes.SINGLETON);
@@ -148,6 +149,16 @@ public class JdbcModule
     public static void bindTablePropertiesProvider(Binder binder, Class<? extends TablePropertiesProvider> type)
     {
         tablePropertiesProviderBinder(binder).addBinding().to(type).in(Scopes.SINGLETON);
+    }
+
+    public static Multibinder<ColumnPropertiesProvider> columnPropertiesProviderBinder(Binder binder)
+    {
+        return newSetBinder(binder, ColumnPropertiesProvider.class);
+    }
+
+    public static void bindColumnPropertiesProvider(Binder binder, Class<? extends ColumnPropertiesProvider> type)
+    {
+        columnPropertiesProviderBinder(binder).addBinding().to(type).in(Scopes.SINGLETON);
     }
 
     @ProvidesIntoOptional(DEFAULT)

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
@@ -47,6 +47,7 @@ import io.trino.plugin.jdbc.PredicatePushdownController;
 import io.trino.plugin.jdbc.PreparedQuery;
 import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.plugin.jdbc.RemoteTableName;
+import io.trino.plugin.jdbc.UnsupportedTypeHandling;
 import io.trino.plugin.jdbc.WriteMapping;
 import io.trino.plugin.jdbc.aggregation.ImplementAvgDecimal;
 import io.trino.plugin.jdbc.aggregation.ImplementAvgFloatingPoint;
@@ -111,10 +112,12 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
@@ -177,6 +180,8 @@ import static io.trino.plugin.jdbc.StandardColumnMappings.varcharReadFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.varcharWriteFunction;
 import static io.trino.plugin.jdbc.TypeHandlingJdbcSessionProperties.getUnsupportedTypeHandling;
 import static io.trino.plugin.jdbc.UnsupportedTypeHandling.CONVERT_TO_VARCHAR;
+import static io.trino.plugin.jdbc.UnsupportedTypeHandling.IGNORE;
+import static io.trino.plugin.mysql.MySqlColumnProperties.AUTO_INCREMENT;
 import static io.trino.spi.StandardErrorCode.ALREADY_EXISTS;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.SCHEMA_NOT_EMPTY;
@@ -209,6 +214,7 @@ import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.String.format;
 import static java.lang.String.join;
+import static java.sql.DatabaseMetaData.columnNoNulls;
 import static java.time.format.DateTimeFormatter.ISO_DATE;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
@@ -472,6 +478,61 @@ public class MySqlClient
     }
 
     @Override
+    public List<JdbcColumnHandle> getColumns(ConnectorSession session, SchemaTableName schemaTableName, RemoteTableName remoteTableName)
+    {
+        try (Connection connection = connectionFactory.openConnection(session);
+             ResultSet resultSet = getColumns(remoteTableName, connection.getMetaData())) {
+            Map<String, CaseSensitivity> caseSensitivityMapping = getCaseSensitivityForColumns(session, connection, schemaTableName, remoteTableName);
+            int allColumns = 0;
+            List<JdbcColumnHandle> columns = new ArrayList<>();
+            while (resultSet.next()) {
+                allColumns++;
+                String columnName = resultSet.getString("COLUMN_NAME");
+                JdbcTypeHandle typeHandle = new JdbcTypeHandle(
+                        getInteger(resultSet, "DATA_TYPE").orElseThrow(() -> new IllegalStateException("DATA_TYPE is null")),
+                        Optional.ofNullable(resultSet.getString("TYPE_NAME")),
+                        getInteger(resultSet, "COLUMN_SIZE"),
+                        getInteger(resultSet, "DECIMAL_DIGITS"),
+                        Optional.empty(),
+                        Optional.ofNullable(caseSensitivityMapping.get(columnName)));
+                Optional<ColumnMapping> columnMapping = toColumnMapping(session, connection, typeHandle);
+                log.debug("Mapping data type of '%s' column '%s': %s mapped to %s", schemaTableName, columnName, typeHandle, columnMapping);
+                boolean nullable = (resultSet.getInt("NULLABLE") != columnNoNulls);
+                boolean autoIncrement = "YES".equals(resultSet.getString("IS_AUTOINCREMENT"));
+                // Note: some databases (e.g. SQL Server) do not return column remarks/comment here.
+                Optional<String> comment = Optional.ofNullable(emptyToNull(resultSet.getString("REMARKS")));
+                // skip unsupported column types
+                columnMapping.ifPresent(mapping -> columns.add(MySqlJdbcColumnHandle.builder()
+                        .setColumnName(columnName)
+                        .setJdbcTypeHandle(typeHandle)
+                        .setColumnType(mapping.getType())
+                        .setNullable(nullable)
+                        .setComment(comment)
+                        .setAutoIncrement(autoIncrement)
+                        .build()));
+                if (columnMapping.isEmpty()) {
+                    UnsupportedTypeHandling unsupportedTypeHandling = getUnsupportedTypeHandling(session);
+                    verify(
+                            unsupportedTypeHandling == IGNORE,
+                            "Unsupported type handling is set to %s, but toColumnMapping() returned empty for %s",
+                            unsupportedTypeHandling,
+                            typeHandle);
+                }
+            }
+            if (columns.isEmpty()) {
+                // A table may have no supported columns. In rare cases (e.g. PostgreSQL) a table might have no columns at all.
+                throw new TableNotFoundException(
+                        schemaTableName,
+                        format("Table '%s' has no supported columns (all %s columns are not supported)", schemaTableName, allColumns));
+            }
+            return ImmutableList.copyOf(columns);
+        }
+        catch (SQLException e) {
+            throw new TrinoException(JDBC_ERROR, e);
+        }
+    }
+
+    @Override
     protected List<String> createTableSqls(RemoteTableName remoteTableName, List<String> columns, ConnectorTableMetadata tableMetadata)
     {
         checkArgument(tableMetadata.getProperties().isEmpty(), "Unsupported table properties: %s", tableMetadata.getProperties());
@@ -487,10 +548,18 @@ public class MySqlClient
             throw new TrinoException(NOT_SUPPORTED, "This connector does not support creating tables with column comment");
         }
 
-        return "%s %s %s".formatted(
+        boolean isAutoIncrement = false;
+        Map<String, Object> properties = column.getProperties();
+        if (properties != null) {
+            isAutoIncrement = (boolean) properties.getOrDefault(AUTO_INCREMENT,false);
+        }
+
+        return "%s %s %s %s".formatted(
                 quoted(columnName),
                 toWriteMapping(session, column.getType()).getDataType(),
-                column.isNullable() ? "NULL" : "NOT NULL");
+                column.isNullable() ? "NULL" : "NOT NULL",
+                isAutoIncrement ? "AUTO_INCREMENT" : ""
+                );
     }
 
     private static String mysqlVarcharLiteral(String value)

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlColumnProperties.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlColumnProperties.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mysql;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import io.trino.plugin.jdbc.ColumnPropertiesProvider;
+import io.trino.spi.session.PropertyMetadata;
+
+import java.util.List;
+
+import static io.trino.spi.session.PropertyMetadata.booleanProperty;
+import static io.trino.spi.session.PropertyMetadata.stringProperty;
+
+public final class MySqlColumnProperties
+    implements ColumnPropertiesProvider
+{
+    public static final String AUTO_INCREMENT = "auto_increment";
+
+    private final List<PropertyMetadata<?>> columnProperties;
+
+    @Inject
+    public MySqlColumnProperties()
+    {
+        columnProperties = ImmutableList.<PropertyMetadata<?>>builder()
+                .add(booleanProperty(
+                        AUTO_INCREMENT,
+                        "If column can auto increment",
+                        false,
+                        false))
+                .build();
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getColumnProperties()
+    {
+        return columnProperties;
+    }
+}

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlJdbcColumnHandle.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlJdbcColumnHandle.java
@@ -1,0 +1,176 @@
+package io.trino.plugin.mysql;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Joiner;
+import io.airlift.slice.SizeOf;
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcTypeHandle;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ColumnSchema;
+import io.trino.spi.type.Type;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * describe:
+ *
+ * @author hqbhoho
+ * @version [v1.0]
+ * @date 2025/02/14
+ */
+public class MySqlJdbcColumnHandle
+        extends JdbcColumnHandle {
+    private static final int INSTANCE_SIZE = instanceSize(MySqlJdbcColumnHandle.class);
+
+    private final boolean autoIncrement;
+
+    // All and only required fields
+    public MySqlJdbcColumnHandle(String columnName, JdbcTypeHandle jdbcTypeHandle, Type columnType)
+    {
+        this(columnName, jdbcTypeHandle, columnType, true, Optional.empty(), false);
+    }
+
+    /**
+     * @deprecated This constructor is intended to be used by JSON deserialization only. Use {@link #builder()} instead.
+     */
+    @Deprecated
+    @JsonCreator
+    public MySqlJdbcColumnHandle(
+            @JsonProperty("columnName") String columnName,
+            @JsonProperty("jdbcTypeHandle") JdbcTypeHandle jdbcTypeHandle,
+            @JsonProperty("columnType") Type columnType,
+            @JsonProperty("nullable") boolean nullable,
+            @JsonProperty("comment") Optional<String> comment,
+            @JsonProperty("autoIncrement") boolean autoIncrement)
+    {
+        super(columnName, jdbcTypeHandle, columnType, nullable, comment);
+        this.autoIncrement = autoIncrement;
+    }
+
+    @JsonProperty
+    public boolean isAutoIncrement()
+    {
+        return autoIncrement;
+    }
+
+    @Override
+    public ColumnMetadata getColumnMetadata()
+    {
+        ColumnMetadata.Builder columnMetadataBuilder = ColumnMetadata.builder()
+                .setName(getColumnName())
+                .setType(getColumnType())
+                .setNullable(isNullable())
+                .setComment(getComment());
+
+        Map<String, Object> properties = new LinkedHashMap<>();
+        if (autoIncrement) {
+            properties.put(MySqlColumnProperties.AUTO_INCREMENT, true);
+        }
+
+        if (!properties.isEmpty()) {
+            columnMetadataBuilder.setProperties(properties);
+        }
+        return columnMetadataBuilder.build();
+    }
+
+
+    public long getRetainedSizeInBytes()
+    {
+        // columnType is not accounted for as the instances are cached (by TypeRegistry) and shared
+        return INSTANCE_SIZE
+                + sizeOf(isNullable())
+                + estimatedSizeOf(getColumnName())
+                + sizeOf(getComment(), SizeOf::estimatedSizeOf)
+                + getJdbcTypeHandle().getRetainedSizeInBytes()
+                + sizeOf(autoIncrement);
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static Builder builderFrom(MySqlJdbcColumnHandle handle)
+    {
+        return new MySqlJdbcColumnHandle.Builder(handle);
+    }
+
+    public static class Builder
+        extends JdbcColumnHandle.Builder
+    {
+        private String columnName;
+        private JdbcTypeHandle jdbcTypeHandle;
+        private Type columnType;
+        private boolean nullable = true;
+        private Optional<String> comment = Optional.empty();
+        private boolean autoIncrement;
+
+        public Builder() {}
+
+        private Builder(MySqlJdbcColumnHandle handle)
+        {
+            this.columnName = handle.getColumnName();
+            this.jdbcTypeHandle = handle.getJdbcTypeHandle();
+            this.columnType = handle.getColumnType();
+            this.nullable = handle.isNullable();
+            this.comment = handle.getComment();
+            this.autoIncrement = handle.isAutoIncrement();
+        }
+
+        public Builder setColumnName(String columnName)
+        {
+            this.columnName = columnName;
+            return this;
+        }
+
+        public Builder setJdbcTypeHandle(JdbcTypeHandle jdbcTypeHandle)
+        {
+            this.jdbcTypeHandle = jdbcTypeHandle;
+            return this;
+        }
+
+        public Builder setColumnType(Type columnType)
+        {
+            this.columnType = columnType;
+            return this;
+        }
+
+        public Builder setNullable(boolean nullable)
+        {
+            this.nullable = nullable;
+            return this;
+        }
+
+        public Builder setComment(Optional<String> comment)
+        {
+            this.comment = comment;
+            return this;
+        }
+
+        public Builder setAutoIncrement(boolean autoIncrement)
+        {
+            this.autoIncrement = autoIncrement;
+            return this;
+        }
+
+        public MySqlJdbcColumnHandle build()
+        {
+            return new MySqlJdbcColumnHandle(
+                    columnName,
+                    jdbcTypeHandle,
+                    columnType,
+                    nullable,
+                    comment,
+                    autoIncrement);
+        }
+    }
+}

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlClient.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlClient.java
@@ -44,14 +44,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestMySqlClient
 {
     private static final JdbcColumnHandle BIGINT_COLUMN =
-            JdbcColumnHandle.builder()
+            MySqlJdbcColumnHandle.builder()
                     .setColumnName("c_bigint")
                     .setColumnType(BIGINT)
                     .setJdbcTypeHandle(new JdbcTypeHandle(Types.BIGINT, Optional.of("int8"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()))
                     .build();
 
     private static final JdbcColumnHandle DOUBLE_COLUMN =
-            JdbcColumnHandle.builder()
+            MySqlJdbcColumnHandle.builder()
                     .setColumnName("c_double")
                     .setColumnType(DOUBLE)
                     .setJdbcTypeHandle(new JdbcTypeHandle(Types.DOUBLE, Optional.of("double"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()))


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Add column properties for base jdbc connector to support auto_increment, default value and other column attribute. 


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Mysql
*  Add support create table with auto increment column
```
