### PR TITLE
Update memory connector doc about TRUNCATE

### DIFF
--- a/docs/src/main/sphinx/connector/memory.md
+++ b/docs/src/main/sphinx/connector/memory.md
@@ -73,7 +73,7 @@ statements, the connector supports the following features:
 
 ### TRUNCATE and DROP TABLE
 
-Upon execution of a `TRUNCATE` and a `DROP TABLE` operation, memory is not released
+Upon execution of a `DROP TABLE` operation, memory is not released
 immediately. It is instead released after the next write operation to the
 catalog.
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Previously, `TRUNCATE` on memory connector never released memory but now memory is released immediately (https://github.com/trinodb/trino/pull/25564).

The documentation needs to be updated.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
