### PR TITLE
Recategorize NPE in StatementAnalyzer

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/query/TestMetadataMismatch.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestMetadataMismatch.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
+import io.trino.connector.MockConnectorFactory;
+import io.trino.connector.MockConnectorPlugin;
+import io.trino.spi.connector.ConnectorTableLayout;
+import io.trino.spi.security.Identity;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.StandaloneQueryRunner;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import java.util.Optional;
+
+import static io.trino.connector.MockConnectorEntities.TPCH_NATION_SCHEMA;
+import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static io.trino.spi.StandardErrorCode.COLUMN_NOT_FOUND;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestMetadataMismatch
+{
+    private static final String LOCAL_CATALOG = "local";
+    private static final String MOCK_CATALOG = "mock";
+    private static final String USER = "user";
+
+    private static final Session SESSION = testSessionBuilder()
+            .setCatalog(LOCAL_CATALOG)
+            .setSchema(TINY_SCHEMA_NAME)
+            .setIdentity(Identity.forUser(USER).build())
+            .build();
+
+    private final QueryAssertions assertions;
+
+    public TestMetadataMismatch()
+    {
+        QueryRunner runner = new StandaloneQueryRunner(SESSION);
+
+        runner.installPlugin(new MockConnectorPlugin(MockConnectorFactory.builder()
+                .withGetColumns(_ -> TPCH_NATION_SCHEMA)
+                .withGetInsertLayout((_, _) ->
+                        Optional.of(new ConnectorTableLayout(ImmutableList.of("year"))))  // nonexistent column in TPCH_NATION_SCHEMA
+                .build()));
+        runner.createCatalog(MOCK_CATALOG, "mock", ImmutableMap.of());
+
+        assertions = new QueryAssertions(runner);
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+    }
+
+    @Test
+    public void testGetInsertLayoutMismatchAgainstColumns()
+    {
+        assertThat(assertions.query("DELETE FROM mock.tiny.nation WHERE nationkey < 3"))
+                .failure()
+                .hasErrorCode(COLUMN_NOT_FOUND)
+                .hasMessage("Missing field index for column: 'year', available columns: ('nationkey', 'regionkey', 'name', 'comment')");
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Recategorize `NullPointerException` that gets thrown when there's a mismatch between columns and insert layout from `Metadata` during `StatementAnalyzer#createMergeAnalysis`.

Instead, it now throws a `TrinoException` with a corresponding message, e.g.:
```
Missing field index for column: 'year', available columns: ('nationkey', 'regionkey', 'name', 'comment')
```

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text
