### PR TITLE
Fix failure when commenting on non-lowercased view columns

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/CommentTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CommentTask.java
@@ -175,7 +175,8 @@ public class CommentTask
     {
         String columnName = statement.getName().getSuffix();
         ViewColumn viewColumn = viewDefinition.getColumns().stream()
-                .filter(column -> column.name().equals(columnName))
+                // TODO (https://github.com/trinodb/trino/issues/17) change to equals()
+                .filter(column -> column.name().equalsIgnoreCase(columnName))
                 .findAny()
                 .orElseThrow(() -> semanticException(COLUMN_NOT_FOUND, statement, "Column does not exist: %s", columnName));
         accessControl.checkCanSetColumnComment(session.toSecurityContext(), originalObjectName);


### PR DESCRIPTION
In case of using case-sensitive column alias during view creation, we are not able to add column comment.

Steps to reproduce:
 - create any table
 - create view with column alias with non-lower case name: 
```
  CREATE VIEW some_view AS 
                SELECT lower_case UPPER_CASE 
                FROM some_table
```
- set column comment:
` COMMENT ON COLUMN some_view.UPPER_CASE IS 'some comment'`

- we got exception: 
`io.trino.spi.TrinoException: line 1:1: Column does not exist: upper_case`

When view is created we parse original query inside `CreateViewTask` and extract columns:
```
List<ViewColumn> columns = analysis.getOutputDescriptor(statement.getQuery())
        .getVisibleFields().stream()
        .map(field -> new ViewColumn(field.getName().get(), field.getType().getTypeId(), Optional.empty()))
        .collect(toImmutableList());
```

keeping the original case of columns, then this information (columns + original SQL) serialized to base64 and stored in metastore like: 
`eyJvcmlnaW5hbFNxbCI6IlNFTEVDVCAqXG5GUk9NXG4gIG15X2NhdGFsb2cuYmF4dGVyLkFQX0FDQ1RHX0RPQ19IRFJfU0FQVE1fVldcbiIsImNhdGFsb2ciOiJzYW1wbGUiLCJzY2hlbWEiOiJidXJzdGJhbmsiLCJjb2x1bW5zIjpbeyJuYW1lIjoiRURIX0VU....`

On next step, when we actually setting up column comment, we follow code path of `CommentTask` ,
which contains mandatory check - does column argument belongs to view:

```
private ViewColumn findAndCheckViewColumn(Comment statement, Session session, ViewDefinition viewDefinition, QualifiedObjectName originalObjectName)
{
    String columnName = statement.getName().getSuffix();
    ViewColumn viewColumn = viewDefinition.getColumns().stream()
            .filter(column -> column.name().equals(columnName))
            .findAny()
            .orElseThrow(() -> semanticException(COLUMN_NOT_FOUND, statement, "Column does not exist: %s", columnName));
    accessControl.checkCanSetColumnComment(session.toSecurityContext(), originalObjectName);
    return viewColumn;
}
 
```

So we load columns information from metastore (which keeps the alias case) and compare it to value, which we got from statement. 
But this value is lower-cased by engine and we are not able to match it.


<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix failure when commenting on non-lowercased view columns. ({issue}`issuenumber`)
```
