### PR TITLE
Disable flaky tests in Iceberg and Delta Lake connectors

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeLocalConcurrentWritesTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeLocalConcurrentWritesTest.java
@@ -23,6 +23,7 @@ import io.trino.filesystem.TrinoOutputFile;
 import io.trino.spi.security.ConnectorIdentity;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -205,6 +206,7 @@ public class TestDeltaLakeLocalConcurrentWritesTest
     }
 
     @Test
+    @Disabled // TODO https://github.com/trinodb/trino/issues/21725 Fix flaky test
     public void testConcurrentInsertsSelectingFromTheSameVersionedTable()
             throws Exception
     {
@@ -391,6 +393,7 @@ public class TestDeltaLakeLocalConcurrentWritesTest
 
     // Copied from BaseDeltaLakeConnectorSmokeTest
     @Test
+    @Disabled // TODO https://github.com/trinodb/trino/issues/22455 Fix flaky test
     public void testConcurrentInsertsReconciliationForMixedInserts()
             throws Exception
     {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
@@ -71,6 +71,7 @@ import org.apache.iceberg.mapping.MappingUtil;
 import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -1440,6 +1441,7 @@ public class TestIcebergV2
     }
 
     @Test
+    @Disabled // TODO https://github.com/trinodb/trino/issues/24539 Fix flaky test
     void testEnvironmentContext()
     {
         try (TestTable table = newTrinoTable("test_environment_context", "(x int)")) {


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
