### PR TITLE
Cleanup previous snapshot files during materialized view refresh

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -2177,33 +2177,7 @@ public class IcebergMetadata
                 IcebergSessionProperties.EXPIRE_SNAPSHOTS_MIN_RETENTION);
 
         long expireTimestampMillis = session.getStart().toEpochMilli() - retention.toMillis();
-        TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), table.io().properties());
-        List<Location> pathsToDelete = new ArrayList<>();
-        // deleteFunction is not accessed from multiple threads unless .executeDeleteWith() is used
-        Consumer<String> deleteFunction = path -> {
-            pathsToDelete.add(Location.of(path));
-            if (pathsToDelete.size() == DELETE_BATCH_SIZE) {
-                try {
-                    fileSystem.deleteFiles(pathsToDelete);
-                    pathsToDelete.clear();
-                }
-                catch (IOException e) {
-                    throw new TrinoException(ICEBERG_FILESYSTEM_ERROR, "Failed to delete files during snapshot expiration", e);
-                }
-            }
-        };
-
-        try {
-            table.expireSnapshots()
-                    .expireOlderThan(expireTimestampMillis)
-                    .deleteWith(deleteFunction)
-                    .commit();
-
-            fileSystem.deleteFiles(pathsToDelete);
-        }
-        catch (IOException e) {
-            throw new TrinoException(ICEBERG_FILESYSTEM_ERROR, "Failed to delete files during snapshot expiration", e);
-        }
+        executeExpireSnapshots(table, session, expireTimestampMillis);
     }
 
     private static void validateTableExecuteParameters(
@@ -3835,6 +3809,15 @@ public class IcebergMetadata
         commitUpdateAndTransaction(appendFiles, session, transaction, "refresh materialized view");
         transaction = null;
         fromSnapshotForRefresh = Optional.empty();
+
+        // cleanup old snapshots
+        try {
+            executeExpireSnapshots(icebergTable, session, System.currentTimeMillis());
+        }
+        catch (Exception e) {
+            log.error(e, "Failed to delete old snapshot files during materialized view refresh");
+        }
+
         return Optional.of(new HiveWrittenPartitions(commitTasks.stream()
                 .map(CommitTaskData::path)
                 .collect(toImmutableList())));
@@ -4095,6 +4078,37 @@ public class IcebergMetadata
     {
         verify(transaction == null, "transaction already set");
         transaction = catalog.newTransaction(icebergTable);
+    }
+
+    private void executeExpireSnapshots(Table icebergTable, ConnectorSession session, long expireTimestampMillis)
+    {
+        TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), icebergTable.io().properties());
+        List<Location> pathsToDelete = new ArrayList<>();
+        // deleteFunction is not accessed from multiple threads unless .executeDeleteWith() is used
+        Consumer<String> deleteFunction = path -> {
+            pathsToDelete.add(Location.of(path));
+            if (pathsToDelete.size() == DELETE_BATCH_SIZE) {
+                try {
+                    fileSystem.deleteFiles(pathsToDelete);
+                    pathsToDelete.clear();
+                }
+                catch (IOException e) {
+                    throw new TrinoException(ICEBERG_FILESYSTEM_ERROR, "Failed to delete files during snapshot expiration", e);
+                }
+            }
+        };
+
+        try {
+            icebergTable.expireSnapshots()
+                    .expireOlderThan(expireTimestampMillis)
+                    .deleteWith(deleteFunction)
+                    .commit();
+
+            fileSystem.deleteFiles(pathsToDelete);
+        }
+        catch (IOException e) {
+            throw new TrinoException(ICEBERG_FILESYSTEM_ERROR, "Failed to delete files during snapshot expiration", e);
+        }
     }
 
     private static IcebergTableHandle checkValidTableHandle(ConnectorTableHandle tableHandle)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
@@ -20,6 +20,8 @@ import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
 import io.trino.connector.MockConnectorFactory;
 import io.trino.connector.MockConnectorPlugin;
+import io.trino.filesystem.FileEntry;
+import io.trino.filesystem.FileIterator;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.plugin.iceberg.fileio.ForwardingFileIo;
@@ -52,6 +54,7 @@ import org.apache.iceberg.TableMetadataParser;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
@@ -1107,6 +1110,99 @@ public abstract class BaseIcebergMaterializedViewTest
         // cleanup
         assertUpdate("DROP MATERIALIZED VIEW %s".formatted(materializedViewName));
         assertUpdate("DROP TABLE %s".formatted(sourceTableName));
+    }
+
+    @Test
+    void testPreviousSnapshotCleanupDuringRefresh()
+            throws IOException
+    {
+        String sourceTableName = "source_table" + randomNameSuffix();
+        String materializedViewName = "test_materialized_view" + randomNameSuffix();
+
+        // create source table and an MV
+        assertUpdate("CREATE TABLE " + sourceTableName + " (a int, b varchar)");
+        assertUpdate("INSERT INTO " + sourceTableName + " VALUES (1, 'abc'), (2, 'def')", 2);
+        assertUpdate("CREATE MATERIALIZED VIEW " + materializedViewName + " AS SELECT a, b FROM " + sourceTableName + " WHERE a < 3 OR a > 5");
+        // Until first MV refresh no data files are created hence perform first MV refresh to get data files created for the MV
+        assertUpdate("REFRESH MATERIALIZED VIEW " + materializedViewName, 2);
+
+        TrinoFileSystem fileSystemFactory = getFileSystemFactory(getQueryRunner()).create(ConnectorIdentity.ofUser("test"));
+
+        // Identify different types of files containing in an MV
+        Location metadataLocation = Location.of(getStorageMetadataLocation(materializedViewName));
+        FileIterator tableFiles = fileSystemFactory.listFiles(Location.of(metadataLocation.toString().substring(0, metadataLocation.toString().indexOf("/metadata"))));
+        ImmutableSet.Builder<FileEntry> previousDataFiles = ImmutableSet.builder();
+        ImmutableSet.Builder<FileEntry> previousMetadataFiles = ImmutableSet.builder();
+        ImmutableSet.Builder<FileEntry> previousManifestsFiles = ImmutableSet.builder();
+        while (tableFiles.hasNext()) {
+            FileEntry file = tableFiles.next();
+            String location = file.location().toString();
+            if (location.contains("/data/")) {
+                previousDataFiles.add(file);
+            }
+            else if (location.contains("/metadata/") && location.endsWith(".json")) {
+                previousMetadataFiles.add(file);
+            }
+            else if (location.contains("/metadata") && !location.contains("snap-") && location.endsWith(".avro")) {
+                previousManifestsFiles.add(file);
+            }
+        }
+
+        // Execute MV refresh after deleting existing records and inserting new records in source table 
+        assertUpdate("DELETE FROM " + sourceTableName + " WHERE a = 1 OR a = 2", 2);
+        assertQueryReturnsEmptyResult("SELECT * FROM " + sourceTableName);
+        assertUpdate("INSERT INTO " + sourceTableName + " VALUES (7, 'pqr'), (8, 'xyz')", 2);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + materializedViewName, 2);
+        assertThat(query("SELECT * FROM " + materializedViewName))
+                .matches("VALUES (7, VARCHAR 'pqr'), (8, VARCHAR 'xyz')");
+
+        // Identify different types of files containing in an MV after MV refresh
+        Location latestMetadataLocation = Location.of(getStorageMetadataLocation(materializedViewName));
+        FileIterator latestTableFiles = fileSystemFactory.listFiles(Location.of(latestMetadataLocation.toString().substring(0, latestMetadataLocation.toString().indexOf("/metadata"))));
+        ImmutableSet.Builder<FileEntry> currentDataFiles = ImmutableSet.builder();
+        ImmutableSet.Builder<FileEntry> currentMetadataFiles = ImmutableSet.builder();
+        ImmutableSet.Builder<FileEntry> currentManifestsFiles = ImmutableSet.builder();
+        while (latestTableFiles.hasNext()) {
+            FileEntry file = latestTableFiles.next();
+            String location = file.location().toString();
+            if (location.contains("/data/")) {
+                currentDataFiles.add(file);
+            }
+            else if (location.contains("/metadata/") && location.endsWith(".json")) {
+                currentMetadataFiles.add(file);
+            }
+            else if (location.contains("/metadata") && !location.contains("snap-") && location.endsWith(".avro")) {
+                currentManifestsFiles.add(file);
+            }
+        }
+
+        // data files from previous snapshot are absent in latest MV snapshot as those are cleaned up after MV refresh
+        assertThat(previousDataFiles.build())
+                .isNotEmpty()
+                .satisfies(dataFilesBeforeMvRefresh -> 
+                        assertThat(currentDataFiles.build())
+                                .isNotEmpty()
+                                .doesNotContainAnyElementsOf(dataFilesBeforeMvRefresh));
+
+        // metadata files from previous snapshot are still present in latest MV snapshot as those are not cleaned up after MV refresh
+        assertThat(previousMetadataFiles.build())
+                .isNotEmpty()
+                .satisfies(metadataFilesBeforeMvRefresh -> 
+                        assertThat(currentMetadataFiles.build())
+                                .isNotEmpty()
+                                .containsAll(metadataFilesBeforeMvRefresh));
+
+        // manifests files from previous snapshot are absent in latest MV snapshot as those are cleaned up after MV refresh
+        assertThat(previousManifestsFiles.build())
+                .isNotEmpty()
+                .satisfies(manifestsBeforeMvRefresh -> 
+                        assertThat(currentManifestsFiles.build())
+                                .isNotEmpty()
+                                .doesNotContainAnyElementsOf(manifestsBeforeMvRefresh));
+
+        // cleanup
+        assertUpdate("DROP MATERIALIZED VIEW " + materializedViewName);
+        assertUpdate("DROP TABLE " + sourceTableName);
     }
 
     protected String getColumnComment(String tableName, String columnName)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergFileOperations.java
@@ -933,8 +933,8 @@ public class TestIcebergFileOperations
                         .add(new FileOperationUtils.FileOperation(MANIFEST, "OutputFile.create"))
                         .add(new FileOperationUtils.FileOperation(MANIFEST, "InputFile.newStream"))
                         .addCopies(new FileOperationUtils.FileOperation(SNAPSHOT, "OutputFile.create"), 2)
-                        .addCopies(new FileOperationUtils.FileOperation(SNAPSHOT, "InputFile.newStream"), 2)
-                        .addCopies(new FileOperationUtils.FileOperation(SNAPSHOT, "InputFile.length"), 2)
+                        .addCopies(new FileOperationUtils.FileOperation(SNAPSHOT, "InputFile.newStream"), 4)
+                        .addCopies(new FileOperationUtils.FileOperation(SNAPSHOT, "InputFile.length"), 4)
                         .build());
 
         assertUpdate(session, "DELETE FROM test_table WHERE a = 1", 1);
@@ -943,10 +943,10 @@ public class TestIcebergFileOperations
                         .add(new FileOperationUtils.FileOperation(METADATA_JSON, "OutputFile.create"))
                         .addCopies(new FileOperationUtils.FileOperation(METADATA_JSON, "InputFile.newStream"), 2)
                         .addCopies(new FileOperationUtils.FileOperation(MANIFEST, "OutputFile.create"), 2)
-                        .addCopies(new FileOperationUtils.FileOperation(MANIFEST, "InputFile.newStream"), 4)
+                        .addCopies(new FileOperationUtils.FileOperation(MANIFEST, "InputFile.newStream"), 6)
                         .addCopies(new FileOperationUtils.FileOperation(SNAPSHOT, "OutputFile.create"), 2)
-                        .addCopies(new FileOperationUtils.FileOperation(SNAPSHOT, "InputFile.newStream"), 3)
-                        .addCopies(new FileOperationUtils.FileOperation(SNAPSHOT, "InputFile.length"), 3)
+                        .addCopies(new FileOperationUtils.FileOperation(SNAPSHOT, "InputFile.newStream"), 10)
+                        .addCopies(new FileOperationUtils.FileOperation(SNAPSHOT, "InputFile.length"), 6)
                         .add(new FileOperationUtils.FileOperation(PUFFIN, "InputFile.newInput"))
                         .build());
 


### PR DESCRIPTION
<!-- Provide an overview for maintainers and reviewers. -->
## Description

`REFRESH MATERIALIZED VIEW` https://trino.io/docs/current/sql/refresh-materialized-view.html doesn't cleanup old snapshot files which causes materialized view size to grow without having any benefit of retaining old data.
Proposed solution uses `org.apache.iceberg.ExpireSnapshots` procedure in `io.trino.plugin.iceberg.IcebergMetadata#finishRefreshMaterializedView` to cleanup previous snapshot created just before the execution of refresh materialized view command.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Clean up old snapshots of the storage table on refresh of materialized views. ({issue}`25343`)
```
