### PR TITLE
Fix bug with iceberg bucket functions and integer to long casts

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergBucketFunction.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergBucketFunction.java
@@ -85,7 +85,7 @@ public class IcebergBucketFunction
                 .orElseThrow(() -> new IllegalArgumentException("Split does not contain partition values"));
 
         if (singleBucketFunction) {
-            long bucket = (long) requireNonNullElse(partitionValues.getFirst(), 0);
+            long bucket = (long) requireNonNullElse(partitionValues.getFirst(), 0L);
             checkArgument(0 <= bucket && bucket < bucketCount, "Bucket value out of range: %s (bucketCount: %s)", bucket, bucketCount);
             return (int) bucket;
         }


### PR DESCRIPTION
## Description

There's a very hard to get to code path that causes a split to have `partitionValues = [null]` (I assume). The default was 0 which raises a casting error thanks to the getFirst being able to return either null or integer. Setting to 0L fixes the bug in the environment I was seeing it in.

I was unable to reproduce this within the test suite using several combinations of what I thought would be equivalent. I was, however, able to build a version of the Trino iceberg plugin with the fix and put that onto the Trino cluster exhibiting this behavior. With that jar in place, the error goes away.

Fixes #25125

## Release notes

```markdown
## Iceberg Connector
* Fix rare failure when `iceberg.bucket-execution` is enabled. ({issue}`25125`)
```
