### PR TITLE
Change Block getSizeInBytes to estimate fully expanded data size

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/buffer/PageSplitterUtil.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/PageSplitterUtil.java
@@ -34,8 +34,8 @@ public final class PageSplitterUtil
         checkArgument(page.getPositionCount() > 0, "page is empty");
         checkArgument(maxPageSizeInBytes > 0, "maxPageSizeInBytes must be > 0");
 
-        // for Pages with certain types of Blocks (e.g., RLE blocks) the size in bytes may remain constant
-        // through the recursive calls, which causes the recursion to only terminate when page.getPositionCount() == 1
+        // In case the size in bytes remains constant through the recursive calls,
+        // the recursion would only terminate when page.getPositionCount() == 1
         // and create potentially a large number of Page's of size 1. So we check here that
         // if the size of the page doesn't improve from the previous call we terminate the recursion.
         if (page.getSizeInBytes() == previousPageSize || page.getSizeInBytes() <= maxPageSizeInBytes || page.getPositionCount() == 1) {

--- a/core/trino-main/src/main/java/io/trino/operator/output/PagePartitioner.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/PagePartitioner.java
@@ -13,7 +13,6 @@
  */
 package io.trino.operator.output;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
 import io.airlift.slice.Slice;
 import io.airlift.units.DataSize;
@@ -46,7 +45,7 @@ import java.util.function.IntUnaryOperator;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
-import static io.trino.execution.buffer.PageSplitterUtil.splitPage;
+import static io.trino.execution.buffer.PageSplitterUtil.splitAndSerializePage;
 import static io.trino.spi.block.PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
@@ -507,17 +506,7 @@ public class PagePartitioner
 
     private void enqueuePage(Page pagePartition, int partition)
     {
-        outputBuffer.enqueue(partition, splitAndSerializePage(pagePartition));
-    }
-
-    private List<Slice> splitAndSerializePage(Page page)
-    {
-        List<Page> split = splitPage(page, DEFAULT_MAX_PAGE_SIZE_IN_BYTES);
-        ImmutableList.Builder<Slice> builder = ImmutableList.builderWithExpectedSize(split.size());
-        for (Page chunk : split) {
-            builder.add(serializer.serialize(chunk));
-        }
-        return builder.build();
+        outputBuffer.enqueue(partition, splitAndSerializePage(pagePartition, serializer));
     }
 
     private void updateMemoryUsage()

--- a/core/trino-main/src/test/java/io/trino/block/AbstractTestBlock.java
+++ b/core/trino-main/src/test/java/io/trino/block/AbstractTestBlock.java
@@ -274,7 +274,10 @@ public abstract class AbstractTestBlock
     {
         if (block instanceof DictionaryBlock dictionaryBlock) {
             // dictionary blocks might become unwrapped when copyRegion is called on a block that is already compact
-            return dictionaryBlock.compact().getSizeInBytes();
+            ValueBlock dictionary = dictionaryBlock.getDictionary();
+            double averageEntrySize = dictionary.getSizeInBytes() * 1.0 / dictionary.getPositionCount();
+            int entryCount = dictionaryBlock.getPositionCount();
+            return (long) (averageEntrySize * entryCount) + ((long) Integer.BYTES * entryCount);
         }
         return copyBlockViaCopyRegion(block).getSizeInBytes();
     }

--- a/core/trino-main/src/test/java/io/trino/block/AbstractTestBlock.java
+++ b/core/trino-main/src/test/java/io/trino/block/AbstractTestBlock.java
@@ -45,7 +45,6 @@ import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
-import static java.util.Arrays.fill;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -238,14 +237,6 @@ public abstract class AbstractTestBlock
         long expectedSecondHalfSize = getCompactedBlockSizeInBytes(secondHalf);
         assertThat(secondHalf.getSizeInBytes()).isEqualTo(expectedSecondHalfSize);
         assertThat(block.getRegionSizeInBytes(firstHalf.getPositionCount(), secondHalf.getPositionCount())).isEqualTo(expectedSecondHalfSize);
-
-        boolean[] positions = new boolean[block.getPositionCount()];
-        fill(positions, 0, firstHalf.getPositionCount(), true);
-        assertThat(block.getPositionsSizeInBytes(positions, firstHalf.getPositionCount())).isEqualTo(expectedFirstHalfSize);
-        fill(positions, true);
-        assertThat(block.getPositionsSizeInBytes(positions, positions.length)).isEqualTo(expectedBlockSize);
-        fill(positions, 0, firstHalf.getPositionCount(), false);
-        assertThat(block.getPositionsSizeInBytes(positions, positions.length - firstHalf.getPositionCount())).isEqualTo(expectedSecondHalfSize);
     }
 
     private <T> void assertBlockPosition(Block block, int position, T expectedValue)

--- a/core/trino-main/src/test/java/io/trino/block/AbstractTestBlock.java
+++ b/core/trino-main/src/test/java/io/trino/block/AbstractTestBlock.java
@@ -125,6 +125,7 @@ public abstract class AbstractTestBlock
                 }
                 else if (type == Block[].class) {
                     Block[] blocks = (Block[]) field.get(block);
+                    retainedSize += sizeOf(blocks);
                     for (Block innerBlock : blocks) {
                         assertRetainedSize(innerBlock);
                         retainedSize += innerBlock.getRetainedSizeInBytes();

--- a/core/trino-main/src/test/java/io/trino/block/TestDictionaryBlock.java
+++ b/core/trino-main/src/test/java/io/trino/block/TestDictionaryBlock.java
@@ -25,7 +25,6 @@ import io.trino.spi.block.VariableWidthBlock;
 import io.trino.spi.block.VariableWidthBlockBuilder;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
 import java.util.Optional;
 import java.util.stream.IntStream;
 
@@ -328,13 +327,6 @@ public class TestDictionaryBlock
         int secondHalfLength = entryCount - firstHalfLength;
         int[] firstHalfIds = IntStream.range(0, firstHalfLength).toArray();
         int[] secondHalfIds = IntStream.range(firstHalfLength, entryCount).toArray();
-
-        boolean[] selectedPositions = new boolean[entryCount];
-        selectedPositions[0] = true;
-        assertThat(DictionaryBlock.create(allIds.length, dictionary, allIds).getPositionsSizeInBytes(selectedPositions, 1)).isEqualTo(((long) averageEntrySize) + Integer.BYTES);
-
-        Arrays.fill(selectedPositions, true);
-        assertThat(DictionaryBlock.create(allIds.length, dictionary, allIds).getPositionsSizeInBytes(selectedPositions, entryCount)).isEqualTo((long) (averageEntrySize * entryCount) + (Integer.BYTES * (long) entryCount));
 
         assertThat(DictionaryBlock.create(firstHalfIds.length, dictionary, firstHalfIds).getSizeInBytes()).isEqualTo((long) (averageEntrySize * firstHalfLength) + (Integer.BYTES * (long) firstHalfLength));
         assertThat(DictionaryBlock.create(secondHalfIds.length, dictionary, secondHalfIds).getSizeInBytes()).isEqualTo((long) (averageEntrySize * secondHalfLength) + (Integer.BYTES * (long) secondHalfLength));

--- a/core/trino-main/src/test/java/io/trino/block/TestRunLengthEncodedBlock.java
+++ b/core/trino-main/src/test/java/io/trino/block/TestRunLengthEncodedBlock.java
@@ -62,26 +62,6 @@ public class TestRunLengthEncodedBlock
     }
 
     @Test
-    public void testPositionsSizeInBytes()
-    {
-        Block valueBlock = createSingleValueBlock(createExpectedValue(10));
-        Block rleBlock = RunLengthEncodedBlock.create(valueBlock, 10);
-        // Size in bytes is not fixed per position
-        assertThat(rleBlock.fixedSizeInBytesPerPosition()).isEmpty();
-        // Accepts specific position selection
-        boolean[] positions = new boolean[rleBlock.getPositionCount()];
-        positions[0] = true;
-        positions[1] = true;
-        assertThat(rleBlock.getPositionsSizeInBytes(positions, 2)).isEqualTo(valueBlock.getSizeInBytes() * 2);
-        // Accepts null positions array with count only
-        assertThat(rleBlock.getPositionsSizeInBytes(null, 2)).isEqualTo(valueBlock.getSizeInBytes() * 2);
-        // Size value count * position count
-        for (int positionCount = 0; positionCount < rleBlock.getPositionCount(); positionCount++) {
-            assertThat(rleBlock.getPositionsSizeInBytes(null, positionCount)).isEqualTo(valueBlock.getSizeInBytes() * positionCount);
-        }
-    }
-
-    @Test
     public void testBuildingFromLongArrayBlockBuilder()
     {
         LongArrayBlockBuilder blockBuilder = new LongArrayBlockBuilder(null, 100);

--- a/core/trino-main/src/test/java/io/trino/block/TestRunLengthEncodedBlock.java
+++ b/core/trino-main/src/test/java/io/trino/block/TestRunLengthEncodedBlock.java
@@ -72,12 +72,12 @@ public class TestRunLengthEncodedBlock
         boolean[] positions = new boolean[rleBlock.getPositionCount()];
         positions[0] = true;
         positions[1] = true;
-        assertThat(rleBlock.getPositionsSizeInBytes(positions, 2)).isEqualTo(valueBlock.getSizeInBytes());
+        assertThat(rleBlock.getPositionsSizeInBytes(positions, 2)).isEqualTo(valueBlock.getSizeInBytes() * 2);
         // Accepts null positions array with count only
-        assertThat(rleBlock.getPositionsSizeInBytes(null, 2)).isEqualTo(valueBlock.getSizeInBytes());
-        // Always reports the same size in bytes regardless of positions
+        assertThat(rleBlock.getPositionsSizeInBytes(null, 2)).isEqualTo(valueBlock.getSizeInBytes() * 2);
+        // Size value count * position count
         for (int positionCount = 0; positionCount < rleBlock.getPositionCount(); positionCount++) {
-            assertThat(rleBlock.getPositionsSizeInBytes(null, positionCount)).isEqualTo(valueBlock.getSizeInBytes());
+            assertThat(rleBlock.getPositionsSizeInBytes(null, positionCount)).isEqualTo(valueBlock.getSizeInBytes() * positionCount);
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestPageSplitterUtil.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestPageSplitterUtil.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
 import static io.airlift.slice.Slices.wrappedBuffer;
@@ -164,18 +163,6 @@ public class TestPageSplitterUtil
         public long getRetainedSizeInBytes()
         {
             return delegate.getRetainedSizeInBytes();
-        }
-
-        @Override
-        public OptionalInt fixedSizeInBytesPerPosition()
-        {
-            return OptionalInt.empty();
-        }
-
-        @Override
-        public long getPositionsSizeInBytes(boolean[] positions, int selectedPositionsCount)
-        {
-            return delegate.getPositionsSizeInBytes(positions, selectedPositionsCount);
         }
 
         @Override

--- a/core/trino-main/src/test/java/io/trino/operator/TestHashAggregationOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestHashAggregationOperator.java
@@ -831,7 +831,7 @@ public class TestHashAggregationOperator
         assertOperatorEquals(operatorFactory, operator2Input, operator2Expected);
 
         // partial aggregation should be enabled again after enough data is processed
-        for (int i = 1; i <= 3; ++i) {
+        for (int i = 1; i <= 4; ++i) {
             List<Page> operatorInput = rowPagesBuilder(false, hashChannels, BIGINT)
                     .addBlocksPage(createLongsBlock(0, 1, 2, 3, 4, 5, 6, 7, 8))
                     .build();
@@ -839,7 +839,7 @@ public class TestHashAggregationOperator
                     .addBlocksPage(createLongsBlock(0, 1, 2, 3, 4, 5, 6, 7, 8), createLongsBlock(0, 1, 2, 3, 4, 5, 6, 7, 8))
                     .build();
             assertOperatorEquals(operatorFactory, operatorInput, operatorExpected);
-            if (i <= 2) {
+            if (i <= 3) {
                 assertThat(partialAggregationController.isPartialAggregationDisabled()).isTrue();
             }
             else {

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppenderPageBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppenderPageBuilder.java
@@ -45,7 +45,7 @@ public class TestPositionsAppenderPageBuilder
                 List.of(VARCHAR),
                 new PositionsAppenderFactory(new BlockTypeOperators()));
 
-        Block rleBlock = RunLengthEncodedBlock.create(VARCHAR, Slices.utf8Slice("test"), 10);
+        RunLengthEncodedBlock rleBlock = (RunLengthEncodedBlock) RunLengthEncodedBlock.create(VARCHAR, Slices.utf8Slice("test"), 10);
         Page inputPage = new Page(rleBlock);
 
         IntArrayList positions = IntArrayList.wrap(new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
@@ -65,7 +65,7 @@ public class TestPositionsAppenderPageBuilder
                 .as("pageBuilder should be full")
                 .isTrue();
         PositionsAppenderSizeAccumulator sizeAccumulator = pageBuilder.computeAppenderSizes();
-        assertThat(sizeAccumulator.getSizeInBytes()).isEqualTo(rleBlock.getSizeInBytes());
+        assertThat(sizeAccumulator.getSizeInBytes()).isEqualTo(rleBlock.getValue().getSizeInBytes());
         assertThat(sizeAccumulator.getDirectSizeInBytes() < maxDirectSize)
                 .as("direct size should still be below threshold")
                 .isTrue();
@@ -90,18 +90,18 @@ public class TestPositionsAppenderPageBuilder
         assertThat(sizeAccumulator.getDirectSizeInBytes()).isEqualTo(0L);
         assertThat(pageBuilder.isFull()).isFalse();
 
-        Block rleBlock = RunLengthEncodedBlock.create(VARCHAR, Slices.utf8Slice("test"), 10);
+        RunLengthEncodedBlock rleBlock = (RunLengthEncodedBlock) RunLengthEncodedBlock.create(VARCHAR, Slices.utf8Slice("test"), 10);
         Page inputPage = new Page(rleBlock);
 
         IntArrayList positions = IntArrayList.wrap(new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
         pageBuilder.appendToOutputPartition(inputPage, positions);
         // 10 positions inserted, size in bytes is still the same since we're in RLE mode but direct size is 10x
         sizeAccumulator = pageBuilder.computeAppenderSizes();
-        assertThat(sizeAccumulator.getSizeInBytes()).isEqualTo(rleBlock.getSizeInBytes());
+        assertThat(sizeAccumulator.getSizeInBytes()).isEqualTo(rleBlock.getValue().getSizeInBytes());
         assertThat(pageBuilder.getSizeInBytes())
                 .as("pageBuilder sizeInBytes must match sizeAccumulator value")
                 .isEqualTo(sizeAccumulator.getSizeInBytes());
-        assertThat(sizeAccumulator.getDirectSizeInBytes()).isEqualTo(rleBlock.getSizeInBytes() * 10);
+        assertThat(sizeAccumulator.getDirectSizeInBytes()).isEqualTo(rleBlock.getValue().getSizeInBytes() * 10);
         assertThat(pageBuilder.isFull()).isFalse();
 
         // Keep inserting until the direct size limit is reached
@@ -112,7 +112,7 @@ public class TestPositionsAppenderPageBuilder
         sizeAccumulator = pageBuilder.computeAppenderSizes();
         assertThat(sizeAccumulator.getSizeInBytes())
                 .as("sizeInBytes must still report the RLE block size only")
-                .isEqualTo(rleBlock.getSizeInBytes());
+                .isEqualTo(rleBlock.getValue().getSizeInBytes());
         assertThat(pageBuilder.getSizeInBytes())
                 .as("pageBuilder sizeInBytes must match sizeAccumulator value")
                 .isEqualTo(sizeAccumulator.getSizeInBytes());

--- a/core/trino-main/src/test/java/io/trino/operator/project/BenchmarkDictionaryBlock.java
+++ b/core/trino-main/src/test/java/io/trino/operator/project/BenchmarkDictionaryBlock.java
@@ -65,12 +65,6 @@ public class BenchmarkDictionaryBlock
     }
 
     @Benchmark
-    public long getPositionsSizeInBytes(BenchmarkData data)
-    {
-        return data.getAllPositionsDictionaryBlock().getPositionsSizeInBytes(data.getSelectedPositionsMask(), data.getSelectedPositionCount());
-    }
-
-    @Benchmark
     public long getPositionsThenGetSizeInBytes(BenchmarkData data)
     {
         int[] positionIds = data.getPositionsIds();
@@ -252,14 +246,6 @@ public class BenchmarkDictionaryBlock
         BenchmarkData data = new BenchmarkData();
         data.setup();
         getSizeInBytes(data);
-    }
-
-    @Test
-    public void testGetPositionsSizeInBytes()
-    {
-        BenchmarkData data = new BenchmarkData();
-        data.setup();
-        getPositionsSizeInBytes(data);
     }
 
     @Test

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -324,6 +324,110 @@
                                     <code>java.method.parameterTypeChanged</code>
                                     <old>method void io.trino.spi.eventlistener.StageTaskStatistics::&lt;init&gt;(int, int, io.trino.spi.eventlistener.LongDistribution, io.trino.spi.eventlistener.LongDistribution, io.trino.spi.eventlistener.LongDistribution, io.trino.spi.eventlistener.LongDistribution, io.trino.spi.eventlistener.LongDistribution, io.trino.spi.eventlistener.LongDistribution, io.trino.spi.eventlistener.LongDistribution, io.trino.spi.eventlistener.LongDistribution, io.trino.spi.eventlistener.LongDistribution, io.trino.spi.eventlistener.LongDistribution, io.trino.spi.eventlistener.LongDistribution, io.trino.spi.eventlistener.LongSymmetricDistribution, io.trino.spi.eventlistener.LongSymmetricDistribution, io.trino.spi.eventlistener.LongSymmetricDistribution, io.trino.spi.eventlistener.LongSymmetricDistribution, io.trino.spi.eventlistener.LongSymmetricDistribution, io.trino.spi.eventlistener.LongSymmetricDistribution, io.trino.spi.eventlistener.DoubleSymmetricDistribution, io.trino.spi.eventlistener.DoubleSymmetricDistribution, io.trino.spi.eventlistener.DoubleSymmetricDistribution, io.trino.spi.eventlistener.DoubleSymmetricDistribution, io.trino.spi.eventlistener.DoubleSymmetricDistribution, io.trino.spi.eventlistener.DoubleSymmetricDistribution, io.trino.spi.eventlistener.DoubleSymmetricDistribution)</old>
                                 </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method java.util.OptionalInt io.trino.spi.block.ArrayBlock::fixedSizeInBytesPerPosition()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method long io.trino.spi.block.ArrayBlock::getPositionsSizeInBytes(boolean[], int)</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method java.util.OptionalInt io.trino.spi.block.Block::fixedSizeInBytesPerPosition()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method long io.trino.spi.block.Block::getPositionsSizeInBytes(boolean[], int)</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method java.util.OptionalInt io.trino.spi.block.ByteArrayBlock::fixedSizeInBytesPerPosition()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method long io.trino.spi.block.ByteArrayBlock::getPositionsSizeInBytes(boolean[], int)</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method java.util.OptionalInt io.trino.spi.block.DictionaryBlock::fixedSizeInBytesPerPosition()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method long io.trino.spi.block.DictionaryBlock::getPositionsSizeInBytes(boolean[], int)</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method java.util.OptionalInt io.trino.spi.block.Fixed12Block::fixedSizeInBytesPerPosition()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method long io.trino.spi.block.Fixed12Block::getPositionsSizeInBytes(boolean[], int)</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method java.util.OptionalInt io.trino.spi.block.Int128ArrayBlock::fixedSizeInBytesPerPosition()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method long io.trino.spi.block.Int128ArrayBlock::getPositionsSizeInBytes(boolean[], int)</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method java.util.OptionalInt io.trino.spi.block.IntArrayBlock::fixedSizeInBytesPerPosition()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method long io.trino.spi.block.IntArrayBlock::getPositionsSizeInBytes(boolean[], int)</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method java.util.OptionalInt io.trino.spi.block.LongArrayBlock::fixedSizeInBytesPerPosition()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method long io.trino.spi.block.LongArrayBlock::getPositionsSizeInBytes(boolean[], int)</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method java.util.OptionalInt io.trino.spi.block.MapBlock::fixedSizeInBytesPerPosition()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method long io.trino.spi.block.MapBlock::getPositionsSizeInBytes(boolean[], int)</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method java.util.OptionalInt io.trino.spi.block.RowBlock::fixedSizeInBytesPerPosition()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method long io.trino.spi.block.RowBlock::getPositionsSizeInBytes(boolean[], int)</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method java.util.OptionalInt io.trino.spi.block.RunLengthEncodedBlock::fixedSizeInBytesPerPosition()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method long io.trino.spi.block.RunLengthEncodedBlock::getPositionsSizeInBytes(boolean[], int)</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method java.util.OptionalInt io.trino.spi.block.ShortArrayBlock::fixedSizeInBytesPerPosition()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method long io.trino.spi.block.ShortArrayBlock::getPositionsSizeInBytes(boolean[], int)</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method java.util.OptionalInt io.trino.spi.block.VariableWidthBlock::fixedSizeInBytesPerPosition()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method long io.trino.spi.block.VariableWidthBlock::getPositionsSizeInBytes(boolean[], int)</old>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlock.java
@@ -16,21 +16,17 @@ package io.trino.spi.block;
 import jakarta.annotation.Nullable;
 
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkReadablePosition;
-import static io.trino.spi.block.BlockUtil.checkValidPositions;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.BlockUtil.compactArray;
 import static io.trino.spi.block.BlockUtil.compactOffsets;
 import static io.trino.spi.block.BlockUtil.copyIsNullAndAppendNull;
 import static io.trino.spi.block.BlockUtil.copyOffsetsAndAppendNull;
-import static io.trino.spi.block.BlockUtil.countAndMarkSelectedPositionsFromOffsets;
-import static io.trino.spi.block.BlockUtil.countSelectedPositionsFromOffsets;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -276,12 +272,6 @@ public final class ArrayBlock
     }
 
     @Override
-    public OptionalInt fixedSizeInBytesPerPosition()
-    {
-        return OptionalInt.empty(); // size per position varies based on the number of entries in each array
-    }
-
-    @Override
     public long getRegionSizeInBytes(int position, int length)
     {
         int positionCount = getPositionCount();
@@ -291,39 +281,6 @@ public final class ArrayBlock
         int valueEnd = offsets[arrayOffset + position + length];
 
         return values.getRegionSizeInBytes(valueStart, valueEnd - valueStart) + ((Integer.BYTES + Byte.BYTES) * (long) length);
-    }
-
-    @Override
-    public long getPositionsSizeInBytes(boolean[] positions, int selectedArrayPositions)
-    {
-        int positionCount = getPositionCount();
-        checkValidPositions(positions, positionCount);
-        if (selectedArrayPositions == 0) {
-            return 0;
-        }
-        if (selectedArrayPositions == positionCount) {
-            return getSizeInBytes();
-        }
-
-        Block rawElementBlock = values;
-        OptionalInt fixedPerElementSizeInBytes = rawElementBlock.fixedSizeInBytesPerPosition();
-        int[] offsets = this.offsets;
-        int offsetBase = arrayOffset;
-        long sizeInBytes;
-
-        if (fixedPerElementSizeInBytes.isPresent()) {
-            sizeInBytes = fixedPerElementSizeInBytes.getAsInt() * (long) countSelectedPositionsFromOffsets(positions, offsets, offsetBase);
-        }
-        else if (rawElementBlock instanceof RunLengthEncodedBlock) {
-            // RLE blocks don't have a fixed-size per position, but accept null for the position array
-            sizeInBytes = rawElementBlock.getPositionsSizeInBytes(null, countSelectedPositionsFromOffsets(positions, offsets, offsetBase));
-        }
-        else {
-            boolean[] selectedElements = new boolean[rawElementBlock.getPositionCount()];
-            int selectedElementCount = countAndMarkSelectedPositionsFromOffsets(positions, offsets, offsetBase, selectedElements);
-            sizeInBytes = rawElementBlock.getPositionsSizeInBytes(selectedElements, selectedElementCount);
-        }
-        return sizeInBytes + ((Integer.BYTES + Byte.BYTES) * (long) selectedArrayPositions);
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Block.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Block.java
@@ -38,15 +38,17 @@ public sealed interface Block
     int getPositionCount();
 
     /**
-     * Returns the size of this block as if it was compacted, ignoring any over-allocations.
-     * For example, in dictionary blocks, this only counts each dictionary entry once,
-     * rather than each time a value is referenced.
+     * Returns the estimated size of this block as if were fully expanded.
+     * This size includes the extra space to represent null values.
+     * For example, the size of an RLE block is the size of the repeated value
+     * times the number of positions in the block. The size of a dictionary
+     * block is the average size of a dictionary entry times the number of
+     * positions in the block.
      */
     long getSizeInBytes();
 
     /**
      * Returns the size of {@code block.getRegion(position, length)}.
-     * The method can be expensive. Do not use it outside an implementation of Block.
      */
     long getRegionSizeInBytes(int position, int length);
 

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Block.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Block.java
@@ -13,7 +13,6 @@
  */
 package io.trino.spi.block;
 
-import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
@@ -50,26 +49,6 @@ public sealed interface Block
      * The method can be expensive. Do not use it outside an implementation of Block.
      */
     long getRegionSizeInBytes(int position, int length);
-
-    /**
-     * Returns the number of bytes (in terms of {@link Block#getSizeInBytes()}) required per position
-     * that this block contains, assuming that the number of bytes required is a known static quantity
-     * and not dependent on any particular specific position. This allows for some complex block wrappings
-     * to potentially avoid having to call {@link Block#getPositionsSizeInBytes(boolean[], int)}  which
-     * would require computing the specific positions selected
-     *
-     * @return The size in bytes, per position, if this block type does not require specific position information to compute its size
-     */
-    OptionalInt fixedSizeInBytesPerPosition();
-
-    /**
-     * Returns the size of all positions marked true in the positions array.
-     * This is equivalent to multiple calls of {@code block.getRegionSizeInBytes(position, length)}
-     * where you mark all positions for the regions first.
-     * The 'selectedPositionsCount' variable may be used to skip iterating through
-     * the positions array in case this is a fixed-width block
-     */
-    long getPositionsSizeInBytes(boolean[] positions, int selectedPositionsCount);
 
     /**
      * Returns the retained size of this block in memory, including over-allocations.

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlock.java
@@ -18,7 +18,6 @@ import io.airlift.slice.Slices;
 import jakarta.annotation.Nullable;
 
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
 import static io.airlift.slice.SizeOf.instanceSize;
@@ -96,21 +95,9 @@ public final class ByteArrayBlock
     }
 
     @Override
-    public OptionalInt fixedSizeInBytesPerPosition()
-    {
-        return OptionalInt.of(SIZE_IN_BYTES_PER_POSITION);
-    }
-
-    @Override
     public long getRegionSizeInBytes(int position, int length)
     {
         return SIZE_IN_BYTES_PER_POSITION * (long) length;
-    }
-
-    @Override
-    public long getPositionsSizeInBytes(boolean[] positions, int selectedPositionsCount)
-    {
-        return (long) SIZE_IN_BYTES_PER_POSITION * selectedPositionsCount;
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Fixed12Block.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Fixed12Block.java
@@ -16,7 +16,6 @@ package io.trino.spi.block;
 import jakarta.annotation.Nullable;
 
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
 import static io.airlift.slice.SizeOf.instanceSize;
@@ -73,12 +72,6 @@ public final class Fixed12Block
     }
 
     @Override
-    public OptionalInt fixedSizeInBytesPerPosition()
-    {
-        return OptionalInt.of(SIZE_IN_BYTES_PER_POSITION);
-    }
-
-    @Override
     public long getSizeInBytes()
     {
         return SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
@@ -88,12 +81,6 @@ public final class Fixed12Block
     public long getRegionSizeInBytes(int position, int length)
     {
         return SIZE_IN_BYTES_PER_POSITION * (long) length;
-    }
-
-    @Override
-    public long getPositionsSizeInBytes(boolean[] positions, int selectedPositionsCount)
-    {
-        return (long) SIZE_IN_BYTES_PER_POSITION * selectedPositionsCount;
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlock.java
@@ -17,7 +17,6 @@ import io.trino.spi.type.Int128;
 import jakarta.annotation.Nullable;
 
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
 import static io.airlift.slice.SizeOf.instanceSize;
@@ -74,12 +73,6 @@ public final class Int128ArrayBlock
     }
 
     @Override
-    public OptionalInt fixedSizeInBytesPerPosition()
-    {
-        return OptionalInt.of(SIZE_IN_BYTES_PER_POSITION);
-    }
-
-    @Override
     public long getSizeInBytes()
     {
         return SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
@@ -89,12 +82,6 @@ public final class Int128ArrayBlock
     public long getRegionSizeInBytes(int position, int length)
     {
         return SIZE_IN_BYTES_PER_POSITION * (long) length;
-    }
-
-    @Override
-    public long getPositionsSizeInBytes(boolean[] positions, int selectedPositionsCount)
-    {
-        return (long) SIZE_IN_BYTES_PER_POSITION * selectedPositionsCount;
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlock.java
@@ -17,7 +17,6 @@ import io.trino.spi.Experimental;
 import jakarta.annotation.Nullable;
 
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
 import static io.airlift.slice.SizeOf.instanceSize;
@@ -73,12 +72,6 @@ public final class IntArrayBlock
     }
 
     @Override
-    public OptionalInt fixedSizeInBytesPerPosition()
-    {
-        return OptionalInt.of(SIZE_IN_BYTES_PER_POSITION);
-    }
-
-    @Override
     public long getSizeInBytes()
     {
         return SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
@@ -88,12 +81,6 @@ public final class IntArrayBlock
     public long getRegionSizeInBytes(int position, int length)
     {
         return SIZE_IN_BYTES_PER_POSITION * (long) length;
-    }
-
-    @Override
-    public long getPositionsSizeInBytes(boolean[] positions, int selectedPositionsCount)
-    {
-        return (long) SIZE_IN_BYTES_PER_POSITION * selectedPositionsCount;
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlock.java
@@ -16,7 +16,6 @@ package io.trino.spi.block;
 import jakarta.annotation.Nullable;
 
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
 import static io.airlift.slice.SizeOf.instanceSize;
@@ -72,12 +71,6 @@ public final class LongArrayBlock
     }
 
     @Override
-    public OptionalInt fixedSizeInBytesPerPosition()
-    {
-        return OptionalInt.of(SIZE_IN_BYTES_PER_POSITION);
-    }
-
-    @Override
     public long getSizeInBytes()
     {
         return SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
@@ -87,12 +80,6 @@ public final class LongArrayBlock
     public long getRegionSizeInBytes(int position, int length)
     {
         return SIZE_IN_BYTES_PER_POSITION * (long) length;
-    }
-
-    @Override
-    public long getPositionsSizeInBytes(boolean[] positions, int selectedPositionsCount)
-    {
-        return (long) SIZE_IN_BYTES_PER_POSITION * selectedPositionsCount;
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/MapBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/MapBlock.java
@@ -19,21 +19,17 @@ import jakarta.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkReadablePosition;
-import static io.trino.spi.block.BlockUtil.checkValidPositions;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.BlockUtil.compactArray;
 import static io.trino.spi.block.BlockUtil.compactOffsets;
 import static io.trino.spi.block.BlockUtil.copyIsNullAndAppendNull;
 import static io.trino.spi.block.BlockUtil.copyOffsetsAndAppendNull;
-import static io.trino.spi.block.BlockUtil.countAndMarkSelectedPositionsFromOffsets;
-import static io.trino.spi.block.BlockUtil.countSelectedPositionsFromOffsets;
 import static io.trino.spi.block.MapHashTables.HASH_MULTIPLIER;
 import static io.trino.spi.block.MapHashTables.HashBuildMode.DUPLICATE_NOT_CHECKED;
 import static java.lang.String.format;
@@ -417,66 +413,6 @@ public final class MapBlock
                 valueBlock.getRegionSizeInBytes(entriesStart, entryCount) +
                 (Integer.BYTES + Byte.BYTES) * (long) length +
                 Integer.BYTES * HASH_MULTIPLIER * (long) entryCount;
-    }
-
-    @Override
-    public OptionalInt fixedSizeInBytesPerPosition()
-    {
-        return OptionalInt.empty(); // size per row is variable on the number of entries in each row
-    }
-
-    private OptionalInt keyAndValueFixedSizeInBytesPerRow()
-    {
-        OptionalInt keyFixedSizePerRow = keyBlock.fixedSizeInBytesPerPosition();
-        if (keyFixedSizePerRow.isEmpty()) {
-            return OptionalInt.empty();
-        }
-        OptionalInt valueFixedSizePerRow = valueBlock.fixedSizeInBytesPerPosition();
-        if (valueFixedSizePerRow.isEmpty()) {
-            return OptionalInt.empty();
-        }
-
-        return OptionalInt.of(keyFixedSizePerRow.getAsInt() + valueFixedSizePerRow.getAsInt());
-    }
-
-    @Override
-    public long getPositionsSizeInBytes(boolean[] positions, int selectedMapPositions)
-    {
-        int positionCount = getPositionCount();
-        checkValidPositions(positions, positionCount);
-        if (selectedMapPositions == 0) {
-            return 0;
-        }
-        if (selectedMapPositions == positionCount) {
-            return getSizeInBytes();
-        }
-
-        int[] offsets = this.offsets;
-        int offsetBase = startOffset;
-        OptionalInt fixedKeyAndValueSizePerRow = keyAndValueFixedSizeInBytesPerRow();
-
-        int selectedEntryCount;
-        long keyAndValuesSizeInBytes;
-        if (fixedKeyAndValueSizePerRow.isPresent()) {
-            // no new positions array need be created, we can just count the number of elements
-            selectedEntryCount = countSelectedPositionsFromOffsets(positions, offsets, offsetBase);
-            keyAndValuesSizeInBytes = fixedKeyAndValueSizePerRow.getAsInt() * (long) selectedEntryCount;
-        }
-        else {
-            // We can use either the getRegionSizeInBytes or getPositionsSizeInBytes
-            // from the underlying raw blocks to implement this function. We chose
-            // getPositionsSizeInBytes with the assumption that constructing a
-            // positions array is cheaper than calling getRegionSizeInBytes for each
-            // used position.
-            boolean[] entryPositions = new boolean[keyBlock.getPositionCount()];
-            selectedEntryCount = countAndMarkSelectedPositionsFromOffsets(positions, offsets, offsetBase, entryPositions);
-            keyAndValuesSizeInBytes = keyBlock.getPositionsSizeInBytes(entryPositions, selectedEntryCount) +
-                    valueBlock.getPositionsSizeInBytes(entryPositions, selectedEntryCount);
-        }
-
-        return keyAndValuesSizeInBytes +
-                (Integer.BYTES + Byte.BYTES) * (long) selectedMapPositions +
-                Integer.BYTES * HASH_MULTIPLIER * (long) selectedEntryCount;
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
@@ -18,7 +18,6 @@ import jakarta.annotation.Nullable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
 import static io.airlift.slice.SizeOf.instanceSize;
@@ -26,7 +25,6 @@ import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.arraySame;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.BlockUtil.checkReadablePosition;
-import static io.trino.spi.block.BlockUtil.checkValidPositions;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.BlockUtil.compactArray;
 import static java.lang.String.format;
@@ -45,7 +43,6 @@ public final class RowBlock
      */
     private final Block[] fieldBlocks;
     private final List<Block> fieldBlocksList;
-    private final int fixedSizePerRow;
 
     private volatile long sizeInBytes = -1;
     private volatile long retainedSizeInBytes = -1;
@@ -82,25 +79,14 @@ public final class RowBlock
 
     static RowBlock createRowBlockInternal(int positionCount, @Nullable boolean[] rowIsNull, Block[] fieldBlocks)
     {
-        int fixedSize = Byte.BYTES;
-        for (Block fieldBlock : fieldBlocks) {
-            OptionalInt fieldFixedSize = fieldBlock.fixedSizeInBytesPerPosition();
-            if (fieldFixedSize.isEmpty()) {
-                // found a block without a single per-position size
-                fixedSize = -1;
-                break;
-            }
-            fixedSize += fieldFixedSize.getAsInt();
-        }
-
-        return new RowBlock(positionCount, rowIsNull, fieldBlocks, fixedSize);
+        return new RowBlock(positionCount, rowIsNull, fieldBlocks);
     }
 
     /**
      * Use createRowBlockInternal or fromFieldBlocks instead of this method. The caller of this method is assumed to have
      * validated the arguments with validateConstructorArguments.
      */
-    private RowBlock(int positionCount, @Nullable boolean[] rowIsNull, Block[] fieldBlocks, int fixedSizePerRow)
+    private RowBlock(int positionCount, @Nullable boolean[] rowIsNull, Block[] fieldBlocks)
     {
         if (positionCount < 0) {
             throw new IllegalArgumentException("positionCount is negative");
@@ -125,7 +111,6 @@ public final class RowBlock
         this.rowIsNull = positionCount == 0 ? null : rowIsNull;
         this.fieldBlocks = fieldBlocks;
         this.fieldBlocksList = List.of(fieldBlocks);
-        this.fixedSizePerRow = fixedSizePerRow;
     }
 
     Block[] getRawFieldBlocks()
@@ -238,7 +223,7 @@ public final class RowBlock
         for (int i = 0; i < fieldBlocks.length; i++) {
             newBlocks[i] = fieldBlocks[i].copyWithAppendedNull();
         }
-        return new RowBlock(positionCount + 1, newRowIsNull, newBlocks, fixedSizePerRow);
+        return new RowBlock(positionCount + 1, newRowIsNull, newBlocks);
     }
 
     @Override
@@ -259,7 +244,7 @@ public final class RowBlock
             }
         }
 
-        return new RowBlock(length, newRowIsNull, newBlocks, fixedSizePerRow);
+        return new RowBlock(length, newRowIsNull, newBlocks);
     }
 
     @Override
@@ -275,13 +260,7 @@ public final class RowBlock
         for (int i = 0; i < newBlocks.length; i++) {
             newBlocks[i] = fieldBlocks[i].getRegion(positionOffset, length);
         }
-        return new RowBlock(length, newRowIsNull, newBlocks, fixedSizePerRow);
-    }
-
-    @Override
-    public OptionalInt fixedSizeInBytesPerPosition()
-    {
-        return fixedSizePerRow > 0 ? OptionalInt.of(fixedSizePerRow) : OptionalInt.empty();
+        return new RowBlock(length, newRowIsNull, newBlocks);
     }
 
     @Override
@@ -294,28 +273,6 @@ public final class RowBlock
             regionSizeInBytes += fieldBlock.getRegionSizeInBytes(position, length);
         }
         return regionSizeInBytes;
-    }
-
-    @Override
-    public long getPositionsSizeInBytes(boolean[] positions, int selectedRowPositions)
-    {
-        checkValidPositions(positions, positionCount);
-        if (selectedRowPositions == 0) {
-            return 0;
-        }
-        if (selectedRowPositions == positionCount) {
-            return getSizeInBytes();
-        }
-
-        if (fixedSizePerRow > 0) {
-            return fixedSizePerRow * (long) selectedRowPositions;
-        }
-
-        long sizeInBytes = Byte.BYTES * (long) selectedRowPositions;
-        for (Block fieldBlock : fieldBlocks) {
-            sizeInBytes += fieldBlock.getPositionsSizeInBytes(positions, selectedRowPositions);
-        }
-        return sizeInBytes;
     }
 
     @Override
@@ -332,7 +289,7 @@ public final class RowBlock
         if (newRowIsNull == rowIsNull && arraySame(newBlocks, fieldBlocks)) {
             return this;
         }
-        return new RowBlock(length, newRowIsNull, newBlocks, fixedSizePerRow);
+        return new RowBlock(length, newRowIsNull, newBlocks);
     }
 
     public SqlRow getRow(int position)
@@ -354,7 +311,7 @@ public final class RowBlock
             newBlocks[i] = fieldBlocks[i].getSingleValueBlock(position);
         }
         boolean[] newRowIsNull = isNull(position) ? new boolean[] {true} : null;
-        return new RowBlock(1, newRowIsNull, newBlocks, fixedSizePerRow);
+        return new RowBlock(1, newRowIsNull, newBlocks);
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
@@ -48,6 +48,7 @@ public final class RowBlock
     private final int fixedSizePerRow;
 
     private volatile long sizeInBytes = -1;
+    private volatile long retainedSizeInBytes = -1;
 
     /**
      * Create a row block directly from field blocks. The returned RowBlock will not contain any null rows, although the fields may contain null values.
@@ -191,9 +192,13 @@ public final class RowBlock
     @Override
     public long getRetainedSizeInBytes()
     {
-        long retainedSizeInBytes = INSTANCE_SIZE + sizeOf(fieldBlocks) + sizeOf(rowIsNull);
-        for (Block fieldBlock : fieldBlocks) {
-            retainedSizeInBytes += fieldBlock.getRetainedSizeInBytes();
+        long retainedSizeInBytes = this.retainedSizeInBytes;
+        if (retainedSizeInBytes < 0) {
+            retainedSizeInBytes = INSTANCE_SIZE + sizeOf(fieldBlocks) + sizeOf(rowIsNull);
+            for (Block fieldBlock : fieldBlocks) {
+                retainedSizeInBytes += fieldBlock.getRetainedSizeInBytes();
+            }
+            this.retainedSizeInBytes = retainedSizeInBytes;
         }
         return retainedSizeInBytes;
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
@@ -191,7 +191,7 @@ public final class RowBlock
     @Override
     public long getRetainedSizeInBytes()
     {
-        long retainedSizeInBytes = INSTANCE_SIZE + sizeOf(rowIsNull);
+        long retainedSizeInBytes = INSTANCE_SIZE + sizeOf(fieldBlocks) + sizeOf(rowIsNull);
         for (Block fieldBlock : fieldBlocks) {
             retainedSizeInBytes += fieldBlock.getRetainedSizeInBytes();
         }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
@@ -15,9 +15,7 @@ package io.trino.spi.block;
 
 import io.trino.spi.predicate.Utils;
 import io.trino.spi.type.Type;
-import jakarta.annotation.Nullable;
 
-import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
 import static io.airlift.slice.SizeOf.instanceSize;
@@ -102,12 +100,6 @@ public final class RunLengthEncodedBlock
     }
 
     @Override
-    public OptionalInt fixedSizeInBytesPerPosition()
-    {
-        return OptionalInt.empty(); // size does not vary per position selected
-    }
-
-    @Override
     public long getSizeInBytes()
     {
         return value.getSizeInBytes() * positionCount;
@@ -163,12 +155,6 @@ public final class RunLengthEncodedBlock
     public long getRegionSizeInBytes(int position, int length)
     {
         return value.getSizeInBytes() * length;
-    }
-
-    @Override
-    public long getPositionsSizeInBytes(@Nullable boolean[] positions, int selectedPositionCount)
-    {
-        return value.getSizeInBytes() * selectedPositionCount;
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
@@ -110,7 +110,7 @@ public final class RunLengthEncodedBlock
     @Override
     public long getSizeInBytes()
     {
-        return value.getSizeInBytes();
+        return value.getSizeInBytes() * positionCount;
     }
 
     @Override
@@ -162,13 +162,13 @@ public final class RunLengthEncodedBlock
     @Override
     public long getRegionSizeInBytes(int position, int length)
     {
-        return value.getSizeInBytes();
+        return value.getSizeInBytes() * length;
     }
 
     @Override
     public long getPositionsSizeInBytes(@Nullable boolean[] positions, int selectedPositionCount)
     {
-        return value.getSizeInBytes();
+        return value.getSizeInBytes() * selectedPositionCount;
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlock.java
@@ -16,7 +16,6 @@ package io.trino.spi.block;
 import jakarta.annotation.Nullable;
 
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
 import static io.airlift.slice.SizeOf.instanceSize;
@@ -72,12 +71,6 @@ public final class ShortArrayBlock
     }
 
     @Override
-    public OptionalInt fixedSizeInBytesPerPosition()
-    {
-        return OptionalInt.of(SIZE_IN_BYTES_PER_POSITION);
-    }
-
-    @Override
     public long getSizeInBytes()
     {
         return SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
@@ -87,12 +80,6 @@ public final class ShortArrayBlock
     public long getRegionSizeInBytes(int position, int length)
     {
         return SIZE_IN_BYTES_PER_POSITION * (long) length;
-    }
-
-    @Override
-    public long getPositionsSizeInBytes(boolean[] positions, int selectedPositionsCount)
-    {
-        return (long) SIZE_IN_BYTES_PER_POSITION * selectedPositionsCount;
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlock.java
@@ -19,7 +19,6 @@ import io.airlift.slice.Slices;
 import jakarta.annotation.Nullable;
 
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.function.ObjLongConsumer;
 
 import static io.airlift.slice.SizeOf.instanceSize;
@@ -119,12 +118,6 @@ public final class VariableWidthBlock
     }
 
     @Override
-    public OptionalInt fixedSizeInBytesPerPosition()
-    {
-        return OptionalInt.empty(); // size varies per element and is not fixed
-    }
-
-    @Override
     public long getSizeInBytes()
     {
         return sizeInBytes;
@@ -134,24 +127,6 @@ public final class VariableWidthBlock
     public long getRegionSizeInBytes(int position, int length)
     {
         return offsets[arrayOffset + position + length] - offsets[arrayOffset + position] + ((Integer.BYTES + Byte.BYTES) * (long) length);
-    }
-
-    @Override
-    public long getPositionsSizeInBytes(boolean[] positions, int selectedPositionsCount)
-    {
-        if (selectedPositionsCount == 0) {
-            return 0;
-        }
-        if (selectedPositionsCount == positionCount) {
-            return getSizeInBytes();
-        }
-        long sizeInBytes = 0;
-        for (int i = 0; i < positions.length; ++i) {
-            if (positions[i]) {
-                sizeInBytes += offsets[arrayOffset + i + 1] - offsets[arrayOffset + i];
-            }
-        }
-        return sizeInBytes + (Integer.BYTES + Byte.BYTES) * (long) selectedPositionsCount;
     }
 
     @Override

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/rcfile/PageSplitterUtil.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/rcfile/PageSplitterUtil.java
@@ -37,8 +37,8 @@ public final class PageSplitterUtil
         checkArgument(page.getPositionCount() > 0, "page is empty");
         checkArgument(maxPageSizeInBytes > 0, "maxPageSizeInBytes must be > 0");
 
-        // for Pages with certain types of Blocks (e.g., RLE blocks) the size in bytes may remain constant
-        // through the recursive calls, which causes the recursion to only terminate when page.getPositionCount() == 1
+        // In case the size in bytes remains constant through the recursive calls,
+        // the recursion would only terminate when page.getPositionCount() == 1
         // and create potentially a large number of Page's of size 1. So we check here that
         // if the size of the page doesn't improve from the previous call we terminate the recursion.
         if (page.getSizeInBytes() == previousPageSize || page.getSizeInBytes() <= maxPageSizeInBytes || page.getPositionCount() == 1) {


### PR DESCRIPTION
## Description
The Block `getSizeinBytes` method has been defined to return the "compacted" size of a block.  This means for an RLE only the size of the single value is returned, and for a dictionary block the size of each position is computed from the dictionary. This computation is quite expensive and requires Blocks to have `getPositionsSizeInBytes` and `fixedSizeInBytesPerPosition` methods. 

This PR changes the implementation to be defined as returning an estimate of the full data size of a block. This means for an RLE block the size is `value.getSizeInBytes() * positionCount` and dictionary is `(dictionary.getSizeInBytes() / dictionary.getPositionCount()) * positionCount`, which is simpler and much faster to compute.

## Current Usage

The `getSizeinBytes` method is typically used to estimate the size needed for output buffers when copying data in operators and generally these usages assume that the value returned is a fully expanded size.  The other main usage is in stats, and here the change will have visible effects.  This method is often used to calculate the input/output size of operators, sources, and sinks.  It is not clear if the these uses intended to have compacted or fully expanded size.

## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## SPI
* Block `getSizeInBytes` now returns an estimate of the full data size of the block. ({issue}`issuenumber`)
```
