### PR TITLE
Use column name based type coersion for OpenX JSON

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitManager.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitManager.java
@@ -486,7 +486,7 @@ public class HiveSplitManager
             return false;
         }
         return switch (storageFormat.get()) {
-            case AVRO, JSON -> true;
+            case AVRO, JSON, OPENX_JSON -> true;
             case ORC -> isUseOrcColumnNames(session);
             case PARQUET -> isUseParquetColumnNames(session);
             default -> false;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
There was an issue where the partition schema mismatched with the table schema, causing type coercion to occur. OpenX JSON was using column order-based type coercion, while the JSON format was using column name-based coercion.

When the partition schema was missing a column that existed in the table columns, the column order-based type coercion could assign incorrect types to the missing column. For example, it would attempt to parse a string column with an integer decoder, resulting in errors such as: `Character 'a' is neither a decimal digit number, decimal point, nor 'e' notation exponential mark.`

This PR makes OpenX JSON use column name based type coersion.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
N/A


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(O) Release notes are required, with the following suggested text:

```markdown
## Hive
* Fix partitioned table schema evolution for tables using the OpenX JSON SerDe ({issue}`25444`)
```
