### PR TITLE
Use UUIDv7 for OpenLineage runId

### DIFF
--- a/docs/src/main/sphinx/admin/event-listeners-openlineage.md
+++ b/docs/src/main/sphinx/admin/event-listeners-openlineage.md
@@ -23,7 +23,7 @@ not limited to) Spark, Airflow, Flink.
     - Trino
     - OpenLineage
 *
-    - `{UUID(Query Id)}`
+    - `{UUIDv7(Query.createTime, hash(Query.Id))}`
     - Run ID
 *
     - `{queryCreatedEvent.getCreateTime()} or {queryCompletedEvent.getEndTime()} `

--- a/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/OpenLineageListener.java
+++ b/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/OpenLineageListener.java
@@ -45,6 +45,7 @@ import io.trino.spi.eventlistener.TableInfo;
 import io.trino.spi.resourcegroups.QueryType;
 
 import java.net.URI;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
@@ -52,6 +53,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.openlineage.client.utils.UUIDUtils.generateStaticUUID;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.ZoneOffset.UTC;
@@ -83,9 +85,7 @@ public class OpenLineageListener
     public void queryCreated(QueryCreatedEvent queryCreatedEvent)
     {
         if (queryTypeSupported(queryCreatedEvent.getContext())) {
-            UUID runID = getQueryId(queryCreatedEvent.getMetadata());
-
-            RunEvent event = getStartEvent(runID, queryCreatedEvent);
+            RunEvent event = getStartEvent(queryCreatedEvent);
             client.emit(event);
             return;
         }
@@ -98,9 +98,7 @@ public class OpenLineageListener
     public void queryCompleted(QueryCompletedEvent queryCompletedEvent)
     {
         if (queryTypeSupported(queryCompletedEvent.getContext())) {
-            UUID runID = getQueryId(queryCompletedEvent.getMetadata());
-
-            RunEvent event = getCompletedEvent(runID, queryCompletedEvent);
+            RunEvent event = getCompletedEvent(queryCompletedEvent);
             client.emit(event);
             return;
         }
@@ -117,9 +115,13 @@ public class OpenLineageListener
                 .orElse(false);
     }
 
-    private UUID getQueryId(QueryMetadata queryMetadata)
+    /*
+     * Construct UUIDv7 from query creation time and queryId hash.
+     * UUIDv7 are both globally unique and ordered.
+     */
+    private UUID getRunId(Instant queryCreateTime, QueryMetadata queryMetadata)
     {
-        return UUID.nameUUIDFromBytes(queryMetadata.getQueryId().getBytes(UTF_8));
+        return generateStaticUUID(queryCreateTime, queryMetadata.getQueryId().getBytes(UTF_8));
     }
 
     private RunFacet getTrinoQueryContextFacet(QueryContext queryContext)
@@ -180,8 +182,9 @@ public class OpenLineageListener
         return trinoQueryStatisticsFacet;
     }
 
-    public RunEvent getStartEvent(UUID runID, QueryCreatedEvent queryCreatedEvent)
+    public RunEvent getStartEvent(QueryCreatedEvent queryCreatedEvent)
     {
+        UUID runID = getRunId(queryCreatedEvent.getCreateTime(), queryCreatedEvent.getMetadata());
         RunFacetsBuilder runFacetsBuilder = getBaseRunFacetsBuilder(queryCreatedEvent.getContext());
 
         runFacetsBuilder.put(OpenLineageTrinoFacet.TRINO_METADATA.asText(),
@@ -197,10 +200,9 @@ public class OpenLineageListener
                     .build();
     }
 
-    public RunEvent getCompletedEvent(UUID runID, QueryCompletedEvent queryCompletedEvent)
+    public RunEvent getCompletedEvent(QueryCompletedEvent queryCompletedEvent)
     {
-        boolean failed = queryCompletedEvent.getMetadata().getQueryState().equals("FAILED");
-
+        UUID runID = getRunId(queryCompletedEvent.getCreateTime(), queryCompletedEvent.getMetadata());
         RunFacetsBuilder runFacetsBuilder = getBaseRunFacetsBuilder(queryCompletedEvent.getContext());
 
         runFacetsBuilder.put(OpenLineageTrinoFacet.TRINO_METADATA.asText(),
@@ -210,6 +212,7 @@ public class OpenLineageListener
         runFacetsBuilder.put(OpenLineageTrinoFacet.TRINO_QUERY_STATISTICS.asText(),
                 getTrinoQueryStatisticsFacet(queryCompletedEvent.getStatistics()));
 
+        boolean failed = queryCompletedEvent.getMetadata().getQueryState().equals("FAILED");
         if (failed) {
             queryCompletedEvent
                     .getFailureInfo()

--- a/plugin/trino-openlineage/src/test/java/io/trino/plugin/openlineage/TestOpenLineageListener.java
+++ b/plugin/trino-openlineage/src/test/java/io/trino/plugin/openlineage/TestOpenLineageListener.java
@@ -24,9 +24,7 @@ import org.junit.jupiter.api.TestInstance;
 
 import java.time.ZonedDateTime;
 import java.util.Map;
-import java.util.UUID;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
 
@@ -40,8 +38,7 @@ final class TestOpenLineageListener
                 "openlineage-event-listener.transport.type", "CONSOLE",
                 "openlineage-event-listener.trino.uri", "http://testhost"));
 
-        UUID runID = UUID.nameUUIDFromBytes("testGetCompleteEvent".getBytes(UTF_8));
-        RunEvent result = listener.getCompletedEvent(runID, TrinoEventData.queryCompleteEvent);
+        RunEvent result = listener.getCompletedEvent(TrinoEventData.queryCompleteEvent);
 
         assertThat(result)
                 .extracting(RunEvent::getEventType)
@@ -55,7 +52,8 @@ final class TestOpenLineageListener
         assertThat(result)
                 .extracting(RunEvent::getRun)
                 .extracting(Run::getRunId)
-                .isEqualTo(runID);
+                 // random UUID part may differ, but prefix is timestamp based
+                .matches(uuid -> uuid.toString().startsWith("01967c23-ae78-7"));
 
         assertThat(result)
                 .extracting(RunEvent::getJob)
@@ -70,8 +68,7 @@ final class TestOpenLineageListener
                 "openlineage-event-listener.transport.type", OpenLineageTransport.CONSOLE.toString(),
                 "openlineage-event-listener.trino.uri", "http://testhost:8080"));
 
-        UUID runID = UUID.nameUUIDFromBytes("testGetStartEvent".getBytes(UTF_8));
-        RunEvent result = listener.getStartEvent(runID, TrinoEventData.queryCreatedEvent);
+        RunEvent result = listener.getStartEvent(TrinoEventData.queryCreatedEvent);
 
         assertThat(result)
                 .extracting(RunEvent::getEventType)
@@ -85,7 +82,8 @@ final class TestOpenLineageListener
         assertThat(result)
                 .extracting(RunEvent::getRun)
                 .extracting(Run::getRunId)
-                .isEqualTo(runID);
+                 // random UUID part may differ, but prefix is timestamp based
+                .matches(uuid -> uuid.toString().startsWith("01967c23-ae78-7"));
 
         assertThat(result)
                 .extracting(RunEvent::getJob)

--- a/plugin/trino-openlineage/src/test/java/io/trino/plugin/openlineage/TrinoEventData.java
+++ b/plugin/trino-openlineage/src/test/java/io/trino/plugin/openlineage/TrinoEventData.java
@@ -149,12 +149,12 @@ public class TrinoEventData
                 queryIOMetadata,
                 Optional.empty(),
                 Collections.emptyList(),
-                Instant.now(),
-                Instant.now(),
-                Instant.now());
+                Instant.parse("2025-04-28T11:23:55.384424Z"),
+                Instant.parse("2025-04-28T11:24:16.256207Z"),
+                Instant.parse("2025-04-28T11:24:26.993340Z"));
 
         queryCreatedEvent = new QueryCreatedEvent(
-                Instant.now(),
+                Instant.parse("2025-04-28T11:23:55.384424Z"),
                 queryContext,
                 queryMetadata);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Previously OpenLineage run.id was generated as `UUIDv3(hash(queryId))`. Now it is generated as `UUIDv7(queryCreateTime, hash(queryId))`, using [UUIDUtils.generateStaticUUID](https://github.com/OpenLineage/OpenLineage/pull/3672) method.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

According to [OpenLineage documentation](https://openlineage.io/docs/spec/object-model#run), it is recommended to use UUID v7 for run.id values.
This also makes values more compatible with B-Tree indexes and allows using internal timestamp as a partition column.

Fixes #25534

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
## OpenLineage
* Use UUIDv7 for OpenLineage `runId` ({issue}`25534`)
```
