### PR TITLE
Rewrite exclude_columns table function into projection

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -220,6 +220,7 @@ import io.trino.sql.planner.iterative.rule.ReplaceJoinOverConstantWithProject;
 import io.trino.sql.planner.iterative.rule.ReplaceRedundantJoinWithProject;
 import io.trino.sql.planner.iterative.rule.ReplaceRedundantJoinWithSource;
 import io.trino.sql.planner.iterative.rule.ReplaceWindowWithRowNumber;
+import io.trino.sql.planner.iterative.rule.RewriteExcludeColumnsFunctionToProjection;
 import io.trino.sql.planner.iterative.rule.RewriteSpatialPartitioningAggregation;
 import io.trino.sql.planner.iterative.rule.RewriteTableFunctionToTableScan;
 import io.trino.sql.planner.iterative.rule.SimplifyCountOverConstant;
@@ -645,6 +646,7 @@ public class PlanOptimizers
                 .add(new PushDistinctLimitIntoTableScan(plannerContext))
                 .add(new PushTopNIntoTableScan(metadata))
                 .add(new RewriteTableFunctionToTableScan(plannerContext)) // must run after ImplementTableFunctionSource
+                .add(new RewriteExcludeColumnsFunctionToProjection()) // must run after ImplementTableFunctionSource
                 .build();
         IterativeOptimizer pushIntoTableScanOptimizer = new IterativeOptimizer(
                 plannerContext,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RewriteExcludeColumnsFunctionToProjection.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RewriteExcludeColumnsFunctionToProjection.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.operator.table.ExcludeColumnsFunction.ExcludeColumnsFunctionHandle;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.ProjectNode;
+import io.trino.sql.planner.plan.TableFunctionProcessorNode;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.sql.planner.plan.Patterns.tableFunctionProcessor;
+
+public class RewriteExcludeColumnsFunctionToProjection
+        implements Rule<TableFunctionProcessorNode>
+{
+    private static final Pattern<TableFunctionProcessorNode> PATTERN = tableFunctionProcessor();
+
+    @Override
+    public Pattern<TableFunctionProcessorNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(TableFunctionProcessorNode node, Captures captures, Context context)
+    {
+        if (!(node.getHandle().functionHandle() instanceof ExcludeColumnsFunctionHandle)) {
+            return Result.empty();
+        }
+
+        List<Symbol> inputSymbols = getOnlyElement(node.getRequiredSymbols());
+        List<Symbol> outputSymbols = node.getOutputSymbols();
+
+        checkState(inputSymbols.size() == outputSymbols.size(), "inputSymbols size differs from outputSymbols size");
+        Assignments.Builder assignments = Assignments.builder();
+        for (int i = 0; i < outputSymbols.size(); i++) {
+            assignments.put(outputSymbols.get(i), inputSymbols.get(i).toSymbolReference());
+        }
+
+        return Result.ofPlanNode(new ProjectNode(
+                node.getId(),
+                node.getSource().orElseThrow(),
+                assignments.build()));
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
@@ -2580,6 +2580,18 @@ public class TestLogicalPlanner
                                         .right(exchange(tableScan("nation"))))))));
     }
 
+    @Test
+    public void testRewriteExcludeColumnsFunctionToProjection()
+    {
+        assertPlan("""
+                   SELECT *
+                   FROM TABLE(system.builtin.exclude_columns(
+                       INPUT => TABLE(orders),
+                       COLUMNS => DESCRIPTOR(comment)))
+                   """,
+                output(tableScan("orders")));
+    }
+
     private Session noJoinReordering()
     {
         return Session.builder(getPlanTester().getDefaultSession())

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRewriteExcludeColumnsFunctionToProjection.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRewriteExcludeColumnsFunctionToProjection.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.operator.table.ExcludeColumnsFunction.ExcludeColumnsFunctionHandle;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.assertions.PlanMatchPattern;
+import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+
+class TestRewriteExcludeColumnsFunctionToProjection
+        extends BaseRuleTest
+{
+    @Test
+    public void rewriteExcludeColumnsFunction()
+    {
+        tester().assertThat(new RewriteExcludeColumnsFunctionToProjection())
+                .on(p -> {
+                    Symbol a = p.symbol("a", BOOLEAN);
+                    Symbol b = p.symbol("b", BIGINT);
+                    Symbol c = p.symbol("c", SMALLINT);
+                    Symbol x = p.symbol("x", BIGINT);
+                    Symbol y = p.symbol("y", SMALLINT);
+                    return p.tableFunctionProcessor(
+                            builder -> builder
+                                    .name("exclude_columns")
+                                    .properOutputs(x, y)
+                                    .pruneWhenEmpty()
+                                    .requiredSymbols(ImmutableList.of(ImmutableList.of(b, c)))
+                                    .connectorHandle(new ExcludeColumnsFunctionHandle())
+                                    .source(p.values(a, b, c)));
+                })
+                .matches(PlanMatchPattern.strictProject(
+                        ImmutableMap.of(
+                                "x", expression(new Reference(BIGINT, "b")),
+                                "y", expression(new Reference(SMALLINT, "c"))),
+                        values("a", "b", "c")));
+    }
+
+    @Test
+    public void doNotRewriteOtherFunction()
+    {
+        tester().assertThat(new RewriteExcludeColumnsFunctionToProjection())
+                .on(p -> {
+                    Symbol a = p.symbol("a", BOOLEAN);
+                    Symbol b = p.symbol("b", BIGINT);
+                    Symbol c = p.symbol("c", SMALLINT);
+                    return p.tableFunctionProcessor(
+                            builder -> builder
+                                    .name("testing_function")
+                                    .requiredSymbols(ImmutableList.of(ImmutableList.of(b, c)))
+                                    .source(p.values(a, b, c)));
+                }).doesNotFire();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/TableFunctionProcessorBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/TableFunctionProcessorBuilder.java
@@ -45,6 +45,7 @@ public class TableFunctionProcessorBuilder
     private Set<Symbol> prePartitioned = ImmutableSet.of();
     private int preSorted;
     private Optional<Symbol> hashSymbol = Optional.empty();
+    private ConnectorTableFunctionHandle connectorHandle = new ConnectorTableFunctionHandle() {};
 
     public TableFunctionProcessorBuilder() {}
 
@@ -114,6 +115,12 @@ public class TableFunctionProcessorBuilder
         return this;
     }
 
+    public TableFunctionProcessorBuilder connectorHandle(ConnectorTableFunctionHandle connectorHandle)
+    {
+        this.connectorHandle = connectorHandle;
+        return this;
+    }
+
     public TableFunctionProcessorNode build(PlanNodeIdAllocator idAllocator)
     {
         return new TableFunctionProcessorNode(
@@ -129,6 +136,6 @@ public class TableFunctionProcessorBuilder
                 prePartitioned,
                 preSorted,
                 hashSymbol,
-                new TableFunctionHandle(TEST_CATALOG_HANDLE, new ConnectorTableFunctionHandle() {}, TestingTransactionHandle.create()));
+                new TableFunctionHandle(TEST_CATALOG_HANDLE, connectorHandle, TestingTransactionHandle.create()));
     }
 }


### PR DESCRIPTION
After this change, the `exclude_columns` table function is rewritten into a projection. It enables pushdown and helps avoid memory issues related to the table function operator.

```markdown
## General
* Improve performance of certain queries involving the `exclude_columns` table function. ({issue}`25117`)
```

Fixes https://github.com/trinodb/trino/issues/25117

cc @takezoe 