### PR TITLE
Revert "Use location directoryPath in isHierarchicalNamespaceEnabled check"

### DIFF
--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystem.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystem.java
@@ -593,7 +593,7 @@ public class AzureFileSystem
     {
         try {
             BlockBlobClient blockBlobClient = createBlobContainerClient(location, Optional.empty())
-                    .getBlobClient(location.directoryPath())
+                    .getBlobClient("/")
                     .getBlockBlobClient();
             return blockBlobClient.exists();
         }


### PR DESCRIPTION
Reverts trinodb/trino#25457

This broke the CI.