### PR TITLE
Fix BlockBuilder resetTo() method for complex types

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/PageBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/PageBuilder.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import static io.trino.spi.block.PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
 import static java.lang.String.format;
+import static java.util.Objects.checkIndex;
 
 public class PageBuilder
 {
@@ -82,6 +83,22 @@ public class PageBuilder
 
         for (int i = 0; i < blockBuilders.length; i++) {
             blockBuilders[i] = blockBuilders[i].newBlockBuilderLike(pageBuilderStatus.createBlockBuilderStatus());
+        }
+    }
+
+    /**
+     * Rolls back added data to the specified position.
+     * Resetting may result in a block without nulls with the may-have-nulls flag set.
+     * The PageBuilder status will not be updated to reflect the removed data size.
+     *
+     * @throws IllegalArgumentException if the position is greater than the current position count
+     */
+    public void resetTo(int position)
+    {
+        checkIndex(position, declaredPositions + 1);
+        declaredPositions = position;
+        for (BlockBuilder blockBuilder : blockBuilders) {
+            blockBuilder.resetTo(position);
         }
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlockBuilder.java
@@ -225,10 +225,8 @@ public class ArrayBlockBuilder
     @Override
     public void resetTo(int position)
     {
-        if (currentEntryOpened) {
-            throw new IllegalStateException("Expected current entry to be closed but was opened");
-        }
         checkIndex(position, positionCount + 1);
+        currentEntryOpened = false;
         positionCount = position;
         values.resetTo(offsets[positionCount]);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/MapBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/MapBlockBuilder.java
@@ -206,10 +206,8 @@ public class MapBlockBuilder
     @Override
     public void resetTo(int position)
     {
-        if (currentEntryOpened) {
-            throw new IllegalStateException("Expected current entry to be closed but was opened");
-        }
         checkIndex(position, positionCount + 1);
+        currentEntryOpened = false;
         positionCount = position;
         keyBlockBuilder.resetTo(offsets[positionCount]);
         valueBlockBuilder.resetTo(offsets[positionCount]);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlockBuilder.java
@@ -330,10 +330,8 @@ public class RowBlockBuilder
     @Override
     public void resetTo(int position)
     {
-        if (currentEntryOpened) {
-            throw new IllegalStateException("Expected current entry to be closed but was opened");
-        }
         checkIndex(position, positionCount + 1);
+        currentEntryOpened = false;
         positionCount = position;
         for (BlockBuilder fieldBlockBuilder : fieldBlockBuilders) {
             fieldBlockBuilder.resetTo(position);


### PR DESCRIPTION
## Description
Fix BlockBuilder resetTo() method for complex types. Previously this method would not work if the complex type was only partially constructed (e.g. an exception was thrown while constructing the ARRAY, MAP, or ROW).

## Additional context and related issues
Also addresses [#23160](https://github.com/trinodb/trino/issues/23160)

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
