### PR TITLE
Expand use of AppendOnlyVariableWidthData

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/FlatSet.java
+++ b/core/trino-main/src/main/java/io/trino/operator/FlatSet.java
@@ -24,9 +24,8 @@ import java.lang.invoke.VarHandle;
 
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static io.trino.operator.VariableWidthData.EMPTY_CHUNK;
-import static io.trino.operator.VariableWidthData.POINTER_SIZE;
-import static io.trino.operator.VariableWidthData.getChunkOffset;
+import static io.trino.operator.AppendOnlyVariableWidthData.POINTER_SIZE;
+import static io.trino.operator.AppendOnlyVariableWidthData.getChunkOffset;
 import static io.trino.spi.StandardErrorCode.GENERIC_INSUFFICIENT_RESOURCES;
 import static java.lang.Math.multiplyExact;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
@@ -65,7 +64,7 @@ final class FlatSet
 
     private byte[] control;
     private byte[][] recordGroups;
-    private final VariableWidthData variableWidthData;
+    private final AppendOnlyVariableWidthData variableWidthData;
 
     private int size;
     private int maxFill;
@@ -90,7 +89,7 @@ final class FlatSet
         control = new byte[capacity + VECTOR_LENGTH];
 
         boolean variableWidth = type.isFlatVariableWidth();
-        variableWidthData = variableWidth ? new VariableWidthData() : null;
+        variableWidthData = variableWidth ? new AppendOnlyVariableWidthData() : null;
 
         recordValueOffset = (variableWidth ? POINTER_SIZE : 0);
         recordSize = recordValueOffset + type.getFlatFixedSize();
@@ -235,7 +234,7 @@ final class FlatSet
         int recordOffset = getRecordOffset(index);
 
         // write value
-        byte[] variableWidthChunk = EMPTY_CHUNK;
+        byte[] variableWidthChunk = null;
         int variableWidthChunkOffset = 0;
         if (variableWidthData != null) {
             int variableWidthLength = type.getFlatVariableWidthSize(block, position);
@@ -329,7 +328,7 @@ final class FlatSet
         int recordOffset = getRecordOffset(index);
 
         try {
-            byte[] variableWidthChunk = EMPTY_CHUNK;
+            byte[] variableWidthChunk = null;
             int variableWidthChunkOffset = 0;
             if (variableWidthData != null) {
                 variableWidthChunk = variableWidthData.getChunk(records, recordOffset);
@@ -364,7 +363,7 @@ final class FlatSet
         byte[] leftRecords = getRecords(leftPosition);
         int leftRecordOffset = getRecordOffset(leftPosition);
 
-        byte[] leftVariableWidthChunk = EMPTY_CHUNK;
+        byte[] leftVariableWidthChunk = null;
         int leftVariableWidthChunkOffset = 0;
         if (variableWidthData != null) {
             leftVariableWidthChunk = variableWidthData.getChunk(leftRecords, leftRecordOffset);

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/arrayagg/FlatArrayBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/arrayagg/FlatArrayBuilder.java
@@ -14,7 +14,7 @@
 package io.trino.operator.aggregation.arrayagg;
 
 import com.google.common.base.Throwables;
-import io.trino.operator.VariableWidthData;
+import io.trino.operator.AppendOnlyVariableWidthData;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.ValueBlock;
 import io.trino.spi.type.Type;
@@ -30,9 +30,8 @@ import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.slice.SizeOf.sizeOfObjectArray;
-import static io.trino.operator.VariableWidthData.EMPTY_CHUNK;
-import static io.trino.operator.VariableWidthData.POINTER_SIZE;
-import static io.trino.operator.VariableWidthData.getChunkOffset;
+import static io.trino.operator.AppendOnlyVariableWidthData.POINTER_SIZE;
+import static io.trino.operator.AppendOnlyVariableWidthData.getChunkOffset;
 import static java.lang.Math.toIntExact;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static java.util.Objects.checkIndex;
@@ -73,7 +72,7 @@ public class FlatArrayBuilder
 
     private byte[] openRecordGroup;
 
-    private final VariableWidthData variableWidthData;
+    private final AppendOnlyVariableWidthData variableWidthData;
 
     private long capacity;
     private long size;
@@ -90,7 +89,7 @@ public class FlatArrayBuilder
         this.hasNextIndex = hasNextIndex;
 
         boolean variableWidth = type.isFlatVariableWidth();
-        variableWidthData = variableWidth ? new VariableWidthData() : null;
+        variableWidthData = variableWidth ? new AppendOnlyVariableWidthData() : null;
         if (hasNextIndex) {
             recordNextIndexOffset = (variableWidth ? POINTER_SIZE : 0);
             recordNullOffset = recordNextIndexOffset + Long.BYTES;
@@ -174,7 +173,7 @@ public class FlatArrayBuilder
             return;
         }
 
-        byte[] variableWidthChunk = EMPTY_CHUNK;
+        byte[] variableWidthChunk = null;
         int variableWidthChunkOffset = 0;
         if (variableWidthData != null) {
             int variableWidthLength = type.getFlatVariableWidthSize(block, position);
@@ -240,7 +239,7 @@ public class FlatArrayBuilder
             return;
         }
 
-        byte[] variableWidthChunk = EMPTY_CHUNK;
+        byte[] variableWidthChunk = null;
         int variableWidthChunkOffset = 0;
         if (variableWidthData != null) {
             variableWidthChunk = variableWidthData.getChunk(records, recordOffset);

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/multimapagg/AbstractMultimapAggregationState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/multimapagg/AbstractMultimapAggregationState.java
@@ -14,7 +14,7 @@
 package io.trino.operator.aggregation.multimapagg;
 
 import com.google.common.base.Throwables;
-import io.trino.operator.VariableWidthData;
+import io.trino.operator.AppendOnlyVariableWidthData;
 import io.trino.operator.aggregation.arrayagg.FlatArrayBuilder;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.ArrayBlockBuilder;
@@ -37,9 +37,8 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static io.trino.operator.VariableWidthData.EMPTY_CHUNK;
-import static io.trino.operator.VariableWidthData.POINTER_SIZE;
-import static io.trino.operator.VariableWidthData.getChunkOffset;
+import static io.trino.operator.AppendOnlyVariableWidthData.POINTER_SIZE;
+import static io.trino.operator.AppendOnlyVariableWidthData.getChunkOffset;
 import static io.trino.spi.StandardErrorCode.GENERIC_INSUFFICIENT_RESOURCES;
 import static java.lang.Math.clamp;
 import static java.lang.Math.multiplyExact;
@@ -98,7 +97,7 @@ public abstract class AbstractMultimapAggregationState
 
     private byte[] control;
     private byte[][] recordGroups;
-    private final VariableWidthData variableWidthData;
+    private final AppendOnlyVariableWidthData variableWidthData;
 
     // head position of each group in the hash table
     @Nullable
@@ -135,7 +134,7 @@ public abstract class AbstractMultimapAggregationState
         groupRecordIndex = grouped ? new int[0] : null;
 
         boolean variableWidth = keyType.isFlatVariableWidth() || valueType.isFlatVariableWidth();
-        variableWidthData = variableWidth ? new VariableWidthData() : null;
+        variableWidthData = variableWidth ? new AppendOnlyVariableWidthData() : null;
         if (grouped) {
             recordGroupIdOffset = (variableWidth ? POINTER_SIZE : 0);
             recordNextIndexOffset = recordGroupIdOffset + Integer.BYTES;
@@ -182,7 +181,7 @@ public abstract class AbstractMultimapAggregationState
         this.recordGroups = Arrays.stream(state.recordGroups)
                 .map(records -> Arrays.copyOf(records, records.length))
                 .toArray(byte[][]::new);
-        this.variableWidthData = state.variableWidthData == null ? null : new VariableWidthData(state.variableWidthData);
+        this.variableWidthData = state.variableWidthData == null ? null : new AppendOnlyVariableWidthData(state.variableWidthData);
         this.groupRecordIndex = state.groupRecordIndex == null ? null : Arrays.copyOf(state.groupRecordIndex, state.groupRecordIndex.length);
 
         this.size = state.size;
@@ -271,7 +270,7 @@ public abstract class AbstractMultimapAggregationState
 
     private void serializeEntry(BlockBuilder keyBuilder, ArrayBlockBuilder valueBuilder, byte[] records, int recordOffset)
     {
-        byte[] variableWidthChunk = EMPTY_CHUNK;
+        byte[] variableWidthChunk = null;
         int variableWidthChunkOffset = 0;
         if (variableWidthData != null) {
             variableWidthChunk = variableWidthData.getChunk(records, recordOffset);
@@ -403,12 +402,12 @@ public abstract class AbstractMultimapAggregationState
             INT_HANDLE.set(records, recordOffset + recordNextIndexOffset, nextRecordIndex);
         }
 
-        byte[] variableWidthChunk = EMPTY_CHUNK;
+        byte[] variableWidthChunk = null;
         int variableWidthChunkOffset = 0;
         if (variableWidthData != null) {
             int keyVariableWidthSize = keyType.getFlatVariableWidthSize(keyBlock, keyPosition);
             variableWidthChunk = variableWidthData.allocate(records, recordOffset, keyVariableWidthSize);
-            variableWidthChunkOffset = VariableWidthData.getChunkOffset(records, recordOffset);
+            variableWidthChunkOffset = getChunkOffset(records, recordOffset);
         }
 
         try {
@@ -543,7 +542,7 @@ public abstract class AbstractMultimapAggregationState
         int recordOffset = getRecordOffset(index);
 
         try {
-            byte[] variableWidthChunk = EMPTY_CHUNK;
+            byte[] variableWidthChunk = null;
             int variableWidthChunkOffset = 0;
             if (variableWidthData != null) {
                 variableWidthChunk = variableWidthData.getChunk(records, recordOffset);
@@ -587,7 +586,7 @@ public abstract class AbstractMultimapAggregationState
             }
         }
 
-        byte[] leftVariableWidthChunk = EMPTY_CHUNK;
+        byte[] leftVariableWidthChunk = null;
         int leftVariableWidthChunkOffset = 0;
         if (variableWidthData != null) {
             leftVariableWidthChunk = variableWidthData.getChunk(leftRecords, leftRecordOffset);

--- a/core/trino-main/src/test/java/io/trino/operator/GroupByHashYieldAssertion.java
+++ b/core/trino-main/src/test/java/io/trino/operator/GroupByHashYieldAssertion.java
@@ -94,8 +94,8 @@ public final class GroupByHashYieldAssertion
                 .addDriverContext();
         Operator operator = operatorFactory.createOperator(driverContext);
 
-        byte[] pointer = new byte[VariableWidthData.POINTER_SIZE];
-        VariableWidthData variableWidthData = new VariableWidthData();
+        byte[] pointer = new byte[AppendOnlyVariableWidthData.POINTER_SIZE];
+        AppendOnlyVariableWidthData variableWidthData = new AppendOnlyVariableWidthData();
 
         // run operator
         int yieldCount = 0;

--- a/core/trino-main/src/test/java/io/trino/operator/TestFlatHashStrategyCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestFlatHashStrategyCompiler.java
@@ -13,12 +13,19 @@
  */
 package io.trino.operator;
 
+import io.trino.spi.block.Block;
 import io.trino.spi.type.TypeOperators;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+
+import static io.trino.block.BlockAssertions.createLongsBlock;
+import static io.trino.block.BlockAssertions.createStringsBlock;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.lang.Math.toIntExact;
 import static java.util.Collections.nCopies;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class TestFlatHashStrategyCompiler
 {
@@ -30,5 +37,69 @@ class TestFlatHashStrategyCompiler
         // this will work with 100K columns, but that uses too much memory for the CI
         FlatHashStrategyCompiler.compileFlatHashStrategy(nCopies(2_001, BIGINT), TYPE_OPERATORS);
         FlatHashStrategyCompiler.compileFlatHashStrategy(nCopies(2_001, VARCHAR), TYPE_OPERATORS);
+    }
+
+    @Test
+    public void testMultiChunkIdenticalAndHash()
+    {
+        int[] testColumns = new int[] {
+                FlatHashStrategyCompiler.COLUMNS_PER_CHUNK - 1,
+                FlatHashStrategyCompiler.COLUMNS_PER_CHUNK,
+                FlatHashStrategyCompiler.COLUMNS_PER_CHUNK + 1};
+        for (int columns : testColumns) {
+            // All variable width, mix of nulls and non nulls
+            testVariableWidthColumns(columns);
+            // All fixed width
+            testFixedWidthColumns(columns);
+        }
+    }
+
+    private static void testVariableWidthColumns(int columns)
+    {
+        Block[] variableBlocks = createVariableWidthTestColumns(columns);
+        FlatHashStrategy hashStrategy = FlatHashStrategyCompiler.compileFlatHashStrategy(nCopies(columns, VARCHAR), TYPE_OPERATORS);
+        byte[] fixedChunk = new byte[hashStrategy.getTotalFlatFixedLength()];
+        int variableLength = toIntExact(Arrays.stream(variableBlocks).mapToLong(block -> VARCHAR.getFlatVariableWidthSize(block, 0)).sum());
+        byte[] variableChunk = new byte[variableLength];
+        hashStrategy.writeFlat(variableBlocks, 0, fixedChunk, 0, variableChunk, 0);
+        assertThat(hashStrategy.valueIdentical(fixedChunk, 0, variableChunk, 0, variableBlocks, 0)).isTrue();
+
+        long blocksHash = hashStrategy.hash(variableBlocks, 0);
+        assertThat(hashStrategy.hash(fixedChunk, 0, variableChunk, 0)).isEqualTo(blocksHash);
+    }
+
+    private static void testFixedWidthColumns(int columns)
+    {
+        Block[] fixedBlocks = createFixedWidthTestColumns(columns);
+        FlatHashStrategy hashStrategy = FlatHashStrategyCompiler.compileFlatHashStrategy(nCopies(columns, BIGINT), TYPE_OPERATORS);
+        byte[] fixedChunk = new byte[hashStrategy.getTotalFlatFixedLength()];
+        byte[] variableChunk = null;
+        hashStrategy.writeFlat(fixedBlocks, 0, fixedChunk, 0, fixedChunk, 0);
+        assertThat(hashStrategy.valueIdentical(fixedChunk, 0, variableChunk, 0, fixedBlocks, 0)).isTrue();
+
+        long blocksHash = hashStrategy.hash(fixedBlocks, 0);
+        assertThat(hashStrategy.hash(fixedChunk, 0, variableChunk, 0)).isEqualTo(blocksHash);
+    }
+
+    private static Block[] createVariableWidthTestColumns(int columns)
+    {
+        Block nonNullBlock = createStringsBlock("test string");
+        Block nullsBlock = VARCHAR.createBlockBuilder(null, 1).appendNull().buildValueBlock();
+        Block[] blocks = new Block[columns];
+        for (int i = 0; i < columns; i++) {
+            blocks[i] = i % 2 == 0 ? nullsBlock : nonNullBlock;
+        }
+        return blocks;
+    }
+
+    private static Block[] createFixedWidthTestColumns(int columns)
+    {
+        Block nonNullBlock = createLongsBlock((long) Integer.MAX_VALUE + 1);
+        Block nullsBlock = BIGINT.createBlockBuilder(null, 1).appendNull().buildValueBlock();
+        Block[] blocks = new Block[columns];
+        for (int i = 0; i < columns; i++) {
+            blocks[i] = i % 2 == 0 ? nullsBlock : nonNullBlock;
+        }
+        return blocks;
     }
 }


### PR DESCRIPTION
## Description
Updates additional places in code to use `AppendOnlyVariableWidthData` (introduced in https://github.com/trinodb/trino/pull/25127) to reduce their memory usage as well.

Also adds a special case to `FlatHashStrategyCompiler` for generating `FlatHashStrategy` classes that have less than 500 columns. In those common cases, simpler logic can be used to in the hash method. Similarly, `FlatHashStrategy#valueIdentical` methods are changed to propagate the variableWidthOffset between calls without allocating a `MutableVariableWidthOffset` instance.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
