### PR TITLE
Add map literal syntax

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -575,6 +575,7 @@ primaryExpression
     | POSITION '(' valueExpression IN valueExpression ')'                                 #position
     | '(' expression (',' expression)+ ')'                                                #rowConstructor
     | ROW '(' expression (',' expression)* ')'                                            #rowConstructor
+    | '{' (mapEntry (',' mapEntry)*)? '}'                                                    #mapConstructor
     | name=LISTAGG '(' setQuantifier? expression (',' string)?
         (ON OVERFLOW listAggOverflowBehavior)? ')'
         (WITHIN GROUP '(' ORDER BY sortItem (',' sortItem)* ')')
@@ -644,6 +645,10 @@ primaryExpression
         )?
         (RETURNING type (FORMAT jsonRepresentation)?)?
      ')'                                                                                  #jsonArray
+    ;
+
+mapEntry
+    : key=expression ':' value=expression
     ;
 
 jsonPathInvocation

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -41,6 +41,7 @@ import io.trino.spi.type.DateType;
 import io.trino.spi.type.DecimalParseResult;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Decimals;
+import io.trino.spi.type.MapType;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.TimeType;
 import io.trino.spi.type.TimeWithTimeZoneType;
@@ -119,6 +120,7 @@ import io.trino.sql.tree.LocalTime;
 import io.trino.sql.tree.LocalTimestamp;
 import io.trino.sql.tree.LogicalExpression;
 import io.trino.sql.tree.LongLiteral;
+import io.trino.sql.tree.MapLiteral;
 import io.trino.sql.tree.MeasureDefinition;
 import io.trino.sql.tree.Node;
 import io.trino.sql.tree.NodeRef;
@@ -1097,6 +1099,15 @@ public class ExpressionAnalyzer
 
             // Subscript on Array or Map uses an operator to resolve Type.
             return getOperator(context, node, SUBSCRIPT, node.getBase(), node.getIndex());
+        }
+
+        @Override
+        protected Type visitMapLiteral(MapLiteral node, Context context)
+        {
+            Type keyType = coerceToSingleType(context, "All MAP keys", node.getKeys());
+            Type valueType = coerceToSingleType(context, "All MAP values", node.getValues());
+            MapType mapType = new MapType(keyType, valueType, plannerContext.getTypeOperators());
+            return setExpressionType(node, mapType);
         }
 
         @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
@@ -74,6 +74,7 @@ import io.trino.sql.tree.LocalTime;
 import io.trino.sql.tree.LocalTimestamp;
 import io.trino.sql.tree.LogicalExpression;
 import io.trino.sql.tree.LongLiteral;
+import io.trino.sql.tree.MapLiteral;
 import io.trino.sql.tree.Node;
 import io.trino.sql.tree.NotExpression;
 import io.trino.sql.tree.NullIfExpression;
@@ -301,6 +302,19 @@ public final class ExpressionFormatter
         protected String visitAllRows(AllRows node, Void context)
         {
             return "ALL";
+        }
+
+        @Override
+        protected String visitMapLiteral(MapLiteral node, Void context)
+        {
+            return node.getEntries().stream()
+                    .map(Formatter::formatMapEntry)
+                    .collect(joining(", ", "{", "}"));
+        }
+
+        private static String formatMapEntry(MapLiteral.EntryLiteral entry)
+        {
+            return formatSql(entry.key()) + " : " + formatSql(entry.value());
         }
 
         @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -167,6 +167,8 @@ import io.trino.sql.tree.LocalTimestamp;
 import io.trino.sql.tree.LogicalExpression;
 import io.trino.sql.tree.LongLiteral;
 import io.trino.sql.tree.LoopStatement;
+import io.trino.sql.tree.MapLiteral;
+import io.trino.sql.tree.MapLiteral.EntryLiteral;
 import io.trino.sql.tree.MeasureDefinition;
 import io.trino.sql.tree.Merge;
 import io.trino.sql.tree.MergeCase;
@@ -2375,6 +2377,16 @@ class AstBuilder
     public Node visitRowConstructor(SqlBaseParser.RowConstructorContext context)
     {
         return new Row(getLocation(context), visit(context.expression(), Expression.class));
+    }
+
+    @Override
+    public Node visitMapConstructor(SqlBaseParser.MapConstructorContext context)
+    {
+        List<EntryLiteral> entries = new ArrayList<>();
+        for (SqlBaseParser.MapEntryContext mapEntry : context.mapEntry()) {
+            entries.add(new EntryLiteral((Expression) visit(mapEntry.key), (Expression) visit(mapEntry.value)));
+        }
+        return new MapLiteral(getLocation(context), entries);
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
@@ -437,6 +437,11 @@ public abstract class AstVisitor<R, C>
         return visitExpression(node, context);
     }
 
+    protected R visitMapLiteral(MapLiteral node, C context)
+    {
+        return visitExpression(node, context);
+    }
+
     protected R visitArray(Array node, C context)
     {
         return visitExpression(node, context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionRewriter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionRewriter.java
@@ -140,6 +140,11 @@ public class ExpressionRewriter<C>
         return rewriteExpression(node, context, treeRewriter);
     }
 
+    public Expression rewriteMapLiteral(MapLiteral node, C context, ExpressionTreeRewriter<C> treeRewriter)
+    {
+        return rewriteExpression(node, context, treeRewriter);
+    }
+
     public Expression rewriteArray(Array node, C context, ExpressionTreeRewriter<C> treeRewriter)
     {
         return rewriteExpression(node, context, treeRewriter);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/MapLiteral.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/MapLiteral.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public final class MapLiteral
+        extends Expression
+{
+    private final List<EntryLiteral> entries;
+
+    public MapLiteral(NodeLocation location, List<EntryLiteral> entries)
+    {
+        super(location);
+        this.entries = ImmutableList.copyOf(requireNonNull(entries, "entries is null"));
+    }
+
+    public List<EntryLiteral> getEntries()
+    {
+        return entries;
+    }
+
+    public List<Expression> getKeys()
+    {
+        return entries.stream()
+                .map(EntryLiteral::key)
+                .collect(toImmutableList());
+    }
+
+    public List<Expression> getValues()
+    {
+        return entries.stream()
+                .map(EntryLiteral::value)
+                .collect(toImmutableList());
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitMapLiteral(this, context);
+    }
+
+    @Override
+    public List<Node> getChildren()
+    {
+        return entries.stream()
+                .flatMap(entry -> Stream.of(entry.key(), entry.value()))
+                .collect(toImmutableList());
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        return (o != null) && (getClass() == o.getClass());
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return MapLiteral.class.hashCode();
+    }
+
+    @Override
+    public boolean shallowEquals(Node other)
+    {
+        return sameClass(this, other);
+    }
+
+    public record EntryLiteral(Expression key, Expression value)
+    {
+        public EntryLiteral
+        {
+            requireNonNull(key, "key is null");
+            requireNonNull(value, "value is null");
+        }
+
+        @Override
+        public String toString()
+        {
+            return key + " => " + value;
+        }
+    }
+}

--- a/core/trino-parser/src/test/java/io/trino/sql/TestExpressionFormatter.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/TestExpressionFormatter.java
@@ -13,10 +13,14 @@
  */
 package io.trino.sql;
 
+import com.google.common.collect.ImmutableList;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.GenericLiteral;
 import io.trino.sql.tree.Identifier;
 import io.trino.sql.tree.IntervalLiteral;
+import io.trino.sql.tree.LongLiteral;
+import io.trino.sql.tree.MapLiteral;
+import io.trino.sql.tree.NodeLocation;
 import io.trino.sql.tree.StringLiteral;
 import org.junit.jupiter.api.Test;
 
@@ -108,6 +112,18 @@ public class TestExpressionFormatter
         assertFormattedExpression(
                 new IntervalLiteral("2", NEGATIVE, HOUR, Optional.of(SECOND)),
                 "INTERVAL -'2' HOUR TO SECOND");
+    }
+
+    @Test
+    public void testMapLiteral()
+    {
+        assertFormattedExpression(
+                new MapLiteral(
+                        new NodeLocation(1, 1),
+                        ImmutableList.of(
+                                new MapLiteral.EntryLiteral(new StringLiteral("a"), new LongLiteral("1")),
+                                new MapLiteral.EntryLiteral(new StringLiteral("b"), new LongLiteral("2")))),
+                "{'a' : 1, 'b' : 2}");
     }
 
     private void assertFormattedExpression(Expression expression, String expected)


### PR DESCRIPTION
## Description
This PR adds a simple map literal syntax to the grammar.  The grammar is similar to JSON object creation except that keys can be any hashable type.

Under the covers the literal is translated to map_from_entries. 

## Examples
```sql
{}
{'x' : 1, 'y' : 2}
{1.1 : 'a', 2.2 : 'b'}
```

## Release notes

(X) Release notes are required, with the following suggested text:

```markdown
## Section
* Add map literal syntax. For example, `{1.1 : 'a', 2.2 : 'b'}` ({issue}`issuenumber`)
```
