### PR TITLE
Document core artifacts and packages repo

### DIFF
--- a/docs/src/main/sphinx/ext/download.py
+++ b/docs/src/main/sphinx/ext/download.py
@@ -20,6 +20,7 @@ from sphinx.errors import SphinxError
 GROUP_ID = 'io.trino'
 ARTIFACTS = {
     'server': ('trino-server', 'tar.gz', None),
+    'server-core': ('trino-server-core', 'tar.gz', None),
     'cli': ('trino-cli', 'jar', 'executable'),
     'jdbc': ('trino-jdbc', 'jar', None),
     #plugins

--- a/docs/src/main/sphinx/installation/containers.md
+++ b/docs/src/main/sphinx/installation/containers.md
@@ -1,9 +1,18 @@
 # Trino in a Docker container
 
-The Trino project provides the [trinodb/trino](https://hub.docker.com/r/trinodb/trino)
-Docker image that includes the Trino server and a default configuration. The
-Docker image is published to Docker Hub and can be used with the Docker runtime,
-among several others.
+The Trino project provides the default
+[trinodb/trino](https://hub.docker.com/r/trinodb/trino) Docker image that
+includes the Trino server, all plugins, and a default configuration.
+
+The additional [trinodb/trino-core](https://hub.docker.com/r/trinodb/trino-core)
+Docker images contains only a minimal set of essential plugins, and it is
+therefore mostly suitable as a base for custom container creation. The
+[trino-packages project](https://github.com/trinodb/trino-packages) includes a
+module to create a customized Docker image with your own selection of plugins.
+
+The Docker images are published to Docker Hub and can be used with the Docker
+runtime, among several others. The images are suitable to use with the [Trino
+Helm chart](https://github.com/trinodb/charts).
 
 ## Running the container
 

--- a/docs/src/main/sphinx/installation/deployment.md
+++ b/docs/src/main/sphinx/installation/deployment.md
@@ -46,6 +46,16 @@ Download the Trino server tarball, {maven_download}`server`, and unpack it. The
 tarball contains a single top-level directory, `trino-server-|trino_version|`,
 which we call the *installation* directory.
 
+The default tarball contains all plugins and must be configured for use. The
+minimal `server-core` tarball, {maven_download}`server-core`, contains a minimal
+set of essential plugins, and it is therefore mostly suitable as a base for
+custom tarball creation.
+
+The [trino-packages project](https://github.com/trinodb/trino-packages) includes
+a module to create a fully configured tarball with an example configuration. The
+custom tarball is ready to use and can be further configured and adjusted to
+your needs.
+
 Trino needs a *data* directory for storing logs, etc. By default, an
 installation from the tarball uses the same location for the installation and data
 directories.

--- a/docs/src/main/sphinx/installation/plugins.md
+++ b/docs/src/main/sphinx/installation/plugins.md
@@ -101,6 +101,10 @@ image](/installation/containers) uses the path `/usr/lib/trino/plugin`.
 
 Restart Trino to use the plugin. 
 
+The [trino-packages project](https://github.com/trinodb/trino-packages) contains
+example projects to create a tarball and Docker image with a selection of
+plugins by installing only the desired plugins.
+
 (plugins-removal)=
 ## Removal
 


### PR DESCRIPTION
## Description

Most of the work is done in the trino-packages repo .. just adding a pointer to the repo and some mention of the -core artifacts.

## Additional context and related issues

Part of #22597 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
