### PR TITLE
[WIP] Add support for periodically refreshing dynamic catalogs from the CatalogStore

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/CatalogRefreshTask.java
+++ b/core/trino-main/src/main/java/io/trino/connector/CatalogRefreshTask.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.connector;
+
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+import io.airlift.units.Duration;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class CatalogRefreshTask
+{
+    private static final Logger log = Logger.get(CatalogRefreshTask.class);
+
+    private final CoordinatorDynamicCatalogManager catalogManager;
+    private final boolean enabled;
+    private final Duration refreshInterval;
+
+    private final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1, daemonThreadsNamed("catalog-refresh"));
+
+    private final AtomicBoolean started = new AtomicBoolean();
+
+    @Inject
+    public CatalogRefreshTask(CatalogRefreshTaskConfig config, CoordinatorDynamicCatalogManager catalogManager)
+    {
+        this.catalogManager = requireNonNull(catalogManager, "catalogManager is null");
+        this.enabled = config.isEnabled();
+        this.refreshInterval = config.getRefreshInterval();
+    }
+
+    @PostConstruct
+    public void start()
+    {
+        if (enabled && !started.getAndSet(true)) {
+            executor.scheduleWithFixedDelay(() -> {
+                try {
+                    catalogManager.refreshCatalogs();
+                }
+                catch (Throwable e) {
+                    // ignore to avoid getting unscheduled
+                    log.warn(e, "Error refreshing catalogs");
+                }
+            }, refreshInterval.toMillis(), refreshInterval.toMillis(), MILLISECONDS);
+        }
+    }
+
+    @PreDestroy
+    public void shutdown()
+    {
+        executor.shutdownNow();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/connector/CatalogRefreshTaskConfig.java
+++ b/core/trino-main/src/main/java/io/trino/connector/CatalogRefreshTaskConfig.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.connector;
+
+import io.airlift.configuration.Config;
+import io.airlift.units.Duration;
+import io.airlift.units.MinDuration;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.concurrent.TimeUnit;
+
+public class CatalogRefreshTaskConfig
+{
+    private boolean enabled = true;
+    private Duration refreshInterval = Duration.succinctDuration(60, TimeUnit.SECONDS);
+
+    public boolean isEnabled()
+    {
+        return enabled;
+    }
+
+    @Config("catalog.refresh.enabled")
+    public CatalogRefreshTaskConfig setEnabled(boolean enabled)
+    {
+        this.enabled = enabled;
+        return this;
+    }
+
+    @MinDuration("60s")
+    @NotNull
+    public Duration getRefreshInterval()
+    {
+        return refreshInterval;
+    }
+
+    @Config("catalog.refresh.refresh-interval")
+    public CatalogRefreshTaskConfig setRefreshInterval(Duration interval)
+    {
+        this.refreshInterval = interval;
+        return this;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/connector/DynamicCatalogManagerModule.java
+++ b/core/trino-main/src/main/java/io/trino/connector/DynamicCatalogManagerModule.java
@@ -41,6 +41,9 @@ public class DynamicCatalogManagerModule
 
             configBinder(binder).bindConfig(CatalogPruneTaskConfig.class);
             binder.bind(CatalogPruneTask.class).in(Scopes.SINGLETON);
+
+            configBinder(binder).bindConfig(CatalogRefreshTaskConfig.class);
+            binder.bind(CatalogRefreshTask.class).in(Scopes.SINGLETON);
         }
         else {
             binder.bind(WorkerDynamicCatalogManager.class).in(Scopes.SINGLETON);


### PR DESCRIPTION
## Description

Proposal to add support for Trino installations using dynamic catalogs to periodically refresh catalogs from the configured `CatalogStore`. It allows Trino to periodically list the catalogs available in the `CatalogStore` and add/remove/update the available catalogs accordingly.

The objective of this proposed change is to allow administrators to externally manage dynamic catalogs and have Trino periodically sync to their configuration, rather than needing to push catalog changes to Trino through `CREATE/DROP CATALOG` statements.

Catalog refreshes are disabled by default and can be enabled through the `catalog.refresh.enabled` configuration property. The refresh interval defaults to 60 seconds and can be configured through the `catalog.refresh.refresh-interval`

Example configuration:

```
catalog.management=dynamic
catalog.refresh.enabled=true
catalog.refresh.refresh-interval=60s
catalog.store=my_catalog_store
```

I would love to hear feedback on whether this change is welcome and on the approach itself. I would also appreciate any recommendations on how to effectively test the change.

## Additional context and related issues

Catalog refreshes are implemented in the `CoordinatorDynamicCatalogManager::refreshCatalogs()` method. The approach is to list the catalogs from the catalog store, compare them to the currently active catalogs and determine the catalogs that were added, removed or updated. With that information, update the catalog state accordingly.

Catalog refreshing is triggered by the `CatalogRefreshTask`, which works very similarly to the existing `CatalogPruneTask`.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: