### PR TITLE
Preserve input order of window functions when planning window operations

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
@@ -176,6 +176,7 @@ import static io.trino.type.IntervalYearMonthType.INTERVAL_YEAR_MONTH;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toUnmodifiableList;
 
 class QueryPlanner
 {
@@ -1431,9 +1432,10 @@ class QueryPlanner
             return subPlan;
         }
 
+        // Need to preserve order of windows and window functions in each window to ensure deterministic query plans
         Map<ResolvedWindow, List<io.trino.sql.tree.FunctionCall>> functions = scopeAwareDistinct(subPlan, windowFunctions)
                 .stream()
-                .collect(Collectors.groupingBy(analysis::getWindow));
+                .collect(Collectors.groupingBy(analysis::getWindow, LinkedHashMap::new, toUnmodifiableList()));
 
         for (Map.Entry<ResolvedWindow, List<io.trino.sql.tree.FunctionCall>> entry : functions.entrySet()) {
             ResolvedWindow window = entry.getKey();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Fixes a bug where initial plans for the exact same query string are non-deterministic when the query includes window functions with different resolved windows over the same window. (Resolved window takes into account `partition by`, `order by`, etc)


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Window functions with the same window are planned in the same operation (see [commit](https://github.com/trinodb/trino/commit/3661df860953167fe1954f0f29f16662f346f4b6)). `QueryPlanner::planWindowFunctions` takes in a list of windowFunctions and converts it into a map to be processed. However, HashMaps do not guarantee input order, leading to different initial query plans for the same query string. 

This PR replaces the default `HashMap` with a `LinkedHashMap` to preserve the order of resolved windows (and by extension their associated window functions) when planning window functions, therefore guaranteeing the same initial plan every time the same query is run. 

Minimal repro and associated diff of initial query plans from 2 different runs **before** this PR:
```
WITH data AS (
    SELECT *
    FROM (VALUES 
        ('A', 1, 100),
        ('A', 2, 200),
        ('A', 1, 150),
        ('B', 1, 300),
        ('B', 2, 100),
        ('B', 1, 200)
    ) AS t(category, subcategory, value)
)
SELECT 
    RANK() OVER (
        PARTITION BY category 
        ORDER BY value DESC
    ) AS rank_by_category,
    RANK() OVER (
        PARTITION BY category, subcategory 
        ORDER BY value DESC
    ) AS rank_by_category_subcategory,
    RANK() OVER (
        PARTITION BY category, subcategory, value
        ORDER BY value DESC
    ) AS rank_by_category_subcategory_value
FROM data;
```

![image](https://github.com/user-attachments/assets/84df4efe-ba6b-4067-8caa-3209478dd9ac)


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
