### PR TITLE
Update minimum Vertica version to 11

### DIFF
--- a/docs/src/main/sphinx/connector/vertica.md
+++ b/docs/src/main/sphinx/connector/vertica.md
@@ -18,7 +18,7 @@ external data source.
 
 To connect to Vertica, you need:
 
-- Vertica 9.1.x or higher.
+- Vertica 11.x or higher.
 - Network access from the coordinator and workers to the Vertica server.
   Port 5433 is the default port.
 

--- a/plugin/trino-vertica/src/test/java/io/trino/plugin/vertica/TestVerticaConnectorSmokeTest.java
+++ b/plugin/trino-vertica/src/test/java/io/trino/plugin/vertica/TestVerticaConnectorSmokeTest.java
@@ -15,7 +15,7 @@ package io.trino.plugin.vertica;
 
 import io.trino.testing.QueryRunner;
 
-import static io.trino.plugin.vertica.TestingVerticaServer.DEFAULT_IMAGE;
+import static io.trino.plugin.vertica.TestingVerticaServer.DEFAULT_VERSION;
 
 public class TestVerticaConnectorSmokeTest
         extends BaseVerticaConnectorSmokeTest
@@ -24,7 +24,7 @@ public class TestVerticaConnectorSmokeTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return VerticaQueryRunner.builder(closeAfterClass(new TestingVerticaServer(DEFAULT_IMAGE)))
+        return VerticaQueryRunner.builder(closeAfterClass(new TestingVerticaServer(DEFAULT_VERSION)))
                 .setTables(REQUIRED_TPCH_TABLES)
                 .build();
     }

--- a/plugin/trino-vertica/src/test/java/io/trino/plugin/vertica/TestVerticaLatestConnectorSmokeTest.java
+++ b/plugin/trino-vertica/src/test/java/io/trino/plugin/vertica/TestVerticaLatestConnectorSmokeTest.java
@@ -15,7 +15,7 @@ package io.trino.plugin.vertica;
 
 import io.trino.testing.QueryRunner;
 
-import static io.trino.plugin.vertica.TestingVerticaServer.LATEST_IMAGE;
+import static io.trino.plugin.vertica.TestingVerticaServer.LATEST_VERSION;
 
 public class TestVerticaLatestConnectorSmokeTest
         extends BaseVerticaConnectorSmokeTest
@@ -24,7 +24,7 @@ public class TestVerticaLatestConnectorSmokeTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return VerticaQueryRunner.builder(closeAfterClass(new TestingVerticaServer(LATEST_IMAGE)))
+        return VerticaQueryRunner.builder(closeAfterClass(new TestingVerticaServer(LATEST_VERSION)))
                 .setTables(REQUIRED_TPCH_TABLES)
                 .build();
     }

--- a/plugin/trino-vertica/src/test/java/io/trino/plugin/vertica/TestVerticaTableStatistics.java
+++ b/plugin/trino-vertica/src/test/java/io/trino/plugin/vertica/TestVerticaTableStatistics.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 
-import static io.trino.plugin.vertica.TestingVerticaServer.LATEST_IMAGE;
+import static io.trino.plugin.vertica.TestingVerticaServer.LATEST_VERSION;
 import static io.trino.plugin.vertica.VerticaQueryRunner.TPCH_SCHEMA;
 import static io.trino.testing.sql.TestTable.fromColumns;
 import static java.lang.String.format;
@@ -54,7 +54,7 @@ public class TestVerticaTableStatistics
             throws Exception
     {
         // Use the latest image to avoid "Must be superuser to run export_statistics"
-        verticaServer = closeAfterClass(new TestingVerticaServer(LATEST_IMAGE));
+        verticaServer = closeAfterClass(new TestingVerticaServer(LATEST_VERSION));
         return VerticaQueryRunner.builder(verticaServer)
                 .addConnectorProperty("statistics.enabled", "true")
                 .setTables(ImmutableList.of(TpchTable.ORDERS, TpchTable.REGION, TpchTable.NATION))

--- a/plugin/trino-vertica/src/test/java/io/trino/plugin/vertica/TestingVerticaServer.java
+++ b/plugin/trino-vertica/src/test/java/io/trino/plugin/vertica/TestingVerticaServer.java
@@ -38,11 +38,10 @@ import static java.util.Objects.requireNonNull;
 public class TestingVerticaServer
         extends JdbcDatabaseContainer<TestingVerticaServer>
 {
-    public static final String LATEST_IMAGE = "vertica/vertica-ce:23.4.0-0";
-    public static final String DEFAULT_IMAGE = "datagrip/vertica:9.1.1";
+    public static final String LATEST_VERSION = "23.4.0-0";
+    public static final String DEFAULT_VERSION = "11.0.0-0";
 
     public static final Integer PORT = 5433;
-    public static final String SCHEMA = "tpch";
 
     public static final String DATABASE = "tpch";
     private static final String USER = "test_user";
@@ -55,17 +54,17 @@ public class TestingVerticaServer
 
     public TestingVerticaServer()
     {
-        this(DEFAULT_IMAGE, DATABASE, USER, PASSWORD);
+        this(DEFAULT_VERSION, DATABASE, USER, PASSWORD);
     }
 
-    public TestingVerticaServer(String dockerImageName)
+    public TestingVerticaServer(String version)
     {
-        this(dockerImageName, DATABASE, USER, PASSWORD);
+        this(version, DATABASE, USER, PASSWORD);
     }
 
-    public TestingVerticaServer(String dockerImageName, String database, String user, String password)
+    public TestingVerticaServer(String version, String database, String user, String password)
     {
-        super(DockerImageName.parse(dockerImageName));
+        super(DockerImageName.parse("vertica/vertica-ce").withTag(version));
         this.database = requireNonNull(database, "database is null");
         this.user = requireNonNull(user, "user is null");
         this.password = requireNonNull(password, "password is null");
@@ -85,19 +84,11 @@ public class TestingVerticaServer
     protected void configure()
     {
         addExposedPort(PORT);
-        if (getDockerImageName().contains("datagrip/vertica:")) {
-            addEnv("VERTICA_DB", database);
-            addEnv("VERTICA_SCHEMA", SCHEMA);
-            addEnv("VERTICA_USER", user);
-            addEnv("VERTICA_PASSWORD", password);
-        }
-        else if (getDockerImageName().contains("vertica/vertica-ce:")) {
-            addEnv("VERTICA_DB_NAME", database);
-            addEnv("APP_DB_USER", user);
-            addEnv("APP_DB_PASSWORD", password);
-            withCopyFileToContainer(MountableFile.forClasspathResource("vmart_define_schema.sql"), "/opt/vertica/examples/VMart_Schema");
-            withCopyFileToContainer(MountableFile.forClasspathResource("vmart_load_data.sql"), "/opt/vertica/examples/VMart_Schema");
-        }
+        addEnv("VERTICA_DB_NAME", database);
+        addEnv("APP_DB_USER", user);
+        addEnv("APP_DB_PASSWORD", password);
+        withCopyFileToContainer(MountableFile.forClasspathResource("vmart_define_schema.sql"), "/opt/vertica/examples/VMart_Schema");
+        withCopyFileToContainer(MountableFile.forClasspathResource("vmart_load_data.sql"), "/opt/vertica/examples/VMart_Schema");
         setStartupAttempts(3);
     }
 


### PR DESCRIPTION
## Description

https://www.microfocus.com/productlifecycle/?term=Vertica

EOL schedule:
* Vertica 9: 31 Oct 2021
* Vertica 10: 28 Feb 2023

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
