### PR TITLE
Support setting compression_codec table property for Iceberg

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -973,8 +973,13 @@ connector using a {doc}`WITH </sql/create-table-as>` clause.
   - Description
 * - `format`
   - Optionally specifies the format of table data files; either `PARQUET`,
-    `ORC`, or `AVRO`. Defaults to the value of the `iceberg.file-format` catalog
-    configuration property, which defaults to `PARQUET`.
+    `ORC`, or `AVRO`. Defaults to the value of the `iceberg.file-format` 
+    catalog configuration property, which defaults to `PARQUET`.
+* - `compression_codec`
+  - Optionally specifies the compression-codec used for writing the table; 
+    either `NONE`, `ZSTD`, `SNAPPY`, `LZ4`, or `GZIP`. Defaults to the value 
+    of the `iceberg.compression-codec` catalog configuration property, which 
+    defaults to `ZSTD`.
 * - `partitioning`
   - Optionally specifies table partitioning. If a table is partitioned by
     columns `c1` and `c2`, the partitioning property is `partitioning =
@@ -1032,9 +1037,9 @@ WITH (
     location = '/var/example_tables/test_table');
 ```
 
-The table definition below specifies to use ORC files, bloom filter index by columns
-`c1` and `c2`, fpp is 0.05, and a file system location of
-`/var/example_tables/test_table`:
+The table definition below specifies to use ORC files with compression_codec
+SNAPPY, bloom filter index by columns `c1` and `c2`, fpp is 0.05, and a file
+system location of `/var/example_tables/test_table`:
 
 ```sql
 CREATE TABLE test_table (
@@ -1043,6 +1048,7 @@ CREATE TABLE test_table (
     c3 DOUBLE)
 WITH (
     format = 'ORC',
+    compression_codec = 'SNAPPY',
     location = '/var/example_tables/test_table',
     orc_bloom_filter_columns = ARRAY['c1', 'c2'],
     orc_bloom_filter_fpp = 0.05);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergAvroFileWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergAvroFileWriter.java
@@ -35,6 +35,8 @@ import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.plugin.iceberg.IcebergAvroDataConversion.toIcebergRecords;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_WRITER_CLOSE_ERROR;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_WRITER_OPEN_ERROR;
+import static io.trino.plugin.iceberg.IcebergFileFormat.AVRO;
+import static io.trino.plugin.iceberg.IcebergTableProperties.validateCompression;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.TableProperties.AVRO_COMPRESSION;
@@ -62,6 +64,8 @@ public final class IcebergAvroFileWriter
         this.rollbackAction = requireNonNull(rollbackAction, "rollbackAction null");
         this.icebergSchema = requireNonNull(icebergSchema, "icebergSchema is null");
         this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
+
+        validateCompression(AVRO, Optional.of(hiveCompressionCodec));
 
         try {
             avroWriter = Avro.write(file)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -42,6 +42,7 @@ import io.trino.plugin.base.classloader.ClassLoaderSafeSystemTable;
 import io.trino.plugin.base.filter.UtcConstraintExtractor;
 import io.trino.plugin.base.projection.ApplyProjectionUtil;
 import io.trino.plugin.base.projection.ApplyProjectionUtil.ProjectedColumnRepresentation;
+import io.trino.plugin.hive.HiveCompressionCodec;
 import io.trino.plugin.hive.HiveStorageFormat;
 import io.trino.plugin.hive.HiveWrittenPartitions;
 import io.trino.plugin.iceberg.aggregation.DataSketchStateSerializer;
@@ -270,6 +271,8 @@ import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_FILESYSTEM_ERROR;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_MISSING_METADATA;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_UNSUPPORTED_VIEW_DIALECT;
+import static io.trino.plugin.iceberg.IcebergFileFormat.ORC;
+import static io.trino.plugin.iceberg.IcebergFileFormat.PARQUET;
 import static io.trino.plugin.iceberg.IcebergMetadataColumn.FILE_MODIFIED_TIME;
 import static io.trino.plugin.iceberg.IcebergMetadataColumn.FILE_PATH;
 import static io.trino.plugin.iceberg.IcebergMetadataColumn.PARTITION;
@@ -292,6 +295,7 @@ import static io.trino.plugin.iceberg.IcebergTableName.isDataTable;
 import static io.trino.plugin.iceberg.IcebergTableName.isIcebergTableName;
 import static io.trino.plugin.iceberg.IcebergTableName.isMaterializedViewStorage;
 import static io.trino.plugin.iceberg.IcebergTableName.tableNameFrom;
+import static io.trino.plugin.iceberg.IcebergTableProperties.COMPRESSION_CODEC;
 import static io.trino.plugin.iceberg.IcebergTableProperties.DATA_LOCATION_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.EXTRA_PROPERTIES_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.FILE_FORMAT_PROPERTY;
@@ -304,6 +308,7 @@ import static io.trino.plugin.iceberg.IcebergTableProperties.PARTITIONING_PROPER
 import static io.trino.plugin.iceberg.IcebergTableProperties.SORTED_BY_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getPartitioning;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getTableLocation;
+import static io.trino.plugin.iceberg.IcebergTableProperties.validateCompression;
 import static io.trino.plugin.iceberg.IcebergUtil.buildPath;
 import static io.trino.plugin.iceberg.IcebergUtil.canEnforceColumnConstraintInSpecs;
 import static io.trino.plugin.iceberg.IcebergUtil.checkFormatForProperty;
@@ -315,7 +320,9 @@ import static io.trino.plugin.iceberg.IcebergUtil.firstSnapshot;
 import static io.trino.plugin.iceberg.IcebergUtil.firstSnapshotAfter;
 import static io.trino.plugin.iceberg.IcebergUtil.getColumnHandle;
 import static io.trino.plugin.iceberg.IcebergUtil.getColumnMetadatas;
+import static io.trino.plugin.iceberg.IcebergUtil.getCompressionPropertyName;
 import static io.trino.plugin.iceberg.IcebergUtil.getFileFormat;
+import static io.trino.plugin.iceberg.IcebergUtil.getHiveCompressionCodec;
 import static io.trino.plugin.iceberg.IcebergUtil.getIcebergTableProperties;
 import static io.trino.plugin.iceberg.IcebergUtil.getPartitionKeys;
 import static io.trino.plugin.iceberg.IcebergUtil.getPartitionValues;
@@ -422,6 +429,7 @@ public class IcebergMetadata
             .add(EXTRA_PROPERTIES_PROPERTY)
             .add(FILE_FORMAT_PROPERTY)
             .add(FORMAT_VERSION_PROPERTY)
+            .add(COMPRESSION_CODEC)
             .add(MAX_COMMIT_RETRY)
             .add(OBJECT_STORE_LAYOUT_ENABLED_PROPERTY)
             .add(DATA_LOCATION_PROPERTY)
@@ -2474,10 +2482,13 @@ public class IcebergMetadata
             }
         }
 
+        IcebergFileFormat oldFileFormat = getFileFormat(icebergTable.properties());
+        IcebergFileFormat newFileFormat = oldFileFormat;
+
         if (properties.containsKey(FILE_FORMAT_PROPERTY)) {
-            IcebergFileFormat fileFormat = (IcebergFileFormat) properties.get(FILE_FORMAT_PROPERTY)
+            newFileFormat = (IcebergFileFormat) properties.get(FILE_FORMAT_PROPERTY)
                     .orElseThrow(() -> new IllegalArgumentException("The format property cannot be empty"));
-            updateProperties.defaultFormat(fileFormat.toIceberg());
+            updateProperties.defaultFormat(newFileFormat.toIceberg());
         }
 
         if (properties.containsKey(FORMAT_VERSION_PROPERTY)) {
@@ -2486,6 +2497,14 @@ public class IcebergMetadata
                     .orElseThrow(() -> new IllegalArgumentException("The format_version property cannot be empty"));
             updateProperties.set(FORMAT_VERSION, Integer.toString(formatVersion));
         }
+
+        Map<String, String> propertiesForCompression = calculateTableCompressionProperties(oldFileFormat, newFileFormat, icebergTable.properties(), properties.entrySet().stream()
+                .filter(e -> e.getValue().isPresent())
+                .collect(toImmutableMap(
+                        Map.Entry::getKey,
+                        e -> e.getValue().get())));
+
+        propertiesForCompression.forEach(updateProperties::set);
 
         if (properties.containsKey(MAX_COMMIT_RETRY)) {
             int maxCommitRetry = (int) properties.get(MAX_COMMIT_RETRY)
@@ -2540,6 +2559,22 @@ public class IcebergMetadata
         }
 
         commitTransaction(transaction, "set table properties");
+    }
+
+    public static Map<String, String> calculateTableCompressionProperties(IcebergFileFormat oldFileFormat, IcebergFileFormat newFileFormat, Map<String, String> existingProperties, Map<String, Object> inputProperties)
+    {
+        ImmutableMap.Builder<String, String> newCompressionProperties = ImmutableMap.builder();
+
+        Optional<HiveCompressionCodec> oldCompressionCodec = getHiveCompressionCodec(oldFileFormat, existingProperties);
+        Optional<HiveCompressionCodec> newCompressionCodec = IcebergTableProperties.getCompressionCodec(inputProperties);
+
+        Optional<HiveCompressionCodec> compressionCodec = newCompressionCodec.or(() -> oldCompressionCodec);
+
+        validateCompression(newFileFormat, compressionCodec);
+
+        compressionCodec.ifPresent(hiveCompressionCodec -> newCompressionProperties.put(getCompressionPropertyName(newFileFormat), hiveCompressionCodec.name()));
+
+        return newCompressionProperties.buildOrThrow();
     }
 
     private static void updatePartitioning(Table icebergTable, Transaction transaction, List<String> partitionColumns)
@@ -4013,7 +4048,7 @@ public class IcebergMetadata
         IcebergTableHandle tableHandle = (IcebergTableHandle) connectorTableHandle;
         IcebergFileFormat storageFormat = getFileFormat(tableHandle.getStorageProperties());
 
-        return storageFormat == IcebergFileFormat.ORC || storageFormat == IcebergFileFormat.PARQUET;
+        return storageFormat == ORC || storageFormat == PARQUET;
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -19,7 +19,6 @@ import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.orc.OrcWriteValidation.OrcWriteValidationMode;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
-import io.trino.plugin.hive.HiveCompressionOption;
 import io.trino.plugin.hive.orc.OrcReaderConfig;
 import io.trino.plugin.hive.orc.OrcWriterConfig;
 import io.trino.plugin.hive.parquet.ParquetReaderConfig;
@@ -65,7 +64,6 @@ public final class IcebergSessionProperties
         implements SessionPropertiesProvider
 {
     public static final String SPLIT_SIZE = "experimental_split_size";
-    private static final String COMPRESSION_CODEC = "compression_codec";
     private static final String USE_FILE_SIZE_FROM_METADATA = "use_file_size_from_metadata";
     private static final String ORC_BLOOM_FILTERS_ENABLED = "orc_bloom_filters_enabled";
     private static final String ORC_MAX_MERGE_DISTANCE = "orc_max_merge_distance";
@@ -131,12 +129,6 @@ public final class IcebergSessionProperties
                         // See https://github.com/trinodb/trino/issues/9018#issuecomment-1752929193 for further discussion.
                         null,
                         true))
-                .add(enumProperty(
-                        COMPRESSION_CODEC,
-                        "Compression codec to use when writing files",
-                        HiveCompressionOption.class,
-                        icebergConfig.getCompressionCodec(),
-                        false))
                 .add(booleanProperty(
                         USE_FILE_SIZE_FROM_METADATA,
                         "Use file size stored in Iceberg metadata",
@@ -516,11 +508,6 @@ public final class IcebergSessionProperties
     public static Optional<DataSize> getSplitSize(ConnectorSession session)
     {
         return Optional.ofNullable(session.getProperty(SPLIT_SIZE, DataSize.class));
-    }
-
-    public static HiveCompressionOption getCompressionCodec(ConnectorSession session)
-    {
-        return session.getProperty(COMPRESSION_CODEC, HiveCompressionOption.class);
     }
 
     public static boolean isUseFileSizeFromMetadata(ConnectorSession session)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -28,6 +28,7 @@ import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoInputFile;
 import io.trino.plugin.hive.HiveCompressionCodec;
+import io.trino.plugin.hive.HiveCompressionOption;
 import io.trino.plugin.iceberg.PartitionTransforms.ColumnTransform;
 import io.trino.plugin.iceberg.catalog.IcebergTableOperations;
 import io.trino.plugin.iceberg.catalog.IcebergTableOperationsProvider;
@@ -88,7 +89,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -112,7 +112,6 @@ import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.metastore.Table.TABLE_COMMENT;
 import static io.trino.parquet.writer.ParquetWriter.SUPPORTED_BLOOM_FILTER_TYPES;
 import static io.trino.plugin.base.io.ByteBuffers.getWrappedBytes;
-import static io.trino.plugin.hive.HiveCompressionCodecs.toCompressionCodec;
 import static io.trino.plugin.iceberg.ColumnIdentity.createColumnIdentity;
 import static io.trino.plugin.iceberg.IcebergColumnHandle.fileModifiedTimeColumnHandle;
 import static io.trino.plugin.iceberg.IcebergColumnHandle.fileModifiedTimeColumnMetadata;
@@ -123,7 +122,9 @@ import static io.trino.plugin.iceberg.IcebergColumnHandle.pathColumnMetadata;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_FILESYSTEM_ERROR;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_PARTITION_VALUE;
-import static io.trino.plugin.iceberg.IcebergSessionProperties.getCompressionCodec;
+import static io.trino.plugin.iceberg.IcebergFileFormat.PARQUET;
+import static io.trino.plugin.iceberg.IcebergMetadata.calculateTableCompressionProperties;
+import static io.trino.plugin.iceberg.IcebergTableProperties.COMPRESSION_CODEC;
 import static io.trino.plugin.iceberg.IcebergTableProperties.DATA_LOCATION_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.FILE_FORMAT_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.FORMAT_VERSION_PROPERTY;
@@ -139,6 +140,7 @@ import static io.trino.plugin.iceberg.IcebergTableProperties.SORTED_BY_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.SUPPORTED_PROPERTIES;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getPartitioning;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getSortOrder;
+import static io.trino.plugin.iceberg.IcebergTableProperties.validateCompression;
 import static io.trino.plugin.iceberg.PartitionFields.parsePartitionFields;
 import static io.trino.plugin.iceberg.PartitionFields.toPartitionFields;
 import static io.trino.plugin.iceberg.SortFieldUtils.parseSortFields;
@@ -176,6 +178,7 @@ import static java.lang.Long.parseLong;
 import static java.lang.String.format;
 import static java.math.RoundingMode.UNNECESSARY;
 import static java.util.Comparator.comparing;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.TableProperties.AVRO_COMPRESSION;
 import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES;
@@ -311,10 +314,17 @@ public final class IcebergUtil
     public static Map<String, Object> getIcebergTableProperties(BaseTable icebergTable)
     {
         ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
-        properties.put(FILE_FORMAT_PROPERTY, getFileFormat(icebergTable));
+        IcebergFileFormat fileFormat = getFileFormat(icebergTable);
+        properties.put(FILE_FORMAT_PROPERTY, fileFormat);
         if (!icebergTable.spec().fields().isEmpty()) {
             properties.put(PARTITIONING_PROPERTY, toPartitionFields(icebergTable.spec()));
         }
+
+        Optional<HiveCompressionCodec> compressionCodec = getHiveCompressionCodec(fileFormat, icebergTable.properties());
+
+        validateCompression(fileFormat, compressionCodec);
+
+        compressionCodec.ifPresent(hiveCompressionCodec -> properties.put(COMPRESSION_CODEC, HiveCompressionOption.valueOf(hiveCompressionCodec.name())));
 
         SortOrder sortOrder = icebergTable.sortOrder();
         // TODO: Support sort column transforms (https://github.com/trinodb/trino/issues/15088)
@@ -533,7 +543,7 @@ public final class IcebergUtil
     {
         return IcebergFileFormat.fromIceberg(FileFormat.valueOf(storageProperties
                 .getOrDefault(DEFAULT_FILE_FORMAT, DEFAULT_FILE_FORMAT_DEFAULT)
-                .toUpperCase(Locale.ENGLISH)));
+                .toUpperCase(ENGLISH)));
     }
 
     public static Optional<String> getTableComment(Table table)
@@ -863,13 +873,28 @@ public final class IcebergUtil
         PartitionSpec partitionSpec = parsePartitionFields(schema, getPartitioning(tableMetadata.getProperties()));
         SortOrder sortOrder = parseSortFields(schema, getSortOrder(tableMetadata.getProperties()));
 
+        Transaction transaction;
+
         if (replace) {
-            return catalog.newCreateOrReplaceTableTransaction(session, schemaTableName, schema, partitionSpec, sortOrder, tableLocation, createTableProperties(session, tableMetadata, allowedExtraProperties));
+            transaction = catalog.newCreateOrReplaceTableTransaction(session, schemaTableName, schema, partitionSpec, sortOrder, tableLocation, createTableProperties(tableMetadata, allowedExtraProperties));
         }
-        return catalog.newCreateTableTransaction(session, schemaTableName, schema, partitionSpec, sortOrder, Optional.ofNullable(tableLocation), createTableProperties(session, tableMetadata, allowedExtraProperties));
+        else {
+            transaction = catalog.newCreateTableTransaction(session, schemaTableName, schema, partitionSpec, sortOrder, Optional.ofNullable(tableLocation), createTableProperties(tableMetadata, allowedExtraProperties));
+        }
+
+        // If user doesn't set compression-codec for parquet, we need to remove write.parquet.compression-codec property,
+        // Otherwise Iceberg will set write.parquet.compression-codec to zstd by default.
+        String parquetCompressionValue = transaction.table().properties().get(PARQUET_COMPRESSION);
+        if (parquetCompressionValue != null && parquetCompressionValue.isEmpty()) {
+            transaction.updateProperties()
+                    .remove(PARQUET_COMPRESSION)
+                    .commit();
+        }
+
+        return transaction;
     }
 
-    public static Map<String, String> createTableProperties(ConnectorSession session, ConnectorTableMetadata tableMetadata, Predicate<String> allowedExtraProperties)
+    public static Map<String, String> createTableProperties(ConnectorTableMetadata tableMetadata, Predicate<String> allowedExtraProperties)
     {
         ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.builder();
         IcebergFileFormat fileFormat = IcebergTableProperties.getFileFormat(tableMetadata.getProperties());
@@ -877,11 +902,18 @@ public final class IcebergUtil
         propertiesBuilder.put(FORMAT_VERSION, Integer.toString(IcebergTableProperties.getFormatVersion(tableMetadata.getProperties())));
         propertiesBuilder.put(COMMIT_NUM_RETRIES, Integer.toString(IcebergTableProperties.getMaxCommitRetry(tableMetadata.getProperties())));
 
-        HiveCompressionCodec compressionCodec = toCompressionCodec(getCompressionCodec(session));
-        switch (fileFormat) {
-            case PARQUET -> propertiesBuilder.put(PARQUET_COMPRESSION, toParquetCompressionCodecTableProperty(compressionCodec));
-            case ORC -> propertiesBuilder.put(ORC_COMPRESSION, compressionCodec.getOrcCompressionKind().name().toLowerCase(Locale.ENGLISH));
-            case AVRO -> propertiesBuilder.put(AVRO_COMPRESSION, toAvroCompressionCodecTableProperty(compressionCodec));
+        Optional<HiveCompressionCodec> compressionCodec = IcebergTableProperties.getCompressionCodec(tableMetadata.getProperties());
+
+        validateCompression(fileFormat, compressionCodec);
+
+        Map<String, String> tableCompressionProperties = calculateTableCompressionProperties(fileFormat, fileFormat, ImmutableMap.of(), tableMetadata.getProperties());
+
+        tableCompressionProperties.forEach(propertiesBuilder::put);
+
+        // Iceberg will set write.parquet.compression-codec to zstd by default if this property is not set: https://github.com/trinodb/trino/issues/20401,
+        // but we don't want to set this property if this is not explicitly set by customer via set table properties.
+        if (!(fileFormat == PARQUET && compressionCodec.isPresent())) {
+            propertiesBuilder.put(PARQUET_COMPRESSION, "");
         }
 
         boolean objectStoreLayoutEnabled = IcebergTableProperties.getObjectStoreLayoutEnabled(tableMetadata.getProperties());
@@ -930,28 +962,6 @@ public final class IcebergUtil
                 .buildOrThrow();
     }
 
-    private static String toAvroCompressionCodecTableProperty(HiveCompressionCodec compressionCodec)
-    {
-        return switch (compressionCodec) {
-            case NONE -> "uncompressed";
-            case SNAPPY -> "snappy";
-            case LZ4 -> throw new TrinoException(NOT_SUPPORTED, "Compression codec LZ4 not supported for Avro");
-            case ZSTD -> "zstd";
-            case GZIP -> "gzip";
-        };
-    }
-
-    private static String toParquetCompressionCodecTableProperty(HiveCompressionCodec compressionCodec)
-    {
-        return switch (compressionCodec) {
-            case NONE -> "uncompressed";
-            case SNAPPY -> "snappy";
-            case LZ4 -> "lz4";
-            case ZSTD -> "zstd";
-            case GZIP -> "gzip";
-        };
-    }
-
     public static void verifyExtraProperties(Set<String> basePropertyKeys, Map<String, String> extraProperties, Predicate<String> allowedExtraProperties)
     {
         Set<String> illegalExtraProperties = ImmutableSet.<String>builder()
@@ -973,6 +983,32 @@ public final class IcebergUtil
                     INVALID_TABLE_PROPERTY,
                     format("Illegal keys in extra_properties: %s", illegalExtraProperties));
         }
+    }
+
+    public static Optional<HiveCompressionCodec> getHiveCompressionCodec(IcebergFileFormat icebergFileFormat, Map<String, String> storageProperties)
+    {
+        String compressionProperty = getCompressionPropertyName(icebergFileFormat);
+
+        return Optional.ofNullable(storageProperties.get(compressionProperty))
+                .filter(value -> !value.isEmpty())
+                .map(value -> {
+                    try {
+                        return HiveCompressionCodec.valueOf(value.toUpperCase(ENGLISH));
+                    }
+                    catch (IllegalArgumentException e) {
+                        throw new TrinoException(INVALID_TABLE_PROPERTY,
+                                format("Compression codec %s is unsupported.", value));
+                    }
+                });
+    }
+
+    public static String getCompressionPropertyName(IcebergFileFormat fileFormat)
+    {
+        return switch (fileFormat) {
+            case AVRO -> AVRO_COMPRESSION;
+            case ORC -> ORC_COMPRESSION;
+            case PARQUET -> PARQUET_COMPRESSION;
+        };
     }
 
     /**

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -75,7 +75,6 @@ import org.apache.iceberg.Transaction;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.types.Type.PrimitiveType;
 import org.apache.iceberg.types.TypeUtil;
-import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.types.Types.StructType;
 
@@ -481,19 +480,19 @@ public final class IcebergUtil
         return columns.buildOrThrow();
     }
 
-    public static List<Types.NestedField> primitiveFields(Schema schema)
+    public static List<NestedField> primitiveFields(Schema schema)
     {
         return primitiveFields(schema.columns())
                 .collect(toImmutableList());
     }
 
-    private static Stream<Types.NestedField> primitiveFields(List<NestedField> nestedFields)
+    private static Stream<NestedField> primitiveFields(List<NestedField> nestedFields)
     {
         return nestedFields.stream()
                 .flatMap(IcebergUtil::primitiveFields);
     }
 
-    private static Stream<Types.NestedField> primitiveFields(NestedField nestedField)
+    private static Stream<NestedField> primitiveFields(NestedField nestedField)
     {
         org.apache.iceberg.types.Type type = nestedField.type();
         if (type.isPrimitiveType()) {
@@ -502,7 +501,7 @@ public final class IcebergUtil
 
         if (type.isNestedType()) {
             return primitiveFields(type.asNestedType().fields())
-                    .map(field -> Types.NestedField.from(field).withName(nestedField.name() + "." + field.name()).build());
+                    .map(field -> NestedField.from(field).withName(nestedField.name() + "." + field.name()).build());
         }
 
         throw new IllegalStateException("Unsupported field type: " + nestedField);
@@ -1253,11 +1252,11 @@ public final class IcebergUtil
 
     public static List<org.apache.iceberg.types.Type> partitionTypes(
             List<PartitionField> partitionFields,
-            Map<Integer, org.apache.iceberg.types.Type.PrimitiveType> idToPrimitiveTypeMapping)
+            Map<Integer, PrimitiveType> idToPrimitiveTypeMapping)
     {
         ImmutableList.Builder<org.apache.iceberg.types.Type> partitionTypeBuilder = ImmutableList.builder();
         for (PartitionField partitionField : partitionFields) {
-            org.apache.iceberg.types.Type.PrimitiveType sourceType = idToPrimitiveTypeMapping.get(partitionField.sourceId());
+            PrimitiveType sourceType = idToPrimitiveTypeMapping.get(partitionField.sourceId());
             org.apache.iceberg.types.Type type = partitionField.transform().getResultType(sourceType);
             partitionTypeBuilder.add(type);
         }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
@@ -312,7 +312,7 @@ public abstract class AbstractTrinoCatalog
         Schema schema = schemaFromMetadata(columns);
         PartitionSpec partitionSpec = parsePartitionFields(schema, getPartitioning(materializedViewProperties));
         SortOrder sortOrder = parseSortFields(schema, getSortOrder(materializedViewProperties));
-        Map<String, String> properties = createTableProperties(session, new ConnectorTableMetadata(storageTableName, columns, materializedViewProperties, Optional.empty()), _ -> false);
+        Map<String, String> properties = createTableProperties(new ConnectorTableMetadata(storageTableName, columns, materializedViewProperties, Optional.empty()), _ -> false);
 
         TableMetadata metadata = newTableMetadata(schema, partitionSpec, sortOrder, tableLocation, properties);
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -85,6 +85,7 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -119,6 +120,7 @@ import static io.trino.SystemSessionProperties.TASK_MAX_WRITER_COUNT;
 import static io.trino.SystemSessionProperties.TASK_MIN_WRITER_COUNT;
 import static io.trino.SystemSessionProperties.TASK_SCALE_WRITERS_ENABLED;
 import static io.trino.SystemSessionProperties.USE_PREFERRED_WRITE_PARTITIONING;
+import static io.trino.hive.formats.compression.CompressionKind.ZSTD;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
 import static io.trino.plugin.iceberg.IcebergFileFormat.AVRO;
 import static io.trino.plugin.iceberg.IcebergFileFormat.ORC;
@@ -129,11 +131,13 @@ import static io.trino.plugin.iceberg.IcebergSessionProperties.COLLECT_EXTENDED_
 import static io.trino.plugin.iceberg.IcebergSessionProperties.DYNAMIC_FILTERING_WAIT_TIMEOUT;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.EXTENDED_STATISTICS_ENABLED;
 import static io.trino.plugin.iceberg.IcebergSplitManager.ICEBERG_DOMAIN_COMPACTION_THRESHOLD;
+import static io.trino.plugin.iceberg.IcebergTableProperties.isCompressionCodecSupportedForFormat;
 import static io.trino.plugin.iceberg.IcebergTestUtils.FILE_IO_FACTORY;
 import static io.trino.plugin.iceberg.IcebergTestUtils.getFileSystemFactory;
 import static io.trino.plugin.iceberg.IcebergTestUtils.withSmallRowGroups;
 import static io.trino.plugin.iceberg.IcebergUtil.TRINO_QUERY_ID_NAME;
 import static io.trino.plugin.iceberg.IcebergUtil.TRINO_USER_NAME;
+import static io.trino.plugin.iceberg.IcebergUtil.getCompressionPropertyName;
 import static io.trino.plugin.iceberg.IcebergUtil.getLatestMetadataLocation;
 import static io.trino.spi.predicate.Domain.multipleValues;
 import static io.trino.spi.predicate.Domain.singleValue;
@@ -153,7 +157,6 @@ import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static io.trino.testing.TransactionBuilder.transaction;
 import static io.trino.testing.assertions.Assert.assertEventually;
-import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
 import static java.lang.String.format;
 import static java.lang.String.join;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -161,7 +164,6 @@ import static java.time.ZoneOffset.UTC;
 import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 import static java.util.Collections.nCopies;
 import static java.util.Locale.ENGLISH;
-import static java.util.Map.entry;
 import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -171,6 +173,9 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.IntStream.range;
 import static org.apache.iceberg.TableMetadata.newTableMetadata;
+import static org.apache.iceberg.TableProperties.AVRO_COMPRESSION;
+import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
+import static org.apache.iceberg.TableProperties.PARQUET_COMPRESSION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.offset;
@@ -6820,6 +6825,219 @@ public abstract class BaseIcebergConnectorTest
     }
 
     @Test
+    public void testCreateTableAsWithCompressionCodecs()
+    {
+        String compressionProperty = getCompressionPropertyName(format);
+
+        for (HiveCompressionCodec compressionCodec : getCompressionCodecs(Optional.empty())) {
+            String tableName = format("test_ctas_%s_codec_%s_%s", compressionCodec.name(), format, randomNameSuffix());
+            if (isCompressionCodecSupportedForFormat(format, compressionCodec)) {
+                assertUpdate(
+                        format("CREATE TABLE %s WITH (format = '%s', compression_codec = '%s') AS SELECT * FROM nation", tableName, format, compressionCodec.name()),
+                        "SELECT count(*) FROM nation");
+
+                assertThat(getTableProperties(tableName))
+                        .containsEntry(DEFAULT_FILE_FORMAT, format.toString())
+                        .containsEntry(compressionProperty, compressionCodec.name());
+
+                assertThat(query("SELECT * FROM " + tableName)).matches("SELECT * FROM nation");
+                assertThat(query(format("SELECT count(*) FROM \"%s$files\" WHERE file_path LIKE '%%.%s'", tableName, format.name().toLowerCase(ENGLISH))))
+                        .matches("SELECT BIGINT '1'");
+
+                assertUpdate(
+                        "INSERT INTO " + tableName + " SELECT * FROM nation WHERE nationkey >= 10",
+                        "SELECT count(*) FROM nation WHERE nationkey >= 10");
+
+                assertUpdate("DROP TABLE " + tableName);
+            }
+            else {
+                assertQueryFails(
+                        format("CREATE TABLE %s WITH (format = '%s', compression_codec = '%s') AS SELECT * FROM nation", tableName, format, compressionCodec.name()),
+                        "Compression codec LZ4 not supported for .*");
+            }
+        }
+    }
+
+    @Test
+    public void testCreateTableAsWithCompressionCodecUnsupported()
+    {
+        String tableName = format("test_ctas_unsupported_%s_%s", format, randomNameSuffix());
+
+        assertQueryFails("CREATE TABLE " + tableName + " WITH (format = '" + format + "', compression_codec = 'unsupported') AS SELECT * FROM nation",
+                ".* \\QUnable to set catalog 'iceberg' table property 'compression_codec' to ['unsupported']: Invalid value [unsupported]. Valid values: [NONE, SNAPPY, LZ4, ZSTD, GZIP]");
+    }
+
+    @Test
+    public void testUpdatingOnlyCompressionCodec()
+    {
+        String tableName = "test_updating_compression_codec_" + randomNameSuffix();
+        HiveCompressionCodec initialCompressionCodec = HiveCompressionCodec.ZSTD;
+
+        List<HiveCompressionCodec> compressionCodecs = getCompressionCodecs(Optional.of(initialCompressionCodec));
+
+        for (HiveCompressionCodec compressionCodec : compressionCodecs) {
+            String compressionProperty = getCompressionPropertyName(format);
+            String newCompressionCodec = compressionCodec.name();
+
+            assertThat(query(format("CREATE TABLE %s WITH (format = '%s', compression_codec = '%s') AS SELECT * FROM nation WHERE nationkey < 10", tableName, format, initialCompressionCodec)))
+                    .matches("SELECT count(*) FROM nation WHERE nationkey < 10");
+            assertThat(getTableProperties(tableName))
+                    .containsEntry(DEFAULT_FILE_FORMAT, format.toString())
+                    .containsEntry(compressionProperty, initialCompressionCodec.name());
+
+            if (isCompressionCodecSupportedForFormat(format, compressionCodec)) {
+                assertUpdate(format("ALTER TABLE %s SET PROPERTIES compression_codec = '%s'", tableName, newCompressionCodec));
+                assertThat(getTableProperties(tableName))
+                        .containsEntry(DEFAULT_FILE_FORMAT, format.toString())
+                        .containsEntry(compressionProperty, newCompressionCodec);
+                assertUpdate(
+                        "INSERT INTO " + tableName + " SELECT * FROM nation WHERE nationkey >= 10",
+                        "SELECT count(*) FROM nation WHERE nationkey >= 10");
+
+                assertThat(query("SELECT * FROM " + tableName)).matches("SELECT * FROM nation");
+                assertThat(query(format("SELECT count(*) FROM \"%s$files\" WHERE file_path LIKE '%%.%s'", tableName, format.name().toLowerCase(ENGLISH))))
+                        .matches("SELECT BIGINT '2'");
+            }
+            else {
+                assertQueryFails(
+                        format("ALTER TABLE %s SET PROPERTIES compression_codec = '%s'", tableName, newCompressionCodec),
+                        "Compression codec LZ4 not supported for .*");
+            }
+            assertUpdate("DROP TABLE " + tableName);
+        }
+    }
+
+    @Test
+    public void testUpdatingOnlyFileFormat()
+    {
+        String tableName = "test_updating_compression_codec_" + randomNameSuffix();
+
+        List<IcebergFileFormat> newFileFormats = getFileFormats(format);
+
+        for (IcebergFileFormat fileFormat : newFileFormats) {
+            for (HiveCompressionCodec compressionCodec : getCompressionCodecs(Optional.empty())) {
+                String compressionProperty = getCompressionPropertyName(format);
+
+                ImmutableMap.Builder<IcebergFileFormat, Integer> fileCounter = ImmutableMap.builder();
+
+                if (isCompressionCodecSupportedForFormat(format, compressionCodec)) {
+                    assertUpdate(
+                            format("CREATE TABLE %s WITH (format = '%s', compression_codec = '%s') AS SELECT * FROM nation WHERE nationkey < 10", tableName, format, compressionCodec),
+                            "SELECT count(*) FROM nation WHERE nationkey < 10");
+
+                    assertThat(getTableProperties(tableName))
+                            .containsEntry(DEFAULT_FILE_FORMAT, format.toString())
+                            .containsEntry(compressionProperty, compressionCodec.name());
+
+                    fileCounter.put(format, 1);
+
+                    compressionProperty = getCompressionPropertyName(fileFormat);
+
+                    if (isCompressionCodecSupportedForFormat(fileFormat, compressionCodec)) {
+                        assertUpdate("ALTER TABLE " + tableName + " SET PROPERTIES format = '" + fileFormat + "'");
+                        assertThat(getTableProperties(tableName))
+                                .containsEntry(DEFAULT_FILE_FORMAT, fileFormat.toString())
+                                .containsEntry(compressionProperty, compressionCodec.name());
+                        assertUpdate(
+                                "INSERT INTO " + tableName + " SELECT * FROM nation WHERE nationkey >= 10",
+                                "SELECT count(*) FROM nation WHERE nationkey >= 10");
+                        fileCounter.put(fileFormat, 1);
+
+                        assertThat(query("SELECT * FROM " + tableName)).matches("SELECT * FROM nation");
+
+                        // Verify number of files per suffix
+                        for (Map.Entry<IcebergFileFormat, Integer> entry : fileCounter.buildOrThrow().entrySet()) {
+                            assertThat(query(format("SELECT count(*) FROM \"%s$files\" WHERE file_path LIKE '%%.%s'", tableName, entry.getKey().name().toLowerCase(ENGLISH))))
+                                    .matches("SELECT BIGINT '1'");
+                        }
+                    }
+                    else {
+                        assertQueryFails("ALTER TABLE " + tableName + " SET PROPERTIES format = '" + fileFormat + "'",
+                                "Compression codec LZ4 not supported for .*");
+                    }
+
+                    assertUpdate("DROP TABLE " + tableName);
+                }
+                else {
+                    assertQueryFails(format("CREATE TABLE %s WITH (format = '%s', compression_codec = '%s') AS SELECT * FROM nation", tableName, format, compressionCodec),
+                            "Compression codec LZ4 not supported for .*");
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testUpdatingCompressionCodecBothFileFormatAndCompression()
+    {
+        String tableName = "test_updating_file_format_compression_codec_" + randomNameSuffix();
+        HiveCompressionCodec initialCompressionCodec = HiveCompressionCodec.ZSTD;
+
+        List<IcebergFileFormat> newFileFormats = getFileFormats(format);
+
+        for (IcebergFileFormat fileFormat : newFileFormats) {
+            List<HiveCompressionCodec> compressionCodecs = getCompressionCodecs(Optional.of(initialCompressionCodec));
+            for (HiveCompressionCodec compressionCodec : compressionCodecs) {
+                String compressionProperty = getCompressionPropertyName(format);
+                String newCompressionCodec = compressionCodec.name();
+
+                ImmutableMap.Builder<IcebergFileFormat, Integer> fileCounter = ImmutableMap.builder();
+
+                // Create initial table
+                assertUpdate(
+                        format("CREATE TABLE %s WITH (format = '%s', compression_codec = '%s') AS SELECT * FROM nation WHERE nationkey < 10", tableName, format, initialCompressionCodec),
+                        "SELECT count(*) FROM nation WHERE nationkey < 10");
+                assertThat(getTableProperties(tableName))
+                        .containsEntry(DEFAULT_FILE_FORMAT, format.toString())
+                        .containsEntry(compressionProperty, initialCompressionCodec.name());
+
+                fileCounter.put(format, 1);
+
+                compressionProperty = getCompressionPropertyName(fileFormat);
+
+                // Modify both storage and compression properties
+                if (isCompressionCodecSupportedForFormat(fileFormat, compressionCodec)) {
+                    assertUpdate(format("ALTER TABLE %s SET PROPERTIES format = '%s', compression_codec = '%s'", tableName, fileFormat, newCompressionCodec));
+                    assertThat(getTableProperties(tableName))
+                            .containsEntry(DEFAULT_FILE_FORMAT, fileFormat.toString())
+                            .containsEntry(compressionProperty, newCompressionCodec);
+                    assertUpdate(
+                            "INSERT INTO " + tableName + " SELECT * FROM nation WHERE nationkey >= 10",
+                            "SELECT count(*) FROM nation WHERE nationkey >= 10");
+                    fileCounter.put(fileFormat, 1);
+
+                    assertThat(query("SELECT * FROM " + tableName)).matches("SELECT * FROM nation");
+
+                    // Verify number of files per suffix
+                    for (Map.Entry<IcebergFileFormat, Integer> entry : fileCounter.buildOrThrow().entrySet()) {
+                        assertThat(query(format("SELECT count(*) FROM \"%s$files\" WHERE file_path LIKE '%%.%s'", tableName, entry.getKey().name().toLowerCase(ENGLISH))))
+                                .matches("SELECT BIGINT '1'");
+                    }
+                }
+                else {
+                    assertQueryFails(format("ALTER TABLE %s SET PROPERTIES format = '%s', compression_codec = '%s'", tableName, fileFormat, newCompressionCodec),
+                            "Compression codec LZ4 not supported for .*");
+                }
+
+                assertUpdate("DROP TABLE " + tableName);
+            }
+        }
+    }
+
+    @Test
+    public void testUpdatingFileFormatCompressionMixed()
+    {
+        try (TestTable table = newTrinoTable("test_updating_file_format_compression_mixed", "WITH (format = 'AVRO') AS SELECT * FROM nation")) {
+            assertThat(getTableProperties(table.getName())).doesNotContainKey(PARQUET_COMPRESSION);
+
+            assertUpdate("ALTER TABLE " + table.getName() + " SET PROPERTIES compression_codec = 'ZSTD'");
+
+            assertThat(getTableProperties(table.getName()))
+                    .containsEntry(DEFAULT_FILE_FORMAT, AVRO.name())
+                    .containsEntry(AVRO_COMPRESSION, ZSTD.name());
+        }
+    }
+
+    @Test
     public void testUpdatingMaxCommitRetry()
     {
         try (TestTable table = newTrinoTable("test_max_commit_retry", "(x int) WITH (max_commit_retry = 1)")) {
@@ -8575,82 +8793,6 @@ public abstract class BaseIcebergConnectorTest
     }
 
     @Test
-    public void testCreateTableWithCompressionCodec()
-    {
-        for (HiveCompressionCodec compressionCodec : HiveCompressionCodec.values()) {
-            testCreateTableWithCompressionCodec(compressionCodec);
-        }
-    }
-
-    private void testCreateTableWithCompressionCodec(HiveCompressionCodec compressionCodec)
-    {
-        Session session = Session.builder(getSession())
-                .setCatalogSessionProperty(getSession().getCatalog().orElseThrow(), "compression_codec", compressionCodec.name())
-                .build();
-        String tableName = "test_table_with_compression_" + compressionCodec;
-        String createTableSql = format("CREATE TABLE %s AS SELECT * FROM tpch.tiny.nation WITH NO DATA", tableName);
-        if (format == AVRO && compressionCodec == HiveCompressionCodec.LZ4) {
-            assertTrinoExceptionThrownBy(() -> computeActual(session, createTableSql))
-                    .hasMessage("Compression codec LZ4 not supported for " + format.humanName());
-            return;
-        }
-        assertUpdate(session, createTableSql, 0);
-        verifyCodecInIcebergTableProperties(tableName, compressionCodec);
-        String insertIntoSql = format("INSERT INTO %s SELECT * FROM tpch.tiny.nation", tableName);
-        // TODO (https://github.com/trinodb/trino/issues/9142) Support LZ4 compression with native Parquet writer
-        if (format == IcebergFileFormat.PARQUET && compressionCodec == HiveCompressionCodec.LZ4) {
-            assertTrinoExceptionThrownBy(() -> computeActual(session, insertIntoSql))
-                    .hasMessage("Compression codec LZ4 not supported for " + format.humanName());
-            return;
-        }
-        assertUpdate(session, insertIntoSql, 25);
-        assertQuery("SELECT * FROM " + tableName, "SELECT * FROM nation");
-        assertQuery("SELECT count(*) FROM " + tableName, "VALUES 25");
-        assertUpdate("DROP TABLE " + tableName);
-    }
-
-    protected void verifyCodecInIcebergTableProperties(String tableName, HiveCompressionCodec codec)
-    {
-        assertThat(tableName).isNotNull();
-        Optional<String> codecName = switch (format) {
-            case AVRO -> switch (codec) {
-                case NONE -> Optional.of("uncompressed");
-                case SNAPPY -> Optional.of("snappy");
-                case LZ4 -> Optional.empty(); // codec unsupported by Iceberg
-                case ZSTD -> Optional.of("zstd");
-                case GZIP -> Optional.of("gzip");
-            };
-            case ORC -> switch (codec) {
-                case NONE -> Optional.of("none");
-                case SNAPPY -> Optional.of("snappy");
-                case LZ4 -> Optional.of("lz4");
-                case ZSTD -> Optional.of("zstd");
-                case GZIP -> Optional.of("zlib");
-            };
-            case PARQUET -> switch (codec) {
-                case NONE -> Optional.of("uncompressed");
-                case SNAPPY -> Optional.of("snappy");
-                case LZ4 -> Optional.of("lz4");
-                case ZSTD -> Optional.of("zstd");
-                case GZIP -> Optional.of("gzip");
-            };
-        };
-        Map<String, String> actual = getTableProperties(tableName);
-        assertThat(actual).contains(entry("write.format.default", format.name()));
-        codecName.ifPresent(name -> assertThat(actual).contains(entry("write.%s.compression-codec".formatted(format.name().toLowerCase(ENGLISH)), name)));
-        if (format != PARQUET) {
-            // this is incorrectly persisted in Iceberg: https://github.com/trinodb/trino/issues/20401
-            assertThat(actual).contains(entry("write.parquet.compression-codec", "zstd"));
-        }
-    }
-
-    private Map<String, String> getTableProperties(String tableName)
-    {
-        return computeActual("SELECT key, value FROM \"" + tableName + "$properties\"").getMaterializedRows().stream()
-                .collect(toImmutableMap(row -> (String) row.getField(0), row -> (String) row.getField(1)));
-    }
-
-    @Test
     public void testTypeCoercionOnCreateTableAsSelect()
     {
         for (TypeCoercionTestSetup setup : typeCoercionOnCreateTableAsSelectProvider()) {
@@ -9337,5 +9479,25 @@ public abstract class BaseIcebergConnectorTest
                 assertThat(tablePartitioning.active()).isFalse();
             }
         };
+    }
+
+    private Map<String, String> getTableProperties(String tableName)
+    {
+        return computeActual("SELECT key, value FROM \"" + tableName + "$properties\"").getMaterializedRows().stream()
+                .collect(toImmutableMap(row -> (String) row.getField(0), row -> (String) row.getField(1)));
+    }
+
+    private static List<HiveCompressionCodec> getCompressionCodecs(Optional<HiveCompressionCodec> codecToExclude)
+    {
+        return Arrays.stream(HiveCompressionCodec.values())
+                .filter(codec -> !(codecToExclude.isPresent() && codec.equals(codecToExclude.get())))
+                .collect(toImmutableList());
+    }
+
+    private static List<IcebergFileFormat> getFileFormats(IcebergFileFormat fileFormatToExclude)
+    {
+        return Arrays.stream(IcebergFileFormat.values())
+                .filter(format -> !format.equals(fileFormatToExclude))
+                .collect(toImmutableList());
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
@@ -772,7 +772,7 @@ public abstract class BaseIcebergSystemTables
             assertThat(dataFile.getField(3)).isEqualTo(0); // spec_id
             assertThat(dataFile.getField(4)).isEqualTo(1L); // record_count
             assertThat((long) dataFile.getField(5)).isPositive(); // file_size_in_bytes
-            assertThat(dataFile.getField(6)).isEqualTo(Map.of(1, 45L)); // column_sizes
+            assertThat(dataFile.getField(6)).isEqualTo(Map.of(1, 51L)); // column_sizes
             assertThat(dataFile.getField(7)).isEqualTo(Map.of(1, 1L)); // value_counts
             assertThat(dataFile.getField(8)).isEqualTo(Map.of(1, 0L)); // null_value_counts
             assertThat(dataFile.getField(9)).isEqualTo(Map.of()); // nan_value_counts
@@ -787,7 +787,7 @@ public abstract class BaseIcebergSystemTables
                     .isEqualTo("""
                             {\
                             "dt":{"column_size":null,"value_count":null,"null_value_count":null,"nan_value_count":null,"lower_bound":null,"upper_bound":null},\
-                            "id":{"column_size":45,"value_count":1,"null_value_count":0,"nan_value_count":null,"lower_bound":1,"upper_bound":1}\
+                            "id":{"column_size":51,"value_count":1,"null_value_count":0,"nan_value_count":null,"lower_bound":1,"upper_bound":1}\
                             }""");
         }
     }
@@ -849,13 +849,6 @@ public abstract class BaseIcebergSystemTables
         try (TestTable table = newTrinoTable("test_properties", "(x BIGINT,y DOUBLE) WITH (sorted_by = ARRAY['y'])")) {
             Table icebergTable = loadTable(table.getName());
             Map<String, String> actualProperties = getTableProperties(table.getName());
-            if (format == PARQUET) {
-                assertThat(actualProperties).hasSize(9);
-            }
-            else {
-                assertThat(actualProperties).hasSize(10);
-                assertThat(actualProperties).contains(entry("write.%s.compression-codec".formatted(format.name().toLowerCase(ENGLISH)), "zstd"));
-            }
             assertThat(actualProperties).contains(
                     entry("format", "iceberg/" + format.name()),
                     entry("provider", "iceberg"),
@@ -864,7 +857,6 @@ public abstract class BaseIcebergSystemTables
                     entry("format-version", "2"),
                     entry("sort-order", "y ASC NULLS FIRST"),
                     entry("write.format.default", format.name()),
-                    entry("write.parquet.compression-codec", "zstd"),
                     entry("commit.retry.num-retries", "4"));
         }
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
@@ -932,7 +932,7 @@ public class TestIcebergV2
                                         (2,
                                         'PARQUET',
                                         1L,
-                                        JSON '{"3":49}',
+                                        JSON '{"3":52}',
                                         JSON '{"3":1}',
                                         JSON '{"3":0}',
                                         JSON '{}',

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
@@ -1638,9 +1638,7 @@ public class TestIcebergSparkCompatibility
         String trinoTableName = trinoTableName(baseTableName);
         String sparkTableName = sparkTableName(baseTableName);
 
-        onTrino().executeQuery("SET SESSION iceberg.compression_codec = '" + compressionCodec + "'");
-
-        String createTable = "CREATE TABLE " + trinoTableName + " WITH (format = '" + storageFormat + "') AS TABLE tpch.tiny.nation";
+        String createTable = "CREATE TABLE " + trinoTableName + " WITH (format = '" + storageFormat + "', compression_codec = '" + compressionCodec + "') AS TABLE tpch.tiny.nation";
         if (storageFormat == StorageFormat.PARQUET && "LZ4".equals(compressionCodec)) {
             // TODO (https://github.com/trinodb/trino/issues/9142) LZ4 is not supported with native Parquet writer
             assertQueryFailure(() -> onTrino().executeQuery(createTable))
@@ -1663,18 +1661,6 @@ public class TestIcebergSparkCompatibility
                 .containsOnly(expected);
 
         onTrino().executeQuery("DROP TABLE " + trinoTableName);
-    }
-
-    @Test(groups = {ICEBERG, PROFILE_SPECIFIC_TESTS})
-    public void verifyCompressionCodecsDataProvider()
-    {
-        assertThat(onTrino().executeQuery("SHOW SESSION LIKE 'iceberg.compression_codec'"))
-                .containsOnly(row(
-                        "iceberg.compression_codec",
-                        "ZSTD",
-                        "ZSTD",
-                        "varchar",
-                        "Compression codec to use when writing files. Possible values: " + compressionCodecs()));
     }
 
     @DataProvider


### PR DESCRIPTION
This PR makes compression_codec a table property and drops support for compression_codec iceberg session property for simplicity.

Users are able to run the following command now to specify the compression_codec to create a new table with compression_codec set to ZSTD.
```
CREATE TABLE example (
    c1 INTEGER,
    c2 DATE,
    c3 DOUBLE
)
WITH (
    format = 'AVRO',
    partitioning = ARRAY['c1', 'c2'],
    sorted_by = ARRAY['c3'],
    compression_codec = 'ZSTD'
);
```
Users are able able to change the compression_codec via statement ```Alter Table Set Properties```.

Example
```
ALTER TABLE example SET PROPERTIES compression_codec = 'GZIP';
```

The write_compression users specify will replace the session variable ```iceberg.compression-codec```. If the user change file_format without changing write_compression, it will inherit the write_compression set for the original file format, if the write_compression for the previous file format is set.

If the user is trying to set a write_compression that is inconsistent with the file format, the system will throw an exception.

The compatibility matrix for write_compression and file format is the following
|  |  Orc  | Parquet |  Avro  |
|:-----------------:|:-----:|:-------:|:------:|
| **NONE**          |   ✅   |    ✅   |    ✅   |
| **SNAPPY**        |   ✅   |    ✅   |    ✅   |
| **LZ4**           |   ✅   |    ❌   |    ❌   |
| **ZSTD**          |   ✅   |    ✅   |    ✅   |
| **GZIP**          |   ✅   |    ✅   |    ✅   |






<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg connector
* Make `compression_codec` a table property and drop support for `compression_codec` session property. ({issue}`25755`)
```
