### PR TITLE
Simplify fetching of catalog name for SplitCompletedEvent

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/SplitOperatorInfo.java
+++ b/core/trino-main/src/main/java/io/trino/operator/SplitOperatorInfo.java
@@ -16,26 +16,20 @@ package io.trino.operator;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.Mergeable;
-import io.trino.spi.connector.CatalogHandle;
 
 import java.util.List;
 import java.util.Map;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static java.util.Objects.requireNonNull;
 
 public class SplitOperatorInfo
         implements OperatorInfo, Mergeable<SplitOperatorInfo>
 {
-    private final CatalogHandle catalogHandle;
     private final Map<String, String> splitInfo;
 
     @JsonCreator
-    public SplitOperatorInfo(
-            @JsonProperty("catalogHandle") CatalogHandle catalogHandle,
-            @JsonProperty("splitInfo") Map<String, String> splitInfo)
+    public SplitOperatorInfo(@JsonProperty("splitInfo") Map<String, String> splitInfo)
     {
-        this.catalogHandle = requireNonNull(catalogHandle, "catalogHandle is null");
         this.splitInfo = splitInfo;
     }
 
@@ -51,12 +45,6 @@ public class SplitOperatorInfo
         return splitInfo;
     }
 
-    @JsonProperty
-    public CatalogHandle getCatalogHandle()
-    {
-        return catalogHandle;
-    }
-
     @Override
     public SplitOperatorInfo mergeWith(SplitOperatorInfo other)
     {
@@ -67,7 +55,6 @@ public class SplitOperatorInfo
     public SplitOperatorInfo mergeWith(List<SplitOperatorInfo> others)
     {
         return new SplitOperatorInfo(
-                catalogHandle,
                 splitInfo.entrySet().stream().collect(toImmutableMap(Map.Entry::getKey, e -> e.getValue() + " (" + others.size() + " more)")));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
@@ -167,7 +167,7 @@ public class TableScanOperator
 
         Map<String, String> splitInfo = split.getInfo();
         if (!splitInfo.isEmpty()) {
-            operatorContext.setInfoSupplier(Suppliers.ofInstance(new SplitOperatorInfo(split.getCatalogHandle(), splitInfo)));
+            operatorContext.setInfoSupplier(Suppliers.ofInstance(new SplitOperatorInfo(splitInfo)));
         }
 
         blocked.set(null);

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorSourceOperatorAdapter.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorSourceOperatorAdapter.java
@@ -86,7 +86,7 @@ public class WorkProcessorSourceOperatorAdapter
 
         Map<String, String> splitInfo = split.getInfo();
         if (!splitInfo.isEmpty()) {
-            operatorContext.setInfoSupplier(Suppliers.ofInstance(new SplitOperatorInfo(split.getCatalogHandle(), splitInfo)));
+            operatorContext.setInfoSupplier(Suppliers.ofInstance(new SplitOperatorInfo(splitInfo)));
         }
 
         splitBuffer.add(split);

--- a/core/trino-main/src/main/java/io/trino/operator/index/IndexSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/index/IndexSourceOperator.java
@@ -130,7 +130,7 @@ public class IndexSourceOperator
 
         Map<String, String> splitInfo = split.getInfo();
         if (!splitInfo.isEmpty()) {
-            operatorContext.setInfoSupplier(Suppliers.ofInstance(new SplitOperatorInfo(split.getCatalogHandle(), splitInfo)));
+            operatorContext.setInfoSupplier(Suppliers.ofInstance(new SplitOperatorInfo(splitInfo)));
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/TestOperatorStats.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestOperatorStats.java
@@ -27,13 +27,12 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 import java.util.Optional;
 
-import static io.trino.testing.TestingHandles.TEST_CATALOG_HANDLE;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestOperatorStats
 {
-    private static final SplitOperatorInfo NON_MERGEABLE_INFO = new SplitOperatorInfo(TEST_CATALOG_HANDLE, Map.of("some_info", "some_value"));
+    private static final SplitOperatorInfo NON_MERGEABLE_INFO = new SplitOperatorInfo(Map.of("some_info", "some_value"));
     private static final PartitionedOutputInfo MERGEABLE_INFO = new PartitionedOutputInfo(1024);
 
     public static final OperatorStats EXPECTED = new OperatorStats(


### PR DESCRIPTION
## Description
This information is available directly without having to go through OperatorStats



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
