### PR TITLE
Limit default `bigquery.metadata.parallelism` value to 32

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConfig.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConfig.java
@@ -39,6 +39,7 @@ public class BigQueryConfig
     public static final int DEFAULT_MAX_READ_ROWS_RETRIES = 3;
     public static final String VIEWS_ENABLED = "bigquery.views-enabled";
     public static final String ARROW_SERIALIZATION_ENABLED = "bigquery.arrow-serialization.enabled";
+    private static final int MAX_METADATA_PARALLELISM = 32;
 
     private Optional<String> projectId = Optional.empty();
     private Optional<String> parentProjectId = Optional.empty();
@@ -63,7 +64,7 @@ public class BigQueryConfig
     private String queryLabelFormat;
     private boolean proxyEnabled;
     private boolean projectionPushDownEnabled = true;
-    private int metadataParallelism = Runtime.getRuntime().availableProcessors();
+    private int metadataParallelism = Math.min(Runtime.getRuntime().availableProcessors(), MAX_METADATA_PARALLELISM);
 
     public Optional<String> getProjectId()
     {
@@ -370,7 +371,7 @@ public class BigQueryConfig
     }
 
     @Min(1)
-    @Max(32)
+    @Max(MAX_METADATA_PARALLELISM)
     public int getMetadataParallelism()
     {
         return metadataParallelism;


### PR DESCRIPTION
## Description

Fixes #25228

## Release notes

```markdown
## BigQuery
* Fix some things. ({issue}`issuenumber`)
```
