### PR TITLE
Add max_partitions_per_writer session property in Iceberg Connector

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -114,7 +114,8 @@ implementation is used:
     in Iceberg version 0.11.0.
   - `true`
 * - `iceberg.max-partitions-per-writer`
-  - Maximum number of partitions handled per writer.
+  - Maximum number of partitions handled per writer. The equivalent catalog session property is
+    `max_partitions_per_writer`.
   - `100`
 * - `iceberg.target-max-file-size`
   - Target maximum size of written files; the actual size may be larger.

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
@@ -41,6 +41,7 @@ import org.apache.iceberg.io.LocationProvider;
 import java.util.Map;
 
 import static com.google.common.collect.Maps.transformValues;
+import static io.trino.plugin.iceberg.IcebergSessionProperties.maxPartitionsPerWriter;
 import static io.trino.plugin.iceberg.IcebergUtil.getLocationProvider;
 import static java.util.Objects.requireNonNull;
 
@@ -51,7 +52,6 @@ public class IcebergPageSinkProvider
     private final JsonCodec<CommitTaskData> jsonCodec;
     private final IcebergFileWriterFactory fileWriterFactory;
     private final PageIndexerFactory pageIndexerFactory;
-    private final int maxOpenPartitions;
     private final DataSize sortingFileWriterBufferSize;
     private final int sortingFileWriterMaxOpenFiles;
     private final TypeManager typeManager;
@@ -63,7 +63,6 @@ public class IcebergPageSinkProvider
             JsonCodec<CommitTaskData> jsonCodec,
             IcebergFileWriterFactory fileWriterFactory,
             PageIndexerFactory pageIndexerFactory,
-            IcebergConfig config,
             SortingFileWriterConfig sortingFileWriterConfig,
             TypeManager typeManager,
             PageSorter pageSorter)
@@ -72,7 +71,6 @@ public class IcebergPageSinkProvider
         this.jsonCodec = requireNonNull(jsonCodec, "jsonCodec is null");
         this.fileWriterFactory = requireNonNull(fileWriterFactory, "fileWriterFactory is null");
         this.pageIndexerFactory = requireNonNull(pageIndexerFactory, "pageIndexerFactory is null");
-        this.maxOpenPartitions = config.getMaxPartitionsPerWriter();
         this.sortingFileWriterBufferSize = sortingFileWriterConfig.getWriterSortBufferSize();
         this.sortingFileWriterMaxOpenFiles = sortingFileWriterConfig.getMaxOpenSortFiles();
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
@@ -109,7 +107,7 @@ public class IcebergPageSinkProvider
                 session,
                 tableHandle.fileFormat(),
                 tableHandle.storageProperties(),
-                maxOpenPartitions,
+                maxPartitionsPerWriter(session),
                 tableHandle.sortOrder(),
                 sortingFileWriterBufferSize,
                 sortingFileWriterMaxOpenFiles,
@@ -140,7 +138,7 @@ public class IcebergPageSinkProvider
                         session,
                         optimizeHandle.fileFormat(),
                         optimizeHandle.tableStorageProperties(),
-                        maxOpenPartitions,
+                        maxPartitionsPerWriter(session),
                         optimizeHandle.sortOrder(),
                         sortingFileWriterBufferSize,
                         sortingFileWriterMaxOpenFiles,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -111,6 +111,7 @@ public final class IcebergSessionProperties
     private static final String INCREMENTAL_REFRESH_ENABLED = "incremental_refresh_enabled";
     public static final String BUCKET_EXECUTION_ENABLED = "bucket_execution_enabled";
     public static final String FILE_BASED_CONFLICT_DETECTION_ENABLED = "file_based_conflict_detection_enabled";
+    private static final String MAX_PARTITIONS_PER_WRITER = "max_partitions_per_writer";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -404,6 +405,18 @@ public final class IcebergSessionProperties
                         "Enable file-based conflict detection: take partition information from the actual written files as a source for the conflict detection system",
                         icebergConfig.isFileBasedConflictDetectionEnabled(),
                         false))
+                .add(integerProperty(
+                        MAX_PARTITIONS_PER_WRITER,
+                        "Maximum number of partitions per writer",
+                        icebergConfig.getMaxPartitionsPerWriter(),
+                        value -> {
+                            if (value < 1 || value > icebergConfig.getMaxPartitionsPerWriter()) {
+                                throw new TrinoException(
+                                        INVALID_SESSION_PROPERTY,
+                                        format("%s must be between 1 and %s", MAX_PARTITIONS_PER_WRITER, icebergConfig.getMaxPartitionsPerWriter()));
+                            }
+                        },
+                        false))
                 .build();
     }
 
@@ -656,5 +669,10 @@ public final class IcebergSessionProperties
     public static boolean isFileBasedConflictDetectionEnabled(ConnectorSession session)
     {
         return session.getProperty(FILE_BASED_CONFLICT_DETECTION_ENABLED, Boolean.class);
+    }
+
+    public static int maxPartitionsPerWriter(ConnectorSession session)
+    {
+        return session.getProperty(MAX_PARTITIONS_PER_WRITER, Integer.class);
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
This PR is making a code change such that ```max_partitions_per_writer``` can be changed at session level for Iceberg connector. 


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

Release notes are required, with the following suggested text:

```markdown
## Iceberg connector
*  Add `max_partitions_per_writer` session property. ({issue}`25662`)
``` 
