### PR TITLE
Make softMemoryLimit optional in resource group spec

### DIFF
--- a/docs/src/main/sphinx/admin/resource-groups.md
+++ b/docs/src/main/sphinx/admin/resource-groups.md
@@ -102,7 +102,7 @@ are reflected automatically for incoming queries.
 
 - `hardConcurrencyLimit` (required): maximum number of running queries.
 
-- `softMemoryLimit` (required): maximum amount of distributed memory this
+- `softMemoryLimit` (optional): maximum amount of distributed memory this
   group may use, before new queries become queued. May be specified as
   an absolute value (i.e. `1GB`) or as a percentage (i.e. `10%`) of the cluster's memory.
 

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/ResourceGroupSpecBuilder.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/ResourceGroupSpecBuilder.java
@@ -30,7 +30,7 @@ public class ResourceGroupSpecBuilder
 {
     private final long id;
     private final ResourceGroupNameTemplate nameTemplate;
-    private final String softMemoryLimit;
+    private final Optional<String> softMemoryLimit;
     private final int maxQueued;
     private final Optional<Integer> softConcurrencyLimit;
     private final int hardConcurrencyLimit;
@@ -45,7 +45,7 @@ public class ResourceGroupSpecBuilder
     ResourceGroupSpecBuilder(
             long id,
             ResourceGroupNameTemplate nameTemplate,
-            String softMemoryLimit,
+            Optional<String> softMemoryLimit,
             int maxQueued,
             Optional<Integer> softConcurrencyLimit,
             int hardConcurrencyLimit,
@@ -126,7 +126,7 @@ public class ResourceGroupSpecBuilder
         {
             long id = resultSet.getLong("resource_group_id");
             ResourceGroupNameTemplate nameTemplate = new ResourceGroupNameTemplate(resultSet.getString("name"));
-            String softMemoryLimit = resultSet.getString("soft_memory_limit");
+            Optional<String> softMemoryLimit = Optional.ofNullable(resultSet.getString("soft_memory_limit"));
             int maxQueued = resultSet.getInt("max_queued");
             Optional<Integer> softConcurrencyLimit = Optional.of(resultSet.getInt("soft_concurrency_limit"));
             if (resultSet.wasNull()) {

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/ResourceGroupsDao.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/ResourceGroupsDao.java
@@ -36,7 +36,7 @@ public interface ResourceGroupsDao
     @SqlUpdate("CREATE TABLE IF NOT EXISTS resource_groups (\n" +
             "  resource_group_id BIGINT NOT NULL AUTO_INCREMENT,\n" +
             "  name VARCHAR(250) NOT NULL,\n" +
-            "  soft_memory_limit VARCHAR(128) NOT NULL,\n" +
+            "  soft_memory_limit VARCHAR(128),\n" +
             "  max_queued INT NOT NULL,\n" +
             "  soft_concurrency_limit INT NULL,\n" +
             "  hard_concurrency_limit INT NOT NULL,\n" +

--- a/plugin/trino-resource-group-managers/src/main/resources/db/migration/mysql/V8__remove_soft_memory_limit_not_null.sql
+++ b/plugin/trino-resource-group-managers/src/main/resources/db/migration/mysql/V8__remove_soft_memory_limit_not_null.sql
@@ -1,0 +1,1 @@
+ALTER TABLE resource_groups MODIFY soft_memory_limit VARCHAR(128) NULL;

--- a/plugin/trino-resource-group-managers/src/main/resources/db/migration/oracle/V8__remove_soft_memory_limit_not_null.sql
+++ b/plugin/trino-resource-group-managers/src/main/resources/db/migration/oracle/V8__remove_soft_memory_limit_not_null.sql
@@ -1,0 +1,1 @@
+ALTER TABLE resource_groups MODIFY soft_memory_limit VARCHAR(128) NULL;

--- a/plugin/trino-resource-group-managers/src/main/resources/db/migration/postgresql/V8__remove_soft_memory_limit_not_null.sql
+++ b/plugin/trino-resource-group-managers/src/main/resources/db/migration/postgresql/V8__remove_soft_memory_limit_not_null.sql
@@ -1,0 +1,1 @@
+ALTER TABLE resource_groups ALTER COLUMN soft_memory_limit DROP NOT NULL;

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestingResourceGroups.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestingResourceGroups.java
@@ -50,7 +50,7 @@ final class TestingResourceGroups
     {
         return new ResourceGroupSpec(
                 new ResourceGroupNameTemplate(segmentName),
-                DataSize.of(100, MEGABYTE).toString(),
+                Optional.of(DataSize.of(100, MEGABYTE).toString()),
                 10,
                 Optional.empty(),
                 Optional.of(10),

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestResourceGroupsDao.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestResourceGroupsDao.java
@@ -83,15 +83,15 @@ public class TestResourceGroupsDao
         dao.insertResourceGroup(2, "bi", "50%", 50, 50, 50, null, null, null, null, null, 1L, ENVIRONMENT);
         List<ResourceGroupSpecBuilder> records = dao.getResourceGroups(ENVIRONMENT);
         assertThat(records).hasSize(2);
-        map.put(1L, new ResourceGroupSpecBuilder(1, new ResourceGroupNameTemplate("global"), "100%", 100, Optional.of(100), 100, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
-        map.put(2L, new ResourceGroupSpecBuilder(2, new ResourceGroupNameTemplate("bi"), "50%", 50, Optional.of(50), 50, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(1L)));
+        map.put(1L, new ResourceGroupSpecBuilder(1, new ResourceGroupNameTemplate("global"), Optional.of("100%"), 100, Optional.of(100), 100, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
+        map.put(2L, new ResourceGroupSpecBuilder(2, new ResourceGroupNameTemplate("bi"), Optional.of("50%"), 50, Optional.of(50), 50, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(1L)));
         compareResourceGroups(map, records);
     }
 
     private static void testResourceGroupUpdate(H2ResourceGroupsDao dao, Map<Long, ResourceGroupSpecBuilder> map)
     {
-        dao.updateResourceGroup(2, "bi", "40%", 40, 30, 30, null, null, true, null, null, 1L, ENVIRONMENT);
-        ResourceGroupSpecBuilder updated = new ResourceGroupSpecBuilder(2, new ResourceGroupNameTemplate("bi"), "40%", 40, Optional.of(30), 30, Optional.empty(), Optional.empty(), Optional.of(true), Optional.empty(), Optional.empty(), Optional.of(1L));
+        dao.updateResourceGroup(2, "bi", null, 40, 30, 30, null, null, true, null, null, 1L, ENVIRONMENT);
+        ResourceGroupSpecBuilder updated = new ResourceGroupSpecBuilder(2, new ResourceGroupNameTemplate("bi"), Optional.empty(), 40, Optional.of(30), 30, Optional.empty(), Optional.empty(), Optional.of(true), Optional.empty(), Optional.empty(), Optional.of(1L));
         map.put(2L, updated);
         compareResourceGroups(map, dao.getResourceGroups(ENVIRONMENT));
     }

--- a/plugin/trino-resource-group-managers/src/test/resources/resource_groups_config.json
+++ b/plugin/trino-resource-group-managers/src/test/resources/resource_groups_config.json
@@ -16,6 +16,11 @@
           "hardConcurrencyLimit": 3,
           "maxQueued": 4,
           "schedulingWeight": 5
+        },
+        {
+          "name": "sub_no_soft_memory_limit",
+          "hardConcurrencyLimit": 4,
+          "schedulingWeight": 1
         }
       ]
     }


### PR DESCRIPTION
softMemoryLimit was previously required. However, it's often unclear for the users what is the implication of setting the limit and it doesn't work well will revocable memory and spilled queries.

This PR makes softMemoryLimit optional and allows to manage query concurrency within query classes (e.g. small, medium, large) which greatly simplifies cluster management.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Make soft memory limit optional in resource groups. ({issue}`issuenumber`)
```
