### PR TITLE
Use cummulative set of change nodes when inserting adaptive plan node

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/AdaptivePlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/AdaptivePlanner.java
@@ -91,6 +91,7 @@ public class AdaptivePlanner
     private final WarningCollector warningCollector;
     private final PlanOptimizersStatsCollector planOptimizersStatsCollector;
     private final CachingTableStatsProvider tableStatsProvider;
+    private final Set<PlanNodeId> cummulativeChangedPlanNodes = new HashSet<>();
 
     public AdaptivePlanner(
             Session session,
@@ -152,8 +153,9 @@ public class AdaptivePlanner
             return root;
         }
 
+        this.cummulativeChangedPlanNodes.addAll(optimizationResult.changedPlanNodes());
         // Add the adaptive plan node recursively where initialPlan remain as it is and optimizedPlan as new currentPlan
-        PlanNode adaptivePlan = addAdaptivePlanNode(idAllocator, initialPlan, optimizationResult.plan(), optimizationResult.changedPlanNodes());
+        PlanNode adaptivePlan = addAdaptivePlanNode(idAllocator, initialPlan, optimizationResult.plan(), cummulativeChangedPlanNodes);
         // validate the adaptive plan
         try (var _ = scopedSpan(plannerContext.getTracer(), "validate-adaptive-plan")) {
             planSanityChecker.validateAdaptivePlan(adaptivePlan, session, plannerContext, warningCollector);


### PR DESCRIPTION
As we are traversing initial and current plan when inserting new adaptive plan nodes we need to take into account all the changes made by multiple calls to adaptive planner; not just the recent one.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## General
* Fix occasional query failures when adaptive planning is used. ({issue}`issuenumber`)
```
