### PR TITLE
Use Guice Inject annotation in Faker

### DIFF
--- a/plugin/trino-faker/pom.xml
+++ b/plugin/trino-faker/pom.xml
@@ -67,11 +67,6 @@
         </dependency>
 
         <dependency>
-            <groupId>jakarta.inject</groupId>
-            <artifactId>jakarta.inject-api</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerConnector.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerConnector.java
@@ -15,6 +15,7 @@
 package io.trino.plugin.faker;
 
 import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
 import io.trino.spi.ErrorCodeSupplier;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.Connector;
@@ -29,7 +30,6 @@ import io.trino.spi.function.FunctionProvider;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.transaction.IsolationLevel;
 import io.trino.spi.type.ArrayType;
-import jakarta.inject.Inject;
 
 import java.util.List;
 import java.util.Optional;

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerMetadata.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerMetadata.java
@@ -17,6 +17,7 @@ package io.trino.plugin.faker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
+import com.google.inject.Inject;
 import io.airlift.slice.Slice;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
@@ -69,7 +70,6 @@ import io.trino.spi.type.VarcharType;
 import io.trino.type.IpAddressType;
 import io.trino.type.JsonType;
 import io.trino.type.TDigestType;
-import jakarta.inject.Inject;
 import net.datafaker.Faker;
 
 import java.util.ArrayList;

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerModule.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerModule.java
@@ -15,11 +15,11 @@
 package io.trino.plugin.faker;
 
 import com.google.inject.Binder;
+import com.google.inject.Inject;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
 import io.trino.spi.NodeManager;
 import io.trino.spi.type.TypeManager;
-import jakarta.inject.Inject;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static java.util.Objects.requireNonNull;

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerPageSourceProvider.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerPageSourceProvider.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.faker;
 
+import com.google.inject.Inject;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.ConnectorPageSourceProvider;
@@ -21,7 +22,6 @@ import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.DynamicFilter;
-import jakarta.inject.Inject;
 import net.datafaker.Faker;
 
 import java.util.List;


### PR DESCRIPTION
## Description

Only Faker uses `jakarta.inject-api`. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
