### PR TITLE
Push TopN through non-identity projection unconditionally

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushTopNThroughProject.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushTopNThroughProject.java
@@ -24,10 +24,7 @@ import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.optimizations.SymbolMapper;
 import io.trino.sql.planner.plan.Assignments;
-import io.trino.sql.planner.plan.FilterNode;
-import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.ProjectNode;
-import io.trino.sql.planner.plan.TableScanNode;
 import io.trino.sql.planner.plan.TopNNode;
 
 import java.util.List;
@@ -46,7 +43,7 @@ import static io.trino.sql.planner.plan.Patterns.topN;
  * <pre>
  * - TopN
  *    - Project (non-identity)
- *       - Source other than Filter(TableScan) or TableScan
+ *       - Source
  * </pre>
  * Into:
  * <pre>
@@ -66,9 +63,7 @@ public final class PushTopNThroughProject
                             project()
                                     // do not push topN through identity projection which could be there for column pruning purposes
                                     .matching(projectNode -> !projectNode.isIdentity())
-                                    .capturedAs(PROJECT_CHILD)
-                                    // do not push topN between projection and table scan so that they can be merged into a PageProcessor
-                                    .with(source().matching(node -> !(node instanceof TableScanNode)))));
+                                    .capturedAs(PROJECT_CHILD)));
 
     @Override
     public Pattern<TopNNode> getPattern()
@@ -88,15 +83,6 @@ public final class PushTopNThroughProject
         if (!extractRowSubscripts(projections, false).isEmpty()
                 && exclusiveDereferences(projections)) {
             return Result.empty();
-        }
-
-        // do not push topN between projection and filter(table scan) so that they can be merged into a PageProcessor
-        PlanNode projectSource = context.getLookup().resolve(projectNode.getSource());
-        if (projectSource instanceof FilterNode) {
-            PlanNode filterSource = context.getLookup().resolve(((FilterNode) projectSource).getSource());
-            if (filterSource instanceof TableScanNode) {
-                return Result.empty();
-            }
         }
 
         Optional<SymbolMapper> symbolMapper = symbolMapper(parent.getOrderingScheme().orderBy(), projectNode.getAssignments());


### PR DESCRIPTION
Before this change, TopN was not pushed through project if TableScanNode or FilterNode(TableScanNode) was the immediate source of the project. The purpose of this limitation was to enable composing scan+project or scan+filter+project into a single operator. However, this was not the optimal choice, and additionally it blocked TopN pushdown into TableScanNode.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
## General
* Improve performance of certain queries involving topN over a projection. ({issue}`#25138`)
```

Fixes https://github.com/trinodb/trino/pull/25193