### PR TITLE
Add `system.bucket` function to Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -47,6 +47,7 @@ import io.trino.plugin.hive.HiveWrittenPartitions;
 import io.trino.plugin.iceberg.aggregation.DataSketchStateSerializer;
 import io.trino.plugin.iceberg.aggregation.IcebergThetaSketchForStats;
 import io.trino.plugin.iceberg.catalog.TrinoCatalog;
+import io.trino.plugin.iceberg.functions.IcebergFunctionProvider;
 import io.trino.plugin.iceberg.procedure.IcebergAddFilesFromTableHandle;
 import io.trino.plugin.iceberg.procedure.IcebergAddFilesHandle;
 import io.trino.plugin.iceberg.procedure.IcebergDropExtendedStatsHandle;
@@ -109,6 +110,11 @@ import io.trino.spi.connector.WriterScalingOptions;
 import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.expression.FunctionName;
 import io.trino.spi.expression.Variable;
+import io.trino.spi.function.BoundSignature;
+import io.trino.spi.function.FunctionDependencyDeclaration;
+import io.trino.spi.function.FunctionId;
+import io.trino.spi.function.FunctionMetadata;
+import io.trino.spi.function.SchemaFunctionName;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.NullableValue;
 import io.trino.spi.predicate.TupleDomain;
@@ -422,6 +428,7 @@ public class IcebergMetadata
             .add(PARTITIONING_PROPERTY)
             .add(SORTED_BY_PROPERTY)
             .build();
+    private static final String SYSTEM_SCHEMA = "system";
 
     public static final String NUMBER_OF_DISTINCT_VALUES_NAME = "NUMBER_OF_DISTINCT_VALUES";
     private static final FunctionName NUMBER_OF_DISTINCT_VALUES_FUNCTION = new FunctionName(IcebergThetaSketchForStats.NAME);
@@ -471,6 +478,32 @@ public class IcebergMetadata
         this.allowedExtraProperties = requireNonNull(allowedExtraProperties, "allowedExtraProperties is null");
         this.icebergScanExecutor = requireNonNull(icebergScanExecutor, "icebergScanExecutor is null");
         this.metadataFetchingExecutor = requireNonNull(metadataFetchingExecutor, "metadataFetchingExecutor is null");
+    }
+
+    @Override
+    public Collection<FunctionMetadata> listFunctions(ConnectorSession session, String schemaName)
+    {
+        return schemaName.equals(SYSTEM_SCHEMA) ? IcebergFunctionProvider.FUNCTIONS : List.of();
+    }
+
+    @Override
+    public Collection<FunctionMetadata> getFunctions(ConnectorSession session, SchemaFunctionName name)
+    {
+        if (!name.getSchemaName().equals(SYSTEM_SCHEMA)) {
+            return List.of();
+        }
+        return IcebergFunctionProvider.FUNCTIONS.stream()
+                .filter(function -> function.getCanonicalName().equals(name.getFunctionName()))
+                .toList();
+    }
+
+    @Override
+    public FunctionMetadata getFunctionMetadata(ConnectorSession session, FunctionId functionId)
+    {
+        return IcebergFunctionProvider.FUNCTIONS.stream()
+                .filter(function -> function.getFunctionId().equals(functionId))
+                .findFirst()
+                .orElseThrow();
     }
 
     @Override
@@ -2327,6 +2360,12 @@ public class IcebergMetadata
         catch (IOException e) {
             throw new TrinoException(ICEBERG_FILESYSTEM_ERROR, "Failed accessing data for table: " + schemaTableName, e);
         }
+    }
+
+    @Override
+    public FunctionDependencyDeclaration getFunctionDependencies(ConnectorSession session, FunctionId functionId, BoundSignature boundSignature)
+    {
+        return FunctionDependencyDeclaration.NO_DEPENDENCIES;
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/IcebergFunctionProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/IcebergFunctionProvider.java
@@ -13,25 +13,238 @@
  */
 package io.trino.plugin.iceberg.functions;
 
+import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
+import io.airlift.slice.Slice;
 import io.trino.plugin.base.classloader.ClassLoaderSafeTableFunctionProcessorProviderFactory;
 import io.trino.plugin.iceberg.functions.tablechanges.TableChangesFunctionHandle;
 import io.trino.plugin.iceberg.functions.tablechanges.TableChangesFunctionProcessorProviderFactory;
+import io.trino.spi.TrinoException;
+import io.trino.spi.function.BoundSignature;
+import io.trino.spi.function.FunctionDependencies;
+import io.trino.spi.function.FunctionId;
+import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.FunctionProvider;
+import io.trino.spi.function.InvocationConvention;
+import io.trino.spi.function.ScalarFunctionAdapter;
+import io.trino.spi.function.ScalarFunctionImplementation;
+import io.trino.spi.function.Signature;
 import io.trino.spi.function.table.ConnectorTableFunctionHandle;
 import io.trino.spi.function.table.TableFunctionProcessorProviderFactory;
+import io.trino.spi.type.BigintType;
+import io.trino.spi.type.DateType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Int128;
+import io.trino.spi.type.IntegerType;
+import io.trino.spi.type.LongTimestamp;
+import io.trino.spi.type.LongTimestampWithTimeZone;
+import io.trino.spi.type.SmallintType;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.TimestampWithTimeZoneType;
+import io.trino.spi.type.TinyintType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeSignature;
+import io.trino.spi.type.VarbinaryType;
+import io.trino.spi.type.VarcharType;
+import org.apache.iceberg.transforms.Transforms;
+import org.apache.iceberg.types.Types;
 
+import java.lang.invoke.MethodHandle;
+import java.math.BigDecimal;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.plugin.iceberg.util.Timestamps.timestampTzToMicros;
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
+import static java.lang.invoke.MethodHandles.lookup;
+import static java.lang.invoke.MethodType.methodType;
+import static java.util.Collections.nCopies;
 import static java.util.Objects.requireNonNull;
 
 public class IcebergFunctionProvider
         implements FunctionProvider
 {
+    public static final List<FunctionMetadata> FUNCTIONS = ImmutableList.<FunctionMetadata>builder()
+            .add(FunctionMetadata.scalarBuilder("bucket")
+                    .functionId(new FunctionId("bucket"))
+                    .nondeterministic()
+                    .description("Perform Iceberg bucket transform")
+                    .signature(Signature.builder()
+                            .typeVariable("T")
+                            .returnType(INTEGER.getTypeSignature())
+                            .argumentTypes(ImmutableList.of(new TypeSignature("T"), INTEGER.getTypeSignature()))
+                            .build())
+                    .nullable()
+                    .build())
+            .build();
+
+    private static final MethodHandle BUCKET_INTEGER;
+    private static final MethodHandle BUCKET_SHORT_DECIMAL;
+    private static final MethodHandle BUCKET_LONG_DECIMAL;
+    private static final MethodHandle BUCKET_VARCHAR;
+    private static final MethodHandle BUCKET_VARBINARY;
+    private static final MethodHandle BUCKET_DATE;
+    private static final MethodHandle BUCKET_SHORT_TIMESTAMP;
+    private static final MethodHandle BUCKET_LONG_TIMESTAMP;
+    private static final MethodHandle BUCKET_SHORT_TIMESTAMP_WITH_TIME_ZONE;
+    private static final MethodHandle BUCKET_LONG_TIMESTAMP_WITH_TIME_ZONE;
+
+    static {
+        try {
+            BUCKET_INTEGER = lookup().findVirtual(IcebergFunctionProvider.class, "bucketInteger", methodType(long.class, long.class, long.class));
+            BUCKET_SHORT_DECIMAL = lookup().findVirtual(IcebergFunctionProvider.class, "bucketShortDecimal", methodType(long.class, DecimalType.class, long.class, long.class));
+            BUCKET_LONG_DECIMAL = lookup().findVirtual(IcebergFunctionProvider.class, "bucketLongDecimal", methodType(long.class, DecimalType.class, Int128.class, long.class));
+            BUCKET_VARCHAR = lookup().findVirtual(IcebergFunctionProvider.class, "bucketVarchar", methodType(long.class, Slice.class, long.class));
+            BUCKET_VARBINARY = lookup().findVirtual(IcebergFunctionProvider.class, "bucketVarbinary", methodType(long.class, Slice.class, long.class));
+            BUCKET_DATE = lookup().findVirtual(IcebergFunctionProvider.class, "bucketDate", methodType(long.class, long.class, long.class));
+            BUCKET_SHORT_TIMESTAMP = lookup().findVirtual(IcebergFunctionProvider.class, "bucketShortTimestamp", methodType(long.class, long.class, long.class));
+            BUCKET_LONG_TIMESTAMP = lookup().findVirtual(IcebergFunctionProvider.class, "bucketLongTimestamp", methodType(long.class, LongTimestamp.class, long.class));
+            BUCKET_SHORT_TIMESTAMP_WITH_TIME_ZONE = lookup().findVirtual(IcebergFunctionProvider.class, "bucketShortTimestampWithTimeZone", methodType(long.class, long.class, long.class));
+            BUCKET_LONG_TIMESTAMP_WITH_TIME_ZONE = lookup().findVirtual(IcebergFunctionProvider.class, "bucketLongTimestampWithTimeZone", methodType(long.class, LongTimestampWithTimeZone.class, long.class));
+        }
+        catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
+    }
+
     private final TableChangesFunctionProcessorProviderFactory tableChangesFunctionProcessorProviderFactory;
 
     @Inject
     public IcebergFunctionProvider(TableChangesFunctionProcessorProviderFactory tableChangesFunctionProcessorProviderFactory)
     {
         this.tableChangesFunctionProcessorProviderFactory = requireNonNull(tableChangesFunctionProcessorProviderFactory, "tableChangesFunctionProcessorProviderFactory is null");
+    }
+
+    @Override
+    public ScalarFunctionImplementation getScalarFunctionImplementation(
+            FunctionId functionId,
+            BoundSignature boundSignature,
+            FunctionDependencies functionDependencies,
+            InvocationConvention invocationConvention)
+    {
+        List<Type> argumentTypes = boundSignature.getArgumentTypes();
+        checkArgument(argumentTypes.size() == 2, "Expected two arguments, but got %s", argumentTypes.size());
+        checkArgument(argumentTypes.getLast() == INTEGER, "The 2nd argument must be integer type, but got %s", argumentTypes.getLast());
+        Type type = argumentTypes.getFirst();
+
+        MethodHandle handle = switch (type) {
+            case TinyintType _, SmallintType _, IntegerType _, BigintType _ -> BUCKET_INTEGER;
+            case DecimalType decimalType -> decimalType.isShort() ? BUCKET_SHORT_DECIMAL : BUCKET_LONG_DECIMAL;
+            case VarcharType _ -> BUCKET_VARCHAR;
+            case VarbinaryType _ -> BUCKET_VARBINARY;
+            case DateType _ -> BUCKET_DATE;
+            case TimestampType timestampType -> timestampType.isShort() ? BUCKET_SHORT_TIMESTAMP : BUCKET_LONG_TIMESTAMP;
+            case TimestampWithTimeZoneType timestampWithTimeZoneType -> timestampWithTimeZoneType.isShort() ? BUCKET_SHORT_TIMESTAMP_WITH_TIME_ZONE : BUCKET_LONG_TIMESTAMP_WITH_TIME_ZONE;
+            default -> throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "Unsupported type: " + type);
+        };
+
+        handle = handle.bindTo(this);
+
+        if (type instanceof DecimalType decimalType) {
+            handle = handle.bindTo(decimalType);
+        }
+
+        InvocationConvention actualConvention = new InvocationConvention(
+                nCopies(boundSignature.getArity(), NEVER_NULL),
+                FAIL_ON_NULL,
+                false,
+                false);
+
+        handle = ScalarFunctionAdapter.adapt(
+                handle,
+                boundSignature.getReturnType(),
+                boundSignature.getArgumentTypes(),
+                actualConvention,
+                invocationConvention);
+
+        return ScalarFunctionImplementation.builder()
+                .methodHandle(handle)
+                .build();
+    }
+
+    @SuppressWarnings("MethodMayBeStatic")
+    public long bucketInteger(long value, long numberOfBuckets)
+    {
+        return Transforms.bucket((int) numberOfBuckets)
+                .bind(Types.LongType.get())
+                .apply(value);
+    }
+
+    @SuppressWarnings("MethodMayBeStatic")
+    public long bucketShortDecimal(DecimalType decimalType, long value, long numberOfBuckets)
+    {
+        return Transforms.bucket((int) numberOfBuckets)
+                .bind(Types.DecimalType.of(decimalType.getPrecision(), decimalType.getScale()))
+                .apply(BigDecimal.valueOf(value));
+    }
+
+    @SuppressWarnings("MethodMayBeStatic")
+    public long bucketLongDecimal(DecimalType decimalType, Int128 value, long numberOfBuckets)
+    {
+        return Transforms.bucket((int) numberOfBuckets)
+                .bind(Types.DecimalType.of(decimalType.getPrecision(), decimalType.getScale()))
+                .apply(new BigDecimal(value.toBigInteger()));
+    }
+
+    @SuppressWarnings("MethodMayBeStatic")
+    public long bucketVarchar(Slice value, long numberOfBuckets)
+    {
+        return (long) Transforms.bucket((int) numberOfBuckets)
+                .bind(Types.StringType.get())
+                .apply(value.toStringUtf8());
+    }
+
+    @SuppressWarnings("MethodMayBeStatic")
+    public long bucketVarbinary(Slice value, long numberOfBuckets)
+    {
+        return (long) Transforms.bucket((int) numberOfBuckets)
+                .bind(Types.BinaryType.get())
+                .apply(value.toByteBuffer());
+    }
+
+    @SuppressWarnings("MethodMayBeStatic")
+    public long bucketDate(long value, long numberOfBuckets)
+    {
+        return Transforms.bucket((int) numberOfBuckets)
+                .bind(Types.DateType.get())
+                .apply((int) value);
+    }
+
+    @SuppressWarnings("MethodMayBeStatic")
+    public long bucketShortTimestamp(long value, long numberOfBuckets)
+    {
+        return Transforms.bucket((int) numberOfBuckets)
+                .bind(Types.TimestampType.withoutZone())
+                .apply(value);
+    }
+
+    @SuppressWarnings("MethodMayBeStatic")
+    public long bucketLongTimestamp(LongTimestamp value, long numberOfBuckets)
+    {
+        return Transforms.bucket((int) numberOfBuckets)
+                .bind(Types.TimestampType.withoutZone())
+                .apply(value.getEpochMicros());
+    }
+
+    @SuppressWarnings("MethodMayBeStatic")
+    public long bucketShortTimestampWithTimeZone(long value, long numberOfBuckets)
+    {
+        return Transforms.bucket((int) numberOfBuckets)
+                .bind(Types.TimestampType.withZone())
+                .apply(unpackMillisUtc(value) * MICROSECONDS_PER_MILLISECOND);
+    }
+
+    @SuppressWarnings("MethodMayBeStatic")
+    public long bucketLongTimestampWithTimeZone(LongTimestampWithTimeZone value, long numberOfBuckets)
+    {
+        return Transforms.bucket((int) numberOfBuckets)
+                .bind(Types.TimestampType.withZone())
+                .apply(timestampTzToMicros(value));
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/functions/TestBucketFunctions.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/functions/TestBucketFunctions.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.functions;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.iceberg.IcebergPlugin;
+import io.trino.sql.SqlPath;
+import io.trino.sql.query.QueryAssertions;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.Optional;
+
+import static io.trino.spi.StandardErrorCode.FUNCTION_NOT_FOUND;
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+final class TestBucketFunctions
+{
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    void init()
+    {
+        assertions = new QueryAssertions(testSessionBuilder()
+                .setPath(SqlPath.buildPath("iceberg.system", Optional.empty()))
+                .build());
+        assertions.addPlugin(new IcebergPlugin());
+        assertions.getQueryRunner().createCatalog("iceberg", "iceberg", ImmutableMap.of("hive.metastore.uri", "thrift://example.net:9083"));
+    }
+
+    @AfterAll
+    void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    void testTinyint()
+    {
+        assertBucket("TINYINT '-128'", 16, 2);
+        assertBucket("TINYINT '127'", 16, 5);
+        assertBucket("CAST(NULL AS TINYINT)", 16, null);
+    }
+
+    @Test
+    void testSmallint()
+    {
+        assertBucket("SMALLINT '-32768'", 16, 1);
+        assertBucket("SMALLINT '32767'", 16, 5);
+        assertBucket("CAST(NULL AS SMALLINT)", 16, null);
+    }
+
+    @Test
+    void testInteger()
+    {
+        assertBucket("1", 1, 0);
+        assertBucket("198765432", 16, 15);
+        assertBucket("1987654329876", 16, 15);
+        assertBucket("CAST(NULL AS INTEGER)", 16, null);
+    }
+
+    @Test
+    void testBigint()
+    {
+        assertBucket("-9223372036854775808", 16, 5);
+        assertBucket("9223372036854775807", 16, 15);
+        assertBucket("CAST(NULL AS BIGINT)", 16, null);
+    }
+
+    @Test
+    void testDecimal()
+    {
+        assertBucket("DECIMAL '36.654'", 16, 1);
+        assertBucket("36.654", 16, 1);
+        assertBucket("99099.9876", 16, 15);
+        assertBucket("1110000000000000000000000.0", 16, 10);
+        assertBucket("CAST(NULL AS DECIMAL(5, 2))", 16, null);
+        assertBucket("CAST(NULL AS DECIMAL(24, 2))", 16, null);
+    }
+
+    @Test
+    void testVarchar()
+    {
+        assertBucket("'trino'", 16, 10);
+        assertBucket("'iceberg'", 16, 9);
+        assertBucket("CAST(NULL AS VARCHAR)", 16, null);
+    }
+
+    @Test
+    void testVarbinary()
+    {
+        assertBucket("x'65683F'", 16, 11);
+        assertBucket("CAST(NULL AS VARBINARY)", 16, null);
+    }
+
+    @Test
+    void testDate()
+    {
+        assertBucket("DATE '0001-01-01'", 16, 9);
+        assertBucket("DATE '2024-11-19'", 16, 11);
+        assertBucket("DATE '9999-12-31'", 16, 9);
+        assertBucket("CAST(NULL AS DATE)", 16, null);
+    }
+
+    @Test
+    void testTimestamp()
+    {
+        assertBucket("TIMESTAMP '0001-01-01 00:00:00'", 1, 0);
+        assertBucket("TIMESTAMP '1970-01-30 16:00:00'", 1, 0);
+        assertBucket("TIMESTAMP '1970-01-30 16:00:00'", 16, 13);
+        assertBucket("TIMESTAMP '1970-01-30 16:00:00.123456789012'", 16, 7);
+        assertBucket("TIMESTAMP '1970-01-30 16:00:00.123456999999'", 16, 7);
+        assertBucket("TIMESTAMP '9999-12-31 23:59:59.123456'", 16, 14);
+        assertBucket("CAST(NULL AS TIMESTAMP)", 16, null);
+        assertBucket("CAST(NULL AS TIMESTAMP(0))", 16, null);
+        assertBucket("CAST(NULL AS TIMESTAMP(12))", 16, null);
+    }
+
+    @Test
+    void testTimestampWithTimeZone()
+    {
+        assertBucket("TIMESTAMP '0001-01-01 00:00:00 +02:09'", 1, 0);
+        assertBucket("TIMESTAMP '1988-04-08 14:15:16 +02:09'", 1, 0);
+        assertBucket("TIMESTAMP '1988-04-08 14:15:16 +02:09'", 16, 0);
+        assertBucket("TIMESTAMP '2025-01-01 00:00:00.123 +01:00'", 16, 10);
+        assertBucket("TIMESTAMP '9999-12-31 23:59:59.123456 +00:00'", 16, 14);
+        assertBucket("CAST(NULL AS TIMESTAMP WITH TIME ZONE)", 16, null);
+        assertBucket("CAST(NULL AS TIMESTAMP(0) WITH TIME ZONE)", 16, null);
+        assertBucket("CAST(NULL AS TIMESTAMP(12) WITH TIME ZONE)", 16, null);
+    }
+
+    @Test
+    void testInvalidArguments()
+    {
+        assertInvalidType("true", "boolean");
+        assertInvalidType("REAL '1.23'", "real");
+        assertInvalidType("DOUBLE '1.23'", "double");
+        assertInvalidType("CHAR 'abc'", "char(3)");
+        assertInvalidType("uuid()", "uuid");
+        assertInvalidType("ROW(1)", "row(integer)");
+        assertInvalidType("ARRAY[1]", "array(integer)");
+        assertInvalidType("MAP(ARRAY[1], ARRAY[2])", "map(integer, integer)");
+
+        assertTrinoExceptionThrownBy(() -> assertions.function("bucket", "'abc'").evaluate())
+                .hasErrorCode(FUNCTION_NOT_FOUND);
+        assertTrinoExceptionThrownBy(() -> assertions.function("bucket", "'abc'", "'abc'", "'abc'").evaluate())
+                .hasErrorCode(FUNCTION_NOT_FOUND);
+    }
+
+    private void assertBucket(@Language("SQL") String input, int bucketCount, Integer expectedBucket)
+    {
+        assertThat(assertions.function("bucket", input, Integer.toString(bucketCount)))
+                .hasType(INTEGER)
+                .isEqualTo(expectedBucket);
+    }
+
+    private void assertInvalidType(@Language("SQL")String input, String type)
+    {
+        assertTrinoExceptionThrownBy(() -> assertions.function("bucket", input, "1").evaluate())
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessage("Unsupported type: " + type);
+    }
+}


### PR DESCRIPTION
## Description

The supported types for the 1st argument: tinyint, smallint, int, bigint, varchar, varbinary, date, timestamp, timestap tz:
```sql
system.bucket(value, integer) -> integer
```

Add a function to expose the iceberg bucket transform via SQL. This can be used to help determine what bucket a value would be placed in. This could be used with the `optimize` procedure to only optimize specific buckets once we support a pushdown of this function.

Spark has a similar UDF - https://iceberg.apache.org/javadoc/1.5.1/org/apache/iceberg/spark/functions/BucketFunction.html

## Release notes

```markdown
## Iceberg
* Add `system.bucket` function. ({issue}`25175`)
```