### PR TITLE
Add support for UUID arrays in PostgreSQL connector

### DIFF
--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/TypeUtils.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/TypeUtils.java
@@ -59,6 +59,8 @@ import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MILLISECOND;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.TypeUtils.readNativeValue;
+import static io.trino.spi.type.UuidType.UUID;
+import static io.trino.spi.type.UuidType.trinoUuidToJavaUuid;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.floorDiv;
 import static java.lang.Math.floorMod;
@@ -221,6 +223,10 @@ final class TypeUtils
         if (trinoType instanceof ArrayType arrayType) {
             // process subarray of multi-dimensional array
             return getJdbcObjectArray(session, arrayType.getElementType(), (Block) trinoNative);
+        }
+
+        if (UUID.equals(trinoType)) {
+            return trinoUuidToJavaUuid((Slice) trinoNative);
         }
 
         throw new TrinoException(NOT_SUPPORTED, "Unsupported type: " + trinoType);

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -1749,6 +1749,58 @@ public class TestPostgreSqlTypeMapping
     }
 
     @Test
+    public void testArrayUuid()
+    {
+        Session session = sessionWithArrayAsArray();
+
+        SqlDataTypeTest.create()
+                .addRoundTrip("uuid[]", "NULL", new ArrayType(UUID), "CAST(NULL AS ARRAY(UUID))")
+                .addRoundTrip("uuid[]", "ARRAY[]::uuid[]", new ArrayType(UUID), "CAST(ARRAY[] AS ARRAY(UUID))")
+
+                .addRoundTrip("uuid[]", "ARRAY[UUID 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11', UUID '00000000-0000-0000-0000-000000000000']", new ArrayType(UUID), "ARRAY[UUID 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', UUID '00000000-0000-0000-0000-000000000000']")
+                .addRoundTrip("uuid[]", "ARRAY[UUID 'a0eebc999c0b4ef8bb6d6bb9bd380a11', UUID '00000000-0000-0000-0000-000000000000']", new ArrayType(UUID), "ARRAY[UUID 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', UUID '00000000-0000-0000-0000-000000000000']")
+                .addRoundTrip("uuid[]", "ARRAY[UUID '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}', UUID '00000000-0000-0000-0000-000000000000']", new ArrayType(UUID), "ARRAY[UUID 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', UUID '00000000-0000-0000-0000-000000000000']")
+                .addRoundTrip("uuid[]", "ARRAY[UUID '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}', UUID '00000000-0000-0000-0000-000000000000']", new ArrayType(UUID), "ARRAY[UUID 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', UUID '00000000-0000-0000-0000-000000000000']")
+
+                .addRoundTrip("uuid[]", "ARRAY[UUID '00000000-0000-0000-0000-000000000000', UUID '12151fd2-7586-11e9-8f9e-2a86e4085a59']", new ArrayType(UUID), "ARRAY[UUID '00000000-0000-0000-0000-000000000000', UUID '12151fd2-7586-11e9-8f9e-2a86e4085a59']")
+                .addRoundTrip("uuid[]", "ARRAY[UUID '123e4567-e89b-12d3-a456-426655440000', UUID 'c9c0b3f4-3e7e-4e1a-83eb-bb3e1a2c3c7e']", new ArrayType(UUID), "ARRAY[UUID '123e4567-e89b-12d3-a456-426655440000', UUID 'c9c0b3f4-3e7e-4e1a-83eb-bb3e1a2c3c7e']")
+                .addRoundTrip("uuid[]", "ARRAY[UUID 'f47ac10b-58cc-4372-a567-0e02b2c3d479', UUID '3c6f4b8e-7a3e-4d7c-bc8e-3a0fbc1c6ad1']", new ArrayType(UUID), "ARRAY[UUID 'f47ac10b-58cc-4372-a567-0e02b2c3d479', UUID '3c6f4b8e-7a3e-4d7c-bc8e-3a0fbc1c6ad1']")
+                .execute(getQueryRunner(), session, postgresCreateAndInsert("postgresql_test_array_uuid_or_empty_or_nulls"));
+
+        SqlDataTypeTest.create()
+                .addRoundTrip("ARRAY(uuid)", "NULL", new ArrayType(UUID), "CAST(NULL AS ARRAY(UUID))")
+                .addRoundTrip("ARRAY(uuid)", "ARRAY[]", new ArrayType(UUID), "CAST(ARRAY[] AS ARRAY(UUID))")
+
+                .addRoundTrip("ARRAY(uuid)", "ARRAY[UUID '00000000-0000-0000-0000-000000000000', UUID '12151fd2-7586-11e9-8f9e-2a86e4085a59']", new ArrayType(UUID), "ARRAY[UUID '00000000-0000-0000-0000-000000000000', UUID '12151fd2-7586-11e9-8f9e-2a86e4085a59']")
+                .addRoundTrip("ARRAY(uuid)", "ARRAY[UUID '123e4567-e89b-12d3-a456-426655440000', UUID 'c9c0b3f4-3e7e-4e1a-83eb-bb3e1a2c3c7e']", new ArrayType(UUID), "ARRAY[UUID '123e4567-e89b-12d3-a456-426655440000', UUID 'c9c0b3f4-3e7e-4e1a-83eb-bb3e1a2c3c7e']")
+                .addRoundTrip("ARRAY(uuid)", "ARRAY[UUID 'f47ac10b-58cc-4372-a567-0e02b2c3d479', UUID '3c6f4b8e-7a3e-4d7c-bc8e-3a0fbc1c6ad1']", new ArrayType(UUID), "ARRAY[UUID 'f47ac10b-58cc-4372-a567-0e02b2c3d479', UUID '3c6f4b8e-7a3e-4d7c-bc8e-3a0fbc1c6ad1']")
+                .execute(getQueryRunner(), session, trinoCreateAsSelect(session, "trino_test_array_uuid_or_empty_or_nulls"))
+                .execute(getQueryRunner(), session, trinoCreateAndInsert(session, "trino_test_array_uuid_or_empty_or_nulls"));
+    }
+
+    @Test
+    public void testArrayNulls()
+    {
+        Session session = sessionWithArrayAsArray();
+
+        // Verify only SELECT instead of using SqlDataTypeTest because array comparison not supported for arrays with null elements
+        try (TestTable table = new TestTable(
+                postgreSqlServer::execute,
+                "test_array_nulls",
+                "(col_boolean boolean[], col_smallint smallint[], col_integer integer[], col_bigint bigint[], col_real real[], col_double double precision[], col_uuid uuid[])")) {
+            assertUpdate(session, format("INSERT INTO %s VALUES(%s, %s, %s, %s, %s, %s, %s)", table.getName(), "ARRAY[NULL, true]", "ARRAY[NULL, 123]", "ARRAY[NULL, 123]", "ARRAY[NULL, 123]", "ARRAY[NULL, 123.45]", "ARRAY[NULL, 123.45]", "ARRAY[NULL, UUID 'f47ac10b-58cc-4372-a567-0e02b2c3d479']"), 1);
+
+            assertThat(query(session, "SELECT col_boolean FROM " + table.getName())).matches("VALUES CAST(ARRAY[NULL, true] AS ARRAY(boolean))");
+            assertThat(query(session, "SELECT col_smallint FROM " + table.getName())).matches("VALUES CAST(ARRAY[NULL, 123] AS ARRAY(smallint))");
+            assertThat(query(session, "SELECT col_integer FROM " + table.getName())).matches("VALUES CAST(ARRAY[NULL, 123] AS ARRAY(integer))");
+            assertThat(query(session, "SELECT col_bigint FROM " + table.getName())).matches("VALUES CAST(ARRAY[NULL, 123] AS ARRAY(bigint))");
+            assertThat(query(session, "SELECT col_real FROM " + table.getName())).matches("VALUES CAST(ARRAY[NULL, 123.45] AS ARRAY(real))");
+            assertThat(query(session, "SELECT col_double FROM " + table.getName())).matches("VALUES CAST(ARRAY[NULL, 123.45] AS ARRAY(double))");
+            assertThat(query(session, "SELECT col_uuid FROM " + table.getName())).matches("VALUES CAST(ARRAY[NULL, UUID 'f47ac10b-58cc-4372-a567-0e02b2c3d479'] AS ARRAY(uuid))");
+        }
+    }
+
+    @Test
     public void testMoney()
     {
         SqlDataTypeTest.create()


### PR DESCRIPTION
## Description

Fix #25557

## Release notes

```markdown
## PostgreSQL
* Add support for `array(uuid)` type. ({issue}`25557`)
```
