### PR TITLE
Allow configuration to disable migrations

### DIFF
--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/DbResourceGroupConfig.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/DbResourceGroupConfig.java
@@ -31,6 +31,7 @@ public class DbResourceGroupConfig
     private boolean exactMatchSelectorEnabled;
     private Duration maxRefreshInterval = new Duration(1, HOURS);
     private Duration refreshInterval = new Duration(1, SECONDS);
+    private boolean runMigrationsEnabled = true;
 
     public String getConfigDbUrl()
     {
@@ -109,6 +110,19 @@ public class DbResourceGroupConfig
     {
         this.exactMatchSelectorEnabled = exactMatchSelectorEnabled;
         return this;
+    }
+
+    @Config("resource-groups.db-migrations-enabled")
+    @ConfigDescription("Whether to run migrations on startup")
+    public DbResourceGroupConfig setRunMigrationsEnabled(boolean runMigrationsEnabled)
+    {
+        this.runMigrationsEnabled = runMigrationsEnabled;
+        return this;
+    }
+
+    public boolean isRunMigrationsEnabled()
+    {
+        return runMigrationsEnabled;
     }
 
     @AssertTrue(message = "maxRefreshInterval must be greater than refreshInterval")

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/FlywayMigration.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/FlywayMigration.java
@@ -43,6 +43,10 @@ public class FlywayMigration
 
     public static void migrate(DbResourceGroupConfig config)
     {
+        if (!config.isRunMigrationsEnabled()) {
+            log.info("Skipping migrations");
+            return;
+        }
         log.info("Performing migrations...");
         Flyway flyway = Flyway.configure()
                 .dataSource(config.getConfigDbUrl(), config.getConfigDbUser(), config.getConfigDbPassword())

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/BaseTestDbResourceGroupsFlywayMigration.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/BaseTestDbResourceGroupsFlywayMigration.java
@@ -38,6 +38,8 @@ public abstract class BaseTestDbResourceGroupsFlywayMigration
 
     protected abstract JdbcDatabaseContainer<?> startContainer();
 
+    protected abstract boolean tableExists(String tableName);
+
     @AfterAll
     public final void close()
     {
@@ -78,6 +80,19 @@ public abstract class BaseTestDbResourceGroupsFlywayMigration
         jdbiHandle.close();
 
         dropAllTables();
+    }
+
+    @Test
+    public void testMigrationDisabled()
+    {
+        DbResourceGroupConfig config = new DbResourceGroupConfig()
+                .setConfigDbUrl(container.getJdbcUrl())
+                .setConfigDbUser(container.getUsername())
+                .setConfigDbPassword(container.getPassword())
+                .setRunMigrationsEnabled(false);
+        FlywayMigration.migrate(config);
+        assertThat(tableExists("resource_groups")).isFalse();
+        assertThat(tableExists("resource_groups_global_properties")).isFalse();
     }
 
     protected void verifyResourceGroupsSchema(int expectedPropertiesCount)

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupConfig.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupConfig.java
@@ -40,7 +40,8 @@ public class TestDbResourceGroupConfig
                 .setConfigDbPassword(null)
                 .setMaxRefreshInterval(new Duration(1, HOURS))
                 .setRefreshInterval(new Duration(1, SECONDS))
-                .setExactMatchSelectorEnabled(false));
+                .setExactMatchSelectorEnabled(false)
+                .setRunMigrationsEnabled(true));
     }
 
     @Test
@@ -53,6 +54,7 @@ public class TestDbResourceGroupConfig
                 .put("resource-groups.max-refresh-interval", "1m")
                 .put("resource-groups.refresh-interval", "2s")
                 .put("resource-groups.exact-match-selector-enabled", "true")
+                .put("resource-groups.db-migrations-enabled", "false")
                 .buildOrThrow();
         DbResourceGroupConfig expected = new DbResourceGroupConfig()
                 .setConfigDbUrl("jdbc:mysql://localhost:3306/config")
@@ -60,7 +62,8 @@ public class TestDbResourceGroupConfig
                 .setConfigDbPassword("trino_admin_pass")
                 .setMaxRefreshInterval(new Duration(1, MINUTES))
                 .setRefreshInterval(new Duration(2, SECONDS))
-                .setExactMatchSelectorEnabled(true);
+                .setExactMatchSelectorEnabled(true)
+                .setRunMigrationsEnabled(false);
 
         assertFullMapping(properties, expected);
         assertThat(expected.isRefreshIntervalValid()).isTrue();

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupsMysqlFlywayMigration.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupsMysqlFlywayMigration.java
@@ -29,6 +29,16 @@ public class TestDbResourceGroupsMysqlFlywayMigration
         return container;
     }
 
+    @Override
+    protected final boolean tableExists(String tableName)
+    {
+        return jdbi.withHandle(handle ->
+                handle.createQuery("SELECT COUNT(*) FROM information_schema.tables WHERE table_name = :tableName")
+                        .bind("tableName", tableName)
+                        .mapTo(Long.class)
+                        .one()) > 0;
+    }
+
     @Test
     public void testMigrationWithOldResourceGroupsSchema()
     {

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupsOracleFlywayMigration.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupsOracleFlywayMigration.java
@@ -36,6 +36,16 @@ public class TestDbResourceGroupsOracleFlywayMigration
     }
 
     @Override
+    protected final boolean tableExists(String tableName)
+    {
+        return jdbi.withHandle(handle ->
+                handle.createQuery("SELECT COUNT(*) FROM user_tables WHERE table_name = :tableName")
+                        .bind("tableName", tableName)
+                        .mapTo(Long.class)
+                        .one()) > 0;
+    }
+
+    @Override
     protected void dropAllTables()
     {
         String propertiesTable = "resource_groups_global_properties".toUpperCase(Locale.ENGLISH);

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupsPostgresqlFlywayMigration.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupsPostgresqlFlywayMigration.java
@@ -26,4 +26,14 @@ public class TestDbResourceGroupsPostgresqlFlywayMigration
         container.start();
         return container;
     }
+
+    @Override
+    protected final boolean tableExists(String tableName)
+    {
+        return jdbi.withHandle(handle ->
+                handle.createQuery("SELECT COUNT(*) FROM information_schema.tables WHERE table_name = :tableName")
+                        .bind("tableName", tableName)
+                        .mapTo(Long.class)
+                        .one()) > 0;
+    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Adding a flag that, during startup, disables migrations for resource groups when DB resource group store is enabled.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

There is a need for us to not use migrations and make database changes manually. This flag allows us to not run migrations and use the same behavior that exists in trino gateway.

## Release notes

```markdown
## Section
* When the configured user does not have DDL privileges we want to be able to disable migration and run SQL updates manually. 
```
