### PR TITLE
Add last_day_of_week_of_month function for timestamp

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
@@ -204,6 +204,7 @@ import io.trino.operator.scalar.timestamp.ExtractYearOfWeek;
 import io.trino.operator.scalar.timestamp.FormatDateTime;
 import io.trino.operator.scalar.timestamp.HumanReadableSeconds;
 import io.trino.operator.scalar.timestamp.LastDayOfMonth;
+import io.trino.operator.scalar.timestamp.LastDayOfWeekOfMonth;
 import io.trino.operator.scalar.timestamp.LocalTimestamp;
 import io.trino.operator.scalar.timestamp.SequenceIntervalDayToSecond;
 import io.trino.operator.scalar.timestamp.SequenceIntervalYearToMonth;
@@ -637,7 +638,8 @@ public final class SystemFunctionBundle
                 .scalar(ExtractDayOfWeek.class)
                 .scalar(ExtractWeekOfYear.class)
                 .scalar(ExtractYearOfWeek.class)
-                .scalar(LastDayOfMonth.class);
+                .scalar(LastDayOfMonth.class)
+                .scalar(LastDayOfWeekOfMonth.class);
 
         // timestamp with timezone operators and functions
         builder
@@ -672,6 +674,7 @@ public final class SystemFunctionBundle
                 .scalar(io.trino.operator.scalar.timestamptz.FormatDateTime.class)
                 .scalar(io.trino.operator.scalar.timestamptz.ToUnixTime.class)
                 .scalar(io.trino.operator.scalar.timestamptz.LastDayOfMonth.class)
+                .scalar(io.trino.operator.scalar.timestamptz.LastDayOfWeekOfMonth.class)
                 .scalar(AtTimeZone.class)
                 .scalar(AtTimeZoneWithOffset.class)
                 .scalar(DateToTimestampWithTimeZoneCast.class)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/LastDayOfWeekOfMonth.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/LastDayOfWeekOfMonth.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar.timestamp;
+
+import io.trino.spi.function.Description;
+import io.trino.spi.function.LiteralParameters;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.type.LongTimestamp;
+import io.trino.spi.type.StandardTypes;
+import org.joda.time.DateTime;
+import org.joda.time.chrono.ISOChronology;
+
+import static io.trino.type.DateTimes.scaleEpochMicrosToMillis;
+
+@Description("Last occurrence of the given day of the week in the month of the given timestamp")
+@ScalarFunction("last_day_of_week_of_month")
+public class LastDayOfWeekOfMonth
+{
+    private LastDayOfWeekOfMonth() {}
+
+    @LiteralParameters("p")
+    @SqlType(StandardTypes.TIMESTAMP)
+    public static long lastDayOfWeekOfMonth(@SqlType("timestamp(p)") long timestamp, @SqlType(StandardTypes.INTEGER) int dayOfWeek)
+    {
+        long epochMillis = scaleEpochMicrosToMillis(timestamp);
+        DateTime dateTime = new DateTime(epochMillis, ISOChronology.getInstanceUTC());
+        DateTime lastDayOfMonth = dateTime.dayOfMonth().withMaximumValue();
+
+        while (lastDayOfMonth.getDayOfWeek() != dayOfWeek) {
+            lastDayOfMonth = lastDayOfMonth.minusDays(1);
+        }
+
+        return lastDayOfMonth.getMillis();
+    }
+
+    @LiteralParameters("p")
+    @SqlType(StandardTypes.TIMESTAMP)
+    public static long lastDayOfWeekOfMonth(@SqlType("timestamp(p)") LongTimestamp timestamp, @SqlType(StandardTypes.INTEGER) int dayOfWeek)
+    {
+        return lastDayOfWeekOfMonth(timestamp.getEpochMicros(), dayOfWeek);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamptz/LastDayOfWeekOfMonth.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamptz/LastDayOfWeekOfMonth.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar.timestamptz;
+
+import io.trino.spi.function.Description;
+import io.trino.spi.function.LiteralParameters;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.type.LongTimestampWithTimeZone;
+import io.trino.spi.type.StandardTypes;
+import org.joda.time.DateTimeField;
+import org.joda.time.chrono.ISOChronology;
+
+import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
+import static io.trino.spi.type.TimeZoneKey.getTimeZoneKey;
+import static io.trino.util.DateTimeZoneIndex.getChronology;
+import static io.trino.util.DateTimeZoneIndex.unpackChronology;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+@Description("Last occurrence of the given day of the week in the month of the given timestamp")
+@ScalarFunction("last_day_of_week_of_month")
+public class LastDayOfWeekOfMonth
+{
+    private static final int MILLISECONDS_IN_DAY = 24 * 3600 * 1000;
+
+    private LastDayOfWeekOfMonth() {}
+
+
+    @LiteralParameters("p")
+    @SqlType(StandardTypes.DATE)
+    public static long lastDayOfWeekOfMonth(
+            @SqlType("timestamp(p) with time zone") long packedEpochMillis,
+            @SqlType(StandardTypes.INTEGER) long dayOfWeek)
+    {
+        return lastDayOfWeekOfMonth(unpackChronology(packedEpochMillis), unpackMillisUtc(packedEpochMillis), (int) dayOfWeek);
+    }
+
+    @LiteralParameters("p")
+    @SqlType(StandardTypes.DATE)
+    public static long lastDayOfWeekOfMonth(
+            @SqlType("timestamp(p) with time zone") LongTimestampWithTimeZone timestamp,
+            @SqlType(StandardTypes.INTEGER) long dayOfWeek)
+    {
+        return lastDayOfWeekOfMonth(getChronology(getTimeZoneKey(timestamp.getTimeZoneKey())), timestamp.getEpochMillis(), (int) dayOfWeek);
+    }
+
+    private static long lastDayOfWeekOfMonth(ISOChronology chronology, long millis, int dayOfWeek)
+    {
+        // Get the first day of the next month
+        millis = chronology.monthOfYear().roundCeiling(millis + 1);
+        // Move back to the last day of the current month
+        millis = chronology.getZone().convertUTCToLocal(millis) - MILLISECONDS_IN_DAY;
+
+        // Find the last occurrence of the given day of the week
+        DateTimeField dayOfWeekField = chronology.dayOfWeek();
+        while (dayOfWeekField.get(millis) != dayOfWeek) {
+            millis -= MILLISECONDS_IN_DAY;
+        }
+
+        return MILLISECONDS.toDays(millis);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestDateTimeFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestDateTimeFunctions.java
@@ -97,8 +97,8 @@ public class TestDateTimeFunctions
         long timeIncrement = TimeUnit.MINUTES.toMillis(53);
         // We expect UTC millis later on so we have to use UTC chronology
         for (long millis = ISOChronology.getInstanceUTC().getDateTimeMillis(2000, 6, 15, 0, 0, 0, 0);
-                millis < ISOChronology.getInstanceUTC().getDateTimeMillis(2016, 6, 15, 0, 0, 0, 0);
-                millis += timeIncrement) {
+             millis < ISOChronology.getInstanceUTC().getDateTimeMillis(2016, 6, 15, 0, 0, 0, 0);
+             millis += timeIncrement) {
             Instant instant = Instant.ofEpochMilli(millis);
             assertCurrentDateAtInstant(kievTimeZoneKey, instant);
             assertCurrentDateAtInstant(bahiaBanderasTimeZoneKey, instant);
@@ -430,6 +430,39 @@ public class TestDateTimeFunctions
 
             assertThat(assertions.function("last_day_of_month", "TIMESTAMP '2019-08-31 23:59:59.999 " + timeZone + "'"))
                     .matches("DATE '2019-8-31'");
+        });
+    }
+
+    @Test
+    public void testLastDayOfWeekOfMonth()
+    {
+        assertThat(assertions.function("last_day_of_week_of_month", "CAST(TIMESTAMP '2020-02-01 23:59:59.999' AS timestamp(3))", "7"))
+                .matches("TIMESTAMP '2020-02-23 00:00:00.000'"); // Last Sunday of February 2020
+
+        assertThat(assertions.function("last_day_of_week_of_month", "CAST(TIMESTAMP '2020-05-23 14:15:16.000' AS timestamp(3))", "1"))
+                .matches("TIMESTAMP '2020-05-25 00:00:00.000'"); // Last Monday of May 2020
+
+        assertThat(assertions.function("last_day_of_week_of_month", "CAST(TIMESTAMP '2020-05-23 14:15:16.000' AS timestamp(3))", "7"))
+                .matches("TIMESTAMP '2020-05-31 00:00:00.000'"); // Last Sunday of May 2020
+
+        assertThat(assertions.function("last_day_of_week_of_month", "CAST(TIMESTAMP '2020-02-23 14:15:16.000' AS timestamp(3))", "6"))
+                .matches("TIMESTAMP '2020-02-29 00:00:00.000'"); // Last Saturday of February 2020 (leap year)
+
+        assertThat(assertions.function("last_day_of_week_of_month", "CAST(TIMESTAMP '2019-02-23 14:15:16.000' AS timestamp(3))", "4"))
+                .matches("TIMESTAMP '2019-02-28 00:00:00.000'"); // Last Thursday of February 2019
+
+        assertThat(assertions.function("last_day_of_week_of_month", "CAST(TIMESTAMP '2020-04-23 14:15:16.000' AS timestamp(3))", "3"))
+                .matches("TIMESTAMP '2020-04-29 00:00:00.000'"); // Last Wednesday of April 2020
+
+        ImmutableList.of("+05:45", "+00:00", "-05:45", "Asia/Tokyo", "Europe/London", "America/Los_Angeles").forEach(timeZone -> {
+            assertThat(assertions.function("last_day_of_week_of_month", "CAST(TIMESTAMP '2020-07-15 17:00:00.000 " + timeZone + "' AS timestamp(3))", "1"))
+                    .matches("TIMESTAMP '2020-07-27 00:00:00.000'"); // Last Monday of July 2020
+
+            assertThat(assertions.function("last_day_of_week_of_month", "CAST(TIMESTAMP '2020-09-01 00:00:00.000 " + timeZone + "' AS timestamp(3))", "5"))
+                    .matches("TIMESTAMP '2020-09-25 00:00:00.000'"); // Last Friday of September 2020
+
+            assertThat(assertions.function("last_day_of_week_of_month", "CAST(TIMESTAMP '2020-02-01 23:59:59.999 " + timeZone + "' AS timestamp(3))", "7"))
+                    .matches("TIMESTAMP '2020-02-23 00:00:00.000'"); // Last Sunday of February 2020
         });
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
This pull request introduces a new function `last_day_of_week_of_month` to the Trino codebase, which calculates the last occurrence of a specified day of the week in the month of a given timestamp. The changes include updates to existing files and the addition of new files to support this functionality.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
This is useful for us to generate reports which are always done in the "Last Monday of the Month"


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
