### PR TITLE
Fix eternal lock when hive metastore down during request with lock

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
@@ -21,7 +21,9 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import io.airlift.units.Duration;
 import io.trino.hive.thrift.metastore.ColumnStatisticsData;
 import io.trino.hive.thrift.metastore.ColumnStatisticsObj;
+import io.trino.hive.thrift.metastore.LockState;
 import io.trino.hive.thrift.metastore.LongColumnStatsData;
+import io.trino.metastore.AcidTransactionOwner;
 import io.trino.metastore.Database;
 import io.trino.metastore.HiveBasicStatistics;
 import io.trino.metastore.HiveColumnStatistics;
@@ -40,6 +42,7 @@ import io.trino.plugin.hive.metastore.thrift.ThriftHiveMetastore;
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastore;
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreClient;
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreStats;
+import io.trino.spi.TrinoException;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.Range;
@@ -54,10 +57,12 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.parallel.Execution;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Executor;
@@ -84,6 +89,7 @@ import static io.trino.plugin.hive.metastore.thrift.MockThriftMetastoreClient.BA
 import static io.trino.plugin.hive.metastore.thrift.MockThriftMetastoreClient.PARTITION_COLUMN_NAMES;
 import static io.trino.plugin.hive.metastore.thrift.MockThriftMetastoreClient.TEST_COLUMN;
 import static io.trino.plugin.hive.metastore.thrift.MockThriftMetastoreClient.TEST_DATABASE;
+import static io.trino.plugin.hive.metastore.thrift.MockThriftMetastoreClient.TEST_EXCEPTION_LOCK_MESSAGE;
 import static io.trino.plugin.hive.metastore.thrift.MockThriftMetastoreClient.TEST_PARTITION1;
 import static io.trino.plugin.hive.metastore.thrift.MockThriftMetastoreClient.TEST_PARTITION1_VALUE;
 import static io.trino.plugin.hive.metastore.thrift.MockThriftMetastoreClient.TEST_PARTITION2;
@@ -1041,6 +1047,32 @@ public class TestCachingHiveMetastore
         assertThat(mockClient.getAccessCount()).isEqualTo(3);
         assertThat(metastore.getAllDatabases()).containsExactly(TEST_DATABASE);
         assertThat(mockClient.getAccessCount()).isEqualTo(3); // should read it from cache
+    }
+
+    @Test
+    public void testAcquireSharedReadLockIfMetastoreDownDuringCheckLock()
+    {
+        long lockId = new Random().nextLong();
+
+        mockClient.setTestLockState(LockState.WAITING);
+        mockClient.setTestLockId(lockId);
+        mockClient.setThrowException(true);
+
+        assertThatThrownBy(this::acquireSharedReadLock)
+                .isInstanceOf(TrinoException.class)
+                .hasMessage(TEST_EXCEPTION_LOCK_MESSAGE.formatted(lockId));
+
+        // 11 is the number of retries(by default 10) + 1 unlock call
+        assertThat(mockClient.getAccessCount()).isEqualTo(11);
+    }
+
+    private void acquireSharedReadLock()
+    {
+        metastore.acquireSharedReadLock(new AcidTransactionOwner("test"),
+                "queryId",
+                5,
+                Collections.singletonList(new SchemaTableName("test", "test")),
+                Collections.emptyList());
     }
 
     private static HiveColumnStatistics intColumnStats(int nullsCount)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Added unlock for case when exception occur during get connection to metastore if we don't unlock this lock, it stills in database and next locks will wait it, this lock have never removed as request finished with exception.
Without fix the one way to unlock is remove raw manually in database

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
