### PR TITLE
Improve docs for support hadoop compatible file system when use HDFS …

### DIFF
--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.md
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.md
@@ -613,8 +613,9 @@ you should enable `exchange.hdfs.skip-directory-scheme-validation` in `exchange-
 when configure `exchange.base-directories` with a specific scheme instead of `hdfs` and the following steps 
 may be necessary.
 
-1. Configure the `AbstractFileSystem` implementation in `core-site.xml`.
-2. Add the relevant client JAR files into the directory `${Trino_HOME}/plugin/exchange-hdfs` 
+1. Configure the `fs.defaultFS` with specific scheme and
+the `AbstractFileSystem` implementation in `core-site.xml`.
+2. Add the relevant client JAR files into the directory `${Trino_HOME}/plugin/exchange-hdfs`
 on all Trino cluster nodes.
 
 (fte-exchange-local-filesystem)=


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Follow up to https://github.com/trinodb/trino/issues/25448
While exchange FileSystem is a singleton instance which use `fs.defaultFS` in `core-site.xml` as default uri,  so when use other hadoop-compatible file system，we should config   `fs.defaultFS` to match hadoop-compatible file system. eg:  we wan't use oss, the `fs.defaultFS` would be configured as `oss://xxxx` in  `core-site.xml`. Therefore, I think we should add some hints in the documentation.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
