### PR TITLE
Upgrade Hudi version to 1.0.2

### DIFF
--- a/plugin/trino-hudi/pom.xml
+++ b/plugin/trino-hudi/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
-        <dep.hudi.version>1.0.1</dep.hudi.version>
+        <dep.hudi.version>1.0.2</dep.hudi.version>
     </properties>
 
     <dependencies>

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/HudiReadOptimizedDirectoryLister.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/HudiReadOptimizedDirectoryLister.java
@@ -24,6 +24,7 @@ import io.trino.plugin.hudi.HudiFileStatus;
 import io.trino.plugin.hudi.HudiTableHandle;
 import io.trino.plugin.hudi.partition.HiveHudiPartitionInfo;
 import io.trino.plugin.hudi.partition.HudiPartitionInfo;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
@@ -59,10 +60,10 @@ public class HudiReadOptimizedDirectoryLister
             List<String> hivePartitionNames,
             boolean ignoreAbsentPartitions)
     {
-        this.fileSystemView = new HoodieTableFileSystemView(
+        this.fileSystemView = HoodieTableFileSystemView.fileListingBasedFileSystemView(
+                new HoodieLocalEngineContext(metaClient.getStorageConf()),
                 metaClient,
-                metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants(),
-                ignoreAbsentPartitions);
+                metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants());
         this.partitionColumns = hiveTable.getPartitionColumns();
         this.allPartitionInfoMap = hivePartitionNames.stream()
                 .collect(Collectors.toMap(

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/storage/TestTrinoHudiStorage.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/storage/TestTrinoHudiStorage.java
@@ -20,6 +20,7 @@ import io.trino.spi.block.TestingSession;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.io.storage.TestHoodieStorageBase;
 import org.apache.hudi.io.util.IOUtils;
+import org.apache.hudi.storage.HoodieInstantWriter;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
@@ -226,7 +227,8 @@ final class TestTrinoHudiStorage
 
         StoragePath path3 = new StoragePath(getTempDir(), "testCreateAppendAndRead/3.file");
         assertThat(storage.exists(path3)).isFalse();
-        storage.createImmutableFileInPath(path3, Option.of(data));
+        storage.createImmutableFileInPath(
+                path3, Option.of(HoodieInstantWriter.convertByteArrayToWriter(data)));
         validatePathInfo(storage, path3, data, false);
 
         StoragePath path4 = new StoragePath(getTempDir(), "testCreateAppendAndRead/4");


### PR DESCRIPTION
## Description

This PR upgrades Hudi version to 1.0.2 for Hudi connector and fixes compilation issues.

## Additional context and related issues

[Hudi 1.0.2 release](https://hudi.apache.org/releases/release-1.0.2) fixes the backwards compatible reader for MDT among other fixes and improvements.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Upgrade Hudi version to 1.0.2
```
