### PR TITLE
Support reading INT32 with integer annotation as DATE in parquet

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
@@ -124,7 +124,7 @@ public final class ColumnReaderFactory
             return createColumnReader(field, valueDecoders::getShortDecoder, SHORT_ADAPTER, memoryContext);
         }
         if (DATE.equals(type) && primitiveType == INT32) {
-            if (annotation == null || annotation instanceof DateLogicalTypeAnnotation) {
+            if (isIntegerAnnotation(annotation) || annotation instanceof DateLogicalTypeAnnotation) {
                 return createColumnReader(field, valueDecoders::getIntDecoder, INT_ADAPTER, memoryContext);
             }
             throw unsupportedException(type, field);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/AbstractTestParquetReader.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/AbstractTestParquetReader.java
@@ -1251,6 +1251,23 @@ public abstract class AbstractTestParquetReader
     }
 
     @Test
+    public void testReadInt32AsDate()
+            throws Exception
+    {
+        List<Integer> writeValues = IntStream.range(0, 1000).boxed().collect(toImmutableList());
+        List<SqlDate> readValues = writeValues.stream()
+                .map(AbstractTestParquetReader::intToSqlDate)
+                .collect(toImmutableList());
+        tester.testRoundTrip(javaIntObjectInspector, writeValues, readValues, DATE);
+        tester.testRoundTrip(
+                javaIntObjectInspector,
+                writeValues,
+                readValues,
+                DATE,
+                Optional.of(parseMessageType("message hive_date { optional INT32 test (INTEGER(16,false)); }")));
+    }
+
+    @Test
     public void testSchemaWithRepeatedOptionalRequiredFields()
             throws Exception
     {


### PR DESCRIPTION
## Description
Support reading INT32 integers annotated with integer logical annotation in parquet as DATE type in Trino


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Hive, Delta, Iceberg, Hudi
* Fix query failures when attempting to read parquet data with integer logical annotation as a DATE column in Trino. ({issue}`issuenumber`)
```
