### PR TITLE
Make it easier to pass complex config for Kafka event listener client

### DIFF
--- a/docs/src/main/sphinx/admin/event-listeners-kafka.md
+++ b/docs/src/main/sphinx/admin/event-listeners-kafka.md
@@ -49,6 +49,31 @@ in [](config-properties):
 event-listener.config-files=etc/kafka-event-listener.properties,...
 ```
 
+In some cases, such as when using specialized authentication methods, it is
+necessary to specify additional Kafka client properties in order to access
+your Kafka cluster. To do so, add the `kafka-event-listener.config.resources`
+property to reference your Kafka config files. Note that configs can be
+overwritten if defined explicitly in `kafka-event-listener.properties`:
+
+```properties
+event-listener.name=kafka
+kafka-event-listener.broker-endpoints=kafka.example.com:9093
+kafka-event-listener.created-event.topic=query_create
+kafka-event-listener.completed-event.topic=query_complete
+kafka-event-listener.client-id=trino-example
+kafka.config.resources=/etc/kafka-configuration.properties
+```
+
+The contents of `/etc/kafka-configuration.properties` can for example be:
+
+```properties
+sasl.mechanism=SCRAM-SHA-512
+security.protocol=SASL_SSL
+sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required \
+  username="kafkaclient1" \
+  password="kafkaclient1-secret";
+```
+
 Use the following properties for further configuration.
 
 :::{list-table} Kafka event listener configuration properties
@@ -95,10 +120,6 @@ Use the following properties for further configuration.
 * - `kafka-event-listener.excluded-fields`
   - Comma-separated list of field names to exclude from the Kafka event, for
     example `payload,user`. Values are replaced with null.
-  - 
-* - `kafka-event-listener.client-config-overrides`
-  - Comma-separated list of key-value pairs to specify Kafka client configuration
-    overrides, for example `buffer.memory=67108864,compression.type=zstd`.
   -
 * - `kafka-event-listener.request-timeout`
   - Timeout [duration](prop-type-duration) to complete a Kafka request. Minimum
@@ -115,5 +136,10 @@ Use the following properties for further configuration.
     environment variable on the cluster is set at
     `TRINO_INSIGHTS_CLUSTER_ID=foo`, then the Kafka payload metadata contains
     `CLUSTER_ID=foo`.
+  -
+* - `kafka-event-listener.config.resources`
+  - A comma-separated list of Kafka client configuration files. These files
+    must exist on the machines running Trino. Only specify this if absolutely
+    necessary to access Kafka. Example: `/etc/kafka-configuration.properties`
   -
 :::

--- a/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/KafkaEventListenerConfig.java
+++ b/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/KafkaEventListenerConfig.java
@@ -33,7 +33,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class KafkaEventListenerConfig
 {
-    private static final Splitter.MapSplitter MAP_SPLITTER = Splitter.on(",").trimResults().omitEmptyStrings().withKeyValueSeparator("=");
+    // for the map splitter we need to only look for first = to make sure values like "key=value=1" are not split and instead passed as is (e.g. JAAS config of the form sasl.jaas.config="org.apache.kafka.common.security.scram.ScramLoginModule required username='trino_eventlistener' password='zzzzzz';")
+    private static final Splitter.MapSplitter MAP_SPLITTER = Splitter.on(",").trimResults().omitEmptyStrings().withKeyValueSeparator(Splitter.on("=").trimResults().omitEmptyStrings().limit(2));
 
     private boolean anonymizationEnabled;
     private boolean publishCreatedEvent = true;

--- a/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/KafkaEventPublisher.java
+++ b/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/KafkaEventPublisher.java
@@ -35,6 +35,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.plugin.kafka.utils.PropertiesUtils.readProperties;
 import static java.util.Objects.requireNonNull;
 
 public class KafkaEventPublisher
@@ -57,7 +58,7 @@ public class KafkaEventPublisher
         String completedTopic = config.getCompletedTopicName().orElse("");
         String splitCompletedTopic = config.getSplitCompletedTopicName().orElse("");
 
-        Map<String, String> configOverrides = config.getKafkaClientOverrides();
+        Map<String, String> configOverrides = readProperties(config.getResourceConfigFiles());
         LOG.info("Creating Kafka publisher (SSL=%s) for topics: %s/%s with excluded fields: %s and kafka config overrides: %s",
                 producerFactory instanceof SSLKafkaProducerFactory, createdTopic, completedTopic, config.getExcludedFields(), configOverrides);
         kafkaProducer = producerFactory.producer(configOverrides);

--- a/plugin/trino-kafka-event-listener/src/test/java/io/trino/plugin/eventlistener/kafka/TestKafkaEventListenerConfig.java
+++ b/plugin/trino-kafka-event-listener/src/test/java/io/trino/plugin/eventlistener/kafka/TestKafkaEventListenerConfig.java
@@ -64,7 +64,7 @@ final class TestKafkaEventListenerConfig
                 .put("kafka-event-listener.split-completed-event.topic", "split_completed")
                 .put("kafka-event-listener.client-id", "dashboard-cluster")
                 .put("kafka-event-listener.excluded-fields", "payload,ioMetadata,groups,cpuTimeDistribution")
-                .put("kafka-event-listener.client-config-overrides", "foo=bar,baz=yoo")
+                .put("kafka-event-listener.client-config-overrides", "foo=bar,baz=yoo,sasl.jaas.config=\"org.apache.kafka.common.security.scram.ScramLoginModule required username='trino_eventlistener' password='zzzzzz';\"")
                 .put("kafka-event-listener.request-timeout", "3s")
                 .put("kafka-event-listener.env-var-prefix", "INSIGHTS_")
                 .put("kafka-event-listener.anonymization.enabled", "true")
@@ -82,7 +82,7 @@ final class TestKafkaEventListenerConfig
                 .setSplitCompletedTopicName("split_completed")
                 .setClientId("dashboard-cluster")
                 .setExcludedFields(Set.of("payload", "ioMetadata", "groups", "cpuTimeDistribution"))
-                .setKafkaClientOverrides("foo=bar,baz=yoo")
+                .setKafkaClientOverrides("foo=bar,baz=yoo,sasl.jaas.config=\"org.apache.kafka.common.security.scram.ScramLoginModule required username='trino_eventlistener' password='zzzzzz';\"")
                 .setRequestTimeout(new Duration(3, TimeUnit.SECONDS))
                 .setEnvironmentVariablePrefix("INSIGHTS_")
                 .setTerminateOnInitializationFailure(false);
@@ -133,6 +133,12 @@ final class TestKafkaEventListenerConfig
         overrides = conf.getKafkaClientOverrides();
         assertThat(overrides)
                 .containsExactly(entry("buffer.memory", "444555"), entry("compression.type", "zstd"));
+
+        // check setting value with =
+        conf.setKafkaClientOverrides("sasl.jaas.config=\"org.apache.kafka.common.security.scram.ScramLoginModule required username='trino_eventlistener' password='zzzzzz';\"");
+        overrides = conf.getKafkaClientOverrides();
+        assertThat(overrides)
+                .containsExactly(entry("sasl.jaas.config", "\"org.apache.kafka.common.security.scram.ScramLoginModule required username='trino_eventlistener' password='zzzzzz';\""));
 
         // check empty trailing param
         conf.setKafkaClientOverrides("buffer.memory=555777,");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Fixes https://github.com/trinodb/trino/discussions/24074 by adding ability to specify Kafka client config overrides in separate file.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

This is a breaking change since old config is removed but IMO it's worth to do it - makes things easier in general.
The first commit is an alternative half-way fix which improves parsing of older config.