### PR TITLE
Allow configuring heap relative to maximum

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/HeapSizeParser.java
+++ b/core/trino-main/src/main/java/io/trino/execution/HeapSizeParser.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Suppliers;
+import io.airlift.units.DataSize;
+
+import java.util.function.Supplier;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Double.parseDouble;
+import static java.util.Objects.requireNonNull;
+
+public class HeapSizeParser
+{
+    private static final String RELATIVE_SUFFIX = "%";
+
+    // Memoize the max heap memory to avoid calling Runtime.getRuntime().maxMemory() multiple times
+    // and to ensure that the value will not change over JVM lifetime.
+    private static final Supplier<Long> AVAILABLE_HEAP_MEMORY = Suppliers.memoize(Runtime.getRuntime()::maxMemory);
+
+    public static final HeapSizeParser DEFAULT = new HeapSizeParser(AVAILABLE_HEAP_MEMORY);
+
+    private final Supplier<Long> maxHeapMemory;
+
+    @VisibleForTesting
+    HeapSizeParser(Supplier<Long> maxHeapMemory)
+    {
+        this.maxHeapMemory = requireNonNull(maxHeapMemory, "maxHeapMemory is null");
+    }
+
+    public DataSize parse(String value)
+    {
+        long maxHeapMemory = this.maxHeapMemory.get();
+        checkState(maxHeapMemory > 0, "maxHeapMemory must be positive");
+
+        if (value.endsWith(RELATIVE_SUFFIX)) {
+            double multiplier = parseDouble(value.substring(0, value.length() - RELATIVE_SUFFIX.length()).trim()) / 100.0;
+            return checkHeapSizeMemory(DataSize.ofBytes(Math.round(maxHeapMemory * multiplier)).succinct(), maxHeapMemory);
+        }
+
+        return checkHeapSizeMemory(DataSize.valueOf(value), maxHeapMemory);
+    }
+
+    private static DataSize checkHeapSizeMemory(DataSize heapSize, long maxHeapMemory)
+    {
+        checkArgument(heapSize.toBytes() <= maxHeapMemory, "Heap size cannot be greater than maximum heap size");
+        checkArgument(heapSize.toBytes() > 0, "Heap size cannot be less than or equal to 0");
+        return heapSize;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/memory/NodeMemoryConfig.java
+++ b/core/trino-main/src/main/java/io/trino/memory/NodeMemoryConfig.java
@@ -17,6 +17,7 @@ import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.DefunctConfig;
 import io.airlift.units.DataSize;
+import io.trino.execution.HeapSizeParser;
 import jakarta.validation.constraints.NotNull;
 
 // This is separate from MemoryManagerConfig because it's difficult to test the default value of maxQueryMemoryPerNode
@@ -29,10 +30,8 @@ import jakarta.validation.constraints.NotNull;
 })
 public class NodeMemoryConfig
 {
-    public static final long AVAILABLE_HEAP_MEMORY = Runtime.getRuntime().maxMemory();
-    private DataSize maxQueryMemoryPerNode = DataSize.ofBytes(Math.round(AVAILABLE_HEAP_MEMORY * 0.3));
-
-    private DataSize heapHeadroom = DataSize.ofBytes(Math.round(AVAILABLE_HEAP_MEMORY * 0.3));
+    private DataSize maxQueryMemoryPerNode = HeapSizeParser.DEFAULT.parse("30%");
+    private DataSize heapHeadroom = HeapSizeParser.DEFAULT.parse("30%");
 
     @NotNull
     public DataSize getMaxQueryMemoryPerNode()
@@ -41,9 +40,9 @@ public class NodeMemoryConfig
     }
 
     @Config("query.max-memory-per-node")
-    public NodeMemoryConfig setMaxQueryMemoryPerNode(DataSize maxQueryMemoryPerNode)
+    public NodeMemoryConfig setMaxQueryMemoryPerNode(String maxQueryMemoryPerNode)
     {
-        this.maxQueryMemoryPerNode = maxQueryMemoryPerNode;
+        this.maxQueryMemoryPerNode = HeapSizeParser.DEFAULT.parse(maxQueryMemoryPerNode);
         return this;
     }
 
@@ -55,9 +54,9 @@ public class NodeMemoryConfig
 
     @Config("memory.heap-headroom-per-node")
     @ConfigDescription("The amount of heap memory to set aside as headroom/buffer (e.g., for untracked allocations)")
-    public NodeMemoryConfig setHeapHeadroom(DataSize heapHeadroom)
+    public NodeMemoryConfig setHeapHeadroom(String heapHeadroom)
     {
-        this.heapHeadroom = heapHeadroom;
+        this.heapHeadroom = HeapSizeParser.DEFAULT.parse(heapHeadroom);
         return this;
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/BaseTestSqlTaskManager.java
+++ b/core/trino-main/src/test/java/io/trino/execution/BaseTestSqlTaskManager.java
@@ -267,7 +267,7 @@ public abstract class BaseTestSqlTaskManager
     public void testSessionPropertyMemoryLimitOverride()
     {
         NodeMemoryConfig memoryConfig = new NodeMemoryConfig()
-                .setMaxQueryMemoryPerNode(DataSize.ofBytes(3));
+                .setMaxQueryMemoryPerNode("3B");
 
         try (SqlTaskManager sqlTaskManager = createSqlTaskManager(new TaskManagerConfig(), memoryConfig)) {
             TaskId reduceLimitsId = new TaskId(new StageId("q1", 0), 1, 0);

--- a/core/trino-main/src/test/java/io/trino/execution/TestHeapSizeParser.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestHeapSizeParser.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution;
+
+import io.airlift.units.DataSize;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Supplier;
+
+import static io.airlift.units.DataSize.Unit.GIGABYTE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TestHeapSizeParser
+{
+    private static final Supplier<Long> MAX_HEAP_MEMORY = () -> DataSize.of(8, GIGABYTE).toBytes();
+    private static final HeapSizeParser HEAP_SIZE_PARSER = new HeapSizeParser(MAX_HEAP_MEMORY);
+
+    @Test
+    void testAbsoluteMemory()
+    {
+        assertThat(HEAP_SIZE_PARSER.parse("1GB")).isEqualTo(DataSize.of(1, GIGABYTE));
+        assertThat(HEAP_SIZE_PARSER.parse("8GB")).isEqualTo(DataSize.of(8, GIGABYTE));
+
+        assertThatThrownBy(() -> HEAP_SIZE_PARSER.parse("9GB"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Heap size cannot be greater than maximum heap size");
+
+        assertThatThrownBy(() -> HEAP_SIZE_PARSER.parse("0B"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Heap size cannot be less than or equal to 0");
+    }
+
+    @Test
+    void testRelativeMemory()
+    {
+        assertThat(HEAP_SIZE_PARSER.parse("12.5%")).isEqualTo(DataSize.of(1, GIGABYTE));
+        assertThat(HEAP_SIZE_PARSER.parse("100%")).isEqualTo(DataSize.of(8, GIGABYTE));
+        assertThat(HEAP_SIZE_PARSER.parse("50%")).isEqualTo(DataSize.of(4, GIGABYTE));
+
+        assertThatThrownBy(() -> HEAP_SIZE_PARSER.parse("125%"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Heap size cannot be greater than maximum heap size");
+
+        assertThatThrownBy(() -> HEAP_SIZE_PARSER.parse("0%"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Heap size cannot be less than or equal to 0");
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/memory/TestLocalMemoryManager.java
+++ b/core/trino-main/src/test/java/io/trino/memory/TestLocalMemoryManager.java
@@ -16,7 +16,7 @@ package io.trino.memory;
 import io.airlift.units.DataSize;
 import org.junit.jupiter.api.Test;
 
-import static io.airlift.units.DataSize.Unit.GIGABYTE;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestLocalMemoryManager
@@ -25,11 +25,11 @@ public class TestLocalMemoryManager
     public void testNotEnoughAvailableMemory()
     {
         NodeMemoryConfig config = new NodeMemoryConfig()
-                .setHeapHeadroom(DataSize.of(10, GIGABYTE))
-                .setMaxQueryMemoryPerNode(DataSize.of(20, GIGABYTE));
+                .setHeapHeadroom("1MB")
+                .setMaxQueryMemoryPerNode("4MB");
 
-        // 25 GB heap is not sufficient for 10 GB heap headroom and 20 GB query.max-memory-per-node
-        assertThatThrownBy(() -> new LocalMemoryManager(config, DataSize.of(25, GIGABYTE).toBytes()))
+        // 4 MB heap is not sufficient for 1 MB heap headroom and 4 MB query.max-memory-per-node
+        assertThatThrownBy(() -> new LocalMemoryManager(config, DataSize.of(4, MEGABYTE).toBytes()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageMatching("Invalid memory configuration\\. The sum of max query memory per node .* and heap headroom .*" +
                         "cannot be larger than the available heap memory .*");

--- a/docs/src/main/sphinx/admin/properties-resource-management.md
+++ b/docs/src/main/sphinx/admin/properties-resource-management.md
@@ -12,8 +12,8 @@ cluster. Queries that exceed this limit are killed.
 (prop-resource-query-max-memory-per-node)=
 ## `query.max-memory-per-node`
 
-- **Type:** {ref}`prop-type-data-size`
-- **Default value:** (JVM max memory * 0.3)
+- **Type:** {ref}`prop-type-heap-size`
+- **Default value:** (30% of maximum heap size on the node)
 
 This is the max amount of user memory a query can use on a worker.
 User memory is allocated during execution for things that are directly
@@ -77,8 +77,8 @@ Does not apply for queries with task level retries enabled (`retry-policy=TASK`)
 (prop-resource-memory-heap-headroom-per-node)=
 ## `memory.heap-headroom-per-node`
 
-- **Type:** {ref}`prop-type-data-size`
-- **Default value:** (JVM max memory * 0.3)
+- **Type:** {ref}`prop-type-heap-size`
+- **Default value:** (30% of maximum heap size on the node)
 
 This is the amount of memory set aside as headroom/buffer in the JVM heap
 for allocations that are not tracked by Trino.

--- a/docs/src/main/sphinx/admin/properties.md
+++ b/docs/src/main/sphinx/admin/properties.md
@@ -94,6 +94,15 @@ Properties of type `duration` also support decimal values, such as `2.25d`.
 These are handled as a fractional value of the specified unit. For example, the
 value `1.5m` equals one and a half minutes, or 90 seconds.
 
+(prop-type-heap-size)=
+### `heap size`
+
+Properties of type `heap size` support values that specify an amount of heap memory.
+These values can be provided in the same format as the `data size` property, or as `double`
+values followed by a `%` suffix. The `%` suffix indicates a percentage of the maximum heap 
+memory available on the node. The minimum allowed value is `1B`, and the maximum is `100%`, 
+which corresponds to the maximum heap memory available on the node.
+
 (prop-type-integer)=
 ### `integer`
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Allow configuring `query.max-memory-per-node` and `memory.heap-headroom-per-node` relative to maximum heap size ({issue}`issuenumber`)
```
