### PR TITLE
Release hash aggregation memory on output

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/BigintGroupByHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/BigintGroupByHash.java
@@ -120,6 +120,13 @@ public class BigintGroupByHash
     }
 
     @Override
+    public void startReleasingOutput()
+    {
+        dictionaryLookBack = null;
+        currentPageSizeInBytes = 0;
+    }
+
+    @Override
     public void appendValuesTo(int groupId, PageBuilder pageBuilder)
     {
         checkArgument(groupId >= 0, "groupId is negative");

--- a/core/trino-main/src/main/java/io/trino/operator/FlatGroupByHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/FlatGroupByHash.java
@@ -393,11 +393,10 @@ public class FlatGroupByHash
         {
             verify(canProcessDictionary(blocks), "invalid call to addDictionaryPage");
             this.dictionaryBlock = (DictionaryBlock) blocks[0];
-
-            this.dictionaries = Arrays.stream(blocks)
-                    .map(block -> (DictionaryBlock) block)
-                    .map(DictionaryBlock::getDictionary)
-                    .toArray(Block[]::new);
+            this.dictionaries = blocks;
+            for (int i = 0; i < dictionaries.length; i++) {
+                dictionaries[i] = ((DictionaryBlock) dictionaries[i]).getDictionary();
+            }
             updateDictionaryLookBack(dictionaries[0]);
         }
 
@@ -620,13 +619,12 @@ public class FlatGroupByHash
             verify(canProcessDictionary(blocks), "invalid call to processDictionary");
 
             this.dictionaryBlock = (DictionaryBlock) blocks[0];
-            this.groupIds = new int[dictionaryBlock.getPositionCount()];
-
-            this.dictionaries = Arrays.stream(blocks)
-                    .map(block -> (DictionaryBlock) block)
-                    .map(DictionaryBlock::getDictionary)
-                    .toArray(Block[]::new);
+            this.dictionaries = blocks;
+            for (int i = 0; i < dictionaries.length; i++) {
+                dictionaries[i] = ((DictionaryBlock) dictionaries[i]).getDictionary();
+            }
             updateDictionaryLookBack(dictionaries[0]);
+            this.groupIds = new int[dictionaryBlock.getPositionCount()];
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/operator/FlatGroupByHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/FlatGroupByHash.java
@@ -130,6 +130,16 @@ public class FlatGroupByHash
     }
 
     @Override
+    public void startReleasingOutput()
+    {
+        currentHashes = null;
+        dictionaryLookBack = null;
+        Arrays.fill(currentBlocks, null);
+        currentPageSizeInBytes = 0;
+        flatHash.startReleasingOutput();
+    }
+
+    @Override
     public void appendValuesTo(int groupId, PageBuilder pageBuilder)
     {
         BlockBuilder[] blockBuilders = currentBlockBuilders;

--- a/core/trino-main/src/main/java/io/trino/operator/FlatGroupByHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/FlatGroupByHash.java
@@ -510,7 +510,7 @@ public class FlatGroupByHash
         public GetNonDictionaryGroupIdsWork(Block[] blocks)
         {
             this.blocks = blocks;
-            this.groupIds = new int[currentBlocks[0].getPositionCount()];
+            this.groupIds = new int[blocks[0].getPositionCount()];
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/operator/FlatHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/FlatHash.java
@@ -170,8 +170,8 @@ public final class FlatHash
 
     public long hashPosition(int groupId)
     {
-        if (groupId < 0) {
-            throw new IllegalArgumentException("groupId is negative");
+        if (groupId < 0 || groupId >= nextGroupId) {
+            throw new IllegalArgumentException("groupId out of range: " + groupId);
         }
         byte[] fixedSizeRecords = getFixedSizeRecords(groupId);
         int fixedRecordOffset = getFixedRecordOffset(groupId);

--- a/core/trino-main/src/main/java/io/trino/operator/FlatHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/FlatHash.java
@@ -22,6 +22,7 @@ import java.lang.invoke.VarHandle;
 import java.util.Arrays;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
@@ -120,8 +121,8 @@ public final class FlatHash
         this.mask = other.mask;
         this.nextGroupId = other.nextGroupId;
         this.maxFill = other.maxFill;
-        this.control = Arrays.copyOf(other.control, other.control.length);
-        this.groupIdsByHash = Arrays.copyOf(other.groupIdsByHash, other.groupIdsByHash.length);
+        this.control = other.control == null ? null : Arrays.copyOf(other.control, other.control.length);
+        this.groupIdsByHash = other.groupIdsByHash == null ? null : Arrays.copyOf(other.groupIdsByHash, other.groupIdsByHash.length);
         this.fixedSizeRecords = Arrays.stream(other.fixedSizeRecords)
                 .map(fixedSizeRecords -> fixedSizeRecords == null ? null : Arrays.copyOf(fixedSizeRecords, fixedSizeRecords.length))
                 .toArray(byte[][]::new);
@@ -149,6 +150,24 @@ public final class FlatHash
         return capacity;
     }
 
+    /**
+     * Releases memory associated with the hash table which is no longer necessary to produce output. Subsequent
+     * calls to insert new elements are rejected, and calls to {@link FlatHash#appendTo(int, BlockBuilder[])} will
+     * incrementally release memory associated with prior groupId values assuming that the caller will only call into
+     * the method to produce output in a sequential fashion.
+     */
+    public void startReleasingOutput()
+    {
+        checkState(!isReleasingOutput(), "already releasing output");
+        control = null;
+        groupIdsByHash = null;
+    }
+
+    private boolean isReleasingOutput()
+    {
+        return control == null;
+    }
+
     public long hashPosition(int groupId)
     {
         if (groupId < 0) {
@@ -156,6 +175,7 @@ public final class FlatHash
         }
         byte[] fixedSizeRecords = getFixedSizeRecords(groupId);
         int fixedRecordOffset = getFixedRecordOffset(groupId);
+        checkState(!isReleasingOutput() || fixedSizeRecords != null, "groupId already released");
         if (cacheHashValue) {
             return (long) LONG_HANDLE.get(fixedSizeRecords, fixedRecordOffset);
         }
@@ -178,7 +198,8 @@ public final class FlatHash
     {
         checkArgument(groupId < nextGroupId, "groupId out of range");
 
-        byte[] fixedSizeRecords = getFixedSizeRecords(groupId);
+        int recordGroupIndex = recordGroupIndexForGroupId(groupId);
+        byte[] fixedSizeRecords = this.fixedSizeRecords[recordGroupIndex];
         int recordOffset = getFixedRecordOffset(groupId);
 
         byte[] variableWidthChunk = null;
@@ -194,6 +215,19 @@ public final class FlatHash
                 variableWidthChunk,
                 variableChunkOffset,
                 blockBuilders);
+
+        // Release memory from the previous fixed size records batch
+        if (isReleasingOutput() && recordOffset == 0 && recordGroupIndex > 0) {
+            byte[] releasedRecords = this.fixedSizeRecords[recordGroupIndex - 1];
+            this.fixedSizeRecords[recordGroupIndex - 1] = null;
+            if (releasedRecords == null) {
+                throw new IllegalStateException("already released previous record batch");
+            }
+            fixedRecordGroupsRetainedSize -= sizeOf(releasedRecords);
+            if (variableWidthData != null) {
+                variableWidthData.freeChunksBefore(fixedSizeRecords, recordOffset + variableWidthOffset);
+            }
+        }
     }
 
     public void computeHashes(Block[] blocks, long[] hashes, int offset, int length)
@@ -228,6 +262,7 @@ public final class FlatHash
 
     private int getIndex(Block[] blocks, int position, long hash)
     {
+        checkState(!isReleasingOutput(), "already releasing output");
         byte hashPrefix = (byte) (hash & 0x7F | 0x80);
         int bucket = bucket((int) (hash >> 7));
 
@@ -328,6 +363,7 @@ public final class FlatHash
 
     public boolean ensureAvailableCapacity(int batchSize)
     {
+        checkState(!isReleasingOutput(), "already releasing output");
         long requiredMaxFill = nextGroupId + batchSize;
         if (requiredMaxFill >= maxFill) {
             long minimumRequiredCapacity = (requiredMaxFill + 1) * 16 / 15;

--- a/core/trino-main/src/main/java/io/trino/operator/GroupByHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupByHash.java
@@ -105,6 +105,14 @@ public interface GroupByHash
 
     void appendValuesTo(int groupId, PageBuilder pageBuilder);
 
+    /**
+     * Signals that no more entries will be inserted, and that only calls to {@link GroupByHash#appendValuesTo(int, PageBuilder)}
+     * with sequential groupId values will be observed after this point, allowing the implementation to potentially
+     * release memory associated with structures required for inserts or associated with values that have already been
+     * output.
+     */
+    void startReleasingOutput();
+
     Work<?> addPage(Page page);
 
     /**

--- a/core/trino-main/src/main/java/io/trino/operator/NoChannelGroupByHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/NoChannelGroupByHash.java
@@ -51,6 +51,12 @@ public class NoChannelGroupByHash
     }
 
     @Override
+    public void startReleasingOutput()
+    {
+        throw new UnsupportedOperationException("NoChannelGroupByHash does not support startReleasingOutput");
+    }
+
+    @Override
     public Work<?> addPage(Page page)
     {
         updateGroupCount(page);

--- a/core/trino-main/src/test/java/io/trino/operator/CyclingGroupByHash.java
+++ b/core/trino-main/src/test/java/io/trino/operator/CyclingGroupByHash.java
@@ -55,6 +55,12 @@ public class CyclingGroupByHash
     }
 
     @Override
+    public void startReleasingOutput()
+    {
+        throw new UnsupportedOperationException("Not yet supported");
+    }
+
+    @Override
     public void appendValuesTo(int groupId, PageBuilder pageBuilder)
     {
         throw new UnsupportedOperationException("Not yet supported");


### PR DESCRIPTION
## Description
Incrementally releases memory from `FlatGroupByHash` when `HashAggregationOperator` starts producing output. Previously, the entire hash table contents were kept in memory until output data was produced from hash aggregations.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Reduce memory usage of aggregations by incrementally releasing memory as output rows are are produced ({issue}`25879`)
```
