### PR TITLE
Fix incorrect rounding in rescaled value computation

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MathFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MathFunctions.java
@@ -41,6 +41,7 @@ import org.apache.commons.math3.distribution.BetaDistribution;
 import org.apache.commons.math3.distribution.TDistribution;
 import org.apache.commons.math3.special.Erf;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.util.concurrent.ThreadLocalRandom;
@@ -853,7 +854,11 @@ public final class MathFunctions
 
         double factor = Math.pow(10, decimals);
         int sign = (num < 0) ? -1 : 1;
-        double rescaled = sign * num * factor;
+        double rescaled = BigDecimal.valueOf(num)
+                .multiply(BigDecimal.valueOf(sign))
+                .multiply(BigDecimal.valueOf(factor))
+                .doubleValue();
+
         long rescaledRound = Math.round(rescaled);
         if (rescaledRound != Long.MAX_VALUE) {
             return sign * (rescaledRound / factor);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
## Summary

This pull request addresses a precision issue in the `MathFunctions.round` function that results in unexpected rounding behavior for certain values.

## Problem Description

When executing the following query:

```sql
select round((133.82500000), 2), round((940.47500000), 2)
```
the results produced are:

```
133.82, 940.48
```
instead of the expected:
```
133.83, 940.48
```

The issue originates from precision loss during the rescaling step in the rounding function. Specifically, the multiplication:

```
double rescaled = sign * num * factor;
```

evaluates as:

```
1 * 133.825 * 100 = 13382.499999999998 instead of 13382.5
```

Due to this slight decimal representation change since `0.49 < 0.5` it will now round down to `133.82` instead of rounding up to `133.83`.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
