### PR TITLE
Add number option to preserve in Iceberg `expire_snapshots` procedure

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergExpireSnapshotsHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergExpireSnapshotsHandle.java
@@ -15,13 +15,27 @@ package io.trino.plugin.iceberg.procedure;
 
 import io.airlift.units.Duration;
 
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
-public record IcebergExpireSnapshotsHandle(Duration retentionThreshold)
+public record IcebergExpireSnapshotsHandle(Duration retentionThreshold, Optional<Integer> retainLast)
         implements IcebergProcedureHandle
 {
     public IcebergExpireSnapshotsHandle
     {
         requireNonNull(retentionThreshold, "retentionThreshold is null");
+        requireNonNull(retainLast, "retainLast is null");
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .omitEmptyValues()
+                .add("retentionThreshold", retentionThreshold)
+                .add("retainLast", retainLast)
+                .toString();
     }
 }


### PR DESCRIPTION
## Description

Add `retain_last` option to `expire_snapshots` procedure in Iceberg connector.
Spark supports this option. https://iceberg.apache.org/docs/latest/spark-procedures/#expire_snapshots

Request in Trino Slack: https://trinodb.slack.com/archives/C0305TQ05KL/p1741348205204709
> Piyush Kumar
Hi Team, how can we keep only last 7 snapshot of table in desc order, currently i m keeping the last 7days snapshot using - ALTER TABLE {{ this }} EXECUTE expire_snapshots(retention_threshold => '7d')

## Release notes

```markdown
## Iceberg
* Fix some things. ({issue}`issuenumber`)
```
