### PR TITLE
Rewrite exclude_columns to Projection to apply optimizations

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -220,6 +220,7 @@ import io.trino.sql.planner.iterative.rule.ReplaceJoinOverConstantWithProject;
 import io.trino.sql.planner.iterative.rule.ReplaceRedundantJoinWithProject;
 import io.trino.sql.planner.iterative.rule.ReplaceRedundantJoinWithSource;
 import io.trino.sql.planner.iterative.rule.ReplaceWindowWithRowNumber;
+import io.trino.sql.planner.iterative.rule.RewriteExcludeColumns;
 import io.trino.sql.planner.iterative.rule.RewriteSpatialPartitioningAggregation;
 import io.trino.sql.planner.iterative.rule.RewriteTableFunctionToTableScan;
 import io.trino.sql.planner.iterative.rule.SimplifyCountOverConstant;
@@ -464,7 +465,8 @@ public class PlanOptimizers
                                         new RewriteSpatialPartitioningAggregation(plannerContext),
                                         new SimplifyCountOverConstant(plannerContext),
                                         new PreAggregateCaseAggregations(plannerContext),
-                                        new RemoveRedundantDistinctAggregation()))
+                                        new RemoveRedundantDistinctAggregation(),
+                                        new RewriteExcludeColumns()))
                                 .build()),
                 // MergeUnion and related projection pruning rules must run before limit pushdown rules, otherwise
                 // an intermediate limit node will prevent unions from being merged later on

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RewriteExcludeColumns.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RewriteExcludeColumns.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.operator.table.ExcludeColumnsFunction;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.ProjectNode;
+import io.trino.sql.planner.plan.TableFunctionProcessorNode;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.trino.sql.planner.plan.Patterns.tableFunctionProcessor;
+
+public class RewriteExcludeColumns
+        implements Rule<TableFunctionProcessorNode>
+{
+    private static final Pattern<TableFunctionProcessorNode> PATTERN = tableFunctionProcessor().matching(x -> x.getName().equals(ExcludeColumnsFunction.NAME));
+
+    @Override
+    public Pattern<TableFunctionProcessorNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(TableFunctionProcessorNode node, Captures captures, Context context)
+    {
+        PlanNode source = node.getSources().getFirst();
+        Map<Symbol, Expression> assignments = new HashMap<>();
+        for (int i = 0; i < node.getOutputSymbols().size(); i++) {
+            assignments.put(node.getOutputSymbols().get(i), source.getOutputSymbols().get(i).toSymbolReference());
+        }
+        return Result.ofPlanNode(new ProjectNode(node.getId(), source, new Assignments(assignments)));
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRewriteExcludeColumns.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRewriteExcludeColumns.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestRewriteExcludeColumns
+        extends BaseRuleTest
+{
+    @Test
+    public void test()
+    {
+        tester().assertThat(new RewriteExcludeColumns())
+                .on(p -> p.tableFunctionProcessor(
+                        builder -> builder
+                                .name("exclude_columns")
+                                .properOutputs(p.symbol("p", BIGINT))
+                                .source(p.values(p.symbol("x", BIGINT), p.symbol("y", BIGINT)))))
+                .matches(project(
+                        ImmutableMap.of("p", expression(new Reference(BIGINT, "x"))), values("x", "y")));
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Rewrite `exclude_columns` to projection not to block optimizations

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
https://github.com/trinodb/trino/issues/25117


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## General
* Enable optimizations through exclude_columns table function ({issue}`25117`)
```
