### PR TITLE
Add support for lock-free commit in Iceberg HMS catalog

### DIFF
--- a/docs/src/main/sphinx/object-storage/metastores.md
+++ b/docs/src/main/sphinx/object-storage/metastores.md
@@ -208,6 +208,39 @@ properties:
   -
 :::
 
+(iceberg-hive-catalog)=
+### Iceberg-specific Hive catalog configuration properties
+
+When using the Hive catalog, the Iceberg connector supports the same
+{ref}`general Thrift metastore configuration properties <hive-thrift-metastore>` 
+as previously described with the following additional property:
+
+:::{list-table} Iceberg Hive catalog configuration property
+:widths: 35, 50, 15
+:header-rows: 1
+
+* - Property name
+  - Description
+  - Default
+* - `iceberg.hive-catalog.locking-enabled`
+  - Commit to tables using Hive locks.
+  - `true`
+:::
+
+:::{warning}
+Setting `iceberg.hive-catalog.locking-enabled=false` will cause the catalog to
+commit to tables without using Hive locks. This should only be set to false if all
+following conditions are met:
+
+* [HIVE-26882](https://issues.apache.org/jira/browse/HIVE-26882) is available on
+  the Hive metastore server. Requires version 2.3.10, 4.0.0-beta-1 or later.
+* [HIVE-28121](https://issues.apache.org/jira/browse/HIVE-28121) is available on
+  the Hive metastore server, if it is backed by MySQL or MariaDB. Requires version
+  2.3.10, 4.1.0, 4.0.1 or later.
+* All other catalogs committing to tables that this catalogs commits to are also
+  on Iceberg 1.3 or later, and disabled Hive locks on commit.
+:::
+
 (hive-thrift-metastore-authentication)=
 ### Thrift metastore authentication
 

--- a/lib/trino-metastore/src/main/java/io/trino/metastore/HiveMetastore.java
+++ b/lib/trino-metastore/src/main/java/io/trino/metastore/HiveMetastore.java
@@ -90,7 +90,7 @@ public interface HiveMetastore
      * alter one field of a table object previously acquired from getTable is
      * probably not what you want.
      */
-    void replaceTable(String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges);
+    void replaceTable(String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges, Map<String, String> environmentContext);
 
     void renameTable(String databaseName, String tableName, String newDatabaseName, String newTableName);
 

--- a/lib/trino-metastore/src/main/java/io/trino/metastore/cache/CachingHiveMetastore.java
+++ b/lib/trino-metastore/src/main/java/io/trino/metastore/cache/CachingHiveMetastore.java
@@ -651,10 +651,10 @@ public final class CachingHiveMetastore
     }
 
     @Override
-    public void replaceTable(String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
+    public void replaceTable(String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges, Map<String, String> environmentContext)
     {
         try {
-            delegate.replaceTable(databaseName, tableName, newTable, principalPrivileges);
+            delegate.replaceTable(databaseName, tableName, newTable, principalPrivileges, environmentContext);
         }
         finally {
             invalidateTable(databaseName, tableName);

--- a/lib/trino-metastore/src/main/java/io/trino/metastore/tracing/TracingHiveMetastore.java
+++ b/lib/trino-metastore/src/main/java/io/trino/metastore/tracing/TracingHiveMetastore.java
@@ -236,13 +236,13 @@ public class TracingHiveMetastore
     }
 
     @Override
-    public void replaceTable(String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
+    public void replaceTable(String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges, Map<String, String> environmentContext)
     {
         Span span = tracer.spanBuilder("HiveMetastore.replaceTable")
                 .setAttribute(SCHEMA, databaseName)
                 .setAttribute(TABLE, tableName)
                 .startSpan();
-        withTracing(span, () -> delegate.replaceTable(databaseName, tableName, newTable, principalPrivileges));
+        withTracing(span, () -> delegate.replaceTable(databaseName, tableName, newTable, principalPrivileges, environmentContext));
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.deltalake.metastore;
 
+import com.google.common.collect.ImmutableMap;
 import io.trino.metastore.Database;
 import io.trino.metastore.HiveMetastore;
 import io.trino.metastore.PrincipalPrivileges;
@@ -108,7 +109,7 @@ public class HiveMetastoreBackedDeltaLakeMetastore
     @Override
     public void replaceTable(Table table, PrincipalPrivileges principalPrivileges)
     {
-        delegate.replaceTable(table.getDatabaseName(), table.getTableName(), table, principalPrivileges);
+        delegate.replaceTable(table.getDatabaseName(), table.getTableName(), table, principalPrivileges, ImmutableMap.of());
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/file/DeltaLakeFileMetastoreTableOperations.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/file/DeltaLakeFileMetastoreTableOperations.java
@@ -47,6 +47,6 @@ public class DeltaLakeFileMetastoreTableOperations
                 .putAll(tableMetadataParameters(version, schemaString, tableComment))
                 .buildKeepingLast();
         Table updatedTable = currentTable.withParameters(parameters);
-        metastore.replaceTable(currentTable.getDatabaseName(), currentTable.getTableName(), updatedTable, buildInitialPrivilegeSet(currentTable.getOwner().orElseThrow()));
+        metastore.replaceTable(currentTable.getDatabaseName(), currentTable.getTableName(), updatedTable, buildInitialPrivilegeSet(currentTable.getOwner().orElseThrow()), ImmutableMap.of());
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/thrift/DeltaLakeThriftMetastoreTableOperations.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/thrift/DeltaLakeThriftMetastoreTableOperations.java
@@ -66,7 +66,7 @@ public class DeltaLakeThriftMetastoreTableOperations
                     .buildKeepingLast();
             Table updatedTable = currentTable.withParameters(parameters);
 
-            metastore.replaceTable(currentTable.getDatabaseName(), currentTable.getTableName(), updatedTable, buildInitialPrivilegeSet(currentTable.getOwner().orElseThrow()));
+            metastore.replaceTable(currentTable.getDatabaseName(), currentTable.getTableName(), updatedTable, buildInitialPrivilegeSet(currentTable.getOwner().orElseThrow()), ImmutableMap.of());
         }
         finally {
             thriftMetastore.releaseTableLock(lockId);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.deltalake;
 
 import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.Multiset;
 import com.google.common.io.Resources;
@@ -1265,6 +1266,6 @@ public class TestDeltaLakeFileOperations
         Table newMetastoreTable = Table.builder(table)
                 .setParameters(filterKeys(table.getParameters(), key -> !key.equals("trino_last_transaction_version")))
                 .build();
-        metastore.replaceTable(table.getDatabaseName(), table.getTableName(), newMetastoreTable, buildInitialPrivilegeSet(table.getOwner().orElseThrow()));
+        metastore.replaceTable(table.getDatabaseName(), table.getTableName(), newMetastoreTable, buildInitialPrivilegeSet(table.getOwner().orElseThrow()), ImmutableMap.of());
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreAccessOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreAccessOperations.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.deltalake.metastore;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multiset;
@@ -574,7 +575,7 @@ public class TestDeltaLakeMetastoreAccessOperations
         Table newMetastoreTable = Table.builder(table)
                 .setParameters(Maps.filterKeys(table.getParameters(), key -> !key.equals("trino_last_transaction_version")))
                 .build();
-        metastore.replaceTable(table.getDatabaseName(), table.getTableName(), newMetastoreTable, buildInitialPrivilegeSet(table.getOwner().orElseThrow()));
+        metastore.replaceTable(table.getDatabaseName(), table.getTableName(), newMetastoreTable, buildInitialPrivilegeSet(table.getOwner().orElseThrow()), ImmutableMap.of());
     }
 
     private Session sessionWithStoreTableMetadata(boolean storeTableMetadata)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TrinoViewHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TrinoViewHiveMetastore.java
@@ -92,7 +92,7 @@ public final class TrinoViewHiveMetastore
                 throw new ViewAlreadyExistsException(schemaViewName);
             }
 
-            metastore.replaceTable(schemaViewName.getSchemaName(), schemaViewName.getTableName(), table, principalPrivileges);
+            metastore.replaceTable(schemaViewName.getSchemaName(), schemaViewName.getTableName(), table, principalPrivileges, ImmutableMap.of());
             return;
         }
 
@@ -225,6 +225,6 @@ public final class TrinoViewHiveMetastore
 
         PrincipalPrivileges principalPrivileges = isUsingSystemSecurity ? NO_PRIVILEGES : buildInitialPrivilegeSet(session.getUser());
 
-        metastore.replaceTable(viewName.getSchemaName(), viewName.getTableName(), viewBuilder.build(), principalPrivileges);
+        metastore.replaceTable(viewName.getSchemaName(), viewName.getTableName(), viewBuilder.build(), principalPrivileges, ImmutableMap.of());
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -594,7 +594,7 @@ public class SemiTransactionalHiveMetastore
 
     public synchronized void replaceTable(String databaseName, String tableName, Table table, PrincipalPrivileges principalPrivileges)
     {
-        setExclusive(delegate -> delegate.replaceTable(databaseName, tableName, table, principalPrivileges));
+        setExclusive(delegate -> delegate.replaceTable(databaseName, tableName, table, principalPrivileges, ImmutableMap.of()));
     }
 
     public synchronized void renameTable(String databaseName, String tableName, String newDatabaseName, String newTableName)
@@ -3063,7 +3063,7 @@ public class SemiTransactionalHiveMetastore
                 metastore.alterTransactionalTable(newTable, transaction.getAcidTransactionId(), transaction.getWriteId(), principalPrivileges);
             }
             else {
-                metastore.replaceTable(newTable.getDatabaseName(), newTable.getTableName(), newTable, principalPrivileges);
+                metastore.replaceTable(newTable.getDatabaseName(), newTable.getTableName(), newTable, principalPrivileges, ImmutableMap.of());
             }
         }
 
@@ -3077,7 +3077,7 @@ public class SemiTransactionalHiveMetastore
                 metastore.alterTransactionalTable(oldTable, transaction.getAcidTransactionId(), transaction.getWriteId(), principalPrivileges);
             }
             else {
-                metastore.replaceTable(oldTable.getDatabaseName(), oldTable.getTableName(), oldTable, principalPrivileges);
+                metastore.replaceTable(oldTable.getDatabaseName(), oldTable.getTableName(), oldTable, principalPrivileges, ImmutableMap.of());
             }
         }
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -586,7 +586,7 @@ public class FileHiveMetastore
     }
 
     @Override
-    public synchronized void replaceTable(String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
+    public synchronized void replaceTable(String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges, Map<String, String> environmentContext)
     {
         Table table = getRequiredTable(databaseName, tableName);
         if (!table.getDatabaseName().equals(databaseName) || !table.getTableName().equals(tableName)) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -606,7 +606,7 @@ public class GlueHiveMetastore
     }
 
     @Override
-    public void replaceTable(String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
+    public void replaceTable(String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges, Map<String, String> environmentContext)
     {
         if (!tableName.equals(newTable.getTableName()) || !databaseName.equals(newTable.getDatabaseName())) {
             throw new TrinoException(NOT_SUPPORTED, "Table rename is not yet supported by Glue service");

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -247,9 +247,9 @@ public class BridgingHiveMetastore
     }
 
     @Override
-    public void replaceTable(String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
+    public void replaceTable(String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges, Map<String, String> environmentContext)
     {
-        alterTable(databaseName, tableName, toMetastoreApiTable(newTable, principalPrivileges));
+        alterTable(databaseName, tableName, toMetastoreApiTable(newTable, principalPrivileges), environmentContext);
     }
 
     @Override
@@ -292,7 +292,7 @@ public class BridgingHiveMetastore
                 .setOwner(Optional.of(principal.getName()))
                 .build();
 
-        delegate.alterTable(databaseName, tableName, toMetastoreApiTable(newTable));
+        delegate.alterTable(databaseName, tableName, toMetastoreApiTable(newTable), ImmutableMap.of());
     }
 
     @Override
@@ -360,7 +360,12 @@ public class BridgingHiveMetastore
 
     private void alterTable(String databaseName, String tableName, io.trino.hive.thrift.metastore.Table table)
     {
-        delegate.alterTable(databaseName, tableName, table);
+        delegate.alterTable(databaseName, tableName, table, ImmutableMap.of());
+    }
+
+    private void alterTable(String databaseName, String tableName, io.trino.hive.thrift.metastore.Table table, Map<String, String> context)
+    {
+        delegate.alterTable(databaseName, tableName, table, context);
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastore.java
@@ -57,7 +57,7 @@ public sealed interface ThriftMetastore
 
     void dropTable(String databaseName, String tableName, boolean deleteData);
 
-    void alterTable(String databaseName, String tableName, Table table);
+    void alterTable(String databaseName, String tableName, Table table, Map<String, String> environmentContext);
 
     void alterTransactionalTable(Table table, long transactionId, long writeId);
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveMetadataListing.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveMetadataListing.java
@@ -340,7 +340,7 @@ public class TestHiveMetadataListing
         }
 
         @Override
-        public void replaceTable(String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
+        public void replaceTable(String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges, Map<String, String> environmentContext)
         {
             throw new UnsupportedOperationException();
         }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/file/FileMetastoreTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/file/FileMetastoreTableOperations.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.iceberg.catalog.file;
 
+import com.google.common.collect.ImmutableMap;
 import io.trino.annotation.NotThreadSafe;
 import io.trino.metastore.PrincipalPrivileges;
 import io.trino.metastore.Table;
@@ -87,7 +88,7 @@ public class FileMetastoreTableOperations
         PrincipalPrivileges privileges = table.getOwner().map(MetastoreUtil::buildInitialPrivilegeSet).orElse(NO_PRIVILEGES);
 
         try {
-            metastore.replaceTable(database, table.getTableName(), updatedTable, privileges);
+            metastore.replaceTable(database, table.getTableName(), updatedTable, privileges, ImmutableMap.of());
         }
         catch (RuntimeException e) {
             if (e instanceof TrinoException trinoException &&

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/HiveMetastoreTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/HiveMetastoreTableOperations.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.iceberg.catalog.hms;
 
+import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.trino.annotation.NotThreadSafe;
 import io.trino.metastore.AcidTransactionOwner;
@@ -28,6 +29,7 @@ import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.io.FileIO;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
 
@@ -36,9 +38,11 @@ import static io.trino.metastore.PrincipalPrivileges.NO_PRIVILEGES;
 import static io.trino.plugin.hive.metastore.thrift.ThriftMetastoreUtil.fromMetastoreApiTable;
 import static io.trino.plugin.iceberg.IcebergTableName.tableNameFrom;
 import static io.trino.plugin.iceberg.IcebergUtil.fixBrokenMetadataLocation;
+import static java.lang.Boolean.parseBoolean;
 import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.BaseMetastoreTableOperations.METADATA_LOCATION_PROP;
 import static org.apache.iceberg.BaseMetastoreTableOperations.PREVIOUS_METADATA_LOCATION_PROP;
+import static org.apache.iceberg.TableProperties.HIVE_LOCK_ENABLED;
 
 @NotThreadSafe
 public class HiveMetastoreTableOperations
@@ -46,11 +50,13 @@ public class HiveMetastoreTableOperations
 {
     private static final Logger log = Logger.get(HiveMetastoreTableOperations.class);
     private final ThriftMetastore thriftMetastore;
+    private final boolean lockingEnabled;
 
     public HiveMetastoreTableOperations(
             FileIO fileIo,
             CachingHiveMetastore metastore,
             ThriftMetastore thriftMetastore,
+            boolean lockingEnabled,
             ConnectorSession session,
             String database,
             String table,
@@ -59,6 +65,7 @@ public class HiveMetastoreTableOperations
     {
         super(fileIo, metastore, session, database, table, owner, location);
         this.thriftMetastore = requireNonNull(thriftMetastore, "thriftMetastore is null");
+        this.lockingEnabled = lockingEnabled;
     }
 
     @Override
@@ -84,11 +91,11 @@ public class HiveMetastoreTableOperations
     private void commitTableUpdate(Table table, TableMetadata metadata, BiFunction<Table, String, Table> tableUpdateFunction)
     {
         String newMetadataLocation = writeNewMetadata(metadata, version.orElseThrow() + 1);
-        long lockId = thriftMetastore.acquireTableExclusiveLock(
-                new AcidTransactionOwner(session.getUser()),
-                session.getQueryId(),
-                table.getDatabaseName(),
-                table.getTableName());
+
+        boolean lockingEnabled = parseBoolean(table.getParameters().getOrDefault(HIVE_LOCK_ENABLED, Boolean.toString(this.lockingEnabled)));
+        HiveLock hiveLock = lockingEnabled ? new ThriftMetastoreLock(table) : new NoLock();
+        hiveLock.acquire();
+
         try {
             Table currentTable = fromMetastoreApiTable(thriftMetastore.getTable(database, table.getTableName())
                     .orElseThrow(() -> new TableNotFoundException(getSchemaTableName())));
@@ -105,7 +112,7 @@ public class HiveMetastoreTableOperations
             // todo privileges should not be replaced for an alter
             PrincipalPrivileges privileges = table.getOwner().map(MetastoreUtil::buildInitialPrivilegeSet).orElse(NO_PRIVILEGES);
             try {
-                metastore.replaceTable(table.getDatabaseName(), table.getTableName(), updatedTable, privileges);
+                metastore.replaceTable(table.getDatabaseName(), table.getTableName(), updatedTable, privileges, environmentContext(metadataLocation));
             }
             catch (RuntimeException e) {
                 // Cannot determine whether the `replaceTable` operation was successful,
@@ -114,6 +121,48 @@ public class HiveMetastoreTableOperations
             }
         }
         finally {
+            hiveLock.release();
+        }
+
+        shouldRefresh = true;
+    }
+
+    private static Map<String, String> environmentContext(String metadataLocation)
+    {
+        if (metadataLocation == null) {
+            return ImmutableMap.of();
+        }
+        return ImmutableMap.<String, String>builder()
+                .put("expected_parameter_key", "metadata_location")
+                .put("expected_parameter_value", metadataLocation)
+                .buildOrThrow();
+    }
+
+    private class ThriftMetastoreLock
+            implements HiveLock
+    {
+        private long lockId;
+
+        private final Table table;
+
+        public ThriftMetastoreLock(Table table)
+        {
+            this.table = requireNonNull(table, "table is null");
+        }
+
+        @Override
+        public void acquire()
+        {
+            lockId = thriftMetastore.acquireTableExclusiveLock(
+                    new AcidTransactionOwner(session.getUser()),
+                    session.getQueryId(),
+                    table.getDatabaseName(),
+                    table.getTableName());
+        }
+
+        @Override
+        public void release()
+        {
             try {
                 thriftMetastore.releaseTableLock(lockId);
             }
@@ -125,7 +174,23 @@ public class HiveMetastoreTableOperations
                 log.error(e, "Failed to release lock %s when committing to table %s", lockId, table.getTableName());
             }
         }
+    }
 
-        shouldRefresh = true;
+    // HIVE-26882 requires HMS client 2 or later. Our HMS client is based on version 3.
+    private static class NoLock
+            implements HiveLock
+    {
+        @Override
+        public void acquire() {}
+
+        @Override
+        public void release() {}
+    }
+
+    private interface HiveLock
+    {
+        void acquire();
+
+        void release();
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/HiveMetastoreTableOperationsProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/HiveMetastoreTableOperationsProvider.java
@@ -31,12 +31,17 @@ public class HiveMetastoreTableOperationsProvider
 {
     private final TrinoFileSystemFactory fileSystemFactory;
     private final ThriftMetastoreFactory thriftMetastoreFactory;
+    private final boolean lockingEnabled;
 
     @Inject
-    public HiveMetastoreTableOperationsProvider(TrinoFileSystemFactory fileSystemFactory, ThriftMetastoreFactory thriftMetastoreFactory)
+    public HiveMetastoreTableOperationsProvider(
+            TrinoFileSystemFactory fileSystemFactory,
+            ThriftMetastoreFactory thriftMetastoreFactory,
+            IcebergHiveCatalogConfig metastoreConfig)
     {
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.thriftMetastoreFactory = requireNonNull(thriftMetastoreFactory, "thriftMetastoreFactory is null");
+        this.lockingEnabled = metastoreConfig.getLockingEnabled();
     }
 
     @Override
@@ -52,6 +57,7 @@ public class HiveMetastoreTableOperationsProvider
                 new ForwardingFileIo(fileSystemFactory.create(session)),
                 ((TrinoHiveCatalog) catalog).getMetastore(),
                 thriftMetastoreFactory.createMetastore(Optional.of(session.getIdentity())),
+                lockingEnabled,
                 session,
                 database,
                 table,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/IcebergHiveCatalogConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/IcebergHiveCatalogConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.hms;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+
+public class IcebergHiveCatalogConfig
+{
+    private boolean lockingEnabled = true;
+
+    public boolean getLockingEnabled()
+    {
+        return lockingEnabled;
+    }
+
+    @Config("iceberg.hive-catalog.locking-enabled")
+    @ConfigDescription("Acquire locks when updating tables")
+    public IcebergHiveCatalogConfig setLockingEnabled(boolean lockingEnabled)
+    {
+        this.lockingEnabled = lockingEnabled;
+        return this;
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/IcebergHiveMetastoreCatalogModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/IcebergHiveMetastoreCatalogModule.java
@@ -21,12 +21,15 @@ import io.trino.plugin.iceberg.catalog.IcebergHiveMetastoreModule;
 import io.trino.plugin.iceberg.catalog.IcebergTableOperationsProvider;
 import io.trino.plugin.iceberg.catalog.TrinoCatalogFactory;
 
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
 public class IcebergHiveMetastoreCatalogModule
         extends AbstractConfigurationAwareModule
 {
     @Override
     protected void setup(Binder binder)
     {
+        configBinder(binder).bindConfig(IcebergHiveCatalogConfig.class);
         binder.bind(IcebergTableOperationsProvider.class).to(HiveMetastoreTableOperationsProvider.class).in(Scopes.SINGLETON);
         binder.bind(TrinoCatalogFactory.class).to(TrinoHiveCatalogFactory.class).in(Scopes.SINGLETON);
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
@@ -600,7 +600,7 @@ public class TrinoHiveCatalog
 
             try {
                 if (existing.isPresent()) {
-                    metastore.replaceTable(viewName.getSchemaName(), viewName.getTableName(), table, principalPrivileges);
+                    metastore.replaceTable(viewName.getSchemaName(), viewName.getTableName(), table, principalPrivileges, ImmutableMap.of());
                 }
                 else {
                     metastore.createTable(table, principalPrivileges);
@@ -663,7 +663,7 @@ public class TrinoHiveCatalog
                 metastore.dropTable(storageSchema, oldStorageTable, true);
             }
             // Replace the existing view definition
-            metastore.replaceTable(viewName.getSchemaName(), viewName.getTableName(), table, principalPrivileges);
+            metastore.replaceTable(viewName.getSchemaName(), viewName.getTableName(), table, principalPrivileges, ImmutableMap.of());
             return;
         }
         // create the view definition
@@ -708,7 +708,7 @@ public class TrinoHiveCatalog
 
         PrincipalPrivileges principalPrivileges = isUsingSystemSecurity ? NO_PRIVILEGES : buildInitialPrivilegeSet(session.getUser());
 
-        metastore.replaceTable(viewName.getSchemaName(), viewName.getTableName(), viewBuilder.build(), principalPrivileges);
+        metastore.replaceTable(viewName.getSchemaName(), viewName.getTableName(), viewBuilder.build(), principalPrivileges, ImmutableMap.of());
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrateProcedure.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrateProcedure.java
@@ -246,7 +246,7 @@ public class MigrateProcedure
                     .setParameter(METADATA_LOCATION_PROP, location)
                     .setParameter(TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE.toUpperCase(ENGLISH))
                     .build();
-            metastore.replaceTable(schemaName, tableName, newTable, principalPrivileges);
+            metastore.replaceTable(schemaName, tableName, newTable, principalPrivileges, ImmutableMap.of());
 
             transaction.commitTransaction();
             log.debug("Successfully migrated %s table to Iceberg format", sourceTableName);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/hms/TestIcebergHiveCatalogConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/hms/TestIcebergHiveCatalogConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.hms;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+final class TestIcebergHiveCatalogConfig
+{
+    @Test
+    void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(IcebergHiveCatalogConfig.class)
+                .setLockingEnabled(true));
+    }
+
+    @Test
+    void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("iceberg.hive-catalog.locking-enabled", "false")
+                .buildOrThrow();
+
+        IcebergHiveCatalogConfig expected = new IcebergHiveCatalogConfig()
+                .setLockingEnabled(false);
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/hms/TestIcebergHiveCatalogWithoutLock.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/hms/TestIcebergHiveCatalogWithoutLock.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.hms;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.hive.containers.Hive4MinioDataLake;
+import io.trino.plugin.iceberg.IcebergQueryRunner;
+import io.trino.plugin.iceberg.SchemaInitializer;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.sql.TestTable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
+import static io.trino.testing.containers.Minio.MINIO_REGION;
+import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+final class TestIcebergHiveCatalogWithoutLock
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        String bucketName = "test-bucket" + randomNameSuffix();
+        Hive4MinioDataLake hiveMinioDataLake = closeAfterClass(new Hive4MinioDataLake(bucketName));
+        hiveMinioDataLake.start();
+
+        return IcebergQueryRunner.builder()
+                .setIcebergProperties(
+                        ImmutableMap.<String, String>builder()
+                                .put("iceberg.catalog.type", "HIVE_METASTORE")
+                                .put("hive.metastore.uri", hiveMinioDataLake.getHiveMetastoreEndpoint().toString())
+                                .put("iceberg.hive-catalog.locking-enabled", "false")
+                                .put("fs.native-s3.enabled", "true")
+                                .put("s3.aws-access-key", MINIO_ACCESS_KEY)
+                                .put("s3.aws-secret-key", MINIO_SECRET_KEY)
+                                .put("s3.region", MINIO_REGION)
+                                .put("s3.endpoint", hiveMinioDataLake.getMinio().getMinioAddress())
+                                .put("s3.path-style-access", "true")
+                                .buildOrThrow())
+                .setSchemaInitializer(
+                        SchemaInitializer.builder()
+                                .withSchemaName("tpch")
+                                .withSchemaProperties(Map.of("location", "'s3://%s/tpch'".formatted(bucketName)))
+                                .build())
+                .build();
+    }
+
+    @Test
+    void testCommitWithoutLock()
+    {
+        try (TestTable table = newTrinoTable("test_lock", "(x int)", List.of("1", "2", "3"))) {
+            assertUpdate("DELETE FROM " + table.getName() + " WHERE x = 1", 1);
+            assertThat(query("SELECT * FROM " + table.getName()))
+                    .matches("VALUES 2, 3");
+
+            assertUpdate("DELETE FROM " + table.getName() + " WHERE x = 2", 1);
+            assertThat(query("SELECT * FROM " + table.getName()))
+                    .matches("VALUES 3");
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/hms/TestTrinoHiveCatalogWithHiveMetastore.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/hms/TestTrinoHiveCatalogWithHiveMetastore.java
@@ -145,21 +145,24 @@ public class TestTrinoHiveCatalogWithHiveMetastore
                 new TrinoViewHiveMetastore(metastore, false, "trino-version", "Test"),
                 fileSystemFactory,
                 new TestingTypeManager(),
-                new HiveMetastoreTableOperationsProvider(fileSystemFactory, new ThriftMetastoreFactory()
-                {
-                    @Override
-                    public boolean isImpersonationEnabled()
-                    {
-                        verify(new ThriftMetastoreConfig().isImpersonationEnabled(), "This test wants to test the default behavior and assumes it's off");
-                        return false;
-                    }
+                new HiveMetastoreTableOperationsProvider(
+                        fileSystemFactory,
+                        new ThriftMetastoreFactory()
+                        {
+                            @Override
+                            public boolean isImpersonationEnabled()
+                            {
+                                verify(new ThriftMetastoreConfig().isImpersonationEnabled(), "This test wants to test the default behavior and assumes it's off");
+                                return false;
+                            }
 
-                    @Override
-                    public ThriftMetastore createMetastore(Optional<ConnectorIdentity> identity)
-                    {
-                        return thriftMetastore;
-                    }
-                }),
+                            @Override
+                            public ThriftMetastore createMetastore(Optional<ConnectorIdentity> identity)
+                            {
+                                return thriftMetastore;
+                            }
+                        },
+                        new IcebergHiveCatalogConfig()),
                 useUniqueTableLocations,
                 false,
                 false,
@@ -270,7 +273,8 @@ public class TestTrinoHiveCatalogWithHiveMetastore
                 Table.builder(metastoreTable)
                         .setParameter(TABLE_TYPE_PROP, tableType)
                         .build(),
-                NO_PRIVILEGES);
+                NO_PRIVILEGES,
+                ImmutableMap.of());
         closer.register(() -> metastore.dropTable(namespace, tableName, true));
         return Optional.of(lowerCaseTableTypeTable);
     }


### PR DESCRIPTION
## Description

Fixes #22182

Request from Iceberg community: https://apache-iceberg.slack.com/archives/C025PH0G1D4/p1743095891453949
Iceberg documentation: https://iceberg.apache.org/docs/nightly/configuration/#hadoop-configuration

## Release notes

```markdown
## Iceberg
* Add support for lock-free commit in Hive catalog. ({issue}`issuenumber`)
```
