### PR TITLE
Reduce memory usage of remove_orphan_files procedure

### DIFF
--- a/plugin/trino-iceberg/src/main/java/org/apache/iceberg/IcebergManifestUtils.java
+++ b/plugin/trino-iceberg/src/main/java/org/apache/iceberg/IcebergManifestUtils.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.iceberg;
+
+import org.apache.iceberg.io.FileIO;
+
+import java.util.List;
+
+public class IcebergManifestUtils
+{
+    private IcebergManifestUtils() {}
+
+    public static List<ManifestFile> read(FileIO fileIO, String manifestListLocation)
+    {
+        // Avoid using snapshot.allManifests() when processing multiple snapshots,
+        // as each Snapshot instance internally caches `org.apache.iceberg.BaseSnapshot.allManifests`
+        // and leads to high memory usage
+        return ManifestLists.read(fileIO.newInputFile(manifestListLocation));
+    }
+}


### PR DESCRIPTION
## Description
Reduces memory usage of coordinator during iceberg remove orphan files procedure for tables with large numbers of snapshots. 

See comment for description of fix:
```
    /**
     * Use instead of loadAllManifestsFromSnapshot when loading manifests from multiple distinct snapshots
     * Each BaseSnapshot object caches manifest files separately, so loading manifests from multiple distinct snapshots
     * results in O(num_snapshots^2) copies of the same manifest file metadata in memory
     */
```


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

To show decreased memory usage:

1. Created a table with 1000 snapshots/1000 manifest files and ran orphan files
```
    @Test
    public void testRemoveOrphanFilesOnTableWithManySnapshots()
    {
        String tableName = "test_remove_orphan_files_on_table_with_many_snapshots_" + randomNameSuffix();
        String fullyQualifiedTableName = "iceberg.%s.%s".formatted(getSession().getSchema().orElseThrow(), tableName);

        // Create table with 10K snapshots
        assertUpdate("SET SESSION iceberg.merge_manifests_on_write = false");
        assertUpdate("CREATE TABLE %s (a) AS VALUES 0".formatted(fullyQualifiedTableName), 1);
        for (int i = 1; i < 1000; i++) {
            assertUpdate("INSERT INTO %s VALUES %d".formatted(fullyQualifiedTableName, i), 1);
        }

        assertQuerySucceeds("ALTER TABLE %s EXECUTE REMOVE_ORPHAN_FILES".formatted(fullyQualifiedTableName));
        assertThat(computeScalar("SELECT count(*) FROM %s".formatted(fullyQualifiedTableName))).isEqualTo(1000L);
        assertUpdate("DROP TABLE %s".formatted(fullyQualifiedTableName));
    }
```
2. Attempted to take heapdump, but it did not show a difference in memory usage attributed to the caching of manifest files on the `BaseSnapshot` object. Root cause was incorrect attribution of memory usage of the List<ManifestFile>, because `BaseSnapshot#cacheManifests` calls `ManifestLists.read` which returns a LinkedList. The heapdump memory attribution logic was not correctly attributing all the objects in the LinkedList to `BaseSnapshot`, only the first node. 
3. Manually inspected `table.snapshots()` in a debugger to confirm the manifest caching was not occurring. 

(before change)
<img width="1369" alt="Screenshot 2025-05-21 at 3 03 13 PM" src="https://github.com/user-attachments/assets/566d0f64-8e27-4d08-bf72-c57e52f5dc19" />
(after change)
<img width="1021" alt="Screenshot 2025-05-21 at 3 06 21 PM" src="https://github.com/user-attachments/assets/df761be1-8848-4c05-b1a5-7986d06de426" />



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Reduce memory usage of remove_orphan_files procedure. ({issue}`25847`)
```
