### PR TITLE
Add register_table procedure usage instructions

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -555,6 +555,8 @@ To prevent unauthorized users from accessing data, this procedure is disabled by
 default. The procedure is enabled only when
 `iceberg.register-table-procedure.enabled` is set to `true`.
 
+Avoid registering multiple tables with the same location.
+
 (iceberg-unregister-table)=
 #### Unregister table
 


### PR DESCRIPTION
## Description

People try to register tables in a different location and face query failures later, add description for this function.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

[#16105](https://github.com/trinodb/trino/issues/16105)

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
