### PR TITLE
Make view data optional parameter for view reader

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -2945,7 +2945,7 @@ public class HiveMetadata
                     }
 
                     ConnectorViewDefinition definition = createViewReader(metastore, session, view, typeManager, this::redirectTable, metadataProvider, hiveViewsRunAsInvoker, hiveViewsTimestampPrecision)
-                            .decodeViewData(view.getViewOriginalText().orElseThrow(), view, catalogName);
+                            .decodeViewData(view.getViewOriginalText(), view, catalogName);
                     // use owner field from table metadata if it exists
                     if (view.getOwner().isPresent() && !definition.isRunAsInvoker()) {
                         definition = new ConnectorViewDefinition(

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/LegacyHiveViewReader.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/LegacyHiveViewReader.java
@@ -40,7 +40,7 @@ public class LegacyHiveViewReader
     }
 
     @Override
-    public ConnectorViewDefinition decodeViewData(String viewData, Table table, CatalogName catalogName)
+    public ConnectorViewDefinition decodeViewData(Optional<String> viewData, Table table, CatalogName catalogName)
     {
         String viewText = table.getViewExpandedText()
                 .orElseThrow(() -> new TrinoException(HIVE_INVALID_METADATA, "No view expanded text: " + table.getSchemaTableName()));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
@@ -73,7 +73,7 @@ public final class ViewReaderUtil
 
     public interface ViewReader
     {
-        ConnectorViewDefinition decodeViewData(String viewData, Table table, CatalogName catalogName);
+        ConnectorViewDefinition decodeViewData(Optional<String> viewData, Table table, CatalogName catalogName);
     }
 
     public static ViewReader createViewReader(
@@ -202,9 +202,9 @@ public final class ViewReaderUtil
             implements ViewReader
     {
         @Override
-        public ConnectorViewDefinition decodeViewData(String viewData, Table table, CatalogName catalogName)
+        public ConnectorViewDefinition decodeViewData(Optional<String> viewData, Table table, CatalogName catalogName)
         {
-            return decodeViewData(viewData);
+            return decodeViewData(viewData.orElseThrow(() -> new TrinoException(HIVE_VIEW_TRANSLATION_ERROR, "Cannot decode view data, view original sql is empty")));
         }
 
         public static ConnectorViewDefinition decodeViewData(String viewData)
@@ -238,7 +238,7 @@ public final class ViewReaderUtil
         }
 
         @Override
-        public ConnectorViewDefinition decodeViewData(String viewSql, Table table, CatalogName catalogName)
+        public ConnectorViewDefinition decodeViewData(Optional<String> viewSql, Table table, CatalogName catalogName)
         {
             try {
                 HiveToRelConverter hiveToRelConverter = new HiveToRelConverter(metastoreClient);


### PR DESCRIPTION
## Description

Only presto view reader implementation uses this field

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
