### PR TITLE
Direct stale PRs to core-dev channel

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/stale@v9.1.0
         with:
-          stale-pr-message: 'This pull request has gone a while without any activity. Tagging for triage help: @mosabua'
+          stale-pr-message: 'This pull request has gone a while without any activity. Ask for help on #core-dev on Trino slack.'
           days-before-pr-stale: 21
           days-before-pr-close: 21
           close-pr-message: 'Closing this pull request, as it has been stale for six weeks. Feel free to re-open at any time.'


### PR DESCRIPTION
## Description

I wont have the bandwidth to handhold all stale PRs anymore. If anyone else could be taking up that job we can add that person but for now I think we can just send people to #core-dev and expand the time to stale and the time to close. What do you all think?

After discussion on slack and different ideas around the timing and workflow I am leaving it unchanged for now. We can figure out next steps separately. The current PR only removes the noise of notifications for me.

## Additional context and related issues


## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
