### PR TITLE
Ensure that createViewSession preserves the trace token

### DIFF
--- a/core/trino-main/src/main/java/io/trino/Session.java
+++ b/core/trino-main/src/main/java/io/trino/Session.java
@@ -661,6 +661,7 @@ public final class Session
                 .setRemoteUserAddress(getRemoteUserAddress().orElse(null))
                 .setUserAgent(getUserAgent().orElse(null))
                 .setClientInfo(getClientInfo().orElse(null))
+                .setTraceToken(getTraceToken())
                 .setStart(getStart())
                 .build();
     }

--- a/core/trino-main/src/test/java/io/trino/TestSession.java
+++ b/core/trino-main/src/test/java/io/trino/TestSession.java
@@ -13,9 +13,17 @@
  */
 package io.trino;
 
+import io.trino.spi.QueryId;
+import io.trino.spi.security.Identity;
+import io.trino.spi.type.TimeZoneKey;
+import io.trino.transaction.TransactionId;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -60,5 +68,54 @@ public class TestSession
                 .isEqualTo(Map.of("some_catalog", Map.of(
                         "first_property", "some_value",
                         "second_property", "another_value")));
+    }
+
+    @Test
+    public void testCreateViewSession()
+    {
+        final var catalog = Optional.of("test_catalog");
+        final var schema = Optional.of("test_schema");
+        final var queryId = new QueryId("test_query_id");
+        final var transactionId = TransactionId.create();
+        final var identity = new Identity.Builder("test_user").build();
+        final var originalIdentity = new Identity.Builder("test_original_user").build();
+        final var source = Optional.of("test_source");
+        final var timeZoneKey = TimeZoneKey.UTC_KEY;
+        final var locale = Locale.ENGLISH;
+        final var remoteUserAddress = Optional.of("1.1.1.1");
+        final var userAgent = Optional.of("test_agent");
+        final var clientInfo = Optional.of("test_client_info");
+        final var traceToken = Optional.of("test_trace_token");
+        final var start = Instant.ofEpochMilli(2L);
+
+        Session originalSession = Session.builder(testSessionBuilder().build())
+                .setQueryId(queryId)
+                .setTransactionId(transactionId)
+                .setOriginalIdentity(originalIdentity)
+                .setSource(source)
+                .setTimeZoneKey(timeZoneKey)
+                .setLocale(locale)
+                .setRemoteUserAddress(remoteUserAddress)
+                .setUserAgent(userAgent)
+                .setClientInfo(clientInfo)
+                .setTraceToken(traceToken)
+                .setStart(start)
+                .build();
+
+        Session viewSession = originalSession.createViewSession(catalog, schema, identity,
+                Collections.emptyList());
+
+        assertThat(viewSession).isNotNull();
+        assertThat(viewSession.getQueryId()).isEqualTo(queryId);
+        assertThat(viewSession.getTransactionId()).isEqualTo(Optional.of(transactionId));
+        assertThat(viewSession.getOriginalIdentity()).isEqualTo(originalIdentity);
+        assertThat(viewSession.getSource()).isEqualTo(source);
+        assertThat(viewSession.getTimeZoneKey()).isEqualTo(timeZoneKey);
+        assertThat(viewSession.getLocale()).isEqualTo(locale);
+        assertThat(viewSession.getRemoteUserAddress()).isEqualTo(remoteUserAddress);
+        assertThat(viewSession.getUserAgent()).isEqualTo(userAgent);
+        assertThat(viewSession.getClientInfo()).isEqualTo(clientInfo);
+        assertThat(viewSession.getTraceToken()).isEqualTo(traceToken);
+        assertThat(viewSession.getStart()).isEqualTo(start);
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

`Session`.`createViewSession` creates a new Session that is used when analysing views.

Presently this does not pass through the trace token. This is breaking the use of views with our custom connectors which mandate that this token is populated.

Therefore this is a very simple PR to ensure that the trace token is populated in `createViewSession` if it is present on the outer session.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* createViewSession should preserve the client trace token ({issue}`issuenumber`)
```
