### PR TITLE
Fix pinot connector ignoring the grpc certain request's exception silently

### DIFF
--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotConfig.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotConfig.java
@@ -64,6 +64,7 @@ public class PinotConfig
     private boolean countDistinctPushdownEnabled = true;
     private boolean proxyEnabled;
     private DataSize targetSegmentPageSize = DataSize.of(1, MEGABYTE);
+    private boolean grpcQueryEnforceMetadataException;
 
     @NotEmpty(message = "pinot.controller-urls cannot be empty")
     public List<URI> getControllerUrls()
@@ -269,5 +270,17 @@ public class PinotConfig
                 .map(URI::getScheme)
                 .distinct()
                 .count() == 1;
+    }
+
+    public boolean isGrpcQueryEnforceMetadataException()
+    {
+        return grpcQueryEnforceMetadataException;
+    }
+
+    @Config("pinot.grpc.query.enforce-metadata-exception")
+    public PinotConfig setGrpcQueryEnforceMetadataException(boolean grpcQueryEnforceMetadataException)
+    {
+        this.grpcQueryEnforceMetadataException = grpcQueryEnforceMetadataException;
+        return this;
     }
 }

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotPageSourceProvider.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotPageSourceProvider.java
@@ -78,7 +78,7 @@ public class PinotPageSourceProvider
         switch (pinotSplit.getSplitType()) {
             case SEGMENT:
                 String segmentQuery = generatePql(pinotTableHandle, handles, pinotSplit.getSuffix(), pinotSplit.getTimePredicate(), limitForSegmentQueries);
-                PinotDataFetcher pinotDataFetcher = pinotDataFetcherFactory.create(segmentQuery, pinotSplit);
+                PinotDataFetcher pinotDataFetcher = pinotDataFetcherFactory.create(session, segmentQuery, pinotSplit);
                 return new PinotSegmentPageSource(
                         targetSegmentPageSizeBytes,
                         handles,

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotSessionProperties.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotSessionProperties.java
@@ -37,54 +37,61 @@ public class PinotSessionProperties
     private static final String SEGMENTS_PER_SPLIT = "segments_per_split";
     private static final String AGGREGATION_PUSHDOWN_ENABLED = "aggregation_pushdown_enabled";
     private static final String COUNT_DISTINCT_PUSHDOWN_ENABLED = "count_distinct_pushdown_enabled";
+    public static final String GRPC_QUERY_ENFORCE_METADATA_EXCEPTION = "grpc_query_enforce_metadata_exception";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
     public PinotSessionProperties(PinotConfig pinotConfig)
     {
-        sessionProperties = ImmutableList.of(
-                booleanProperty(
+        sessionProperties = ImmutableList.<PropertyMetadata<?>>builder()
+                .add(booleanProperty(
+                        GRPC_QUERY_ENFORCE_METADATA_EXCEPTION,
+                        "When true, enforce metadata exception in gRPC query even when response type is metadata",
+                        pinotConfig.isGrpcQueryEnforceMetadataException(),
+                        false))
+                .add(booleanProperty(
                         PREFER_BROKER_QUERIES,
                         "Prefer queries to broker even when parallel scan is enabled for aggregation queries",
                         pinotConfig.isPreferBrokerQueries(),
-                        false),
-                booleanProperty(
+                        false))
+                .add(booleanProperty(
                         FORBID_SEGMENT_QUERIES,
                         "Forbid segment queries",
                         pinotConfig.isForbidSegmentQueries(),
-                        false),
-                integerProperty(
+                        false))
+                .add(integerProperty(
                         RETRY_COUNT,
                         "Retry count for retriable pinot data fetch calls",
                         pinotConfig.getFetchRetryCount(),
-                        false),
-                integerProperty(
+                        false))
+                .add(integerProperty(
                         NON_AGGREGATE_LIMIT_FOR_BROKER_QUERIES,
                         "Max limit for non aggregate queries to the pinot broker",
                         pinotConfig.getNonAggregateLimitForBrokerQueries(),
-                        false),
-                durationProperty(
+                        false))
+                .add(durationProperty(
                         CONNECTION_TIMEOUT,
                         "Connection Timeout to talk to Pinot servers",
                         pinotConfig.getConnectionTimeout(),
-                        false),
-                integerProperty(
+                        false))
+                .add(integerProperty(
                         SEGMENTS_PER_SPLIT,
                         "Number of segments of the same host per split",
                         pinotConfig.getSegmentsPerSplit(),
                         value -> checkArgument(value > 0, "Number of segments per split must be more than zero"),
-                        false),
-                booleanProperty(
+                        false))
+                .add(booleanProperty(
                         AGGREGATION_PUSHDOWN_ENABLED,
                         "Enable aggregation pushdown",
                         pinotConfig.isAggregationPushdownEnabled(),
-                        false),
-                booleanProperty(
+                        false))
+                .add(booleanProperty(
                         COUNT_DISTINCT_PUSHDOWN_ENABLED,
                         "Enable count distinct pushdown",
                         pinotConfig.isCountDistinctPushdownEnabled(),
-                        false));
+                        false))
+                .build();
     }
 
     public static boolean isPreferBrokerQueries(ConnectorSession session)
@@ -128,6 +135,11 @@ public class PinotSessionProperties
         // This should never fail as this method would never be called unless aggregation pushdown is enabled
         verify(isAggregationPushdownEnabled(session), "%s must be enabled when %s is enabled", AGGREGATION_PUSHDOWN_ENABLED, COUNT_DISTINCT_PUSHDOWN_ENABLED);
         return session.getProperty(COUNT_DISTINCT_PUSHDOWN_ENABLED, Boolean.class);
+    }
+
+    public static boolean isGrpcQueryEnforceMetadataException(ConnectorSession session)
+    {
+        return session.getProperty(GRPC_QUERY_ENFORCE_METADATA_EXCEPTION, Boolean.class);
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotDataFetcher.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotDataFetcher.java
@@ -16,6 +16,7 @@ package io.trino.plugin.pinot.client;
 import com.google.common.collect.ImmutableList;
 import io.trino.plugin.pinot.PinotException;
 import io.trino.plugin.pinot.PinotSplit;
+import io.trino.spi.connector.ConnectorSession;
 import org.apache.pinot.common.datatable.DataTable;
 
 import java.util.List;
@@ -70,7 +71,7 @@ public interface PinotDataFetcher
 
     interface Factory
     {
-        PinotDataFetcher create(String query, PinotSplit split);
+        PinotDataFetcher create(ConnectorSession session, String query, PinotSplit split);
 
         int getRowLimit();
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
When making grpc requests towards pinot server, certain exceptions are carried back in metadata type of response, for example, query timeout, or segment missing exception. Due to the fact that EndOfData() return too early we actually never had a chance to deserialize these exceptions, which means when exception happens we may return empty or partial result instead of raising an exception. However, to maintain backward compatibility, a config/session property knob is introduced to gate the new behavior.

To test this, I spinned up a pinot cluster with extremely small timeout `pinot.server.query.executor.timeout=1`, with enabling pinot plugin on trino 
without the new config, it will silently return the empty result even underlying it hits timeout exception
<img width="629" alt="Screenshot 2025-03-26 at 12 34 54 AM" src="https://github.com/user-attachments/assets/3e3cf64f-9595-4cc4-b189-afd41211097e" />

with the `pinot.grpc.query.enforce-metadata-exception=true` set in pinot.properties, timeout exception is raised to end user

<img width="635" alt="Screenshot 2025-03-26 at 12 34 50 AM" src="https://github.com/user-attachments/assets/c11f7253-1692-4515-9da1-6b33796a44e2" />

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
