### PR TITLE
Add support for basic auth to Kafka schema registry

### DIFF
--- a/docs/src/main/sphinx/connector/kafka.md
+++ b/docs/src/main/sphinx/connector/kafka.md
@@ -417,6 +417,20 @@ Inserts are not supported, and the only data format supported is AVRO.
   - Comma-separated list of URL addresses for the Confluent schema registry.
     For example, `http://schema-registry-1.example.org:8081,http://schema-registry-2.example.org:8081`
   -
+* - `kafka.confluent-schema-registry.auth-type`
+  - The type of authentication implemented on Confluent schema registry.
+    Allowed values are: `BASIC_AUTH` and `NONE`
+    * `NONE` - No authentication is configured for the Schema Registry
+    * `BASIC_AUTH` - HTTP Basic Authentication (username and password) is enabled for the Schema Registry
+  - `NONE`
+* - `kafka.confluent-schema-registry.basic-auth.username`
+  - Only if `kafka.confluent-schema-registry.auth-type` is set to `BASIC_AUTH`.
+    Sets the username to use for logging in Confluent schema registry.
+  - 
+* - `kafka.confluent-schema-registry.basic-auth.password`
+  - Only if `kafka.confluent-schema-registry.auth-type` is set to `BASIC_AUTH`.
+    Sets the password to use for logging in Confluent schema registry.
+  -
 * - `kafka.confluent-schema-registry-client-cache-size`
   - The maximum number of subjects that can be stored in the local cache. The
     cache stores the schemas locally by subjectId, and is provided by the

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/KafkaSchemaRegistryClientPropertiesProvider.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/KafkaSchemaRegistryClientPropertiesProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka.schema;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import io.trino.plugin.kafka.schema.confluent.SchemaRegistryClientPropertiesProvider;
+
+public class KafkaSchemaRegistryClientPropertiesProvider
+        implements SchemaRegistryClientPropertiesProvider
+{
+    private final SchemaRegistryClientPropertiesProvider auth;
+
+    @Inject
+    public KafkaSchemaRegistryClientPropertiesProvider(SchemaRegistryClientPropertiesProvider auth)
+    {
+        this.auth = auth;
+    }
+
+    @Override
+    public ImmutableMap<String, Object> getSchemaRegistryClientProperties()
+    {
+        ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
+        properties.putAll(auth.getSchemaRegistryClientProperties());
+        return properties.buildOrThrow();
+    }
+}

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/BasicAuthConfig.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/BasicAuthConfig.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka.schema.confluent;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigSecuritySensitive;
+import jakarta.validation.constraints.NotNull;
+
+public class BasicAuthConfig
+{
+    private String username;
+    private String password;
+
+    @NotNull
+    public String getConfluentSchemaRegistryUsername()
+    {
+        return username;
+    }
+
+    @Config("kafka.confluent-schema-registry.basic-auth.username")
+    @ConfigDescription("The username for the Confluent Schema Registry")
+    @ConfigSecuritySensitive
+    public BasicAuthConfig setConfluentSchemaRegistryUsername(String username)
+    {
+        this.username = username;
+        return this;
+    }
+
+    @NotNull
+    public String getConfluentSchemaRegistryPassword()
+    {
+        return password;
+    }
+
+    @Config("kafka.confluent-schema-registry.basic-auth.password")
+    @ConfigSecuritySensitive
+    public BasicAuthConfig setConfluentSchemaRegistryPassword(String password)
+    {
+        this.password = password;
+        return this;
+    }
+}

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentModule.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentModule.java
@@ -51,6 +51,7 @@ import io.trino.plugin.kafka.encoder.avro.AvroRowEncoder;
 import io.trino.plugin.kafka.encoder.protobuf.ProtobufRowEncoder;
 import io.trino.plugin.kafka.encoder.protobuf.ProtobufSchemaParser;
 import io.trino.plugin.kafka.schema.ContentSchemaProvider;
+import io.trino.plugin.kafka.schema.KafkaSchemaRegistryClientPropertiesProvider;
 import io.trino.plugin.kafka.schema.ProtobufAnySupportConfig;
 import io.trino.plugin.kafka.schema.TableDescriptionSupplier;
 import io.trino.spi.HostAddress;
@@ -72,6 +73,7 @@ import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static io.airlift.bootstrap.ClosingBinder.closingBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.trino.plugin.kafka.encoder.EncoderModule.encoderFactory;
+import static io.trino.plugin.kafka.schema.confluent.ConfluentSchemaRegistryConfig.ConfluentSchemaRegistryAuthType.BASIC_AUTH;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.util.Objects.requireNonNull;
 
@@ -89,7 +91,10 @@ public class ConfluentModule
                 .addBinding()
                 .to(SchemaRegistryClientTtlProvider.class)
                 .in(SINGLETON);
+        newSetBinder(binder, SchemaRegistryClientPropertiesProvider.class).addBinding().to(KafkaSchemaRegistryClientPropertiesProvider.class).in(Scopes.SINGLETON);
+        newSetBinder(binder, SchemaRegistryClientPropertiesProvider.class);
         newSetBinder(binder, SchemaProvider.class).addBinding().to(AvroSchemaProvider.class).in(Scopes.SINGLETON);
+
         // Each SchemaRegistry object should have a new instance of SchemaProvider
         newSetBinder(binder, SchemaProvider.class).addBinding().to(LazyLoadedProtobufSchemaProvider.class);
         binder.bind(DynamicMessageProvider.Factory.class).to(ConfluentSchemaRegistryDynamicMessageProvider.Factory.class).in(SINGLETON);
@@ -98,6 +103,15 @@ public class ConfluentModule
         newMapBinder(binder, String.class, SchemaParser.class).addBinding("AVRO").to(AvroSchemaParser.class).in(Scopes.SINGLETON);
         newMapBinder(binder, String.class, SchemaParser.class).addBinding("PROTOBUF").to(LazyLoadedProtobufSchemaParser.class).in(Scopes.SINGLETON);
 
+        // Bind the appropriate ConfluentSchemaRegistryAuth implementation based on configuration
+        ConfluentSchemaRegistryConfig schemaRegistryConfig = buildConfigObject(ConfluentSchemaRegistryConfig.class);
+        if (schemaRegistryConfig.getConfluentSchemaRegistryAuthType() == BASIC_AUTH) {
+            configBinder(binder).bindConfig(BasicAuthConfig.class);
+            binder.bind(SchemaRegistryClientPropertiesProvider.class).to(ConfluentSchemaRegistryBasicAuth.class).in(Scopes.SINGLETON);
+        }
+        else {
+            binder.bind(SchemaRegistryClientPropertiesProvider.class).to(ConfluentSchemaRegistryNoAuth.class).in(Scopes.SINGLETON);
+        }
         closingBinder(binder)
                 .registerCloseable(SchemaRegistryClient.class);
     }

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentSchemaRegistryBasicAuth.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentSchemaRegistryBasicAuth.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka.schema.confluent;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+
+import static java.util.Objects.requireNonNull;
+
+public class ConfluentSchemaRegistryBasicAuth
+        implements SchemaRegistryClientPropertiesProvider
+{
+    private final String user;
+    private final String password;
+
+    @Inject
+    public ConfluentSchemaRegistryBasicAuth(BasicAuthConfig basicAuthConfig)
+    {
+        this.user = requireNonNull(basicAuthConfig.getConfluentSchemaRegistryUsername(), "user is null");
+        this.password = requireNonNull(basicAuthConfig.getConfluentSchemaRegistryPassword(), "password is null");
+    }
+
+    @Override
+    public ImmutableMap<String, Object> getSchemaRegistryClientProperties()
+    {
+        // Please refer to client configuration for confluent scema registry here:
+        // https://docs.confluent.io/platform/current/schema-registry/security/index.html#configuring-the-rest-api-for-basic-http-authentication
+        return ImmutableMap.<String, Object>builder()
+                .put("basic.auth.credentials.source", "USER_INFO")
+                .put("basic.auth.user.info", user + ":" + password)
+                .buildOrThrow();
+    }
+}

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentSchemaRegistryConfig.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentSchemaRegistryConfig.java
@@ -33,9 +33,16 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public class ConfluentSchemaRegistryConfig
 {
     private Set<HostAddress> confluentSchemaRegistryUrls = ImmutableSet.of();
+    private ConfluentSchemaRegistryAuthType confluentSchemaRegistryAuthType = ConfluentSchemaRegistryAuthType.NONE;
     private int confluentSchemaRegistryClientCacheSize = 1000;
     private EmptyFieldStrategy emptyFieldStrategy = IGNORE;
     private Duration confluentSubjectsCacheRefreshInterval = new Duration(1, SECONDS);
+
+    public enum ConfluentSchemaRegistryAuthType
+    {
+        NONE,
+        BASIC_AUTH,
+    }
 
     @Size(min = 1)
     public Set<HostAddress> getConfluentSchemaRegistryUrls()
@@ -50,6 +57,19 @@ public class ConfluentSchemaRegistryConfig
         this.confluentSchemaRegistryUrls = confluentSchemaRegistryUrls.stream()
                 .map(ConfluentSchemaRegistryConfig::toHostAddress)
                 .collect(toImmutableSet());
+        return this;
+    }
+
+    public ConfluentSchemaRegistryAuthType getConfluentSchemaRegistryAuthType()
+    {
+        return confluentSchemaRegistryAuthType;
+    }
+
+    @Config("kafka.confluent-schema-registry.auth-type")
+    @ConfigDescription("Auth type for logging in Confluent Schema Registry")
+    public ConfluentSchemaRegistryConfig setConfluentSchemaRegistryAuthType(ConfluentSchemaRegistryAuthType confluentSchemaRegistryAuthType)
+    {
+        this.confluentSchemaRegistryAuthType = confluentSchemaRegistryAuthType;
         return this;
     }
 

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentSchemaRegistryNoAuth.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentSchemaRegistryNoAuth.java
@@ -11,23 +11,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.kafka;
+package io.trino.plugin.kafka.schema.confluent;
 
-import io.trino.testing.AbstractTestQueries;
-import io.trino.testing.QueryRunner;
-import io.trino.testing.kafka.TestingKafka;
+import com.google.common.collect.ImmutableMap;
 
-public class TestKafkaDistributed
-        extends AbstractTestQueries
+/* Empty Schema Registry Auth for registries without any authentication */
+public class ConfluentSchemaRegistryNoAuth
+        implements SchemaRegistryClientPropertiesProvider
 {
     @Override
-    protected QueryRunner createQueryRunner()
-            throws Exception
+    public ImmutableMap<String, Object> getSchemaRegistryClientProperties()
     {
-        TestingKafka testingKafka = closeAfterClass(TestingKafka.create());
-        testingKafka.start();
-        return KafkaQueryRunner.builder(testingKafka)
-                .setTables(REQUIRED_TPCH_TABLES)
-                .build();
+        return ImmutableMap.of();
     }
 }

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/AbstractTestKafkaConfluentSchemaRegistry.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/AbstractTestKafkaConfluentSchemaRegistry.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka.schema.confluent;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import dev.failsafe.Failsafe;
+import dev.failsafe.RetryPolicy;
+import io.trino.plugin.kafka.KafkaQueryRunner;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.kafka.TestingKafka;
+import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.jupiter.api.parallel.Execution;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import static io.trino.testing.assertions.Assert.assertEventually;
+import static java.lang.Math.multiplyExact;
+import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
+
+@Execution(SAME_THREAD)
+public class AbstractTestKafkaConfluentSchemaRegistry
+        extends AbstractTestQueryFramework
+{
+    protected static final String RECORD_NAME = "test_record";
+    protected static final int MESSAGE_COUNT = 100;
+    protected static final Schema INITIAL_SCHEMA = SchemaBuilder.record(RECORD_NAME)
+            .fields()
+            .name("col_1").type().nullable().longType().noDefault()
+            .name("col_2").type().nullable().stringType().noDefault()
+            .endRecord();
+    protected static final Schema EVOLVED_SCHEMA = SchemaBuilder.record(RECORD_NAME)
+            .fields()
+            .name("col_1").type().nullable().longType().noDefault()
+            .name("col_2").type().nullable().stringType().noDefault()
+            .name("col_3").type().optional().doubleType()
+            .endRecord();
+
+    protected TestingKafka testingKafka;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        testingKafka = closeAfterClass(TestingKafka.createWithSchemaRegistry());
+        testingKafka.start();
+        return KafkaQueryRunner.builderForConfluentSchemaRegistry(testingKafka)
+                .addConnectorProperties(ImmutableMap.of("kafka.confluent-subjects-cache-refresh-interval", "1ms"))
+                .build();
+    }
+
+    protected void assertTopic(
+            String topicName,
+            String initialQuery,
+            String evolvedQuery,
+            boolean isKeyIncluded,
+            Map<String, String> producerConfig)
+    {
+        assertNotExists(topicName);
+
+        List<ProducerRecord<Long, GenericRecord>> messages = createMessages(topicName, MESSAGE_COUNT, true);
+        testingKafka.sendMessages(messages.stream(), producerConfig);
+
+        waitUntilTableExists(topicName);
+        assertCount(topicName, MESSAGE_COUNT);
+
+        assertThat(query(initialQuery)).matches(getExpectedValues(messages, INITIAL_SCHEMA, isKeyIncluded));
+
+        List<ProducerRecord<Long, GenericRecord>> newMessages = createMessages(topicName, MESSAGE_COUNT, false);
+        testingKafka.sendMessages(newMessages.stream(), producerConfig);
+
+        List<ProducerRecord<Long, GenericRecord>> allMessages = ImmutableList.<ProducerRecord<Long, GenericRecord>>builder()
+                .addAll(messages)
+                .addAll(newMessages)
+                .build();
+        assertCount(topicName, allMessages.size());
+
+        String expectedValues = getExpectedValues(messages, EVOLVED_SCHEMA, isKeyIncluded);
+        assertEventually(io.airlift.units.Duration.valueOf("5s"), () -> assertThat(query(evolvedQuery)).containsAll(expectedValues));
+    }
+
+    protected static String getExpectedValues(List<ProducerRecord<Long, GenericRecord>> messages, Schema schema, boolean isKeyIncluded)
+    {
+        StringBuilder valuesBuilder = new StringBuilder("VALUES ");
+        ImmutableList.Builder<String> rowsBuilder = ImmutableList.builder();
+        for (ProducerRecord<Long, GenericRecord> message : messages) {
+            ImmutableList.Builder<String> columnsBuilder = ImmutableList.builder();
+
+            if (isKeyIncluded) {
+                columnsBuilder.add(format("CAST(%s as bigint)", message.key()));
+            }
+
+            addExpectedColumns(schema, message.value(), columnsBuilder);
+
+            rowsBuilder.add(format("(%s)", String.join(", ", columnsBuilder.build())));
+        }
+        valuesBuilder.append(String.join(", ", rowsBuilder.build()));
+        return valuesBuilder.toString();
+    }
+
+    protected static void addExpectedColumns(Schema schema, GenericRecord record, ImmutableList.Builder<String> columnsBuilder)
+    {
+        for (Schema.Field field : schema.getFields()) {
+            Object value = getValue(record, field.name());
+            if (value == null && field.schema().getType().equals(Schema.Type.UNION) && field.schema().getTypes().contains(Schema.create(Schema.Type.NULL))) {
+                if (field.schema().getTypes().contains(Schema.create(Schema.Type.DOUBLE))) {
+                    columnsBuilder.add("CAST(null AS double)");
+                }
+                else {
+                    throw new IllegalArgumentException("Unsupported field: " + field);
+                }
+            }
+            else if (field.schema().getType().equals(Schema.Type.STRING)
+                    || (field.schema().getType().equals(Schema.Type.UNION) && field.schema().getTypes().contains(Schema.create(Schema.Type.STRING)))) {
+                columnsBuilder.add(format("VARCHAR '%s'", value));
+            }
+            else if (field.schema().getType().equals(Schema.Type.LONG)
+                    || (field.schema().getType().equals(Schema.Type.UNION) && field.schema().getTypes().contains(Schema.create(Schema.Type.LONG)))) {
+                columnsBuilder.add(format("CAST(%s AS bigint)", value));
+            }
+            else {
+                throw new IllegalArgumentException("Unsupported field: " + field);
+            }
+        }
+    }
+
+    protected static Object getValue(GenericRecord record, String columnName)
+    {
+        try {
+            return record.get(columnName);
+        }
+        catch (AvroRuntimeException e) {
+            if (e.getMessage().contains("Not a valid schema field")) {
+                return null;
+            }
+
+            throw e;
+        }
+    }
+
+    protected void assertNotExists(String tableName)
+    {
+        if (schemaExists()) {
+            assertThat(getQueryRunner().execute("SHOW TABLES LIKE " + toSingleQuoted(tableName)).getRowCount()).isZero();
+        }
+    }
+
+    protected void waitUntilTableExists(String tableName)
+    {
+        Failsafe.with(
+                        RetryPolicy.builder()
+                                .withMaxAttempts(10)
+                                .withDelay(Duration.ofMillis(100))
+                                .build())
+                .run(() -> assertThat(schemaExists()).isTrue());
+        Failsafe.with(
+                        RetryPolicy.builder()
+                                .withMaxAttempts(10)
+                                .withDelay(Duration.ofMillis(100))
+                                .build())
+                .run(() -> assertThat(tableExists(tableName)).isTrue());
+    }
+
+    protected boolean schemaExists()
+    {
+        return getQueryRunner().execute(format(
+                        "SHOW SCHEMAS FROM %s LIKE '%s'",
+                        getSession().getCatalog().orElseThrow(),
+                        getSession().getSchema().orElseThrow()))
+                .getRowCount() == 1;
+    }
+
+    protected boolean tableExists(String tableName)
+    {
+        return getQueryRunner().execute(format("SHOW TABLES LIKE '%s'", tableName.toLowerCase(ENGLISH))).getRowCount() == 1;
+    }
+
+    protected void assertCount(String tableName, long count)
+    {
+        assertThat(getQueryRunner().execute("SELECT count(*) FROM " + toDoubleQuoted(tableName)).getOnlyValue()).isEqualTo(count);
+    }
+
+    protected static String toDoubleQuoted(String tableName)
+    {
+        return format("\"%s\"", tableName);
+    }
+
+    protected static String toSingleQuoted(Object value)
+    {
+        requireNonNull(value, "value is null");
+        return format("'%s'", value);
+    }
+
+    protected static List<ProducerRecord<Long, GenericRecord>> createMessages(String topicName, int messageCount, boolean useInitialSchema)
+    {
+        ImmutableList.Builder<ProducerRecord<Long, GenericRecord>> producerRecordBuilder = ImmutableList.builder();
+        if (useInitialSchema) {
+            for (long key = 0; key < messageCount; key++) {
+                producerRecordBuilder.add(new ProducerRecord<>(topicName, key, createRecordWithInitialSchema(key)));
+            }
+        }
+        else {
+            for (long key = 0; key < messageCount; key++) {
+                producerRecordBuilder.add(new ProducerRecord<>(topicName, key, createRecordWithEvolvedSchema(key)));
+            }
+        }
+        return producerRecordBuilder.build();
+    }
+
+    protected static GenericRecord createRecordWithInitialSchema(long key)
+    {
+        return new GenericRecordBuilder(INITIAL_SCHEMA)
+                .set("col_1", multiplyExact(key, 100))
+                .set("col_2", format("string-%s", key))
+                .build();
+    }
+
+    protected static GenericRecord createRecordWithEvolvedSchema(long key)
+    {
+        return new GenericRecordBuilder(EVOLVED_SCHEMA)
+                .set("col_1", multiplyExact(key, 100))
+                .set("col_2", format("string-%s", key))
+                .set("col_3", (key + 10.1D) / 10.0D)
+                .build();
+    }
+
+    protected record JsonValue(int id, String value)
+    {
+        protected JsonValue
+        {
+            requireNonNull(value, "value is null");
+        }
+    }
+}

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestConfluentSchemaRegistryBasicAuthConfig.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestConfluentSchemaRegistryBasicAuthConfig.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka.schema.confluent;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public final class TestConfluentSchemaRegistryBasicAuthConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(BasicAuthConfig.class)
+                .setConfluentSchemaRegistryUsername(null)
+                .setConfluentSchemaRegistryPassword(null));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("kafka.confluent-schema-registry.basic-auth.username", "user")
+                .put("kafka.confluent-schema-registry.basic-auth.password", "31337")
+                .buildOrThrow();
+
+        BasicAuthConfig expected = new BasicAuthConfig()
+                .setConfluentSchemaRegistryUsername("user")
+                .setConfluentSchemaRegistryPassword("31337");
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestConfluentSchemaRegistryConfig.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestConfluentSchemaRegistryConfig.java
@@ -23,11 +23,12 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.trino.plugin.kafka.schema.confluent.ConfluentSchemaRegistryConfig.ConfluentSchemaRegistryAuthType.BASIC_AUTH;
 import static io.trino.plugin.kafka.schema.confluent.EmptyFieldStrategy.IGNORE;
 import static io.trino.plugin.kafka.schema.confluent.EmptyFieldStrategy.MARK;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-public class TestConfluentSchemaRegistryConfig
+public final class TestConfluentSchemaRegistryConfig
 {
     @Test
     public void testDefaults()
@@ -35,6 +36,7 @@ public class TestConfluentSchemaRegistryConfig
         assertRecordedDefaults(recordDefaults(ConfluentSchemaRegistryConfig.class)
                 .setConfluentSchemaRegistryUrls(ImmutableSet.of())
                 .setConfluentSchemaRegistryClientCacheSize(1000)
+                .setConfluentSchemaRegistryAuthType(ConfluentSchemaRegistryConfig.ConfluentSchemaRegistryAuthType.NONE)
                 .setEmptyFieldStrategy(IGNORE)
                 .setConfluentSubjectsCacheRefreshInterval(new Duration(1, SECONDS)));
     }
@@ -44,6 +46,7 @@ public class TestConfluentSchemaRegistryConfig
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("kafka.confluent-schema-registry-url", "http://schema-registry-a:8081, http://schema-registry-b:8081")
+                .put("kafka.confluent-schema-registry.auth-type", "BASIC_AUTH")
                 .put("kafka.confluent-schema-registry-client-cache-size", "1500")
                 .put("kafka.empty-field-strategy", "MARK")
                 .put("kafka.confluent-subjects-cache-refresh-interval", "2s")
@@ -51,6 +54,7 @@ public class TestConfluentSchemaRegistryConfig
 
         ConfluentSchemaRegistryConfig expected = new ConfluentSchemaRegistryConfig()
                 .setConfluentSchemaRegistryUrls(ImmutableSet.of("http://schema-registry-a:8081", "http://schema-registry-b:8081"))
+                .setConfluentSchemaRegistryAuthType(BASIC_AUTH)
                 .setConfluentSchemaRegistryClientCacheSize(1500)
                 .setEmptyFieldStrategy(MARK)
                 .setConfluentSubjectsCacheRefreshInterval(new Duration(2, SECONDS));

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestKafkaWithConfluentSchemaRegistryBasicAuth.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestKafkaWithConfluentSchemaRegistryBasicAuth.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka.schema.confluent;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import io.trino.plugin.kafka.KafkaQueryRunner;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.kafka.TestingKafka;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+
+import static io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE;
+import static io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG;
+import static io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig.USER_INFO_CONFIG;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static java.lang.String.format;
+import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
+
+@Execution(SAME_THREAD)
+public final class TestKafkaWithConfluentSchemaRegistryBasicAuth
+        extends AbstractTestKafkaConfluentSchemaRegistry
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        testingKafka = closeAfterClass(TestingKafka.createWithSchemaRegistry(true));
+        testingKafka.start();
+        return KafkaQueryRunner.builderForConfluentSchemaRegistry(testingKafka)
+                .addConnectorProperties(ImmutableMap.of(
+                        "kafka.confluent-subjects-cache-refresh-interval", "1ms",
+                        "kafka.confluent-schema-registry.basic-auth.username", "user",
+                        "kafka.confluent-schema-registry.basic-auth.password", "31337",
+                        "kafka.confluent-schema-registry-auth-type", "BASIC_AUTH"))
+                .build();
+    }
+
+    @Test
+    public void testBasicTopicBasicAuth()
+    {
+        String topic = "topic-basic-MixedCase-" + randomNameSuffix();
+        assertTopic(
+                topic,
+                format("SELECT col_1, col_2 FROM %s", toDoubleQuoted(topic)),
+                format("SELECT col_1, col_2, col_3 FROM %s", toDoubleQuoted(topic)),
+                false,
+                schemaRegistryAwareProducerBasicAuth(testingKafka)
+                        .put(KEY_SERIALIZER_CLASS_CONFIG, LongSerializer.class.getName())
+                        .put(VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName())
+                        .buildOrThrow());
+    }
+
+    private static ImmutableMap.Builder<String, String> schemaRegistryAwareProducerBasicAuth(TestingKafka testingKafka)
+    {
+        return ImmutableMap.<String, String>builder()
+                .put(SCHEMA_REGISTRY_URL_CONFIG, testingKafka.getSchemaRegistryConnectString())
+                .put(BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO")
+                .put(USER_INFO_CONFIG, "user:31337");
+    }
+}

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestKafkaWithConfluentSchemaRegistryMinimalFunctionality.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestKafkaWithConfluentSchemaRegistryMinimalFunctionality.java
@@ -13,22 +13,13 @@
  */
 package io.trino.plugin.kafka.schema.confluent;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import dev.failsafe.Failsafe;
-import dev.failsafe.RetryPolicy;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializer;
 import io.confluent.kafka.serializers.subject.RecordNameStrategy;
 import io.confluent.kafka.serializers.subject.TopicRecordNameStrategy;
-import io.trino.plugin.kafka.KafkaQueryRunner;
 import io.trino.sql.query.QueryAssertions;
-import io.trino.testing.AbstractTestQueryFramework;
-import io.trino.testing.QueryRunner;
 import io.trino.testing.kafka.TestingKafka;
-import org.apache.avro.AvroRuntimeException;
-import org.apache.avro.Schema;
-import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -36,7 +27,6 @@ import org.apache.kafka.common.serialization.LongSerializer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
@@ -45,11 +35,7 @@ import java.util.stream.LongStream;
 import static io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG;
 import static io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig.VALUE_SUBJECT_NAME_STRATEGY;
 import static io.trino.testing.TestingNames.randomNameSuffix;
-import static io.trino.testing.assertions.Assert.assertEventually;
-import static java.lang.Math.multiplyExact;
 import static java.lang.String.format;
-import static java.util.Locale.ENGLISH;
-import static java.util.Objects.requireNonNull;
 import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -57,36 +43,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
 @Execution(SAME_THREAD)
-public class TestKafkaWithConfluentSchemaRegistryMinimalFunctionality
-        extends AbstractTestQueryFramework
+public final class TestKafkaWithConfluentSchemaRegistryMinimalFunctionality
+        extends AbstractTestKafkaConfluentSchemaRegistry
 {
-    private static final String RECORD_NAME = "test_record";
-    private static final int MESSAGE_COUNT = 100;
-    private static final Schema INITIAL_SCHEMA = SchemaBuilder.record(RECORD_NAME)
-            .fields()
-            .name("col_1").type().nullable().longType().noDefault()
-            .name("col_2").type().nullable().stringType().noDefault()
-            .endRecord();
-    private static final Schema EVOLVED_SCHEMA = SchemaBuilder.record(RECORD_NAME)
-            .fields()
-            .name("col_1").type().nullable().longType().noDefault()
-            .name("col_2").type().nullable().stringType().noDefault()
-            .name("col_3").type().optional().doubleType()
-            .endRecord();
-
-    private TestingKafka testingKafka;
-
-    @Override
-    protected QueryRunner createQueryRunner()
-            throws Exception
-    {
-        testingKafka = closeAfterClass(TestingKafka.createWithSchemaRegistry());
-        testingKafka.start();
-        return KafkaQueryRunner.builderForConfluentSchemaRegistry(testingKafka)
-                .addConnectorProperties(ImmutableMap.of("kafka.confluent-subjects-cache-refresh-interval", "1ms"))
-                .build();
-    }
-
     @Test
     public void testBasicTopic()
     {
@@ -259,188 +218,5 @@ public class TestKafkaWithConfluentSchemaRegistryMinimalFunctionality
     {
         return ImmutableMap.<String, String>builder()
                 .put(SCHEMA_REGISTRY_URL_CONFIG, testingKafka.getSchemaRegistryConnectString());
-    }
-
-    private void assertTopic(
-            String topicName,
-            String initialQuery,
-            String evolvedQuery,
-            boolean isKeyIncluded,
-            Map<String, String> producerConfig)
-    {
-        assertNotExists(topicName);
-
-        List<ProducerRecord<Long, GenericRecord>> messages = createMessages(topicName, MESSAGE_COUNT, true);
-        testingKafka.sendMessages(messages.stream(), producerConfig);
-
-        waitUntilTableExists(topicName);
-        assertCount(topicName, MESSAGE_COUNT);
-
-        assertThat(query(initialQuery)).matches(getExpectedValues(messages, INITIAL_SCHEMA, isKeyIncluded));
-
-        List<ProducerRecord<Long, GenericRecord>> newMessages = createMessages(topicName, MESSAGE_COUNT, false);
-        testingKafka.sendMessages(newMessages.stream(), producerConfig);
-
-        List<ProducerRecord<Long, GenericRecord>> allMessages = ImmutableList.<ProducerRecord<Long, GenericRecord>>builder()
-                .addAll(messages)
-                .addAll(newMessages)
-                .build();
-        assertCount(topicName, allMessages.size());
-
-        String expectedValues = getExpectedValues(messages, EVOLVED_SCHEMA, isKeyIncluded);
-        assertEventually(io.airlift.units.Duration.valueOf("5s"), () -> assertThat(query(evolvedQuery)).containsAll(expectedValues));
-    }
-
-    private static String getExpectedValues(List<ProducerRecord<Long, GenericRecord>> messages, Schema schema, boolean isKeyIncluded)
-    {
-        StringBuilder valuesBuilder = new StringBuilder("VALUES ");
-        ImmutableList.Builder<String> rowsBuilder = ImmutableList.builder();
-        for (ProducerRecord<Long, GenericRecord> message : messages) {
-            ImmutableList.Builder<String> columnsBuilder = ImmutableList.builder();
-
-            if (isKeyIncluded) {
-                columnsBuilder.add(format("CAST(%s as bigint)", message.key()));
-            }
-
-            addExpectedColumns(schema, message.value(), columnsBuilder);
-
-            rowsBuilder.add(format("(%s)", String.join(", ", columnsBuilder.build())));
-        }
-        valuesBuilder.append(String.join(", ", rowsBuilder.build()));
-        return valuesBuilder.toString();
-    }
-
-    private static void addExpectedColumns(Schema schema, GenericRecord record, ImmutableList.Builder<String> columnsBuilder)
-    {
-        for (Schema.Field field : schema.getFields()) {
-            Object value = getValue(record, field.name());
-            if (value == null && field.schema().getType().equals(Schema.Type.UNION) && field.schema().getTypes().contains(Schema.create(Schema.Type.NULL))) {
-                if (field.schema().getTypes().contains(Schema.create(Schema.Type.DOUBLE))) {
-                    columnsBuilder.add("CAST(null AS double)");
-                }
-                else {
-                    throw new IllegalArgumentException("Unsupported field: " + field);
-                }
-            }
-            else if (field.schema().getType().equals(Schema.Type.STRING)
-                    || (field.schema().getType().equals(Schema.Type.UNION) && field.schema().getTypes().contains(Schema.create(Schema.Type.STRING)))) {
-                columnsBuilder.add(format("VARCHAR '%s'", value));
-            }
-            else if (field.schema().getType().equals(Schema.Type.LONG)
-                    || (field.schema().getType().equals(Schema.Type.UNION) && field.schema().getTypes().contains(Schema.create(Schema.Type.LONG)))) {
-                columnsBuilder.add(format("CAST(%s AS bigint)", value));
-            }
-            else {
-                throw new IllegalArgumentException("Unsupported field: " + field);
-            }
-        }
-    }
-
-    public static Object getValue(GenericRecord record, String columnName)
-    {
-        try {
-            return record.get(columnName);
-        }
-        catch (AvroRuntimeException e) {
-            if (e.getMessage().contains("Not a valid schema field")) {
-                return null;
-            }
-
-            throw e;
-        }
-    }
-
-    private void assertNotExists(String tableName)
-    {
-        if (schemaExists()) {
-            assertThat(getQueryRunner().execute("SHOW TABLES LIKE " + toSingleQuoted(tableName)).getRowCount()).isZero();
-        }
-    }
-
-    private void waitUntilTableExists(String tableName)
-    {
-        Failsafe.with(
-                        RetryPolicy.builder()
-                                .withMaxAttempts(10)
-                                .withDelay(Duration.ofMillis(100))
-                                .build())
-                .run(() -> assertThat(schemaExists()).isTrue());
-        Failsafe.with(
-                        RetryPolicy.builder()
-                                .withMaxAttempts(10)
-                                .withDelay(Duration.ofMillis(100))
-                                .build())
-                .run(() -> assertThat(tableExists(tableName)).isTrue());
-    }
-
-    private boolean schemaExists()
-    {
-        return getQueryRunner().execute(format(
-                        "SHOW SCHEMAS FROM %s LIKE '%s'",
-                        getSession().getCatalog().orElseThrow(),
-                        getSession().getSchema().orElseThrow()))
-                .getRowCount() == 1;
-    }
-
-    private boolean tableExists(String tableName)
-    {
-        return getQueryRunner().execute(format("SHOW TABLES LIKE '%s'", tableName.toLowerCase(ENGLISH))).getRowCount() == 1;
-    }
-
-    private void assertCount(String tableName, long count)
-    {
-        assertThat(getQueryRunner().execute("SELECT count(*) FROM " + toDoubleQuoted(tableName)).getOnlyValue()).isEqualTo(count);
-    }
-
-    private static String toDoubleQuoted(String tableName)
-    {
-        return format("\"%s\"", tableName);
-    }
-
-    private static String toSingleQuoted(Object value)
-    {
-        requireNonNull(value, "value is null");
-        return format("'%s'", value);
-    }
-
-    private static List<ProducerRecord<Long, GenericRecord>> createMessages(String topicName, int messageCount, boolean useInitialSchema)
-    {
-        ImmutableList.Builder<ProducerRecord<Long, GenericRecord>> producerRecordBuilder = ImmutableList.builder();
-        if (useInitialSchema) {
-            for (long key = 0; key < messageCount; key++) {
-                producerRecordBuilder.add(new ProducerRecord<>(topicName, key, createRecordWithInitialSchema(key)));
-            }
-        }
-        else {
-            for (long key = 0; key < messageCount; key++) {
-                producerRecordBuilder.add(new ProducerRecord<>(topicName, key, createRecordWithEvolvedSchema(key)));
-            }
-        }
-        return producerRecordBuilder.build();
-    }
-
-    private static GenericRecord createRecordWithInitialSchema(long key)
-    {
-        return new GenericRecordBuilder(INITIAL_SCHEMA)
-                .set("col_1", multiplyExact(key, 100))
-                .set("col_2", format("string-%s", key))
-                .build();
-    }
-
-    private static GenericRecord createRecordWithEvolvedSchema(long key)
-    {
-        return new GenericRecordBuilder(EVOLVED_SCHEMA)
-                .set("col_1", multiplyExact(key, 100))
-                .set("col_2", format("string-%s", key))
-                .set("col_3", (key + 10.1D) / 10.0D)
-                .build();
-    }
-
-    private record JsonValue(int id, String value)
-    {
-        private JsonValue
-        {
-            requireNonNull(value, "value is null");
-        }
     }
 }

--- a/testing/trino-testing-kafka/src/main/java/io/trino/testing/kafka/TestingKafka.java
+++ b/testing/trino-testing-kafka/src/main/java/io/trino/testing/kafka/TestingKafka.java
@@ -69,6 +69,7 @@ public final class TestingKafka
     private final ConfluentKafkaContainer kafka;
     private final GenericContainer<?> schemaRegistry;
     private final boolean withSchemaRegistry;
+    private final boolean withBasicAuth;
     private final Closer closer = Closer.create();
     private boolean stopped;
 
@@ -79,17 +80,28 @@ public final class TestingKafka
 
     public static TestingKafka create(String confluentPlatformVersions)
     {
-        return new TestingKafka(confluentPlatformVersions, false);
+        return new TestingKafka(confluentPlatformVersions, false, false);
+    }
+
+    public static TestingKafka create(String confluentPlatformVersions, boolean withSchemaRegistry)
+    {
+        return new TestingKafka(confluentPlatformVersions, withSchemaRegistry, false);
     }
 
     public static TestingKafka createWithSchemaRegistry()
     {
-        return new TestingKafka(DEFAULT_CONFLUENT_PLATFORM_VERSION, true);
+        return new TestingKafka(DEFAULT_CONFLUENT_PLATFORM_VERSION, true, false);
     }
 
-    private TestingKafka(String confluentPlatformVersion, boolean withSchemaRegistry)
+    public static TestingKafka createWithSchemaRegistry(boolean withBasicAuth)
+    {
+        return new TestingKafka(DEFAULT_CONFLUENT_PLATFORM_VERSION, true, withBasicAuth);
+    }
+
+    private TestingKafka(String confluentPlatformVersion, boolean withSchemaRegistry, boolean withBasicAuth)
     {
         this.withSchemaRegistry = withSchemaRegistry;
+        this.withBasicAuth = withBasicAuth;
         network = Network.newNetwork();
         closer.register(network::close);
 
@@ -97,6 +109,8 @@ public final class TestingKafka
         // Modify the template directly instead.
         MountableFile kafkaLogTemplate = forClasspathResource("log4j-kafka.properties.template");
         MountableFile schemaRegistryLogTemplate = forClasspathResource("log4j-schema-registry.properties.template");
+        MountableFile schemaRegistryJaasConfig = forClasspathResource("schema_registry_jaas_config.conf");
+        MountableFile schemaRegistryPasswordFile = forClasspathResource("schema_registry_password-file");
         kafka = new ConfluentKafkaContainer(KAFKA_IMAGE_NAME.withTag(confluentPlatformVersion))
                 .withStartupAttempts(3)
                 .withNetwork(network)
@@ -105,19 +119,46 @@ public final class TestingKafka
                 .withCopyFileToContainer(
                         kafkaLogTemplate,
                         "/etc/confluent/docker/log4j.properties.template");
-        schemaRegistry = new GenericContainer<>(SCHEMA_REGISTRY_IMAGE_NAME.withTag(confluentPlatformVersion))
-                .withStartupAttempts(3)
-                .withNetwork(network)
-                .withNetworkAliases("schema-registry")
-                .withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka:9093")
-                .withEnv("SCHEMA_REGISTRY_HOST_NAME", "0.0.0.0")
-                .withEnv("SCHEMA_REGISTRY_LISTENERS", "http://0.0.0.0:" + SCHEMA_REGISTRY_PORT)
-                .withEnv("SCHEMA_REGISTRY_HEAP_OPTS", "-Xmx1G")
-                .withExposedPorts(SCHEMA_REGISTRY_PORT)
-                .withCopyFileToContainer(
-                        schemaRegistryLogTemplate,
-                        "/etc/confluent/docker/log4j.properties.template")
-                .dependsOn(kafka);
+        if (this.withBasicAuth) {
+            schemaRegistry = new GenericContainer<>(SCHEMA_REGISTRY_IMAGE_NAME.withTag(confluentPlatformVersion))
+                    .withStartupAttempts(3)
+                    .withNetwork(network)
+                    .withNetworkAliases("schema-registry")
+                    .withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka:9092")
+                    .withEnv("SCHEMA_REGISTRY_HOST_NAME", "0.0.0.0")
+                    .withEnv("SCHEMA_REGISTRY_LISTENERS", "http://0.0.0.0:" + SCHEMA_REGISTRY_PORT)
+                    .withEnv("SCHEMA_REGISTRY_HEAP_OPTS", "-Xmx1G")
+                    .withEnv(Map.of(
+                            "SCHEMA_REGISTRY_LOG4J_ROOT_LOGLEVEL", "INFO",
+                            "SCHEMA_REGISTRY_AUTHENTICATION_METHOD", "BASIC",
+                            "SCHEMA_REGISTRY_AUTHENTICATION_REALM", "SchemaRegistry-Props",
+                            "SCHEMA_REGISTRY_AUTHENTICATION_ROLES", "admin",
+                            "SCHEMA_REGISTRY_OPTS", "-Djava.security.auth.login.config=/etc/confluent/docker/schema_registry_jaas_config.conf"))
+                    .withExposedPorts(SCHEMA_REGISTRY_PORT)
+                    .withCopyFileToContainer(
+                            schemaRegistryLogTemplate,
+                            "/etc/confluent/docker/log4j.properties.template")
+                    .withCopyFileToContainer(schemaRegistryJaasConfig,
+                            "/etc/confluent/docker/schema_registry_jaas_config.conf")
+                    .withCopyFileToContainer(schemaRegistryPasswordFile,
+                            "/etc/confluent/docker/password-file")
+                    .dependsOn(kafka);
+        }
+        else {
+            schemaRegistry = new GenericContainer<>(SCHEMA_REGISTRY_IMAGE_NAME.withTag(confluentPlatformVersion))
+                    .withStartupAttempts(3)
+                    .withNetwork(network)
+                    .withNetworkAliases("schema-registry")
+                    .withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka:9092")
+                    .withEnv("SCHEMA_REGISTRY_HOST_NAME", "0.0.0.0")
+                    .withEnv("SCHEMA_REGISTRY_LISTENERS", "http://0.0.0.0:" + SCHEMA_REGISTRY_PORT)
+                    .withEnv("SCHEMA_REGISTRY_HEAP_OPTS", "-Xmx1G")
+                    .withExposedPorts(SCHEMA_REGISTRY_PORT)
+                    .withCopyFileToContainer(
+                            schemaRegistryLogTemplate,
+                            "/etc/confluent/docker/log4j.properties.template")
+                    .dependsOn(kafka);
+        }
         closer.register(kafka::stop);
         closer.register(schemaRegistry::stop);
 

--- a/testing/trino-testing-kafka/src/main/resources/README.md
+++ b/testing/trino-testing-kafka/src/main/resources/README.md
@@ -1,0 +1,22 @@
+# Description of resource files
+
+## schema_registry_jaas_config.conf
+Standard JAAS Login Configuration File
+This implementation will:
+* enable PropertyFileLoginModule
+* set password file to `/etc/confluent/docker/password-file` (this will be copied from [schema_registry_password-file](./schema_registry_password-file))
+* enable debug logs for more visibility 
+
+Reference:  
+https://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/tutorials/LoginConfigFile.html
+
+## schema_registry_password-file
+Confluent password file.  
+Contains usernames, password hashes and roles.  
+File format:
+```
+<username>: <password-hash>,<role1>[,<role2>,...]
+```
+
+Reference:  
+https://docs.confluent.io/platform/current/schema-registry/security/index.html#configuring-the-rest-api-for-basic-http-authentication

--- a/testing/trino-testing-kafka/src/main/resources/schema_registry_jaas_config.conf
+++ b/testing/trino-testing-kafka/src/main/resources/schema_registry_jaas_config.conf
@@ -1,0 +1,5 @@
+SchemaRegistry-Props {
+  org.eclipse.jetty.jaas.spi.PropertyFileLoginModule required
+  file="/etc/confluent/docker/password-file"
+  debug="false";
+};

--- a/testing/trino-testing-kafka/src/main/resources/schema_registry_password-file
+++ b/testing/trino-testing-kafka/src/main/resources/schema_registry_password-file
@@ -1,0 +1,2 @@
+user: MD5:6f3249aa304055d63828af3bfab778f6,admin
+fred: MD5:0d107d09f5bbe40cade3de5c71e9e9b7,admin


### PR DESCRIPTION
## Description
This is a clone of https://github.com/trinodb/trino/pull/23317
add config options to pass username\password to confluent schema registry for kafka plugin

due to GitHub limitations (see https://github.com/isaacs/github/issues/361) i've re-created the MR

## Additional context and related issues
resolves https://github.com/trinodb/trino/issues/12195 and https://github.com/trinodb/trino/issues/22679

## Release notes
Release notes are required. Please propose a release note for me.