### PR TITLE
Remove code for Cassandra <= 2.2.0

### DIFF
--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraMetadata.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraMetadata.java
@@ -294,8 +294,7 @@ public class CassandraMetadata
             CassandraClusteringPredicatesExtractor clusteringPredicatesExtractor = new CassandraClusteringPredicatesExtractor(
                     cassandraTypeManager,
                     cassandraSession.getTable(handle.getSchemaTableName()).clusteringKeyColumns(),
-                    partitionResult.unenforcedConstraint(),
-                    cassandraSession.getCassandraVersion());
+                    partitionResult.unenforcedConstraint());
             clusteringKeyPredicates = clusteringPredicatesExtractor.getClusteringKeyPredicates();
             unenforcedConstraint = clusteringPredicatesExtractor.getUnenforcedConstraints();
         }

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSplitManager.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSplitManager.java
@@ -131,8 +131,7 @@ public class CassandraSplitManager
         CassandraClusteringPredicatesExtractor clusteringPredicatesExtractor = new CassandraClusteringPredicatesExtractor(
                 cassandraTypeManager,
                 session.getTable(tableHandle.getSchemaTableName()).clusteringKeyColumns(),
-                partitionResult.unenforcedConstraint(),
-                session.getCassandraVersion());
+                partitionResult.unenforcedConstraint());
         return clusteringPredicatesExtractor.getClusteringKeyPredicates();
     }
 

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
@@ -1858,13 +1858,6 @@ public class TestCassandraConnectorTest
                 "VALUES ('CANADA', 'AMERICA')");
     }
 
-    @Test
-    public void testProtocolVersion()
-    {
-        assertQuery("SELECT native_protocol_version FROM system.local",
-                "VALUES 4");
-    }
-
     private void assertSelect(String tableName)
     {
         String sql = "SELECT " +

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/util/TestCassandraClusteringPredicatesExtractor.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/util/TestCassandraClusteringPredicatesExtractor.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.cassandra.util;
 
-import com.datastax.oss.driver.api.core.Version;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.cassandra.CassandraClusteringPredicatesExtractor;
@@ -37,7 +36,6 @@ public class TestCassandraClusteringPredicatesExtractor
     private static final CassandraColumnHandle col3;
     private static final CassandraColumnHandle col4;
     private static final CassandraTable cassandraTable;
-    private static final Version cassandraVersion;
 
     static {
         col1 = new CassandraColumnHandle("partitionKey1", 1, CassandraTypes.BIGINT, true, false, false, false);
@@ -47,8 +45,6 @@ public class TestCassandraClusteringPredicatesExtractor
 
         cassandraTable = new CassandraTable(
                 new CassandraNamedRelationHandle("test", "records"), ImmutableList.of(col1, col2, col3, col4));
-
-        cassandraVersion = Version.parse("3.0");
     }
 
     @Test
@@ -59,7 +55,7 @@ public class TestCassandraClusteringPredicatesExtractor
                         col1, Domain.singleValue(BIGINT, 23L),
                         col2, Domain.singleValue(BIGINT, 34L),
                         col4, Domain.singleValue(BIGINT, 26L)));
-        CassandraClusteringPredicatesExtractor predicatesExtractor = new CassandraClusteringPredicatesExtractor(CASSANDRA_TYPE_MANAGER, cassandraTable.clusteringKeyColumns(), tupleDomain, cassandraVersion);
+        CassandraClusteringPredicatesExtractor predicatesExtractor = new CassandraClusteringPredicatesExtractor(CASSANDRA_TYPE_MANAGER, cassandraTable.clusteringKeyColumns(), tupleDomain);
         String predicate = predicatesExtractor.getClusteringKeyPredicates();
         assertThat(predicate).isEqualTo("\"clusteringKey1\" = 34");
     }
@@ -71,7 +67,7 @@ public class TestCassandraClusteringPredicatesExtractor
                 ImmutableMap.of(
                         col2, Domain.singleValue(BIGINT, 34L),
                         col4, Domain.singleValue(BIGINT, 26L)));
-        CassandraClusteringPredicatesExtractor predicatesExtractor = new CassandraClusteringPredicatesExtractor(CASSANDRA_TYPE_MANAGER, cassandraTable.clusteringKeyColumns(), tupleDomain, cassandraVersion);
+        CassandraClusteringPredicatesExtractor predicatesExtractor = new CassandraClusteringPredicatesExtractor(CASSANDRA_TYPE_MANAGER, cassandraTable.clusteringKeyColumns(), tupleDomain);
         TupleDomain<ColumnHandle> unenforcedPredicates = TupleDomain.withColumnDomains(ImmutableMap.of(col4, Domain.singleValue(BIGINT, 26L)));
         assertThat(predicatesExtractor.getUnenforcedConstraints()).isEqualTo(unenforcedPredicates);
     }


### PR DESCRIPTION
## Description

Cassandra 2.2.0 already reached EOL and https://github.com/trinodb/trino/pull/14562 removed support for the version.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
