### PR TITLE
Add simpler array literal syntax

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -594,6 +594,7 @@ primaryExpression
     | CAST '(' expression AS type ')'                                                     #cast
     | TRY_CAST '(' expression AS type ')'                                                 #cast
     | ARRAY '[' (expression (',' expression)*)? ']'                                       #arrayConstructor
+    | '[' (expression (',' expression)*)? ']'                                             #arrayConstructor
     | value=primaryExpression '[' index=valueExpression ']'                               #subscript
     | identifier                                                                          #columnReference
     | base=primaryExpression '.' fieldName=identifier                                     #dereference

--- a/core/trino-main/src/test/java/io/trino/type/TestArrayOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestArrayOperators.java
@@ -137,12 +137,31 @@ public class TestArrayOperators
     @Test
     public void testTypeConstructor()
     {
+        assertThat(assertions.expression("ARRAY[]"))
+                .hasType(new ArrayType(UNKNOWN))
+                .isEqualTo(ImmutableList.of());
+
+        assertThat(assertions.expression("[]"))
+                .hasType(new ArrayType(UNKNOWN))
+                .isEqualTo(ImmutableList.of());
+
         assertThat(assertions.expression("ARRAY[a]")
                 .binding("a", "7"))
                 .hasType(new ArrayType(INTEGER))
                 .isEqualTo(ImmutableList.of(7));
 
+        assertThat(assertions.expression("[a]")
+                .binding("a", "7"))
+                .hasType(new ArrayType(INTEGER))
+                .isEqualTo(ImmutableList.of(7));
+
         assertThat(assertions.expression("ARRAY[a, b]")
+                .binding("a", "12.34E0")
+                .binding("b", "56.78E0"))
+                .hasType(new ArrayType(DOUBLE))
+                .isEqualTo(ImmutableList.of(12.34, 56.78));
+
+        assertThat(assertions.expression("[a, b]")
                 .binding("a", "12.34E0")
                 .binding("b", "56.78E0"))
                 .hasType(new ArrayType(DOUBLE))


### PR DESCRIPTION
## Description

Support array literal using just square brackets.  For example:
```
[]
['a', 'b']
```
## Release notes

(X) Release notes are required, with the following suggested text:

```markdown
## Section
* Add ARRAY literal syntax using just square brackets. For example, `['a', 'b']` ({issue}`issuenumber`)
```
