### PR TITLE
Fix miscategorized exception in orphan file cleanup in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -2271,6 +2271,9 @@ public class IcebergMetadata
                 catch (IOException e) {
                     throw new TrinoException(ICEBERG_FILESYSTEM_ERROR, "Unable to list manifest file content from " + manifest.path(), e);
                 }
+                catch (NotFoundException e) {
+                    throw new TrinoException(ICEBERG_INVALID_METADATA, "Manifest file does not exist: " + manifest.path());
+                }
             }
         }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -120,6 +120,7 @@ import static io.trino.SystemSessionProperties.TASK_MAX_WRITER_COUNT;
 import static io.trino.SystemSessionProperties.TASK_MIN_WRITER_COUNT;
 import static io.trino.SystemSessionProperties.TASK_SCALE_WRITERS_ENABLED;
 import static io.trino.SystemSessionProperties.USE_PREFERRED_WRITE_PARTITIONING;
+import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
 import static io.trino.plugin.iceberg.IcebergFileFormat.AVRO;
 import static io.trino.plugin.iceberg.IcebergFileFormat.ORC;
 import static io.trino.plugin.iceberg.IcebergFileFormat.PARQUET;
@@ -6602,6 +6603,22 @@ public abstract class BaseIcebergConnectorTest
         assertQueryFails(
                 "ALTER TABLE nation EXECUTE EXPIRE_SNAPSHOTS (retention_threshold => '33s')",
                 "\\QRetention specified (33.00s) is shorter than the minimum retention configured in the system (7.00d). Minimum retention can be changed with iceberg.expire-snapshots.min-retention configuration property or iceberg.expire_snapshots_min_retention session property");
+    }
+
+    @Test
+    public void testRemoveOrphanFilesWithUnexpectedMissingManifest()
+            throws Exception
+    {
+        String tableName = "test_remove_orphan_files_with_missing_manifest_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " (key varchar, value integer)");
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('one', 1)", 1);
+        String manifestFileToRemove = (String) computeScalar("SELECT path FROM \"" + tableName + "$manifests\"");
+        fileSystem.deleteFile(Location.of(manifestFileToRemove));
+
+        assertThat(query("ALTER TABLE " + tableName + " EXECUTE REMOVE_ORPHAN_FILES"))
+                .failure()
+                .hasErrorCode(ICEBERG_INVALID_METADATA)
+                .hasMessage("Manifest file does not exist: " + manifestFileToRemove);
     }
 
     @Test


### PR DESCRIPTION
Fix the problem that missing manifest file caused incorrect exception classification during orphan file cleanup in Iceberg by catching `NotFoundException` and materialized it to external exception

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

The stacktrace when doing cleanup among the corrupted table:
```
	Suppressed: java.lang.Exception: SQL: ALTER TABLE test_remove_orphan_files_with_missing_manifest_oe9bnvdqt3 EXECUTE REMOVE_ORPHAN_FILES
		at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:572)
		... 10 more
Caused by: org.apache.iceberg.exceptions.NotFoundException: Failed to open input stream for file: local:///tpch/test_remove_orphan_files_with_missing_manifest_oe9bnvdqt3-aa1fbac9a99143dea362bc718ac39b22/metadata/8f654ea3-dcf9-4a00-9379-2c07bb3986bd-m0.avro
	at io.trino.plugin.iceberg.fileio.ForwardingInputFile.newStream(ForwardingInputFile.java:55)
	at org.apache.iceberg.avro.AvroIterable.newFileReader(AvroIterable.java:102)
	at org.apache.iceberg.avro.AvroIterable.getMetadata(AvroIterable.java:66)
	at org.apache.iceberg.ManifestReader.readMetadata(ManifestReader.java:157)
	at org.apache.iceberg.ManifestReader.readPartitionSpec(ManifestReader.java:136)
	at org.apache.iceberg.ManifestReader.<init>(ManifestReader.java:129)
	at org.apache.iceberg.ManifestFiles.read(ManifestFiles.java:138)
	at org.apache.iceberg.ManifestFiles.read(ManifestFiles.java:114)
	at io.trino.plugin.iceberg.IcebergMetadata.readerForManifest(IcebergMetadata.java:2339)
	at io.trino.plugin.iceberg.IcebergMetadata.removeOrphanFiles(IcebergMetadata.java:2268)
	at io.trino.plugin.iceberg.IcebergMetadata.executeRemoveOrphanFiles(IcebergMetadata.java:2242)
	at io.trino.plugin.iceberg.IcebergMetadata.executeTableExecute(IcebergMetadata.java:2104)
	at io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata.executeTableExecute(ClassLoaderSafeConnectorMetadata.java:217)
	at io.trino.tracing.TracingConnectorMetadata.executeTableExecute(TracingConnectorMetadata.java:188)
	at io.trino.metadata.MetadataManager.executeTableExecute(MetadataManager.java:371)
	at io.trino.tracing.TracingMetadata.executeTableExecute(TracingMetadata.java:238)
	at io.trino.operator.SimpleTableExecuteOperator.getOutput(SimpleTableExecuteOperator.java:128)
	at io.trino.operator.Driver.processInternal(Driver.java:403)
	at io.trino.operator.Driver.lambda$process$8(Driver.java:306)
	at io.trino.operator.Driver.tryWithLock(Driver.java:709)
	at io.trino.operator.Driver.process(Driver.java:298)
	at io.trino.operator.Driver.processForDuration(Driver.java:269)
	at io.trino.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:890)
	at io.trino.execution.executor.dedicated.SplitProcessor.run(SplitProcessor.java:77)
	at io.trino.execution.executor.dedicated.TaskEntry$VersionEmbedderBridge.lambda$run$0(TaskEntry.java:201)
	at io.trino.$gen.Trino_testversion____20250507_061334_71.run(Unknown Source)
	at io.trino.execution.executor.dedicated.TaskEntry$VersionEmbedderBridge.run(TaskEntry.java:202)
	at io.trino.execution.executor.scheduler.FairScheduler.runTask(FairScheduler.java:177)
	at io.trino.execution.executor.scheduler.FairScheduler.lambda$submit$0(FairScheduler.java:164)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:128)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:74)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:80)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1575)
Caused by: java.io.FileNotFoundException: local:///tpch/test_remove_orphan_files_with_missing_manifest_oe9bnvdqt3-aa1fbac9a99143dea362bc718ac39b22/metadata/8f654ea3-dcf9-4a00-9379-2c07bb3986bd-m0.avro
	at io.trino.filesystem.memory.MemoryFileSystemCache.handleException(MemoryFileSystemCache.java:192)
	at io.trino.filesystem.memory.MemoryFileSystemCache.getOrLoadFromCache(MemoryFileSystemCache.java:172)
	at io.trino.filesystem.memory.MemoryFileSystemCache.cacheStream(MemoryFileSystemCache.java:92)
	at io.trino.filesystem.tracing.TracingFileSystemCache.lambda$cacheStream$1(TracingFileSystemCache.java:66)
	at io.trino.filesystem.tracing.Tracing.withTracing(Tracing.java:51)
	at io.trino.filesystem.tracing.TracingFileSystemCache.cacheStream(TracingFileSystemCache.java:66)
	at io.trino.filesystem.cache.CacheInputFile.newStream(CacheInputFile.java:63)
	at io.trino.plugin.iceberg.fileio.ForwardingInputFile.newStream(ForwardingInputFile.java:52)
	... 35 more
Caused by: java.io.FileNotFoundException: local:///tpch/test_remove_orphan_files_with_missing_manifest_oe9bnvdqt3-aa1fbac9a99143dea362bc718ac39b22/metadata/8f654ea3-dcf9-4a00-9379-2c07bb3986bd-m0.avro
	at io.trino.filesystem.local.LocalUtils.handleException(LocalUtils.java:31)
	at io.trino.filesystem.local.LocalInputFile.newInput(LocalInputFile.java:71)
	at io.trino.filesystem.tracing.TracingInputFile.lambda$newInput$0(TracingInputFile.java:55)
	at io.trino.filesystem.tracing.Tracing.withTracing(Tracing.java:51)
	at io.trino.filesystem.tracing.TracingInputFile.newInput(TracingInputFile.java:55)
	at io.trino.filesystem.memory.MemoryFileSystemCache.load(MemoryFileSystemCache.java:183)
	at io.trino.filesystem.memory.MemoryFileSystemCache.lambda$getOrLoadFromCache$3(MemoryFileSystemCache.java:169)
	at com.google.common.cache.LocalCache$LocalManualCache$1.load(LocalCache.java:4860)
	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3551)
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2302)
	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2177)
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2068)
	at com.google.common.cache.LocalCache.get(LocalCache.java:3986)
	at com.google.common.cache.LocalCache$LocalManualCache.get(LocalCache.java:4855)
	at io.trino.cache.EvictableCache.get(EvictableCache.java:119)
	at io.trino.filesystem.memory.MemoryFileSystemCache.getOrLoadFromCache(MemoryFileSystemCache.java:169)
	... 41 more
Caused by: java.io.FileNotFoundException: /var/folders/lh/g0w6wqsj6bn89r833mg1wz380000gp/T/TrinoTest9300946782825374816/iceberg_data/tpch/test_remove_orphan_files_with_missing_manifest_oe9bnvdqt3-aa1fbac9a99143dea362bc718ac39b22/metadata/8f654ea3-dcf9-4a00-9379-2c07bb3986bd-m0.avro (No such file or directory)
	at java.base/java.io.RandomAccessFile.open0(Native Method)
	at java.base/java.io.RandomAccessFile.open(RandomAccessFile.java:366)
	at java.base/java.io.RandomAccessFile.<init>(RandomAccessFile.java:285)
	at java.base/java.io.RandomAccessFile.<init>(RandomAccessFile.java:231)
	at io.trino.filesystem.local.LocalInput.<init>(LocalInput.java:42)
	at io.trino.filesystem.local.LocalInputFile.newInput(LocalInputFile.java:68)
	... 55 more
``` 

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
