### PR TITLE
Fix wrong variable name in JWT authenticator documentation

### DIFF
--- a/docs/src/main/sphinx/security/jwt.md
+++ b/docs/src/main/sphinx/security/jwt.md
@@ -118,8 +118,8 @@ either:
   :::
 
 - The path to a local file in {doc}`PEM </security/inspect-pem>` or [HMAC](https://wikipedia.org/wiki/HMAC) format that contains a single key.
-  If the file path contains `$KEYID`, then Trino interpolates the `keyid`
-  from the JWT into the file path before loading this key. This enables support
+  If the file path contains `${KID}`, then Trino interpolates the `kid`
+  from the JWT header into the file path before loading this key. This enables support
   for setups with multiple keys.
 
 ## Using JWTs with clients


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Documentation currently defines that a placeholder `$KEYID` can be used when specifying `http-server.authentication.jwt.key-file` [while the code looks for `${KID}` instead](https://github.com/trinodb/trino/blob/8bb87dd44820774040927aa872eeaddc62830b87/core/trino-main/src/main/java/io/trino/server/security/jwt/FileSigningKeyLocator.java#L52C52-L52C58).
Also, [the JWT header field is called `kid`](https://www.rfc-editor.org/rfc/rfc7515#section-4.1.4) instead of the currently used `keyid`.

This MR adapts the documentation so it matches the actual implementation and the official field name.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
