### PR TITLE
Add varchar casting note for listagg function

### DIFF
--- a/docs/src/main/sphinx/functions/aggregate.md
+++ b/docs/src/main/sphinx/functions/aggregate.md
@@ -181,6 +181,12 @@ LISTAGG( expression [, separator] [ON OVERFLOW overflow_behaviour])
     WITHIN GROUP (ORDER BY sort_item, [...]) [FILTER (WHERE condition)]
 ```
 
+:::{note}
+The `expression` value must evaluate to a string data type (`varchar`). You must
+explicitly cast non-string datatypes to `varchar` using `CAST(expression AS
+VARCHAR)` before you use them with `listagg`.
+:::
+
 If `separator` is not specified, the empty string will be used as `separator`.
 
 In its simplest form the function looks like:
@@ -196,6 +202,21 @@ and results in:
 csv_value
 -----------
 'a,b,c'
+```
+
+The following example casts a `value` to `varchar`:
+
+```
+SELECT listagg(CAST(value AS VARCHAR), ',') WITHIN GROUP (ORDER BY value) csv_value
+FROM (VALUES 1, 3, 2) t(value);
+```
+
+and results in
+
+```
+csv_value
+-----------
+'1,2,3'
 ```
 
 The overflow behaviour is by default to throw an error in case that the length of the output


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

I add a note indicating that parameters must be cast to `varchar` when using `listagg` function
I also added an example query showing a value cast to `varchar`

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
