### PR TITLE
Add detailed client information to User-Agent

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/QueryRunner.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/QueryRunner.java
@@ -24,11 +24,14 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static io.trino.client.ClientSession.stripTransactionId;
 import static io.trino.client.StatementClientFactory.newStatementClient;
+import static io.trino.client.UserAgentBuilder.createUserAgent;
 import static java.util.Objects.requireNonNull;
 
 public class QueryRunner
         implements Closeable
 {
+    private static final String USER_AGENT = createUserAgent("trino-cli");
+
     private final AtomicReference<ClientSession> session;
     private final boolean debug;
     private final OkHttpClient httpClient;
@@ -37,9 +40,9 @@ public class QueryRunner
     public QueryRunner(TrinoUri uri, ClientSession session, boolean debug)
     {
         this.session = new AtomicReference<>(requireNonNull(session, "session is null"));
-        this.httpClient = HttpClientFactory.toHttpClientBuilder(uri, session.getSource()).build();
+        this.httpClient = HttpClientFactory.toHttpClientBuilder(uri, USER_AGENT).build();
         this.segmentHttpClient = HttpClientFactory
-                .unauthenticatedClientBuilder(uri, session.getSource())
+                .unauthenticatedClientBuilder(uri, USER_AGENT)
                 .build();
         this.debug = debug;
     }

--- a/client/trino-client/src/main/java/io/trino/client/StatementClientV1.java
+++ b/client/trino-client/src/main/java/io/trino/client/StatementClientV1.java
@@ -56,7 +56,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.getCausalChain;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -65,6 +64,7 @@ import static com.google.common.net.HttpHeaders.USER_AGENT;
 import static io.trino.client.HttpStatusCodes.shouldRetry;
 import static io.trino.client.ProtocolHeaders.TRINO_HEADERS;
 import static io.trino.client.TrinoJsonCodec.jsonCodec;
+import static io.trino.client.UserAgentBuilder.createUserAgent;
 import static java.lang.String.format;
 import static java.net.HttpURLConnection.HTTP_BAD_METHOD;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
@@ -82,10 +82,7 @@ class StatementClientV1
     private static final TrinoJsonCodec<QueryResults> QUERY_RESULTS_CODEC = jsonCodec(QueryResults.class);
 
     private static final Splitter COLLECTION_HEADER_SPLITTER = Splitter.on('=').limit(2).trimResults();
-    private static final String USER_AGENT_VALUE = StatementClientV1.class.getSimpleName() +
-            "/" +
-            firstNonNull(StatementClientV1.class.getPackage().getImplementationVersion(), "unknown");
-
+    private static final String USER_AGENT_VALUE = createUserAgent(StatementClientV1.class.getSimpleName());
     private final Call.Factory httpCallFactory;
     private final String query;
     private final AtomicReference<QueryResults> currentResults = new AtomicReference<>();

--- a/client/trino-client/src/main/java/io/trino/client/StatementClientV1.java
+++ b/client/trino-client/src/main/java/io/trino/client/StatementClientV1.java
@@ -60,11 +60,9 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.getCausalChain;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.net.HttpHeaders.ACCEPT_ENCODING;
-import static com.google.common.net.HttpHeaders.USER_AGENT;
 import static io.trino.client.HttpStatusCodes.shouldRetry;
 import static io.trino.client.ProtocolHeaders.TRINO_HEADERS;
 import static io.trino.client.TrinoJsonCodec.jsonCodec;
-import static io.trino.client.UserAgentBuilder.createUserAgent;
 import static java.lang.String.format;
 import static java.net.HttpURLConnection.HTTP_BAD_METHOD;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
@@ -82,7 +80,6 @@ class StatementClientV1
     private static final TrinoJsonCodec<QueryResults> QUERY_RESULTS_CODEC = jsonCodec(QueryResults.class);
 
     private static final Splitter COLLECTION_HEADER_SPLITTER = Splitter.on('=').limit(2).trimResults();
-    private static final String USER_AGENT_VALUE = createUserAgent(StatementClientV1.class.getSimpleName());
     private final Call.Factory httpCallFactory;
     private final String query;
     private final AtomicReference<QueryResults> currentResults = new AtomicReference<>();
@@ -381,9 +378,7 @@ class StatementClientV1
 
     private Request.Builder prepareRequest(HttpUrl url)
     {
-        Request.Builder builder = new Request.Builder()
-                .addHeader(USER_AGENT, USER_AGENT_VALUE)
-                .url(url);
+        Request.Builder builder = new Request.Builder().url(url);
         user.ifPresent(requestUser -> builder.addHeader(TRINO_HEADERS.requestUser(), requestUser));
         originalUser.ifPresent(originalUser -> builder.addHeader(TRINO_HEADERS.requestOriginalUser(), originalUser));
         if (compressionDisabled) {

--- a/client/trino-client/src/main/java/io/trino/client/UserAgentBuilder.java
+++ b/client/trino-client/src/main/java/io/trino/client/UserAgentBuilder.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Joiner;
+import com.google.common.base.StandardSystemProperty;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Locale;
+import java.util.Map;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+public class UserAgentBuilder
+{
+    private static final Joiner.MapJoiner MAP_JOINER = Joiner.on(" ").withKeyValueSeparator("=");
+    private static final String LANGUAGE = "lang/java";
+    private static final String OS_NAME = "os";
+    private static final String OS_VERSION = "os/version";
+    private static final String ARCH = "arch";
+    private static final String VENDOR = "java/vendor";
+    private static final String VM_NAME = "java/vm";
+    private static final String LOCALE = "locale";
+
+    private UserAgentBuilder() {}
+
+    public static String createUserAgent(String product)
+    {
+        return createUserAgent(product, getProductVersion());
+    }
+
+    public static String createUserAgent(String product, String version)
+    {
+        return createUserAgent(product, version, ImmutableMap.of());
+    }
+
+    public static String createUserAgent(String product, Map<String, String> metadata)
+    {
+        return createUserAgent(product, getProductVersion(), metadata);
+    }
+
+    public static String createUserAgent(String product, String version, Map<String, String> metadata)
+    {
+        ImmutableMap.Builder<String, String> sourceBuilder = ImmutableMap.builder();
+        sourceBuilder.put(OS_NAME, sanitize(StandardSystemProperty.OS_NAME.value()));
+        sourceBuilder.put(OS_VERSION, sanitize(StandardSystemProperty.OS_VERSION.value()));
+        sourceBuilder.put(ARCH, sanitize(StandardSystemProperty.OS_ARCH.value()));
+        sourceBuilder.put(LANGUAGE, StandardSystemProperty.JAVA_VM_VERSION.value());
+        sourceBuilder.put(VM_NAME, sanitize(StandardSystemProperty.JAVA_VM_NAME.value()));
+        sourceBuilder.put(VENDOR, sanitize(StandardSystemProperty.JAVA_VENDOR.value()));
+        sourceBuilder.put(LOCALE, Locale.getDefault().toLanguageTag());
+        sourceBuilder.putAll(metadata);
+
+        return String.format("%s/%s", product, version) + " " + MAP_JOINER.join(sourceBuilder.buildOrThrow());
+    }
+
+    @VisibleForTesting
+    static String sanitize(String value)
+    {
+        return value.replaceAll("[^a-zA-Z0-9_.-]+", "_");
+    }
+
+    private static String getProductVersion()
+    {
+        String version = UserAgentBuilder.class.getPackage().getImplementationVersion();
+        return firstNonNull(version, "unknown");
+    }
+}

--- a/client/trino-client/src/test/java/io/trino/client/TestUserAgentBuilder.java
+++ b/client/trino-client/src/test/java/io/trino/client/TestUserAgentBuilder.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client;
+
+import com.google.common.base.Splitter;
+import com.google.common.base.StandardSystemProperty;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+import java.util.Map;
+
+import static io.trino.client.UserAgentBuilder.createUserAgent;
+import static io.trino.client.UserAgentBuilder.sanitize;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestUserAgentBuilder
+{
+    private static final Splitter.MapSplitter MAP_SPLITTER = Splitter.on(' ').omitEmptyStrings().withKeyValueSeparator('=');
+
+    @Test
+    void testUserAgent()
+    {
+        String userAgent = createUserAgent("trino-cli", "1.0.0", Map.of("md/lang", "en-US", "md/feature", "experimental"));
+        assertThat(userAgent).startsWith("trino-cli/1.0.0");
+
+        Map<String, String> metadata = MAP_SPLITTER.split(userAgent.substring("trino-cli/1.0.0".length() + 1));
+        assertThat(metadata)
+                .containsEntry("lang/java", StandardSystemProperty.JAVA_VM_VERSION.value())
+                .containsEntry("java/vm", sanitize(StandardSystemProperty.JAVA_VM_NAME.value()))
+                .containsEntry("java/vendor", sanitize(StandardSystemProperty.JAVA_VENDOR.value()))
+                .containsEntry("os", sanitize(StandardSystemProperty.OS_NAME.value()))
+                .containsEntry("os/version", sanitize(StandardSystemProperty.OS_VERSION.value()))
+                .containsEntry("arch", sanitize(StandardSystemProperty.OS_ARCH.value()))
+                .containsEntry("locale", Locale.getDefault().toLanguageTag())
+                .containsEntry("md/lang", "en-US")
+                .containsEntry("md/feature", "experimental");
+    }
+
+    @Test
+    void testSanitization()
+    {
+        assertThat(sanitize("")).isEmpty();
+        assertThat(sanitize(" ")).isEqualTo("_");
+        assertThat(sanitize("a")).isEqualTo("a");
+        assertThat(sanitize("a b")).isEqualTo("a_b");
+        assertThat(sanitize("a b c")).isEqualTo("a_b_c");
+        assertThat(sanitize("a   b c")).isEqualTo("a_b_c");
+        assertThat(sanitize("a -+   b c")).isEqualTo("a_-_b_c");
+    }
+}

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/NonRegisteringTrinoDriver.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/NonRegisteringTrinoDriver.java
@@ -29,6 +29,7 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.util.Properties;
 import java.util.logging.Logger;
 
+import static io.trino.client.UserAgentBuilder.createUserAgent;
 import static io.trino.jdbc.DriverInfo.DRIVER_NAME;
 import static io.trino.jdbc.DriverInfo.DRIVER_VERSION;
 import static io.trino.jdbc.DriverInfo.DRIVER_VERSION_MAJOR;
@@ -37,7 +38,8 @@ import static io.trino.jdbc.DriverInfo.DRIVER_VERSION_MINOR;
 public class NonRegisteringTrinoDriver
         implements Driver, Closeable
 {
-    private static final String USER_AGENT = DRIVER_NAME + "/" + DRIVER_VERSION;
+    private static final String USER_AGENT = createUserAgent(DRIVER_NAME, DRIVER_VERSION);
+
     private final Dispatcher dispatcher;
     private final ConnectionPool pool;
 


### PR DESCRIPTION
This sends more information about the client to the Trino cluster.

Structure is similiar to other tools like AWS SDK:

```
aws-sdk-java/2.31.42 md/io#sync md/http#Apache ua/2.1 os/Linux#5.10.236-228.935.amzn2.aarch64 lang/java#24.0.1 md/OpenJDK_64-Bit_Server_VM#24.0.1+9 md/vendor#Eclipse_Adoptium md/en_US app/Trino cfg/auth-source#stsweb m/D
```

For our own clients it will be similiar to:

```
trino-cli/1.0.0 os=Mac_OS_X os/version=15.3.1 arch=aarch64 lang/java=24+36 java/vm=OpenJDK_64-Bit_Server_VM java/vendor=Eclipse_Adoptium locale=pl-PL md/lang=en-US md/feature=experimental
```

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## CLI, JDBC, client
* Send detailed client information in the source ({issue}`issuenumber`)
```
