### PR TITLE
Add release note and documentation for OpenTelemetry HTTP export support

### DIFF
--- a/docs/src/main/sphinx/admin/opentelemetry.md
+++ b/docs/src/main/sphinx/admin/opentelemetry.md
@@ -43,6 +43,10 @@ is accessible from the coordinator and all workers of the cluster. The preceding
 example uses a observability platform deployment available by
 HTTP at the host `observe.example.com`, port `4317`.
 
+Use the `tracing.exporter.protocol` property to configure the protocol for exporting traces. 
+Defaults to the gRPC protocol with the `grpc` value. Set the value to `http/protobuf` for 
+exporting traces using protocol buffers with HTTP transport.
+
 ## Example use
 
 The following steps provide a simple demo setup to run the open source

--- a/docs/src/main/sphinx/release/release-475.md
+++ b/docs/src/main/sphinx/release/release-475.md
@@ -14,6 +14,8 @@
 * Fix incorrect results when using window functions with `DISTINCT`. ({issue}`25434`)
 * Fix query failures with `EXCEEDED_LOCAL_MEMORY_LIMIT` errors due to incorrect memory accounting. ({issue}`25600`)
 * Properly handle inline session properties for `EXPLAIN` queries. ({issue}`25496`)
+* Add support for exporting OpenTelemetry traces using the HTTP protocol with the `tracing.exporter.protocol` 
+  configuration property set to `http/protobuf`. ({issue}`25573`)
 
 ## Security
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

- Add a release note in 475 mentioning support for exporting OpenTelemetry traces using the HTTP (OTLP/HTTP) protocol.
- Document the new `tracing.exporter.protocol` configuration property.
- Note that the feature was implemented in the Airlift repository.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

https://github.com/trinodb/trino/issues/25338

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
