### PR TITLE
Add Moto testcontainer with S3 and Glue tests

### DIFF
--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemMoto.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemMoto.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.s3;
+
+import io.airlift.units.DataSize;
+import io.opentelemetry.api.OpenTelemetry;
+import io.trino.testing.containers.MotoContainer;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import static io.trino.testing.containers.MotoContainer.MOTO_ACCESS_KEY;
+import static io.trino.testing.containers.MotoContainer.MOTO_REGION;
+import static io.trino.testing.containers.MotoContainer.MOTO_SECRET_KEY;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Testcontainers
+public class TestS3FileSystemMoto
+        extends AbstractTestS3FileSystem
+{
+    private static final String BUCKET = "test-bucket";
+
+    @Container
+    private static final MotoContainer MOTO = new MotoContainer();
+
+    @Override
+    protected void initEnvironment()
+    {
+        MOTO.createBucket(BUCKET);
+    }
+
+    @Override
+    protected String bucket()
+    {
+        return BUCKET;
+    }
+
+    @Override
+    protected S3Client createS3Client()
+    {
+        return S3Client.builder().applyMutation(MOTO::updateClient).build();
+    }
+
+    @Override
+    protected S3FileSystemFactory createS3FileSystemFactory()
+    {
+        return new S3FileSystemFactory(OpenTelemetry.noop(), new S3FileSystemConfig()
+                .setEndpoint(MOTO.getEndpoint().toString())
+                .setRegion(MOTO_REGION)
+                .setPathStyleAccess(true)
+                .setAwsAccessKey(MOTO_ACCESS_KEY)
+                .setAwsSecretKey(MOTO_SECRET_KEY)
+                .setSupportsExclusiveCreate(true)
+                .setStreamingPartSize(DataSize.valueOf("5.5MB")), new S3FileSystemStats());
+    }
+
+    @Test
+    @Override
+    public void testPreSignedUris()
+    {
+        // Moto doesn't expire pre-signed URLs
+        assertThatThrownBy(super::testPreSignedUris)
+                .hasMessageContaining("Expecting code to raise a throwable");
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueMetastoreModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueMetastoreModule.java
@@ -38,7 +38,6 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
-import software.amazon.awssdk.http.apache.ProxyConfiguration;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.retries.api.BackoffStrategy;
@@ -173,9 +172,7 @@ public class GlueMetastoreModule
         if (config.getGlueEndpointUrl().isPresent()) {
             checkArgument(config.getGlueRegion().isPresent(), "Glue region must be set when Glue endpoint URL is set");
             glue.region(Region.of(config.getGlueRegion().get()));
-            httpClient.proxyConfiguration(ProxyConfiguration.builder()
-                    .endpoint(URI.create(config.getGlueEndpointUrl().get()))
-                    .build());
+            glue.endpointOverride(URI.create(config.getGlueEndpointUrl().get()));
         }
         else if (config.getGlueRegion().isPresent()) {
             glue.region(Region.of(config.getGlueRegion().get()));

--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -303,6 +303,11 @@
         </dependency>
 
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <scope>provided</scope>
@@ -700,6 +705,7 @@
                         <ignoredNonTestScopedDependencies>
                             <ignoredNonTestScopedDependency>org.apache.parquet:parquet-common</ignoredNonTestScopedDependency>
                             <ignoredNonTestScopedDependency>software.amazon.awssdk:aws-core</ignoredNonTestScopedDependency>
+                            <ignoredNonTestScopedDependency>software.amazon.awssdk:utils</ignoredNonTestScopedDependency>
                         </ignoredNonTestScopedDependencies>
                     </configuration>
                 </plugin>

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMotoConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMotoConnectorSmokeTest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.filesystem.Location;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.containers.MotoContainer;
+import org.apache.iceberg.FileFormat;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import software.amazon.awssdk.services.glue.GlueClient;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Map;
+
+import static io.trino.plugin.iceberg.IcebergTestUtils.checkParquetFileSorting;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.testing.containers.MotoContainer.MOTO_ACCESS_KEY;
+import static io.trino.testing.containers.MotoContainer.MOTO_REGION;
+import static io.trino.testing.containers.MotoContainer.MOTO_SECRET_KEY;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
+
+@Execution(SAME_THREAD) // Moto is not concurrency safe
+public class TestIcebergMotoConnectorSmokeTest
+        extends BaseIcebergConnectorSmokeTest
+{
+    private final String bucketName = "test-iceberg-" + randomNameSuffix();
+    private final String schemaName = "test_iceberg_smoke_" + randomNameSuffix();
+    private GlueClient glueClient;
+
+    public TestIcebergMotoConnectorSmokeTest()
+    {
+        super(FileFormat.PARQUET);
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        MotoContainer moto = closeAfterClass(new MotoContainer());
+        moto.start();
+        moto.createBucket(bucketName);
+
+        glueClient = closeAfterClass(GlueClient.builder().applyMutation(moto::updateClient).build());
+
+        return IcebergQueryRunner.builder()
+                .setIcebergProperties(ImmutableMap.<String, String>builder()
+                        .put("iceberg.file-format", format.name())
+                        .put("iceberg.catalog.type", "glue")
+                        .put("hive.metastore.glue.region", MOTO_REGION)
+                        .put("hive.metastore.glue.endpoint-url", moto.getEndpoint().toString())
+                        .put("hive.metastore.glue.aws-access-key", MOTO_ACCESS_KEY)
+                        .put("hive.metastore.glue.aws-secret-key", MOTO_SECRET_KEY)
+                        .put("hive.metastore.glue.default-warehouse-dir", "s3://%s/".formatted(bucketName))
+                        .put("fs.native-s3.enabled", "true")
+                        .put("s3.region", MOTO_REGION)
+                        .put("s3.endpoint", moto.getEndpoint().toString())
+                        .put("s3.aws-access-key", MOTO_ACCESS_KEY)
+                        .put("s3.aws-secret-key", MOTO_SECRET_KEY)
+                        .put("s3.path-style-access", "true")
+                        .put("iceberg.register-table-procedure.enabled", "true")
+                        .put("iceberg.allowed-extra-properties", "write.metadata.delete-after-commit.enabled,write.metadata.previous-versions-max")
+                        .buildOrThrow())
+                .setSchemaInitializer(SchemaInitializer.builder()
+                        .withSchemaName(schemaName)
+                        .withClonedTpchTables(REQUIRED_TPCH_TABLES)
+                        .withSchemaProperties(Map.of("location", "'s3://%s/%s/'".formatted(bucketName, schemaName)))
+                        .build())
+                .build();
+    }
+
+    @Override
+    protected void deleteDirectory(String location)
+    {
+        try {
+            fileSystem.deleteDirectory(Location.of(location));
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    protected boolean isFileSorted(Location path, String sortColumnName)
+    {
+        return checkParquetFileSorting(fileSystem.newInputFile(path), sortColumnName);
+    }
+
+    @Override
+    protected void dropTableFromMetastore(String tableName)
+    {
+        glueClient.deleteTable(x -> x.databaseName(schemaName).name(tableName));
+    }
+
+    @Override
+    protected String getMetadataLocation(String tableName)
+    {
+        return glueClient.getTable(x -> x.databaseName(schemaName).name(tableName))
+                .table().parameters().get("metadata_location");
+    }
+
+    @Override
+    protected String schemaPath()
+    {
+        return "s3://%s/%s".formatted(bucketName, schemaName);
+    }
+
+    @Override
+    protected boolean locationExists(String location)
+    {
+        try {
+            return fileSystem.directoryExists(Location.of(location)).orElse(false);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Test
+    @Disabled("Moto is not concurrency safe")
+    @Override
+    public void testDeleteRowsConcurrently() {}
+
+    @Test
+    @Override
+    public void testRenameSchema()
+    {
+        assertThatThrownBy(super::testRenameSchema)
+                .hasStackTraceContaining("renameNamespace is not supported for Iceberg Glue catalogs");
+    }
+}

--- a/testing/trino-testing-containers/pom.xml
+++ b/testing/trino-testing-containers/pom.xml
@@ -85,6 +85,48 @@
         </dependency>
 
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-core</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>regions</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sdk-core</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>junit-extensions</artifactId>
             <scope>test</scope>

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/MotoContainer.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/MotoContainer.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing.containers;
+
+import org.testcontainers.containers.GenericContainer;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+
+import java.net.URI;
+
+public final class MotoContainer
+        extends GenericContainer<MotoContainer>
+{
+    public static final String MOTO_ACCESS_KEY = "accesskey";
+    public static final String MOTO_SECRET_KEY = "secretkey";
+    public static final String MOTO_REGION = "us-east-1";
+
+    private static final int MOTO_PORT = 5000;
+
+    public MotoContainer()
+    {
+        super("motoserver/moto:latest");
+        addExposedPort(MOTO_PORT);
+    }
+
+    public URI getEndpoint()
+    {
+        return URI.create("http://" + getHost() + ":" + getMappedPort(MOTO_PORT));
+    }
+
+    public void updateClient(AwsClientBuilder<?, ?> client)
+    {
+        client.endpointOverride(getEndpoint());
+        client.region(Region.of(MOTO_REGION));
+        client.credentialsProvider(StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(MOTO_ACCESS_KEY, MOTO_SECRET_KEY)));
+        if (client instanceof S3ClientBuilder s3) {
+            s3.forcePathStyle(true);
+        }
+    }
+
+    public void createBucket(String bucketName)
+    {
+        try (S3Client s3 = S3Client.builder().applyMutation(this::updateClient).build()) {
+            s3.createBucket(builder -> builder.bucket(bucketName));
+        }
+    }
+}


### PR DESCRIPTION
## Description

[Moto](http://docs.getmoto.org/en/latest/) provides mock instances of AWS services, including S3 and Glue.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Delta Lake
* Fix Glue endpoint URL override. ({issue}`25324`)

## Iceberg
* Fix Glue endpoint URL override. ({issue}`25324`)

## Hive
* Fix Glue endpoint URL override. ({issue}`25324`)

## Hudi
* Fix Glue endpoint URL override. ({issue}`25324`)

