### PR TITLE
Improve PageProcessor retained bytes calculations

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/project/SelectedPositions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/SelectedPositions.java
@@ -17,12 +17,15 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkPositionIndexes;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.instanceSize;
+import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.System.arraycopy;
 import static java.util.Objects.checkFromIndexSize;
 import static java.util.Objects.requireNonNull;
 
 public class SelectedPositions
 {
+    private static final long INSTANCE_SIZE = instanceSize(SelectedPositions.class);
     private static final SelectedPositions EMPTY = positionsRange(0, 0);
 
     private final boolean isList;
@@ -52,6 +55,11 @@ public class SelectedPositions
         if (isList) {
             checkPositionIndexes(offset, offset + size, positions.length);
         }
+    }
+
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE + sizeOf(positions);
     }
 
     public boolean isList()

--- a/core/trino-main/src/test/java/io/trino/operator/TestingSourcePage.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestingSourcePage.java
@@ -21,11 +21,15 @@ import java.util.Arrays;
 import java.util.function.ObjLongConsumer;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.instanceSize;
+import static io.airlift.slice.SizeOf.sizeOf;
 import static java.util.Objects.requireNonNull;
 
 public class TestingSourcePage
         implements SourcePage
 {
+    private static final long INSTANCE_SIZE = instanceSize(TestingSourcePage.class);
+
     private final int positionCount;
     private final Block[] blocks;
     private final boolean[] loaded;
@@ -59,7 +63,9 @@ public class TestingSourcePage
     @Override
     public long getRetainedSizeInBytes()
     {
-        long retainedSizeInBytes = 0;
+        long retainedSizeInBytes = INSTANCE_SIZE +
+                sizeOf(blocks) +
+                sizeOf(loaded);
         for (Block block : blocks) {
             if (block != null) {
                 retainedSizeInBytes += block.getRetainedSizeInBytes();
@@ -71,6 +77,9 @@ public class TestingSourcePage
     @Override
     public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
+        consumer.accept(this, INSTANCE_SIZE);
+        consumer.accept(blocks, sizeOf(blocks));
+        consumer.accept(loaded, sizeOf(loaded));
         for (Block block : blocks) {
             if (block != null) {
                 block.retainedBytesForEachPart(consumer);

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/FixedSourcePage.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/FixedSourcePage.java
@@ -18,11 +18,14 @@ import io.trino.spi.block.Block;
 
 import java.util.function.ObjLongConsumer;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 
 final class FixedSourcePage
         implements SourcePage
 {
+    private static final long INSTANCE_SIZE = instanceSize(FixedSourcePage.class);
+
     private Page page;
 
     FixedSourcePage(Page page)
@@ -46,12 +49,14 @@ final class FixedSourcePage
     @Override
     public long getRetainedSizeInBytes()
     {
-        return page.getRetainedSizeInBytes();
+        return INSTANCE_SIZE + page.getRetainedSizeInBytes();
     }
 
     @Override
     public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
+        consumer.accept(this, INSTANCE_SIZE);
+        consumer.accept(page, Page.getInstanceSizeInBytes(page.getChannelCount()));
         for (int i = 0; i < page.getChannelCount(); i++) {
             page.getBlock(i).retainedBytesForEachPart(consumer);
         }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/PositionCountSourcePage.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/PositionCountSourcePage.java
@@ -19,9 +19,13 @@ import io.trino.spi.block.Block;
 import java.util.Objects;
 import java.util.function.ObjLongConsumer;
 
+import static io.airlift.slice.SizeOf.instanceSize;
+
 final class PositionCountSourcePage
         implements SourcePage
 {
+    private static final long INSTANCE_SIZE = instanceSize(PositionCountSourcePage.class);
+
     private int positionCount;
 
     PositionCountSourcePage(int positionCount)
@@ -47,11 +51,14 @@ final class PositionCountSourcePage
     @Override
     public long getRetainedSizeInBytes()
     {
-        return 0;
+        return INSTANCE_SIZE;
     }
 
     @Override
-    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer) {}
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
+    {
+        consumer.accept(this, INSTANCE_SIZE);
+    }
 
     @Override
     public int getChannelCount()

--- a/lib/trino-array/src/main/java/io/trino/array/ReferenceCountMap.java
+++ b/lib/trino-array/src/main/java/io/trino/array/ReferenceCountMap.java
@@ -47,6 +47,16 @@ public final class ReferenceCountMap
     }
 
     /**
+     * Increments the reference count of an object by 1, using the extraIdentity parameter to produce a more
+     * varied hashCode. This calling convention should not be mixed with calling {@link ReferenceCountMap#incrementAndGet(Object)}
+     * since doing so may produce different hash codes
+     */
+    public int incrementAndGetWithExtraIdentity(Object key, long extraIdentity)
+    {
+        return addTo(getHashCode(key, (int) extraIdentity), 1) + 1;
+    }
+
+    /**
      * Decrements the reference count of an object by 1 and returns the updated reference count
      */
     public int decrementAndGet(Object key)
@@ -68,9 +78,9 @@ public final class ReferenceCountMap
     }
 
     /**
-     * Get the 64-bit hash code for an object
+     * Get the additional argument to use in order to produce the 64-bit hash code for an object
      */
-    private static long getHashCode(Object key)
+    private static int getExtraIdentity(Object key)
     {
         // identityHashCode of two objects are not guaranteed to be different.
         // Any additional identity information can reduce collisions.
@@ -97,6 +107,19 @@ public final class ReferenceCountMap
         else {
             throw new IllegalArgumentException(format("Unsupported type for %s", key));
         }
+        return extraIdentity;
+    }
+
+    /**
+     * Get the 64 bit hash code for the value, using the built-in extra identity argument resolution
+     */
+    private static long getHashCode(Object key)
+    {
+        return getHashCode(key, getExtraIdentity(key));
+    }
+
+    private static long getHashCode(Object key, int extraIdentity)
+    {
         return (((long) System.identityHashCode(key)) << Integer.SIZE) + extraIdentity;
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcDeletedRows.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcDeletedRows.java
@@ -110,6 +110,8 @@ public class OrcDeletedRows
     private class OrcAcidMaskedSourcePage
             implements SourcePage
     {
+        private static final long INSTANCE_SIZE = instanceSize(OrcAcidMaskedSourcePage.class);
+
         private final OptionalLong startRowId;
         private final SourcePage sourcePage;
         private boolean deleteMaskApplied;
@@ -139,12 +141,13 @@ public class OrcDeletedRows
         @Override
         public long getRetainedSizeInBytes()
         {
-            return sourcePage.getRetainedSizeInBytes();
+            return INSTANCE_SIZE + sourcePage.getRetainedSizeInBytes();
         }
 
         @Override
         public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
         {
+            consumer.accept(this, INSTANCE_SIZE);
             sourcePage.retainedBytesForEachPart(consumer);
         }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -128,6 +128,8 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Maps.uniqueIndex;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static io.airlift.slice.SizeOf.instanceSize;
+import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.orc.OrcReader.INITIAL_BATCH_SIZE;
@@ -1514,6 +1516,8 @@ public class IcebergPageSourceProvider
     private record PrefixColumnsSourcePage(SourcePage sourcePage, int channelCount, int[] channels)
             implements SourcePage
     {
+        private static final long INSTANCE_SIZE = instanceSize(PrefixColumnsSourcePage.class);
+
         private PrefixColumnsSourcePage
         {
             requireNonNull(sourcePage, "sourcePage is null");
@@ -1542,12 +1546,16 @@ public class IcebergPageSourceProvider
         @Override
         public long getRetainedSizeInBytes()
         {
-            return sourcePage.getRetainedSizeInBytes();
+            return INSTANCE_SIZE +
+                    sizeOf(channels) +
+                    sourcePage.getRetainedSizeInBytes();
         }
 
         @Override
         public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
         {
+            consumer.accept(this, INSTANCE_SIZE);
+            consumer.accept(channels, sizeOf(channels));
             sourcePage.retainedBytesForEachPart(consumer);
         }
 


### PR DESCRIPTION
## Description
Follows up from https://github.com/trinodb/trino/pull/25600 by account for all necessary components of `SourcePage` implementations in `SourcePage#getRetainedBytes()` and `SourcePage#retainedBytesForEachPart` methods. Also includes `SelectedPositions` and `Block[] previouslyComputedResults` in the `PageProcessor.ProjectSelectedPositions` retained size calculation.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

