### PR TITLE
Disable migrate procedure test on Iceberg Glue catalog

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestSharedGlueMetastore.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestSharedGlueMetastore.java
@@ -26,6 +26,7 @@ import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
 import io.trino.tpch.TpchTable;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 
@@ -147,4 +148,14 @@ public class TestSharedGlueMetastore
                 ")";
         return format(expectedIcebergCreateSchema, catalogName, tpchSchema, dataDirectory.toUri());
     }
+
+    // TODO https://github.com/trinodb/trino/issues/25859 Fix broken migrate procedure on Glue metastore
+    @Test
+    @Override
+    public void testMigrateTable() {}
+
+    // TODO https://github.com/trinodb/trino/issues/25859 Fix broken migrate procedure on Glue metastore
+    @Test
+    @Override
+    public void testMigratePartitionedTable() {}
 }


### PR DESCRIPTION
## Description

Relates to #25859

It seems AWS changed Glue behavior recently. The procedure throws "updating `table_type` parameter is not supported" error. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
