### PR TITLE
Refactor `TransactionLogTail#loadNewTail` method

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TransactionLogTail.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TransactionLogTail.java
@@ -19,6 +19,7 @@ import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoInputFile;
 import io.trino.plugin.deltalake.transactionlog.DeltaLakeTransactionLogEntry;
+import io.trino.plugin.deltalake.transactionlog.MissingTransactionLogException;
 import io.trino.plugin.deltalake.transactionlog.Transaction;
 import io.trino.plugin.deltalake.transactionlog.TransactionLogEntries;
 
@@ -31,6 +32,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
 import static io.airlift.slice.SizeOf.instanceSize;
+import static io.trino.plugin.deltalake.transactionlog.TransactionLogUtil.getTransactionLogDir;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogUtil.getTransactionLogJsonEntryPath;
 import static java.util.Objects.requireNonNull;
 
@@ -45,6 +47,31 @@ public class TransactionLogTail
     {
         this.entries = ImmutableList.copyOf(requireNonNull(entries, "entries is null"));
         this.version = version;
+    }
+
+    // Load a section of the Transaction Log JSON entries. Optionally from a given start version (exclusive) through an end version (inclusive)
+    public static TransactionLogTail loadNewTail(
+            TrinoFileSystem fileSystem,
+            String tableLocation,
+            Optional<Long> startVersion,
+            Optional<Long> endVersion,
+            DataSize transactionLogMaxCachedFileSize)
+            throws IOException
+    {
+        if (startVersion.isPresent() && endVersion.isPresent() && startVersion.get().equals(endVersion.get())) {
+            // This is time travel to a specific checkpoint. No need to read transaction log files.
+            return new TransactionLogTail(ImmutableList.of(), startVersion.get());
+        }
+
+        if (endVersion.isPresent()) {
+            return loadNewTailBackward(fileSystem, tableLocation, startVersion, endVersion.get(), transactionLogMaxCachedFileSize);
+        }
+
+        if (startVersion.isPresent()) {
+            return loadNewTail(fileSystem, tableLocation, startVersion.get(), startVersion.get() + 1, transactionLogMaxCachedFileSize);
+        }
+
+        return loadNewTail(fileSystem, tableLocation, 0L, 0L, transactionLogMaxCachedFileSize);
     }
 
     /**
@@ -94,5 +121,74 @@ public class TransactionLogTail
         return INSTANCE_SIZE
                 + SIZE_OF_LONG
                 + estimatedSizeOf(entries, Transaction::getRetainedSizeInBytes);
+    }
+
+    /**
+     * Loads a section of the Transaction Log JSON entries starting from {@code startVersion} (inclusive) up to the latest version.
+     *
+     * the {@code version} is the latest table version, which is the last entry number in the transaction log we already know,
+     * the {@code starVersion} is the first entry number we want to load, but it is not guaranteed to be the first entry in the transaction log.
+     */
+    private static TransactionLogTail loadNewTail(
+            TrinoFileSystem fileSystem,
+            String tableLocation,
+            long version,
+            long startVersion,
+            DataSize transactionLogMaxCachedFileSize)
+            throws IOException
+    {
+        ImmutableList.Builder<Transaction> entriesBuilder = ImmutableList.builder();
+        String transactionLogDir = getTransactionLogDir(tableLocation);
+
+        long entryNumber = startVersion;
+        while (true) {
+            Optional<TransactionLogEntries> results = getEntriesFromJson(entryNumber, transactionLogDir, fileSystem, transactionLogMaxCachedFileSize);
+            if (results.isEmpty()) {
+                break;
+            }
+
+            entriesBuilder.add(new Transaction(entryNumber, results.get()));
+            version = entryNumber;
+            entryNumber++;
+        }
+
+        return new TransactionLogTail(entriesBuilder.build(), version);
+    }
+
+    // Load a section of the Transaction Log JSON entries. Optionally from a given end version (inclusive) through a start version (exclusive)
+    private static TransactionLogTail loadNewTailBackward(
+            TrinoFileSystem fileSystem,
+            String tableLocation,
+            Optional<Long> startVersion,
+            long endVersion,
+            DataSize transactionLogMaxCachedFileSize)
+            throws IOException
+    {
+        ImmutableList.Builder<Transaction> transactionsBuilder = ImmutableList.builder();
+        String transactionLogDir = getTransactionLogDir(tableLocation);
+
+        long version = endVersion;
+        long entryNumber = version;
+        boolean endOfHead = false;
+
+        while (!endOfHead) {
+            Optional<TransactionLogEntries> results = getEntriesFromJson(entryNumber, transactionLogDir, fileSystem, transactionLogMaxCachedFileSize);
+            if (results.isPresent()) {
+                transactionsBuilder.add(new Transaction(entryNumber, results.get()));
+                version = entryNumber;
+                entryNumber--;
+            }
+            else {
+                // When there is a gap in the transaction log version, indicate the end of the current head
+                endOfHead = true;
+                if (startVersion.isPresent() && entryNumber > startVersion.get() + 1) {
+                    throw new MissingTransactionLogException(getTransactionLogJsonEntryPath(transactionLogDir, entryNumber).toString());
+                }
+            }
+            if ((startVersion.isPresent() && version == startVersion.get() + 1) || entryNumber < 0) {
+                endOfHead = true;
+            }
+        }
+        return new TransactionLogTail(transactionsBuilder.build().reversed(), endVersion);
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/reader/FileSystemTransactionLogReader.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/reader/FileSystemTransactionLogReader.java
@@ -13,23 +13,14 @@
  */
 package io.trino.plugin.deltalake.transactionlog.reader;
 
-import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
-import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
-import io.trino.plugin.deltalake.transactionlog.MissingTransactionLogException;
-import io.trino.plugin.deltalake.transactionlog.Transaction;
-import io.trino.plugin.deltalake.transactionlog.TransactionLogEntries;
 import io.trino.plugin.deltalake.transactionlog.checkpoint.TransactionLogTail;
 import io.trino.spi.connector.ConnectorSession;
 
 import java.io.IOException;
 import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static io.trino.plugin.deltalake.transactionlog.TransactionLogUtil.getTransactionLogDir;
-import static io.trino.plugin.deltalake.transactionlog.TransactionLogUtil.getTransactionLogJsonEntryPath;
-import static io.trino.plugin.deltalake.transactionlog.checkpoint.TransactionLogTail.getEntriesFromJson;
 import static java.util.Objects.requireNonNull;
 
 public class FileSystemTransactionLogReader
@@ -52,41 +43,6 @@ public class FileSystemTransactionLogReader
             DataSize transactionLogMaxCachedFileSize)
             throws IOException
     {
-        ImmutableList.Builder<Transaction> entriesBuilder = ImmutableList.builder();
-
-        if (startVersion.isPresent() && endVersion.isPresent() && startVersion.get().equals(endVersion.get())) {
-            // This is time travel to a specific checkpoint. No need to read transaction log files.
-            return new TransactionLogTail(entriesBuilder.build(), startVersion.get());
-        }
-
-        // TODO: check if we should use startVersion or endVersion, in the case that startVersion is not present this could returns empty entries which is not correct
-        long version = startVersion.orElse(0L);
-        long entryNumber = startVersion.map(start -> start + 1).orElse(0L);
-        checkArgument(endVersion.isEmpty() || entryNumber <= endVersion.get(), "Invalid start/end versions: %s, %s", startVersion, endVersion);
-
-        String transactionLogDir = getTransactionLogDir(tableLocation);
-        TrinoFileSystem fileSystem = fileSystemFactory.create(session);
-
-        boolean endOfTail = false;
-        while (!endOfTail) {
-            Optional<TransactionLogEntries> results = getEntriesFromJson(entryNumber, transactionLogDir, fileSystem, transactionLogMaxCachedFileSize);
-            if (results.isPresent()) {
-                entriesBuilder.add(new Transaction(entryNumber, results.get()));
-                version = entryNumber;
-                entryNumber++;
-            }
-            else {
-                if (endVersion.isPresent()) {
-                    throw new MissingTransactionLogException(getTransactionLogJsonEntryPath(transactionLogDir, entryNumber).toString());
-                }
-                endOfTail = true;
-            }
-
-            if (endVersion.isPresent() && version == endVersion.get()) {
-                endOfTail = true;
-            }
-        }
-
-        return new TransactionLogTail(entriesBuilder.build(), version);
+        return TransactionLogTail.loadNewTail(fileSystemFactory.create(session), tableLocation, startVersion, endVersion, transactionLogMaxCachedFileSize);
     }
 }


### PR DESCRIPTION
Refactor `TransactionLogTail#loadNewTail` to support loading transaction log to based on param `startVersion` and `endVersion` conditional. Previously, the method only supported forward traversal from head to tail, which posed a risk when early transaction logs were missing -- maybe due to cleanup. This refactor enables both forward and backward traversal, increasing robustness and flexibility in tail loading logic.

Additionally, remove `BaseTransactionsTable#loadNewTailBackward` and use the enhanced loadNewTail method.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
