### PR TITLE
Fix null handling in cosine_distance and cosine_similarity

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayVectorFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayVectorFunctions.java
@@ -16,6 +16,7 @@ package io.trino.operator.scalar;
 import io.trino.spi.block.Block;
 import io.trino.spi.function.Description;
 import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlNullable;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.type.StandardTypes;
 
@@ -59,9 +60,14 @@ public final class ArrayVectorFunctions
     @Description("Calculates the cosine similarity between two vectors")
     @ScalarFunction
     @SqlType(StandardTypes.DOUBLE)
-    public static double cosineSimilarity(@SqlType("array(double)") Block first, @SqlType("array(double)") Block second)
+    @SqlNullable
+    public static Double cosineSimilarity(@SqlType("array(double)") Block first, @SqlType("array(double)") Block second)
     {
         checkCondition(first.getPositionCount() == second.getPositionCount(), INVALID_FUNCTION_ARGUMENT, "The arguments must have the same length");
+
+        if (first.hasNull() || second.hasNull()) {
+            return null;
+        }
 
         double firstMagnitude = 0.0;
         double secondMagnitude = 0.0;
@@ -81,8 +87,13 @@ public final class ArrayVectorFunctions
     @Description("Calculates the cosine distance between two vectors")
     @ScalarFunction
     @SqlType(StandardTypes.DOUBLE)
-    public static double cosineDistance(@SqlType("array(double)") Block first, @SqlType("array(double)") Block second)
+    @SqlNullable
+    public static Double cosineDistance(@SqlType("array(double)") Block first, @SqlType("array(double)") Block second)
     {
-        return 1.0 - cosineSimilarity(first, second);
+        Double cosineSimilarity = cosineSimilarity(first, second);
+        if (cosineSimilarity == null) {
+            return null;
+        }
+        return 1.0 - cosineSimilarity;
     }
 }

--- a/core/trino-main/src/test/java/io/trino/block/AbstractTestBlock.java
+++ b/core/trino-main/src/test/java/io/trino/block/AbstractTestBlock.java
@@ -36,6 +36,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.IntStream;
 
@@ -197,6 +198,13 @@ public abstract class AbstractTestBlock
         assertThat(block.getPositionCount()).isEqualTo(expectedValues.length);
         for (int position = 0; position < block.getPositionCount(); position++) {
             assertBlockPosition(block, position, expectedValues[position]);
+        }
+        if (Arrays.stream(expectedValues).anyMatch(Objects::isNull)) {
+            assertThat(block.hasNull()).isTrue();
+            assertThat(block.mayHaveNull()).isTrue();
+        }
+        else {
+            assertThat(block.hasNull()).isFalse();
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestArrayVectorFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestArrayVectorFunctions.java
@@ -330,6 +330,11 @@ final class TestArrayVectorFunctions
                 .hasType(DOUBLE)
                 .isEqualTo(NaN);
 
+        assertThat(assertions.function("cosine_distance", "ARRAY[1, 2]", "ARRAY[3, null]"))
+                .isNull(DOUBLE);
+        assertThat(assertions.function("cosine_distance", "ARRAY[1, null]", "ARRAY[3, 4]"))
+                .isNull(DOUBLE);
+
         assertTrinoExceptionThrownBy(assertions.function("cosine_distance", "ARRAY[]", "ARRAY[]")::evaluate)
                 .hasMessage("Vector magnitude cannot be zero");
         assertTrinoExceptionThrownBy(assertions.function("cosine_distance", "ARRAY[]", "ARRAY[1]")::evaluate)
@@ -339,6 +344,111 @@ final class TestArrayVectorFunctions
         assertTrinoExceptionThrownBy(assertions.function("cosine_distance", "ARRAY[1]", "ARRAY[1, 2]")::evaluate)
                 .hasMessage("The arguments must have the same length");
         assertTrinoExceptionThrownBy(assertions.function("cosine_distance", "ARRAY[1, 2]", "ARRAY[1]")::evaluate)
+                .hasMessage("The arguments must have the same length");
+    }
+
+    @Test
+    void testCosineSimilarity()
+    {
+        assertThat(assertions.function("cosine_similarity", "ARRAY[1]", "ARRAY[2]"))
+                .hasType(DOUBLE)
+                .isEqualTo(1.0);
+        assertThat(assertions.function("cosine_similarity", "ARRAY[1, 2]", "ARRAY[3, 4]"))
+                .hasType(DOUBLE)
+                .isEqualTo(1.0 - 0.01613008990009257);
+        assertThat(assertions.function("cosine_similarity", "ARRAY[4, 5, 6]", "ARRAY[4, 5, 6]"))
+                .hasType(DOUBLE)
+                .isEqualTo(1.0);
+        assertThat(assertions.function("cosine_similarity", "ARRAY[REAL '1.1', REAL '2.2', REAL '3.3']", "ARRAY[REAL '4.4', REAL '5.5', REAL '6.6']"))
+                .hasType(DOUBLE)
+                .isEqualTo(1.0 - 0.025368154060122383);
+        assertThat(assertions.function("cosine_similarity", "ARRAY[DOUBLE '1.1', DOUBLE '2.2', DOUBLE '3.3']", "ARRAY[DOUBLE '4.4', DOUBLE '5.5', DOUBLE '6.6']"))
+                .hasType(DOUBLE)
+                .isEqualTo(1.0 - 0.025368153802923676);
+        assertThat(assertions.function("cosine_similarity", "ARRAY[1.1, 2.2, 3.3]", "ARRAY[4.4, 5.5, 6.6]"))
+                .hasType(DOUBLE)
+                .isEqualTo(1.0 - 0.025368153802923676);
+
+        // real type's min and max
+        assertThat(assertions.function("cosine_similarity", "ARRAY[REAL '3.4028235e+38f']", "ARRAY[REAL '3.4028235e+38f']"))
+                .hasType(DOUBLE)
+                .isEqualTo(1.0);
+        assertThat(assertions.function("cosine_similarity", "ARRAY[REAL '-3.4028235e+38f']", "ARRAY[REAL '-3.4028235e+38f']"))
+                .hasType(DOUBLE)
+                .isEqualTo(1.0);
+        assertThat(assertions.function("cosine_similarity", "ARRAY[REAL '3.4028235e+38f']", "ARRAY[REAL '-3.4028235e+38f']"))
+                .hasType(DOUBLE)
+                .isEqualTo(1.0 - 2.0);
+        assertThat(assertions.function("cosine_similarity", "ARRAY[REAL '-3.4028235e+38f']", "ARRAY[REAL '3.4028235e+38f']"))
+                .hasType(DOUBLE)
+                .isEqualTo(1.0 - 2.0);
+        assertThat(assertions.function("cosine_similarity", "ARRAY[REAL '1.4E-45']", "ARRAY[REAL '1.4E-45']"))
+                .hasType(DOUBLE)
+                .isEqualTo(1.0);
+        assertThat(assertions.function("cosine_similarity", "ARRAY[REAL '-1.4E-45']", "ARRAY[REAL '-1.4E-45']"))
+                .hasType(DOUBLE)
+                .isEqualTo(1.0);
+        assertThat(assertions.function("cosine_similarity", "ARRAY[REAL '1.4E-45']", "ARRAY[REAL '-1.4E-45']"))
+                .hasType(DOUBLE)
+                .isEqualTo(1.0 - 2.0);
+        assertThat(assertions.function("cosine_similarity", "ARRAY[REAL '-1.4E-45']", "ARRAY[REAL '1.4E-45']"))
+                .hasType(DOUBLE)
+                .isEqualTo(1.0 - 2.0);
+        assertThat(assertions.function("cosine_similarity", "ARRAY[REAL '3.4028235e+38f']", "ARRAY[REAL '1.4E-45']"))
+                .hasType(DOUBLE)
+                .isEqualTo(1.0);
+        assertThat(assertions.function("cosine_similarity", "ARRAY[REAL '1.4E-45']", "ARRAY[REAL '3.4028235e+38f']"))
+                .hasType(DOUBLE)
+                .isEqualTo(1.0);
+
+        // double type's min and max
+        assertThat(assertions.function("cosine_similarity", "ARRAY[DOUBLE '1.7976931348623157E+309']", "ARRAY[DOUBLE '1.7976931348623157E+309']"))
+                .hasType(DOUBLE)
+                .isEqualTo(NaN);
+        assertThat(assertions.function("cosine_similarity", "ARRAY[DOUBLE '-1.7976931348623157E+308']", "ARRAY[DOUBLE '-1.7976931348623157E+308']"))
+                .hasType(DOUBLE)
+                .isEqualTo(NaN);
+        assertThat(assertions.function("cosine_similarity", "ARRAY[DOUBLE '1.7976931348623157E+309']", "ARRAY[DOUBLE '-1.7976931348623157E+308']"))
+                .hasType(DOUBLE)
+                .isEqualTo(NaN);
+        assertThat(assertions.function("cosine_similarity", "ARRAY[DOUBLE '-1.7976931348623157E+308']", "ARRAY[DOUBLE '1.7976931348623157E+309']"))
+                .hasType(DOUBLE)
+                .isEqualTo(NaN);
+
+        // NaN and infinity
+        assertThat(assertions.function("cosine_similarity", "ARRAY[1]", "ARRAY[nan()]"))
+                .hasType(DOUBLE)
+                .isEqualTo(NaN);
+        assertThat(assertions.function("cosine_similarity", "ARRAY[nan()]", "ARRAY[1]"))
+                .hasType(DOUBLE)
+                .isEqualTo(NaN);
+        assertThat(assertions.function("cosine_similarity", "ARRAY[1]", "ARRAY[-infinity()]"))
+                .hasType(DOUBLE)
+                .isEqualTo(NaN);
+        assertThat(assertions.function("cosine_similarity", "ARRAY[-infinity()]", "ARRAY[1]"))
+                .hasType(DOUBLE)
+                .isEqualTo(NaN);
+        assertThat(assertions.function("cosine_similarity", "ARRAY[1]", "ARRAY[infinity()]"))
+                .hasType(DOUBLE)
+                .isEqualTo(NaN);
+        assertThat(assertions.function("cosine_similarity", "ARRAY[infinity()]", "ARRAY[1]"))
+                .hasType(DOUBLE)
+                .isEqualTo(NaN);
+
+        assertThat(assertions.function("cosine_similarity", "ARRAY[1, 2]", "ARRAY[3, null]"))
+                .isNull(DOUBLE);
+        assertThat(assertions.function("cosine_similarity", "ARRAY[1, null]", "ARRAY[3, 4]"))
+                .isNull(DOUBLE);
+
+        assertTrinoExceptionThrownBy(assertions.function("cosine_similarity", "ARRAY[]", "ARRAY[]")::evaluate)
+                .hasMessage("Vector magnitude cannot be zero");
+        assertTrinoExceptionThrownBy(assertions.function("cosine_similarity", "ARRAY[]", "ARRAY[1]")::evaluate)
+                .hasMessage("The arguments must have the same length");
+        assertTrinoExceptionThrownBy(assertions.function("cosine_similarity", "ARRAY[1]", "ARRAY[]")::evaluate)
+                .hasMessage("The arguments must have the same length");
+        assertTrinoExceptionThrownBy(assertions.function("cosine_similarity", "ARRAY[1]", "ARRAY[1, 2]")::evaluate)
+                .hasMessage("The arguments must have the same length");
+        assertTrinoExceptionThrownBy(assertions.function("cosine_similarity", "ARRAY[1, 2]", "ARRAY[1]")::evaluate)
                 .hasMessage("The arguments must have the same length");
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlock.java
@@ -199,6 +199,20 @@ public final class ArrayBlock
     }
 
     @Override
+    public boolean hasNull()
+    {
+        if (valueIsNull == null) {
+            return false;
+        }
+        for (int i = 0; i < positionCount; i++) {
+            if (valueIsNull[i + arrayOffset]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
     public String toString()
     {
         return "ArrayBlock{positionCount=" + getPositionCount() + '}';

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Block.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Block.java
@@ -150,6 +150,19 @@ public sealed interface Block
     }
 
     /**
+     * Does this block have a null value? This method is expected to be O(N).
+     */
+    default boolean hasNull()
+    {
+        for (int i = 0; i < getPositionCount(); i++) {
+            if (isNull(i)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Is the specified position null?
      *
      * @throws IllegalArgumentException if this position is not valid. The method may return false

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlock.java
@@ -154,6 +154,20 @@ public final class ByteArrayBlock
     }
 
     @Override
+    public boolean hasNull()
+    {
+        if (valueIsNull == null) {
+            return false;
+        }
+        for (int i = 0; i < positionCount; i++) {
+            if (valueIsNull[i + arrayOffset]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
     public boolean isNull(int position)
     {
         checkReadablePosition(this, position);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
@@ -375,6 +375,12 @@ public final class DictionaryBlock
     }
 
     @Override
+    public boolean hasNull()
+    {
+        return mayHaveNull && dictionary.hasNull();
+    }
+
+    @Override
     public boolean isNull(int position)
     {
         if (!mayHaveNull) {

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Fixed12Block.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Fixed12Block.java
@@ -157,6 +157,20 @@ public final class Fixed12Block
     }
 
     @Override
+    public boolean hasNull()
+    {
+        if (valueIsNull == null) {
+            return false;
+        }
+        for (int i = 0; i < positionCount; i++) {
+            if (valueIsNull[i + positionOffset]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
     public boolean isNull(int position)
     {
         checkReadablePosition(this, position);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlock.java
@@ -151,6 +151,20 @@ public final class Int128ArrayBlock
     }
 
     @Override
+    public boolean hasNull()
+    {
+        if (valueIsNull == null) {
+            return false;
+        }
+        for (int i = 0; i < positionCount; i++) {
+            if (valueIsNull[i + positionOffset]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
     public boolean isNull(int position)
     {
         checkReadablePosition(this, position);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlock.java
@@ -137,6 +137,20 @@ public final class IntArrayBlock
     }
 
     @Override
+    public boolean hasNull()
+    {
+        if (valueIsNull == null) {
+            return false;
+        }
+        for (int i = 0; i < positionCount; i++) {
+            if (valueIsNull[i + arrayOffset]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
     public boolean isNull(int position)
     {
         checkReadablePosition(this, position);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LazyBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LazyBlock.java
@@ -163,6 +163,12 @@ public final class LazyBlock
         return getBlock().mayHaveNull();
     }
 
+    @Override
+    public boolean hasNull()
+    {
+        return getBlock().hasNull();
+    }
+
     public Block getBlock()
     {
         return lazyData.getTopLevelBlock();

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlock.java
@@ -136,6 +136,20 @@ public final class LongArrayBlock
     }
 
     @Override
+    public boolean hasNull()
+    {
+        if (valueIsNull == null) {
+            return false;
+        }
+        for (int i = 0; i < positionCount; i++) {
+            if (valueIsNull[i + arrayOffset]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
     public boolean isNull(int position)
     {
         checkReadablePosition(this, position);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/MapBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/MapBlock.java
@@ -232,6 +232,20 @@ public final class MapBlock
     }
 
     @Override
+    public boolean hasNull()
+    {
+        if (mapIsNull == null) {
+            return false;
+        }
+        for (int i = 0; i < positionCount; i++) {
+            if (mapIsNull[i + startOffset]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
     public int getPositionCount()
     {
         return positionCount;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
@@ -152,6 +152,20 @@ public final class RowBlock
         return rowIsNull != null;
     }
 
+    @Override
+    public boolean hasNull()
+    {
+        if (rowIsNull == null) {
+            return false;
+        }
+        for (int i = 0; i < positionCount; i++) {
+            if (rowIsNull[i]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     boolean[] getRawRowIsNull()
     {
         return rowIsNull;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
@@ -197,6 +197,12 @@ public final class RunLengthEncodedBlock
     }
 
     @Override
+    public boolean hasNull()
+    {
+        return mayHaveNull();
+    }
+
+    @Override
     public boolean isNull(int position)
     {
         checkReadablePosition(this, position);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlock.java
@@ -136,6 +136,20 @@ public final class ShortArrayBlock
     }
 
     @Override
+    public boolean hasNull()
+    {
+        if (valueIsNull == null) {
+            return false;
+        }
+        for (int i = 0; i < positionCount; i++) {
+            if (valueIsNull[i + arrayOffset]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
     public boolean isNull(int position)
     {
         checkReadablePosition(this, position);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlock.java
@@ -192,6 +192,20 @@ public final class VariableWidthBlock
     }
 
     @Override
+    public boolean hasNull()
+    {
+        if (valueIsNull == null) {
+            return false;
+        }
+        for (int i = 0; i < positionCount; i++) {
+            if (valueIsNull[i + arrayOffset]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
     public boolean isNull(int position)
     {
         checkReadablePosition(this, position);

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlVectorType.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlVectorType.java
@@ -354,8 +354,8 @@ final class TestPostgreSqlVectorType
                     .isNotFullyPushedDown(ProjectNode.class);
             assertThat(query("SELECT id FROM " + table.getName() + " ORDER BY cosine_distance(v, ARRAY[REAL 'NaN']) LIMIT 1"))
                     .isNotFullyPushedDown(ProjectNode.class);
-            assertQueryFails("SELECT id FROM " + table.getName() + " ORDER BY cosine_distance(v, ARRAY[CAST(NULL AS REAL)]) LIMIT 1",
-                    "Vector magnitude cannot be zero");
+            assertThat(query("SELECT id FROM " + table.getName() + " ORDER BY cosine_distance(v, ARRAY[CAST(NULL AS REAL)]) LIMIT 1"))
+                    .isNotFullyPushedDown(ProjectNode.class);
             assertThat(query("SELECT id FROM " + table.getName() + " ORDER BY cosine_distance(v, NULL) LIMIT 1"))
                     .isNotFullyPushedDown(ProjectNode.class);
         }


### PR DESCRIPTION
## Description
Previously nulls were ignored producing in an arbitrary result.
To make the implementation easier and more performant I added a hasNull method to block.

## Release notes

(X) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix null handling in cosine_distance and cosine_similarity to return null when array contains null. ({issue}`issuenumber`)
```
