### PR TITLE
Rephrase error message for MethodTooLargeException

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/gen/PageFunctionCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/PageFunctionCompiler.java
@@ -208,7 +208,7 @@ public class PageFunctionCompiler
         catch (Exception e) {
             if (Throwables.getRootCause(e) instanceof MethodTooLargeException) {
                 throw new TrinoException(QUERY_EXCEEDED_COMPILER_LIMIT,
-                        "Query exceeded maximum columns. Please reduce the number of columns referenced and re-run the query.", e);
+                        "Failed to execute query; there may be too many columns used or expressions are too complex", e);
             }
             throw new TrinoException(COMPILER_ERROR, e);
         }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLocalExecutionPlanner.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLocalExecutionPlanner.java
@@ -62,7 +62,7 @@ public class TestLocalExecutionPlanner
 
         assertTrinoExceptionThrownBy(() -> runner.execute("SELECT " + outer + " FROM (VALUES rand()) t(x)"))
                 .hasErrorCode(QUERY_EXCEEDED_COMPILER_LIMIT)
-                .hasMessage("Query exceeded maximum columns. Please reduce the number of columns referenced and re-run the query.");
+                .hasMessage("Failed to execute query; there may be too many columns used or expressions are too complex");
     }
 
     @Test

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestServer.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestServer.java
@@ -306,7 +306,7 @@ public class TestServer
                     String.join(" || ", Collections.nCopies(10, array)) +
                     "FROM " + tableName;
 
-            checkVersionOnError(query, "TrinoException: Query exceeded maximum columns(?s:.*)at io.trino.sql.gen.PageFunctionCompiler.compileProjectionInternal");
+            checkVersionOnError(query, "TrinoException: Failed to execute query; (?s:.*)at io.trino.sql.gen.PageFunctionCompiler.compileProjectionInternal");
         }
     }
 


### PR DESCRIPTION
Previous exception message for MethodTooLargeException was too specific and was misleading at times.

