### PR TITLE
Use the new facility to create tables with PK in MySQL tests

### DIFF
--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlGlobalTransactionMyConnectorSmokeTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlGlobalTransactionMyConnectorSmokeTest.java
@@ -17,21 +17,17 @@ import io.trino.Session;
 import io.trino.plugin.jdbc.BaseJdbcConnectorSmokeTest;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
-import io.trino.testing.sql.TestTable;
 
 import static io.trino.plugin.jdbc.JdbcWriteSessionProperties.NON_TRANSACTIONAL_MERGE;
-import static java.lang.String.format;
 
 public class TestMySqlGlobalTransactionMyConnectorSmokeTest
         extends BaseJdbcConnectorSmokeTest
 {
-    private TestingMySqlServer mySqlServer;
-
     @Override
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        mySqlServer = closeAfterClass(new TestingMySqlServer(true));
+        TestingMySqlServer mySqlServer = closeAfterClass(new TestingMySqlServer(true));
         return MySqlQueryRunner.builder(mySqlServer)
                 .setInitialTables(REQUIRED_TPCH_TABLES)
                 .build();
@@ -58,10 +54,8 @@ public class TestMySqlGlobalTransactionMyConnectorSmokeTest
     }
 
     @Override
-    protected TestTable createTestTableForWrites(String tablePrefix)
+    protected String getCreateTableDefaultDefinition()
     {
-        TestTable table = super.createTestTableForWrites(tablePrefix);
-        mySqlServer.execute(format("ALTER TABLE %s ADD PRIMARY KEY (a)", table.getName()));
-        return table;
+        return "(a bigint NOT NULL, b double) WITH (primary_key = ARRAY['a'])";
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

We no longer have to override the `createTestTableForWrites` to separately add the PK, and can instead provide the table definition that includes the PK.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This facility was added in #24930.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
