### PR TITLE
add more exception message when getIcebergView failed

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -712,7 +712,9 @@ public class TrinoRestCatalog
             return Optional.empty();
         }
         catch (RESTException e) {
-            throw new TrinoException(ICEBERG_CATALOG_ERROR, "Failed to load view '%s'".formatted(viewName.getTableName()), e);
+            throw new TrinoException(ICEBERG_CATALOG_ERROR,
+                    "Failed to load view '%s', the configuration 'iceberg.rest-catalog.view-endpoints-enabled' is '%s'".formatted(viewName.getTableName(),
+                    restSessionCatalog.properties().getOrDefault("view-endpoints-supported", "false")), e);
         }
     }
 


### PR DESCRIPTION
## Description
Add configuration `iceberg.rest-catalog.view-endpoints-enabled` value in exception message when get iceberg view failed.

## Additional context and related issues
#25556

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.