### PR TITLE
Fix failure with specifying format for date partition projection in Hive connector

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveInsertTableHandle.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveInsertTableHandle.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.plugin.hive.metastore.HivePageSinkMetadata;
+import io.trino.plugin.hive.projection.PartitionProjection;
 import io.trino.spi.connector.ConnectorInsertTableHandle;
 
 import java.util.List;
@@ -37,7 +38,8 @@ public class HiveInsertTableHandle
             @JsonProperty("tableStorageFormat") HiveStorageFormat tableStorageFormat,
             @JsonProperty("partitionStorageFormat") HiveStorageFormat partitionStorageFormat,
             @JsonProperty("transaction") AcidTransaction transaction,
-            @JsonProperty("retriesEnabled") boolean retriesEnabled)
+            @JsonProperty("retriesEnabled") boolean retriesEnabled,
+            @JsonProperty("partitionProjection") Optional<PartitionProjection> partitionProjection)
     {
         super(
                 schemaName,
@@ -49,6 +51,7 @@ public class HiveInsertTableHandle
                 tableStorageFormat,
                 partitionStorageFormat,
                 transaction,
-                retriesEnabled);
+                retriesEnabled,
+                partitionProjection);
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveOutputTableHandle.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveOutputTableHandle.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.plugin.hive.metastore.HivePageSinkMetadata;
+import io.trino.plugin.hive.projection.PartitionProjection;
 import io.trino.spi.connector.ConnectorOutputTableHandle;
 
 import java.util.List;
@@ -51,7 +52,8 @@ public class HiveOutputTableHandle
             @JsonProperty("additionalTableParameters") Map<String, String> additionalTableParameters,
             @JsonProperty("transaction") AcidTransaction transaction,
             @JsonProperty("external") boolean external,
-            @JsonProperty("retriesEnabled") boolean retriesEnabled)
+            @JsonProperty("retriesEnabled") boolean retriesEnabled,
+            @JsonProperty("partitionProjection") Optional<PartitionProjection> partitionProjection)
     {
         super(
                 schemaName,
@@ -63,7 +65,8 @@ public class HiveOutputTableHandle
                 tableStorageFormat,
                 partitionStorageFormat,
                 transaction,
-                retriesEnabled);
+                retriesEnabled,
+                partitionProjection);
 
         this.partitionedBy = ImmutableList.copyOf(requireNonNull(partitionedBy, "partitionedBy is null"));
         this.tableOwner = requireNonNull(tableOwner, "tableOwner is null");

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSinkProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSinkProvider.java
@@ -163,7 +163,8 @@ public class HivePageSinkProvider
                 session,
                 hiveWriterStats,
                 temporaryStagingDirectoryEnabled,
-                temporaryStagingDirectoryPath);
+                temporaryStagingDirectoryPath,
+                handle.getPartitionProjection());
 
         return new HivePageSink(
                 writerFactory,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceProvider.java
@@ -26,6 +26,7 @@ import io.trino.plugin.hive.HiveSplit.BucketValidation;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.plugin.hive.coercions.CoercionUtils.CoercionContext;
 import io.trino.plugin.hive.coercions.TypeCoercer;
+import io.trino.plugin.hive.projection.PartitionProjection;
 import io.trino.plugin.hive.util.HiveBucketing.BucketingVersion;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ColumnHandle;
@@ -132,7 +133,8 @@ public class HivePageSourceProvider
                 hiveSplit.getPath(),
                 hiveSplit.getTableBucketNumber(),
                 hiveSplit.getEstimatedFileSize(),
-                hiveSplit.getFileModifiedTime());
+                hiveSplit.getFileModifiedTime(),
+                hiveTable.getPartitionProjection());
 
         // Perform dynamic partition pruning in case coordinator didn't prune split.
         // This can happen when dynamic filters are collected after partition splits were listed.
@@ -465,7 +467,8 @@ public class HivePageSourceProvider
                 String path,
                 OptionalInt bucketNumber,
                 long estimatedFileSize,
-                long fileModifiedTime)
+                long fileModifiedTime,
+                Optional<PartitionProjection> partitionProjection)
         {
             Map<String, HivePartitionKey> partitionKeysByName = uniqueIndex(partitionKeys, HivePartitionKey::name);
 
@@ -515,7 +518,7 @@ public class HivePageSourceProvider
                 else {
                     columnMappings.add(prefilled(
                             column,
-                            getPrefilledColumnValue(column, partitionKeysByName.get(column.getName()), path, bucketNumber, estimatedFileSize, fileModifiedTime, partitionName),
+                            getPrefilledColumnValue(column, partitionKeysByName.get(column.getName()), path, bucketNumber, estimatedFileSize, fileModifiedTime, partitionName, partitionProjection),
                             baseTypeCoercionFrom));
                 }
             }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableExecuteHandle.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableExecuteHandle.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.plugin.hive.metastore.HivePageSinkMetadata;
+import io.trino.plugin.hive.projection.PartitionProjection;
 import io.trino.spi.connector.ConnectorTableExecuteHandle;
 
 import java.util.List;
@@ -47,7 +48,8 @@ public class HiveTableExecuteHandle
             @JsonProperty("tableStorageFormat") HiveStorageFormat tableStorageFormat,
             @JsonProperty("partitionStorageFormat") HiveStorageFormat partitionStorageFormat,
             @JsonProperty("transaction") AcidTransaction transaction,
-            @JsonProperty("retriesEnabled") boolean retriesEnabled)
+            @JsonProperty("retriesEnabled") boolean retriesEnabled,
+            @JsonProperty("partitionProjection") Optional<PartitionProjection> partitionProjection)
     {
         super(
                 schemaName,
@@ -59,7 +61,8 @@ public class HiveTableExecuteHandle
                 tableStorageFormat,
                 partitionStorageFormat,
                 transaction,
-                retriesEnabled);
+                retriesEnabled,
+                partitionProjection);
 
         // todo to be added soon
         verify(bucketInfo.isEmpty(), "bucketed tables not supported yet");
@@ -102,7 +105,8 @@ public class HiveTableExecuteHandle
                 getTableStorageFormat(),
                 getPartitionStorageFormat(),
                 getTransaction(),
-                isRetriesEnabled());
+                isRetriesEnabled(),
+                getPartitionProjection());
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWritableTableHandle.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWritableTableHandle.java
@@ -21,6 +21,7 @@ import io.trino.metastore.SortingColumn;
 import io.trino.metastore.Table;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.plugin.hive.metastore.HivePageSinkMetadata;
+import io.trino.plugin.hive.projection.PartitionProjection;
 import io.trino.plugin.hive.util.HiveBucketing.BucketingVersion;
 import io.trino.spi.connector.SchemaTableName;
 
@@ -42,6 +43,7 @@ public class HiveWritableTableHandle
     private final HiveStorageFormat partitionStorageFormat;
     private final AcidTransaction transaction;
     private final boolean retriesEnabled;
+    private final Optional<PartitionProjection> partitionProjection;
 
     public HiveWritableTableHandle(
             String schemaName,
@@ -53,7 +55,8 @@ public class HiveWritableTableHandle
             HiveStorageFormat tableStorageFormat,
             HiveStorageFormat partitionStorageFormat,
             AcidTransaction transaction,
-            boolean retriesEnabled)
+            boolean retriesEnabled,
+            Optional<PartitionProjection> partitionProjection)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -65,6 +68,7 @@ public class HiveWritableTableHandle
         this.partitionStorageFormat = requireNonNull(partitionStorageFormat, "partitionStorageFormat is null");
         this.transaction = requireNonNull(transaction, "transaction is null");
         this.retriesEnabled = retriesEnabled;
+        this.partitionProjection = requireNonNull(partitionProjection, "partitionProjection is null");
     }
 
     @JsonProperty
@@ -137,6 +141,12 @@ public class HiveWritableTableHandle
     public boolean isRetriesEnabled()
     {
         return retriesEnabled;
+    }
+
+    @JsonProperty
+    public Optional<PartitionProjection> getPartitionProjection()
+    {
+        return partitionProjection;
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/projection/DateProjection.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/projection/DateProjection.java
@@ -22,16 +22,17 @@ import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
-import java.util.Date;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalQueries;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -49,14 +50,15 @@ import static io.trino.plugin.hive.projection.PartitionProjectionProperties.getP
 import static io.trino.plugin.hive.projection.PartitionProjectionProperties.getProjectionPropertyValue;
 import static io.trino.spi.predicate.Domain.singleValue;
 import static java.lang.String.format;
+import static java.time.ZoneOffset.UTC;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static java.time.temporal.ChronoUnit.HOURS;
 import static java.time.temporal.ChronoUnit.MINUTES;
 import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.SECONDS;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
-import static java.util.TimeZone.getTimeZone;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 final class DateProjection
@@ -71,7 +73,7 @@ final class DateProjection
     private static final Pattern DATE_RANGE_BOUND_EXPRESSION_PATTERN = Pattern.compile("^\\s*NOW\\s*(([+-])\\s*([0-9]+)\\s*(DAY|HOUR|MINUTE|SECOND)S?\\s*)?$");
 
     private final String columnName;
-    private final DateFormat dateFormat;
+    private final DateTimeFormatter dateFormat;
     private final Supplier<Instant> leftBound;
     private final Supplier<Instant> rightBound;
     private final int interval;
@@ -104,13 +106,10 @@ final class DateProjection
             throw invalidRangeProperty(columnName, dateFormatPattern, Optional.empty());
         }
 
-        SimpleDateFormat dateFormat = new SimpleDateFormat(dateFormatPattern);
-        dateFormat.setLenient(false);
-        dateFormat.setTimeZone(getTimeZone(UTC_TIME_ZONE_ID));
-        this.dateFormat = requireNonNull(dateFormat, "dateFormatPattern is null");
+        this.dateFormat = DateTimeFormatter.ofPattern(dateFormatPattern, ENGLISH);
 
-        leftBound = parseDateRangerBound(columnName, range.get(0), dateFormat);
-        rightBound = parseDateRangerBound(columnName, range.get(1), dateFormat);
+        leftBound = parseDateRangerBound(columnName, range.get(0), dateFormatPattern, dateFormat);
+        rightBound = parseDateRangerBound(columnName, range.get(1), dateFormatPattern, dateFormat);
         if (!leftBound.get().isBefore(rightBound.get())) {
             throw invalidRangeProperty(columnName, dateFormatPattern, Optional.empty());
         }
@@ -156,16 +155,17 @@ final class DateProjection
     {
         String formatted = formatValue(value.with(ChronoField.MILLI_OF_SECOND, 0));
         try {
-            return dateFormat.parse(formatted).toInstant();
+            return parse(formatted, dateFormat);
         }
-        catch (ParseException e) {
+        catch (DateTimeParseException e) {
             throw new InvalidProjectionException(formatted, e.getMessage());
         }
     }
 
     private String formatValue(Instant current)
     {
-        return dateFormat.format(new Date(current.toEpochMilli()));
+        LocalDateTime localDateTime = LocalDateTime.ofInstant(current, UTC_TIME_ZONE_ID);
+        return localDateTime.format(dateFormat);
     }
 
     private boolean isValueInDomain(Optional<Domain> valueDomain, Instant value, String formattedValue)
@@ -206,7 +206,7 @@ final class DateProjection
         return MONTHS;
     }
 
-    private static Supplier<Instant> parseDateRangerBound(String columnName, String value, SimpleDateFormat dateFormat)
+    private static Supplier<Instant> parseDateRangerBound(String columnName, String value, String dateFormatPattern, DateTimeFormatter dateFormat)
     {
         Matcher matcher = DATE_RANGE_BOUND_EXPRESSION_PATTERN.matcher(value);
         if (matcher.matches()) {
@@ -214,7 +214,7 @@ final class DateProjection
             String multiplierString = matcher.group(3);
             String unitString = matcher.group(4);
             if (nonNull(operator) && nonNull(multiplierString) && nonNull(unitString)) {
-                unitString = unitString.toUpperCase(Locale.ENGLISH);
+                unitString = unitString.toUpperCase(ENGLISH);
                 return new DateExpressionBound(
                         Integer.parseInt(multiplierString),
                         ChronoUnit.valueOf(unitString + "S"),
@@ -224,17 +224,27 @@ final class DateProjection
                 Instant now = Instant.now();
                 return () -> now;
             }
-            throw invalidRangeProperty(columnName, dateFormat.toPattern(), Optional.of("Invalid expression"));
+            throw invalidRangeProperty(columnName, dateFormatPattern, Optional.of("Invalid expression"));
         }
 
-        Instant dateBound;
-        try {
-            dateBound = dateFormat.parse(value).toInstant();
+        return () -> {
+            try {
+                return parse(value, dateFormat);
+            }
+            catch (DateTimeParseException e) {
+                throw invalidRangeProperty(columnName, dateFormatPattern, Optional.of(e.getMessage()));
+            }
+        };
+    }
+
+    private static Instant parse(String value, DateTimeFormatter dateFormat)
+            throws DateTimeParseException
+    {
+        TemporalAccessor parsed = dateFormat.parse(value);
+        if (parsed.query(TemporalQueries.localDate()) != null && parsed.query(TemporalQueries.localTime()) == null) {
+            return LocalDate.from(parsed).atStartOfDay().toInstant(UTC);
         }
-        catch (ParseException e) {
-            throw invalidRangeProperty(columnName, dateFormat.toPattern(), Optional.of(e.getMessage()));
-        }
-        return () -> dateBound;
+        return LocalDateTime.from(parsed).toInstant(UTC);
     }
 
     private static TrinoException invalidRangeProperty(String columnName, String dateFormatPattern, Optional<String> errorDetail)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/projection/EnumProjection.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/projection/EnumProjection.java
@@ -13,6 +13,8 @@
  */
 package io.trino.plugin.hive.projection;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
@@ -29,11 +31,18 @@ import static io.trino.spi.predicate.Domain.singleValue;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
-final class EnumProjection
+public final class EnumProjection
         implements Projection
 {
     private final String columnName;
     private final List<String> values;
+
+    @JsonCreator
+    public EnumProjection(@JsonProperty("columnName") String columnName, @JsonProperty("values") List<String> values)
+    {
+        this.columnName = requireNonNull(columnName, "columnName is null");
+        this.values = requireNonNull(values, "values is null");
+    }
 
     public EnumProjection(String columnName, Type columnType, Map<String, Object> columnProperties)
     {
@@ -69,5 +78,17 @@ final class EnumProjection
             return valueDomain.contains(singleValue(type, utf8Slice(value)));
         }
         throw new InvalidProjectionException(columnName, type);
+    }
+
+    @JsonProperty
+    public String getColumnName()
+    {
+        return columnName;
+    }
+
+    @JsonProperty
+    public List<String> getValues()
+    {
+        return values;
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/projection/InjectedProjection.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/projection/InjectedProjection.java
@@ -13,6 +13,8 @@
  */
 package io.trino.plugin.hive.projection;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.ValueSet;
 import io.trino.spi.type.Type;
@@ -25,10 +27,16 @@ import static io.trino.plugin.hive.metastore.MetastoreUtil.canConvertSqlTypeToSt
 import static io.trino.plugin.hive.metastore.MetastoreUtil.sqlScalarToString;
 import static java.util.Objects.requireNonNull;
 
-final class InjectedProjection
+public final class InjectedProjection
         implements Projection
 {
     private final String columnName;
+
+    @JsonCreator
+    public InjectedProjection(@JsonProperty("columnName") String columnName)
+    {
+        this.columnName = requireNonNull(columnName, "columnName is null");
+    }
 
     public InjectedProjection(String columnName, Type columnType)
     {
@@ -57,5 +65,11 @@ final class InjectedProjection
                     return stringValue;
                 })
                 .collect(toImmutableList());
+    }
+
+    @JsonProperty
+    public String getColumnName()
+    {
+        return columnName;
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/projection/IntegerProjection.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/projection/IntegerProjection.java
@@ -13,6 +13,8 @@
  */
 package io.trino.plugin.hive.projection;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 import io.trino.spi.predicate.Domain;
@@ -36,7 +38,7 @@ import static io.trino.spi.predicate.Domain.singleValue;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
-final class IntegerProjection
+public final class IntegerProjection
         implements Projection
 {
     private final String columnName;
@@ -44,6 +46,21 @@ final class IntegerProjection
     private final int rightBound;
     private final int interval;
     private final Optional<Integer> digits;
+
+    @JsonCreator
+    public IntegerProjection(
+            @JsonProperty("columnName") String columnName,
+            @JsonProperty("leftBound") int leftBound,
+            @JsonProperty("rightBound") int rightBound,
+            @JsonProperty("interval") int interval,
+            @JsonProperty("digits") Optional<Integer> digits)
+    {
+        this.columnName = requireNonNull(columnName, "columnName is null");
+        this.leftBound = leftBound;
+        this.rightBound = rightBound;
+        this.interval = interval;
+        this.digits = requireNonNull(digits, "digits is null");
+    }
 
     public IntegerProjection(String columnName, Type columnType, Map<String, Object> columnProperties)
     {
@@ -102,5 +119,35 @@ final class IntegerProjection
             return domain.contains(singleValue(type, (long) value));
         }
         throw new InvalidProjectionException(columnName, type);
+    }
+
+    @JsonProperty
+    public String getColumnName()
+    {
+        return columnName;
+    }
+
+    @JsonProperty
+    public int getLeftBound()
+    {
+        return leftBound;
+    }
+
+    @JsonProperty
+    public int getRightBound()
+    {
+        return rightBound;
+    }
+
+    @JsonProperty
+    public int getInterval()
+    {
+        return interval;
+    }
+
+    @JsonProperty
+    public Optional<Integer> getDigits()
+    {
+        return digits;
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/projection/PartitionProjection.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/projection/PartitionProjection.java
@@ -21,6 +21,7 @@ import io.trino.metastore.Column;
 import io.trino.metastore.Partition;
 import io.trino.metastore.Table;
 import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.NullableValue;
 import io.trino.spi.predicate.TupleDomain;
 
 import java.util.List;
@@ -53,6 +54,24 @@ public final class PartitionProjection
     {
         this.storageLocationTemplate = requireNonNull(storageLocationTemplate, "storageLocationTemplate is null");
         this.columnProjections = ImmutableMap.copyOf(requireNonNull(columnProjections, "columnProjections is null"));
+    }
+
+    public Optional<NullableValue> parsePartitionValue(String columnName, String partitionValue)
+    {
+        Projection projection = columnProjections.get(columnName);
+        if (projection == null) {
+            return Optional.empty();
+        }
+        return projection.parsePartitionValue(partitionValue);
+    }
+
+    public Optional<String> toPartitionValue(String columnName, Object value)
+    {
+        Projection projection = columnProjections.get(columnName);
+        if (projection == null) {
+            return Optional.empty();
+        }
+        return projection.toPartitionValue(value);
     }
 
     public Optional<List<String>> getProjectedPartitionNamesByFilter(List<String> columnNames, TupleDomain<String> partitionKeysFilter)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/projection/PartitionProjection.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/projection/PartitionProjection.java
@@ -13,6 +13,8 @@
  */
 package io.trino.plugin.hive.projection;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableMap;
 import io.trino.metastore.Column;
@@ -46,7 +48,8 @@ public final class PartitionProjection
     private final Optional<String> storageLocationTemplate;
     private final Map<String, Projection> columnProjections;
 
-    public PartitionProjection(Optional<String> storageLocationTemplate, Map<String, Projection> columnProjections)
+    @JsonCreator
+    public PartitionProjection(@JsonProperty("storageLocationTemplate") Optional<String> storageLocationTemplate, @JsonProperty("columnProjections") Map<String, Projection> columnProjections)
     {
         this.storageLocationTemplate = requireNonNull(storageLocationTemplate, "storageLocationTemplate is null");
         this.columnProjections = ImmutableMap.copyOf(requireNonNull(columnProjections, "columnProjections is null"));
@@ -127,5 +130,17 @@ public final class PartitionProjection
         }
         matcher.appendTail(location);
         return location.toString();
+    }
+
+    @JsonProperty
+    public Optional<String> getStorageLocationTemplate()
+    {
+        return storageLocationTemplate;
+    }
+
+    @JsonProperty
+    public Map<String, Projection> getColumnProjections()
+    {
+        return columnProjections;
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/projection/PartitionProjectionProperties.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/projection/PartitionProjectionProperties.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.metastore.Column;
 import io.trino.metastore.Table;
+import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.type.Type;
@@ -35,6 +36,7 @@ import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.plugin.hive.HiveTableProperties.getPartitionedBy;
 import static io.trino.plugin.hive.HiveTimestampPrecision.DEFAULT_PRECISION;
 import static io.trino.plugin.hive.util.HiveTypeUtil.getType;
@@ -203,7 +205,34 @@ public final class PartitionProjectionProperties
                 tableProperties);
     }
 
-    private static Optional<PartitionProjection> createPartitionProjection(List<String> dataColumns, Map<String, Type> partitionColumns, Map<String, String> tableProperties)
+    public static Optional<PartitionProjection> createPartitionProjection(List<HiveColumnHandle> dataColumns, List<HiveColumnHandle> partitionColumns, Optional<Map<String, String>> tableParameters)
+    {
+        if (partitionColumns.isEmpty() || tableParameters.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Map<String, String> parameters = tableParameters.orElseThrow();
+
+        if (parseBoolean(parameters.get(METASTORE_PROPERTY_PROJECTION_IGNORE)) ||
+                !parseBoolean(parameters.get(METASTORE_PROPERTY_PROJECTION_ENABLED))) {
+            return Optional.empty();
+        }
+
+        Set<String> partitionColumnNames = partitionColumns.stream()
+                .map(HiveColumnHandle::getName)
+                .collect(toImmutableSet());
+
+        List<String> columns = dataColumns.stream()
+                .map(HiveColumnHandle::getName)
+                .filter(partitionColumnNames::contains)
+                .collect(toImmutableList());
+        Map<String, Type> partitionColumnTypes = partitionColumns.stream()
+                .collect(toImmutableMap(HiveColumnHandle::getName, HiveColumnHandle::getType));
+
+        return createPartitionProjection(columns, partitionColumnTypes, parameters);
+    }
+
+    public static Optional<PartitionProjection> createPartitionProjection(List<String> dataColumns, Map<String, Type> partitionColumns, Map<String, String> tableProperties)
     {
         // This method is used during table creation to validate the properties. The validation is performed even if the projection is disabled.
         boolean enabled = parseBoolean(tableProperties.get(METASTORE_PROPERTY_PROJECTION_ENABLED));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/projection/Projection.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/projection/Projection.java
@@ -13,12 +13,23 @@
  */
 package io.trino.plugin.hive.projection;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.trino.spi.predicate.Domain;
 
 import java.util.List;
 import java.util.Optional;
 
-sealed interface Projection
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        property = "@type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = DateProjection.class, name = "date"),
+        @JsonSubTypes.Type(value = EnumProjection.class, name = "enum"),
+        @JsonSubTypes.Type(value = InjectedProjection.class, name = "injected"),
+        @JsonSubTypes.Type(value = IntegerProjection.class, name = "integer")
+})
+public sealed interface Projection
         permits DateProjection, EnumProjection, InjectedProjection, IntegerProjection
 {
     List<String> getProjectedValues(Optional<Domain> partitionValueFilter);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/projection/Projection.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/projection/Projection.java
@@ -16,6 +16,7 @@ package io.trino.plugin.hive.projection;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.NullableValue;
 
 import java.util.List;
 import java.util.Optional;
@@ -33,4 +34,14 @@ public sealed interface Projection
         permits DateProjection, EnumProjection, InjectedProjection, IntegerProjection
 {
     List<String> getProjectedValues(Optional<Domain> partitionValueFilter);
+
+    default Optional<NullableValue> parsePartitionValue(String value)
+    {
+        return Optional.empty();
+    }
+
+    default Optional<String> toPartitionValue(Object value)
+    {
+        return Optional.empty();
+    }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
@@ -33,6 +33,7 @@ import io.trino.orc.OrcWriterOptions;
 import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.plugin.hive.HivePartitionKey;
 import io.trino.plugin.hive.HiveTimestampPrecision;
+import io.trino.plugin.hive.projection.PartitionProjection;
 import io.trino.spi.ErrorCodeSupplier;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ColumnMetadata;
@@ -234,9 +235,16 @@ public final class HiveUtil
                 type instanceof CharType;
     }
 
-    public static NullableValue parsePartitionValue(String partitionName, String value, Type type)
+    public static NullableValue parsePartitionValue(String partitionName, String value, Type type, String partitionColumnName, Optional<PartitionProjection> partitionProjection)
     {
         verifyPartitionTypeSupported(partitionName, type);
+
+        if (partitionProjection.isPresent()) {
+            Optional<NullableValue> nullableValue = partitionProjection.flatMap(projection -> projection.parsePartitionValue(partitionColumnName, value));
+            if (nullableValue.isPresent()) {
+                return nullableValue.get();
+            }
+        }
 
         boolean isNull = HIVE_DEFAULT_DYNAMIC_PARTITION.equals(value);
 
@@ -596,7 +604,8 @@ public final class HiveUtil
             OptionalInt bucketNumber,
             long fileSize,
             long fileModifiedTime,
-            String partitionName)
+            String partitionName,
+            Optional<PartitionProjection> partitionProjection)
     {
         String columnValue;
         if (partitionKey != null) {
@@ -619,6 +628,13 @@ public final class HiveUtil
         }
         else {
             throw new TrinoException(NOT_SUPPORTED, "unsupported hidden column: " + columnHandle);
+        }
+
+        if (partitionProjection.isPresent()) {
+            Optional<NullableValue> nullableValue = partitionProjection.get().parsePartitionValue(columnHandle.getName(), columnValue);
+            if (nullableValue.isPresent()) {
+                return nullableValue.get();
+            }
         }
 
         byte[] bytes = columnValue.getBytes(UTF_8);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveOnDataLake.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveOnDataLake.java
@@ -936,7 +936,7 @@ abstract class BaseTestHiveOnDataLake
                         "  short_name2 date WITH (" +
                         "    partition_projection_type='date', " +
                         "    partition_projection_format='yyyy-MM-dd', " +
-                        "    partition_projection_range=ARRAY['2001-1-22', '2001-1-25']" +
+                        "    partition_projection_range=ARRAY['2001-01-22', '2001-01-25']" +
                         "  )" +
                         ") WITH ( " +
                         "  partitioned_by=ARRAY['short_name1', 'short_name2'], " +
@@ -951,7 +951,7 @@ abstract class BaseTestHiveOnDataLake
                 .containsPattern("[ |]+projection\\.short_name1\\.values[ |]+PL1,CZ1[ |]+")
                 .containsPattern("[ |]+projection\\.short_name2\\.type[ |]+date[ |]+")
                 .containsPattern("[ |]+projection\\.short_name2\\.format[ |]+yyyy-MM-dd[ |]+")
-                .containsPattern("[ |]+projection\\.short_name2\\.range[ |]+2001-1-22,2001-1-25[ |]+");
+                .containsPattern("[ |]+projection\\.short_name2\\.range[ |]+2001-01-22,2001-01-25[ |]+");
 
         computeActual(createInsertStatement(
                 fullyQualifiedTestTableName,
@@ -1011,7 +1011,7 @@ abstract class BaseTestHiveOnDataLake
                         "  short_name2 timestamp WITH (" +
                         "    partition_projection_type='date', " +
                         "    partition_projection_format='yyyy-MM-dd HH:mm:ss', " +
-                        "    partition_projection_range=ARRAY['2001-1-22 00:00:00', '2001-1-22 00:00:06'], " +
+                        "    partition_projection_range=ARRAY['2001-01-22 00:00:00', '2001-01-22 00:00:06'], " +
                         "    partition_projection_interval=2, " +
                         "    partition_projection_interval_unit='SECONDS'" +
                         "  )" +
@@ -1028,7 +1028,7 @@ abstract class BaseTestHiveOnDataLake
                 .containsPattern("[ |]+projection\\.short_name1\\.values[ |]+PL1,CZ1[ |]+")
                 .containsPattern("[ |]+projection\\.short_name2\\.type[ |]+date[ |]+")
                 .containsPattern("[ |]+projection\\.short_name2\\.format[ |]+yyyy-MM-dd HH:mm:ss[ |]+")
-                .containsPattern("[ |]+projection\\.short_name2\\.range[ |]+2001-1-22 00:00:00,2001-1-22 00:00:06[ |]+")
+                .containsPattern("[ |]+projection\\.short_name2\\.range[ |]+2001-01-22 00:00:00,2001-01-22 00:00:06[ |]+")
                 .containsPattern("[ |]+projection\\.short_name2\\.interval[ |]+2[ |]+")
                 .containsPattern("[ |]+projection\\.short_name2\\.interval\\.unit[ |]+seconds[ |]+");
 
@@ -1582,7 +1582,7 @@ abstract class BaseTestHiveOnDataLake
                         "  partition_projection_enabled=true " +
                         ")"))
                 .hasMessage("Column projection for column 'short_name1' failed. Property: 'partition_projection_range' needs to be a list of 2 valid dates formatted as 'yyyy-MM-dd HH' " +
-                        "or '^\\s*NOW\\s*(([+-])\\s*([0-9]+)\\s*(DAY|HOUR|MINUTE|SECOND)S?\\s*)?$' that are sequential: Unparseable date: \"2001-01-01\"");
+                        "or '^\\s*NOW\\s*(([+-])\\s*([0-9]+)\\s*(DAY|HOUR|MINUTE|SECOND)S?\\s*)?$' that are sequential: Text '2001-01-01' could not be parsed at index 10");
 
         assertThatThrownBy(() -> getQueryRunner().execute(
                 "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomNameSuffix()) + " ( " +
@@ -1597,7 +1597,7 @@ abstract class BaseTestHiveOnDataLake
                         "  partition_projection_enabled=true " +
                         ")"))
                 .hasMessage("Column projection for column 'short_name1' failed. Property: 'partition_projection_range' needs to be a list of 2 valid dates formatted as 'yyyy-MM-dd' " +
-                        "or '^\\s*NOW\\s*(([+-])\\s*([0-9]+)\\s*(DAY|HOUR|MINUTE|SECOND)S?\\s*)?$' that are sequential: Unparseable date: \"NOW*3DAYS\"");
+                        "or '^\\s*NOW\\s*(([+-])\\s*([0-9]+)\\s*(DAY|HOUR|MINUTE|SECOND)S?\\s*)?$' that are sequential: Text 'NOW*3DAYS' could not be parsed at index 0");
 
         assertThatThrownBy(() -> getQueryRunner().execute(
                 "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomNameSuffix()) + " ( " +
@@ -1703,7 +1703,7 @@ abstract class BaseTestHiveOnDataLake
         // Expect invalid Partition Projection properties to fail
         assertThatThrownBy(() -> getQueryRunner().execute("SELECT * FROM " + fullyQualifiedTestTableName))
                 .hasMessage("Column projection for column 'date_time' failed. Property: 'partition_projection_range' needs to be a list of 2 valid dates formatted as 'yyyy-MM-dd HH' " +
-                        "or '^\\s*NOW\\s*(([+-])\\s*([0-9]+)\\s*(DAY|HOUR|MINUTE|SECOND)S?\\s*)?$' that are sequential: Unparseable date: \"2001-01-01\"");
+                        "or '^\\s*NOW\\s*(([+-])\\s*([0-9]+)\\s*(DAY|HOUR|MINUTE|SECOND)S?\\s*)?$' that are sequential: Text '2001-01-01' could not be parsed at index 10");
 
         // Append kill switch table property to ignore Partition Projection properties
         hiveMinioDataLake.runOnHive(

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveOnDataLake.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveOnDataLake.java
@@ -918,6 +918,67 @@ abstract class BaseTestHiveOnDataLake
     }
 
     @Test
+    public void testDatePartitionProjectionWithFormat()
+    {
+        String tableName = "partition_projection_custom_date" + randomNameSuffix();
+        String fullyQualifiedTestTableName = getFullyQualifiedTestTableName(tableName);
+
+        computeActual(
+                "CREATE TABLE " + fullyQualifiedTestTableName + " ( " +
+                        "  name varchar(25), " +
+                        "  comment varchar(152), " +
+                        "  dt DATE WITH (" +
+                        "    partition_projection_format='yyyy/MM/dd',\n" +
+                        "    partition_projection_interval=1,\n" +
+                        "    partition_projection_interval_unit='DAYS', \n" +
+                        "    partition_projection_range=ARRAY['2025/01/01', '2025/01/30'], \n" +
+                        "    partition_projection_type='date'" +
+                        "  ), " +
+                        "  ts timestamp WITH (" +
+                        "    partition_projection_type='date', " +
+                        "    partition_projection_format='yyyy/M/dd HH@mm@ss', " +
+                        "    partition_projection_range=ARRAY['2025/1/20 00@00@00', '2025/1/21 00@00@00'], " +
+                        "    partition_projection_interval=1, " +
+                        "    partition_projection_interval_unit='HOURS'" +
+                        "  )" +
+                        ") WITH ( " +
+                        "  partitioned_by=ARRAY['dt','ts'], " +
+                        "  partition_projection_enabled=true " +
+                        ")");
+
+        assertThat(
+                hiveMinioDataLake
+                        .runOnHive("SHOW TBLPROPERTIES " + getHiveTestTableName(tableName)))
+                .containsPattern("[ |]+projection\\.enabled[ |]+true[ |]+")
+                .containsPattern("[ |]+projection\\.dt\\.type[ |]+date[ |]+")
+                .containsPattern("[ |]+projection\\.dt\\.format[ |]+yyyy/MM/dd[ |]+")
+                .containsPattern("[ |]+projection\\.dt\\.interval.unit[ |]+days[ |]+")
+                .containsPattern("[ |]+projection\\.dt\\.range[ |]+2025/01/01,2025/01/30[ |]+")
+                .containsPattern("[ |]+projection\\.ts\\.type[ |]+date[ |]+")
+                .containsPattern("[ |]+projection\\.ts\\.format[ |]+yyyy/M/dd HH@mm@ss[ |]+")
+                .containsPattern("[ |]+projection\\.ts\\.interval.unit[ |]+hours[ |]+")
+                .containsPattern("[ |]+projection\\.ts\\.range[ |]+2025/1/20 00@00@00,2025/1/21 00@00@00[ |]+");
+
+        computeActual(createInsertStatement(
+                fullyQualifiedTestTableName,
+                ImmutableList.of(
+                        ImmutableList.of("'POLAND_1'", "'Comment'", "DATE '2025-1-23'", "TIMESTAMP '2025-1-20 01:00:00'"),
+                        ImmutableList.of("'POLAND_2'", "'Comment'", "DATE '2025-1-23'", "TIMESTAMP '2025-1-20 02:00:00'"),
+                        ImmutableList.of("'CZECH_2'", "'Comment'", "DATE '2025-1-24'", "TIMESTAMP '2025-1-20 10:00:00'"))));
+
+        assertQuery("SELECT * FROM " + fullyQualifiedTestTableName + " WHERE name = 'POLAND_1'", "VALUES ('POLAND_1', 'Comment', DATE '2025-01-23', TIMESTAMP '2025-01-20 01:00:00')");
+
+        assertQuery("SELECT * FROM " + fullyQualifiedTestTableName + " WHERE dt = DATE '2025-01-23'",
+                "VALUES ('POLAND_1', 'Comment', DATE '2025-01-23', TIMESTAMP '2025-01-20 01:00:00')," +
+                        "('POLAND_2', 'Comment', DATE '2025-01-23', TIMESTAMP '2025-01-20 02:00:00')");
+        assertQuery("SELECT * FROM " + fullyQualifiedTestTableName + " WHERE dt = DATE '2025-01-23' AND ts > TIMESTAMP '2025-1-20 01:00:00'",
+                "VALUES ('POLAND_2', 'Comment', DATE '2025-01-23', TIMESTAMP '2025-01-20 02:00:00')");
+        assertQuery("SELECT * FROM " + fullyQualifiedTestTableName + " WHERE dt IN (DATE '2025-01-23', DATE '2025-01-24', DATE '2025-01-25') AND ts > TIMESTAMP '2025-1-20 01:00:00'",
+                "VALUES ('POLAND_2', 'Comment', DATE '2025-01-23', TIMESTAMP '2025-01-20 02:00:00')," +
+                        "('CZECH_2', 'Comment', DATE '2025-1-24', TIMESTAMP '2025-1-20 10:00:00')");
+    }
+
+    @Test
     public void testDatePartitionProjectionOnDateColumnWithDefaults()
     {
         String tableName = "nation_" + randomNameSuffix();

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
@@ -996,7 +996,8 @@ public final class TestHiveFileFormats
                 location.toString(),
                 OptionalInt.empty(),
                 paddedFileSize,
-                Instant.now().toEpochMilli());
+                Instant.now().toEpochMilli(),
+                Optional.empty());
 
         ConnectorPageSource pageSource = HivePageSourceProvider.createHivePageSource(
                 ImmutableSet.of(sourceFactory),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSink.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSink.java
@@ -380,7 +380,8 @@ public class TestHivePageSink
                 ImmutableMap.of(),
                 NO_ACID_TRANSACTION,
                 false,
-                false);
+                false,
+                Optional.empty());
         JsonCodec<PartitionUpdate> partitionUpdateCodec = JsonCodec.jsonCodec(PartitionUpdate.class);
         HivePageSinkProvider provider = new HivePageSinkProvider(
                 getDefaultHiveFileWriterFactories(config, fileSystemFactory),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSource.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSource.java
@@ -85,7 +85,8 @@ public class TestHivePageSource
                 null,
                 tableBucketNumber,
                 0,
-                0);
+                0,
+                Optional.empty());
 
         List<HivePageSourceProvider.ColumnMapping> regularAndInterimColumnMappings = HivePageSourceProvider.ColumnMapping.extractRegularAndInterimColumnMappings(columnMappings);
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOrcPageSourceMemoryTracking.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOrcPageSourceMemoryTracking.java
@@ -569,7 +569,8 @@ public class TestOrcPageSourceMemoryTracking
                     fileSplit.getPath().toString(),
                     OptionalInt.empty(),
                     fileSplit.getLength(),
-                    Instant.now().toEpochMilli());
+                    Instant.now().toEpochMilli(),
+                    Optional.empty());
 
             ConnectorPageSource connectorPageSource = HivePageSourceProvider.createHivePageSource(
                     ImmutableSet.of(orcPageSourceFactory),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcPredicates.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcPredicates.java
@@ -174,7 +174,8 @@ class TestOrcPredicates
                 location.toString(),
                 OptionalInt.empty(),
                 length,
-                Instant.now().toEpochMilli());
+                Instant.now().toEpochMilli(),
+                Optional.empty());
 
         return HivePageSourceProvider.createHivePageSource(
                         ImmutableSet.of(readerFactory),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/statistics/TestMetastoreHiveStatisticsProvider.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/statistics/TestMetastoreHiveStatisticsProvider.java
@@ -430,7 +430,7 @@ public class TestMetastoreHiveStatisticsProvider
 
     private static void assertConvertPartitionValueToDouble(Type type, String value, double expected)
     {
-        Object trinoValue = parsePartitionValue(format("p=%s", value), value, type).getValue();
+        Object trinoValue = parsePartitionValue(format("p=%s", value), value, type, null, Optional.empty()).getValue();
         assertThat(convertPartitionValueToDouble(type, trinoValue)).isEqualTo(OptionalDouble.of(expected));
     }
 
@@ -853,7 +853,7 @@ public class TestMetastoreHiveStatisticsProvider
 
     private static HivePartition partition(String name)
     {
-        return parsePartition(TABLE, name, ImmutableList.of(PARTITION_COLUMN_1, PARTITION_COLUMN_2));
+        return parsePartition(TABLE, name, ImmutableList.of(PARTITION_COLUMN_1, PARTITION_COLUMN_2), Optional.empty());
     }
 
     private static PartitionStatistics rowsCount(long rowsCount)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestHiveWriteUtils.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestHiveWriteUtils.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.hive.util;
 
+import com.google.common.collect.ImmutableList;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.block.BlockBuilder;
@@ -23,6 +24,7 @@ import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Optional;
 
 import static io.trino.plugin.hive.util.HiveWriteUtils.createPartitionValues;
 import static io.trino.spi.type.DecimalType.createDecimalType;
@@ -64,7 +66,7 @@ public class TestHiveWriteUtils
         assertThat(HiveDecimal.create(decimal.toBigDecimal()).toString())
                 .isEqualTo(expectedValue);
 
-        assertThat(createPartitionValues(types, page, 0))
+        assertThat(createPartitionValues(ImmutableList.of("dummy"), types, page, 0, Optional.empty()))
                 .isEqualTo(List.of(expectedValue));
     }
 

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiUtil.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiUtil.java
@@ -36,6 +36,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_INVALID_METADATA;
 import static io.trino.plugin.hive.util.HiveUtil.checkCondition;
@@ -96,7 +97,7 @@ public final class HudiUtil
             TupleDomain<HiveColumnHandle> constraintSummary)
     {
         HivePartition partition = HivePartitionManager.parsePartition(
-                tableName, hivePartitionName, partitionColumnHandles);
+                tableName, hivePartitionName, partitionColumnHandles, Optional.empty());
 
         return partitionMatches(partitionColumnHandles, constraintSummary, partition);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Closes #25642 

In the Hive connector, the partition formats for date and timestamp types were previously fixed. For example, the date type used HiveUtils.HIVE_DATE_FORMATTER and HiveWriteUtils.HIVE_DATE_FORMATTER for reading and writing partition values.
However, partition projection supports user-specified formats, which led to inconsistencies and failures when custom formats were used, especially during parsing partition values at read or write time.

This PR addresses the issue by delegating the reading and writing of partition values to the partition projection mechanism when the column is projected.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Hive
* Fix failure with specifying format for date partition projection in Hive connector. ({issue}`25642`)
```
