### PR TITLE
Fixed a bug that wrong sidecar size passed into reader

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TableSnapshot.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TableSnapshot.java
@@ -347,7 +347,7 @@ public class TableSnapshot
                     CheckpointEntryIterator iterator = new CheckpointEntryIterator(
                             fileSystem.newInputFile(sidecar),
                             session,
-                            fileSize,
+                            entry.getSidecar().sizeInBytes(),
                             checkpointSchemaManager,
                             typeManager,
                             dataEntryTypes,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

According to Deltalake spec: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#v2-spec

Sidecar entries from V2 checkpoint have sidecar file entries like
```
{"sidecar":{"path":"3a0d65cd-4056-49b8-937b-95f9e3ee90e5.parquet","sizeInBytes":2341330,"modificationTime":1512909768000,"tags":{}}
{"sidecar":{"path":"016ae953-37a9-438e-8683-9a9a4a79a395.parquet","sizeInBytes":8468120,"modificationTime":1512909848000,"tags":{}}
```

The sidecar file is the actual parquet file that contains the add entries, and need to be read through parquet reader.

Without this fix, the checkpoint file size will be passed in instead of sidecar size. Causing parquet reader always think the file going to be read is small (because checkpoint file itself will be small) and always use ```MemoryParquetDataSource``` because they almost always smaller than 3Mb regardless the actual sidecar file can be 100Mb, and the whole sidecar file will be downloaded without any parquet level pruning.

This fix will add significant performance boost when sidecar files are much larger than 3Mb.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
