### PR TITLE
Fix trino/docs

### DIFF
--- a/docs/src/main/sphinx/installation/plugins.md
+++ b/docs/src/main/sphinx/installation/plugins.md
@@ -30,7 +30,7 @@ Typically, downloading a plugin is not necessary because Trino binaries include
 many plugins as part of the binary package.
 
 Every Trino release publishes each plugin as a ZIP archive to the [Maven Central
-Repository](https://central.sonatype.com/). Refer to [plugins-list] for details.
+Repository](https://central.sonatype.com/). Refer to the [](plugins-list) for details.
 The specific location is derived from the Maven coordinates of each plugin as
 defined in the `pom.xml` of the source code for the plugin.
 
@@ -174,7 +174,7 @@ with the listed coordinates.
   - {maven_download}`duckdb`
 * - elasticsearch
   - [](/connector/elasticsearch)
-  - [io.trinotrino-elasticsearch](https://central.sonatype.com/search?q=io.trino%3Atrino-elasticsearch)
+  - [io.trino:trino-elasticsearch](https://central.sonatype.com/search?q=io.trino%3Atrino-elasticsearch)
   - {maven_download}`elasticsearch`
 * - example-http
   - [](/develop/example-http)
@@ -222,7 +222,7 @@ with the listed coordinates.
   - {maven_download}`http-server-event-listener`
 * - hudi
   - [](/connector/hudi)
-  - [io.trinotrino-:hudi](https://central.sonatype.com/search?q=io.trino%3Atrino-hudi)
+  - [io.trino:trino-hudi](https://central.sonatype.com/search?q=io.trino%3Atrino-hudi)
   - {maven_download}`hudi`
 * - iceberg
   - [](/connector/iceberg)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
1. Fix typos in installation/plugins page
2.  Fix broken anchor links in installation/plugins page

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
These were the issues that were fixed-
1. The plugin addresses were misrepresented for `trino-elasticsearch` & `trino-hudi` plugins.
2. The anchor linked to the `List of Plugins` section on the same page was broken.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.