### PR TITLE
Revert "Disable 25-ea job temporarily"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,7 @@ jobs:
       matrix:
         include:
           - { java-version: 24, cache: 'true', cleanup-node: true }
-          # TODO Re-enable once incorrect JAVA_HOME environment variable error is fixed
-          # - { java-version: 25-ea, cache: 'restore', cleanup-node: true }
+          - { java-version: 25-ea, cache: 'restore', cleanup-node: true }
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This reverts commit e9064ed2a1798f4f12b3026583b252c46a050c2a.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
