### PR TITLE
Remove @JsonValue from SqlInterval* types

### DIFF
--- a/core/trino-main/src/main/java/io/trino/type/SqlIntervalDayTime.java
+++ b/core/trino-main/src/main/java/io/trino/type/SqlIntervalDayTime.java
@@ -13,8 +13,6 @@
  */
 package io.trino.type;
 
-import com.fasterxml.jackson.annotation.JsonValue;
-
 import java.util.Objects;
 
 import static io.trino.client.IntervalDayTime.formatMillis;
@@ -53,7 +51,6 @@ public class SqlIntervalDayTime
         return this.milliSeconds == other.milliSeconds;
     }
 
-    @JsonValue
     @Override
     public String toString()
     {

--- a/core/trino-main/src/main/java/io/trino/type/SqlIntervalYearMonth.java
+++ b/core/trino-main/src/main/java/io/trino/type/SqlIntervalYearMonth.java
@@ -13,8 +13,6 @@
  */
 package io.trino.type;
 
-import com.fasterxml.jackson.annotation.JsonValue;
-
 import java.util.Objects;
 
 import static io.trino.client.IntervalYearMonth.formatMonths;
@@ -53,7 +51,6 @@ public class SqlIntervalYearMonth
         return this.months == other.months;
     }
 
-    @JsonValue
     @Override
     public String toString()
     {


### PR DESCRIPTION
This is no longer used as these types have special handling in the JsonEncodingUtils

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
