### PR TITLE
Remove unnecessary catalog access check in FileBasedSystemAccessControl

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
@@ -668,10 +668,6 @@ public class FileBasedSystemAccessControl
     @Override
     public void checkCanSelectFromColumns(SystemSecurityContext context, CatalogSchemaTableName table, Set<String> columns)
     {
-        if (!canAccessCatalog(context, table.getCatalogName(), READ_ONLY)) {
-            denySelectTable(table.toString());
-        }
-
         if (INFORMATION_SCHEMA_NAME.equals(table.getSchemaTableName().getSchemaName())) {
             return;
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
`FileBasedSystemAccessControl.checkCanSelectFromColumns()` checks catalog read access but no need to check there because it's checked in `AccessControlManager`.

https://github.com/trinodb/trino/blob/17fcbb7a4c302921194cfc9e70fca82fb7b34398/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java#L1094-L1105

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
