### PR TITLE
Fix memory size calculation when memory table is truncated

### DIFF
--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryPagesStore.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryPagesStore.java
@@ -136,7 +136,8 @@ public class MemoryPagesStore
 
     public synchronized void purge(long tableId)
     {
-        tables.remove(tableId);
+        TableData tableData = tables.remove(tableId);
+        currentBytes = currentBytes - tableData.getPages().stream().mapToLong(Page::getRetainedSizeInBytes).sum();
     }
 
     public synchronized void cleanUp(Set<Long> activeTableIds)

--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryPagesStore.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryPagesStore.java
@@ -133,6 +133,15 @@ public class TestMemoryPagesStore
                 .hasMessageMatching("Memory limit.*");
     }
 
+    @Test
+    public void testTruncate()
+    {
+        createTable(0L, 0L);
+        insertToTable(0L, createOneMegaBytePage(), 0L);
+        truncateTable(0L, 0L);
+        insertToTable(0L, createOneMegaBytePage(), 0L);
+    }
+
     private void insertToTable(long tableId, Long... activeTableIds)
     {
         insertToTable(tableId, createPage(), activeTableIds);
@@ -159,6 +168,16 @@ public class TestMemoryPagesStore
         pageSink.finish();
     }
 
+    private void truncateTable(long tableId, Long... activeTableIds)
+    {
+        ConnectorPageSink pageSink = pageSinkProvider.createPageSink(
+                MemoryTransactionHandle.INSTANCE,
+                SESSION,
+                createOverwriteMemoryInsertTableHandle(tableId, activeTableIds),
+                TESTING_PAGE_SINK_ID);
+        pageSink.finish();
+    }
+
     private static ConnectorOutputTableHandle createMemoryOutputTableHandle(long tableId, Long... activeTableIds)
     {
         return new MemoryOutputTableHandle(tableId, ImmutableSet.copyOf(activeTableIds));
@@ -167,6 +186,11 @@ public class TestMemoryPagesStore
     private static ConnectorInsertTableHandle createMemoryInsertTableHandle(long tableId, Long[] activeTableIds)
     {
         return new MemoryInsertTableHandle(tableId, InsertMode.APPEND, ImmutableSet.copyOf(activeTableIds));
+    }
+
+    private static ConnectorInsertTableHandle createOverwriteMemoryInsertTableHandle(long tableId, Long[] activeTableIds)
+    {
+        return new MemoryInsertTableHandle(tableId, InsertMode.OVERWRITE, ImmutableSet.copyOf(activeTableIds));
     }
 
     private static Page createPage()


### PR DESCRIPTION
## Description
Memory connector has the max memory size limit and `MEMORY_LIMIT_EXCEEDED` is thrown if the total size of pages exceeds it. Currently, however, `TRUNCATE TABLE` doesn't reduce the memory size. Therefore, `MEMORY_LIMIT_EXCEEDED` error eventually occurs if we repeat `TRUNCATE` and `INSERT` on memory tables.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Memory
* Fix accounting of memory usage for truncated tables. ({issue}`25564`)
```
