### PR TITLE
Add Synonyms to SqlServerConnector

### DIFF
--- a/docs/src/main/sphinx/connector/sqlserver.md
+++ b/docs/src/main/sphinx/connector/sqlserver.md
@@ -106,6 +106,10 @@ behavior of the connector and the issues queries to the database.
   - Control the automatic use of snapshot isolation for transactions issued by
       Trino in SQL Server. Defaults to `false`, which means that snapshot
       isolation is enabled.
+* - `sqlserver.synonyms.enabled=true`
+  - Include [synonyms](https://learn.microsoft.com/en-us/sql/relational-databases/synonyms/synonyms-database-engine?view=sql-server-ver16)
+      as queryable entities. Defaults to `false`, which means synonyms are not
+      included by default.
 :::
 
 ```{include} jdbc-case-insensitive-matching.fragment

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerConfig.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerConfig.java
@@ -23,6 +23,7 @@ public class SqlServerConfig
     private boolean bulkCopyForWrite;
     private boolean bulkCopyForWriteLockDestinationTable;
     private boolean storedProcedureTableFunctionEnabled;
+    private boolean synonymsEnabled;
 
     public boolean isBulkCopyForWrite()
     {
@@ -75,5 +76,18 @@ public class SqlServerConfig
     {
         this.storedProcedureTableFunctionEnabled = storedProcedureTableFunctionEnabled;
         return this;
+    }
+
+    @Config("sqlserver.synonyms.enabled")
+    @ConfigDescription("Allows SQL Server Synonym manipulation")
+    public SqlServerConfig setSynonymsEnabled(boolean enabled)
+    {
+        this.synonymsEnabled = enabled;
+        return this;
+    }
+
+    public boolean isSynonymsEnabled()
+    {
+        return synonymsEnabled;
     }
 }

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
@@ -120,6 +120,14 @@ public abstract class BaseSqlServerConnectorTest
         }
     }
 
+    @Test
+    public void testSynonyms()
+    {
+        try (TestSynonym synonym = new TestSynonym(onRemoteDatabase(), "test_synonym", "FOR ORDERS")) {
+            assertQueryFails("SELECT orderkey FROM " + synonym.getName(), "line 1:22: Table 'sqlserver.*' does not exist");
+        }
+    }
+
     @Override
     protected void verifyAddNotNullColumnToNonEmptyTableFailurePermissible(Throwable e)
     {

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerClient.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerClient.java
@@ -58,6 +58,7 @@ public class TestSqlServerClient
 
     private static final JdbcClient JDBC_CLIENT = new SqlServerClient(
             new BaseJdbcConfig(),
+            new SqlServerConfig(),
             new JdbcStatisticsConfig(),
             session -> {
                 throw new UnsupportedOperationException();

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConfig.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConfig.java
@@ -28,6 +28,7 @@ public class TestSqlServerConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(SqlServerConfig.class)
+                .setSynonymsEnabled(false)
                 .setBulkCopyForWrite(false)
                 .setBulkCopyForWriteLockDestinationTable(false)
                 .setSnapshotIsolationDisabled(false)
@@ -38,6 +39,7 @@ public class TestSqlServerConfig
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("sqlserver.synonyms.enabled", "true")
                 .put("sqlserver.bulk-copy-for-write.enabled", "true")
                 .put("sqlserver.bulk-copy-for-write.lock-destination-table", "true")
                 .put("sqlserver.snapshot-isolation.disabled", "true")
@@ -45,6 +47,7 @@ public class TestSqlServerConfig
                 .buildOrThrow();
 
         SqlServerConfig expected = new SqlServerConfig()
+                .setSynonymsEnabled(true)
                 .setBulkCopyForWrite(true)
                 .setBulkCopyForWriteLockDestinationTable(true)
                 .setStoredProcedureTableFunctionEnabled(true)

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSynonym.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSynonym.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.sqlserver;
+
+import io.trino.testing.sql.SqlExecutor;
+
+import java.io.Closeable;
+
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static java.lang.String.format;
+
+public class TestSynonym
+        implements Closeable
+{
+    private final SqlExecutor sqlExecutor;
+    private final String name;
+
+    public TestSynonym(SqlExecutor sqlExecutor, String namePrefix, String definition)
+    {
+        this.sqlExecutor = sqlExecutor;
+        this.name = namePrefix + "_" + randomNameSuffix();
+        sqlExecutor.execute(format("CREATE SYNONYM %s %s", name, definition));
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    @Override
+    public void close()
+    {
+        sqlExecutor.execute("DROP SYNONYM " + name);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Adds a configuration option to allow users to opt-in to having Trino be able to interact with  SQL Server Synonym table types. 
Fixes #24206

A lot of the implementation here was shared from the OracleConnector's version of handling synonyms.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x ) Release notes are required, with the following suggested text:

```markdown
## SQL Server connector
 * Adds `sqlserver.synonyms.enabled` configuration option #24206
```
