### PR TITLE
Disable extra compression for segment data

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/OkHttpSegmentLoader.java
+++ b/client/trino-client/src/main/java/io/trino/client/OkHttpSegmentLoader.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static com.google.common.net.HttpHeaders.ACCEPT_ENCODING;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -56,6 +57,7 @@ public class OkHttpSegmentLoader
         Request request = new Request.Builder()
                 .url(segment.getDataUri().toString())
                 .headers(toHeaders(segment.getHeaders()))
+                .addHeader(ACCEPT_ENCODING, "identity")
                 .build();
 
         Response response = callFactory.newCall(request).execute();


### PR DESCRIPTION
When going through the coordinator or the worker as a proxy we don't want to apply Jetty-based gzip compression to segment data which can be compressed on it's own. This just adds an overhead without any benefits.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
