### PR TITLE
Release grouped top n memory on output

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRowNumberBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRowNumberBuilder.java
@@ -21,6 +21,7 @@ import io.trino.operator.RowReferencePageManager.LoadCursor;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.type.Type;
+import jakarta.annotation.Nullable;
 
 import java.util.Iterator;
 import java.util.List;
@@ -42,7 +43,8 @@ public class GroupedTopNRowNumberBuilder
     private final List<Type> sourceTypes;
     private final boolean produceRowNumber;
     private final int[] groupByChannels;
-    private final GroupByHash groupByHash;
+    @Nullable
+    private GroupByHash groupByHash; // null after output starts
     private final RowReferencePageManager pageManager = new RowReferencePageManager();
     private final GroupedTopNRowNumberAccumulator groupedTopNRowNumberAccumulator;
     private final PageWithPositionComparator comparator;
@@ -77,6 +79,9 @@ public class GroupedTopNRowNumberBuilder
     @Override
     public Work<?> processPage(Page page)
     {
+        if (groupByHash == null) {
+            throw new IllegalStateException("already producing output");
+        }
         return new TransformWork<>(
                 groupByHash.getGroupIds(page.getColumns(groupByChannels)),
                 groupIds -> {
@@ -88,14 +93,19 @@ public class GroupedTopNRowNumberBuilder
     @Override
     public Iterator<Page> buildResult()
     {
-        return new ResultIterator();
+        if (groupByHash == null) {
+            throw new IllegalStateException("already producing output");
+        }
+        int groupIdCount = groupByHash.getGroupCount();
+        groupByHash = null;
+        return new ResultIterator(groupIdCount);
     }
 
     @Override
     public long getEstimatedSizeInBytes()
     {
         return INSTANCE_SIZE
-                + groupByHash.getEstimatedSize()
+                + (groupByHash == null ? 0L : groupByHash.getEstimatedSize())
                 + pageManager.sizeOf()
                 + groupedTopNRowNumberAccumulator.sizeOf();
     }
@@ -119,6 +129,7 @@ public class GroupedTopNRowNumberBuilder
         pageManager.compactIfNeeded();
     }
 
+    @Nullable
     @VisibleForTesting
     GroupByHash getGroupByHash()
     {
@@ -129,14 +140,15 @@ public class GroupedTopNRowNumberBuilder
             extends AbstractIterator<Page>
     {
         private final PageBuilder pageBuilder;
-        private final int groupIdCount = groupByHash.getGroupCount();
+        private final int groupIdCount;
         private int currentGroupId = -1;
         private final LongBigArray rowIdOutput = new LongBigArray();
         private long currentGroupSize;
         private int currentIndexInGroup;
 
-        ResultIterator()
+        private ResultIterator(int groupIdCount)
         {
+            this.groupIdCount = groupIdCount;
             ImmutableList.Builder<Type> sourceTypesBuilders = ImmutableList.<Type>builder().addAll(sourceTypes);
             if (produceRowNumber) {
                 sourceTypesBuilders.add(BIGINT);


### PR DESCRIPTION
## Description
Releases `GroupByHash` and associated memory from grouped top N ranking and row number operations once output begins since the hash table is no longer necessary after that point.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Similar to https://github.com/trinodb/trino/pull/25879


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Reduce memory consumed by grouped Top N rank and row number operations ({issue}`25946`)
```
