### PR TITLE
Fix vulnerable python packages in trino-docs

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:slim
+FROM python:3.12-slim
 
 # Required by pillow
 RUN apt update -y && apt install -y zlib1g-dev libjpeg-dev libxml2-dev libxslt-dev build-essential xsltproc

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,7 +10,7 @@ babel==2.10.3
     # via sphinx
 beautifulsoup4==4.9.1
     # via sphinx-material
-certifi==2019.11.28
+certifi==2024.7.4
     # via requests
 chardet==3.0.4
     # via requests
@@ -20,11 +20,11 @@ docutils==0.18.1
     # via
     #   myst-parser
     #   sphinx
-idna==2.9
+idna==3.7
     # via requests
 imagesize==1.4.1
     # via sphinx
-jinja2==3.1.3
+jinja2==3.1.6
     # via
     #   myst-parser
     #   sphinx
@@ -46,7 +46,7 @@ myst-parser==2.0.0
     # via -r requirements.in
 packaging==21.0
     # via sphinx
-pillow==9.2.0
+pillow==10.3.0
     # via -r requirements.in
 pygments==2.17.2
     # via sphinx
@@ -58,7 +58,7 @@ pytz==2019.3
     # via babel
 pyyaml==6.0.1
     # via myst-parser
-requests==2.25.0
+requests==2.32.0
     # via sphinx
 snowballstemmer==2.2.0
     # via sphinx
@@ -94,5 +94,5 @@ text-unidecode==1.3
     # via python-slugify
 unidecode==1.1.1
     # via python-slugify
-urllib3==1.26.18
+urllib3==2.2.2
     # via requests


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
* bump up versions of packages used in requirements.txt used in the dockerfile to resolve identified vulnerabilities.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
| Package  | Version in use | Version bumped to | Vulnerabilities fixed                                          |
|----------|----------------|-------------------|----------------------------------------------------------------|
| certifi  | 2019.11.28     | 2024.7.4          | CVE-2023-37920; CVE-2022-23491                                 |
| idna     | 2.9            | 3.7               | CVE-2024-3651                                                   |
| jinja2   | 3.1.3          | 3.1.6             | CVE-2024-56201; CVE-2024-56326; CVE-2025-27516; CVE-2024-34064 |
| pillow   | 9.2.0          | 10.3.0            | CVE-2023-50447; CVE-2022-45199; CVE-2023-44271                 |
| requests | 2.25.0         | 2.32.0            | CVE-2023-32681; CVE-2024-35195;                                |
| urllib3  | 1.26.18        | 2.2.2             | CVE-2024-37891                                                 |


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes
(x) This is not user-visible or is docs only, and no release notes are required.
