### PR TITLE
Fix iceberg REST catalog expire_snapshots

### DIFF
--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystem.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystem.java
@@ -196,10 +196,9 @@ final class S3FileSystem
                         .toList();
 
                 DeleteObjectsRequest request = DeleteObjectsRequest.builder()
-                        .overrideConfiguration(context::applyCredentialProviderOverride)
+                        .overrideConfiguration(builder -> context.applyCredentialProviderOverride(disableStrongIntegrityChecksums(builder)))
                         .requestPayer(requestPayer)
                         .bucket(bucket)
-                        .overrideConfiguration(disableStrongIntegrityChecksums())
                         .delete(builder -> builder.objects(objects).quiet(true))
                         .build();
 
@@ -398,10 +397,8 @@ final class S3FileSystem
     // TODO (https://github.com/trinodb/trino/issues/24955):
     // remove me once all of the S3-compatible storage support strong integrity checks
     @SuppressWarnings("deprecation")
-    static AwsRequestOverrideConfiguration disableStrongIntegrityChecksums()
+    static AwsRequestOverrideConfiguration.Builder disableStrongIntegrityChecksums(AwsRequestOverrideConfiguration.Builder builder)
     {
-        return AwsRequestOverrideConfiguration.builder()
-            .signer(AwsS3V4Signer.create())
-            .build();
+        return builder.signer(AwsS3V4Signer.create());
     }
 }

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/AbstractTestS3FileSystem.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/AbstractTestS3FileSystem.java
@@ -41,7 +41,6 @@ import java.util.List;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.filesystem.encryption.EncryptionKey.randomAes256;
-import static io.trino.filesystem.s3.S3FileSystem.disableStrongIntegrityChecksums;
 import static io.trino.filesystem.s3.S3SseCUtils.encoded;
 import static io.trino.filesystem.s3.S3SseCUtils.md5Checksum;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -157,7 +156,7 @@ public abstract class AbstractTestS3FileSystem
                             builder.sseCustomerKeyMD5(md5Checksum(randomEncryptionKey));
                         }
                     })
-                    .overrideConfiguration(disableStrongIntegrityChecksums())
+                    .overrideConfiguration(S3FileSystem::disableStrongIntegrityChecksums)
                     .build();
 
             s3Client.putObject(putObjectRequest, RequestBody.fromBytes(contents.clone()));
@@ -274,7 +273,7 @@ public abstract class AbstractTestS3FileSystem
         public void create()
         {
             s3Client.putObject(request -> request
-                    .overrideConfiguration(disableStrongIntegrityChecksums())
+                    .overrideConfiguration(S3FileSystem::disableStrongIntegrityChecksums)
                     .bucket(bucket()).key(path), RequestBody.empty());
         }
 

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemAwsS3.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemAwsS3.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.util.List;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static io.trino.filesystem.s3.S3FileSystem.disableStrongIntegrityChecksums;
 import static io.trino.testing.SystemEnvironmentUtils.requireEnv;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -88,7 +87,7 @@ public class TestS3FileSystemAwsS3
                     .bucket(bucket())
                     .key(key)
                     .storageClass(storageClass.toString())
-                    .overrideConfiguration(disableStrongIntegrityChecksums())
+                    .overrideConfiguration(S3FileSystem::disableStrongIntegrityChecksums)
                     .build();
             s3Client.putObject(
                     putObjectRequestBuilder,


### PR DESCRIPTION
## Description
Fixes https://github.com/trinodb/trino/issues/25780

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg connector
* Fix expire_snapshots functionality when using an Iceberg REST catalog and S3 compatible storage ({issue}`25782`)
```
