### PR TITLE
Preserve field names in row type

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/ir/ExpressionTreeRewriter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/ExpressionTreeRewriter.java
@@ -110,7 +110,7 @@ public final class ExpressionTreeRewriter<C>
             List<Expression> items = rewrite(node.items(), context);
 
             if (!sameElements(node.items(), items)) {
-                return new Row(items);
+                return new Row(items, node.type());
             }
 
             return node;

--- a/core/trino-main/src/main/java/io/trino/sql/ir/Row.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/Row.java
@@ -24,9 +24,14 @@ import java.util.stream.Collectors;
 import static java.util.Objects.requireNonNull;
 
 @JsonSerialize
-public record Row(List<Expression> items)
+public record Row(List<Expression> items, Type type)
         implements Expression
 {
+    public Row(List<Expression> items)
+    {
+        this(items, RowType.anonymous(items.stream().map(io.trino.sql.ir.Expression::type).collect(Collectors.toList())));
+    }
+
     public Row
     {
         requireNonNull(items, "items is null");
@@ -36,7 +41,7 @@ public record Row(List<Expression> items)
     @Override
     public Type type()
     {
-        return RowType.anonymous(items.stream().map(Expression::type).collect(Collectors.toList()));
+        return type;
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionOptimizer.java
@@ -192,7 +192,7 @@ public class IrExpressionOptimizer
             case Logical logical -> process(logical.terms(), session, bindings).map(arguments -> new Logical(logical.operator(), arguments));
             case Call call -> process(call.arguments(), session, bindings).map(arguments -> new Call(call.function(), arguments));
             case Array array -> process(array.elements(), session, bindings).map(elements -> new Array(array.elementType(), elements));
-            case Row row -> process(row.items(), session, bindings).map(fields -> new Row(fields));
+            case Row row -> process(row.items(), session, bindings).map(fields -> new Row(fields, row.type()));
             case Between between -> {
                 Optional<Expression> value = process(between.value(), session, bindings);
                 Optional<Expression> min = process(between.min(), session, bindings);

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/EvaluateRow.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/EvaluateRow.java
@@ -37,7 +37,7 @@ public class EvaluateRow
     @Override
     public Optional<Expression> apply(Expression expression, Session session, Map<Symbol, Expression> bindings)
     {
-        if (!(expression instanceof Row(List<Expression> fields)) || !fields.stream().allMatch(Constant.class::isInstance)) {
+        if (!(expression instanceof Row(List<Expression> fields, _)) || !fields.stream().allMatch(Constant.class::isInstance)) {
             return Optional.empty();
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
@@ -547,9 +547,11 @@ public class TranslationMap
 
     private io.trino.sql.ir.Expression translate(Row expression)
     {
-        return new io.trino.sql.ir.Row(expression.getItems().stream()
+        return new io.trino.sql.ir.Row(
+                expression.getItems().stream()
                 .map(this::translateExpression)
-                .collect(toImmutableList()));
+                .collect(toImmutableList()),
+                analysis.getType(expression));
     }
 
     private io.trino.sql.ir.Expression translate(ComparisonExpression expression)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushCastIntoRow.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushCastIntoRow.java
@@ -82,7 +82,7 @@ public class PushCastIntoRow
                         }
                         items.add(item);
                     }
-                    return new Row(items.build());
+                    return new Row(items.build(), node.type());
                 }
             }
 

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestIssue25864.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestIssue25864.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestIssue25864
+{
+    @Test
+    public void test()
+    {
+        try (QueryAssertions assertions = new QueryAssertions()) {
+            assertThat(assertions.query(
+                    """
+                    VALUES
+                        CAST(
+                          ROW(ARRAY[CAST(
+                            ROW(rand(1))
+                            AS row(x integer))])
+                          AS row(r array(row(x integer))))
+                    """))
+                    .matches(
+                            """
+                            VALUES
+                                CAST(ARRAY[ROW(INTEGER '0')] AS array(row(x integer)))
+                            """);
+        }
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/type/RowType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/RowType.java
@@ -190,11 +190,6 @@ public class RowType
 
     private static TypeSignature makeSignature(List<Field> fields)
     {
-        int size = fields.size();
-        if (size == 0) {
-            throw new IllegalArgumentException("Row type must have at least 1 field");
-        }
-
         List<TypeSignatureParameter> parameters = fields.stream()
                 .map(field -> new NamedTypeSignature(field.getName().map(RowFieldName::new), field.getType().getTypeSignature()))
                 .map(TypeSignatureParameter::namedTypeParameter)


### PR DESCRIPTION
Fixes #25864 

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix failure for queries involving casts with row types. ({issue}`25864`)
```
