### PR TITLE
Fixes a bug in Trino JDBC where exception handling in TrinoResultSet …

### DIFF
--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoResultSet.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoResultSet.java
@@ -129,7 +129,7 @@ public class TrinoResultSet
             QueryStatusInfo results = client.currentStatusInfo();
             progressCallback.accept(QueryStats.create(results.getId(), results.getStats()));
             List<Column> columns = results.getColumns();
-            if (columns != null) {
+            if (columns != null && !results.getStats().getState().equals("FAILED")) {
                 return columns;
             }
             client.advance();

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcPartitionFilterRequired.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcPartitionFilterRequired.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.jdbc;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import io.airlift.log.Logging;
+import io.trino.plugin.blackhole.BlackHolePlugin;
+import io.trino.plugin.hive.HivePlugin;
+import io.trino.server.testing.TestingTrinoServer;
+import io.trino.spi.connector.*;
+import io.trino.spi.predicate.TupleDomain;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import java.sql.*;
+import java.util.concurrent.ExecutorService;
+
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.testing.Closeables.closeAll;
+import static io.trino.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
+import static io.trino.spi.connector.SystemTable.Distribution.ALL_NODES;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static java.lang.String.format;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestJdbcPartitionFilterRequired
+{
+    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed(getClass().getName()));
+
+    private TestingTrinoServer server;
+
+    @BeforeAll
+    public void setupServer()
+            throws Exception
+    {
+        Logging.initialize();
+        Module systemTables = binder -> newSetBinder(binder, SystemTable.class)
+                .addBinding().to(ExtraCredentialsSystemTable.class).in(Scopes.SINGLETON);
+        server = TestingTrinoServer.builder()
+                .setAdditionalModule(systemTables)
+                .build();
+        server.installPlugin(new HivePlugin());
+        server.createCatalog("hive", "hive", ImmutableMap.<String, String>builder()
+                .put("hive.metastore", "file")
+                .put("hive.metastore.catalog.dir", server.getBaseDataDir().resolve("hive").toAbsolutePath().toString())
+                .put("hive.security", "sql-standard")
+                .put("fs.hadoop.enabled", "true")
+                .put("hive.query-partition-filter-required", "true")
+                .buildOrThrow());
+        server.installPlugin(new BlackHolePlugin());
+
+        try (Connection connection = createConnection()) {
+            Statement statement = connection.createStatement();
+            statement.execute("SET ROLE admin IN hive");
+            statement.execute("CREATE SCHEMA default");
+
+            statement.execute("CREATE TABLE test_required_partition_filter(id integer, a varchar, b varchar, ds varchar) WITH (partitioned_by = ARRAY['ds'])");
+            statement.execute("INSERT INTO test_required_partition_filter(id, a, ds) VALUES (1, 'a', '1')");
+        }
+    }
+
+    @AfterAll
+    public void tearDown()
+            throws Exception
+    {
+        closeAll(
+                server,
+                executor::shutdownNow);
+        server = null;
+    }
+
+    @Test
+    public void testFilterRequiredPartitions()
+            throws SQLException
+    {
+        String sql = "SELECT id FROM test_required_partition_filter WHERE a = '1' ";
+        assertThatThrownBy(() -> {
+            try (Connection connection = createConnection()) {
+                Statement statement = connection.createStatement();
+                statement.execute(sql);
+                ResultSet resultSet = statement.getResultSet();
+                assertThat(resultSet.next()).isTrue();
+            }
+        }).isInstanceOf(SQLException.class);
+    }
+
+    private Connection createConnection()
+            throws SQLException
+    {
+        return createConnection("");
+    }
+
+    private Connection createConnection(String extra)
+            throws SQLException
+    {
+        String url = format("jdbc:trino://%s/hive/default?%s", server.getAddress(), extra);
+        return DriverManager.getConnection(url, "admin", null);
+    }
+
+    private static class ExtraCredentialsSystemTable
+            implements SystemTable
+    {
+        private static final SchemaTableName NAME = new SchemaTableName("test", "extra_credentials");
+
+        private static final ConnectorTableMetadata METADATA = tableMetadataBuilder(NAME)
+                .column("name", createUnboundedVarcharType())
+                .column("value", createUnboundedVarcharType())
+                .build();
+
+        @Override
+        public Distribution getDistribution()
+        {
+            return ALL_NODES;
+        }
+
+        @Override
+        public ConnectorTableMetadata getTableMetadata()
+        {
+            return METADATA;
+        }
+
+        @Override
+        public RecordCursor cursor(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
+        {
+            InMemoryRecordSet.Builder table = InMemoryRecordSet.builder(METADATA);
+            session.getIdentity().getExtraCredentials().forEach(table::addRow);
+            return table.build().cursor();
+        }
+    }
+}


### PR DESCRIPTION
### Description
When using the configuration setting hive.query-partition-filter-required=true in Trino's JDBC client, a SQLException is expected to be thrown when a query is missing a required partition column. However, no error was raised in this case.
The root cause is that when a query fails due to a missing partition filter, results.getColumns() returns an empty List<Column> object (i.e., a list with a size of 0). As a result, the exception handling logic that depends on the presence of columns was not triggered as expected.
This fix ensures that when the query execution result is FAILED, the column retrieval will also fail accordingly, allowing the exception handling code to run as intended.

---

Change Summary  
- Type: Bug fix  
- Impact Area: JDBC Client  
- User-facing Description: Fixes a bug in Trino JDBC where exception handling in TrinoResultSet was not triggered when a query failed due to missing partition filters.
