### PR TITLE
Add debug logging to BigQuery getTable api failure

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
@@ -312,6 +312,7 @@ public class BigQueryClient
             return Optional.ofNullable(bigQuery.getTable(remoteTableId));
         }
         catch (BigQueryException e) {
+            log.debug(e, "Failed to get table '%s'", remoteTableId);
             // getTable method throws an exception in some situations, e.g. wild card tables
             return Optional.empty();
         }


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
