### PR TITLE
Remove deprecated getSplitBucketFunction

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorNodePartitioningProvider.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorNodePartitioningProvider.java
@@ -48,16 +48,7 @@ public interface ConnectorNodePartitioningProvider
             ConnectorPartitioningHandle partitioningHandle,
             int bucketCount)
     {
-        return getSplitBucketFunction(transactionHandle, session, partitioningHandle);
-    }
-
-    /**
-     * @deprecated Use {@link #getSplitBucketFunction(ConnectorTransactionHandle, ConnectorSession, ConnectorPartitioningHandle, int)} instead
-     */
-    @Deprecated(forRemoval = true)
-    default ToIntFunction<ConnectorSplit> getSplitBucketFunction(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle)
-    {
-        return split -> {
+        return _ -> {
             throw new UnsupportedOperationException();
         };
     }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeNodePartitioningProvider.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeNodePartitioningProvider.java
@@ -75,12 +75,4 @@ public final class ClassLoaderSafeNodePartitioningProvider
             return delegate.getSplitBucketFunction(transactionHandle, session, partitioningHandle, bucketCount);
         }
     }
-
-    @Override
-    public ToIntFunction<ConnectorSplit> getSplitBucketFunction(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle)
-    {
-        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getSplitBucketFunction(transactionHandle, session, partitioningHandle);
-        }
-    }
 }


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
