### PR TITLE
Skip subquery plan if subqueryExpression List is empty for efficiency

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/SubqueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/SubqueryPlanner.java
@@ -134,6 +134,10 @@ class SubqueryPlanner
      */
     private <T extends io.trino.sql.tree.Expression> List<T> selectSubqueries(PlanBuilder subPlan, io.trino.sql.tree.Expression parent, List<T> candidates)
     {
+        if (candidates.isEmpty()) {
+            return ImmutableList.of();
+        }
+
         SuccessorsFunction<Node> recurse = expression -> {
             if (!(expression instanceof io.trino.sql.tree.Expression value) ||
                     (!analysis.isColumnReference(value) && // no point in following dereference chains


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

As the title. 
In some CPU-bound scenarios, according to the cpu-profiler result, if there is no subqueries, the method `cluster()` and `selectSubqueries()` are no need to be executed to reduce cpu usage. 


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(-) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
