### PR TITLE
Remove offsets from flat representation

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionManager.java
@@ -255,8 +255,9 @@ public class FunctionManager
                 case FLAT:
                     verifyFunctionSignature(parameterType.equals(byte[].class) &&
                                     methodType.parameterType(parameterIndex + 1).equals(int.class) &&
-                                    methodType.parameterType(parameterIndex + 2).equals(byte[].class),
-                            "Expected FLAT argument types to be byte[], int, byte[]");
+                                    methodType.parameterType(parameterIndex + 2).equals(byte[].class) &&
+                                    methodType.parameterType(parameterIndex + 3).equals(int.class),
+                            "Expected FLAT argument types to be byte[], int, byte[], int");
                     break;
                 case IN_OUT:
                     verifyFunctionSignature(parameterType.equals(InOut.class), "Expected IN_OUT argument type to be InOut");

--- a/core/trino-main/src/main/java/io/trino/operator/FlatHashStrategy.java
+++ b/core/trino-main/src/main/java/io/trino/operator/FlatHashStrategy.java
@@ -24,7 +24,7 @@ public interface FlatHashStrategy
 
     int getTotalVariableWidth(Block[] blocks, int position);
 
-    void readFlat(byte[] fixedChunk, int fixedOffset, byte[] variableChunk, BlockBuilder[] blockBuilders);
+    void readFlat(byte[] fixedChunk, int fixedOffset, byte[] variableChunk, int variableOffset, BlockBuilder[] blockBuilders);
 
     void writeFlat(Block[] blocks, int position, byte[] fixedChunk, int fixedOffset, byte[] variableChunk, int variableOffset);
 
@@ -32,12 +32,13 @@ public interface FlatHashStrategy
             byte[] leftFixedChunk,
             int leftFixedOffset,
             byte[] leftVariableChunk,
+            int leftVariableOffset,
             Block[] rightBlocks,
             int rightPosition);
 
     long hash(Block[] blocks, int position);
 
-    long hash(byte[] fixedChunk, int fixedOffset, byte[] variableChunk);
+    long hash(byte[] fixedChunk, int fixedOffset, byte[] variableChunk, int variableOffset);
 
     void hashBlocksBatched(Block[] blocks, long[] hashes, int offset, int length);
 }

--- a/core/trino-main/src/main/java/io/trino/operator/FlatHashStrategyCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/operator/FlatHashStrategyCompiler.java
@@ -30,6 +30,7 @@ import io.airlift.bytecode.Variable;
 import io.airlift.bytecode.control.ForLoop;
 import io.airlift.bytecode.control.IfStatement;
 import io.airlift.bytecode.expression.BytecodeExpression;
+import io.trino.annotation.UsedByGeneratedCode;
 import io.trino.cache.CacheStatsMBean;
 import io.trino.operator.scalar.CombineHashFunction;
 import io.trino.spi.block.Block;
@@ -63,6 +64,7 @@ import static io.airlift.bytecode.expression.BytecodeExpressions.constantBoolean
 import static io.airlift.bytecode.expression.BytecodeExpressions.constantFalse;
 import static io.airlift.bytecode.expression.BytecodeExpressions.constantInt;
 import static io.airlift.bytecode.expression.BytecodeExpressions.constantLong;
+import static io.airlift.bytecode.expression.BytecodeExpressions.constantNull;
 import static io.airlift.bytecode.expression.BytecodeExpressions.constantTrue;
 import static io.airlift.bytecode.expression.BytecodeExpressions.equal;
 import static io.airlift.bytecode.expression.BytecodeExpressions.invokeDynamic;
@@ -168,9 +170,9 @@ public final class FlatHashStrategyCompiler
 
         generateReadFlat(definition, chunkClasses);
         generateWriteFlat(definition, chunkClasses);
-        generateIdenticalMethod(definition, chunkClasses);
+        generateIdenticalMethod(definition, chunkClasses, anyVariableWidth);
         generateHashBlock(definition, chunkClasses);
-        generateHashFlat(definition, chunkClasses);
+        generateHashFlat(definition, chunkClasses, anyVariableWidth);
         generateHashBlocksBatched(definition, chunkClasses);
 
         try {
@@ -270,6 +272,7 @@ public final class FlatHashStrategyCompiler
         Parameter fixedChunk = arg("fixedChunk", type(byte[].class));
         Parameter fixedOffset = arg("fixedOffset", type(int.class));
         Parameter variableChunk = arg("variableChunk", type(byte[].class));
+        Parameter variableOffset = arg("variableOffset", type(int.class));
         Parameter blockBuilders = arg("blockBuilders", type(BlockBuilder[].class));
         MethodDefinition methodDefinition = definition.declareMethod(
                 a(PUBLIC),
@@ -278,10 +281,11 @@ public final class FlatHashStrategyCompiler
                 fixedChunk,
                 fixedOffset,
                 variableChunk,
+                variableOffset,
                 blockBuilders);
         BytecodeBlock body = methodDefinition.getBody();
         for (ChunkClass chunkClass : chunkClasses) {
-            body.append(invokeStatic(chunkClass.readFlatChunk(), fixedChunk, fixedOffset, variableChunk, blockBuilders));
+            body.append(variableOffset.set(invokeStatic(chunkClass.readFlatChunk(), fixedChunk, fixedOffset, variableChunk, variableOffset, blockBuilders)));
         }
         body.ret();
     }
@@ -291,33 +295,47 @@ public final class FlatHashStrategyCompiler
         Parameter fixedChunk = arg("fixedChunk", type(byte[].class));
         Parameter fixedOffset = arg("fixedOffset", type(int.class));
         Parameter variableChunk = arg("variableChunk", type(byte[].class));
+        Parameter variableOffset = arg("variableOffset", type(int.class));
         Parameter blockBuilders = arg("blockBuilders", type(BlockBuilder[].class));
         MethodDefinition methodDefinition = definition.declareMethod(
                 a(PUBLIC, STATIC),
                 "readFlat",
-                type(void.class),
+                type(int.class),
                 fixedChunk,
                 fixedOffset,
                 variableChunk,
+                variableOffset,
                 blockBuilders);
         BytecodeBlock body = methodDefinition.getBody();
 
         for (KeyField keyField : keyFields) {
+            BytecodeBlock readNonNull = new BytecodeBlock()
+                    .append(invokeDynamic(
+                            BOOTSTRAP_METHOD,
+                            ImmutableList.of(callSiteBinder.bind(keyField.readFlatMethod()).getBindingId()),
+                            "readFlat",
+                            void.class,
+                            fixedChunk,
+                            add(fixedOffset, constantInt(keyField.fieldFixedOffset())),
+                            variableChunk,
+                            variableOffset,
+                            blockBuilders.getElement(keyField.index())));
+            if (keyField.type().isFlatVariableWidth()) {
+                // variableOffset += type.getFlatVariableWidthLength(fixedChunk, fixedOffset + fieldFixedOffset);
+                readNonNull.append(variableOffset.set(add(
+                        variableOffset,
+                        constantType(callSiteBinder, keyField.type()).invoke(
+                                "getFlatVariableWidthLength",
+                                int.class,
+                                fixedChunk,
+                                add(fixedOffset, constantInt(keyField.fieldFixedOffset()))))));
+            }
             body.append(new IfStatement()
                     .condition(notEqual(fixedChunk.getElement(add(fixedOffset, constantInt(keyField.fieldIsNullOffset()))).cast(int.class), constantInt(0)))
                     .ifTrue(blockBuilders.getElement(keyField.index()).invoke("appendNull", BlockBuilder.class).pop())
-                    .ifFalse(new BytecodeBlock()
-                            .append(invokeDynamic(
-                                    BOOTSTRAP_METHOD,
-                                    ImmutableList.of(callSiteBinder.bind(keyField.readFlatMethod()).getBindingId()),
-                                    "readFlat",
-                                    void.class,
-                                    fixedChunk,
-                                    add(fixedOffset, constantInt(keyField.fieldFixedOffset())),
-                                    variableChunk,
-                                    blockBuilders.getElement(keyField.index())))));
+                    .ifFalse(readNonNull));
         }
-        body.ret();
+        body.append(variableOffset.ret());
         return methodDefinition;
     }
 
@@ -379,12 +397,12 @@ public final class FlatHashStrategyCompiler
                             variableChunk,
                             variableOffset));
             if (keyField.type().isFlatVariableWidth()) {
-                // variableOffset += type.getFlatVariableWidthSize(blocks[i], position);
+                // variableOffset += type.getFlatVariableWidthLength(fixedChunk, fixedOffset + fieldFixedOffset);
                 writeNonNullFlat.append(variableOffset.set(add(variableOffset, constantType(callSiteBinder, keyField.type()).invoke(
-                        "getFlatVariableWidthSize",
+                        "getFlatVariableWidthLength",
                         int.class,
-                        blocks.getElement(keyField.index()),
-                        position))));
+                        fixedChunk,
+                        add(fixedOffset, constantInt(keyField.fieldFixedOffset()))))));
             }
             body.append(new IfStatement()
                     .condition(blocks.getElement(keyField.index()).invoke("isNull", boolean.class, position))
@@ -395,11 +413,12 @@ public final class FlatHashStrategyCompiler
         return methodDefinition;
     }
 
-    private static void generateIdenticalMethod(ClassDefinition definition, List<ChunkClass> chunkClasses)
+    private static void generateIdenticalMethod(ClassDefinition definition, List<ChunkClass> chunkClasses, boolean anyVariableWidth)
     {
         Parameter leftFixedChunk = arg("leftFixedChunk", type(byte[].class));
         Parameter leftFixedOffset = arg("leftFixedOffset", type(int.class));
         Parameter leftVariableChunk = arg("leftVariableChunk", type(byte[].class));
+        Parameter leftVariableChunkOffset = arg("leftVariableChunkOffset", type(int.class));
         Parameter rightBlocks = arg("rightBlocks", type(Block[].class));
         Parameter rightPosition = arg("rightPosition", type(int.class));
         MethodDefinition methodDefinition = definition.declareMethod(
@@ -409,12 +428,20 @@ public final class FlatHashStrategyCompiler
                 leftFixedChunk,
                 leftFixedOffset,
                 leftVariableChunk,
+                leftVariableChunkOffset,
                 rightBlocks,
                 rightPosition);
         BytecodeBlock body = methodDefinition.getBody();
+        Variable leftMutableVariableChunkOffset = methodDefinition.getScope().declareVariable(MutableVariableWidthOffset.class, "leftMutableVariableChunkOffset");
+        if (anyVariableWidth) {
+            body.append(leftMutableVariableChunkOffset.set(invokeStatic(MutableVariableWidthOffset.class, "create", MutableVariableWidthOffset.class, leftVariableChunkOffset)));
+        }
+        else {
+            body.append(leftMutableVariableChunkOffset.set(constantNull(MutableVariableWidthOffset.class)));
+        }
         for (ChunkClass chunkClass : chunkClasses) {
             body.append(new IfStatement()
-                    .condition(invokeStatic(chunkClass.identicalMethodChunk(), leftFixedChunk, leftFixedOffset, leftVariableChunk, rightBlocks, rightPosition))
+                    .condition(invokeStatic(chunkClass.identicalMethodChunk(), leftFixedChunk, leftFixedOffset, leftVariableChunk, leftMutableVariableChunkOffset, rightBlocks, rightPosition))
                     .ifFalse(constantFalse().ret()));
         }
         body.append(constantTrue().ret());
@@ -425,6 +452,7 @@ public final class FlatHashStrategyCompiler
         Parameter leftFixedChunk = arg("leftFixedChunk", type(byte[].class));
         Parameter leftFixedOffset = arg("leftFixedOffset", type(int.class));
         Parameter leftVariableChunk = arg("leftVariableChunk", type(byte[].class));
+        Parameter leftMutableVariableChunkOffset = arg("leftMutableVariableChunkOffset", type(MutableVariableWidthOffset.class));
         Parameter rightBlocks = arg("rightBlocks", type(Block[].class));
         Parameter rightPosition = arg("rightPosition", type(int.class));
         MethodDefinition methodDefinition = definition.declareMethod(
@@ -434,6 +462,7 @@ public final class FlatHashStrategyCompiler
                 leftFixedChunk,
                 leftFixedOffset,
                 leftVariableChunk,
+                leftMutableVariableChunkOffset,
                 rightBlocks,
                 rightPosition);
         BytecodeBlock body = methodDefinition.getBody();
@@ -441,7 +470,7 @@ public final class FlatHashStrategyCompiler
         for (KeyField keyField : keyFields) {
             MethodDefinition identicalMethod = generateIdenticalMethod(definition, keyField, callSiteBinder);
             body.append(new IfStatement()
-                    .condition(invokeStatic(identicalMethod, leftFixedChunk, leftFixedOffset, leftVariableChunk, rightBlocks.getElement(keyField.index()), rightPosition))
+                    .condition(invokeStatic(identicalMethod, leftFixedChunk, leftFixedOffset, leftVariableChunk, leftMutableVariableChunkOffset, rightBlocks.getElement(keyField.index()), rightPosition))
                     .ifFalse(constantFalse().ret()));
         }
         body.append(constantTrue().ret());
@@ -453,6 +482,7 @@ public final class FlatHashStrategyCompiler
         Parameter leftFixedChunk = arg("leftFixedChunk", type(byte[].class));
         Parameter leftFixedOffset = arg("leftFixedOffset", type(int.class));
         Parameter leftVariableChunk = arg("leftVariableChunk", type(byte[].class));
+        Parameter leftMutableVariableChunkOffset = arg("leftMutableVariableChunkOffset", type(MutableVariableWidthOffset.class));
         Parameter rightBlock = arg("rightBlock", type(Block.class));
         Parameter rightPosition = arg("rightPosition", type(int.class));
         MethodDefinition methodDefinition = definition.declareMethod(
@@ -462,6 +492,7 @@ public final class FlatHashStrategyCompiler
                 leftFixedChunk,
                 leftFixedOffset,
                 leftVariableChunk,
+                leftMutableVariableChunkOffset,
                 rightBlock,
                 rightPosition);
         BytecodeBlock body = methodDefinition.getBody();
@@ -484,6 +515,22 @@ public final class FlatHashStrategyCompiler
                 .condition(rightIsNull)
                 .ifTrue(constantFalse().ret()));
 
+        BytecodeExpression leftVariableWidthOffset;
+        if (keyField.type().isFlatVariableWidth()) {
+            // leftMutableVariableChunkOffset.getAndAdd(type.getFlatVariableWidthLength(fixedChunk, fixedOffset + fieldFixedOffset))
+            leftVariableWidthOffset = leftMutableVariableChunkOffset.invoke(
+                    "getAndAdd",
+                    int.class,
+                    constantType(callSiteBinder, keyField.type()).invoke(
+                            "getFlatVariableWidthLength",
+                            int.class,
+                            leftFixedChunk,
+                            add(leftFixedOffset, constantInt(keyField.fieldFixedOffset()))));
+        }
+        else {
+            leftVariableWidthOffset = constantInt(0);
+        }
+
         body.append(invokeDynamic(
                 BOOTSTRAP_METHOD,
                 ImmutableList.of(callSiteBinder.bind(keyField.identicalFlatBlockMethod()).getBindingId()),
@@ -492,6 +539,7 @@ public final class FlatHashStrategyCompiler
                 leftFixedChunk,
                 add(leftFixedOffset, constantInt(keyField.fieldFixedOffset())),
                 leftVariableChunk,
+                leftVariableWidthOffset,
                 rightBlock,
                 rightPosition)
                 .ret());
@@ -714,24 +762,33 @@ public final class FlatHashStrategyCompiler
         return methodDefinition;
     }
 
-    private static void generateHashFlat(ClassDefinition definition, List<ChunkClass> chunkClasses)
+    private static void generateHashFlat(ClassDefinition definition, List<ChunkClass> chunkClasses, boolean anyVariableWidth)
     {
         Parameter fixedChunk = arg("fixedChunk", type(byte[].class));
         Parameter fixedOffset = arg("fixedOffset", type(int.class));
         Parameter variableChunk = arg("variableChunk", type(byte[].class));
+        Parameter variableChunkOffset = arg("variableChunkOffset", type(int.class));
         MethodDefinition methodDefinition = definition.declareMethod(
                 a(PUBLIC),
                 "hash",
                 type(long.class),
                 fixedChunk,
                 fixedOffset,
-                variableChunk);
+                variableChunk,
+                variableChunkOffset);
         BytecodeBlock body = methodDefinition.getBody();
 
         Scope scope = methodDefinition.getScope();
         Variable result = scope.declareVariable("result", body, constantLong(INITIAL_HASH_VALUE));
+        Variable mutableVariableWidthOffset = scope.declareVariable(MutableVariableWidthOffset.class, "mutableOffset");
+        if (anyVariableWidth) {
+            body.append(mutableVariableWidthOffset.set(invokeStatic(MutableVariableWidthOffset.class, "create", MutableVariableWidthOffset.class, variableChunkOffset)));
+        }
+        else {
+            body.append(mutableVariableWidthOffset.set(constantNull(MutableVariableWidthOffset.class)));
+        }
         for (ChunkClass chunkClass : chunkClasses) {
-            body.append(result.set(invokeStatic(chunkClass.hashFlatChunk(), fixedChunk, fixedOffset, variableChunk, result)));
+            body.append(result.set(invokeStatic(chunkClass.hashFlatChunk(), fixedChunk, fixedOffset, variableChunk, mutableVariableWidthOffset, result)));
         }
         body.append(result.ret());
     }
@@ -741,6 +798,7 @@ public final class FlatHashStrategyCompiler
         Parameter fixedChunk = arg("fixedChunk", type(byte[].class));
         Parameter fixedOffset = arg("fixedOffset", type(int.class));
         Parameter variableChunk = arg("variableChunk", type(byte[].class));
+        Parameter mutableVariableChunkOffset = arg("mutableVariableChunkOffset", type(MutableVariableWidthOffset.class));
         Parameter seed = arg("seed", type(long.class));
         MethodDefinition methodDefinition = definition.declareMethod(
                 a(PUBLIC, STATIC),
@@ -749,6 +807,7 @@ public final class FlatHashStrategyCompiler
                 fixedChunk,
                 fixedOffset,
                 variableChunk,
+                mutableVariableChunkOffset,
                 seed);
         BytecodeBlock body = methodDefinition.getBody();
 
@@ -757,6 +816,21 @@ public final class FlatHashStrategyCompiler
         Variable hash = scope.declareVariable(long.class, "hash");
 
         for (KeyField keyField : keyFields) {
+            BytecodeExpression variableWidthOffset;
+            if (keyField.type().isFlatVariableWidth()) {
+                // mutableVariableChunkOffset.getAndAdd(type.getFlatVariableWidthLength(fixedChunk, fixedOffset + fieldFixedOffset))
+                variableWidthOffset = mutableVariableChunkOffset.invoke(
+                        "getAndAdd",
+                        int.class,
+                        constantType(callSiteBinder, keyField.type()).invoke(
+                                "getFlatVariableWidthLength",
+                                int.class,
+                                fixedChunk,
+                                add(fixedOffset, constantInt(keyField.fieldFixedOffset()))));
+            }
+            else {
+                variableWidthOffset = constantInt(0);
+            }
             body.append(new IfStatement()
                     .condition(notEqual(fixedChunk.getElement(add(fixedOffset, constantInt(keyField.fieldIsNullOffset()))).cast(int.class), constantInt(0)))
                     .ifTrue(hash.set(constantLong(NULL_HASH_CODE)))
@@ -767,11 +841,35 @@ public final class FlatHashStrategyCompiler
                             long.class,
                             fixedChunk,
                             add(fixedOffset, constantInt(keyField.fieldFixedOffset())),
-                            variableChunk))));
+                            variableChunk,
+                            variableWidthOffset))));
             body.append(result.set(invokeStatic(CombineHashFunction.class, "getHash", long.class, result, hash)));
         }
         body.append(result.ret());
         return methodDefinition;
+    }
+
+    @UsedByGeneratedCode
+    public static final class MutableVariableWidthOffset
+    {
+        private int offset;
+
+        public MutableVariableWidthOffset(int offset)
+        {
+            this.offset = offset;
+        }
+
+        public int getAndAdd(int length)
+        {
+            int offset = this.offset;
+            this.offset += length;
+            return offset;
+        }
+
+        public static MutableVariableWidthOffset create(int offset)
+        {
+            return new MutableVariableWidthOffset(offset);
+        }
     }
 
     private record KeyField(

--- a/core/trino-main/src/main/java/io/trino/operator/FlatSet.java
+++ b/core/trino-main/src/main/java/io/trino/operator/FlatSet.java
@@ -26,6 +26,7 @@ import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.operator.VariableWidthData.EMPTY_CHUNK;
 import static io.trino.operator.VariableWidthData.POINTER_SIZE;
+import static io.trino.operator.VariableWidthData.getChunkOffset;
 import static io.trino.spi.StandardErrorCode.GENERIC_INSUFFICIENT_RESOURCES;
 import static java.lang.Math.multiplyExact;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
@@ -239,7 +240,7 @@ final class FlatSet
         if (variableWidthData != null) {
             int variableWidthLength = type.getFlatVariableWidthSize(block, position);
             variableWidthChunk = variableWidthData.allocate(records, recordOffset, variableWidthLength);
-            variableWidthChunkOffset = VariableWidthData.getChunkOffset(records, recordOffset);
+            variableWidthChunkOffset = getChunkOffset(records, recordOffset);
         }
 
         try {
@@ -329,14 +330,17 @@ final class FlatSet
 
         try {
             byte[] variableWidthChunk = EMPTY_CHUNK;
+            int variableWidthChunkOffset = 0;
             if (variableWidthData != null) {
                 variableWidthChunk = variableWidthData.getChunk(records, recordOffset);
+                variableWidthChunkOffset = getChunkOffset(records, recordOffset);
             }
 
             return (long) hashFlat.invokeExact(
                     records,
                     recordOffset + recordValueOffset,
-                    variableWidthChunk);
+                    variableWidthChunk,
+                    variableWidthChunkOffset);
         }
         catch (Throwable throwable) {
             Throwables.throwIfUnchecked(throwable);
@@ -361,8 +365,10 @@ final class FlatSet
         int leftRecordOffset = getRecordOffset(leftPosition);
 
         byte[] leftVariableWidthChunk = EMPTY_CHUNK;
+        int leftVariableWidthChunkOffset = 0;
         if (variableWidthData != null) {
             leftVariableWidthChunk = variableWidthData.getChunk(leftRecords, leftRecordOffset);
+            leftVariableWidthChunkOffset = getChunkOffset(leftRecords, leftRecordOffset);
         }
 
         try {
@@ -370,6 +376,7 @@ final class FlatSet
                     leftRecords,
                     leftRecordOffset + recordValueOffset,
                     leftVariableWidthChunk,
+                    leftVariableWidthChunkOffset,
                     right,
                     rightPosition);
         }

--- a/core/trino-main/src/main/java/io/trino/operator/JoinDomainBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/JoinDomainBuilder.java
@@ -517,14 +517,17 @@ public class JoinDomainBuilder
 
         try {
             byte[] variableWidthChunk = EMPTY_CHUNK;
+            int variableChunkOffset = 0;
             if (distinctVariableWidthData != null) {
                 variableWidthChunk = distinctVariableWidthData.getChunk(distinctRecords, recordOffset);
+                variableChunkOffset = VariableWidthData.getChunkOffset(distinctRecords, recordOffset);
             }
 
             return (Object) readFlat.invokeExact(
                     distinctRecords,
                     recordOffset + distinctRecordValueOffset,
-                    variableWidthChunk);
+                    variableWidthChunk,
+                    variableChunkOffset);
         }
         catch (Throwable throwable) {
             Throwables.throwIfUnchecked(throwable);
@@ -543,14 +546,17 @@ public class JoinDomainBuilder
 
         try {
             byte[] variableWidthChunk = EMPTY_CHUNK;
+            int variableWidthOffset = 0;
             if (distinctVariableWidthData != null) {
                 variableWidthChunk = distinctVariableWidthData.getChunk(values, recordOffset);
+                variableWidthOffset = VariableWidthData.getChunkOffset(values, recordOffset);
             }
 
             return (long) hashFlat.invokeExact(
                     values,
                     recordOffset + distinctRecordValueOffset,
-                    variableWidthChunk);
+                    variableWidthChunk,
+                    variableWidthOffset);
         }
         catch (Throwable throwable) {
             Throwables.throwIfUnchecked(throwable);
@@ -574,8 +580,10 @@ public class JoinDomainBuilder
         byte[] leftFixedRecordChunk = distinctRecords;
         int leftRecordOffset = getRecordOffset(leftPosition);
         byte[] leftVariableWidthChunk = EMPTY_CHUNK;
+        int leftVariableWidthOffset = 0;
         if (distinctVariableWidthData != null) {
             leftVariableWidthChunk = distinctVariableWidthData.getChunk(leftFixedRecordChunk, leftRecordOffset);
+            leftVariableWidthOffset = VariableWidthData.getChunkOffset(leftFixedRecordChunk, leftRecordOffset);
         }
 
         try {
@@ -583,6 +591,7 @@ public class JoinDomainBuilder
                     leftFixedRecordChunk,
                     leftRecordOffset + distinctRecordValueOffset,
                     leftVariableWidthChunk,
+                    leftVariableWidthOffset,
                     right,
                     rightPosition);
         }
@@ -597,15 +606,19 @@ public class JoinDomainBuilder
         byte[] leftFixedRecordChunk = distinctRecords;
         int leftRecordOffset = getRecordOffset(leftPosition);
         byte[] leftVariableWidthChunk = EMPTY_CHUNK;
+        int leftVariableWidthOffset = 0;
         if (distinctVariableWidthData != null) {
             leftVariableWidthChunk = distinctVariableWidthData.getChunk(leftFixedRecordChunk, leftRecordOffset);
+            leftVariableWidthOffset = VariableWidthData.getChunkOffset(leftFixedRecordChunk, leftRecordOffset);
         }
 
         byte[] rightFixedRecordChunk = rightValues;
         int rightRecordOffset = getRecordOffset(rightPosition);
         byte[] rightVariableWidthChunk = EMPTY_CHUNK;
+        int rightVariableWidthOffset = 0;
         if (rightVariableWidthData != null) {
             rightVariableWidthChunk = rightVariableWidthData.getChunk(rightFixedRecordChunk, rightRecordOffset);
+            rightVariableWidthOffset = VariableWidthData.getChunkOffset(rightFixedRecordChunk, rightRecordOffset);
         }
 
         try {
@@ -613,9 +626,11 @@ public class JoinDomainBuilder
                     leftFixedRecordChunk,
                     leftRecordOffset + distinctRecordValueOffset,
                     leftVariableWidthChunk,
+                    leftVariableWidthOffset,
                     rightFixedRecordChunk,
                     rightRecordOffset + distinctRecordValueOffset,
-                    rightVariableWidthChunk);
+                    rightVariableWidthChunk,
+                    rightVariableWidthOffset);
         }
         catch (Throwable throwable) {
             Throwables.throwIfUnchecked(throwable);
@@ -645,9 +660,13 @@ public class JoinDomainBuilder
 
         byte[] leftVariableWidthChunk = EMPTY_CHUNK;
         byte[] rightVariableWidthChunk = EMPTY_CHUNK;
+        int leftVariableWidthOffset = 0;
+        int rightVariableWidthOffset = 0;
         if (distinctVariableWidthData != null) {
             leftVariableWidthChunk = distinctVariableWidthData.getChunk(distinctRecords, leftRecordOffset);
             rightVariableWidthChunk = distinctVariableWidthData.getChunk(distinctRecords, rightRecordOffset);
+            leftVariableWidthOffset = VariableWidthData.getChunkOffset(distinctRecords, leftRecordOffset);
+            rightVariableWidthOffset = VariableWidthData.getChunkOffset(distinctRecords, rightRecordOffset);
         }
 
         try {
@@ -655,9 +674,11 @@ public class JoinDomainBuilder
                     distinctRecords,
                     leftRecordOffset + distinctRecordValueOffset,
                     leftVariableWidthChunk,
+                    leftVariableWidthOffset,
                     distinctRecords,
                     rightRecordOffset + distinctRecordValueOffset,
-                    rightVariableWidthChunk);
+                    rightVariableWidthChunk,
+                    rightVariableWidthOffset);
         }
         catch (Throwable throwable) {
             Throwables.throwIfUnchecked(throwable);

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/arrayagg/FlatArrayBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/arrayagg/FlatArrayBuilder.java
@@ -241,8 +241,10 @@ public class FlatArrayBuilder
         }
 
         byte[] variableWidthChunk = EMPTY_CHUNK;
+        int variableWidthChunkOffset = 0;
         if (variableWidthData != null) {
             variableWidthChunk = variableWidthData.getChunk(records, recordOffset);
+            variableWidthChunkOffset = getChunkOffset(records, recordOffset);
         }
 
         try {
@@ -250,6 +252,7 @@ public class FlatArrayBuilder
                     records,
                     recordOffset + recordValueOffset,
                     variableWidthChunk,
+                    variableWidthChunkOffset,
                     blockBuilder);
         }
         catch (Throwable throwable) {

--- a/core/trino-main/src/main/java/io/trino/type/FunctionType.java
+++ b/core/trino-main/src/main/java/io/trino/type/FunctionType.java
@@ -225,7 +225,7 @@ public class FunctionType
     }
 
     @Override
-    public int relocateFlatVariableWidthOffsets(byte[] fixedSizeSlice, int fixedSizeOffset, byte[] variableSizeSlice, int variableSizeOffset)
+    public int getFlatVariableWidthLength(byte[] fixedSizeSlice, int fixedSizeOffset)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-main/src/main/java/io/trino/type/IpAddressType.java
+++ b/core/trino-main/src/main/java/io/trino/type/IpAddressType.java
@@ -28,6 +28,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 import io.trino.spi.type.AbstractType;
@@ -186,7 +187,8 @@ public class IpAddressType
     private static Slice readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return Slices.wrappedBuffer(fixedSizeSlice, fixedSizeOffset, INT128_BYTES);
     }
@@ -196,6 +198,7 @@ public class IpAddressType
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
             @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset,
             BlockBuilder blockBuilder)
     {
         ((Int128ArrayBlockBuilder) blockBuilder).writeInt128(

--- a/core/trino-main/src/main/java/io/trino/type/UnknownType.java
+++ b/core/trino-main/src/main/java/io/trino/type/UnknownType.java
@@ -22,6 +22,7 @@ import io.trino.spi.block.PageBuilderStatus;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 import io.trino.spi.type.AbstractType;
@@ -143,7 +144,8 @@ public final class UnknownType
     private static boolean readFlat(
             @FlatFixed byte[] unusedFixedSizeSlice,
             @FlatFixedOffset int unusedFixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         throw new AssertionError("value of unknown type should all be NULL");
     }

--- a/core/trino-main/src/test/java/io/trino/operator/GroupByHashYieldAssertion.java
+++ b/core/trino-main/src/test/java/io/trino/operator/GroupByHashYieldAssertion.java
@@ -245,9 +245,7 @@ public final class GroupByHashYieldAssertion
                 Integer.BYTES + // groupId
                 Long.BYTES + // rawHash (optional, but present in this test)
                 Byte.BYTES + // field null
-                Integer.BYTES + // field variable length
-                Long.BYTES + // field first 8 bytes
-                Integer.BYTES; // field variable offset (or 4 more field bytes)
+                Integer.BYTES; // field variable length
         return (long) capacity * sizePerEntry;
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/TestFlatHashStrategy.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestFlatHashStrategy.java
@@ -87,12 +87,12 @@ class TestFlatHashStrategy
                 assertThat(fixedChunk).startsWith(new byte[FIXED_CHUNK_OFFSET]);
                 assertThat(variableChunk).startsWith(new byte[VARIABLE_CHUNK_OFFSET]);
 
-                assertThat(flatHashStrategy.hash(fixedChunk, FIXED_CHUNK_OFFSET, variableChunk)).isEqualTo(manualHash(types, blocks, position));
-                assertThat(flatHashStrategy.valueIdentical(fixedChunk, FIXED_CHUNK_OFFSET, variableChunk, blocks, position)).isTrue();
-                assertThat(flatHashStrategy.valueIdentical(fixedChunk, FIXED_CHUNK_OFFSET, variableChunk, blocks, 3)).isFalse();
+                assertThat(flatHashStrategy.hash(fixedChunk, FIXED_CHUNK_OFFSET, variableChunk, VARIABLE_CHUNK_OFFSET)).isEqualTo(manualHash(types, blocks, position));
+                assertThat(flatHashStrategy.valueIdentical(fixedChunk, FIXED_CHUNK_OFFSET, variableChunk, VARIABLE_CHUNK_OFFSET, blocks, position)).isTrue();
+                assertThat(flatHashStrategy.valueIdentical(fixedChunk, FIXED_CHUNK_OFFSET, variableChunk, VARIABLE_CHUNK_OFFSET, blocks, 3)).isFalse();
 
                 BlockBuilder[] blockBuilders = types.stream().map(type -> type.createBlockBuilder(null, 1)).toArray(BlockBuilder[]::new);
-                flatHashStrategy.readFlat(fixedChunk, FIXED_CHUNK_OFFSET, variableChunk, blockBuilders);
+                flatHashStrategy.readFlat(fixedChunk, FIXED_CHUNK_OFFSET, variableChunk, VARIABLE_CHUNK_OFFSET, blockBuilders);
                 List<Block> output = Arrays.stream(blockBuilders).map(BlockBuilder::build).toList();
                 Page actualPage = new Page(output.toArray(Block[]::new));
                 Page expectedPage = new Page(blocks).getSingleValuePage(position);

--- a/core/trino-main/src/test/java/io/trino/type/AbstractTestType.java
+++ b/core/trino-main/src/test/java/io/trino/type/AbstractTestType.java
@@ -224,9 +224,10 @@ public abstract class AbstractTestType
         int variableOffset = 0;
         for (int i = 0; i < expectedStackValues.size(); i++) {
             writeFlatMethod.invoke(expectedStackValues.get(i), fixed, i * flatFixedSize, variable, variableOffset);
+            assertThat(type.getFlatVariableWidthLength(fixed, i * flatFixedSize)).isEqualTo(variableLengths[i]);
             variableOffset += variableLengths[i];
         }
-        assertFlat(fixed, 0, variable);
+        assertFlat(fixed, 0, variable, 0);
 
         Arrays.fill(fixed, (byte) 0);
         Arrays.fill(variable, (byte) 0);
@@ -235,7 +236,7 @@ public abstract class AbstractTestType
             writeBlockToFlatMethod.invokeExact(testBlock, i, fixed, i * flatFixedSize, variable, variableOffset);
             variableOffset += variableLengths[i];
         }
-        assertFlat(fixed, 0, variable);
+        assertFlat(fixed, 0, variable, 0);
 
         // test relocation
         byte[] newFixed = new byte[fixed.length + 73];
@@ -245,16 +246,14 @@ public abstract class AbstractTestType
         Arrays.fill(fixed, (byte) 0);
         Arrays.fill(variable, (byte) 0);
 
-        variableOffset = 101;
         for (int i = 0; i < expectedStackValues.size(); i++) {
-            int variableSize = type.relocateFlatVariableWidthOffsets(newFixed, 73 + i * flatFixedSize, newVariable, variableOffset);
-            variableOffset += variableSize;
+            int variableSize = type.getFlatVariableWidthLength(newFixed, 73 + i * flatFixedSize);
             assertThat(variableSize).isEqualTo(variableLengths[i]);
         }
-        assertFlat(newFixed, 73, newVariable);
+        assertFlat(newFixed, 73, newVariable, 101);
     }
 
-    private void assertFlat(byte[] fixed, int fixedOffset, byte[] variable)
+    private void assertFlat(byte[] fixed, int fixedOffset, byte[] variable, int variableOffset)
             throws Throwable
     {
         int flatFixedSize = type.getFlatFixedSize();
@@ -262,47 +261,51 @@ public abstract class AbstractTestType
             Object expectedStackValue = expectedStackValues.get(i);
             int elementFixedOffset = fixedOffset + (i * flatFixedSize);
             if (type.getJavaType() == boolean.class) {
-                assertThat((boolean) readFlatMethod.invokeExact(fixed, elementFixedOffset, variable)).isEqualTo(expectedStackValue);
+                assertThat((boolean) readFlatMethod.invokeExact(fixed, elementFixedOffset, variable, variableOffset)).isEqualTo(expectedStackValue);
             }
             else if (type.getJavaType() == long.class) {
-                assertThat((long) readFlatMethod.invokeExact(fixed, elementFixedOffset, variable)).isEqualTo(expectedStackValue);
+                assertThat((long) readFlatMethod.invokeExact(fixed, elementFixedOffset, variable, variableOffset)).isEqualTo(expectedStackValue);
             }
             else if (type.getJavaType() == double.class) {
-                assertThat((double) readFlatMethod.invokeExact(fixed, elementFixedOffset, variable)).isEqualTo(expectedStackValue);
+                assertThat((double) readFlatMethod.invokeExact(fixed, elementFixedOffset, variable, variableOffset)).isEqualTo(expectedStackValue);
             }
             else if (type.getJavaType() == Slice.class) {
-                assertThat((Slice) readFlatMethod.invokeExact(fixed, elementFixedOffset, variable)).isEqualTo(expectedStackValue);
+                assertThat((Slice) readFlatMethod.invokeExact(fixed, elementFixedOffset, variable, variableOffset)).isEqualTo(expectedStackValue);
             }
             else if (type.getJavaType() == Block.class) {
-                assertBlockEquals((Block) readFlatMethod.invokeExact(fixed, elementFixedOffset, variable), (Block) expectedStackValue);
+                assertBlockEquals((Block) readFlatMethod.invokeExact(fixed, elementFixedOffset, variable, variableOffset), (Block) expectedStackValue);
             }
             else if (stackStackEqualOperator != null) {
-                assertThat((Boolean) stackStackEqualOperator.invoke(readFlatMethod.invoke(fixed, elementFixedOffset, variable), expectedStackValue)).isTrue();
+                assertThat((Boolean) stackStackEqualOperator.invoke(readFlatMethod.invoke(fixed, elementFixedOffset, variable, variableOffset), expectedStackValue)).isTrue();
             }
             else {
-                assertThat(readFlatMethod.invoke(fixed, elementFixedOffset, variable)).isEqualTo(expectedStackValue);
+                assertThat(readFlatMethod.invoke(fixed, elementFixedOffset, variable, variableOffset)).isEqualTo(expectedStackValue);
             }
 
             BlockBuilder blockBuilder = type.createBlockBuilder(null, 1);
-            writeFlatToBlockMethod.invokeExact(fixed, elementFixedOffset, variable, blockBuilder);
+            writeFlatToBlockMethod.invokeExact(fixed, elementFixedOffset, variable, variableOffset, blockBuilder);
             assertPositionEquals(testBlock, i, expectedStackValue, expectedObjectValues.get(i));
 
             if (type.isComparable()) {
-                assertThat((Boolean) flatFlatEqualOperator.invokeExact(fixed, elementFixedOffset, variable, fixed, elementFixedOffset, variable)).isTrue();
-                assertThat((Boolean) flatBlockPositionEqualOperator.invokeExact(fixed, elementFixedOffset, variable, testBlock, i)).isTrue();
-                assertThat((Boolean) blockPositionFlatEqualOperator.invokeExact(testBlock, i, fixed, elementFixedOffset, variable)).isTrue();
+                assertThat((Boolean) flatFlatEqualOperator.invokeExact(fixed, elementFixedOffset, variable, variableOffset, fixed, elementFixedOffset, variable, variableOffset)).isTrue();
+                assertThat((Boolean) flatBlockPositionEqualOperator.invokeExact(fixed, elementFixedOffset, variable, variableOffset, testBlock, i)).isTrue();
+                assertThat((Boolean) blockPositionFlatEqualOperator.invokeExact(testBlock, i, fixed, elementFixedOffset, variable, variableOffset)).isTrue();
 
-                assertThat((long) flatHashCodeOperator.invokeExact(fixed, elementFixedOffset, variable)).isEqualTo(hashCodeOperator.hashCodeNullSafe(testBlock, i));
+                assertThat((long) flatHashCodeOperator.invokeExact(fixed, elementFixedOffset, variable, variableOffset)).isEqualTo(hashCodeOperator.hashCodeNullSafe(testBlock, i));
 
-                assertThat((long) flatXxHash64Operator.invokeExact(fixed, elementFixedOffset, variable)).isEqualTo(xxHash64Operator.xxHash64(testBlock, i));
+                assertThat((long) flatXxHash64Operator.invokeExact(fixed, elementFixedOffset, variable, variableOffset)).isEqualTo(xxHash64Operator.xxHash64(testBlock, i));
 
-                assertThat((boolean) flatFlatIdenticalOperator.invokeExact(fixed, elementFixedOffset, variable, fixed, elementFixedOffset, variable)).isTrue();
-                assertThat((boolean) flatBlockPositionIdenticalOperator.invokeExact(fixed, elementFixedOffset, variable, testBlock, i)).isTrue();
-                assertThat((boolean) blockPositionFlatIdenticalOperator.invokeExact(testBlock, i, fixed, elementFixedOffset, variable)).isTrue();
+                assertThat((boolean) flatFlatIdenticalOperator.invokeExact(fixed, elementFixedOffset, variable, variableOffset, fixed, elementFixedOffset, variable, variableOffset)).isTrue();
+                assertThat((boolean) flatBlockPositionIdenticalOperator.invokeExact(fixed, elementFixedOffset, variable, variableOffset, testBlock, i)).isTrue();
+                assertThat((boolean) blockPositionFlatIdenticalOperator.invokeExact(testBlock, i, fixed, elementFixedOffset, variable, variableOffset)).isTrue();
 
                 ValueBlock nullValue = type.createBlockBuilder(null, 1).appendNull().buildValueBlock();
-                assertThat((boolean) flatBlockPositionIdenticalOperator.invokeExact(fixed, elementFixedOffset, variable, nullValue, 0)).isFalse();
-                assertThat((boolean) blockPositionFlatIdenticalOperator.invokeExact(nullValue, 0, fixed, elementFixedOffset, variable)).isFalse();
+                assertThat((boolean) flatBlockPositionIdenticalOperator.invokeExact(fixed, elementFixedOffset, variable, variableOffset, nullValue, 0)).isFalse();
+                assertThat((boolean) blockPositionFlatIdenticalOperator.invokeExact(nullValue, 0, fixed, elementFixedOffset, variable, variableOffset)).isFalse();
+            }
+            // advance offset
+            if (type.isFlatVariableWidth()) {
+                variableOffset += type.getFlatVariableWidthLength(fixed, elementFixedOffset);
             }
         }
     }

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -314,6 +314,48 @@
                                     <old>method long io.trino.spi.connector.Connector::getInitialMemoryRequirement()</old>
                                     <justification>Remove unused connector method</justification>
                                 </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.addedToInterface</code>
+                                    <new>method int io.trino.spi.type.Type::getFlatVariableWidthLength(byte[], int)</new>
+                                    <justification>New interface method required for new flat variable width data layouts</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method int io.trino.spi.type.Type::relocateFlatVariableWidthOffsets(byte[], int, byte[], int)</old>
+                                    <justification>Remove flat offsets relocation method since offsets are no longer stored in flat representations</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method int io.trino.spi.type.AbstractVariableWidthType::relocateFlatVariableWidthOffsets(byte[], int, byte[], int)</old>
+                                    <justification>Remove flat offsets relocation method since offsets are no longer stored in flat representations</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method int io.trino.spi.type.ArrayType::relocateFlatVariableWidthOffsets(byte[], int, byte[], int)</old>
+                                    <justification>Remove flat offsets relocation method since offsets are no longer stored in flat representations</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method int io.trino.spi.type.FixedWidthType::relocateFlatVariableWidthOffsets(byte[], int, byte[], int)</old>
+                                    <justification>Remove flat offsets relocation method since offsets are no longer stored in flat representations</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method int io.trino.spi.type.MapType::relocateFlatVariableWidthOffsets(byte[], int, byte[], int)</old>
+                                    <justification>Remove flat offsets relocation method since offsets are no longer stored in flat representations</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method int io.trino.spi.type.RowType::relocateFlatVariableWidthOffsets(byte[], int, byte[], int)</old>
+                                    <justification>Remove flat offsets relocation method since offsets are no longer stored in flat representations</justification>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/function/FlatVariableOffset.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/FlatVariableOffset.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.function;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface FlatVariableOffset
+{
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/function/InvocationConvention.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/InvocationConvention.java
@@ -138,7 +138,7 @@ public class InvocationConvention
         /**
          * Argument is passed as a flat slice. The sql value may not be null.
          */
-        FLAT(false, 3),
+        FLAT(false, 4),
         /**
          * Argument is passed in an InOut. The sql value may be null.
          */

--- a/core/trino-spi/src/main/java/io/trino/spi/type/AbstractIntType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/AbstractIntType.java
@@ -25,6 +25,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -166,7 +167,8 @@ public abstract class AbstractIntType
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return (int) INT_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/AbstractLongType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/AbstractLongType.java
@@ -24,6 +24,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -144,7 +145,8 @@ public abstract class AbstractLongType
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return (long) LONG_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/BooleanType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/BooleanType.java
@@ -25,6 +25,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -178,7 +179,8 @@ public final class BooleanType
     private static boolean readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return fixedSizeSlice[fixedSizeOffset] != 0;
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/DoubleType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/DoubleType.java
@@ -25,6 +25,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.IsNull;
 import io.trino.spi.function.ScalarOperator;
@@ -178,7 +179,8 @@ public final class DoubleType
     private static double readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return (double) DOUBLE_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/FixedWidthType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/FixedWidthType.java
@@ -54,7 +54,7 @@ public interface FixedWidthType
     }
 
     @Override
-    default int relocateFlatVariableWidthOffsets(byte[] fixedSizeSlice, int fixedSizeOffset, byte[] variableSizeSlice, int variableSizeOffset)
+    default int getFlatVariableWidthLength(byte[] fixedSizeSlice, int fixedSizeOffset)
     {
         return 0;
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/LongDecimalType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/LongDecimalType.java
@@ -25,6 +25,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -141,7 +142,8 @@ final class LongDecimalType
     private static Int128 readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return Int128.valueOf(
                 (long) LONG_HANDLE.get(fixedSizeSlice, fixedSizeOffset),
@@ -153,6 +155,7 @@ final class LongDecimalType
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
             @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset,
             BlockBuilder blockBuilder)
     {
         ((Int128ArrayBlockBuilder) blockBuilder).writeInt128(

--- a/core/trino-spi/src/main/java/io/trino/spi/type/LongTimeWithTimeZoneType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/LongTimeWithTimeZoneType.java
@@ -25,6 +25,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -159,7 +160,8 @@ final class LongTimeWithTimeZoneType
     private static LongTimeWithTimeZone readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return new LongTimeWithTimeZone(
                 (long) LONG_HANDLE.get(fixedSizeSlice, fixedSizeOffset),
@@ -171,6 +173,7 @@ final class LongTimeWithTimeZoneType
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
             @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset,
             BlockBuilder blockBuilder)
     {
         write(blockBuilder,

--- a/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestampType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestampType.java
@@ -25,6 +25,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -177,7 +178,8 @@ final class LongTimestampType
     private static LongTimestamp readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return new LongTimestamp(
                 (long) LONG_HANDLE.get(fixedSizeSlice, fixedSizeOffset),
@@ -189,6 +191,7 @@ final class LongTimestampType
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
             @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset,
             BlockBuilder blockBuilder)
     {
         write(blockBuilder,

--- a/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestampWithTimeZoneType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestampWithTimeZoneType.java
@@ -25,6 +25,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -220,7 +221,8 @@ final class LongTimestampWithTimeZoneType
     private static LongTimestampWithTimeZone readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         long packedEpochMillis = (long) LONG_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
         int picosOfMilli = (int) INT_HANDLE.get(fixedSizeSlice, fixedSizeOffset + Long.BYTES);
@@ -232,6 +234,7 @@ final class LongTimestampWithTimeZoneType
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
             @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset,
             BlockBuilder blockBuilder)
     {
         write(blockBuilder,

--- a/core/trino-spi/src/main/java/io/trino/spi/type/RealType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/RealType.java
@@ -20,6 +20,7 @@ import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.IsNull;
 import io.trino.spi.function.ScalarOperator;
@@ -121,7 +122,8 @@ public final class RealType
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return (int) INT_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/ShortDecimalType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ShortDecimalType.java
@@ -25,6 +25,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -197,7 +198,8 @@ final class ShortDecimalType
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return (long) LONG_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimeWithTimeZoneType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimeWithTimeZoneType.java
@@ -25,6 +25,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -148,7 +149,8 @@ final class ShortTimeWithTimeZoneType
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return (long) LONG_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimestampType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimestampType.java
@@ -25,6 +25,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -183,7 +184,8 @@ final class ShortTimestampType
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return (long) LONG_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimestampWithTimeZoneType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimestampWithTimeZoneType.java
@@ -25,6 +25,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -148,7 +149,8 @@ final class ShortTimestampWithTimeZoneType
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return (long) LONG_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/SmallintType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/SmallintType.java
@@ -26,6 +26,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -229,7 +230,8 @@ public final class SmallintType
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return (short) SHORT_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TimeType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TimeType.java
@@ -19,6 +19,7 @@ import io.trino.spi.block.Block;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -135,7 +136,8 @@ public final class TimeType
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return (long) LONG_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TinyintType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TinyintType.java
@@ -26,6 +26,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -224,7 +225,8 @@ public final class TinyintType
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return fixedSizeSlice[fixedSizeOffset];
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/Type.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/Type.java
@@ -247,14 +247,9 @@ public interface Type
     int getFlatVariableWidthSize(Block block, int position);
 
     /**
-     * Update the variable width offsets recorded in the value.
-     * This method is called after the value has been moved to a new location, and therefore the offsets
-     * need to be updated.
-     * Returns the length of the variable width data, so container types can update their offsets.
-     *
-     * @return the length of the variable width data
+     * Returns the variable width size of the value already written at the specified position within a flat buffer
      */
-    int relocateFlatVariableWidthOffsets(byte[] fixedSizeSlice, int fixedSizeOffset, byte[] variableSizeSlice, int variableSizeOffset);
+    int getFlatVariableWidthLength(byte[] fixedSizeSlice, int fixedSizeOffset);
 
     final class Range
     {

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperatorDeclaration.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperatorDeclaration.java
@@ -22,6 +22,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.InvocationConvention;
 import io.trino.spi.function.InvocationConvention.InvocationArgumentConvention;
@@ -605,12 +606,14 @@ public final class TypeOperatorDeclaration
                 }
             }
             else if (isAnnotationPresent(parameterAnnotations.get(0), FlatFixed.class)) {
-                if (parameterTypes.size() > 2 &&
+                if (parameterTypes.size() > 3 &&
                         isAnnotationPresent(parameterAnnotations.get(1), FlatFixedOffset.class) &&
                         isAnnotationPresent(parameterAnnotations.get(2), FlatVariableWidth.class) &&
+                        isAnnotationPresent(parameterAnnotations.get(3), FlatVariableOffset.class) &&
                         parameterTypes.get(0).equals(byte[].class) &&
                         parameterTypes.get(1).equals(int.class) &&
-                        parameterTypes.get(2).equals(byte[].class)) {
+                        parameterTypes.get(2).equals(byte[].class) &&
+                        parameterTypes.get(3).equals(int.class)) {
                     return FLAT;
                 }
             }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/UuidType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/UuidType.java
@@ -27,6 +27,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
+import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
 
@@ -196,7 +197,8 @@ public class UuidType
     private static Slice readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
-            @FlatVariableWidth byte[] unusedVariableSizeSlice)
+            @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset)
     {
         return wrappedBuffer(fixedSizeSlice, fixedSizeOffset, INT128_BYTES);
     }
@@ -217,6 +219,7 @@ public class UuidType
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
             @FlatVariableWidth byte[] unusedVariableSizeSlice,
+            @FlatVariableOffset int unusedVariableSizeOffset,
             BlockBuilder blockBuilder)
     {
         ((Int128ArrayBlockBuilder) blockBuilder).writeInt128(

--- a/core/trino-spi/src/test/java/io/trino/spi/function/TestScalarFunctionAdapter.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/function/TestScalarFunctionAdapter.java
@@ -554,6 +554,7 @@ public class TestScalarFunctionAdapter
                     callArguments.add(fixedSlice);
                     callArguments.add(0);
                     callArguments.add(variableSlice);
+                    callArguments.add(0);
                 }
                 case IN_OUT -> callArguments.add(new TestingInOut(argumentType, testValue));
                 default -> throw new IllegalArgumentException("Unsupported argument convention: " + argumentConvention);

--- a/core/trino-spi/src/test/java/io/trino/spi/type/TestTypeOperators.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/type/TestTypeOperators.java
@@ -102,6 +102,7 @@ class TestTypeOperators
                 callArguments.add(fixedSlice);
                 callArguments.add(0);
                 callArguments.add(new byte[0]);
+                callArguments.add(0);
             }
             default -> throw new UnsupportedOperationException();
         }


### PR DESCRIPTION
## Description
Avoids directly storing fixed offsets in the flat representation for all types. This avoids the need to "relocate" those offsets when the variable width data is moved and reduces the required overhead for variable width data types that previously required storing both the offset and the length.

This change requires callers of the equals and readFlat method handles to pass the starting offset explicitly.

This change also removes the "short string" optimization from variable width type.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
