### PR TITLE
Fix typo in BigQueryConfig

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConfig.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConfig.java
@@ -392,7 +392,7 @@ public class BigQueryConfig
     }
 
     @AssertTrue(message = VIEWS_ENABLED + " config property must be enabled when bigquery.skip-view-materialization is enabled")
-    public boolean isValidViewsWehnEnabledSkipViewMaterialization()
+    public boolean isValidViewsWhenEnabledSkipViewMaterialization()
     {
         return !skipViewMaterialization || viewsEnabled;
     }

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConfig.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConfig.java
@@ -132,7 +132,7 @@ public class TestBigQueryConfig
                 new BigQueryConfig()
                         .setSkipViewMaterialization(true)
                         .setViewsEnabled(false),
-                "validViewsWehnEnabledSkipViewMaterialization",
+                "validViewsWhenEnabledSkipViewMaterialization",
                 "bigquery.views-enabled config property must be enabled when bigquery.skip-view-materialization is enabled",
                 AssertTrue.class);
 


### PR DESCRIPTION
## Description

There is no other "Wehn" typo. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
