### PR TITLE
Correct parquet row group pruning logic

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/metadata/BlockMetadata.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/metadata/BlockMetadata.java
@@ -15,7 +15,7 @@ package io.trino.parquet.metadata;
 
 import java.util.List;
 
-public record BlockMetadata(long rowCount, List<ColumnChunkMetadata> columns)
+public record BlockMetadata(long fileRowCountOffset, long rowCount, List<ColumnChunkMetadata> columns)
 {
     public long getStartingPos()
     {

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/metadata/ParquetMetadata.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/metadata/ParquetMetadata.java
@@ -103,8 +103,14 @@ public class ParquetMetadata
         MessageType messageType = readParquetSchema(schema);
         List<BlockMetadata> blocks = new ArrayList<>();
         List<RowGroup> rowGroups = parquetMetadata.getRow_groups();
+
+        long fileRowCount = 0;
+
         if (rowGroups != null) {
             for (RowGroup rowGroup : rowGroups) {
+                long fileRowCountOffset = fileRowCount;
+                fileRowCount += rowGroup.getNum_rows(); // Update fileRowCount for all row groups
+
                 if (rowGroup.isSetFile_offset()) {
                     long rowGroupStart = rowGroup.getFile_offset();
                     boolean splitContainsRowGroup = splitStart <= rowGroupStart && rowGroupStart < splitStart + splitLength;
@@ -146,7 +152,7 @@ public class ParquetMetadata
                     column.setBloomFilterOffset(metaData.bloom_filter_offset);
                     columnMetadataBuilder.add(column);
                 }
-                blocks.add(new BlockMetadata(rowGroup.getNum_rows(), columnMetadataBuilder.build()));
+                blocks.add(new BlockMetadata(fileRowCountOffset, rowGroup.getNum_rows(), columnMetadataBuilder.build()));
             }
         }
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/PredicateUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/PredicateUtils.java
@@ -193,7 +193,6 @@ public final class PredicateUtils
             ParquetReaderOptions options)
             throws IOException
     {
-        long fileRowCount = 0;
         ImmutableList.Builder<RowGroupInfo> rowGroupInfoBuilder = ImmutableList.builder();
         for (BlockMetadata block : parquetMetadata.getBlocks(splitStart, splitLength)) {
             long blockStart = block.getStartingPos();
@@ -215,12 +214,11 @@ public final class PredicateUtils
                             bloomFilterStore,
                             timeZone,
                             domainCompactionThreshold)) {
-                        rowGroupInfoBuilder.add(new RowGroupInfo(columnsMetadata, fileRowCount, columnIndex));
+                        rowGroupInfoBuilder.add(new RowGroupInfo(columnsMetadata, block.fileRowCountOffset(), columnIndex));
                         break;
                     }
                 }
             }
-            fileRowCount += block.rowCount();
         }
         return rowGroupInfoBuilder.build();
     }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriter.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriter.java
@@ -402,6 +402,7 @@ public class TestParquetWriter
         List<BlockMetadata> blocks = parquetMetadata.getBlocks();
         assertThat(blocks.size()).isGreaterThan(1);
 
+        long fileRowCountOffset = 0;
         List<RowGroup> rowGroups = parquetMetadata.getParquetMetadata().getRow_groups();
         assertThat(rowGroups.size()).isEqualTo(blocks.size());
         for (int rowGroupIndex = 0; rowGroupIndex < rowGroups.size(); rowGroupIndex++) {
@@ -409,6 +410,8 @@ public class TestParquetWriter
             assertThat(rowGroup.isSetFile_offset()).isTrue();
             BlockMetadata blockMetadata = blocks.get(rowGroupIndex);
             assertThat(blockMetadata.getStartingPos()).isEqualTo(rowGroup.getFile_offset());
+            assertThat(blockMetadata.fileRowCountOffset()).isEqualTo(fileRowCountOffset);
+            fileRowCountOffset += rowGroup.getNum_rows();
         }
     }
 


### PR DESCRIPTION
## Description

Fix https://github.com/trinodb/trino/issues/25151

I found the logic for pruning in [2ef6dc1c94](https://github.com/trinodb/trino/commit/2ef6dc1c9484b6726a44e15fdaeb36853e2bcd35#diff-705548e3717786bbc076aba181f1eca081ec69200050c18100bfa959e05095df) has correctness issue which caused the problems raised in
#25151

The reason is when rowGroup is skipped, the fileRowCount in `PredicateUtils` can not be updated correctly,
this pr add the `fileRowCountOffset` into `BlockMetadata` to correctly hold this semantic of data.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues




<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Fix incorrect results for reads on iceberg tables with deletes. ({issue}`25151`)
```
