### PR TITLE
Sanitize schema and catalog case in Session

### DIFF
--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcConnection.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcConnection.java
@@ -163,6 +163,8 @@ public class TestJdbcConnection
                 Statement statement = connection.createStatement()) {
             statement.execute("SET ROLE admin IN hive");
             statement.execute("CREATE SCHEMA default");
+            statement.execute("CREATE TABLE hive.default.dummy(a bigint)");
+
             statement.execute("CREATE SCHEMA fruit");
             statement.execute(
                     "CREATE TABLE blackhole.default.devzero(dummy bigint) " +
@@ -649,6 +651,37 @@ public class TestJdbcConnection
 
         assertThatCode(() -> createConnectionUsingInvalidPassword("validateConnection=false"))
                 .doesNotThrowAnyException();
+    }
+
+    private Connection createConnectionCatalogSchema(String catalog, String schema)
+            throws SQLException
+    {
+        String url = format("jdbc:trino://localhost:%s/%s/%s", server.getHttpsAddress().getPort(), catalog, schema);
+        Properties properties = new Properties();
+        properties.put("user", TEST_USER);
+        properties.put("password", TEST_PASSWORD);
+        properties.setProperty("SSL", "true");
+        properties.setProperty("SSLTrustStorePath", sslTrustStorePath);
+        properties.setProperty("SSLTrustStorePassword", "changeit");
+        return DriverManager.getConnection(url, properties);
+    }
+
+    @Test
+    public void testMixedCaseSchema()
+            throws SQLException
+    {
+        try (Connection conn = createConnectionCatalogSchema("hive", "DeFaUlT")) {
+            assertThat(conn.createStatement().execute("select * from dummy")).isTrue();
+        }
+    }
+
+    @Test
+    public void testMixedCaseCatalog()
+            throws SQLException
+    {
+        try (Connection conn = createConnectionCatalogSchema("HiVe", "default")) {
+            assertThat(conn.createStatement().execute("select * from dummy")).isTrue();
+        }
     }
 
     private void testConcurrentCancellationOnConnectionClose(boolean autoCommit)

--- a/core/trino-main/src/main/java/io/trino/server/HttpRequestSessionContextFactory.java
+++ b/core/trino-main/src/main/java/io/trino/server/HttpRequestSessionContextFactory.java
@@ -46,6 +46,7 @@ import java.net.URLDecoder;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -103,8 +104,8 @@ public class HttpRequestSessionContextFactory
         catch (ProtocolDetectionException e) {
             throw new BadRequestException(e.getMessage());
         }
-        Optional<String> catalog = Optional.ofNullable(trimEmptyToNull(headers.getFirst(protocolHeaders.requestCatalog())));
-        Optional<String> schema = Optional.ofNullable(trimEmptyToNull(headers.getFirst(protocolHeaders.requestSchema())));
+        Optional<String> catalog = Optional.ofNullable(trimEmptyToNull(headers.getFirst(protocolHeaders.requestCatalog()))).map(value -> value.toLowerCase(Locale.ENGLISH));
+        Optional<String> schema = Optional.ofNullable(trimEmptyToNull(headers.getFirst(protocolHeaders.requestSchema()))).map(value -> value.toLowerCase(Locale.ENGLISH));
         Optional<String> path = Optional.ofNullable(trimEmptyToNull(headers.getFirst(protocolHeaders.requestPath())));
         assertRequest(catalog.isPresent() || schema.isEmpty(), "Schema is set but catalog is not");
 

--- a/core/trino-main/src/test/java/io/trino/server/TestHttpRequestSessionContextFactory.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestHttpRequestSessionContextFactory.java
@@ -79,8 +79,8 @@ public class TestHttpRequestSessionContextFactory
                 Optional.of("testRemote"),
                 Optional.empty());
         assertThat(context.getSource().orElse(null)).isEqualTo("testSource");
-        assertThat(context.getCatalog().orElse(null)).isEqualTo("testCatalog");
-        assertThat(context.getSchema().orElse(null)).isEqualTo("testSchema");
+        assertThat(context.getCatalog().orElse(null)).isEqualTo("testcatalog"); // lowercased
+        assertThat(context.getSchema().orElse(null)).isEqualTo("testschema"); // lowercased
         assertThat(context.getPath().orElse(null)).isEqualTo("testPath");
         assertThat(context.getIdentity()).isEqualTo(Identity.forUser("testUser")
                 .withGroups(ImmutableSet.of("testUser"))

--- a/core/trino-main/src/test/java/io/trino/server/TestQuerySessionSupplier.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestQuerySessionSupplier.java
@@ -86,8 +86,8 @@ public class TestQuerySessionSupplier
         assertThat(session.getQueryId()).isEqualTo(new QueryId("test_query_id"));
         assertThat(session.getUser()).isEqualTo("testUser");
         assertThat(session.getSource().get()).isEqualTo("testSource");
-        assertThat(session.getCatalog().get()).isEqualTo("testCatalog");
-        assertThat(session.getSchema().get()).isEqualTo("testSchema");
+        assertThat(session.getCatalog().get()).isEqualTo("testcatalog"); // lowercased
+        assertThat(session.getSchema().get()).isEqualTo("testschema"); // lowercased
         assertThat(session.getPath().getRawPath()).isEqualTo("testPath");
         assertThat(session.getLocale()).isEqualTo(Locale.TAIWAN);
         assertThat(session.getTimeZoneKey()).isEqualTo(getTimeZoneKey("Asia/Taipei"));


### PR DESCRIPTION
It was possible to provide non-lowercase catalog/schema via connection uri used with JDBC driver. That caused failures of checks during analysis that both schema and catalog must be lowercase.

The fix sanitizes schema and catalog case when Session objects, which holds these, is consturucted.

This fixes JDBC failure scenario and potential other scenarios where different clients would send non-lowercase schema/catalog over Trino protocol.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## General
* Fix query failures if catalog/schema passed over Trino connection string were not lower case. ({issue}`25903`)
```
