### PR TITLE
Fix flaky TestLokiIntegration.testSelectTimestampLogsQuery

### DIFF
--- a/plugin/trino-loki/src/test/java/io/trino/plugin/loki/TestLokiIntegration.java
+++ b/plugin/trino-loki/src/test/java/io/trino/plugin/loki/TestLokiIntegration.java
@@ -154,13 +154,13 @@ final class TestLokiIntegration
     void testSelectTimestampLogsQuery()
             throws Exception
     {
-        Instant start = Instant.now().truncatedTo(ChronoUnit.DAYS).minus(Duration.ofHours(12));
-        Instant end = start.plus(Duration.ofHours(4));
-        Instant firstLineTimestamp = start.truncatedTo(ChronoUnit.MILLIS);
+        Instant start = Instant.now().truncatedTo(ChronoUnit.HOURS);
+        Instant end = start.plus(Duration.ofHours(1));
+        Instant firstLineTimestamp = start.plus(Duration.ofMinutes(5)).truncatedTo(ChronoUnit.SECONDS);
 
         client.pushLogLine("line 1", firstLineTimestamp, ImmutableMap.of("test", "select_timestamp_query"));
-        client.pushLogLine("line 2", firstLineTimestamp.plus(Duration.ofHours(1)), ImmutableMap.of("test", "select_timestamp_query"));
-        client.pushLogLine("line 3", firstLineTimestamp.plus(Duration.ofHours(2)), ImmutableMap.of("test", "select_timestamp_query"));
+        client.pushLogLine("line 2", firstLineTimestamp.plus(Duration.ofMinutes(1)), ImmutableMap.of("test", "select_timestamp_query"));
+        client.pushLogLine("line 3", firstLineTimestamp.plus(Duration.ofMinutes(2)), ImmutableMap.of("test", "select_timestamp_query"));
         client.flush();
         assertQuery(format("""
                         SELECT


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
The Loki query was selecting the second line of the test data. This is because the timestamp for the first line and start of the query were the same. All other tests move the timestamps for each line away from the start and end to avoid such a flake.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

Fixes #25035
