### PR TITLE
Fix size in bytes calculation for ORC DictionaryBuilder

### DIFF
--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/DictionaryBuilder.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/DictionaryBuilder.java
@@ -75,7 +75,7 @@ public class DictionaryBuilder
 
     public long getSizeInBytes()
     {
-        return sliceOutput.size() + sizeOf(offsets);
+        return sliceOutput.size() + Integer.BYTES * (long) entryCount;
     }
 
     public long getRetainedSizeInBytes()

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestDictionaryBuilder.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestDictionaryBuilder.java
@@ -37,5 +37,6 @@ public class TestDictionaryBuilder
             positions.add(dictionaryBuilder.putIfAbsent(new VariableWidthBlock(1, wrappedBuffer(new byte[] {2}), new int[] {0, 1}, Optional.of(new boolean[] {false})), 0));
         }
         assertThat(positions).isEqualTo(ImmutableSet.of(1, 2));
+        assertThat(dictionaryBuilder.getSizeInBytes()).isEqualTo(14);
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
https://github.com/trinodb/trino/commit/a1fcb0d23f49d13b658bdc3e414d49bcf7f2a48c introduced a change to refactor `VariableWidthBlockBuilder` out of the ORC DictionaryBuilder class. Previously the DictionaryBuilder class would report the size in bytes by calling on the underlying `elementBlock.getSizeInBytes()` whose size was calculated based off the [output slice size and the bytes stored per entry/position](https://github.com/trinodb/trino/blob/47f9fa50e1172699643fbbdb57f6fd7570c053d0/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlockBuilder.java#L112-L113).

After this refactor, DictionaryBuilder size is now being reported as the sum of the slice output size and the size of the offsets array, which is causing the size to be over-reported as not all positions of the offset array may be used. Over reporting the size in bytes of the DictionaryBuilder causes issues downstream when doing file size optimizations.

This PR corrects the size in bytes calculation to be similar to what it was before the refactor to accurately report how many bytes are actually in use.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Hive
* Fix ORC writer issue that could result in switching from dictionary to direct encoding too eagerly in output files ({issue}`issuenumber`)
```
