### PR TITLE
Improve cache invalidation by keying on path and table name

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
@@ -525,7 +525,7 @@ public class BackgroundHiveSplitLoader
     {
         TrinoFileSystem trinoFileSystem = fileSystemFactory.create(session);
         // Check if location is cached BEFORE using the directoryLister
-        boolean isCached = directoryLister.isCached(location);
+        boolean isCached = directoryLister.isCached(location, table.getSchemaTableName());
 
         Map<String, TrinoFileStatus> fileStatuses = new HashMap<>();
         Iterator<TrinoFileStatus> fileStatusIterator = new HiveFileIterator(table, location, trinoFileSystem, directoryLister, RECURSE);
@@ -540,7 +540,7 @@ public class BackgroundHiveSplitLoader
                     .anyMatch(path -> !fileStatuses.containsKey(path.path()));
             // Invalidate the cache and reload
             if (missing) {
-                directoryLister.invalidate(location);
+                directoryLister.invalidate(location, table.getSchemaTableName());
 
                 fileStatuses.clear();
                 fileStatusIterator = new HiveFileIterator(table, location, trinoFileSystem, directoryLister, RECURSE);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TableInvalidationCallback.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TableInvalidationCallback.java
@@ -16,15 +16,16 @@ package io.trino.plugin.hive;
 import io.trino.filesystem.Location;
 import io.trino.metastore.Partition;
 import io.trino.metastore.Table;
+import io.trino.spi.connector.SchemaTableName;
 
 public interface TableInvalidationCallback
 {
-    default boolean isCached(Location location)
+    default boolean isCached(Location location, SchemaTableName schemaTableName)
     {
         return false;
     }
 
-    default void invalidate(Location location) {}
+    default void invalidate(Location location, SchemaTableName schemaTableName) {}
 
     default void invalidate(Partition partition) {}
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/CachingDirectoryLister.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/CachingDirectoryLister.java
@@ -18,6 +18,7 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.Weigher;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
+import io.airlift.log.Logger;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.cache.EvictableCacheBuilder;
@@ -51,9 +52,9 @@ import static java.util.function.Predicate.not;
 public class CachingDirectoryLister
         implements DirectoryLister
 {
-    //TODO use a cache key based on Path & SchemaTableName and iterate over the cache keys
-    // to deal more efficiently with cache invalidation scenarios for partitioned tables.
-    private final Cache<Location, ValueHolder> cache;
+    private static final Logger log = Logger.get(CachingDirectoryLister.class);
+
+    private final Cache<CacheKey, ValueHolder> cache;
     private final Predicate<SchemaTableName> tablePredicate;
     private final Predicate<FileEntry> filterPredicate;
 
@@ -82,7 +83,7 @@ public class CachingDirectoryLister
         requireNonNull(filterPredicate, "filterPredicate is null");
         this.cache = EvictableCacheBuilder.newBuilder()
                 .maximumWeight(maxSize.toBytes())
-                .weigher((Weigher<Location, ValueHolder>) (key, value) -> toIntExact(estimatedSizeOf(key.toString()) + value.getRetainedSizeInBytes()))
+                .weigher((Weigher<CacheKey, ValueHolder>) (key, value) -> toIntExact(key.getRetainedSizeInBytes() + value.getRetainedSizeInBytes()))
                 .expireAfterWrite(expireAfterWrite.toMillis(), TimeUnit.MILLISECONDS)
                 .shareNothingWhenDisabled()
                 .recordStats()
@@ -123,18 +124,19 @@ public class CachingDirectoryLister
             return new TrinoFileStatusRemoteIterator(fs.listFiles(location), filterPredicate);
         }
 
-        return listInternal(fs, location);
+        return listInternal(fs, location, table.getSchemaTableName());
     }
 
-    private RemoteIterator<TrinoFileStatus> listInternal(TrinoFileSystem fs, Location location)
+    private RemoteIterator<TrinoFileStatus> listInternal(TrinoFileSystem fs, Location location, SchemaTableName schemaTableName)
             throws IOException
     {
-        ValueHolder cachedValueHolder = uncheckedCacheGet(cache, location, ValueHolder::new);
+        CacheKey cacheKey = new CacheKey(location, schemaTableName);
+        ValueHolder cachedValueHolder = uncheckedCacheGet(cache, cacheKey, ValueHolder::new);
         if (cachedValueHolder.getFiles().isPresent()) {
             return new SimpleRemoteIterator(cachedValueHolder.getFiles().get().iterator());
         }
 
-        return cachingRemoteIterator(cachedValueHolder, createListingRemoteIterator(fs, location, filterPredicate), location);
+        return cachingRemoteIterator(cachedValueHolder, createListingRemoteIterator(fs, location, filterPredicate), cacheKey);
     }
 
     private static RemoteIterator<TrinoFileStatus> createListingRemoteIterator(TrinoFileSystem fs, Location location, Predicate<FileEntry> filterPredicate)
@@ -144,9 +146,10 @@ public class CachingDirectoryLister
     }
 
     @Override
-    public void invalidate(Location location)
+    public void invalidate(Location location, SchemaTableName schemaTableName)
     {
-        cache.invalidate(location);
+        log.debug("Invalidating cache for schemaTableName: %s and location: %s", schemaTableName, location);
+        cache.invalidate(new CacheKey(location, schemaTableName));
     }
 
     @Override
@@ -154,11 +157,14 @@ public class CachingDirectoryLister
     {
         if (isCacheEnabledFor(table.getSchemaTableName()) && isLocationPresent(table.getStorage())) {
             if (table.getPartitionColumns().isEmpty()) {
-                cache.invalidate(Location.of(table.getStorage().getLocation()));
+                log.debug("Invalidating cache for unpartitioned table: %s", table.getSchemaTableName());
+                cache.invalidate(new CacheKey(Location.of(table.getStorage().getLocation()), table.getSchemaTableName()));
             }
             else {
                 // a partitioned table can have multiple paths in cache
-                cache.invalidateAll();
+                SchemaTableName tableName = table.getSchemaTableName();
+                log.debug("Invalidating cache for partitioned table: %s", table.getSchemaTableName());
+                cache.asMap().keySet().removeIf(key -> key.schemaTableName().equals(tableName));
             }
         }
     }
@@ -167,17 +173,20 @@ public class CachingDirectoryLister
     public void invalidate(Partition partition)
     {
         if (isCacheEnabledFor(partition.getSchemaTableName()) && isLocationPresent(partition.getStorage())) {
-            cache.invalidate(Location.of(partition.getStorage().getLocation()));
+            log.debug("Invalidating partition cache for table: %s partition: %s", partition.getSchemaTableName(), partition.getStorage().getLocation());
+            Location partitionLocation = Location.of(partition.getStorage().getLocation());
+            cache.invalidate(new CacheKey(partitionLocation, partition.getSchemaTableName()));
         }
     }
 
     @Override
     public void invalidateAll()
     {
+        log.debug("Invalidating partition cache (all)");
         cache.invalidateAll();
     }
 
-    private RemoteIterator<TrinoFileStatus> cachingRemoteIterator(ValueHolder cachedValueHolder, RemoteIterator<TrinoFileStatus> iterator, Location location)
+    private RemoteIterator<TrinoFileStatus> cachingRemoteIterator(ValueHolder cachedValueHolder, RemoteIterator<TrinoFileStatus> iterator, CacheKey cacheKey)
     {
         return new RemoteIterator<>()
         {
@@ -191,7 +200,7 @@ public class CachingDirectoryLister
                 if (!hasNext) {
                     // The cachedValueHolder acts as an invalidation guard. If a cache invalidation happens while this iterator goes over
                     // the files from the specified path, the eventually outdated file listing will not be added anymore to the cache.
-                    cache.asMap().replace(location, cachedValueHolder, new ValueHolder(files));
+                    cache.asMap().replace(cacheKey, cachedValueHolder, new ValueHolder(files));
                 }
                 return hasNext;
             }
@@ -244,9 +253,9 @@ public class CachingDirectoryLister
     }
 
     @Override
-    public boolean isCached(Location location)
+    public boolean isCached(Location location, SchemaTableName schemaTableName)
     {
-        ValueHolder cached = cache.getIfPresent(location);
+        ValueHolder cached = cache.getIfPresent(new CacheKey(location, schemaTableName));
         return cached != null && cached.getFiles().isPresent();
     }
 
@@ -291,6 +300,24 @@ public class CachingDirectoryLister
         public long getRetainedSizeInBytes()
         {
             return INSTANCE_SIZE + sizeOf(files, value -> estimatedSizeOf(value, TrinoFileStatus::getRetainedSizeInBytes));
+        }
+    }
+
+    private record CacheKey(Location location, SchemaTableName schemaTableName)
+    {
+        private static final long INSTANCE_SIZE = instanceSize(CacheKey.class);
+
+        private CacheKey(Location location, SchemaTableName schemaTableName)
+        {
+            this.location = requireNonNull(location, "location is null");
+            this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
+        }
+
+        public long getRetainedSizeInBytes()
+        {
+            return INSTANCE_SIZE +
+                    estimatedSizeOf(location.toString()) +
+                    schemaTableName.getRetainedSizeInBytes();
         }
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/TransactionDirectoryListingCacheKey.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/TransactionDirectoryListingCacheKey.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.hive.fs;
 
 import io.trino.filesystem.Location;
+import io.trino.spi.connector.SchemaTableName;
 
 import java.util.Objects;
 
@@ -28,11 +29,13 @@ public class TransactionDirectoryListingCacheKey
 
     private final long transactionId;
     private final Location path;
+    private final SchemaTableName schemaTableName;
 
-    public TransactionDirectoryListingCacheKey(long transactionId, Location path)
+    public TransactionDirectoryListingCacheKey(long transactionId, Location path, SchemaTableName schemaTableName)
     {
         this.transactionId = transactionId;
         this.path = requireNonNull(path, "path is null");
+        this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
     }
 
     public Location getPath()
@@ -40,9 +43,16 @@ public class TransactionDirectoryListingCacheKey
         return path;
     }
 
+    public SchemaTableName getSchemaTableName()
+    {
+        return schemaTableName;
+    }
+
     public long getRetainedSizeInBytes()
     {
-        return INSTANCE_SIZE + estimatedSizeOf(path.toString());
+        return INSTANCE_SIZE +
+               estimatedSizeOf(path.toString()) +
+                schemaTableName.getRetainedSizeInBytes();
     }
 
     @Override
@@ -55,13 +65,15 @@ public class TransactionDirectoryListingCacheKey
             return false;
         }
         TransactionDirectoryListingCacheKey that = (TransactionDirectoryListingCacheKey) o;
-        return transactionId == that.transactionId && path.equals(that.path);
+        return transactionId == that.transactionId &&
+               path.equals(that.path) &&
+               schemaTableName.equals(that.schemaTableName);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(transactionId, path);
+        return Objects.hash(transactionId, path, schemaTableName);
     }
 
     @Override
@@ -70,6 +82,7 @@ public class TransactionDirectoryListingCacheKey
         return toStringHelper(this)
                 .add("transactionId", transactionId)
                 .add("path", path)
+                .add("schemaTableName", schemaTableName)
                 .toString();
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/TransactionScopeCachingDirectoryListerFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/TransactionScopeCachingDirectoryListerFactory.java
@@ -29,8 +29,6 @@ import static java.util.Objects.requireNonNull;
 
 public class TransactionScopeCachingDirectoryListerFactory
 {
-    //TODO use a cache key based on Path & SchemaTableName and iterate over the cache keys
-    // to deal more efficiently with cache invalidation scenarios for partitioned tables.
     private final Optional<Cache<TransactionDirectoryListingCacheKey, FetchingValueHolder>> cache;
     private final AtomicLong nextTransactionId = new AtomicLong();
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/BaseCachingDirectoryListerTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/BaseCachingDirectoryListerTest.java
@@ -36,6 +36,7 @@ import java.util.concurrent.TimeUnit;
 
 import static io.trino.plugin.hive.HiveQueryRunner.TPCH_SCHEMA;
 import static io.trino.plugin.hive.TestingHiveUtils.getConnectorService;
+import static io.trino.spi.connector.SchemaTableName.schemaTableName;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -68,19 +69,19 @@ public abstract class BaseCachingDirectoryListerTest
         // The listing for the invalidate_non_partitioned_table1 should be in the directory cache after this call
         assertQuery("SELECT sum(col1) FROM partial_cache_invalidation_table1", "VALUES (6)");
         String cachedTable1Location = getTableLocation(TPCH_SCHEMA, "partial_cache_invalidation_table1");
-        assertThat(isCached(cachedTable1Location)).isTrue();
+        assertThat(isCached(cachedTable1Location, schemaTableName(TPCH_SCHEMA, "partial_cache_invalidation_table1"))).isTrue();
 
         assertUpdate("CREATE TABLE partial_cache_invalidation_table2 (col1 int) WITH (format = 'ORC')");
         assertUpdate("INSERT INTO partial_cache_invalidation_table2 VALUES (11), (12)", 2);
         // The listing for the invalidate_non_partitioned_table2 should be in the directory cache after this call
         assertQuery("SELECT sum(col1) FROM partial_cache_invalidation_table2", "VALUES (23)");
         String cachedTable2Location = getTableLocation(TPCH_SCHEMA, "partial_cache_invalidation_table2");
-        assertThat(isCached(cachedTable2Location)).isTrue();
+        assertThat(isCached(cachedTable2Location, schemaTableName(TPCH_SCHEMA, "partial_cache_invalidation_table2"))).isTrue();
 
         assertUpdate("INSERT INTO partial_cache_invalidation_table1 VALUES (4), (5)", 2);
         // Inserting into the invalidate_non_partitioned_table1 should invalidate only the cached listing of the files belonging only to this table.
-        assertThat(isCached(cachedTable1Location)).isFalse();
-        assertThat(isCached(cachedTable2Location)).isTrue();
+        assertThat(isCached(cachedTable1Location, schemaTableName(TPCH_SCHEMA, "partial_cache_invalidation_table1"))).isFalse();
+        assertThat(isCached(cachedTable2Location, schemaTableName(TPCH_SCHEMA, "partial_cache_invalidation_table2"))).isTrue();
 
         assertQuery("SELECT sum(col1) FROM partial_cache_invalidation_table1", "VALUES (15)");
         assertQuery("SELECT sum(col1) FROM partial_cache_invalidation_table2", "VALUES (23)");
@@ -97,27 +98,27 @@ public abstract class BaseCachingDirectoryListerTest
         // The listing for the invalidate_non_partitioned_table1 should be in the directory cache after this call
         assertQuery("SELECT sum(col1) FROM full_cache_invalidation_non_partitioned_table", "VALUES (6)");
         String nonPartitionedTableLocation = getTableLocation(TPCH_SCHEMA, "full_cache_invalidation_non_partitioned_table");
-        assertThat(isCached(nonPartitionedTableLocation)).isTrue();
+        assertThat(isCached(nonPartitionedTableLocation, schemaTableName(TPCH_SCHEMA, "full_cache_invalidation_non_partitioned_table"))).isTrue();
 
         assertUpdate("CREATE TABLE full_cache_invalidation_partitioned_table (col1 int, col2 varchar) WITH (format = 'ORC', partitioned_by = ARRAY['col2'])");
         assertUpdate("INSERT INTO full_cache_invalidation_partitioned_table VALUES (1, 'group1'), (2, 'group1'), (3, 'group2'), (4, 'group2')", 4);
         assertQuery("SELECT col2, sum(col1) FROM full_cache_invalidation_partitioned_table GROUP BY col2", "VALUES ('group1', 3), ('group2', 7)");
         String partitionedTableGroup1PartitionLocation = getPartitionLocation(TPCH_SCHEMA, "full_cache_invalidation_partitioned_table", ImmutableList.of("group1"));
         String partitionedTableGroup2PartitionLocation = getPartitionLocation(TPCH_SCHEMA, "full_cache_invalidation_partitioned_table", ImmutableList.of("group2"));
-        assertThat(isCached(partitionedTableGroup1PartitionLocation)).isTrue();
-        assertThat(isCached(partitionedTableGroup2PartitionLocation)).isTrue();
+        assertThat(isCached(partitionedTableGroup1PartitionLocation, schemaTableName(TPCH_SCHEMA, "full_cache_invalidation_partitioned_table"))).isTrue();
+        assertThat(isCached(partitionedTableGroup2PartitionLocation, schemaTableName(TPCH_SCHEMA, "full_cache_invalidation_partitioned_table"))).isTrue();
 
         assertUpdate("INSERT INTO full_cache_invalidation_non_partitioned_table VALUES (4), (5)", 2);
         // Inserting into the invalidate_non_partitioned_table1 should invalidate only the cached listing of the files belonging only to this table.
-        assertThat(isCached(nonPartitionedTableLocation)).isFalse();
-        assertThat(isCached(partitionedTableGroup1PartitionLocation)).isTrue();
-        assertThat(isCached(partitionedTableGroup2PartitionLocation)).isTrue();
+        assertThat(isCached(nonPartitionedTableLocation, schemaTableName(TPCH_SCHEMA, "full_cache_invalidation_non_partitioned_table"))).isFalse();
+        assertThat(isCached(partitionedTableGroup1PartitionLocation, schemaTableName(TPCH_SCHEMA, "full_cache_invalidation_partitioned_table"))).isTrue();
+        assertThat(isCached(partitionedTableGroup2PartitionLocation, schemaTableName(TPCH_SCHEMA, "full_cache_invalidation_partitioned_table"))).isTrue();
 
         assertUpdate("DROP TABLE full_cache_invalidation_partitioned_table");
         // Invalidation of the partitioned table causes the full invalidation of the cache
-        assertThat(isCached(nonPartitionedTableLocation)).isFalse();
-        assertThat(isCached(partitionedTableGroup1PartitionLocation)).isFalse();
-        assertThat(isCached(partitionedTableGroup2PartitionLocation)).isFalse();
+        assertThat(isCached(nonPartitionedTableLocation, schemaTableName(TPCH_SCHEMA, "full_cache_invalidation_non_partitioned_table"))).isFalse();
+        assertThat(isCached(partitionedTableGroup1PartitionLocation, schemaTableName(TPCH_SCHEMA, "full_cache_invalidation_partitioned_table"))).isFalse();
+        assertThat(isCached(partitionedTableGroup2PartitionLocation, schemaTableName(TPCH_SCHEMA, "full_cache_invalidation_partitioned_table"))).isFalse();
 
         assertQuery("SELECT sum(col1) FROM full_cache_invalidation_non_partitioned_table", "VALUES (15)");
 
@@ -132,20 +133,20 @@ public abstract class BaseCachingDirectoryListerTest
         // The listing for the invalidate_non_partitioned_table1 should be in the directory cache after this call
         assertQuery("SELECT sum(col1) FROM partition_path_cache_invalidation_non_partitioned_table", "VALUES (6)");
         String nonPartitionedTableLocation = getTableLocation(TPCH_SCHEMA, "partition_path_cache_invalidation_non_partitioned_table");
-        assertThat(isCached(nonPartitionedTableLocation)).isTrue();
+        assertThat(isCached(nonPartitionedTableLocation, schemaTableName(TPCH_SCHEMA, "partition_path_cache_invalidation_non_partitioned_table"))).isTrue();
 
         assertUpdate("CREATE TABLE partition_path_cache_invalidation_partitioned_table (col1 int, col2 varchar) WITH (format = 'ORC', partitioned_by = ARRAY['col2'])");
         assertUpdate("INSERT INTO partition_path_cache_invalidation_partitioned_table VALUES (1, 'group1'), (2, 'group1'), (3, 'group2'), (4, 'group2')", 4);
         assertQuery("SELECT col2, sum(col1) FROM partition_path_cache_invalidation_partitioned_table GROUP BY col2", "VALUES ('group1', 3), ('group2', 7)");
         String partitionedTableGroup1PartitionLocation = getPartitionLocation(TPCH_SCHEMA, "partition_path_cache_invalidation_partitioned_table", ImmutableList.of("group1"));
         String partitionedTableGroup2PartitionLocation = getPartitionLocation(TPCH_SCHEMA, "partition_path_cache_invalidation_partitioned_table", ImmutableList.of("group2"));
-        assertThat(isCached(partitionedTableGroup1PartitionLocation)).isTrue();
-        assertThat(isCached(partitionedTableGroup2PartitionLocation)).isTrue();
+        assertThat(isCached(partitionedTableGroup1PartitionLocation, schemaTableName(TPCH_SCHEMA, "partition_path_cache_invalidation_partitioned_table"))).isTrue();
+        assertThat(isCached(partitionedTableGroup2PartitionLocation, schemaTableName(TPCH_SCHEMA, "partition_path_cache_invalidation_partitioned_table"))).isTrue();
 
         assertUpdate("DELETE FROM partition_path_cache_invalidation_partitioned_table WHERE col2='group1'");
-        assertThat(isCached(nonPartitionedTableLocation)).isTrue();
-        assertThat(isCached(partitionedTableGroup1PartitionLocation)).isFalse();
-        assertThat(isCached(partitionedTableGroup2PartitionLocation)).isTrue();
+        assertThat(isCached(nonPartitionedTableLocation, schemaTableName(TPCH_SCHEMA, "partition_path_cache_invalidation_non_partitioned_table"))).isTrue();
+        assertThat(isCached(partitionedTableGroup1PartitionLocation, schemaTableName(TPCH_SCHEMA, "partition_path_cache_invalidation_partitioned_table"))).isFalse();
+        assertThat(isCached(partitionedTableGroup2PartitionLocation, schemaTableName(TPCH_SCHEMA, "partition_path_cache_invalidation_partitioned_table"))).isTrue();
 
         assertQuery("SELECT sum(col1) FROM partition_path_cache_invalidation_non_partitioned_table", "VALUES (6)");
         assertQuery("SELECT col2, sum(col1) FROM partition_path_cache_invalidation_partitioned_table GROUP BY col2", "VALUES ('group2', 7)");
@@ -161,10 +162,10 @@ public abstract class BaseCachingDirectoryListerTest
         assertUpdate("INSERT INTO insert_into_non_partitioned_table VALUES (1), (2), (3)", 3);
         // The listing for the table should be in the directory cache after this call
         assertQuery("SELECT sum(col1) FROM insert_into_non_partitioned_table", "VALUES (6)");
-        assertThat(isCached(getTableLocation(TPCH_SCHEMA, "insert_into_non_partitioned_table"))).isTrue();
+        assertThat(isCached(getTableLocation(TPCH_SCHEMA, "insert_into_non_partitioned_table"), schemaTableName(TPCH_SCHEMA, "insert_into_non_partitioned_table"))).isTrue();
         assertUpdate("INSERT INTO insert_into_non_partitioned_table VALUES (4), (5)", 2);
         // Inserting into the table should invalidate the cached listing of the files belonging to the table.
-        assertThat(isCached(getTableLocation(TPCH_SCHEMA, "insert_into_non_partitioned_table"))).isFalse();
+        assertThat(isCached(getTableLocation(TPCH_SCHEMA, "insert_into_non_partitioned_table"), schemaTableName(TPCH_SCHEMA, "insert_into_non_partitioned_table"))).isFalse();
 
         assertQuery("SELECT sum(col1) FROM insert_into_non_partitioned_table", "VALUES (15)");
 
@@ -180,13 +181,13 @@ public abstract class BaseCachingDirectoryListerTest
         assertQuery("SELECT col2, sum(col1) FROM insert_into_partitioned_table GROUP BY col2", "VALUES ('group1', 3), ('group2', 7)");
         String tableGroup1PartitionLocation = getPartitionLocation(TPCH_SCHEMA, "insert_into_partitioned_table", ImmutableList.of("group1"));
         String tableGroup2PartitionLocation = getPartitionLocation(TPCH_SCHEMA, "insert_into_partitioned_table", ImmutableList.of("group2"));
-        assertThat(isCached(tableGroup1PartitionLocation)).isTrue();
-        assertThat(isCached(tableGroup2PartitionLocation)).isTrue();
+        assertThat(isCached(tableGroup1PartitionLocation, schemaTableName(TPCH_SCHEMA, "insert_into_partitioned_table"))).isTrue();
+        assertThat(isCached(tableGroup2PartitionLocation, schemaTableName(TPCH_SCHEMA, "insert_into_partitioned_table"))).isTrue();
 
         assertUpdate("INSERT INTO insert_into_partitioned_table  VALUES (5, 'group2'), (6, 'group3')", 2);
-        assertThat(isCached(tableGroup1PartitionLocation)).isTrue();
+        assertThat(isCached(tableGroup1PartitionLocation, schemaTableName(TPCH_SCHEMA, "insert_into_partitioned_table"))).isTrue();
         // Inserting into the table should invalidate the cached listing of the partitions affected by the insert statement
-        assertThat(isCached(tableGroup2PartitionLocation)).isFalse();
+        assertThat(isCached(tableGroup2PartitionLocation, schemaTableName(TPCH_SCHEMA, "insert_into_partitioned_table"))).isFalse();
         assertQuery("SELECT col2, sum(col1) FROM insert_into_partitioned_table GROUP BY col2", "VALUES ('group1', 3), ('group2', 12), ('group3', 6)");
 
         assertUpdate("DROP TABLE insert_into_partitioned_table");
@@ -202,13 +203,13 @@ public abstract class BaseCachingDirectoryListerTest
         String tableGroup1PartitionLocation = getPartitionLocation(TPCH_SCHEMA, "delete_from_partitioned_table", ImmutableList.of("group1"));
         String tableGroup2PartitionLocation = getPartitionLocation(TPCH_SCHEMA, "delete_from_partitioned_table", ImmutableList.of("group2"));
         String tableGroup3PartitionLocation = getPartitionLocation(TPCH_SCHEMA, "delete_from_partitioned_table", ImmutableList.of("group3"));
-        assertThat(isCached(tableGroup1PartitionLocation)).isTrue();
-        assertThat(isCached(tableGroup2PartitionLocation)).isTrue();
+        assertThat(isCached(tableGroup1PartitionLocation, schemaTableName(TPCH_SCHEMA, "delete_from_partitioned_table"))).isTrue();
+        assertThat(isCached(tableGroup2PartitionLocation, schemaTableName(TPCH_SCHEMA, "delete_from_partitioned_table"))).isTrue();
         assertUpdate("DELETE FROM delete_from_partitioned_table WHERE col2 = 'group1' OR col2 = 'group2'");
         // Deleting from the table should invalidate the cached listing of the partitions dropped from the table.
-        assertThat(isCached(tableGroup1PartitionLocation)).isFalse();
-        assertThat(isCached(tableGroup2PartitionLocation)).isFalse();
-        assertThat(isCached(tableGroup3PartitionLocation)).isTrue();
+        assertThat(isCached(tableGroup1PartitionLocation, schemaTableName(TPCH_SCHEMA, "delete_from_partitioned_table"))).isFalse();
+        assertThat(isCached(tableGroup2PartitionLocation, schemaTableName(TPCH_SCHEMA, "delete_from_partitioned_table"))).isFalse();
+        assertThat(isCached(tableGroup3PartitionLocation, schemaTableName(TPCH_SCHEMA, "delete_from_partitioned_table"))).isTrue();
         assertQuery("SELECT col2, sum(col1) FROM delete_from_partitioned_table GROUP BY col2", "VALUES ('group3', 5)");
 
         assertUpdate("DROP TABLE delete_from_partitioned_table");
@@ -225,19 +226,19 @@ public abstract class BaseCachingDirectoryListerTest
         String table20220202UsPartitionLocation = getPartitionLocation(TPCH_SCHEMA, "delete_from_partitioned_table", ImmutableList.of("2022-02-02", "US"));
         String table20220201AtPartitionLocation = getPartitionLocation(TPCH_SCHEMA, "delete_from_partitioned_table", ImmutableList.of("2022-02-01", "AT"));
         String table20220202AtPartitionLocation = getPartitionLocation(TPCH_SCHEMA, "delete_from_partitioned_table", ImmutableList.of("2022-02-02", "AT"));
-        assertThat(isCached(table20220201UsPartitionLocation)).isTrue();
-        assertThat(isCached(table20220202UsPartitionLocation)).isTrue();
-        assertThat(isCached(table20220201AtPartitionLocation)).isTrue();
-        assertThat(isCached(table20220202AtPartitionLocation)).isTrue();
+        assertThat(isCached(table20220201UsPartitionLocation, schemaTableName(TPCH_SCHEMA, "delete_from_partitioned_table"))).isTrue();
+        assertThat(isCached(table20220202UsPartitionLocation, schemaTableName(TPCH_SCHEMA, "delete_from_partitioned_table"))).isTrue();
+        assertThat(isCached(table20220201AtPartitionLocation, schemaTableName(TPCH_SCHEMA, "delete_from_partitioned_table"))).isTrue();
+        assertThat(isCached(table20220202AtPartitionLocation, schemaTableName(TPCH_SCHEMA, "delete_from_partitioned_table"))).isTrue();
         assertUpdate("DELETE FROM delete_from_partitioned_table WHERE day = DATE '2022-02-01'");
         // Deleting from the table should invalidate the cached listing of the partitions dropped from the table.
-        assertThat(isCached(table20220201UsPartitionLocation)).isFalse();
-        assertThat(isCached(table20220202UsPartitionLocation)).isTrue();
-        assertThat(isCached(table20220201AtPartitionLocation)).isFalse();
-        assertThat(isCached(table20220202AtPartitionLocation)).isTrue();
+        assertThat(isCached(table20220201UsPartitionLocation, schemaTableName(TPCH_SCHEMA, "delete_from_partitioned_table"))).isFalse();
+        assertThat(isCached(table20220202UsPartitionLocation, schemaTableName(TPCH_SCHEMA, "delete_from_partitioned_table"))).isTrue();
+        assertThat(isCached(table20220201AtPartitionLocation, schemaTableName(TPCH_SCHEMA, "delete_from_partitioned_table"))).isFalse();
+        assertThat(isCached(table20220202AtPartitionLocation, schemaTableName(TPCH_SCHEMA, "delete_from_partitioned_table"))).isTrue();
         assertUpdate("DELETE FROM delete_from_partitioned_table WHERE country = 'US'");
-        assertThat(isCached(table20220202UsPartitionLocation)).isFalse();
-        assertThat(isCached(table20220202AtPartitionLocation)).isTrue();
+        assertThat(isCached(table20220202UsPartitionLocation, schemaTableName(TPCH_SCHEMA, "delete_from_partitioned_table"))).isFalse();
+        assertThat(isCached(table20220202AtPartitionLocation, schemaTableName(TPCH_SCHEMA, "delete_from_partitioned_table"))).isTrue();
         assertQuery("SELECT day, country, sum(clicks) FROM delete_from_partitioned_table GROUP BY day, country", "VALUES (DATE '2022-02-02', 'AT', 2500)");
 
         assertUpdate("DROP TABLE delete_from_partitioned_table");
@@ -252,23 +253,23 @@ public abstract class BaseCachingDirectoryListerTest
         assertQuery("SELECT col2, sum(col1) FROM register_unregister_partition_table GROUP BY col2", "VALUES ('group1', 3), ('group2', 7)");
         String tableGroup1PartitionLocation = getPartitionLocation(TPCH_SCHEMA, "register_unregister_partition_table", ImmutableList.of("group1"));
         String tableGroup2PartitionLocation = getPartitionLocation(TPCH_SCHEMA, "register_unregister_partition_table", ImmutableList.of("group2"));
-        assertThat(isCached(tableGroup1PartitionLocation)).isTrue();
-        assertThat(isCached(tableGroup2PartitionLocation)).isTrue();
+        assertThat(isCached(tableGroup1PartitionLocation, schemaTableName(TPCH_SCHEMA, "register_unregister_partition_table"))).isTrue();
+        assertThat(isCached(tableGroup2PartitionLocation, schemaTableName(TPCH_SCHEMA, "register_unregister_partition_table"))).isTrue();
 
         List<MaterializedRow> paths = getQueryRunner().execute(getSession(), "SELECT \"$path\" FROM register_unregister_partition_table WHERE col2 = 'group1' LIMIT 1").toTestTypes().getMaterializedRows();
         String group1PartitionPath = Location.of((String) paths.get(0).getField(0)).parentDirectory().toString();
 
         assertUpdate(format("CALL system.unregister_partition('%s', '%s', ARRAY['col2'], ARRAY['group1'])", TPCH_SCHEMA, "register_unregister_partition_table"));
         // Unregistering the partition in the table should invalidate the cached listing of all the partitions belonging to the table.
-        assertThat(isCached(tableGroup1PartitionLocation)).isFalse();
-        assertThat(isCached(tableGroup2PartitionLocation)).isTrue();
+        assertThat(isCached(tableGroup1PartitionLocation, schemaTableName(TPCH_SCHEMA, "register_unregister_partition_table"))).isFalse();
+        assertThat(isCached(tableGroup2PartitionLocation, schemaTableName(TPCH_SCHEMA, "register_unregister_partition_table"))).isTrue();
         assertQuery("SELECT col2, sum(col1) FROM register_unregister_partition_table GROUP BY col2", "VALUES ('group2', 7)");
-        assertThat(isCached(tableGroup2PartitionLocation)).isTrue();
+        assertThat(isCached(tableGroup2PartitionLocation, schemaTableName(TPCH_SCHEMA, "register_unregister_partition_table"))).isTrue();
 
         assertUpdate(format("CALL system.register_partition('%s', '%s', ARRAY['col2'], ARRAY['group1'], '%s')", TPCH_SCHEMA, "register_unregister_partition_table", group1PartitionPath));
         // Registering the partition in the table should invalidate the cached listing of all the partitions belonging to the table.
-        assertThat(isCached(tableGroup1PartitionLocation)).isFalse();
-        assertThat(isCached(tableGroup2PartitionLocation)).isTrue();
+        assertThat(isCached(tableGroup1PartitionLocation, schemaTableName(TPCH_SCHEMA, "register_unregister_partition_table"))).isFalse();
+        assertThat(isCached(tableGroup2PartitionLocation, schemaTableName(TPCH_SCHEMA, "register_unregister_partition_table"))).isTrue();
 
         assertQuery("SELECT col2, sum(col1) FROM register_unregister_partition_table GROUP BY col2", "VALUES ('group1', 3), ('group2', 7)");
 
@@ -283,10 +284,10 @@ public abstract class BaseCachingDirectoryListerTest
         // The listing for the table should be in the directory cache after this call
         assertQuery("SELECT sum(col1) FROM table_to_be_renamed", "VALUES (6)");
         String tableLocation = getTableLocation(TPCH_SCHEMA, "table_to_be_renamed");
-        assertThat(isCached(tableLocation)).isTrue();
+        assertThat(isCached(tableLocation, schemaTableName(TPCH_SCHEMA, "table_to_be_renamed"))).isTrue();
         assertUpdate("ALTER TABLE table_to_be_renamed RENAME TO table_renamed");
         // Altering the table should invalidate the cached listing of the files belonging to the table.
-        assertThat(isCached(tableLocation)).isFalse();
+        assertThat(isCached(tableLocation, schemaTableName(TPCH_SCHEMA, "table_to_be_renamed"))).isFalse();
 
         assertUpdate("DROP TABLE table_renamed");
     }
@@ -299,10 +300,10 @@ public abstract class BaseCachingDirectoryListerTest
         // The listing for the table should be in the directory cache after this call
         assertQuery("SELECT sum(col1) FROM table_to_be_dropped", "VALUES (6)");
         String tableLocation = getTableLocation(TPCH_SCHEMA, "table_to_be_dropped");
-        assertThat(isCached(tableLocation)).isTrue();
+        assertThat(isCached(tableLocation, schemaTableName(TPCH_SCHEMA, "table_to_be_dropped"))).isTrue();
         assertUpdate("DROP TABLE table_to_be_dropped");
         // Dropping the table should invalidate the cached listing of the files belonging to the table.
-        assertThat(isCached(tableLocation)).isFalse();
+        assertThat(isCached(tableLocation, schemaTableName(TPCH_SCHEMA, "table_to_be_dropped"))).isFalse();
     }
 
     @Test
@@ -315,13 +316,27 @@ public abstract class BaseCachingDirectoryListerTest
         String tableGroup1PartitionLocation = getPartitionLocation(TPCH_SCHEMA, "drop_partitioned_table", ImmutableList.of("group1"));
         String tableGroup2PartitionLocation = getPartitionLocation(TPCH_SCHEMA, "drop_partitioned_table", ImmutableList.of("group2"));
         String tableGroup3PartitionLocation = getPartitionLocation(TPCH_SCHEMA, "drop_partitioned_table", ImmutableList.of("group3"));
-        assertThat(isCached(tableGroup1PartitionLocation)).isTrue();
-        assertThat(isCached(tableGroup2PartitionLocation)).isTrue();
-        assertThat(isCached(tableGroup3PartitionLocation)).isTrue();
+        assertThat(isCached(tableGroup1PartitionLocation, schemaTableName(TPCH_SCHEMA, "drop_partitioned_table"))).isTrue();
+        assertThat(isCached(tableGroup2PartitionLocation, schemaTableName(TPCH_SCHEMA, "drop_partitioned_table"))).isTrue();
+        assertThat(isCached(tableGroup3PartitionLocation, schemaTableName(TPCH_SCHEMA, "drop_partitioned_table"))).isTrue();
+
+        // Create another table and ensure it's in the cache
+        assertUpdate("CREATE TABLE other_table (col1 int) WITH (format = 'ORC')");
+        assertUpdate("INSERT INTO other_table VALUES (1), (2), (3)", 3);
+        assertQuery("SELECT sum(col1) FROM other_table", "VALUES (6)");
+        String otherTableLocation = getTableLocation(TPCH_SCHEMA, "other_table");
+        assertThat(isCached(otherTableLocation, schemaTableName(TPCH_SCHEMA, "other_table"))).isTrue();
+
         assertUpdate("DROP TABLE drop_partitioned_table");
-        assertThat(isCached(tableGroup1PartitionLocation)).isFalse();
-        assertThat(isCached(tableGroup2PartitionLocation)).isFalse();
-        assertThat(isCached(tableGroup3PartitionLocation)).isFalse();
+        assertThat(isCached(tableGroup1PartitionLocation, schemaTableName(TPCH_SCHEMA, "drop_partitioned_table"))).isFalse();
+        assertThat(isCached(tableGroup2PartitionLocation, schemaTableName(TPCH_SCHEMA, "drop_partitioned_table"))).isFalse();
+        assertThat(isCached(tableGroup3PartitionLocation, schemaTableName(TPCH_SCHEMA, "drop_partitioned_table"))).isFalse();
+
+        // Verify that other_table is still cached
+        assertThat(isCached(otherTableLocation, schemaTableName(TPCH_SCHEMA, "other_table"))).isTrue();
+        assertQuery("SELECT sum(col1) FROM other_table", "VALUES (6)");
+
+        assertUpdate("DROP TABLE other_table");
     }
 
     @Test
@@ -422,8 +437,8 @@ public abstract class BaseCachingDirectoryListerTest
                 .orElseThrow(() -> new NoSuchElementException(format("The partition %s from the table %s.%s could not be found", partitionValues, schemaName, tableName)));
     }
 
-    protected boolean isCached(String path)
+    protected boolean isCached(String path, SchemaTableName schemaTableName)
     {
-        return directoryLister.isCached(Location.of(path));
+        return directoryLister.isCached(Location.of(path), schemaTableName);
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/TestCachingDirectoryListerRecursiveFilesOnly.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/TestCachingDirectoryListerRecursiveFilesOnly.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.metastore.Table;
 import io.trino.plugin.hive.metastore.MetastoreUtil;
+import io.trino.spi.connector.SchemaTableName;
 import io.trino.testing.QueryRunner;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -69,17 +70,17 @@ public class TestCachingDirectoryListerRecursiveFilesOnly
         assertQuery("SELECT sum(clicks) FROM recursive_directories", "VALUES (11000)");
 
         String tableLocation = getTableLocation(TPCH_SCHEMA, "recursive_directories");
-        assertThat(isCached(tableLocation)).isTrue();
+        assertThat(isCached(tableLocation, SchemaTableName.schemaTableName(TPCH_SCHEMA, "recursive_directories"))).isTrue();
 
         // Insert should invalidate cache, even at the root directory path
         assertUpdate("INSERT INTO recursive_directories VALUES (1000)", 1);
-        assertThat(isCached(tableLocation)).isFalse();
+        assertThat(isCached(tableLocation, SchemaTableName.schemaTableName(TPCH_SCHEMA, "recursive_directories"))).isFalse();
 
         // Results should include the new insert which is at the table location root for the unpartitioned table
         assertQuery("SELECT sum(clicks) FROM recursive_directories", "VALUES (12000)");
 
         assertUpdate("DROP TABLE recursive_directories");
 
-        assertThat(isCached(tableLocation)).isFalse();
+        assertThat(isCached(tableLocation, SchemaTableName.schemaTableName(TPCH_SCHEMA, "recursive_directories"))).isFalse();
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/TestTransactionScopeCachingDirectoryLister.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/TestTransactionScopeCachingDirectoryLister.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -159,8 +160,8 @@ public class TestTransactionScopeCachingDirectoryLister
             implements DirectoryLister
     {
         private final Map<Location, List<TrinoFileStatus>> fileStatuses;
-        private int listCount;
-        private boolean throwException;
+        private final AtomicInteger listCount = new AtomicInteger();
+        private volatile boolean throwException;
 
         public CountingDirectoryLister(Map<Location, List<TrinoFileStatus>> fileStatuses)
         {
@@ -171,7 +172,7 @@ public class TestTransactionScopeCachingDirectoryLister
         public RemoteIterator<TrinoFileStatus> listFilesRecursively(TrinoFileSystem fs, Table table, Location location)
         {
             // No specific recursive files-only listing implementation
-            listCount++;
+            listCount.incrementAndGet();
             return throwingRemoteIterator(requireNonNull(fileStatuses.get(location)), throwException);
         }
 
@@ -182,7 +183,7 @@ public class TestTransactionScopeCachingDirectoryLister
 
         public int getListCount()
         {
-            return listCount;
+            return listCount.get();
         }
 
         @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
This change updates the cache key to use both Path and
SchemaTableName, enabling more precise identification of cached entries.
It allows us to iterate over cache keys effectively and target only the
relevant entries during invalidation.

This is especially useful for partitioned tables, where coarse-grained
invalidation can lead to unnecessary cache evictions and performance
degradation.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
In response to this in the `CachingDirectoryListener`
```
//TODO use a cache key based on Path & SchemaTableName and iterate over the cache keys
// to deal more efficiently with cache invalidation scenarios for partitioned tables.
```


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
