### PR TITLE
Rename hive.s3.storage-class-filter and add documentation

### DIFF
--- a/docs/src/main/sphinx/connector/hive.md
+++ b/docs/src/main/sphinx/connector/hive.md
@@ -284,6 +284,9 @@ Hive connector documentation.
 * - `hive.partition-projection-enabled`
   - Enables Athena partition projection support
   - `true`
+* - `hive.s3-glacier-filter`
+  - Filter S3 objects based on their storage class and restored status if applicable
+  - `true`
 * - `hive.max-partition-drops-per-query`
   - Maximum number of partitions to drop in a single query.
   - 100,000

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
@@ -172,7 +172,7 @@ public class HiveConfig
 
     private boolean partitionProjectionEnabled = true;
 
-    private S3StorageClassFilter s3StorageClassFilter = S3StorageClassFilter.READ_ALL;
+    private S3GlacierFilter s3GlacierFilter = S3GlacierFilter.READ_ALL;
 
     private int metadataParallelism = 8;
 
@@ -1255,16 +1255,17 @@ public class HiveConfig
         return this;
     }
 
-    public S3StorageClassFilter getS3StorageClassFilter()
+    public S3GlacierFilter getS3GlacierFilter()
     {
-        return s3StorageClassFilter;
+        return s3GlacierFilter;
     }
 
-    @Config("hive.s3.storage-class-filter")
+    @LegacyConfig("hive.s3.storage-class-filter")
+    @Config("hive.s3-glacier-filter")
     @ConfigDescription("Filter based on storage class of S3 object")
-    public HiveConfig setS3StorageClassFilter(S3StorageClassFilter s3StorageClassFilter)
+    public HiveConfig setS3GlacierFilter(S3GlacierFilter s3GlacierFilter)
     {
-        this.s3StorageClassFilter = s3StorageClassFilter;
+        this.s3GlacierFilter = s3GlacierFilter;
         return this;
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/S3GlacierFilter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/S3GlacierFilter.java
@@ -19,7 +19,7 @@ import java.util.function.Predicate;
 
 import static com.google.common.base.Predicates.alwaysTrue;
 
-public enum S3StorageClassFilter {
+public enum S3GlacierFilter {
     READ_ALL,
     READ_NON_GLACIER,
     READ_NON_GLACIER_AND_RESTORED;
@@ -52,8 +52,8 @@ public enum S3StorageClassFilter {
     {
         return switch (this) {
             case READ_ALL -> alwaysTrue();
-            case READ_NON_GLACIER -> S3StorageClassFilter::isNotGlacierObject;
-            case READ_NON_GLACIER_AND_RESTORED -> S3StorageClassFilter::isCompletedRestoredObject;
+            case READ_NON_GLACIER -> S3GlacierFilter::isNotGlacierObject;
+            case READ_NON_GLACIER_AND_RESTORED -> S3GlacierFilter::isCompletedRestoredObject;
         };
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/CachingDirectoryLister.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/CachingDirectoryLister.java
@@ -62,7 +62,7 @@ public class CachingDirectoryLister
                 hiveClientConfig.getFileStatusCacheExpireAfterWrite(),
                 hiveClientConfig.getFileStatusCacheMaxRetainedSize(),
                 hiveClientConfig.getFileStatusCacheTables(),
-                hiveClientConfig.getS3StorageClassFilter().toFileEntryPredicate());
+                hiveClientConfig.getS3GlacierFilter().toFileEntryPredicate());
     }
 
     public CachingDirectoryLister(

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
@@ -117,7 +117,7 @@ public class TestHiveConfig
                 .setHudiCatalogName(null)
                 .setAutoPurge(false)
                 .setPartitionProjectionEnabled(true)
-                .setS3StorageClassFilter(S3StorageClassFilter.READ_ALL)
+                .setS3GlacierFilter(S3GlacierFilter.READ_ALL)
                 .setMetadataParallelism(8));
     }
 
@@ -203,7 +203,7 @@ public class TestHiveConfig
                 .put("hive.hudi-catalog-name", "hudi")
                 .put("hive.auto-purge", "true")
                 .put("hive.partition-projection-enabled", "false")
-                .put("hive.s3.storage-class-filter", "READ_NON_GLACIER_AND_RESTORED")
+                .put("hive.s3-glacier-filter", "READ_NON_GLACIER_AND_RESTORED")
                 .put("hive.metadata.parallelism", "10")
                 .buildOrThrow();
 
@@ -286,7 +286,7 @@ public class TestHiveConfig
                 .setHudiCatalogName("hudi")
                 .setAutoPurge(true)
                 .setPartitionProjectionEnabled(false)
-                .setS3StorageClassFilter(S3StorageClassFilter.READ_NON_GLACIER_AND_RESTORED)
+                .setS3GlacierFilter(S3GlacierFilter.READ_NON_GLACIER_AND_RESTORED)
                 .setMetadataParallelism(10);
 
         assertFullMapping(properties, expected);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Rename ```hive.s3.storage-class-filter``` to ```hive.s3-glacier-filter``` and add documentation as a follow up item for PR: https://github.com/trinodb/trino/pull/24979

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(X) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
```
## Hive
- Rename hive configuration property ``hive.s3.storage-class-filter`` to ``hive.s3-glacier-filter`` to better reflect its purpose ({issue}`25633`)
```