### PR TITLE
 Fix incorrect order of primary key in MySQL connector

### DIFF
--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlConnectorTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlConnectorTest.java
@@ -200,7 +200,7 @@ public abstract class BaseMySqlConnectorTest
     public void testCreateTableWithPrimaryKey()
     {
         verifyCreateTableDefinition(
-                "(a bigint NOT NULL, b bigint, c bigint) with (primary_key = ARRAY['a'])",
+                "(a bigint NOT NULL, b bigint, c bigint) WITH (primary_key = ARRAY['a'])",
                 """
                 CREATE TABLE %s.%s.%s (
                    a bigint NOT NULL,
@@ -214,7 +214,7 @@ public abstract class BaseMySqlConnectorTest
         );
 
         verifyCreateTableDefinition(
-                "(a bigint NOT NULL, b bigint NOT NULL, c bigint) with (primary_key = ARRAY['a', 'b'])",
+                "(a bigint NOT NULL, b bigint NOT NULL, c bigint) WITH (primary_key = ARRAY['a', 'b'])",
                 """
                 CREATE TABLE %s.%s.%s (
                    a bigint NOT NULL,
@@ -241,12 +241,12 @@ public abstract class BaseMySqlConnectorTest
     {
         String tableName = "test_create_with_invalid_primary_key";
         // primary key must be not null
-        assertQueryFails("CREATE TABLE " + tableName + " (a bigint, b bigint, c bigint) with (primary_key = ARRAY['a'])",
+        assertQueryFails("CREATE TABLE " + tableName + " (a bigint, b bigint, c bigint) WITH (primary_key = ARRAY['a'])",
                 "Primary key must be NOT NULL in MySQL");
         // primary key must exist in column list
-        assertQueryFails("CREATE TABLE " + tableName + " (a bigint, b bigint, c bigint) with (primary_key = ARRAY['d'])",
+        assertQueryFails("CREATE TABLE " + tableName + " (a bigint, b bigint, c bigint) WITH (primary_key = ARRAY['d'])",
                 "Column 'd' specified in property 'primary_key' doesn't exist in table");
-        assertQueryFails("CREATE TABLE " + tableName + " (a bigint, b bigint, c bigint) with (primary_key = ARRAY['A'])",
+        assertQueryFails("CREATE TABLE " + tableName + " (a bigint, b bigint, c bigint) WITH (primary_key = ARRAY['A'])",
                 "Column 'A' specified in property 'primary_key' doesn't exist in table");
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
The order of columns in a MySQL primary key definition is significant. 
PRIMARY KEY (A, B) is different from PRIMARY KEY (B, A)

`KEY_SEQ` is a sequence number within primary key( a value of 1 represents the first column of the primary key, a value of 2 would represent the second column within the primary key)




<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
