### PR TITLE
Remove reorder from Iceberg schema evolution docs

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -784,7 +784,7 @@ The {ref}`sql-schema-table-management` functionality includes support for:
 
 #### Schema evolution
 
-Iceberg supports schema evolution, with safe column add, drop, reorder, and
+Iceberg supports schema evolution, with safe column add, drop, and
 rename operations, including in nested structures.
 
 Iceberg supports updating column types only for widening operations:


### PR DESCRIPTION
## Description

Trino engine and Iceberg connector don't support column reorder. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
