### PR TITLE
Use new parseHiveDate for OpenX reader to remove any characters after yyyy-mm-dd

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/openxjson/README.md
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/openxjson/README.md
@@ -134,7 +134,15 @@ Values that fail to parse properly, or that are outside the allowed range, resul
 
 ### Formats
 
-* `YYYY-MM-DD` with any trailing text after a space
+* YYYY-MM-DD format where:
+  * Year can be 1-4 digits
+  * Month can be 1-2 digits
+  * Day can be 1-2 digits
+  * Any trailing text after the date portion is ignored
+  * Leading zeros are optional for month and day
+  * Date components use lenient resolution, meaning:
+    * Values that exceed normal ranges will roll over (e.g., month 13 becomes January of next year)
+    * Invalid dates will be adjusted to valid ones (e.g., "2023-02-30" becomes "2023-03-02")
 * Decimal number of days since `1970-01-01`
 * Hex `0x1234` days. Negative numbers are not supported.
 * Octal `01234` days. Negative numbers are not supported.
@@ -146,6 +154,8 @@ Values that fail to parse properly, or that are outside the allowed range, resul
 * Rcongiu does not support integer days since epoch format.
 * Starburst fails for boolean
 * Starburst and Rcongiu writes all `DATE` values as `null`
+* Starburst doesn't allow more than 10 digits for year, 2 digits for month, and 2 digits for day.
+* Rcongiu uses java.text.SimpleDateFormat and allows for any number of digits for year, month, and day. 
 
 ## TIMESTAMP
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

The [parseHiveDate](https://github.com/trinodb/trino/blob/master/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/HiveFormatUtils.java#L146) method in HiveFormatUtils.java that the native OpenX reader was using only supported 
a space delimiter to remove any characters after 'yyyy-mm-dd'. As a result, while '2025-01-04 00:00:00.000Z' 
was correctly parsed as '2025-01-04', strings like '2025-01-04T00:00:00.000Z' or '2025-01-04AA00:00:00.000Z' 
were throwing exceptions and being parsed as null.
This new parseHiveDate method removes any characters after 'yyyy-mm-dd', regardless of the delimiter using regex.

This change adopts Hive 4's fix in https://github.com/apache/hive/blob/84b42876441ec8984f1a39367ae77627cc96a275/common/src/java/org/apache/hadoop/hive/common/type/Date.java#L179-L200
https://github.com/apache/hive/blob/84b42876441ec8984f1a39367ae77627cc96a275/common/src/java/org/apache/hadoop/hive/common/type/Date.java#L86-L89

The only difference is that it uses ResolverStyle.LENIENT while Hive 4's fix uses ResolverStyle.STRICT

Additionally, we introduce strict parsing for the date format yyyy-mm-dd, where we don't allow more than 4 digits for year, 2 digits for month, and 2 digits for day.

Thus, following date values will be parsed differently
02025-01-01 => null (after), 2025-01-01 (before)
2025-011-01 => null (after), 2025-11-01 (before)
2025-01-011 => null (after), 2025-01-11 (before)
202510-01-01 => null (after), +202510-01-01 (before)
2025-100-01 => null (after), 2033-04-01 (before)
2025-01-100 => null (after), 2025-04-10 (before)


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(O) Release notes are required, with the following suggested text:

```markdown
## Hive connector
* The OpenX JSON reader now ignores any extra characters after parsing a timestamp value as a date.
  Previously, it only supported parsing timestamps with a space separator between the date and
  timestamp, but now it supports parsing with other separators such as `T` used by ISO 8601
  timestamps. Dates are now validated to enforce no more than 4 digit years, 2 digit months, and 2 digit
  day of month values. ({issue}`25792`)
```
