### PR TITLE
Downgrade AWS SDK v2 to 2.31.47

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -305,7 +305,7 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.31.49</version>
+                <version>2.31.47</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
## Description

Iceberg `migrate` procedure started failing after upgrading to 2.31.49.

https://github.com/trinodb/trino/actions/runs/15212548249/job/42846755983
```
Error:  io.trino.plugin.iceberg.catalog.glue.TestSharedGlueMetastore.testMigrateTable -- Time elapsed: 1.000 s <<< ERROR!
io.trino.testing.QueryFailedException: Failed to migrate table
	at io.trino.testing.AbstractTestingTrinoClient.execute(AbstractTestingTrinoClient.java:138)
	at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:565)
	at io.trino.testing.DistributedQueryRunner.executeWithPlan(DistributedQueryRunner.java:554)
	at io.trino.testing.QueryAssertions.assertDistributedUpdate(QueryAssertions.java:106)
	at io.trino.testing.QueryAssertions.assertUpdate(QueryAssertions.java:60)
	at io.trino.testing.AbstractTestQueryFramework.assertUpdate(AbstractTestQueryFramework.java:416)
	at io.trino.testing.AbstractTestQueryFramework.assertUpdate(AbstractTestQueryFramework.java:411)
	at io.trino.plugin.iceberg.BaseSharedMetastoreTest.testMigrateTable(BaseSharedMetastoreTest.java:240)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:507)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.tryRemoveAndExec(ForkJoinPool.java:1434)
	at java.base/java.util.concurrent.ForkJoinPool.helpJoin(ForkJoinPool.java:2197)
	at java.base/java.util.concurrent.ForkJoinTask.awaitDone(ForkJoinTask.java:495)
	at java.base/java.util.concurrent.ForkJoinTask.join(ForkJoinTask.java:662)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:507)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1394)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1970)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
	Suppressed: java.lang.Exception: SQL: CALL iceberg.system.migrate('test_mutable_shared_schema_2ualh9b3mb', 'test_migrate_pxakcv9a11')
		at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:572)
		... 16 more
Caused by: io.trino.spi.TrinoException: Failed to migrate table
	at io.trino.plugin.iceberg.procedure.MigrateProcedure.doMigrate(MigrateProcedure.java:255)
	at io.trino.plugin.iceberg.procedure.MigrateProcedure.migrate(MigrateProcedure.java:170)
	at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:735)
	at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:760)
	at io.trino.execution.CallTask.execute(CallTask.java:210)
	at io.trino.execution.CallTask.execute(CallTask.java:70)
	at io.trino.execution.DataDefinitionExecution.start(DataDefinitionExecution.java:152)
	at io.trino.execution.SqlQueryManager.createQuery(SqlQueryManager.java:272)
	at io.trino.dispatcher.LocalDispatchQuery.startExecution(LocalDispatchQuery.java:150)
	at io.trino.dispatcher.LocalDispatchQuery.lambda$waitForMinimumWorkers$1(LocalDispatchQuery.java:134)
	at io.airlift.concurrent.MoreFutures.lambda$addSuccessCallback$12(MoreFutures.java:570)
	at io.airlift.concurrent.MoreFutures$3.onSuccess(MoreFutures.java:545)
	at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1132)
	at io.trino.$gen.Trino_testversion____20250525_052808_316.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1095)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:619)
	at java.base/java.lang.Thread.run(Thread.java:1447)
Caused by: io.trino.spi.TrinoException: updating `table_type` parameter is not supported. (Service: Glue, Status Code: 400, Request ID: 2[383](https://github.com/trinodb/trino/actions/runs/15234419066/job/42847312717#step:17:384)07d2-82ce-4f3d-9f31-afd0c483a15c) (SDK Attempt Count: 1)
	at io.trino.plugin.hive.metastore.glue.GlueHiveMetastore.updateTable(GlueHiveMetastore.java:626)
	at io.trino.plugin.hive.metastore.glue.GlueHiveMetastore.replaceTable(GlueHiveMetastore.java:601)
	at io.trino.metastore.tracing.TracingHiveMetastore.lambda$replaceTable$0(TracingHiveMetastore.java:244)
	at io.trino.metastore.tracing.Tracing.lambda$withTracing$0(Tracing.java:35)
	at io.trino.metastore.tracing.Tracing.withTracing(Tracing.java:43)
	at io.trino.metastore.tracing.Tracing.withTracing(Tracing.java:34)
	at io.trino.metastore.tracing.TracingHiveMetastore.replaceTable(TracingHiveMetastore.java:244)
	at io.trino.plugin.iceberg.procedure.MigrateProcedure.doMigrate(MigrateProcedure.java:249)
	... 16 more
Caused by: software.amazon.awssdk.services.glue.model.InvalidInputException: updating `table_type` parameter is not supported. (Service: Glue, Status Code: 400, Request ID: 238307d2-82ce-4f3d-9f31-afd0c483a15c) (SDK Attempt Count: 1)
	at software.amazon.awssdk.services.glue.model.InvalidInputException$BuilderImpl.build(InvalidInputException.java:215)
	at software.amazon.awssdk.services.glue.model.InvalidInputException$BuilderImpl.build(InvalidInputException.java:146)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.utils.RetryableStageHelper.retryPolicyDisallowedRetryException(RetryableStageHelper.java:168)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:73)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:36)
	at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
	at software.amazon.awssdk.core.internal.http.StreamManagingStage.execute(StreamManagingStage.java:53)
	at software.amazon.awssdk.core.internal.http.StreamManagingStage.execute(StreamManagingStage.java:35)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.executeWithTimer(ApiCallTimeoutTrackingStage.java:82)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.execute(ApiCallTimeoutTrackingStage.java:62)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.execute(ApiCallTimeoutTrackingStage.java:43)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallMetricCollectionStage.execute(ApiCallMetricCollectionStage.java:50)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallMetricCollectionStage.execute(ApiCallMetricCollectionStage.java:32)
	at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
	at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ExecutionFailureExceptionReportingStage.execute(ExecutionFailureExceptionReportingStage.java:37)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ExecutionFailureExceptionReportingStage.execute(ExecutionFailureExceptionReportingStage.java:26)
	at software.amazon.awssdk.core.internal.http.AmazonSyncHttpClient$RequestExecutionBuilderImpl.execute(AmazonSyncHttpClient.java:210)
	at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.invoke(BaseSyncClientHandler.java:103)
	at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.doExecute(BaseSyncClientHandler.java:173)
	at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.lambda$execute$1(BaseSyncClientHandler.java:80)
	at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.measureApiCallSuccess(BaseSyncClientHandler.java:182)
	at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.execute(BaseSyncClientHandler.java:74)
	at software.amazon.awssdk.core.client.handler.SdkSyncClientHandler.execute(SdkSyncClientHandler.java:45)
	at software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler.execute(AwsSyncClientHandler.java:53)
	at software.amazon.awssdk.services.glue.DefaultGlueClient.updateTable(DefaultGlueClient.java:51929)
	at software.amazon.awssdk.services.glue.GlueClient.updateTable(GlueClient.java:28264)
	at io.trino.plugin.hive.metastore.glue.GlueHiveMetastore.lambda$updateTable$1(GlueHiveMetastore.java:618)
	at io.trino.plugin.hive.metastore.glue.AwsApiCallStats.call(AwsApiCallStats.java:36)
	at io.trino.plugin.hive.metastore.glue.GlueHiveMetastore.updateTable(GlueHiveMetastore.java:618)
	... 23 more
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
