### PR TITLE
Remove redundant default Hadoop FS config

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
@@ -119,7 +119,6 @@ public final class DeltaLakeQueryRunner
         public Builder addS3Properties(Minio minio, String bucketName)
         {
             addDeltaProperties(ImmutableMap.<String, String>builder()
-                    .put("fs.hadoop.enabled", "false")
                     .put("fs.native-s3.enabled", "true")
                     .put("s3.aws-access-key", MINIO_ACCESS_KEY)
                     .put("s3.aws-secret-key", MINIO_SECRET_KEY)
@@ -162,7 +161,8 @@ public final class DeltaLakeQueryRunner
                     deltaProperties.put("hive.metastore", "file");
                 }
 
-                if (!deltaProperties.containsKey("fs.hadoop.enabled")) {
+                if (deltaProperties.keySet().stream().noneMatch(key ->
+                        key.equals("fs.hadoop.enabled") || key.startsWith("fs.native-"))) {
                     deltaProperties.put("fs.hadoop.enabled", "true");
                 }
                 queryRunner.createCatalog(DELTA_CATALOG, CONNECTOR_NAME, deltaProperties);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAdlsConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAdlsConnectorSmokeTest.java
@@ -112,7 +112,6 @@ public class TestDeltaLakeAdlsConnectorSmokeTest
     protected Map<String, String> hiveStorageConfiguration()
     {
         return ImmutableMap.<String, String>builder()
-                .put("fs.hadoop.enabled", "false")
                 .put("fs.native-azure.enabled", "true")
                 .put("azure.auth-type", "ACCESS_KEY")
                 .put("azure.access-key", accessKey)

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAdlsStorage.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAdlsStorage.java
@@ -84,7 +84,6 @@ public class TestDeltaLakeAdlsStorage
         return DeltaLakeQueryRunner.builder()
                 .setDeltaProperties(ImmutableMap.<String, String>builder()
                         .put("hive.metastore.uri", hiveHadoop.getHiveMetastoreEndpoint().toString())
-                        .put("fs.hadoop.enabled", "false")
                         .put("fs.native-azure.enabled", "true")
                         .put("azure.auth-type", "ACCESS_KEY")
                         .put("azure.access-key", accessKey)

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeGcsConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeGcsConnectorSmokeTest.java
@@ -136,7 +136,6 @@ public class TestDeltaLakeGcsConnectorSmokeTest
     protected Map<String, String> hiveStorageConfiguration()
     {
         return ImmutableMap.<String, String>builder()
-                .put("fs.hadoop.enabled", "false")
                 .put("fs.native-gcs.enabled", "true")
                 .put("gcs.json-key", gcpCredentials)
                 .buildOrThrow();

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMinioAndHmsConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMinioAndHmsConnectorSmokeTest.java
@@ -35,7 +35,6 @@ public class TestDeltaLakeMinioAndHmsConnectorSmokeTest
     protected Map<String, String> hiveStorageConfiguration()
     {
         return ImmutableMap.<String, String>builder()
-                .put("fs.hadoop.enabled", "false")
                 .put("fs.native-s3.enabled", "true")
                 .put("s3.aws-access-key", MINIO_ACCESS_KEY)
                 .put("s3.aws-secret-key", MINIO_SECRET_KEY)
@@ -50,7 +49,6 @@ public class TestDeltaLakeMinioAndHmsConnectorSmokeTest
     protected Map<String, String> deltaStorageConfiguration()
     {
         return ImmutableMap.<String, String>builder()
-                .put("fs.hadoop.enabled", "false")
                 .put("fs.native-s3.enabled", "true")
                 .put("s3.aws-access-key", MINIO_ACCESS_KEY)
                 .put("s3.aws-secret-key", MINIO_SECRET_KEY)

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSharedHiveMetastoreWithViews.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSharedHiveMetastoreWithViews.java
@@ -55,7 +55,6 @@ public class TestDeltaLakeSharedHiveMetastoreWithViews
             queryRunner.createCatalog("hive", "hive", ImmutableMap.<String, String>builder()
                     .put("hive.metastore", "thrift")
                     .put("hive.metastore.uri", hiveMinioDataLake.getHiveMetastoreEndpoint().toString())
-                    .put("fs.hadoop.enabled", "false")
                     .put("fs.native-s3.enabled", "true")
                     .put("s3.aws-access-key", MINIO_ACCESS_KEY)
                     .put("s3.aws-secret-key", MINIO_SECRET_KEY)

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaS3AndGlueMetastoreTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaS3AndGlueMetastoreTest.java
@@ -45,7 +45,6 @@ public class TestDeltaS3AndGlueMetastoreTest
                 .setDeltaProperties(ImmutableMap.<String, String>builder()
                         .put("hive.metastore", "glue")
                         .put("hive.metastore.glue.default-warehouse-dir", schemaPath())
-                        .put("fs.hadoop.enabled", "false")
                         .put("fs.native-s3.enabled", "true")
                         .put("delta.enable-non-concurrent-writes", "true")
                         .buildOrThrow())

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
@@ -222,7 +222,8 @@ public final class HiveQueryRunner
                     hiveProperties.put("hive.metastore", "file");
                     hiveProperties.put("hive.metastore.catalog.dir", queryRunner.getCoordinator().getBaseDataDir().resolve("hive_data").toString());
                 }
-                if (!hiveProperties.buildOrThrow().containsKey("fs.hadoop.enabled")) {
+                if (hiveProperties.buildOrThrow().keySet().stream().noneMatch(key ->
+                        key.equals("fs.hadoop.enabled") || key.startsWith("fs.native-"))) {
                     hiveProperties.put("fs.hadoop.enabled", "true");
                 }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveCustomCatalogConnectorSmokeTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveCustomCatalogConnectorSmokeTest.java
@@ -59,7 +59,6 @@ public class TestHiveCustomCatalogConnectorSmokeTest
                 .addHiveProperty("hive.metastore", "thrift")
                 .addHiveProperty("hive.metastore.uri", hiveMinioDataLake.getHiveMetastoreEndpoint().toString())
                 .addHiveProperty("hive.metastore.thrift.catalog-name", HIVE_CUSTOM_CATALOG)
-                .addHiveProperty("fs.hadoop.enabled", "false")
                 .addHiveProperty("fs.native-s3.enabled", "true")
                 .addHiveProperty("s3.path-style-access", "true")
                 .addHiveProperty("s3.region", MINIO_REGION)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveS3AndGlueMetastoreTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveS3AndGlueMetastoreTest.java
@@ -62,7 +62,6 @@ public class TestHiveS3AndGlueMetastoreTest
                 .addHiveProperty("hive.metastore.glue.default-warehouse-dir", schemaPath())
                 .addHiveProperty("hive.security", "allow-all")
                 .addHiveProperty("hive.non-managed-table-writes-enabled", "true")
-                .addHiveProperty("fs.hadoop.enabled", "false")
                 .addHiveProperty("fs.native-s3.enabled", "true")
                 .build();
         queryRunner.execute("CREATE SCHEMA " + schemaName + " WITH (location = '" + schemaPath() + "')");

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestHiveMetastoreCatalogs.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestHiveMetastoreCatalogs.java
@@ -80,7 +80,6 @@ public class TestHiveMetastoreCatalogs
         return ImmutableMap.<String, String>builder()
                 .put("hive.metastore", "thrift")
                 .put("hive.metastore.uri", hiveMinioDataLake.getHiveMetastoreEndpoint().toString())
-                .put("fs.hadoop.enabled", "false")
                 .put("fs.native-s3.enabled", "true")
                 .put("s3.path-style-access", "true")
                 .put("s3.region", MINIO_REGION)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/S3HiveQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/S3HiveQueryRunner.java
@@ -155,7 +155,6 @@ public final class S3HiveQueryRunner
             String lowerCaseS3Endpoint = s3Endpoint.toLowerCase(Locale.ENGLISH);
             checkArgument(lowerCaseS3Endpoint.startsWith("http://") || lowerCaseS3Endpoint.startsWith("https://"), "Expected http URI for S3 endpoint; got %s", s3Endpoint);
 
-            addHiveProperty("fs.hadoop.enabled", "false");
             addHiveProperty("fs.native-s3.enabled", "true");
             addHiveProperty("s3.region", s3Region);
             addHiveProperty("s3.endpoint", s3Endpoint);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/TestS3FileSystemAccessOperations.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/TestS3FileSystemAccessOperations.java
@@ -66,7 +66,6 @@ public class TestS3FileSystemAccessOperations
         return HiveQueryRunner.builder()
                 .setHiveProperties(ImmutableMap.<String, String>builder()
                         .put("hive.metastore.disable-location-checks", "true")
-                        .put("fs.hadoop.enabled", "false")
                         .put("fs.native-s3.enabled", "true")
                         .put("s3.aws-access-key", MINIO_ACCESS_KEY)
                         .put("s3.aws-secret-key", MINIO_SECRET_KEY)

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/HudiQueryRunner.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/HudiQueryRunner.java
@@ -59,7 +59,6 @@ public final class HudiQueryRunner
     public static Builder builder(Hive3MinioDataLake hiveMinioDataLake)
     {
         return new Builder("s3://" + hiveMinioDataLake.getBucketName() + "/")
-                .addConnectorProperty("fs.hadoop.enabled", "false")
                 .addConnectorProperty("fs.native-s3.enabled", "true")
                 .addConnectorProperty("s3.aws-access-key", MINIO_ACCESS_KEY)
                 .addConnectorProperty("s3.aws-secret-key", MINIO_SECRET_KEY)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMinioConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMinioConnectorSmokeTest.java
@@ -73,7 +73,6 @@ public abstract class BaseIcebergMinioConnectorSmokeTest
                                 .put("iceberg.catalog.type", "HIVE_METASTORE")
                                 .put("hive.metastore.uri", hiveMinioDataLake.getHiveMetastoreEndpoint().toString())
                                 .put("hive.metastore.thrift.client.read-timeout", "1m") // read timed out sometimes happens with the default timeout
-                                .put("fs.hadoop.enabled", "false")
                                 .put("fs.native-s3.enabled", "true")
                                 .put("s3.aws-access-key", MINIO_ACCESS_KEY)
                                 .put("s3.aws-secret-key", MINIO_SECRET_KEY)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
@@ -167,7 +167,8 @@ public final class IcebergQueryRunner
                     queryRunner.createCatalog("tpcds", "tpcds");
                 }
 
-                if (!icebergProperties.buildOrThrow().containsKey("fs.hadoop.enabled")) {
+                if (icebergProperties.buildOrThrow().keySet().stream().noneMatch(key ->
+                        key.equals("fs.hadoop.enabled") || key.startsWith("fs.native-"))) {
                     icebergProperties.put("fs.hadoop.enabled", "true");
                 }
 
@@ -327,7 +328,6 @@ public final class IcebergQueryRunner
                     .setIcebergProperties(Map.of(
                             "iceberg.catalog.type", "HIVE_METASTORE",
                             "hive.metastore.uri", hiveMinioDataLake.getHiveHadoop().getHiveMetastoreEndpoint().toString(),
-                            "fs.hadoop.enabled", "false",
                             "fs.native-s3.enabled", "true",
                             "s3.aws-access-key", MINIO_ACCESS_KEY,
                             "s3.aws-secret-key", MINIO_SECRET_KEY,
@@ -369,7 +369,6 @@ public final class IcebergQueryRunner
                     .setIcebergProperties(Map.of(
                             "iceberg.catalog.type", "TESTING_FILE_METASTORE",
                             "hive.metastore.catalog.dir", "s3://%s/".formatted(bucketName),
-                            "fs.hadoop.enabled", "false",
                             "fs.native-s3.enabled", "true",
                             "s3.aws-access-key", MINIO_ACCESS_KEY,
                             "s3.aws-secret-key", MINIO_SECRET_KEY,
@@ -422,7 +421,6 @@ public final class IcebergQueryRunner
                     .setIcebergProperties(Map.of(
                             "iceberg.catalog.type", "HIVE_METASTORE",
                             "hive.metastore.uri", hiveHadoop.getHiveMetastoreEndpoint().toString(),
-                            "fs.hadoop.enabled", "false",
                             "fs.native-azure.enabled", "true",
                             "azure.auth-type", "ACCESS_KEY",
                             "azure.access-key", azureAccessKey))

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergAbfsConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergAbfsConnectorSmokeTest.java
@@ -86,7 +86,6 @@ public class TestIcebergAbfsConnectorSmokeTest
                                 .put("iceberg.catalog.type", "HIVE_METASTORE")
                                 .put("hive.metastore.uri", hiveHadoop.getHiveMetastoreEndpoint().toString())
                                 .put("hive.metastore.thrift.client.read-timeout", "1m") // read timed out sometimes happens with the default timeout
-                                .put("fs.hadoop.enabled", "false")
                                 .put("fs.native-azure.enabled", "true")
                                 .put("azure.auth-type", "ACCESS_KEY")
                                 .put("azure.access-key", accessKey)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGcsConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGcsConnectorSmokeTest.java
@@ -94,7 +94,6 @@ public class TestIcebergGcsConnectorSmokeTest
         return IcebergQueryRunner.builder()
                 .setIcebergProperties(ImmutableMap.<String, String>builder()
                         .put("iceberg.catalog.type", "hive_metastore")
-                        .put("fs.hadoop.enabled", "false")
                         .put("fs.native-gcs.enabled", "true")
                         .put("gcs.json-key", gcpCredentials)
                         .put("hive.metastore.uri", hiveHadoop.getHiveMetastoreEndpoint().toString())

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMinioOrcConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMinioOrcConnectorTest.java
@@ -65,6 +65,7 @@ public class TestIcebergMinioOrcConnectorTest
                 .setIcebergProperties(
                         ImmutableMap.<String, String>builder()
                                 .put("iceberg.file-format", format.name())
+                                .put("fs.hadoop.enabled", "true")
                                 .put("fs.native-s3.enabled", "true")
                                 .put("s3.aws-access-key", MINIO_ACCESS_KEY)
                                 .put("s3.aws-secret-key", MINIO_SECRET_KEY)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetWithBloomFiltersMixedCase.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetWithBloomFiltersMixedCase.java
@@ -56,7 +56,6 @@ public class TestIcebergParquetWithBloomFiltersMixedCase
         QueryRunner queryRunner = IcebergQueryRunner.builder()
                 .setIcebergProperties(
                         ImmutableMap.<String, String>builder()
-                                .put("fs.hadoop.enabled", "false")
                                 .put("fs.native-s3.enabled", "true")
                                 .put("s3.aws-access-key", MINIO_ACCESS_KEY)
                                 .put("s3.aws-secret-key", MINIO_SECRET_KEY)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergReadVersionedTableByTemporal.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergReadVersionedTableByTemporal.java
@@ -51,7 +51,6 @@ public class TestIcebergReadVersionedTableByTemporal
         QueryRunner queryRunner = IcebergQueryRunner.builder()
                 .setIcebergProperties(
                         ImmutableMap.<String, String>builder()
-                                .put("fs.hadoop.enabled", "false")
                                 .put("fs.native-s3.enabled", "true")
                                 .put("s3.aws-access-key", MINIO_ACCESS_KEY)
                                 .put("s3.aws-secret-key", MINIO_SECRET_KEY)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestSharedHiveThriftMetastore.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestSharedHiveThriftMetastore.java
@@ -83,7 +83,6 @@ public class TestSharedHiveThriftMetastore
                         .put("iceberg.catalog.type", "HIVE_METASTORE")
                         .put("hive.metastore.uri", hiveMinioDataLake.getHiveHadoop().getHiveMetastoreEndpoint().toString())
                         .put("hive.metastore.thrift.client.read-timeout", "1m") // read timed out sometimes happens with the default timeout
-                        .put("fs.hadoop.enabled", "false")
                         .put("fs.native-s3.enabled", "true")
                         .put("s3.aws-access-key", MINIO_ACCESS_KEY)
                         .put("s3.aws-secret-key", MINIO_SECRET_KEY)
@@ -102,7 +101,6 @@ public class TestSharedHiveThriftMetastore
                         .put("iceberg.catalog.type", "HIVE_METASTORE")
                         .put("hive.metastore.uri", hiveMinioDataLake.getHiveHadoop().getHiveMetastoreEndpoint().toString())
                         .put("hive.metastore.thrift.client.read-timeout", "1m") // read timed out sometimes happens with the default timeout
-                        .put("fs.hadoop.enabled", "false")
                         .put("fs.native-s3.enabled", "true")
                         .put("s3.aws-access-key", MINIO_ACCESS_KEY)
                         .put("s3.aws-secret-key", MINIO_SECRET_KEY)
@@ -120,7 +118,6 @@ public class TestSharedHiveThriftMetastore
         Map<String, String> hiveProperties = ImmutableMap.<String, String>builder()
                 .put("hive.metastore", "thrift")
                 .put("hive.metastore.uri", hiveMinioDataLake.getHiveHadoop().getHiveMetastoreEndpoint().toString())
-                .put("fs.hadoop.enabled", "false")
                 .put("fs.native-s3.enabled", "true")
                 .put("s3.aws-access-key", MINIO_ACCESS_KEY)
                 .put("s3.aws-secret-key", MINIO_SECRET_KEY)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergS3AndGlueMetastoreTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergS3AndGlueMetastoreTest.java
@@ -49,7 +49,6 @@ public class TestIcebergS3AndGlueMetastoreTest
                 .setIcebergProperties(ImmutableMap.<String, String>builder()
                         .put("iceberg.catalog.type", "glue")
                         .put("hive.metastore.glue.default-warehouse-dir", schemaPath())
-                        .put("fs.hadoop.enabled", "false")
                         .put("fs.native-s3.enabled", "true")
                         .buildOrThrow())
                 .setSchemaInitializer(SchemaInitializer.builder()

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergS3TablesConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergS3TablesConnectorSmokeTest.java
@@ -76,7 +76,6 @@ final class TestIcebergS3TablesConnectorSmokeTest
                 .addIcebergProperty("iceberg.rest-catalog.signing-name", "glue")
                 .addIcebergProperty("iceberg.writer-sort-buffer-size", "1MB")
                 .addIcebergProperty("iceberg.allowed-extra-properties", "write.metadata.delete-after-commit.enabled,write.metadata.previous-versions-max")
-                .addIcebergProperty("fs.hadoop.enabled", "false")
                 .addIcebergProperty("fs.native-s3.enabled", "true")
                 .addIcebergProperty("s3.region", AWS_REGION)
                 .addIcebergProperty("s3.aws-access-key", AWS_ACCESS_KEY_ID)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergVendingRestCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergVendingRestCatalogConnectorSmokeTest.java
@@ -122,7 +122,6 @@ public class TestIcebergVendingRestCatalogConnectorSmokeTest
                                 .put("iceberg.rest-catalog.vended-credentials-enabled", "true")
                                 .put("iceberg.writer-sort-buffer-size", "1MB")
                                 .put("iceberg.allowed-extra-properties", "write.metadata.delete-after-commit.enabled,write.metadata.previous-versions-max")
-                                .put("fs.hadoop.enabled", "false")
                                 .put("fs.native-s3.enabled", "true")
                                 .put("s3.region", MINIO_REGION)
                                 .put("s3.endpoint", minio.getMinioAddress())


### PR DESCRIPTION
## Description

Hadoop is disabled by default now.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
