### PR TITLE
Fix issue with reading footer of orc file with large stripe

### DIFF
--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcRecordReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcRecordReader.java
@@ -748,7 +748,7 @@ public class OrcRecordReader
         }
     }
 
-    private void validateWriteStripe(int rowCount)
+    private void validateWriteStripe(long rowCount)
     {
         writeChecksumBuilder.ifPresent(builder -> builder.addStripe(rowCount));
     }

--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcWriteValidation.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcWriteValidation.java
@@ -492,10 +492,10 @@ public class OrcWriteValidation
             return new WriteChecksumBuilder(readTypes);
         }
 
-        public void addStripe(int rowCount)
+        public void addStripe(long rowCount)
         {
-            longSlice.setInt(0, rowCount);
-            stripeHash.update(longBuffer, 0, Integer.BYTES);
+            longSlice.setLong(0, rowCount);
+            stripeHash.update(longBuffer, 0, Long.BYTES);
         }
 
         public void addPage(Page page)
@@ -885,7 +885,7 @@ public class OrcWriteValidation
             return this;
         }
 
-        public OrcWriteValidationBuilder addStripe(int rowCount)
+        public OrcWriteValidationBuilder addStripe(long rowCount)
         {
             checksum.addStripe(rowCount);
             return this;

--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcWriterFlushStats.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcWriterFlushStats.java
@@ -57,7 +57,7 @@ public class OrcWriterFlushStats
         return dictionaryBytes;
     }
 
-    public void recordStripeWritten(long stripeBytes, int stripeRows, int dictionaryBytes)
+    public void recordStripeWritten(long stripeBytes, long stripeRows, int dictionaryBytes)
     {
         this.stripeBytes.add(stripeBytes);
         this.stripeRows.add(stripeRows);

--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcWriterStats.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcWriterStats.java
@@ -38,7 +38,7 @@ public class OrcWriterStats
     private final OrcWriterFlushStats closedFlush = new OrcWriterFlushStats(CLOSED.name());
     private final AtomicLong writerSizeInBytes = new AtomicLong();
 
-    public void recordStripeWritten(FlushReason flushReason, long stripeBytes, int stripeRows, int dictionaryBytes)
+    public void recordStripeWritten(FlushReason flushReason, long stripeBytes, long stripeRows, int dictionaryBytes)
     {
         getFlushStats(flushReason).recordStripeWritten(stripeBytes, stripeRows, dictionaryBytes);
         allFlush.recordStripeWritten(stripeBytes, stripeRows, dictionaryBytes);

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/OrcMetadataReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/OrcMetadataReader.java
@@ -163,7 +163,7 @@ public class OrcMetadataReader
     private static StripeInformation toStripeInformation(OrcProto.StripeInformation stripeInformation)
     {
         return new StripeInformation(
-                toIntExact(stripeInformation.getNumberOfRows()),
+                stripeInformation.getNumberOfRows(),
                 stripeInformation.getOffset(),
                 stripeInformation.getIndexLength(),
                 stripeInformation.getDataLength(),

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/StripeInformation.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/StripeInformation.java
@@ -18,13 +18,13 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 public class StripeInformation
 {
-    private final int numberOfRows;
+    private final long numberOfRows;
     private final long offset;
     private final long indexLength;
     private final long dataLength;
     private final long footerLength;
 
-    public StripeInformation(int numberOfRows, long offset, long indexLength, long dataLength, long footerLength)
+    public StripeInformation(long numberOfRows, long offset, long indexLength, long dataLength, long footerLength)
     {
         // dataLength can be zero when the stripe only contains empty flat maps.
         checkArgument(numberOfRows > 0, "Stripe must have at least one row");
@@ -36,7 +36,7 @@ public class StripeInformation
         this.footerLength = footerLength;
     }
 
-    public int getNumberOfRows()
+    public long getNumberOfRows()
     {
         return numberOfRows;
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
We have tables in dds layer that look like
```
CREATE TABLE dwh.dds.some_table (
   id1 bigint,
   flag boolean,
   id2 bigint
)
WITH (
   external_location = 's3a://some_path',
   format = 'ORC'
)
```
where `id1` is unique and `id2` has only two values. The data file has 70 MB size and more than 7 000 000 000 rows.
When we try to read data the error occurs
```
TrinoExternalError(type=EXTERNAL, name=HIVE_CANNOT_OPEN_SPLIT, message="Error opening Hive split s3a://some_path/some_table.orc (offset=0, length=71782995): integer overflow", query_id= 20250417_090308_49505_msr65)
```
It happens because OrcProto support `long` type, but in the trino code we have `int` type.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Hive, Iceberg
* Fix query failure when reading ORC files with a large row count. ({issue}`25634`)
```
