### PR TITLE
Use OptionalLong for JoinStatisticsCounter

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/join/JoinOperatorInfo.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/JoinOperatorInfo.java
@@ -19,7 +19,7 @@ import io.trino.operator.OperatorInfo;
 import io.trino.operator.join.LookupJoinOperatorFactory.JoinType;
 import io.trino.spi.Mergeable;
 
-import java.util.Optional;
+import java.util.OptionalLong;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -32,11 +32,11 @@ public class JoinOperatorInfo
     private final JoinType joinType;
     private final long[] logHistogramProbes;
     private final long[] logHistogramOutput;
-    private final Optional<Long> lookupSourcePositions;
+    private final OptionalLong lookupSourcePositions;
     private final long rleProbes;
     private final long totalProbes;
 
-    public static JoinOperatorInfo createJoinOperatorInfo(JoinType joinType, long[] logHistogramCounters, Optional<Long> lookupSourcePositions, long rleProbes, long totalProbes)
+    public static JoinOperatorInfo createJoinOperatorInfo(JoinType joinType, long[] logHistogramCounters, OptionalLong lookupSourcePositions, long rleProbes, long totalProbes)
     {
         long[] logHistogramProbes = new long[HISTOGRAM_BUCKETS];
         long[] logHistogramOutput = new long[HISTOGRAM_BUCKETS];
@@ -52,7 +52,7 @@ public class JoinOperatorInfo
             @JsonProperty("joinType") JoinType joinType,
             @JsonProperty("logHistogramProbes") long[] logHistogramProbes,
             @JsonProperty("logHistogramOutput") long[] logHistogramOutput,
-            @JsonProperty("lookupSourcePositions") Optional<Long> lookupSourcePositions,
+            @JsonProperty("lookupSourcePositions") OptionalLong lookupSourcePositions,
             @JsonProperty("rleProbes") long rleProbes,
             @JsonProperty("totalProbes") long totalProbes)
     {
@@ -88,7 +88,7 @@ public class JoinOperatorInfo
      * Estimated number of positions in on the build side
      */
     @JsonProperty
-    public Optional<Long> getLookupSourcePositions()
+    public OptionalLong getLookupSourcePositions()
     {
         return lookupSourcePositions;
     }
@@ -129,9 +129,9 @@ public class JoinOperatorInfo
             logHistogramOutput[i] = this.logHistogramOutput[i] + other.logHistogramOutput[i];
         }
 
-        Optional<Long> mergedSourcePositions = Optional.empty();
+        OptionalLong mergedSourcePositions = OptionalLong.empty();
         if (this.lookupSourcePositions.isPresent() || other.lookupSourcePositions.isPresent()) {
-            mergedSourcePositions = Optional.of(this.lookupSourcePositions.orElse(0L) + other.lookupSourcePositions.orElse(0L));
+            mergedSourcePositions = OptionalLong.of(this.lookupSourcePositions.orElse(0L) + other.lookupSourcePositions.orElse(0L));
         }
 
         return new JoinOperatorInfo(this.joinType, logHistogramProbes, logHistogramOutput, mergedSourcePositions, this.rleProbes + other.rleProbes, this.totalProbes + other.totalProbes);

--- a/core/trino-main/src/main/java/io/trino/operator/join/JoinStatisticsCounter.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/JoinStatisticsCounter.java
@@ -16,7 +16,7 @@ package io.trino.operator.join;
 import io.trino.operator.OperatorInfo;
 import io.trino.operator.join.LookupJoinOperatorFactory.JoinType;
 
-import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.function.Supplier;
 
 import static io.trino.operator.join.JoinOperatorInfo.createJoinOperatorInfo;
@@ -43,7 +43,7 @@ public class JoinStatisticsCounter
     /**
      * Estimated number of positions in on the build side
      */
-    private Optional<Long> lookupSourcePositions = Optional.empty();
+    private OptionalLong lookupSourcePositions = OptionalLong.empty();
 
     public JoinStatisticsCounter(JoinType joinType)
     {
@@ -52,7 +52,7 @@ public class JoinStatisticsCounter
 
     public void updateLookupSourcePositions(long lookupSourcePositionsDelta)
     {
-        this.lookupSourcePositions = Optional.of(this.lookupSourcePositions.orElse(0L) + lookupSourcePositionsDelta);
+        this.lookupSourcePositions = OptionalLong.of(this.lookupSourcePositions.orElse(0L) + lookupSourcePositionsDelta);
     }
 
     public void recordProbe(int numSourcePositions)

--- a/core/trino-main/src/test/java/io/trino/operator/join/TestJoinOperatorInfo.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/TestJoinOperatorInfo.java
@@ -15,7 +15,7 @@ package io.trino.operator.join;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Optional;
+import java.util.OptionalLong;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.operator.join.LookupJoinOperatorFactory.JoinType.INNER;
@@ -30,21 +30,21 @@ public class TestJoinOperatorInfo
                 INNER,
                 makeHistogramArray(10, 20, 30, 40, 50, 60, 70, 80),
                 makeHistogramArray(12, 22, 32, 42, 52, 62, 72, 82),
-                Optional.of(1L),
+                OptionalLong.of(1L),
                 2,
                 3);
         JoinOperatorInfo other = new JoinOperatorInfo(
                 INNER,
                 makeHistogramArray(11, 21, 31, 41, 51, 61, 71, 81),
                 makeHistogramArray(15, 25, 35, 45, 55, 65, 75, 85),
-                Optional.of(2L),
+                OptionalLong.of(2L),
                 4,
                 7);
 
         JoinOperatorInfo merged = base.mergeWith(other);
         assertThat(makeHistogramArray(21, 41, 61, 81, 101, 121, 141, 161)).isEqualTo(merged.getLogHistogramProbes());
         assertThat(makeHistogramArray(27, 47, 67, 87, 107, 127, 147, 167)).isEqualTo(merged.getLogHistogramOutput());
-        assertThat(merged.getLookupSourcePositions()).isEqualTo(Optional.of(3L));
+        assertThat(merged.getLookupSourcePositions()).isEqualTo(OptionalLong.of(3L));
         assertThat(merged.getRleProbes()).isEqualTo(6);
         assertThat(merged.getTotalProbes()).isEqualTo(10);
     }


### PR DESCRIPTION
## Description
Minor improvement to `JoinOperatorInfo` and `JoinStatisticsCounter` to use `OptionalLong` instead of boxed `Optional<Long>`.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: