### PR TITLE
make Geometry comparable

### DIFF
--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestGeoSpatialQueries.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestGeoSpatialQueries.java
@@ -48,6 +48,18 @@ public class TestGeoSpatialQueries
     }
 
     @Test
+    public void testDistinctGeometry()
+    {
+        assertThat(query("""
+                         SELECT DISTINCT ST_GeometryFromText(point)
+                         FROM (VALUES 'POINT (-90 38.99)', 'POINT (-90 38.99)') t(point)
+                         """))
+                .result().matches(MaterializedResult.resultBuilder(getSession(), GEOMETRY)
+                        .row("POINT (-90 38.99)")
+                        .build());
+    }
+
+    @Test
     public void testGeometryResult()
     {
         assertThat(query("SELECT ST_Point(52.233, 21.016)"))


### PR DESCRIPTION
In PostGIS, instances of Geometry are comparable (that is, you can run `select distinct` on those columns).
This PR allows Trino to do the same and addresses #24961.

e.g. with the patch applied:
```
trino> describe postgis.public.movement;                            
     Column      |     Type     | Extra | Comment 
-----------------+--------------+-------+---------
 id              | integer      |       |         
 thing_id        | integer      |       |         
 geometry        | Geometry     |       |         
 geometry_string | varchar(50)  |       |         
 dt              | timestamp(6) |       |          
 speed_mph       | integer      |       |         
(6 rows)                                                           

Query 20250305_174904_00016_abpcz, FINISHED, 1 node                                                                                    
Splits: 19 total, 19 done (100.00%)
0.40 [6 rows, 364B] [14 rows/s, 901B/s]
trino> select geometry from postgis.public.movement;
      geometry       
---------------------
 POINT (-90 38.5)    
 POINT (-90 38.501)  
 POINT (-90 38.5)    
 POINT (-90.1 38.58) 
(4 rows)

Query 20250305_174913_00017_abpcz, FINISHED, 1 node
Splits: 1 total, 1 done (100.00%)
0.23 [4 rows, 0B] [17 rows/s, 0B/s]

trino> select distinct geometry from postgis.public.movement;
      geometry       
---------------------
 POINT (-90 38.501)  
 POINT (-90 38.5)    
 POINT (-90.1 38.58) 
(3 rows)

Query 20250305_174919_00018_abpcz, FINISHED, 1 node
Splits: 1 total, 1 done (100.00%)
0.26 [3 rows, 0B] [11 rows/s, 0B/s]
```

EDIT:
I got the formatter to run (using intellij).