### PR TITLE
Set dataSequenceNumber during iceberg EXECUTE OPTIMIZE

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -2017,6 +2017,8 @@ public class IcebergMetadata
 
         // Table.snapshot method returns null if there is no matching snapshot
         Snapshot snapshot = requireNonNull(icebergTable.snapshot(optimizeHandle.snapshotId().get()), "snapshot is null");
+        // Set dataSequenceNumber to avoid contention between OPTIMIZE and concurrent writing of equality deletes
+        rewriteFiles.dataSequenceNumber(snapshot.sequenceNumber());
         rewriteFiles.validateFromSnapshot(snapshot.snapshotId());
         commitUpdateAndTransaction(rewriteFiles, session, transaction, "optimize");
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Fixes: https://github.com/trinodb/trino/issues/25584

Concurrency errors could occur when trino runs EXECUTE OPTIMIZE and another system writes equality deletes. See above issue for details. 


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Explicitly setting RewriteFiles.dataSequenceNumber. See iceberg java doc: https://iceberg.apache.org/javadoc/1.7.0/org/apache/iceberg/RewriteFiles.html#dataSequenceNumber(long)
```
Configure the data sequence number for this rewrite operation. This data sequence number will be used for all new data files that are added in this rewrite. This method is helpful to avoid commit conflicts between data compaction and adding equality deletes.
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Fix OPTIMIZE failures due to commit conflicts from addition of equality deletes. ({issue}`25584`)
```
