### PR TITLE
Fix FlatHash

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/FlatHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/FlatHash.java
@@ -262,7 +262,7 @@ public final class FlatHash
     private int getIndex(Block[] blocks, int position, long hash)
     {
         byte hashPrefix = (byte) (hash & 0x7F | 0x80);
-        int bucket = bucket((int) hash >> 7);
+        int bucket = bucket((int) (hash >> 7));
 
         int step = 1;
         long repeated = repeat(hashPrefix);

--- a/core/trino-main/src/main/java/io/trino/operator/FlatHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/FlatHash.java
@@ -216,12 +216,28 @@ public final class FlatHash
 
     public void computeHashes(Block[] blocks, long[] hashes, int offset, int length)
     {
-        flatHashStrategy.hashBlocksBatched(blocks, hashes, offset, length);
+        if (hasPrecomputedHash) {
+            Block hashBlock = blocks[blocks.length - 1];
+            for (int i = 0; i < length; i++) {
+                hashes[i] = BIGINT.getLong(hashBlock, offset + i);
+            }
+        }
+        else {
+            flatHashStrategy.hashBlocksBatched(blocks, hashes, offset, length);
+        }
     }
 
     public int putIfAbsent(Block[] blocks, int position)
     {
-        return putIfAbsent(blocks, position, flatHashStrategy.hash(blocks, position));
+        long hash;
+        if (hasPrecomputedHash) {
+            hash = BIGINT.getLong(blocks[blocks.length - 1], position);
+        }
+        else {
+            hash = flatHashStrategy.hash(blocks, position);
+        }
+
+        return putIfAbsent(blocks, position, hash);
     }
 
     public int putIfAbsent(Block[] blocks, int position, long hash)

--- a/core/trino-main/src/main/java/io/trino/operator/FlatHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/FlatHash.java
@@ -204,16 +204,6 @@ public final class FlatHash
         }
     }
 
-    public boolean contains(Block[] blocks, int position)
-    {
-        return contains(blocks, position, flatHashStrategy.hash(blocks, position));
-    }
-
-    public boolean contains(Block[] blocks, int position, long hash)
-    {
-        return getIndex(blocks, position, hash) >= 0;
-    }
-
     public void computeHashes(Block[] blocks, long[] hashes, int offset, int length)
     {
         if (hasPrecomputedHash) {


### PR DESCRIPTION
## Description
One correctness fix and two small cleanups after https://github.com/trinodb/trino/pull/25127:
- **Fix**: uses a consistent control bucket hash lookup argument (parenthesizing `(hash >> 7)` in both places). The associativity of casting and shifting differences with and without the parenthesis would break the has probing logic and result in incorrect results when more than 2^25 (~33.5M) unique entries are inserted into the table.
- Adds back logic that was accidentally removed from `FlatHash` for `GroupByHashMode.PRECOMPUTED` handling. That logic is unnecessary in production since that codepath is no longer reachable except in benchmarks and tests
- Removes the unused `FlatHash#contains` methods

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
