### PR TITLE
Fix resource files for TPCH stats

### DIFF
--- a/plugin/trino-tpch/src/main/resources/tpch/statistics/sf3000.0/customer.json
+++ b/plugin/trino-tpch/src/main/resources/tpch/statistics/sf3000.0/customer.json
@@ -1,40 +1,40 @@
  {
-    "rowCount" : 4.5E8,
+    "rowCount" : 450000000,
      "columns" : {
         "c_phone" : {
-             "dataSize" : 6.75E9,
-             "distinctValuesCount" : 4.50049407E8
+             "dataSize" : 6750000000,
+             "distinctValuesCount" : 450049407
         },
         "c_nationkey" : {
-             "distinctValuesCount" : 19.0,
+             "distinctValuesCount" : 19,
              "min" : 0,
              "max" : 24
         },
         "c_custkey" : {
-             "distinctValuesCount" : 4.12697126E8,
+             "distinctValuesCount" : 412697126,
              "min" : 1,
              "max" : 450000000
         },
         "c_name" : {
-             "dataSize" : 8.1E9,
-             "distinctValuesCount" : 4.90782358E8
+             "dataSize" : 8100000000,
+             "distinctValuesCount" : 490782358
         },
         "c_acctbal" : {
-             "distinctValuesCount" : 806049.0,
+             "distinctValuesCount" : 806049,
              "min" : -999.99,
              "max" : 9999.99
         },
         "c_address" : {
-             "dataSize" : 1.1249934912E10,
-             "distinctValuesCount" : 2.15484394E8
+             "dataSize" : 11249934912,
+             "distinctValuesCount" : 215484394
         },
         "c_comment" : {
-             "dataSize" : 3.2624827583E10,
-             "distinctValuesCount" : 2.56255575E8
+             "dataSize" : 32624827583,
+             "distinctValuesCount" : 256255575
         },
         "c_mktsegment" : {
-             "dataSize" : 4.04999546E9,
-             "distinctValuesCount" : 7.0
+             "dataSize" : 4049995460,
+             "distinctValuesCount" : 7
         }
     }
 }

--- a/plugin/trino-tpch/src/main/resources/tpch/statistics/sf3000.0/lineitem.json
+++ b/plugin/trino-tpch/src/main/resources/tpch/statistics/sf3000.0/lineitem.json
@@ -1,78 +1,78 @@
  {
-    "rowCount" : 1.8000048306E10,
+    "rowCount" : 18000048306,
      "columns" : {
         "l_shipdate" : {
-             "distinctValuesCount" : 2535.0,
+             "distinctValuesCount" : 2535,
              "min" : "1992-01-02",
              "max" : "1998-12-01"
         },
         "l_comment" : {
-             "dataSize" : 4.76996438477E11,
-             "distinctValuesCount" : 1.89222466E8
+             "dataSize" : 476996438477,
+             "distinctValuesCount" : 189222466
         },
         "l_linestatus" : {
-             "dataSize" : 1.8000048306E10,
-             "distinctValuesCount" : 2.0
+             "dataSize" : 18000048306,
+             "distinctValuesCount" : 2
         },
         "l_returnflag" : {
-             "dataSize" : 1.8000048306E10,
-             "distinctValuesCount" : 2.0
+             "dataSize" : 18000048306,
+             "distinctValuesCount" : 2
         },
         "l_receiptdate" : {
-             "distinctValuesCount" : 2535.0,
+             "distinctValuesCount" : 2535,
              "min" : "1992-01-03",
              "max" : "1998-12-31"
         },
         "l_linenumber" : {
-             "distinctValuesCount" : 6.0,
+             "distinctValuesCount" : 6,
              "min" : 1,
              "max" : 7
         },
         "l_quantity" : {
-             "distinctValuesCount" : 61.0,
+             "distinctValuesCount" : 61,
              "min" : 1.0,
              "max" : 50.0
         },
         "l_tax" : {
-             "distinctValuesCount" : 9.0,
+             "distinctValuesCount" : 9,
              "min" : 0.0,
              "max" : 0.08
         },
         "l_partkey" : {
-             "distinctValuesCount" : 5.35201957E8,
+             "distinctValuesCount" : 535201957,
              "min" : 1,
              "max" : 600000000
         },
         "l_extendedprice" : {
-             "distinctValuesCount" : 5192536.0,
+             "distinctValuesCount" : 5192536,
              "min" : 900.0,
              "max" : 104950.0
         },
         "l_discount" : {
-             "distinctValuesCount" : 11.0,
+             "distinctValuesCount" : 11,
              "min" : 0.0,
              "max" : 0.1
         },
         "l_orderkey" : {
-             "distinctValuesCount" : 1.80019763E9,
+             "distinctValuesCount" : 1800197630,
              "min" : 1,
              "max" : 18000000000
         },
         "l_commitdate" : {
-             "distinctValuesCount" : 2427.0,
+             "distinctValuesCount" : 2427,
              "min" : "1992-01-31",
              "max" : "1998-10-31"
         },
         "l_shipinstruct" : {
-             "dataSize" : 2.16000462173E11,
-             "distinctValuesCount" : 4.0
+             "dataSize" : 216000462173,
+             "distinctValuesCount" : 4
         },
         "l_shipmode" : {
-             "dataSize" : 7.7143107284E10,
-             "distinctValuesCount" : 7.0
+             "dataSize" : 77143107284,
+             "distinctValuesCount" : 7
         },
         "l_suppkey" : {
-             "distinctValuesCount" : 4.5300013E7,
+             "distinctValuesCount" : 45300013,
              "min" : 1,
              "max" : 30000000
         }

--- a/plugin/trino-tpch/src/main/resources/tpch/statistics/sf3000.0/nation.json
+++ b/plugin/trino-tpch/src/main/resources/tpch/statistics/sf3000.0/nation.json
@@ -1,23 +1,23 @@
  {
-    "rowCount" : 25.0,
+    "rowCount" : 25,
      "columns" : {
         "n_regionkey" : {
-             "distinctValuesCount" : 5.0,
+             "distinctValuesCount" : 5,
              "min" : 0,
              "max" : 4
         },
         "n_nationkey" : {
-             "distinctValuesCount" : 19.0,
+             "distinctValuesCount" : 19,
              "min" : 0,
              "max" : 24
         },
         "n_name" : {
-             "dataSize" : 177.0,
-             "distinctValuesCount" : 24.0
+             "dataSize" : 177,
+             "distinctValuesCount" : 24
         },
         "n_comment" : {
-             "dataSize" : 1857.0,
-             "distinctValuesCount" : 31.0
+             "dataSize" : 1857,
+             "distinctValuesCount" : 31
         }
     }
 }

--- a/plugin/trino-tpch/src/main/resources/tpch/statistics/sf3000.0/orders.json
+++ b/plugin/trino-tpch/src/main/resources/tpch/statistics/sf3000.0/orders.json
@@ -1,46 +1,46 @@
  {
-    "rowCount" : 4.5E9,
+    "rowCount" : 4500000000,
      "columns" : {
         "o_orderstatus" : {
-             "dataSize" : 4.5E9,
-             "distinctValuesCount" : 3.0
+             "dataSize" : 4500000000,
+             "distinctValuesCount" : 3
         },
         "o_orderpriority" : {
-             "dataSize" : 3.7799988176E10,
-             "distinctValuesCount" : 5.0
+             "dataSize" : 37799988176,
+             "distinctValuesCount" : 5
         },
         "o_shippriority" : {
-             "distinctValuesCount" : 2.0,
+             "distinctValuesCount" : 2,
              "min" : 0,
              "max" : 0
         },
         "o_comment" : {
-             "dataSize" : 2.18247624576E11,
-             "distinctValuesCount" : 3.62400109E8
+             "dataSize" : 218247624576,
+             "distinctValuesCount" : 362400109
         },
         "o_orderkey" : {
-             "distinctValuesCount" : 1.80019763E9,
+             "distinctValuesCount" : 1800197630,
              "min" : 1,
              "max" : 18000000000
         },
         "o_totalprice" : {
-             "distinctValuesCount" : 3.8092619E7,
+             "distinctValuesCount" : 38092619,
              "min" : 812.61,
              "max" : 601034.19
         },
         "o_orderdate" : {
-             "distinctValuesCount" : 2427.0,
+             "distinctValuesCount" : 2427,
              "min" : "1992-01-01",
              "max" : "1998-08-02"
         },
         "o_custkey" : {
-             "distinctValuesCount" : 2.67600978E8,
+             "distinctValuesCount" : 267600978,
              "min" : 1,
              "max" : 449999999
         },
         "o_clerk" : {
-             "dataSize" : 6.75E10,
-             "distinctValuesCount" : 2486195.0
+             "dataSize" : 67500000000,
+             "distinctValuesCount" : 2486195
         }
     }
 }

--- a/plugin/trino-tpch/src/main/resources/tpch/statistics/sf3000.0/part.json
+++ b/plugin/trino-tpch/src/main/resources/tpch/statistics/sf3000.0/part.json
@@ -1,44 +1,44 @@
  {
-    "rowCount" : 6.0E8,
+    "rowCount" : 600000000,
      "columns" : {
         "p_name" : {
-             "dataSize" : 1.9649937305E10,
-             "distinctValuesCount" : 5.83641873E8
+             "dataSize" : 19649937305,
+             "distinctValuesCount" : 583641873
         },
         "p_partkey" : {
-             "distinctValuesCount" : 5.35201957E8,
+             "distinctValuesCount" : 535201957,
              "min" : 1,
              "max" : 600000000
         },
         "p_size" : {
-             "distinctValuesCount" : 36.0,
+             "distinctValuesCount" : 36,
              "min" : 1,
              "max" : 50
         },
         "p_container" : {
-             "dataSize" : 4.544987506E9,
-             "distinctValuesCount" : 29.0
+             "dataSize" : 4544987506,
+             "distinctValuesCount" : 29
         },
         "p_brand" : {
-             "dataSize" : 4.8E9,
-             "distinctValuesCount" : 13.0
+             "dataSize" : 4800000000,
+             "distinctValuesCount" : 13
         },
         "p_type" : {
-             "dataSize" : 1.2359998293E10,
-             "distinctValuesCount" : 165.0
+             "dataSize" : 12359998293,
+             "distinctValuesCount" : 165
         },
         "p_retailprice" : {
-             "distinctValuesCount" : 125124.0,
+             "distinctValuesCount" : 125124,
              "min" : 900.0,
              "max" : 2099.0
         },
         "p_comment" : {
-             "dataSize" : 8.099867343E9,
-             "distinctValuesCount" : 1.6725061E7
+             "dataSize" : 8099867343,
+             "distinctValuesCount" : 16725061
         },
         "p_mfgr" : {
-             "dataSize" : 8.4E9,
-             "distinctValuesCount" : 5.0
+             "dataSize" : 8400000000,
+             "distinctValuesCount" : 5
         }
     }
 }

--- a/plugin/trino-tpch/src/main/resources/tpch/statistics/sf3000.0/partsupp.json
+++ b/plugin/trino-tpch/src/main/resources/tpch/statistics/sf3000.0/partsupp.json
@@ -1,27 +1,27 @@
  {
-    "rowCount" : 2.4E9,
+    "rowCount" : 2400000000,
      "columns" : {
         "ps_suppkey" : {
-             "distinctValuesCount" : 4.5300013E7,
+             "distinctValuesCount" : 45300013,
              "min" : 1,
              "max" : 30000000
         },
         "ps_partkey" : {
-             "distinctValuesCount" : 5.35201957E8,
+             "distinctValuesCount" : 535201957,
              "min" : 1,
              "max" : 600000000
         },
         "ps_comment" : {
-             "dataSize" : 2.96396748667E11,
-             "distinctValuesCount" : 2.79448686E8
+             "dataSize" : 296396748667,
+             "distinctValuesCount" : 279448686
         },
         "ps_availqty" : {
-             "distinctValuesCount" : 13152.0,
+             "distinctValuesCount" : 13152,
              "min" : 1,
              "max" : 9999
         },
         "ps_supplycost" : {
-             "distinctValuesCount" : 100756.0,
+             "distinctValuesCount" : 100756,
              "min" : 1.0,
              "max" : 1000.0
         }

--- a/plugin/trino-tpch/src/main/resources/tpch/statistics/sf3000.0/region.json
+++ b/plugin/trino-tpch/src/main/resources/tpch/statistics/sf3000.0/region.json
@@ -1,18 +1,18 @@
  {
-    "rowCount" : 5.0,
+    "rowCount" : 5,
      "columns" : {
         "r_regionkey" : {
-             "distinctValuesCount" : 5.0,
+             "distinctValuesCount" : 5,
              "min" : 0,
              "max" : 4
         },
         "r_comment" : {
-             "dataSize" : 330.0,
-             "distinctValuesCount" : 6.0
+             "dataSize" : 330,
+             "distinctValuesCount" : 6
         },
         "r_name" : {
-             "dataSize" : 34.0,
-             "distinctValuesCount" : 7.0
+             "dataSize" : 34,
+             "distinctValuesCount" : 7
         }
     }
 }

--- a/plugin/trino-tpch/src/main/resources/tpch/statistics/sf3000.0/supplier.json
+++ b/plugin/trino-tpch/src/main/resources/tpch/statistics/sf3000.0/supplier.json
@@ -1,34 +1,34 @@
  {
-    "rowCount" : 3.0E7,
+    "rowCount" : 30000000,
      "columns" : {
         "s_phone" : {
-             "dataSize" : 4.5E8,
-             "distinctValuesCount" : 3.9779123E7
+             "dataSize" : 450000000,
+             "distinctValuesCount" : 39779123
         },
         "s_nationkey" : {
-             "distinctValuesCount" : 19.0,
+             "distinctValuesCount" : 19,
              "min" : 0,
              "max" : 24
         },
         "s_comment" : {
-             "dataSize" : 1.874956852E9,
-             "distinctValuesCount" : 2.6935549E7
+             "dataSize" : 1874956852,
+             "distinctValuesCount" : 26935549
         },
         "s_name" : {
-             "dataSize" : 5.4E8,
-             "distinctValuesCount" : 4.1540295E7
+             "dataSize" : 540000000,
+             "distinctValuesCount" : 41540295
         },
         "s_acctbal" : {
-             "distinctValuesCount" : 806049.0,
+             "distinctValuesCount" : 806049,
              "min" : -999.99,
              "max" : 9999.99
         },
         "s_address" : {
-             "dataSize" : 7.50004849E8,
-             "distinctValuesCount" : 2.579357E7
+             "dataSize" : 750004849,
+             "distinctValuesCount" : 25793570
         },
         "s_suppkey" : {
-             "distinctValuesCount" : 4.5300013E7,
+             "distinctValuesCount" : 45300013,
              "min" : 1,
              "max" : 30000000
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

After commit 78a3f46c8ae38f60b33e8d5753ef60b17cb9d62f, the TPCH plugin uses not a custom `ObjectMapper`, but the one created by Airlift's `ObjectMapperProvider`, which is more strict than the one with default settings, and these files become invalid because float values are not  compatible with the expected `long` Java type.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
