### PR TITLE
Rename plugin folder for Ranger in binaries

### DIFF
--- a/core/trino-server/src/main/provisio/trino.xml
+++ b/core/trino-server/src/main/provisio/trino.xml
@@ -16,12 +16,6 @@
         </artifact>
     </artifactSet>
 
-    <artifactSet to="plugin/apache-ranger">
-        <artifact id="${project.groupId}:trino-ranger:zip:${project.version}">
-            <unpack />
-        </artifact>
-    </artifactSet>
-
     <artifactSet to="plugin/bigquery">
         <artifact id="${project.groupId}:trino-bigquery:zip:${project.version}">
             <unpack />
@@ -249,6 +243,13 @@
             <unpack />
         </artifact>
     </artifactSet>
+
+    <artifactSet to="plugin/ranger">
+        <artifact id="${project.groupId}:trino-ranger:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
+
 
     <artifactSet to="plugin/redis">
         <artifact id="${project.groupId}:trino-redis:zip:${project.version}">

--- a/docs/src/main/sphinx/installation/plugins.md
+++ b/docs/src/main/sphinx/installation/plugins.md
@@ -144,10 +144,6 @@ with the listed coordinates.
   - [](/functions/ai)
   - [io.trino:trino-ai-functions](https://central.sonatype.com/search?q=io.trino%3Atrino-ai-functions)
   - {maven_download}`ai-functions`  
-* - apache-ranger
-  - [](/security/ranger-access-control)
-  - [io.trino:trino-ranger](https://central.sonatype.com/search?q=io.trino%3Atrino-ranger)
-  - {maven_download}`ranger`
 * - bigquery
   - [](/connector/bigquery)
   - [io.trino:trino-bigquery](https://central.sonatype.com/search?q=io.trino%3Atrino-bigquery)
@@ -308,6 +304,10 @@ with the listed coordinates.
   - [](/connector/prometheus)
   - [io.trino:trino-prometheus](https://central.sonatype.com/search?q=io.trino%3Atrino-prometheus)
   - {maven_download}`prometheus`
+* - ranger
+  - [](/security/ranger-access-control)
+  - [io.trino:trino-ranger](https://central.sonatype.com/search?q=io.trino%3Atrino-ranger)
+  - {maven_download}`ranger`
 * - redis
   - [](/connector/redis)
   - [io.trino:trino-redis](https://central.sonatype.com/search?q=io.trino%3Atrino-redis)


### PR DESCRIPTION
## Description

To be consistent with all the other plugins. Best to do now while we expose how to install and remove plugins. Came up in other PR in discussion with @wendigo 

## Additional context and related issues


## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

In my opinion the folder name is an implementation detail and it does not need to be exposed in the release notes as such. The doc update is sufficient.