### PR TITLE
Store catalog names in lower case

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/FileCatalogStore.java
+++ b/core/trino-main/src/main/java/io/trino/connector/FileCatalogStore.java
@@ -55,6 +55,7 @@ import static io.trino.spi.connector.CatalogHandle.createRootCatalogHandle;
 import static java.nio.file.Files.createDirectories;
 import static java.nio.file.Files.deleteIfExists;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
 public final class FileCatalogStore
@@ -75,7 +76,7 @@ public final class FileCatalogStore
         List<String> disabledCatalogs = firstNonNull(config.getDisabledCatalogs(), ImmutableList.of());
 
         for (File file : listCatalogFiles(catalogsDirectory)) {
-            String catalogName = getNameWithoutExtension(file.getName());
+            String catalogName = getNameWithoutExtension(file.getName()).toLowerCase(ENGLISH);
             checkArgument(!catalogName.equals(GlobalSystemConnector.NAME), "Catalog name SYSTEM is reserved for internal usage");
             if (disabledCatalogs.contains(catalogName)) {
                 log.info("Skipping disabled catalog %s", catalogName);


### PR DESCRIPTION
Store catalog names in lower case

This makes FileCatalogStore be in line with CreateCatalogTask, where
when a new catalog is created its name is lower cased.

Trino is not well prepared to non lower cased names, there is a plenty
of places where we use lower cased names (see QualifiedName#mapIdentifier as an example)
causing that catalogs are not then found.


Without this even simple queries like SHOW SCHEMAS FROM "CASE_CATalog" where failing as "case_catalog" was not found. 

I have tested the change manually. I am not sure if and how to add good testing.
