### PR TITLE
Add warning to release 474

### DIFF
--- a/docs/src/main/sphinx/release/release-474.md
+++ b/docs/src/main/sphinx/release/release-474.md
@@ -1,5 +1,10 @@
 # Release 474 (21 Mar 2025)
 
+```{warning}
+This release contains a bug in memory tracking that can cause queries to fail
+with EXCEEDED_LOCAL_MEMORY_LIMIT unnecessarily. See: ({issue}`25600`)
+```
+
 ## General
 
 * Add `originalUser` and `authenticatedUser` as resource group selectors. ({issue}`24662`)


### PR DESCRIPTION
## Description
Adds a warning to release 474 about the memory tracking bug included in it

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
