### PR TITLE
docs: add deepwiki badge to enable docs auto-refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@
     src="https://img.shields.io/badge/Trino%3A%20The%20Definitive%20Guide-download-brightgreen"
     alt="Trino: The Definitive Guide book download"
   /></a>
+  <a href="https://deepwiki.com/trinodb/trino" style="text-decoration: none"><img 
+    src="https://deepwiki.com/badge.svg" 
+    alt="Ask DeepWiki"
+  /></a>
 </p>
 
 ## Development
@@ -38,6 +42,8 @@ Learn about development for all Trino organization projects:
 Further information in the [development section of the
 website](https://trino.io/development) includes different roles, like
 contributors, reviewers, and maintainers, related processes, and other aspects.
+
+See [DeepWiki](https://deepwiki.com/trinodb/trino) for an in-depth look at the code base.
 
 See [the Trino developer guide](https://trino.io/docs/current/develop.html) for
 information about the SPI, implementing connectors and other plugins plugins,


### PR DESCRIPTION
Signed-off-by: Eugene Tolbakov <ev.tolbakov@gmail.com>

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Hey folks,
I've noticed that trino repo has been added to the [DeepWiki](https://deepwiki.com/trinodb/trino) but due to the badge absence it's not auto-refreshed.
<img width="348" alt="image" src="https://github.com/user-attachments/assets/a6a48d65-0a65-460c-ab8c-662123ae4f24" />

When badge is added, the auto-refreshed is going to be done weekly.
<img width="309" alt="image" src="https://github.com/user-attachments/assets/c394c17f-a0cc-478b-91c0-ca1f359eecb6" />

Please let me know if you are happy with this change.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
