### PR TITLE
Fix code example in documentation

### DIFF
--- a/docs/src/main/sphinx/udf/sql/begin.md
+++ b/docs/src/main/sphinx/udf/sql/begin.md
@@ -38,10 +38,10 @@ The following example computes the value `42`:
 
 ```sql
 FUNCTION meaning_of_life()
-  RETURNS tinyint
+  RETURNS integer
   BEGIN
-    DECLARE a tinyint DEFAULT 6;
-    DECLARE b tinyint DEFAULT 7;
+    DECLARE a integer DEFAULT 6;
+    DECLARE b integer DEFAULT 7;
     RETURN a * b;
   END
 ```


### PR DESCRIPTION
## Description

Trying to run the code example in [this documentation page](https://trino.io/docs/current/udf/sql/begin.html#begin) raises the following exception:

```
Value of DEFAULT must evaluate to tinyint (actual: integer)
```