### PR TITLE
Only check access control on underlying MV tables on refresh

### DIFF
--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
@@ -630,7 +630,7 @@ public class TestEventListenerBasic
         TableInfo table = tables.get(0);
         assertThat(table)
                 .hasCatalogSchemaTable("tpch", "tiny", "nation")
-                .hasAuthorization("user")
+                .hasAuthorization("alice")
                 .isDirectlyReferenced()
                 .hasColumnsWithoutMasking("nationkey")
                 .hasNoRowFilters()


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

This change only checks access control of queries which support a materialized view when running a refresh. The actual refresh permissions check is unaffected. Before this change, permissions on the underlying MV query were always checked, even on a SELECT. More details can be found in https://github.com/trinodb/trino/issues/23747

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

https://github.com/trinodb/trino/issues/23747

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Only check permissions of underlying MV query on MV refresh. ({issue}`23747`)
```
