### PR TITLE
Ensure deterministic order of aggregates

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPartialAggregationThroughJoin.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPartialAggregationThroughJoin.java
@@ -14,6 +14,7 @@
 package io.trino.sql.planner.iterative.rule;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
 import io.trino.Session;
@@ -36,7 +37,6 @@ import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.ProjectNode;
 import org.assertj.core.util.VisibleForTesting;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -328,7 +328,7 @@ public class PushPartialAggregationThroughJoin
 
     private PlanNode toIntermediateAggregation(AggregationNode partialAggregation, PlanNode source, Context context)
     {
-        Map<Symbol, AggregationNode.Aggregation> intermediateAggregation = new HashMap<>();
+        ImmutableMap.Builder<Symbol, Aggregation> intermediateAggregation = ImmutableMap.builder();
         for (Map.Entry<Symbol, AggregationNode.Aggregation> entry : partialAggregation.getAggregations().entrySet()) {
             AggregationNode.Aggregation aggregation = entry.getValue();
             ResolvedFunction resolvedFunction = aggregation.getResolvedFunction();
@@ -353,7 +353,7 @@ public class PushPartialAggregationThroughJoin
         return new AggregationNode(
                 context.getIdAllocator().getNextId(),
                 source,
-                intermediateAggregation,
+                intermediateAggregation.buildOrThrow(),
                 partialAggregation.getGroupingSets(),
                 // preGroupedSymbols reflect properties of the input. Splitting the aggregation and pushing partial aggregation
                 // through the join may or may not preserve these properties. Hence, it is safest to drop preGroupedSymbols here.


### PR DESCRIPTION
Use ImmutableMap instead of HashMap when pushing partial aggregation through join

## Release notes

( x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
