### PR TITLE
Remove signer override

### DIFF
--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystem.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystem.java
@@ -24,8 +24,6 @@ import io.trino.filesystem.TrinoInputFile;
 import io.trino.filesystem.TrinoOutputFile;
 import io.trino.filesystem.UriLocation;
 import io.trino.filesystem.encryption.EncryptionKey;
-import software.amazon.awssdk.auth.signer.AwsS3V4Signer;
-import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CommonPrefix;
@@ -199,7 +197,6 @@ final class S3FileSystem
                         .overrideConfiguration(context::applyCredentialProviderOverride)
                         .requestPayer(requestPayer)
                         .bucket(bucket)
-                        .overrideConfiguration(disableStrongIntegrityChecksums())
                         .delete(builder -> builder.objects(objects).quiet(true))
                         .build();
 
@@ -393,15 +390,5 @@ final class S3FileSystem
     private static void validateS3Location(Location location)
     {
         new S3Location(location);
-    }
-
-    // TODO (https://github.com/trinodb/trino/issues/24955):
-    // remove me once all of the S3-compatible storage support strong integrity checks
-    @SuppressWarnings("deprecation")
-    static AwsRequestOverrideConfiguration disableStrongIntegrityChecksums()
-    {
-        return AwsRequestOverrideConfiguration.builder()
-            .signer(AwsS3V4Signer.create())
-            .build();
     }
 }

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/AbstractTestS3FileSystem.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/AbstractTestS3FileSystem.java
@@ -41,7 +41,6 @@ import java.util.List;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.filesystem.encryption.EncryptionKey.randomAes256;
-import static io.trino.filesystem.s3.S3FileSystem.disableStrongIntegrityChecksums;
 import static io.trino.filesystem.s3.S3SseCUtils.encoded;
 import static io.trino.filesystem.s3.S3SseCUtils.md5Checksum;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -157,7 +156,6 @@ public abstract class AbstractTestS3FileSystem
                             builder.sseCustomerKeyMD5(md5Checksum(randomEncryptionKey));
                         }
                     })
-                    .overrideConfiguration(disableStrongIntegrityChecksums())
                     .build();
 
             s3Client.putObject(putObjectRequest, RequestBody.fromBytes(contents.clone()));
@@ -273,9 +271,7 @@ public abstract class AbstractTestS3FileSystem
 
         public void create()
         {
-            s3Client.putObject(request -> request
-                    .overrideConfiguration(disableStrongIntegrityChecksums())
-                    .bucket(bucket()).key(path), RequestBody.empty());
+            s3Client.putObject(request -> request.bucket(bucket()).key(path), RequestBody.empty());
         }
 
         @Override

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemAwsS3.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemAwsS3.java
@@ -19,6 +19,8 @@ import io.trino.filesystem.FileEntry;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
+import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -29,7 +31,6 @@ import java.io.IOException;
 import java.util.List;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static io.trino.filesystem.s3.S3FileSystem.disableStrongIntegrityChecksums;
 import static io.trino.testing.SystemEnvironmentUtils.requireEnv;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -63,6 +64,8 @@ public class TestS3FileSystemAwsS3
         return S3Client.builder()
                 .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
                 .region(Region.of(region))
+                .responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED)
+                .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED)
                 .build();
     }
 
@@ -88,7 +91,6 @@ public class TestS3FileSystemAwsS3
                     .bucket(bucket())
                     .key(key)
                     .storageClass(storageClass.toString())
-                    .overrideConfiguration(disableStrongIntegrityChecksums())
                     .build();
             s3Client.putObject(
                     putObjectRequestBuilder,

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemAwsS3.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemAwsS3.java
@@ -28,9 +28,11 @@ import software.amazon.awssdk.services.s3.model.ObjectStorageClass;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.List;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.testing.SystemEnvironmentUtils.isEnvSet;
 import static io.trino.testing.SystemEnvironmentUtils.requireEnv;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,6 +43,7 @@ public class TestS3FileSystemAwsS3
     private String secretKey;
     private String region;
     private String bucket;
+    private String endpoint;
 
     @Override
     protected void initEnvironment()
@@ -50,6 +53,13 @@ public class TestS3FileSystemAwsS3
         region = requireEnv("AWS_REGION");
 
         bucket = requireEnv("EMPTY_S3_BUCKET");
+
+        if (isEnvSet("AWS_ENDPOINT")) {
+            endpoint = requireEnv("AWS_ENDPOINT");
+        }
+        else {
+            endpoint = "https://s3." + region + ".amazonaws.com";
+        }
     }
 
     @Override
@@ -66,6 +76,7 @@ public class TestS3FileSystemAwsS3
                 .region(Region.of(region))
                 .responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED)
                 .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED)
+                .endpointOverride(URI.create(endpoint))
                 .build();
     }
 
@@ -76,6 +87,7 @@ public class TestS3FileSystemAwsS3
                 .setAwsAccessKey(accessKey)
                 .setAwsSecretKey(secretKey)
                 .setRegion(region)
+                .setEndpoint(endpoint)
                 .setSupportsExclusiveCreate(true)
                 .setStreamingPartSize(DataSize.valueOf("5.5MB")), new S3FileSystemStats());
     }

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/MotoContainer.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/MotoContainer.java
@@ -17,11 +17,15 @@ import org.testcontainers.containers.GenericContainer;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.LegacyMd5Plugin;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 
 import java.net.URI;
+
+import static software.amazon.awssdk.core.checksums.ResponseChecksumValidation.WHEN_REQUIRED;
 
 public final class MotoContainer
         extends GenericContainer<MotoContainer>
@@ -51,7 +55,10 @@ public final class MotoContainer
                 AwsBasicCredentials.create(MOTO_ACCESS_KEY, MOTO_SECRET_KEY)));
         if (client instanceof S3ClientBuilder s3) {
             s3.forcePathStyle(true);
+            s3.responseChecksumValidation(WHEN_REQUIRED);
+            s3.requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED);
         }
+        client.addPlugin(LegacyMd5Plugin.create());
     }
 
     public void createBucket(String bucketName)


### PR DESCRIPTION
It's no longer needed since AWS SDK v2 added a LegacyMd5Plugin to ensure backward compatibility with S3-compliant storage.

Should fix https://github.com/trinodb/trino/issues/25780

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
