### PR TITLE
Fix PageProcessor retained bytes tracking

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
@@ -260,6 +260,9 @@ public class PageProcessor
 
         private void updateRetainedSize()
         {
+            // TODO: This is an estimate without knowing anything about the SourcePage implementation details. SourcePage
+            // should expose this information directly
+            retainedSizeInBytes = Page.getInstanceSizeInBytes(page.getChannelCount());
             // increment the size only when it is the first reference
             ReferenceCountMap referenceCountMap = new ReferenceCountMap();
             page.retainedBytesForEachPart((object, size) -> {


### PR DESCRIPTION
## Description
Fixes `PageProcessor` retained bytes tracking logic broken in https://github.com/trinodb/trino/commit/99c022cde1353411a25cf1561cc29ab022778ceb


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Attempts to fix https://github.com/trinodb/trino/issues/25465


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix memory tracking logic that could lead to unnecessary query failures due to EXCEEDED_LOCAL_MEMORY_LIMIT ({issue}`25600`)
```
