### PR TITLE
Send query heartbeat while spooled data is downloaded

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/ClientSession.java
+++ b/client/trino-client/src/main/java/io/trino/client/ClientSession.java
@@ -32,6 +32,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class ClientSession
 {
@@ -57,6 +58,7 @@ public class ClientSession
     private final Duration clientRequestTimeout;
     private final boolean compressionDisabled;
     private final Optional<String> encoding;
+    private final Duration heartbeatInterval;
 
     public static Builder builder()
     {
@@ -97,7 +99,8 @@ public class ClientSession
             String transactionId,
             Duration clientRequestTimeout,
             boolean compressionDisabled,
-            Optional<String> encoding)
+            Optional<String> encoding,
+            Duration heartbeatInterval)
     {
         this.server = requireNonNull(server, "server is null");
         this.user = requireNonNull(user, "user is null");
@@ -121,6 +124,7 @@ public class ClientSession
         this.clientRequestTimeout = clientRequestTimeout;
         this.compressionDisabled = compressionDisabled;
         this.encoding = requireNonNull(encoding, "encoding is null");
+        this.heartbeatInterval = requireNonNull(heartbeatInterval, "heartbeatInterval is null");
 
         for (String clientTag : clientTags) {
             checkArgument(!clientTag.contains(","), "client tag cannot contain ','");
@@ -269,6 +273,11 @@ public class ClientSession
         return encoding;
     }
 
+    public Duration getHeartbeatInterval()
+    {
+        return heartbeatInterval;
+    }
+
     @Override
     public String toString()
     {
@@ -292,6 +301,7 @@ public class ClientSession
                 .add("clientRequestTimeout", clientRequestTimeout)
                 .add("compressionDisabled", compressionDisabled)
                 .add("encoding", encoding)
+                .add("heartbeatInterval", heartbeatInterval)
                 .omitNullValues()
                 .toString();
     }
@@ -320,6 +330,7 @@ public class ClientSession
         private Duration clientRequestTimeout;
         private boolean compressionDisabled;
         private Optional<String> encoding = Optional.empty();
+        private Duration heartbeatInterval = new Duration(30, SECONDS);
 
         private Builder() {}
 
@@ -482,6 +493,12 @@ public class ClientSession
             return this;
         }
 
+        public Builder heartbeatInterval(Duration heartbeatInterval)
+        {
+            this.heartbeatInterval = heartbeatInterval;
+            return this;
+        }
+
         public ClientSession build()
         {
             return new ClientSession(
@@ -506,7 +523,8 @@ public class ClientSession
                     transactionId,
                     clientRequestTimeout,
                     compressionDisabled,
-                    encoding);
+                    encoding,
+                    heartbeatInterval);
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/QueryManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryManagerConfig.java
@@ -358,7 +358,7 @@ public class QueryManagerConfig
         return this;
     }
 
-    @MinDuration("5s")
+    @MinDuration("1s")
     @NotNull
     public Duration getClientTimeout()
     {

--- a/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResource.java
@@ -34,6 +34,7 @@ import jakarta.annotation.PreDestroy;
 import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HEAD;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
@@ -157,6 +158,19 @@ public class ExecutingStatementResource
     {
         Query query = getQuery(queryId, slug, token);
         asyncQueryResults(query, token, externalUriInfo, asyncResponse);
+    }
+
+    @HEAD
+    @Path("{queryId}/{slug}/{token}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response heartbeat(@PathParam("queryId") QueryId queryId, @PathParam("slug") String slug, @PathParam("token") long token)
+    {
+        Query query = queries.get(queryId);
+        if (query != null && query.isSlugValid(slug, token)) {
+            queryManager.recordHeartbeat(queryId);
+            return Response.ok().build();
+        }
+        throw new NotFoundException("Query not found");
     }
 
     protected Query getQuery(QueryId queryId, String slug, long token)

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestServer.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestServer.java
@@ -27,16 +27,23 @@ import io.airlift.http.client.jetty.JettyHttpClient;
 import io.airlift.json.JsonCodec;
 import io.airlift.json.JsonCodecFactory;
 import io.airlift.json.ObjectMapperProvider;
+import io.airlift.units.Duration;
+import io.trino.client.ClientSession;
 import io.trino.client.QueryDataClientJacksonModule;
 import io.trino.client.QueryError;
 import io.trino.client.QueryResults;
 import io.trino.client.ResultRowsDecoder;
+import io.trino.client.StatementClient;
+import io.trino.client.StatementClientFactory;
+import io.trino.client.uri.TrinoUri;
 import io.trino.plugin.memory.MemoryPlugin;
+import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.server.BasicQueryInfo;
 import io.trino.server.testing.TestingTrinoServer;
 import io.trino.spi.QueryId;
 import io.trino.spi.type.TimeZoneNotSupportedException;
 import io.trino.testing.TestingTrinoClient;
+import okhttp3.OkHttpClient;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -45,10 +52,12 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 
 import java.net.URI;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
@@ -76,6 +85,7 @@ import static io.trino.SystemSessionProperties.QUERY_MAX_MEMORY;
 import static io.trino.client.ClientCapabilities.PATH;
 import static io.trino.client.ClientCapabilities.SESSION_AUTHORIZATION;
 import static io.trino.client.ProtocolHeaders.TRINO_HEADERS;
+import static io.trino.client.uri.HttpClientFactory.toHttpClientBuilder;
 import static io.trino.spi.StandardErrorCode.INCOMPATIBLE_CLIENT;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -106,11 +116,13 @@ public class TestServer
     public void setup()
     {
         server = TestingTrinoServer.builder()
-                .setProperties(ImmutableMap.of("http-server.process-forwarded", "true"))
+                .setProperties(ImmutableMap.of("http-server.process-forwarded", "true", "query.client.timeout", "1s"))
                 .build();
 
         server.installPlugin(new MemoryPlugin());
+        server.installPlugin(new TpchPlugin());
         server.createCatalog("memory", "memory");
+        server.createCatalog("tpch", "tpch");
 
         client = new JettyHttpClient();
     }
@@ -178,7 +190,7 @@ public class TestServer
         QueryResults results = data.orElseThrow();
 
         try (ResultRowsDecoder decoder = new ResultRowsDecoder()) {
-            assertThat(decoder.toRows(results)).containsOnly(ImmutableList.of("memory"), ImmutableList.of("system"));
+            assertThat(decoder.toRows(results)).containsOnly(ImmutableList.of("memory"), ImmutableList.of("system"), ImmutableList.of("tpch"));
         }
     }
 
@@ -236,7 +248,7 @@ public class TestServer
         assertThat(queryInfo.getSession().getPreparedStatements()).isEqualTo(ImmutableMap.of("foo", "select * from bar"));
 
         List<List<Object>> rows = data.build();
-        assertThat(rows).isEqualTo(ImmutableList.of(ImmutableList.of("memory"), ImmutableList.of("system")));
+        assertThat(rows).isEqualTo(ImmutableList.of(ImmutableList.of("memory"), ImmutableList.of("system"), ImmutableList.of("tpch")));
     }
 
     @Test
@@ -322,6 +334,46 @@ public class TestServer
         try (TestingTrinoClient testingClient = new TestingTrinoClient(server, testSessionBuilder().setClientCapabilities(Set.of(
                 SESSION_AUTHORIZATION.name())).build())) {
             testingClient.execute("SET SESSION AUTHORIZATION userA");
+        }
+    }
+
+    @Test
+    public void testAbandonedQueries()
+            throws InterruptedException
+    {
+        TrinoUri trinoUri = TrinoUri.builder()
+                .setUri(server.getBaseUrl())
+                .build();
+
+        OkHttpClient httpClient = toHttpClientBuilder(trinoUri, "Trino Test").build();
+        ClientSession session = ClientSession.builder()
+                .server(server.getBaseUrl())
+                .source("test")
+                .timeZone(ZoneId.of("UTC"))
+                .user(Optional.of("user"))
+                .heartbeatInterval(new Duration(1, TimeUnit.SECONDS))
+                .build();
+
+        try (StatementClient client = StatementClientFactory.newStatementClient(httpClient, session, "SELECT * FROM tpch.sf1.nation")) {
+            client.advance();
+            Thread.sleep(2000); // client timeout exceeded
+            client.advance();
+            assertThat(client.currentStatusInfo().getError().getMessage())
+                    .contains("was abandoned by the client, as it may have exited or stopped checking for query results");
+        }
+
+        try (StatementClient client = StatementClientFactory.newStatementClient(httpClient, session, "SELECT * FROM tpch.sf1.nation")) {
+            while (client.advance()) {
+                client.currentRows().forEach(_ -> {
+                    try {
+                        Thread.sleep(100); // 25 rows * 100 ms = 2500 ms > client timeout
+                    }
+                    catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+                assertThat(client.currentStatusInfo().getError()).isNull();
+            }
         }
     }
 


### PR DESCRIPTION
This prevents a situation when long list of segments is returned and client slowly progresses over it which could take longer than a query abandoned timeout.

This change allows to send a heartbeat while client is progressing over data.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
