### PR TITLE
Add validation cpu time calculation in AbstractDeltaLakePageSink

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/AbstractDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/AbstractDeltaLakePageSink.java
@@ -104,6 +104,7 @@ public abstract class AbstractDeltaLakePageSink
     private final long idleWriterMinFileSize;
     private long writtenBytes;
     private long memoryUsage;
+    private long validationCpuNanos;
 
     private final List<Closeable> closedWriterRollbackActions = new ArrayList<>();
     private final List<Boolean> activeWriters = new ArrayList<>();
@@ -217,7 +218,7 @@ public abstract class AbstractDeltaLakePageSink
     @Override
     public long getValidationCpuNanos()
     {
-        return 0;
+        return validationCpuNanos;
     }
 
     @Override
@@ -427,6 +428,7 @@ public abstract class AbstractDeltaLakePageSink
 
         writtenBytes += writer.getWrittenBytes() - currentWritten;
         memoryUsage -= currentMemory;
+        validationCpuNanos += writer.getValidationCpuNanos();
 
         writers.set(writerIndex, null);
         currentOpenWriters--;

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeWriter.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeWriter.java
@@ -170,7 +170,7 @@ public final class DeltaLakeWriter
     @Override
     public long getValidationCpuNanos()
     {
-        return 0;
+        return fileWriter.getValidationCpuNanos();
     }
 
     public long getRowCount()


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Fix that the `validationCpuNanos` already hold by the `FileWriter` but not pass to the `PageSink` in Delta Lake.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
