### PR TITLE
Improve error classification for empty cells range

### DIFF
--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsClient.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsClient.java
@@ -54,6 +54,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.plugin.google.sheets.SheetsErrorCode.SHEETS_BAD_CREDENTIALS_ERROR;
 import static io.trino.plugin.google.sheets.SheetsErrorCode.SHEETS_INSERT_ERROR;
+import static io.trino.plugin.google.sheets.SheetsErrorCode.SHEETS_INVALID_TABLE_FORMAT;
 import static io.trino.plugin.google.sheets.SheetsErrorCode.SHEETS_METASTORE_ERROR;
 import static io.trino.plugin.google.sheets.SheetsErrorCode.SHEETS_TABLE_LOAD_ERROR;
 import static io.trino.plugin.google.sheets.SheetsErrorCode.SHEETS_UNKNOWN_TABLE_ERROR;
@@ -311,7 +312,7 @@ public class SheetsClient
             log.debug("Accessing sheet id [%s] with range [%s]", sheetId, defaultRange);
             List<List<Object>> values = sheetsService.spreadsheets().values().get(sheetId, defaultRange).execute().getValues();
             if (values == null) {
-                throw new TrinoException(SHEETS_TABLE_LOAD_ERROR, "No non-empty cells found in sheet: " + sheetExpression);
+                throw new TrinoException(SHEETS_INVALID_TABLE_FORMAT, "No non-empty cells found in sheet: " + sheetExpression);
             }
             return values;
         }

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsErrorCode.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsErrorCode.java
@@ -29,6 +29,7 @@ public enum SheetsErrorCode
     SHEETS_UNKNOWN_TABLE_ERROR(2, USER_ERROR),
     SHEETS_TABLE_LOAD_ERROR(3, INTERNAL_ERROR),
     SHEETS_INSERT_ERROR(4, INTERNAL_ERROR),
+    SHEETS_INVALID_TABLE_FORMAT(5, EXTERNAL)
     /**/;
 
     private final ErrorCode errorCode;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Google Sheets connector
* Use SHEETS_INVALID_TABLE_FORMAT error code for the case where there is request for querying empty sheet range. ({issue}`25937`)
```
