### PR TITLE
Make max parallelism configurable in BigQuery

### DIFF
--- a/docs/src/main/sphinx/connector/bigquery.md
+++ b/docs/src/main/sphinx/connector/bigquery.md
@@ -211,6 +211,10 @@ a few caveats:
   - Enable using Apache Arrow serialization when reading data from BigQuery.
     Read this [section](bigquery-arrow-serialization-support) before using this feature.
   - `true`
+* - `bigquery.max-parallelism`
+  - The max number of partitions to split the data into. Reduce this number if
+    the default parallelism (number of workers x 3) is too high.
+  -
 * - `bigquery.channel-pool.initial-size`
   - The initial size of the connection pool, also known as a channel pool,
     used for gRPC communication.

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConfig.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConfig.java
@@ -65,6 +65,7 @@ public class BigQueryConfig
     private boolean proxyEnabled;
     private boolean projectionPushDownEnabled = true;
     private int metadataParallelism = Math.min(Runtime.getRuntime().availableProcessors(), MAX_METADATA_PARALLELISM);
+    private Optional<Integer> maxParallelism = Optional.empty();
 
     public Optional<String> getProjectId()
     {
@@ -382,6 +383,20 @@ public class BigQueryConfig
     public BigQueryConfig setMetadataParallelism(int metadataParallelism)
     {
         this.metadataParallelism = metadataParallelism;
+        return this;
+    }
+
+    @NotNull
+    public Optional<@Min(1) Integer> getMaxParallelism()
+    {
+        return maxParallelism;
+    }
+
+    @Config("bigquery.max-parallelism")
+    @ConfigDescription("The max number of partitions to split the data into")
+    public BigQueryConfig setMaxParallelism(Integer maxParallelism)
+    {
+        this.maxParallelism = Optional.ofNullable(maxParallelism);
         return this;
     }
 

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySessionProperties.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySessionProperties.java
@@ -21,9 +21,11 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.session.PropertyMetadata;
 
 import java.util.List;
+import java.util.Optional;
 
 import static io.trino.spi.session.PropertyMetadata.booleanProperty;
 import static io.trino.spi.session.PropertyMetadata.enumProperty;
+import static io.trino.spi.session.PropertyMetadata.integerProperty;
 
 public final class BigQuerySessionProperties
         implements SessionPropertiesProvider
@@ -33,6 +35,7 @@ public final class BigQuerySessionProperties
     private static final String QUERY_RESULTS_CACHE_ENABLED = "query_results_cache_enabled";
     private static final String CREATE_DISPOSITION_TYPE = "create_disposition_type";
     private static final String PROJECTION_PUSHDOWN_ENABLED = "projection_pushdown_enabled";
+    private static final String MAX_PARALLELISM = "max_parallelism";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -66,6 +69,11 @@ public final class BigQuerySessionProperties
                         "Dereference push down for STRUCT type",
                         config.isProjectionPushdownEnabled(),
                         false))
+                .add(integerProperty(
+                        MAX_PARALLELISM,
+                        "The max number of partitions to split the data into.",
+                        config.getMaxParallelism().orElse(null),
+                        false))
                 .build();
     }
 
@@ -98,5 +106,10 @@ public final class BigQuerySessionProperties
     public static boolean isProjectionPushdownEnabled(ConnectorSession session)
     {
         return session.getProperty(PROJECTION_PUSHDOWN_ENABLED, Boolean.class);
+    }
+
+    public static Optional<Integer> getMaxParallelism(ConnectorSession session)
+    {
+        return Optional.ofNullable(session.getProperty(MAX_PARALLELISM, Integer.class));
     }
 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitSource.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitSource.java
@@ -51,6 +51,7 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.plugin.bigquery.BigQueryClient.TABLE_TYPES;
 import static io.trino.plugin.bigquery.BigQueryClient.selectSql;
 import static io.trino.plugin.bigquery.BigQueryErrorCode.BIGQUERY_FAILED_TO_EXECUTE_QUERY;
+import static io.trino.plugin.bigquery.BigQuerySessionProperties.getMaxParallelism;
 import static io.trino.plugin.bigquery.BigQueryUtil.buildNativeQuery;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.util.Objects.requireNonNull;
@@ -214,7 +215,7 @@ public class BigQuerySplitSource
     @VisibleForTesting
     ReadSession createReadSession(ConnectorSession session, TableId remoteTableId, List<BigQueryColumnHandle> columns, Optional<String> filter)
     {
-        ReadSessionCreator readSessionCreator = new ReadSessionCreator(bigQueryClientFactory, bigQueryReadClientFactory, viewEnabled, arrowSerializationEnabled, viewExpiration, maxReadRowsRetries);
+        ReadSessionCreator readSessionCreator = new ReadSessionCreator(bigQueryClientFactory, bigQueryReadClientFactory, viewEnabled, arrowSerializationEnabled, viewExpiration, maxReadRowsRetries, getMaxParallelism(session));
         return readSessionCreator.create(session, remoteTableId, columns, filter, nodeManager.getRequiredWorkerNodes().size());
     }
 

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
@@ -21,6 +21,7 @@ import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.trino.Session;
+import io.trino.operator.OperatorStats;
 import io.trino.spi.QueryId;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.sql.planner.assertions.PlanMatchPattern;
@@ -43,6 +44,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
@@ -1451,6 +1453,42 @@ public abstract class BaseBigQueryConnectorTest
                             results -> assertThat(results.getRowCount()).isEqualTo(2));
                 },
                 results -> assertThat(results.getRowCount()).isEqualTo(2));
+    }
+
+    @Test
+    void testMaxParallelism()
+    {
+        Session singleParallelism = Session.builder(getSession())
+                .setCatalogSessionProperty("bigquery", "max_parallelism", "1")
+                .build();
+
+        try (TestTable table = new TestTable(bigQuerySqlExecutor, "tpch.test_max_parallelism", "AS SELECT repeat('x', 1000) x FROM UNNEST(GENERATE_ARRAY(1, 1000000))")) {
+            assertThat(getSplitCount(getSession(), "SELECT * FROM " + table.getName())).isGreaterThan(1);
+            assertThat(getSplitCount(singleParallelism, "SELECT * FROM " + table.getName())).isEqualTo(1);
+        }
+    }
+
+    private long getSplitCount(Session session, @Language("SQL") String query)
+    {
+        MaterializedResultWithPlan result = getQueryRunner().executeWithPlan(session, query);
+        return getOperatorStats(result.queryId()).getTotalDrivers();
+    }
+
+    private OperatorStats getOperatorStats(QueryId queryId)
+    {
+        try {
+            return getDistributedQueryRunner().getCoordinator()
+                    .getQueryManager()
+                    .getFullQueryInfo(queryId)
+                    .getQueryStats()
+                    .getOperatorSummaries()
+                    .stream()
+                    .filter(summary -> summary.getOperatorType().startsWith("TableScan") || summary.getOperatorType().startsWith("Scan"))
+                    .collect(onlyElement());
+        }
+        catch (NoSuchElementException e) {
+            throw new RuntimeException("Couldn't find operator summary, probably due to query statistic collection error", e);
+        }
     }
 
     @Test

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConfig.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConfig.java
@@ -57,7 +57,8 @@ public class TestBigQueryConfig
                 .setQueryLabelFormat(null)
                 .setProxyEnabled(false)
                 .setProjectionPushdownEnabled(true)
-                .setMetadataParallelism(Runtime.getRuntime().availableProcessors()));
+                .setMetadataParallelism(Runtime.getRuntime().availableProcessors())
+                .setMaxParallelism(null));
     }
 
     @Test
@@ -86,6 +87,7 @@ public class TestBigQueryConfig
                 .put("bigquery.job.label-format", "$TRACE_TOKEN")
                 .put("bigquery.rpc-proxy.enabled", "true")
                 .put("bigquery.metadata.parallelism", "31")
+                .put("bigquery.max-parallelism", "100")
                 .put("bigquery.projection-pushdown-enabled", "false")
                 .buildOrThrow();
 
@@ -112,7 +114,8 @@ public class TestBigQueryConfig
                 .setQueryLabelFormat("$TRACE_TOKEN")
                 .setProxyEnabled(true)
                 .setProjectionPushdownEnabled(false)
-                .setMetadataParallelism(31);
+                .setMetadataParallelism(31)
+                .setMaxParallelism(100);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description

We made parallelism non-configurable in #22279. 
This works well in most cases, but users may still want to limit the max parallelism. 

## Release notes

```markdown
## BigQuery
* TBD. ({issue}`issuenumber`)
```
