### PR TITLE
Improve messages for column access error in FileBasedAccessControl

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
@@ -85,7 +85,7 @@ import static io.trino.spi.security.AccessDeniedException.denyRenameView;
 import static io.trino.spi.security.AccessDeniedException.denyRevokeRoles;
 import static io.trino.spi.security.AccessDeniedException.denyRevokeSchemaPrivilege;
 import static io.trino.spi.security.AccessDeniedException.denyRevokeTablePrivilege;
-import static io.trino.spi.security.AccessDeniedException.denySelectTable;
+import static io.trino.spi.security.AccessDeniedException.denySelectColumns;
 import static io.trino.spi.security.AccessDeniedException.denySetCatalogSessionProperty;
 import static io.trino.spi.security.AccessDeniedException.denySetMaterializedViewProperties;
 import static io.trino.spi.security.AccessDeniedException.denySetRole;
@@ -389,7 +389,7 @@ public class FileBasedAccessControl
                 .findFirst()
                 .orElse(false);
         if (!allowed) {
-            denySelectTable(tableName.toString());
+            denySelectColumns(tableName.toString(), columnNames);
         }
     }
 
@@ -475,7 +475,7 @@ public class FileBasedAccessControl
                 .findFirst()
                 .orElse(null);
         if (rule == null || !rule.canSelectColumns(columnNames)) {
-            denySelectTable(tableName.toString());
+            denySelectColumns(tableName.toString(), columnNames);
         }
         if (!rule.getPrivileges().contains(GRANT_SELECT)) {
             denyCreateViewWithSelect(tableName.toString(), context.getIdentity());

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
@@ -105,6 +105,7 @@ import static io.trino.spi.security.AccessDeniedException.denyRenameView;
 import static io.trino.spi.security.AccessDeniedException.denyRevokeRoles;
 import static io.trino.spi.security.AccessDeniedException.denyRevokeSchemaPrivilege;
 import static io.trino.spi.security.AccessDeniedException.denyRevokeTablePrivilege;
+import static io.trino.spi.security.AccessDeniedException.denySelectColumns;
 import static io.trino.spi.security.AccessDeniedException.denySelectTable;
 import static io.trino.spi.security.AccessDeniedException.denySetCatalogSessionProperty;
 import static io.trino.spi.security.AccessDeniedException.denySetMaterializedViewProperties;
@@ -683,7 +684,7 @@ public class FileBasedSystemAccessControl
                 .findFirst()
                 .orElse(false);
         if (!allowed) {
-            denySelectTable(table.toString());
+            denySelectColumns(table.toString(), columns);
         }
     }
 
@@ -765,7 +766,7 @@ public class FileBasedSystemAccessControl
                 .findFirst()
                 .orElse(null);
         if (rule == null || !rule.canSelectColumns(columns)) {
-            denySelectTable(table.toString());
+            denySelectColumns(table.toString(), columns);
         }
         if (!rule.getPrivileges().contains(GRANT_SELECT)) {
             denyCreateViewWithSelect(table.toString(), context.getIdentity());

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/BaseFileBasedSystemAccessControlTest.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/BaseFileBasedSystemAccessControlTest.java
@@ -103,7 +103,7 @@ public abstract class BaseFileBasedSystemAccessControlTest
     private static final String REVOKE_SCHEMA_ACCESS_DENIED_MESSAGE = "Cannot revoke privilege %s on schema %s%s";
 
     private static final String SHOWN_TABLES_ACCESS_DENIED_MESSAGE = "Cannot show tables of .*";
-    private static final String SELECT_TABLE_ACCESS_DENIED_MESSAGE = "Cannot select from table .*";
+    private static final String SELECT_COLUMN_ACCESS_DENIED_MESSAGE = "Cannot select from columns .*";
     private static final String SHOW_COLUMNS_ACCESS_DENIED_MESSAGE = "Cannot show columns of table .*";
     private static final String ADD_COLUMNS_ACCESS_DENIED_MESSAGE = "Cannot add a column to table .*";
     private static final String DROP_COLUMNS_ACCESS_DENIED_MESSAGE = "Cannot drop a column from table .*";
@@ -450,7 +450,7 @@ public abstract class BaseFileBasedSystemAccessControlTest
                         CHARLIE,
                         new CatalogSchemaTableName("some-catalog", "bobschema", "bobcolumns"),
                         ImmutableSet.of("bobcolumn", "private")),
-                SELECT_TABLE_ACCESS_DENIED_MESSAGE);
+                SELECT_COLUMN_ACCESS_DENIED_MESSAGE);
         accessControl.checkCanSelectFromColumns(JOE, new CatalogSchemaTableName("some-catalog", "bobschema", "bobcolumns"), ImmutableSet.of());
 
         assertAccessDenied(
@@ -458,13 +458,13 @@ public abstract class BaseFileBasedSystemAccessControlTest
                         ADMIN,
                         new CatalogSchemaTableName("secret", "secret", "secret"),
                         ImmutableSet.of()),
-                SELECT_TABLE_ACCESS_DENIED_MESSAGE);
+                SELECT_COLUMN_ACCESS_DENIED_MESSAGE);
         assertAccessDenied(
                 () -> accessControl.checkCanSelectFromColumns(
                         JOE,
                         new CatalogSchemaTableName("secret", "secret", "secret"),
                         ImmutableSet.of()),
-                SELECT_TABLE_ACCESS_DENIED_MESSAGE);
+                SELECT_COLUMN_ACCESS_DENIED_MESSAGE);
     }
 
     @Test
@@ -494,7 +494,7 @@ public abstract class BaseFileBasedSystemAccessControlTest
                         CHARLIE,
                         new CatalogSchemaTableName("some-catalog", "bobschema", "bobcolumns_with_grant"),
                         ImmutableSet.of("bobcolumn", "private")),
-                SELECT_TABLE_ACCESS_DENIED_MESSAGE);
+                SELECT_COLUMN_ACCESS_DENIED_MESSAGE);
     }
 
     @Test

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileBasedSecurity.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileBasedSecurity.java
@@ -74,7 +74,7 @@ public class TestHiveFileBasedSecurity
         Session bob = getSession("bob");
         assertThatThrownBy(() -> queryRunner.execute(bob, "SELECT * FROM nation"))
                 .isInstanceOf(RuntimeException.class)
-                .hasMessageMatching(".*Access Denied: Cannot select from table tpch.nation.*");
+                .hasMessageMatching(".*Access Denied: Cannot select from columns \\[nationkey, regionkey, name, comment\\] in table or view tpch\\.nation");
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Improve messages for column access error in `FileBasedAccessControl` and `FileBasedSystemAccessControl` to make those messages consistent with other access control implementations.

Other access controls show requested columns when column-level access check fails. 

https://github.com/trinodb/trino/blob/3848661b280414855cab526433f5c8ad7697c574/plugin/trino-ranger/src/main/java/io/trino/plugin/ranger/RangerSystemAccessControl.java#L519-L526

https://github.com/trinodb/trino/blob/3848661b280414855cab526433f5c8ad7697c574/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaAccessControl.java#L437-L441


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
- https://github.com/trinodb/trino/pull/24873
- https://github.com/trinodb/trino/pull/24938


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
