### PR TITLE
Workaround Jetty async thread hanging under contention

### DIFF
--- a/core/trino-main/pom.xml
+++ b/core/trino-main/pom.xml
@@ -353,6 +353,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-io</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.gaul</groupId>
             <artifactId>modernizer-maven-annotations</artifactId>
         </dependency>

--- a/core/trino-main/src/main/java/io/trino/server/ThrowableMapper.java
+++ b/core/trino-main/src/main/java/io/trino/server/ThrowableMapper.java
@@ -26,6 +26,7 @@ import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.ResponseBuilder;
 import jakarta.ws.rs.ext.ExceptionMapper;
+import org.eclipse.jetty.io.EofException;
 
 import java.util.concurrent.TimeoutException;
 
@@ -88,6 +89,9 @@ public class ThrowableMapper
             case JsonParsingException parsingException -> Response.status(Response.Status.BAD_REQUEST)
                     .entity(Throwables.getStackTraceAsString(parsingException))
                     .build();
+            // Workaround for Jetty managed async hang issue,
+            // see: https://github.com/jetty/jetty.project/issues/13066#issuecomment-2886850448
+            case EofException _ -> null;
             default -> {
                 ResponseBuilder responseBuilder = plainTextError(Response.Status.INTERNAL_SERVER_ERROR);
                 if (includeExceptionInResponse) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix rare bug when server can hang under load ({issue}`issuenumber`)
```
