### PR TITLE
Do not format null plan fragment

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
@@ -450,6 +450,9 @@ public class PlanPrinter
                 queryStats.getExecutionTime().convertToMostSuccinctTimeUnit()));
 
         for (StageInfo stageInfo : allStages) {
+            if (stageInfo.getPlan() == null) {
+                continue;
+            }
             builder.append(formatFragment(
                     tableScanNode -> tableInfos.get(tableScanNode.getId()),
                     dynamicFilterDomainStats,


### PR DESCRIPTION
Do not format null plan fragment

PlanFragment in StageInfo is Nullable and so it could be null. In such
case calling formatFragment method for it does not make much sense as it
simply throws NPE.


```
java.lang.NullPointerException: Cannot invoke "io.trino.sql.planner.PlanFragment.getId()" because "fragment" is null
	at io.trino.sql.planner.planprinter.PlanPrinter.formatFragment(PlanPrinter.java:505)
	at io.trino.sql.planner.planprinter.PlanPrinter.textDistributedPlan(PlanPrinter.java:464)
 ....
```
