### PR TITLE
Return null for new columns in Iceberg `$partitions` system table

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionsTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionsTable.java
@@ -274,26 +274,22 @@ public class PartitionsTable
 
             // add column level metrics
             dataColumnType.ifPresent(dataColumnType -> {
-                try {
-                    row.add(buildRowValue(dataColumnType, fields -> {
-                        for (int i = 0; i < columnMetricTypes.size(); i++) {
-                            Integer fieldId = nonPartitionPrimitiveColumns.get(i).fieldId();
-                            Object min = icebergStatistics.minValues().get(fieldId);
-                            Object max = icebergStatistics.maxValues().get(fieldId);
-                            Long nullCount = icebergStatistics.nullCounts().get(fieldId);
-                            Long nanCount = icebergStatistics.nanCounts().get(fieldId);
-                            if (min == null && max == null && nullCount == null) {
-                                throw new MissingColumnMetricsException();
-                            }
-
-                            RowType columnMetricType = columnMetricTypes.get(i);
+                row.add(buildRowValue(dataColumnType, fields -> {
+                    for (int i = 0; i < columnMetricTypes.size(); i++) {
+                        Integer fieldId = nonPartitionPrimitiveColumns.get(i).fieldId();
+                        Object min = icebergStatistics.minValues().get(fieldId);
+                        Object max = icebergStatistics.maxValues().get(fieldId);
+                        Long nullCount = icebergStatistics.nullCounts().get(fieldId);
+                        Long nanCount = icebergStatistics.nanCounts().get(fieldId);
+                        RowType columnMetricType = columnMetricTypes.get(i);
+                        if (min == null && max == null && nullCount == null) {
+                            fields.get(i).appendNull();
+                        }
+                        else {
                             columnMetricType.writeObject(fields.get(i), getColumnMetricBlock(columnMetricType, min, max, nullCount, nanCount));
                         }
-                    }));
-                }
-                catch (MissingColumnMetricsException _) {
-                    row.add(null);
-                }
+                    }
+                }));
             });
 
             records.add(row);
@@ -301,10 +297,6 @@ public class PartitionsTable
 
         return new InMemoryRecordSet(resultTypes, records.build()).cursor();
     }
-
-    private static class MissingColumnMetricsException
-            extends Exception
-    {}
 
     private List<Type> partitionTypes()
     {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -4236,7 +4236,14 @@ public abstract class BaseIcebergConnectorTest
                             // total_size is not exactly deterministic, so grab whatever value there is
                             "(SELECT total_size FROM \"test_partitions_with_conflict$partitions\"), " +
                             "CAST(" +
-                            " NULL AS row(" +
+                            "  ROW (" +
+                            (partitioned ? "" : "  NULL, ") +
+                            "    NULL, " +
+                            "    NULL, " +
+                            "    NULL, " +
+                            "    NULL " +
+                            "  ) " +
+                            " AS row(" +
                             (partitioned ? "" : "    p row(min integer, max integer, null_count bigint, nan_count bigint), ") +
                             "    row_count row(min integer, max integer, null_count bigint, nan_count bigint), " +
                             "    record_count row(min integer, max integer, null_count bigint, nan_count bigint), " +

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
@@ -134,7 +134,7 @@ public abstract class BaseIcebergSystemTables
     }
 
     @Test
-    public void testPartitionTable()
+    public void testPartitionsTable()
     {
         assertQuery("SELECT count(*) FROM test_schema.test_table", "VALUES 6");
         assertQuery("SHOW COLUMNS FROM test_schema.\"test_table$partitions\"",
@@ -162,7 +162,7 @@ public abstract class BaseIcebergSystemTables
     }
 
     @Test
-    public void testPartitionTableWithNan()
+    public void testPartitionsTableWithNan()
     {
         assertQuery("SELECT count(*) FROM test_schema.test_table_nan", "VALUES 6");
 
@@ -198,7 +198,7 @@ public abstract class BaseIcebergSystemTables
     }
 
     @Test
-    public void testPartitionTableOnDropColumn()
+    public void testPartitionsTableOnDropColumn()
     {
         MaterializedResult resultAfterDrop = computeActual("SELECT * from test_schema.\"test_table_drop_column$partitions\"");
         assertThat(resultAfterDrop.getRowCount()).isEqualTo(3);
@@ -768,7 +768,7 @@ public abstract class BaseIcebergSystemTables
     }
 
     @Test
-    public void testPartitionColumns()
+    public void testPartitionsColumns()
     {
         try (TestTable testTable = newTrinoTable("test_partition_columns", """
                 WITH (partitioning = ARRAY[

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
@@ -198,6 +198,22 @@ public abstract class BaseIcebergSystemTables
     }
 
     @Test
+    public void testPartitionsTableAfterAddColumn()
+    {
+        try (TestTable table = newTrinoTable("test_partitions_new_column", "AS SELECT 1 col")) {
+            assertThat(computeScalar("SELECT data.col FROM \"" + table.getName() + "$partitions\""))
+                    .isEqualTo(new MaterializedRow(DEFAULT_PRECISION, 1, 1, 0L, null));
+
+            assertUpdate("ALTER TABLE " + table.getName() + " ADD COLUMN new_col int");
+
+            assertThat(computeScalar("SELECT data.col FROM \"" + table.getName() + "$partitions\""))
+                    .isEqualTo(new MaterializedRow(DEFAULT_PRECISION, 1, 1, 0L, null));
+            assertThat(computeScalar("SELECT data.new_col FROM \"" + table.getName() + "$partitions\""))
+                    .isNull();
+        }
+    }
+
+    @Test
     public void testPartitionsTableOnDropColumn()
     {
         MaterializedResult resultAfterDrop = computeActual("SELECT * from test_schema.\"test_table_drop_column$partitions\"");

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
@@ -2109,7 +2109,7 @@ public class TestIcebergSparkCompatibility
         onSpark().executeQuery("CREATE TABLE " + sparkTableName + " (name STRING, country STRING) USING ICEBERG " +
                 "PARTITIONED BY (country) TBLPROPERTIES ('write.metadata.metrics.default'='none')");
         onSpark().executeQuery("INSERT INTO " + sparkTableName + " VALUES ('Christoph', 'AT'), (NULL, 'RO')");
-        assertThat(onTrino().executeQuery(format("SELECT count(*) FROM %s.%s.\"%s$partitions\" WHERE data IS NOT NULL", TRINO_CATALOG, TEST_SCHEMA_NAME, tableName)))
+        assertThat(onTrino().executeQuery(format("SELECT count(*) FROM %s.%s.\"%s$partitions\" WHERE data.name IS NOT NULL", TRINO_CATALOG, TEST_SCHEMA_NAME, tableName)))
                 .containsOnly(row(0));
 
         onSpark().executeQuery("DROP TABLE " + sparkTableName);


### PR DESCRIPTION
## Description

The entire `data` column became null after https://github.com/trinodb/trino/commit/f8cd48cd29c78a66eccc4bfc967f15de4b946ab2. We can return known values instead likes:
```sql
CREATE TABLE test(col int);
{col -> {min -> ...}}

ALTER TABLE test ADD COLUMN new_col int;
{col -> {min -> ...}, new_col -> {NULL}}
```

Fixes #25529

## Release notes

```markdown
## Iceberg
* Fix some things. ({issue}`issuenumber`)
```
