### PR TITLE
[Doc] Update MySQL Configuration Properties Link

### DIFF
--- a/docs/src/main/sphinx/admin/event-listeners-mysql.md
+++ b/docs/src/main/sphinx/admin/event-listeners-mysql.md
@@ -39,7 +39,7 @@ The `mysql-event-listener.db.url` defines the connection to a MySQL database
 available at the domain `example.net` on port 3306. You can pass further
 parameters to the MySQL JDBC driver. The supported parameters for the URL are
 documented in the [MySQL Developer
-Guide](https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-configuration-properties.html).
+Guide](https://dev.mysql.com/doc/connector-j/en/connector-j-reference-configuration-properties.html).
 
 And set `event-listener.config-files` to `etc/mysql-event-listener.properties`
 in {ref}`config-properties`:

--- a/docs/src/main/sphinx/connector/mysql.md
+++ b/docs/src/main/sphinx/connector/mysql.md
@@ -38,7 +38,7 @@ connection-password=secret
 
 The `connection-url` defines the connection information and parameters to pass
 to the MySQL JDBC driver. The supported parameters for the URL are
-available in the [MySQL Developer Guide](https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-configuration-properties.html).
+available in the [MySQL Developer Guide](https://dev.mysql.com/doc/connector-j/en/connector-j-reference-configuration-properties.html).
 
 For example, the following `connection-url` allows you to require encrypted
 connections to the MySQL server:


### PR DESCRIPTION
## Description
## Additional context and related issues

The MySQL Event Listener and MySQL Connector documentation are pointing to an incorrect page. It should be updated to link to the correct one.

## Additional context and related issues
Fixes #25846 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
