### PR TITLE
Fix concurrency issue with load snapshot from DeltaLakeMetadata

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -524,7 +524,8 @@ public class DeltaLakeMetadata
         try {
             TableSnapshot snapshot = transactionLogAccess.loadSnapshot(session, table, tableLocation, version);
             // Lack of concurrency for given query is currently guaranteed by DeltaLakeMetadata
-            checkState(latestTableVersions.put(table, snapshot.getVersion()) == null || atVersion.isPresent(), "latestTableVersions changed concurrently for %s", table);
+            Long currentVersion = latestTableVersions.put(table, snapshot.getVersion());
+            checkState(currentVersion == null || currentVersion == snapshot.getVersion() || atVersion.isPresent(), "latestTableVersions changed concurrently for %s", table);
             queriedSnapshots.put(new QueriedTable(table, snapshot.getVersion()), snapshot);
             return snapshot;
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

If getTableHandle called concurrently for same table, `getSnapshot` method could produce concurrency issue:

steps to reproduce:

- create some table: `CREATE table my_catalog_delta.my_schema.my_table_1 AS SELECT 1 as a;`
- run query: 
```
SELECT
  t.table_name,
  t.table_type,
  mv.catalog_name IS NOT NULL as is_materialized_view
FROM
  my_catalog_delta.information_schema.tables t
  LEFT JOIN system.metadata.materialized_views mv 
    ON 
       t.table_catalog = mv.catalog_name AND 
       t.table_schema = mv.schema_name AND 
       t.table_name = mv.name
WHERE
  t.table_schema = 'my_schema'
  AND t.table_name = 'my_table_1'
  AND t.table_type IN ('BASE TABLE', 'VIEW')
ORDER by
  t.table_name
```

If you repeat it a few times, you will notice that sometime query failed with : `latestTableVersions changed concurrently` exception.

It happens because there is multiple concurrent calls to `getSnapshot` and first call updated `latestTableVersions` map but not yet `queriedSnapshots` map and second call see these 2 tables in inconsistent state ().



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
