### PR TITLE
Redshift batch inserts using COPY FROM operation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -739,6 +739,7 @@ jobs:
           REDSHIFT_VPC_SECURITY_GROUP_IDS: ${{ vars.REDSHIFT_VPC_SECURITY_GROUP_IDS }}
           REDSHIFT_S3_TPCH_TABLES_ROOT: ${{ vars.REDSHIFT_S3_TPCH_TABLES_ROOT }}
           REDSHIFT_S3_UNLOAD_ROOT: ${{ vars.REDSHIFT_S3_UNLOAD_ROOT }}
+          REDSHIFT_S3_COPY_ROOT: ${{ vars.REDSHIFT_S3_COPY_ROOT }}
         if: >-
           contains(matrix.modules, 'trino-redshift') &&
           (contains(matrix.profile, 'cloud-tests') || contains(matrix.profile, 'fte-tests')) &&
@@ -752,6 +753,7 @@ jobs:
             -Dtest.redshift.jdbc.endpoint="${REDSHIFT_ENDPOINT}:${REDSHIFT_PORT}/" \
             -Dtest.redshift.s3.tpch.tables.root="${REDSHIFT_S3_TPCH_TABLES_ROOT}" \
             -Dtest.redshift.s3.unload.root="${REDSHIFT_S3_UNLOAD_ROOT}" \
+            -Dtest.redshift.s3.copy.root="${REDSHIFT_S3_COPY_ROOT}" \
             -Dtest.redshift.iam.role="${REDSHIFT_IAM_ROLES}" \
             -Dtest.redshift.aws.region="${AWS_REGION}" \
             -Dtest.redshift.aws.access-key="${AWS_ACCESS_KEY_ID}" \

--- a/docs/src/main/sphinx/connector/redshift.md
+++ b/docs/src/main/sphinx/connector/redshift.md
@@ -262,3 +262,35 @@ potentially re-activate it again afterward.
 Additionally, define further required [S3 configuration such as IAM key, role,
 or region](/object-storage/file-system-s3), except `fs.native-s3.enabled`,
 
+### Batch inserts from S3 using Redshift `COPY FROM`
+
+The connector supports the Redshift `COPY FROM` command to 
+efficiently write large batches of data to Redshift by staging them as 
+Parquet files on Amazon S3. This method significantly improves sink 
+performance compared to the default JDBC batch inserts for Redshift.
+
+This feature is disabled by default.  To enable this feature, configure a 
+writeable S3 location with the following configuration properties:
+
+:::{list-table} Parallel write configuration properties
+:widths: 30, 60
+:header-rows: 1
+
+* - Property
+   - Description
+* - `redshift.batched-inserts-copy-location`
+   - A writeable location in Amazon S3 in the same AWS region as the 
+     Redshift cluster. Used for temporary Parquet staging files during 
+     insert operations. These files are automatically cleaned up after the load.
+* - `redshift.batched-inserts-copy-iam-role`
+   - Fully specified ARN of the IAM Role to use for the `COPY FROM` 
+     command. This role must have read access to the S3 bucket.
+
+:::
+
+Use the `batched_inserts_copy_enabled` [catalog session property](/sql/set-session) to
+deactivate the batch inserts using copy for a specific query, and
+potentially re-activate it again afterward.
+
+Additionally, define further required [S3 configuration such as IAM key, role,
+or region](/object-storage/file-system-s3).

--- a/plugin/trino-redshift/pom.xml
+++ b/plugin/trino-redshift/pom.xml
@@ -74,6 +74,10 @@
             <groupId>io.trino</groupId>
             <artifactId>trino-filesystem-s3</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-hive</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.trino</groupId>
@@ -108,6 +112,17 @@
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-column</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-format-structures</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftBatchedInsertsCopyPageSink.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftBatchedInsertsCopyPageSink.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.redshift;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.log.Logger;
+import io.airlift.slice.Slice;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.parquet.writer.ParquetSchemaConverter;
+import io.trino.parquet.writer.ParquetWriterOptions;
+import io.trino.plugin.hive.parquet.ParquetFileWriter;
+import io.trino.spi.Page;
+import io.trino.spi.connector.ConnectorPageSink;
+import io.trino.spi.connector.ConnectorPageSinkId;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.TimestampWithTimeZoneType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeOperators;
+import org.apache.parquet.format.CompressionCodec;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class RedshiftBatchedInsertsCopyPageSink
+        implements ConnectorPageSink
+{
+    private static final Logger log = Logger.get(RedshiftBatchedInsertsCopyPageSink.class);
+
+    private static final int MAX_ROWS_PER_FILE = 100_000;
+
+    private final TrinoFileSystem fileSystem;
+    private final TypeOperators typeOperators;
+    private final Location copyLocation;
+    private final List<Type> columnTypes;
+    private final String trinoVersion;
+    private final ConnectorPageSinkId pageSinkId;
+    private ParquetFileWriter parquetWriter;
+    private long rowsInCurrentFile;
+    private int filePartNumber;
+
+    public RedshiftBatchedInsertsCopyPageSink(
+            ConnectorSession session,
+            ConnectorPageSinkId pageSinkId,
+            TrinoFileSystemFactory fileSystemFactory,
+            TypeOperators typeOperators,
+            Location copyLocation,
+            List<String> columnNames,
+            List<Type> columnTypes,
+            String trinoVersion)
+    {
+        this.pageSinkId = requireNonNull(pageSinkId, "pageSinkId is null");
+        this.fileSystem = requireNonNull(fileSystemFactory, "fileSystemFactory is null").create(session);
+        this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
+        this.copyLocation = copyLocation;
+        this.columnTypes = ImmutableList.copyOf(requireNonNull(columnTypes, "columnTypes is null"));
+        this.trinoVersion = trinoVersion;
+        checkArgument(columnNames.size() == columnTypes.size(), "columnNames and columnTypes must have the same size");
+
+        startNewPart();
+    }
+
+    @Override
+    public CompletableFuture<?> appendPage(Page page)
+    {
+        long positionCount = page.getPositionCount();
+        if (positionCount == 0) {
+            return NOT_BLOCKED;
+        }
+
+        parquetWriter.appendRows(page);
+        rowsInCurrentFile += positionCount;
+
+        if (rowsInCurrentFile >= MAX_ROWS_PER_FILE) {
+            flushCurrentFile();
+            startNewPart();
+            rowsInCurrentFile = 0;
+        }
+
+        return NOT_BLOCKED;
+    }
+
+    private void startNewPart()
+    {
+        Location objectKey = copyLocation.appendPath(Long.toHexString(pageSinkId.getId())).appendPath(format("part-%d.parquet", filePartNumber++));
+        this.parquetWriter = createParquetFileWriter(objectKey);
+    }
+
+    @Override
+    public CompletableFuture<Collection<Slice>> finish()
+    {
+        if (rowsInCurrentFile > 0) {
+            flushCurrentFile();
+        }
+
+        return CompletableFuture.completedFuture(List.of());
+    }
+
+    @Override
+    public void abort()
+    {
+        cleanupFiles();
+    }
+
+    public void cleanupFiles()
+    {
+        try {
+            fileSystem.deleteDirectory(copyLocation);
+        }
+        catch (IOException e) {
+            log.warn("Unable to cleanup location %s: %s", copyLocation, e.getMessage());
+            // We don't want to rethrow here, as the query has already completed successfully
+        }
+    }
+
+    private ParquetFileWriter createParquetFileWriter(Location path)
+    {
+        log.debug("Creating parquet file at location: %s", path.toString());
+        ParquetWriterOptions parquetWriterOptions = ParquetWriterOptions.builder().build();
+        CompressionCodec compressionCodec = CompressionCodec.SNAPPY;
+
+        try {
+            Closeable rollbackAction = this::abort;
+
+            // According to Redshift docs, COPY inserts columns in the same order as the columns in the parquet. We
+            // don't need the column names to match. We will instead create arbitrary column name to avoid any of the
+            // parquet restrictions on column names.
+            // See: https://docs.aws.amazon.com/redshift/latest/dg/copy-usage_notes-copy-from-columnar.html
+            List<String> columnNames = new ArrayList<>();
+            for (int i = 0; i < columnTypes.size(); i++) {
+                columnNames.add(String.format("col%d", i));
+            }
+
+            ParquetSchemaConverter converter = new ParquetSchemaConverter(
+                    columnTypes,
+                    columnNames,
+                    false,
+                    false);
+
+            List<Type> parquetTypes = columnTypes.stream()
+                    .map(type -> RedshiftParquetTypes.toParquetType(typeOperators, type))
+                    .collect(toImmutableList());
+
+            // we use identity column mapping; input page already contains only data columns per
+            // DataLagePageSink.getDataPage()
+            int[] identityMapping = new int[columnTypes.size()];
+            for (int i = 0; i < identityMapping.length; ++i) {
+                identityMapping[i] = i;
+            }
+
+            return new ParquetFileWriter(
+                    fileSystem.newOutputFile(path),
+                    rollbackAction,
+                    parquetTypes,
+                    columnNames,
+                    converter.getMessageType(),
+                    converter.getPrimitiveTypes(),
+                    parquetWriterOptions,
+                    identityMapping,
+                    compressionCodec,
+                    trinoVersion,
+                    Optional.empty(),
+                    Optional.empty());
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private void flushCurrentFile()
+    {
+        parquetWriter.commit();
+    }
+
+    public static final class RedshiftParquetTypes
+    {
+        public static Type toParquetType(TypeOperators typeOperators, Type type)
+        {
+            if (type instanceof TimestampWithTimeZoneType timestamp) {
+                verify(timestamp.getPrecision() == 3, "Unsupported type: %s", type);
+                return TIMESTAMP_MILLIS;
+            }
+            if (type instanceof ArrayType arrayType) {
+                return new ArrayType(toParquetType(typeOperators, arrayType.getElementType()));
+            }
+            if (type instanceof MapType mapType) {
+                return new MapType(toParquetType(typeOperators, mapType.getKeyType()), toParquetType(typeOperators, mapType.getValueType()), typeOperators);
+            }
+            if (type instanceof RowType rowType) {
+                return RowType.from(rowType.getFields().stream()
+                        .map(field -> RowType.field(field.getName().orElseThrow(), toParquetType(typeOperators, field.getType())))
+                        .collect(toImmutableList()));
+            }
+            return type;
+        }
+    }
+}

--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftConfig.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftConfig.java
@@ -30,6 +30,8 @@ public class RedshiftConfig
     private Integer fetchSize;
     private String unloadLocation;
     private String unloadIamRole;
+    private String batchedInsertsCopyLocation;
+    private String batchedInsertsCopyIamRole;
 
     public Optional<@Min(0) Integer> getFetchSize()
     {
@@ -67,6 +69,32 @@ public class RedshiftConfig
     public RedshiftConfig setUnloadIamRole(String unloadIamRole)
     {
         this.unloadIamRole = unloadIamRole;
+        return this;
+    }
+
+    public Optional<@Pattern(regexp = "^s3://[^/]+(/[^/]+)?$", message = "Path shouldn't end with trailing slash") String> getBatchedInsertsCopyLocation()
+    {
+        return Optional.ofNullable(batchedInsertsCopyLocation);
+    }
+
+    @Config("redshift.batched-inserts-copy-location")
+    @ConfigDescription("A writeable location in Amazon S3, to be used to stage data for using Redshift COPY FROM statement during batched inserts")
+    public RedshiftConfig setBatchedInsertsCopyLocation(String batchedInsertsCopyLocation)
+    {
+        this.batchedInsertsCopyLocation = batchedInsertsCopyLocation;
+        return this;
+    }
+
+    public Optional<String> getBatchedInsertsCopyIamRole()
+    {
+        return Optional.ofNullable(batchedInsertsCopyIamRole);
+    }
+
+    @Config("redshift.batched-inserts-copy-iam-role")
+    @ConfigDescription("Fully specified ARN of the IAM Role attached to the Redshift cluster and having access to S3")
+    public RedshiftConfig setBatchedInsertsCopyIamRole(String batchedInsertsCopyIamRole)
+    {
+        this.batchedInsertsCopyIamRole = batchedInsertsCopyIamRole;
         return this;
     }
 }

--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftConnector.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftConnector.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.redshift;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
+import io.airlift.bootstrap.LifeCycleManager;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.filesystem.s3.FileSystemS3;
+import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata;
+import io.trino.plugin.base.metrics.FileFormatDataSourceStats;
+import io.trino.plugin.base.session.SessionPropertiesProvider;
+import io.trino.plugin.jdbc.JdbcTransactionManager;
+import io.trino.plugin.jdbc.TablePropertiesProvider;
+import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorAccessControl;
+import io.trino.spi.connector.ConnectorCapabilities;
+import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorPageSinkProvider;
+import io.trino.spi.connector.ConnectorPageSourceProvider;
+import io.trino.spi.connector.ConnectorRecordSetProvider;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplitManager;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.function.table.ConnectorTableFunction;
+import io.trino.spi.procedure.Procedure;
+import io.trino.spi.session.PropertyMetadata;
+import io.trino.spi.transaction.IsolationLevel;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Sets.immutableEnumSet;
+import static io.trino.spi.connector.ConnectorCapabilities.NOT_NULL_COLUMN_CONSTRAINT;
+import static java.util.Objects.requireNonNull;
+
+public class RedshiftConnector
+        implements Connector
+{
+    private final LifeCycleManager lifeCycleManager;
+    private final ConnectorSplitManager jdbcSplitManager;
+    private final RedshiftPageSinkProvider redshiftPageSinkProvider;
+    private final Optional<ConnectorAccessControl> accessControl;
+    private final Set<Procedure> procedures;
+    private final Set<ConnectorTableFunction> connectorTableFunctions;
+    private final List<PropertyMetadata<?>> sessionProperties;
+    private final List<PropertyMetadata<?>> tableProperties;
+    private final JdbcTransactionManager transactionManager;
+    private final RedshiftPageSourceProvider pageSourceProvider;
+
+    // RedshiftConnector is conditionally injected for Unload and CopyFrom operations
+    @Inject
+    public RedshiftConnector(
+            LifeCycleManager lifeCycleManager,
+            ConnectorSplitManager jdbcSplitManager,
+            ConnectorPageSourceProvider jdbcPageSourceProvider,
+            RedshiftPageSinkProvider redshiftPageSinkProvider,
+            Optional<ConnectorAccessControl> accessControl,
+            Set<Procedure> procedures,
+            Set<ConnectorTableFunction> connectorTableFunctions,
+            Set<SessionPropertiesProvider> sessionProperties,
+            Set<TablePropertiesProvider> tableProperties,
+            JdbcTransactionManager transactionManager,
+            @FileSystemS3 TrinoFileSystemFactory fileSystemFactory,
+            FileFormatDataSourceStats fileFormatDataSourceStats)
+    {
+        this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
+        this.jdbcSplitManager = requireNonNull(jdbcSplitManager, "jdbcSplitManager is null");
+        this.redshiftPageSinkProvider = requireNonNull(redshiftPageSinkProvider, "redshiftPageSinkProvider is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+        this.procedures = ImmutableSet.copyOf(requireNonNull(procedures, "procedures is null"));
+        this.connectorTableFunctions = ImmutableSet.copyOf(requireNonNull(connectorTableFunctions, "connectorTableFunctions is null"));
+        this.sessionProperties = sessionProperties.stream()
+                .flatMap(sessionPropertiesProvider -> sessionPropertiesProvider.getSessionProperties().stream())
+                .collect(toImmutableList());
+        this.tableProperties = tableProperties.stream()
+                .flatMap(tablePropertiesProvider -> tablePropertiesProvider.getTableProperties().stream())
+                .collect(toImmutableList());
+        this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+        this.pageSourceProvider = new RedshiftPageSourceProvider(jdbcPageSourceProvider, fileSystemFactory, fileFormatDataSourceStats);
+    }
+
+    @Override
+    public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly, boolean autoCommit)
+    {
+        return transactionManager.beginTransaction(isolationLevel, readOnly, autoCommit);
+    }
+
+    @Override
+    public ConnectorMetadata getMetadata(ConnectorSession session, ConnectorTransactionHandle transaction)
+    {
+        return new ClassLoaderSafeConnectorMetadata(transactionManager.getMetadata(transaction), getClass().getClassLoader());
+    }
+
+    @Override
+    public void commit(ConnectorTransactionHandle transaction)
+    {
+        transactionManager.commit(transaction);
+    }
+
+    @Override
+    public void rollback(ConnectorTransactionHandle transaction)
+    {
+        transactionManager.rollback(transaction);
+    }
+
+    @Override
+    public ConnectorSplitManager getSplitManager()
+    {
+        return jdbcSplitManager;
+    }
+
+    @Override
+    public ConnectorRecordSetProvider getRecordSetProvider()
+    {
+        // throwing this exception will ensure using the RedshiftPageSourceProvider, that supports two modes of operation
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ConnectorPageSourceProvider getPageSourceProvider()
+    {
+        return pageSourceProvider;
+    }
+
+    @Override
+    public ConnectorPageSinkProvider getPageSinkProvider()
+    {
+        return redshiftPageSinkProvider;
+    }
+
+    @Override
+    public ConnectorAccessControl getAccessControl()
+    {
+        return accessControl.orElseThrow(UnsupportedOperationException::new);
+    }
+
+    @Override
+    public Set<Procedure> getProcedures()
+    {
+        return procedures;
+    }
+
+    @Override
+    public Set<ConnectorTableFunction> getTableFunctions()
+    {
+        return connectorTableFunctions;
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getSessionProperties()
+    {
+        return sessionProperties;
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getTableProperties()
+    {
+        return tableProperties;
+    }
+
+    @Override
+    public final void shutdown()
+    {
+        lifeCycleManager.stop();
+    }
+
+    @Override
+    public Set<ConnectorCapabilities> getCapabilities()
+    {
+        return immutableEnumSet(NOT_NULL_COLUMN_CONSTRAINT);
+    }
+}

--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftPageSinkProvider.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftPageSinkProvider.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.redshift;
+
+import com.google.inject.Inject;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.filesystem.s3.FileSystemS3;
+import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.JdbcOutputTableHandle;
+import io.trino.plugin.jdbc.JdbcPageSinkProvider;
+import io.trino.plugin.jdbc.QueryBuilder;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
+import io.trino.spi.NodeManager;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorInsertTableHandle;
+import io.trino.spi.connector.ConnectorOutputTableHandle;
+import io.trino.spi.connector.ConnectorPageSink;
+import io.trino.spi.connector.ConnectorPageSinkId;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.type.TypeManager;
+
+import static io.trino.plugin.jdbc.JdbcWriteSessionProperties.NON_TRANSACTIONAL_INSERT;
+import static io.trino.plugin.redshift.RedshiftSessionProperties.isBatchedInsertsCopyEnabled;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static java.util.Objects.requireNonNull;
+
+public class RedshiftPageSinkProvider
+        extends JdbcPageSinkProvider
+{
+    private final TrinoFileSystemFactory fileSystemFactory;
+    private final TypeManager typeManager;
+    private final RedshiftConfig redshiftConfig;
+    private final String trinoVersion;
+
+    @Inject
+    public RedshiftPageSinkProvider(
+            JdbcClient jdbcClient,
+            RemoteQueryModifier remoteQueryModifier,
+            QueryBuilder queryBuilder,
+            @FileSystemS3 TrinoFileSystemFactory fileSystemFactory,
+            RedshiftConfig redshiftConfig,
+            TypeManager typeManager,
+            NodeManager nodeManager)
+    {
+        super(jdbcClient, remoteQueryModifier, queryBuilder);
+
+        this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
+        this.redshiftConfig = requireNonNull(redshiftConfig, "redshiftConfig is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.trinoVersion = requireNonNull(nodeManager, "nodeManager is null").getCurrentNode().getVersion();
+    }
+
+    @Override
+    public ConnectorPageSink createPageSink(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorOutputTableHandle outputTableHandle,
+            ConnectorPageSinkId pageSinkId)
+    {
+        if (isBatchedInsertsCopyEnabled(session)) {
+            if (session.getProperty(NON_TRANSACTIONAL_INSERT, Boolean.class)) {
+                throw new TrinoException(NOT_SUPPORTED, "Batched inserts with COPY are not supported in non-transactional mode");
+            }
+
+            JdbcOutputTableHandle handle = (JdbcOutputTableHandle) outputTableHandle;
+            return new RedshiftBatchedInsertsCopyPageSink(
+                    session,
+                    pageSinkId,
+                    fileSystemFactory,
+                    typeManager.getTypeOperators(),
+                    RedshiftClient.sinkPrefix(session, redshiftConfig.getBatchedInsertsCopyLocation()),
+                    handle.getColumnNames(),
+                    handle.getColumnTypes(),
+                    trinoVersion);
+        }
+        else {
+            // Otherwise, default jdbc behavior
+            return super.createPageSink(transactionHandle, session, outputTableHandle, pageSinkId);
+        }
+    }
+
+    @Override
+    public ConnectorPageSink createPageSink(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorInsertTableHandle insertTableHandle,
+            ConnectorPageSinkId pageSinkId)
+    {
+        if (isBatchedInsertsCopyEnabled(session)) {
+            return createPageSink(transactionHandle, session, (ConnectorOutputTableHandle) insertTableHandle, pageSinkId);
+        }
+        else {
+            // Otherwise, default jdbc behavior
+            return super.createPageSink(transactionHandle, session, insertTableHandle, pageSinkId);
+        }
+    }
+}

--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftSessionProperties.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftSessionProperties.java
@@ -29,6 +29,7 @@ public class RedshiftSessionProperties
         implements SessionPropertiesProvider
 {
     private static final String UNLOAD_ENABLED = "unload_enabled";
+    private static final String BATCHED_INSERTS_COPY_ENABLED = "batched_inserts_copy_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -46,6 +47,16 @@ public class RedshiftSessionProperties
                             }
                         },
                         false))
+                .add(booleanProperty(
+                        BATCHED_INSERTS_COPY_ENABLED,
+                        "Use COPY statements for batched inserts",
+                        config.getBatchedInsertsCopyLocation().isPresent(),
+                        value -> {
+                            if (value && config.getBatchedInsertsCopyLocation().isEmpty()) {
+                                throw new TrinoException(INVALID_SESSION_PROPERTY, "Cannot use COPY for batch inserts when location is not configured");
+                            }
+                        },
+                        false))
                 .build();
     }
 
@@ -58,5 +69,10 @@ public class RedshiftSessionProperties
     public static boolean isUnloadEnabled(ConnectorSession session)
     {
         return session.getProperty(UNLOAD_ENABLED, Boolean.class);
+    }
+
+    public static boolean isBatchedInsertsCopyEnabled(ConnectorSession session)
+    {
+        return session.getProperty(BATCHED_INSERTS_COPY_ENABLED, Boolean.class);
     }
 }

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/RedshiftQueryRunner.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/RedshiftQueryRunner.java
@@ -58,7 +58,7 @@ public final class RedshiftQueryRunner
     private static final String S3_TPCH_TABLES_ROOT = requiredNonEmptySystemProperty("test.redshift.s3.tpch.tables.root");
     public static final String IAM_ROLE = requiredNonEmptySystemProperty("test.redshift.iam.role");
 
-    private static final String TEST_CATALOG = "redshift";
+    public static final String TEST_CATALOG = "redshift";
     private static final String CONNECTOR_NAME = "redshift";
     private static final String TPCH_CATALOG = "tpch";
 

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftBatchedInsertsCopyPageSink.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftBatchedInsertsCopyPageSink.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.redshift;
+
+import io.trino.Session;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.MaterializedRow;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+
+import static io.trino.plugin.redshift.RedshiftQueryRunner.IAM_ROLE;
+import static io.trino.plugin.redshift.RedshiftQueryRunner.TEST_CATALOG;
+import static io.trino.plugin.redshift.TestingRedshiftServer.TEST_SCHEMA;
+import static io.trino.plugin.redshift.TestingRedshiftServer.executeInRedshift;
+import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.tpch.TpchTable.NATION;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+final class TestRedshiftBatchedInsertsCopyPageSink
+        extends AbstractTestQueryFramework
+{
+    private static final String S3_COPY_ROOT = requiredNonEmptySystemProperty("test.redshift.s3.copy.root");
+    private static final String AWS_REGION = requiredNonEmptySystemProperty("test.redshift.aws.region");
+    private static final String AWS_ACCESS_KEY = requiredNonEmptySystemProperty("test.redshift.aws.access-key");
+    private static final String AWS_SECRET_KEY = requiredNonEmptySystemProperty("test.redshift.aws.secret-key");
+
+    private List<String> tableNames;
+
+    @BeforeAll
+    public void setup()
+    {
+        tableNames = new ArrayList<>();
+    }
+
+    @AfterAll
+    public void cleanup()
+    {
+        tableNames.forEach(tableName -> executeInRedshift(format("DROP TABLE IF EXISTS %s.%s", TEST_SCHEMA, tableName)));
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return RedshiftQueryRunner.builder()
+                .setConnectorProperties(
+                        Map.of(
+                                "redshift.batched-inserts-copy-location", S3_COPY_ROOT,
+                                "redshift.batched-inserts-copy-iam-role", IAM_ROLE,
+                                "s3.region", AWS_REGION,
+                                "s3.aws-access-key", AWS_ACCESS_KEY,
+                                "s3.aws-secret-key", AWS_SECRET_KEY))
+                .setInitialTables(List.of(NATION))
+                .build();
+    }
+
+    @Test
+    void testCopyEnabled()
+    {
+        assertQuery(
+                "SHOW SESSION LIKE 'redshift.batched_inserts_copy_enabled'",
+                "VALUES ('redshift.batched_inserts_copy_enabled', 'true', 'true', 'boolean', 'Use COPY statements for batched inserts')");
+    }
+
+    @Test
+    void testCopyFromPageSink()
+    {
+        String tableName = getTableName();
+        assertQueryStats(
+                getSession(),
+                format("CREATE TABLE %s.%s.%s AS SELECT * FROM tpch.sf1.lineitem LIMIT 10", TEST_CATALOG, TEST_SCHEMA, tableName),
+                queryStats -> {
+                    // From what I can tell, there is no succinct way to check if the query was executed using the copy command
+                },
+                results -> assertThat(results.getRowCount()).isEqualTo(1));
+        assertQueryStats(
+                getSession(),
+                format("SELECT * FROM %s.%s.%s", TEST_CATALOG, TEST_SCHEMA, tableName),
+                queryStats -> {},
+                results -> assertThat(results.getRowCount()).isEqualTo(10));
+    }
+
+    @Test
+    void testInsertIntoPageSink()
+    {
+        String tableName = getTableName();
+        assertQueryStats(
+                getSession(),
+                format("CREATE TABLE %s.%s.%s AS SELECT * FROM tpch.sf1.lineitem LIMIT 10", TEST_CATALOG, TEST_SCHEMA, tableName),
+                queryStats -> {},
+                results -> assertThat(results.getRowCount()).isEqualTo(1));
+        assertQueryStats(
+                getSession(),
+                format("INSERT INTO %s.%s.%s SELECT * FROM tpch.sf1.lineitem LIMIT 10", TEST_CATALOG, TEST_SCHEMA, tableName),
+                queryStats -> {},
+                results -> assertThat(results.getRowCount()).isEqualTo(1));
+        assertQueryStats(
+                getSession(),
+                format("SELECT * FROM %s.%s.%s", TEST_CATALOG, TEST_SCHEMA, tableName),
+                queryStats -> {},
+                results -> assertThat(results.getRowCount()).isEqualTo(20));
+    }
+
+    @Test
+    void testQueryWithNoResults()
+    {
+        String tableName = getTableName();
+        assertQuerySucceeds(
+                getSession(),
+                format("CREATE TABLE %s.%s.%s AS SELECT * FROM tpch.sf1.lineitem LIMIT 0", TEST_CATALOG, TEST_SCHEMA, tableName));
+        assertQueryStats(
+                getSession(),
+                format("SELECT * FROM %s.%s.%s", TEST_CATALOG, TEST_SCHEMA, tableName),
+                queryStats -> {},
+                results -> assertThat(results.getRowCount()).isEqualTo(0));
+    }
+
+    @Test
+    void testCopyFromDisabled()
+    {
+        String tableName = getTableName();
+        Session copyDisabledSession = testSessionBuilder(getSession())
+                .setCatalogSessionProperty("redshift", "batched_inserts_copy_enabled", "false")
+                .build();
+        assertQuerySucceeds(
+                copyDisabledSession,
+                format("CREATE TABLE %s.%s.%s AS SELECT * FROM tpch.sf1.lineitem LIMIT 10", TEST_CATALOG, TEST_SCHEMA, tableName));
+        assertQueryStats(
+                copyDisabledSession,
+                format("SELECT * FROM %s.%s.%s", TEST_CATALOG, TEST_SCHEMA, tableName),
+                queryStats -> {},
+                results -> assertThat(results.getRowCount()).isEqualTo(10));
+    }
+
+    @Test
+    void testVariousColumnTypes()
+    {
+        String tableName = getTableName();
+        assertQuerySucceeds(
+                getSession(),
+                format("""
+        CREATE TABLE %s.%s.%s AS
+                        SELECT
+                            CAST('Sample Text' AS VARCHAR) AS varchar_column,
+                            CAST(123 AS INT) AS int_column,
+                            CAST(123.45 AS DOUBLE) AS double_column,
+                            CAST(123.45 AS DECIMAL(10,2)) AS decimal_column,
+                            CAST('2025-02-16' AS DATE) AS date_column,
+                            CAST('2025-02-16 10:30:00' AS TIMESTAMP) AS timestamp_column,
+                            CAST('true' AS BOOLEAN) AS boolean_column,
+                            CAST(1234567890123456789 AS BIGINT) AS bigint_column,
+                            CAST('A' AS CHAR(1)) AS char_column,
+                            CAST(CAST(CAST(0xCAFEBABE AS BIGINT) AS VARCHAR) AS VARBINARY) AS varbinary_column,
+                            CAST('' AS VARCHAR) as empty_column,
+                            CAST(NULL AS VARCHAR) as null_column,
+                            CAST('あたい' AS VARCHAR) AS special_char0,
+                            CAST('a\\backslash' AS VARCHAR) AS special_char1
+        """, TEST_CATALOG, TEST_SCHEMA, tableName));
+        assertQueryStats(
+                getSession(),
+                format("SELECT * FROM %s.%s.%s", TEST_CATALOG, TEST_SCHEMA, tableName),
+                queryStats -> {},
+                results -> {
+                    List<String> cols = List.of(
+                            "varchar_column",
+                            "int_column",
+                            "double_column",
+                            "decimal_column",
+                            "date_column",
+                            "timestamp_column",
+                            "boolean_column",
+                            "bigint_column",
+                            "char_column",
+                            "varbinary_column",
+                            "empty_column",
+                            "null_column",
+                            "special_char0",
+                            "special_char1");
+
+                    assertThat(results.getRowCount()).isEqualTo(1);
+                    assertThat(results.getColumnNames()).isEqualTo(cols);
+
+                    List<MaterializedRow> rows = results.getMaterializedRows();
+                    Map<String, Object> fields = fieldsForRow(cols, rows.getFirst());
+                    assertThat(fields.get("varchar_column")).isEqualTo("Sample Text");
+                    assertThat(fields.get("int_column")).isEqualTo(123);
+                    assertThat(fields.get("double_column")).isEqualTo(123.45);
+                    assertThat(fields.get("decimal_column")).isEqualTo(BigDecimal.valueOf(123.45));
+                    assertThat(fields.get("date_column")).isEqualTo(LocalDate.of(2025, 2, 16));
+                    assertThat(fields.get("timestamp_column")).isEqualTo(LocalDateTime.of(2025, 2, 16, 10, 30));
+                    assertThat(fields.get("boolean_column")).isEqualTo(true);
+                    assertThat(fields.get("bigint_column")).isEqualTo(1234567890123456789L);
+                    assertThat(fields.get("char_column")).isEqualTo("A");
+                    assertThat(Long.toHexString(Long.parseLong(new String((byte[]) fields.get("varbinary_column"), StandardCharsets.UTF_8))).toUpperCase(Locale.ENGLISH)).isEqualTo("CAFEBABE");
+                    assertThat(fields.get("empty_column")).isEqualTo("");
+                    assertThat(fields.get("null_column")).isNull();
+                    assertThat(fields.get("special_char0")).isEqualTo("あたい");
+                    assertThat(fields.get("special_char1")).isEqualTo("a\\backslash");
+                });
+    }
+
+    Map<String, Object> fieldsForRow(List<String> cols, MaterializedRow row)
+    {
+        Map<String, Object> fields = new HashMap<>(row.getFieldCount());
+        for (int i = 0; i < row.getFieldCount(); i++) {
+            fields.put(cols.get(i), row.getField(i));
+        }
+
+        return fields;
+    }
+
+    String getTableName()
+    {
+        String tableName = format("t_%s", UUID.randomUUID().toString().replace("-", "_"));
+        tableNames.add(tableName);
+        return tableName;
+    }
+}

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConfig.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConfig.java
@@ -30,7 +30,9 @@ public class TestRedshiftConfig
         assertRecordedDefaults(recordDefaults(RedshiftConfig.class)
                 .setFetchSize(null)
                 .setUnloadLocation(null)
-                .setUnloadIamRole(null));
+                .setUnloadIamRole(null)
+                .setBatchedInsertsCopyLocation(null)
+                .setBatchedInsertsCopyIamRole(null));
     }
 
     @Test
@@ -38,14 +40,18 @@ public class TestRedshiftConfig
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("redshift.fetch-size", "2000")
-                .put("redshift.unload-location", "s3://bucket")
+                .put("redshift.unload-location", "s3://bucket/unload")
                 .put("redshift.unload-iam-role", "arn:aws:iam::123456789000:role/redshift_iam_role")
+                .put("redshift.batched-inserts-copy-location", "s3://bucket/sink")
+                .put("redshift.batched-inserts-copy-iam-role", "arn:aws:iam::123456789000:role/redshift_iam_role")
                 .buildOrThrow();
 
         RedshiftConfig expected = new RedshiftConfig()
                 .setFetchSize(2000)
-                .setUnloadLocation("s3://bucket")
-                .setUnloadIamRole("arn:aws:iam::123456789000:role/redshift_iam_role");
+                .setUnloadLocation("s3://bucket/unload")
+                .setUnloadIamRole("arn:aws:iam::123456789000:role/redshift_iam_role")
+                .setBatchedInsertsCopyLocation("s3://bucket/sink")
+                .setBatchedInsertsCopyIamRole("arn:aws:iam::123456789000:role/redshift_iam_role");
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description

Fixes #24546

This PR aims to allow the use of `COPY FROM` statements when sinking data into Redshift.  

The Redshift connector inherits `BaseJdbcConnector` which uses batched INSERT statements to execute sink operations.  Even when using non transactional mode, this can only push about 1000 rows per second.  This change stages the rows to a parquet file first, then issues a `COPY FROM` statement to load the table.  We are noticing 250K rows per second or more using this method.

This has been running in production for 2+ months on our own branch. 

This functionality needs to be enabled by specifying the following config option:
```
redshift.batched-inserts-copy-location=s3://my-bucket/my-prefix
```

The following options are also required when specifying the above:
```
redshift.batched-inserts-copy-iam-role=arn:aws:iam::123456789000:role/redshift_iam_role
s3.region=region
s3.aws-access-key=KEY
s3.aws-secret-key=SECRET
```

A suggested IAM Policy to for this role and user:
```
{
	"Version": "2012-10-17",
	"Statement": [
		{
			"Effect": "Allow",
			"Action": [
				"s3:ListBucket"
			],
			"Resource": "arn:aws:s3:::my-bucket"
		},
		{
			"Effect": "Allow",
			"Action": [
				"s3:GetObject",
				"s3:PutObject",
				"s3:DeleteObject"
			],
			"Resource": "arn:aws:s3:::my-bucket/*"
		}
	]
}
```

## Additional context and related issues

- This is designed to work alongside and compliments the new Redshift UNLOAD feature #24117
- When the above configuration is not supplied, it will default to base JDBC behaviour.
- There needs to be a new GHA var added to the repo `REDSHIFT_S3_COPY_ROOT` similar to `REDSHIFT_S3_UNLOAD_ROOT`

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Redshift
* Add support for Redshift COPY FROM statements for batch insert operations ({issue}`24546`)
```
