### PR TITLE
Set setRoles after roles are reset in trino-jdbc

### DIFF
--- a/client/trino-jdbc/pom.xml
+++ b/client/trino-jdbc/pom.xml
@@ -102,6 +102,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>runtime</scope>

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
@@ -885,8 +885,6 @@ public class TrinoConnection
         preparedStatements.putAll(client.getAddedPreparedStatements());
         client.getDeallocatedPreparedStatements().forEach(preparedStatements::remove);
 
-        roles.putAll(client.getSetRoles());
-
         client.getSetCatalog().ifPresent(catalog::set);
         client.getSetSchema().ifPresent(schema::set);
         client.getSetPath().ifPresent(path::set);
@@ -899,6 +897,8 @@ public class TrinoConnection
             authorizationUser.set(null);
             roles.clear();
         }
+
+        roles.putAll(client.getSetRoles());
 
         if (client.getStartedTransactionId() != null) {
             transactionId.set(client.getStartedTransactionId());


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Information from X-Trino-Set-Role should be stored even after setting or resetting authorized user.
This is also aligned with the order of operations in trino-cli



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix roles being cleared after resetting authorization
```
