### PR TITLE
Fix timestamp parsing issue in Regex and OpenX json deserializer

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/HiveFormatUtils.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/HiveFormatUtils.java
@@ -232,10 +232,15 @@ public final class HiveFormatUtils
             }
         }
 
-        return parseHiveTimestamp(value);
+        return parseTrimmedHiveTimestamp(value);
     }
 
     public static DecodedTimestamp parseHiveTimestamp(String value)
+    {
+        return parseTrimmedHiveTimestamp(value.trim());
+    }
+
+    private static DecodedTimestamp parseTrimmedHiveTimestamp(String value)
     {
         // Otherwise try default timestamp parsing
         // default parser uses Java util time

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/TestHiveFormatUtils.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/TestHiveFormatUtils.java
@@ -15,6 +15,7 @@ package io.trino.hive.formats;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.base.type.DecodedTimestamp;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
@@ -22,6 +23,7 @@ import java.time.LocalDate;
 import static io.trino.hive.formats.HiveFormatUtils.TIMESTAMP_FORMATS_KEY;
 import static io.trino.hive.formats.HiveFormatUtils.getTimestampFormatsSchemaProperty;
 import static io.trino.hive.formats.HiveFormatUtils.parseHiveDate;
+import static io.trino.hive.formats.HiveFormatUtils.parseHiveTimestamp;
 import static io.trino.hive.formats.HiveFormatsErrorCode.HIVE_INVALID_METADATA;
 import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,6 +33,7 @@ public class TestHiveFormatUtils
     @Test
     public void test()
     {
+        assertThat(parseHiveTimestamp("2024-11-28 21:04:54.982 ")).isEqualTo(new DecodedTimestamp(1732827894, 982000000));
         assertThat(parseHiveDate("5881580-07-11")).isEqualTo(LocalDate.of(5881580, 7, 11));
         assertThat(parseHiveDate("+5881580-07-11")).isEqualTo(LocalDate.of(5881580, 7, 11));
         assertThat(parseHiveDate("-5877641-06-23")).isEqualTo(LocalDate.of(-5877641, 6, 23));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Regex and OpenX JSON reader has parsing issues with timestamp types:
- A timestamp with trailing whitespace `2024-11-28 21:04:54.982 ` is parsed as null

After this change, it correctly outputs `2024-11-28 21:04:54.982` instead of null

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
N/A


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( O ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix edge case timestamp parsing issues in Regex and OpenX JSON. A timestamp with trailing spaces will be output correctly instead of null ({issue}`issuenumber`)
```
