### PR TITLE
Switch documentation theme to immaterial (w/ support for dark mode)

### DIFF
--- a/docs/build
+++ b/docs/build
@@ -6,9 +6,15 @@ cd "${BASH_SOURCE%/*}"
 
 test -t 1 && OPTS='-it' || OPTS=''
 
-SPHINX_IMAGE=${SPHINX_IMAGE:-ghcr.io/trinodb/build/sphinx:114}
+SPHINX_IMAGE=${SPHINX_IMAGE:-ghcr.io/trinodb/build/sphinx:115}
 
-docker run --security-opt label:disable --rm $OPTS -e TRINO_VERSION -u $(id -u):$(id -g) -v "$PWD":/docs $SPHINX_IMAGE \
+# Ensure target is empty so that sitemap is always fully generated
+rm -Rf target
+
+# Ensure a writable cache directory
+mkdir -p target/.cache
+
+docker run --security-opt label:disable --rm $OPTS -e TRINO_VERSION -e XDG_CACHE_HOME=/docs/target/.cache -u $(id -u):$(id -g) -v "$PWD":/docs $SPHINX_IMAGE \
   sphinx-build -q -j auto -b html -W --keep-going -d target/doctrees src/main/sphinx target/html
 
 # Sort sitemap for reproducible builds

--- a/docs/src/main/sphinx/admin.md
+++ b/docs/src/main/sphinx/admin.md
@@ -40,8 +40,6 @@ with Trino for further analysis or reporting.
 The following event listeners are available:
 
 ```{toctree}
-:titlesonly: true
-
 admin/event-listeners-http
 admin/event-listeners-kafka
 admin/event-listeners-mysql

--- a/docs/src/main/sphinx/admin/properties.md
+++ b/docs/src/main/sphinx/admin/properties.md
@@ -12,8 +12,6 @@ catalog configuration properties. For more information on catalog configuration
 properties, refer to the {doc}`connector documentation </connector/>`.
 
 ```{toctree}
-:titlesonly: true
-
 General <properties-general>
 Client protocol <properties-client-protocol>
 HTTP server <properties-http-server>

--- a/docs/src/main/sphinx/conf.py
+++ b/docs/src/main/sphinx/conf.py
@@ -160,7 +160,9 @@ html_theme_options = {
         'toc.follow',
     ],
     'icon': {
-        'repo': 'fontawesome/brands/github-alt'
+        'repo': 'fontawesome/brands/github-alt',
+        'edit': 'material/file-edit-outline',
+        'view': 'material/file-eye-outline'
     },
     'palette': [
         {
@@ -190,6 +192,7 @@ html_theme_options = {
     ],
     'repo_url': 'https://github.com/trinodb/trino',
     'repo_name': 'Trino',
+    'edit_uri': 'blob/master/docs/src/main/sphinx',
     'version_dropdown': True,
     'version_json': '../versions.json'
 }

--- a/docs/src/main/sphinx/conf.py
+++ b/docs/src/main/sphinx/conf.py
@@ -192,9 +192,7 @@ html_theme_options = {
     ],
     'repo_url': 'https://github.com/trinodb/trino',
     'repo_name': 'Trino',
-    'edit_uri': 'blob/master/docs/src/main/sphinx',
-    'version_dropdown': True,
-    'version_json': '../versions.json'
+    'edit_uri': 'blob/master/docs/src/main/sphinx'
 }
 
 html_css_files = [

--- a/docs/src/main/sphinx/conf.py
+++ b/docs/src/main/sphinx/conf.py
@@ -145,8 +145,6 @@ html_theme_options = {
     'site_url': html_baseurl,
     'toc_title': 'Contents',
     'features': [
-        'content.action.edit',
-        'content.action.view',
         'content.code.copy',
         'content.tabs.link',
         'content.tooltips'

--- a/docs/src/main/sphinx/conf.py
+++ b/docs/src/main/sphinx/conf.py
@@ -81,14 +81,15 @@ extensions = [
     'issue',
     'sphinx_copybutton',
     'redirects',
-    'sphinxcontrib.jquery'
+    'sphinxcontrib.jquery',
+    'sphinx_immaterial'
 ]
 
 redirects_file = 'redirects.txt'
 
 templates_path = ['templates']
 
-source_suffix = '.rst'
+source_suffix = '.md'
 
 master_doc = 'index'
 
@@ -122,7 +123,7 @@ myst_substitutions = {
 
 # -- Options for HTML output ---------------------------------------------------
 
-html_theme = 'sphinx_material'
+html_theme = 'sphinx_immaterial'
 
 html_static_path = ['static']
 
@@ -141,17 +142,56 @@ html_sidebars = {
 }
 
 html_theme_options = {
-    'base_url': html_baseurl,
-    'globaltoc_depth': -1,
-    'theme_color': '2196f3',
-    'color_primary': '',  # set in CSS
-    'color_accent': '',   # set in CSS
+    'site_url': html_baseurl,
+    'toc_title': 'Contents',
+    'features': [
+        'content.action.edit',
+        'content.action.view',
+        'content.code.copy',
+        'content.tabs.link',
+        'content.tooltips'
+        'navigation.expand',
+        'navigation.footer',
+        'navigation.sections',
+        'navigation.top',
+        'navigation.tracking',
+        'search.share',
+        'search.suggest',
+        'toc.follow',
+    ],
+    'icon': {
+        'repo': 'fontawesome/brands/github-alt'
+    },
+    'palette': [
+        {
+            'media': '(prefers-color-scheme)',
+            'scheme': 'default',
+            'toggle': {
+                'icon': 'material/brightness-auto',
+                'name': 'Switch to light mode',
+            }
+        },
+        {
+            'media': '(prefers-color-scheme: light)',
+            'scheme': 'default',
+            'toggle': {
+                'icon': 'material/weather-sunny',
+                'name': 'Switch to dark mode',
+            }
+        },
+        {
+            'media': '(prefers-color-scheme: dark)',
+            'scheme': 'slate',
+            'toggle': {
+                'icon': 'material/weather-night',
+                'name': 'Switch to system preference',
+            }
+        },
+    ],
     'repo_url': 'https://github.com/trinodb/trino',
     'repo_name': 'Trino',
-    'version_json': '../versions.json',
-    'nav_previous_text': 'Previous',
-    'nav_next_text': 'Next',
-    'search_placeholder_text': 'Search'
+    'version_dropdown': True,
+    'version_json': '../versions.json'
 }
 
 html_css_files = [
@@ -160,4 +200,12 @@ html_css_files = [
 
 suppress_warnings = [
     'config.cache'
+]
+
+object_description_options = [
+    ("c:.*", dict(toc_icon_class=None, toc_icon_text=None)),
+    ("cpp:.*", dict(toc_icon_class=None, toc_icon_text=None)),
+    ("py:.*", dict(toc_icon_class=None, toc_icon_text=None)),
+    ("json:.*", dict(toc_icon_class=None, toc_icon_text=None)),
+    ("std:.*", dict(toc_icon_class=None, toc_icon_text=None))
 ]

--- a/docs/src/main/sphinx/index.md
+++ b/docs/src/main/sphinx/index.md
@@ -1,8 +1,6 @@
 # Trino documentation
 
 ```{toctree}
-:titlesonly: true
-
 overview
 installation
 client
@@ -22,7 +20,5 @@ appendix
 
 ```{toctree}
 :maxdepth: 1
-:titlesonly: true
-
 release
 ```

--- a/docs/src/main/sphinx/static/trino.css
+++ b/docs/src/main/sphinx/static/trino.css
@@ -89,3 +89,8 @@ button.copybtn {
     position: relative;
     top: -5.5rem;
 }
+
+.toctree-wrapper ul {
+    list-style-type: none;
+    padding-left: 0;
+}

--- a/docs/src/main/sphinx/static/trino.css
+++ b/docs/src/main/sphinx/static/trino.css
@@ -12,10 +12,6 @@ html {
     scroll-behavior: smooth;
 }
 
-div.highlight {
-    background-color: #f5f5f5;
-}
-
 .md-header, .md-hero, .md-tabs {
     background-color: #0B1367;
 }
@@ -53,16 +49,13 @@ div.highlight {
     height: 48px;
 }
 
-.md-typeset h1 {
-    color: rgba(0, 0, 0, .80);
-}
-
 .sig-name, .sig-paren {
     font-weight: bold;
 }
 
 .md-typeset code {
     padding: 0 0.3em;
+    border-radius: 0.3rem;
 }
 
 pre.literal-block {
@@ -81,15 +74,6 @@ pre.literal-block {
     font-size: unset;
 }
 
-@media only screen and (min-width: 88.25em) {
-    .md-grid {
-        max-width: 75rem;
-    }
-
-    .md-sidebar--secondary {
-        margin-left: 75rem;
-    }
-}
 
 .copybtn:hover {
     cursor: copy;

--- a/docs/src/main/sphinx/udf.md
+++ b/docs/src/main/sphinx/udf.md
@@ -7,7 +7,6 @@ value, similar to [built-in functions](/functions).
 More details are available in the following sections:
 
 ```{toctree}
-:titlesonly: true
 :maxdepth: 1
 
 udf/introduction

--- a/docs/src/main/sphinx/udf/python.md
+++ b/docs/src/main/sphinx/udf/python.md
@@ -61,7 +61,6 @@ The same UDF can also be declared as [](udf-catalog).
 Refer to the [](/udf/python/examples) for more complex use cases and examples.
 
 ```{toctree}
-:titlesonly: true
 :hidden:
 
 /udf/python/examples

--- a/docs/src/main/sphinx/udf/sql.md
+++ b/docs/src/main/sphinx/udf/sql.md
@@ -23,7 +23,6 @@ operators](/functions) and other UDFs:
 * [](/udf/sql/while)
 
 ```{toctree}
-:titlesonly: true
 :hidden:
 
 sql/examples


### PR DESCRIPTION
<!-- Provide an overview for maintainers and reviewers. -->
## Description
* The contents of the PR introduces the feature requested in #25719 
* Configuration and respective setup files are update to use [`sphinx-immaterial`](https://jbms.github.io/sphinx-immaterial/) theme.
* Styling files are amended to use the theme customization options provided by the theme to achieve the same look and feel as before while introducing the light/dark toggle feature.
* Local TOCtree is displayed in the left sidebar
* The theme can be toggled between the following modes
    - Auto mode: as per browser setting
      ![Screenshot_20250506_192945](https://github.com/user-attachments/assets/4b54b3fd-373e-40db-a31b-0f1be631cfee)
    - Light mode
      ![Screenshot_20250506_193005](https://github.com/user-attachments/assets/e4f999ed-6723-48e6-879b-52a25f0230a7)
    - Dark mode
      ![Screenshot_20250506_193019](https://github.com/user-attachments/assets/55285de5-15c0-44e8-9de3-0f8f162d3d49)

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
* Why the choice of sphinx-immaterial?
	- As can be inferred from this discussion on `sphinx-material` theme repo at https://github.com/bashtage/sphinx-material/issues/89, there's a fork of this theme which includes this light/dark toggle feature- https://jbms.github.io/sphinx-immaterial/
	- `sphinx-immaterial` theme is being actively maintained unlike the `sphinx-material` theme repo that isn't seeing active code updates.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x ) Release notes are required. Please propose a release note for me.