### PR TITLE
WIP: Include principal field to opa payload

### DIFF
--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/schema/TrinoIdentity.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/schema/TrinoIdentity.java
@@ -22,18 +22,21 @@ import static java.util.Objects.requireNonNull;
 
 public record TrinoIdentity(
         String user,
+        String principal,
         Set<String> groups)
 {
     public static TrinoIdentity fromTrinoIdentity(Identity identity)
     {
         return new TrinoIdentity(
                 identity.getUser(),
+                identity.getPrincipal().isPresent() ? identity.getPrincipal().get().getName() : identity.getUser(),
                 identity.getGroups());
     }
 
     public TrinoIdentity
     {
         requireNonNull(user, "user is null");
+        requireNonNull(principal, "principal is null");
         groups = ImmutableSet.copyOf(requireNonNull(groups, "groups is null"));
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
The PR is about including principal information to OPA payload



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
My use case is for Metabase x Trino integration and its impersonation mode. If the mode is enabled, Trino acknowledges queries are fired by a specific email from users. The problem arises when there are multiple impersonation Metabase connections; the underlying OPA cannot differentiate which connection a user is using to apply connection-level constraints. Hence, including a principal field (similar to authenticatedUser in resource group selector) can help forward necessary information to OPA to know which Trino user is actually impersonating a Metabase user.




<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:
Include `principal` information to OPA's context identity 

```markdown
## Section
* Fix some things. (#25415 )
```
