### PR TITLE
Disable 25-ea job temporarily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,8 @@ jobs:
       matrix:
         include:
           - { java-version: 24, cache: 'true', cleanup-node: true }
-          - { java-version: 25-ea, cache: 'restore', cleanup-node: true }
+          # TODO Re-enable once incorrect JAVA_HOME environment variable error is fixed
+          # - { java-version: 25-ea, cache: 'restore', cleanup-node: true }
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description

The job is consistently failing. Disabling the job temporarily as we couldn't find the solution. 
* https://github.com/trinodb/trino/actions/runs/14925170935/job/41928309800
* https://github.com/trinodb/trino/actions/runs/14923315000/job/41922601481

```
The JAVA_HOME environment variable is not defined correctly,
this environment variable is needed to run this program.
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
