### PR TITLE
Enable Authentication for Google Sheet Connector Using Delegated User Credentials

### DIFF
--- a/docs/src/main/sphinx/connector/googlesheets.md
+++ b/docs/src/main/sphinx/connector/googlesheets.md
@@ -21,16 +21,17 @@ gsheets.metadata-sheet-id=exampleId
 
 The following configuration properties are available:
 
-| Property name                 | Description                                                      |
-| ----------------------------- | ---------------------------------------------------------------- |
-| `gsheets.credentials-path`    | Path to the Google API JSON key file                             |
-| `gsheets.credentials-key`     | The base64 encoded credentials key                               |
-| `gsheets.metadata-sheet-id`   | Sheet ID of the spreadsheet, that contains the table mapping     |
-| `gsheets.max-data-cache-size` | Maximum number of spreadsheets to cache, defaults to `1000`      |
-| `gsheets.data-cache-ttl`      | How long to cache spreadsheet data or metadata, defaults to `5m` |
-| `gsheets.connection-timeout`  | Timeout when connection to Google Sheets API, defaults to `20s`  |
-| `gsheets.read-timeout`        | Timeout when reading from Google Sheets API, defaults to `20s`   |
-| `gsheets.write-timeout`       | Timeout when writing to Google Sheets API, defaults to `20s`     |
+| Property name                  | Description                                                                       |
+|--------------------------------|-----------------------------------------------------------------------------------|
+| `gsheets.credentials-path`     | Path to the Google API JSON key file                                              |
+| `gsheets.credentials-key`      | The base64 encoded credentials key                                                |
+| `gsheets.delegated-user-email` | User email to impersonate the service account with domain-wide delegation enabled |
+| `gsheets.metadata-sheet-id`    | Sheet ID of the spreadsheet, that contains the table mapping                      |
+| `gsheets.max-data-cache-size`  | Maximum number of spreadsheets to cache, defaults to `1000`                       |
+| `gsheets.data-cache-ttl`       | How long to cache spreadsheet data or metadata, defaults to `5m`                  |
+| `gsheets.connection-timeout`   | Timeout when connection to Google Sheets API, defaults to `20s`                   |
+| `gsheets.read-timeout`         | Timeout when reading from Google Sheets API, defaults to `20s`                    |
+| `gsheets.write-timeout`        | Timeout when writing to Google Sheets API, defaults to `20s`                      |
 
 ## Credentials
 
@@ -50,6 +51,9 @@ The exact name of the file does not matter -- it can be named anything.
 
 Alternatively, set the `gsheets.credentials-key` configuration property.
 It should contain the contents of the JSON file, encoded using base64.
+
+Optionally, set the `gsheets.delegated-user-email` property to impersonate a user.
+This allows you to share Google Sheets with this email instead of the service account.
 
 ## Metadata sheet
 

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsConfig.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsConfig.java
@@ -31,6 +31,7 @@ public class SheetsConfig
 {
     private Optional<String> credentialsFilePath = Optional.empty();
     private Optional<String> credentialsKey = Optional.empty();
+    private String delegatedUserEmail;
     private Optional<String> metadataSheetId = Optional.empty();
     private int sheetsDataMaxCacheSize = 1000;
     private Duration sheetsDataExpireAfterWrite = new Duration(5, TimeUnit.MINUTES);
@@ -72,6 +73,20 @@ public class SheetsConfig
     public SheetsConfig setCredentialsKey(String credentialsKey)
     {
         this.credentialsKey = Optional.ofNullable(credentialsKey);
+        return this;
+    }
+
+    @NotNull
+    public Optional<String> getDelegatedUserEmail()
+    {
+        return Optional.ofNullable(delegatedUserEmail);
+    }
+
+    @Config("gsheets.delegated-user-email")
+    @ConfigDescription("Delegated user email to impersonate the service account")
+    public SheetsConfig setDelegatedUserEmail(String delegatedUserEmail)
+    {
+        this.delegatedUserEmail = delegatedUserEmail;
         return this;
     }
 

--- a/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestSheetsConfig.java
+++ b/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestSheetsConfig.java
@@ -46,6 +46,7 @@ public class TestSheetsConfig
         assertRecordedDefaults(recordDefaults(SheetsConfig.class)
                 .setCredentialsFilePath(null)
                 .setCredentialsKey(null)
+                .setDelegatedUserEmail(null)
                 .setMetadataSheetId(null)
                 .setSheetsDataMaxCacheSize(1000)
                 .setSheetsDataExpireAfterWrite(new Duration(5, TimeUnit.MINUTES))
@@ -62,6 +63,7 @@ public class TestSheetsConfig
 
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("gsheets.credentials-path", credentialsFile.toString())
+                .put("gsheets.delegated-user-email", "fooBar@gmail.com")
                 .put("gsheets.metadata-sheet-id", "foo_bar_sheet_id#Sheet1")
                 .put("gsheets.max-data-cache-size", "2000")
                 .put("gsheets.data-cache-ttl", "10m")
@@ -75,6 +77,7 @@ public class TestSheetsConfig
 
         assertThat(config.getCredentialsKey()).isEqualTo(Optional.empty());
         assertThat(config.getCredentialsFilePath()).isEqualTo(Optional.of(credentialsFile.toString()));
+        assertThat(config.getDelegatedUserEmail()).contains("fooBar@gmail.com");
         assertThat(config.getMetadataSheetId()).isEqualTo(Optional.of("foo_bar_sheet_id#Sheet1"));
         assertThat(config.getSheetsDataMaxCacheSize()).isEqualTo(2000);
         assertThat(config.getSheetsDataExpireAfterWrite()).isEqualTo(Duration.valueOf("10m"));
@@ -88,6 +91,7 @@ public class TestSheetsConfig
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("gsheets.credentials-key", BASE_64_ENCODED_TEST_KEY)
+                .put("gsheets.delegated-user-email", "fooBar@gmail.com")
                 .put("gsheets.metadata-sheet-id", "foo_bar_sheet_id#Sheet1")
                 .put("gsheets.max-data-cache-size", "2000")
                 .put("gsheets.data-cache-ttl", "10m")
@@ -99,6 +103,7 @@ public class TestSheetsConfig
 
         assertThat(config.getCredentialsKey()).isEqualTo(Optional.of(BASE_64_ENCODED_TEST_KEY));
         assertThat(config.getCredentialsFilePath()).isEqualTo(Optional.empty());
+        assertThat(config.getDelegatedUserEmail()).contains("fooBar@gmail.com");
         assertThat(config.getMetadataSheetId()).isEqualTo(Optional.of("foo_bar_sheet_id#Sheet1"));
         assertThat(config.getSheetsDataMaxCacheSize()).isEqualTo(2000);
         assertThat(config.getSheetsDataExpireAfterWrite()).isEqualTo(Duration.valueOf("10m"));


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
This change lets the Google Sheets connector to authenticate by using delegated user credentials instead of raw service-account identity (which lives outside the domain). By supplying a “delegated user” email address, the connector will:
1. Obtain domain-wide delegated credentials for that user
2. Build a Sheets client under the user’s identity

Since the domain of google service account is different from the organization's Google workspace domain, this change allows to share the google sheets only within the Google workspace domain of the organization. 
<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

1. **New Config option**: `gsheets.delegated-user-email`
2. **Auth Flow Update**: If `gsheets.delegated-user-email` is set, we load the service-account key, request the delegated credentials for that user, and build the Sheets client with those credentials.
3. **Backward compatibility**: Falls back to plain service-account authentication when no delegated user email is provided.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x ) Release notes are required, with the following suggested text:

```markdown
## Google Sheets Connector
* Add support for authentication using delegated user credentials using the `gsheets.delegated-user-email` config property. 
```
