### PR TITLE
Pushdown Prometheus Predicates #8742

### DIFF
--- a/plugin/trino-prometheus/pom.xml
+++ b/plugin/trino-prometheus/pom.xml
@@ -81,6 +81,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-matching</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-plugin-toolkit</artifactId>
         </dependency>
 

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusClient.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusClient.java
@@ -28,7 +28,6 @@ import jakarta.annotation.Nullable;
 import okhttp3.Credentials;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
-import okhttp3.OkHttpClient.Builder;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
@@ -74,7 +73,8 @@ public class PrometheusClient
         requireNonNull(metricCodec, "metricCodec is null");
         requireNonNull(typeManager, "typeManager is null");
 
-        Builder clientBuilder = new Builder().readTimeout(Duration.ofMillis(config.getReadTimeout().toMillis()));
+        OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder().readTimeout(
+                Duration.ofMillis(config.getReadTimeout().toMillis()));
         setupBasicAuth(clientBuilder, config.getUser(), config.getPassword());
         setupTokenAuth(clientBuilder, getBearerAuthInfoFromFile(config.getBearerTokenFile()), config.getHttpAuthHeaderName());
         clientBuilder.addInterceptor(addAdditionalHeaders(config.getAdditionalHeaders()));

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusConnector.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusConnector.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Set;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.trino.plugin.prometheus.PrometheusTransactionHandle.INSTANCE;
 import static java.util.Objects.requireNonNull;
 
 public class PrometheusConnector
@@ -64,7 +63,7 @@ public class PrometheusConnector
     @Override
     public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly, boolean autoCommit)
     {
-        return INSTANCE;
+        return PrometheusTransactionHandle.INSTANCE;
     }
 
     @Override

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusConnectorConfig.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusConnectorConfig.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.prometheus;
 
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HttpHeaders;
 import io.airlift.configuration.Config;
@@ -29,6 +30,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 
 import static java.lang.String.format;
 
@@ -199,7 +201,7 @@ public class PrometheusConnectorConfig
             String kvDelim = "(?<!\\\\):";
             Map<String, String> temp = new HashMap<>();
             if (httpHeaders != null) {
-                for (String kv : httpHeaders.split(headersDelim)) {
+                for (String kv : Splitter.on(Pattern.compile(headersDelim)).split(httpHeaders)) {
                     String key = kv.split(kvDelim, 2)[0].trim();
                     String val = kv.split(kvDelim, 2)[1].trim();
                     temp.put(key, val);

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/expression/LabelFilterExpression.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/expression/LabelFilterExpression.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.prometheus.expression;
+
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+
+import java.util.List;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public record LabelFilterExpression(String labelName, String labelValue, boolean isRegex, boolean isNegative)
+{
+    public static final Set<ConnectorExpressionRule<?, List<LabelFilterExpression>>> APPLICABLE_EXPRESSION_RULES = Set.of(
+            new RewriteEqAndNeq(),
+            new RewriteIn(),
+            new RewriteAnd(),
+            new RewriteLikeWithCaseSensitivity(),
+            new RewriteLikeEscapeWithCaseSensitivity());
+
+    public LabelFilterExpression
+    {
+        requireNonNull(labelName, "labelName is null");
+        requireNonNull(labelValue, "labelValue is null");
+    }
+}

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/expression/RewriteAnd.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/expression/RewriteAnd.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.prometheus.expression;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.Verify.verify;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.spi.expression.StandardFunctions.AND_FUNCTION_NAME;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+
+class RewriteAnd
+        implements ConnectorExpressionRule<Call, List<LabelFilterExpression>>
+{
+    private static final Pattern<Call> PATTERN = call()
+            .with(functionName().equalTo(AND_FUNCTION_NAME))
+            .with(type().equalTo(BOOLEAN));
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<List<LabelFilterExpression>> rewrite(Call call, Captures captures, RewriteContext<List<LabelFilterExpression>> context)
+    {
+        List<ConnectorExpression> arguments = call.getArguments();
+        verify(!arguments.isEmpty(), "no arguments");
+        ImmutableList.Builder<LabelFilterExpression> terms = ImmutableList.builderWithExpectedSize(arguments.size());
+        for (ConnectorExpression argument : arguments) {
+            verify(argument.getType() == BOOLEAN, "Unexpected type of argument: %s", argument.getType());
+            Optional<List<LabelFilterExpression>> rewritten = context.defaultRewrite(argument);
+            if (rewritten.isEmpty()) {
+                return Optional.empty();
+            }
+            terms.addAll(rewritten.get());
+        }
+
+        return Optional.of(terms.build());
+    }
+}

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/expression/RewriteEqAndNeq.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/expression/RewriteEqAndNeq.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.prometheus.expression;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.Constant;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argument;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argumentCount;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.constant;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.prometheus.expression.RewriteHelpers.LABEL_MAP_CHECK_CORRECT_TYPE;
+import static io.trino.plugin.prometheus.expression.RewriteHelpers.extractLabelName;
+import static io.trino.plugin.prometheus.expression.RewriteHelpers.extractVarchar;
+import static io.trino.spi.expression.StandardFunctions.EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.NOT_EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+
+public class RewriteEqAndNeq
+        implements ConnectorExpressionRule<Call, List<LabelFilterExpression>>
+{
+    private static final Capture<Call> LABEL_NAME = newCapture();
+    private static final Capture<Constant> LABEL_VALUE = newCapture();
+
+    private static final Pattern<Call> PATTERN = call()
+            .with(functionName().matching(functionName -> ImmutableSet.of(
+                    EQUAL_OPERATOR_FUNCTION_NAME,
+                    NOT_EQUAL_OPERATOR_FUNCTION_NAME
+            ).contains(functionName)))
+            .with(type().equalTo(BOOLEAN))
+            .with(argumentCount().equalTo(2))
+            .with(argument(0).matching(call()
+                    .matching(LABEL_MAP_CHECK_CORRECT_TYPE)
+                    .capturedAs(LABEL_NAME)))
+            .with(argument(1).matching(constant()
+                    .with(type().matching(RewriteHelpers::isCharOrStringType))
+                    .capturedAs(LABEL_VALUE)));
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<List<LabelFilterExpression>> rewrite(Call call, Captures captures, RewriteContext<List<LabelFilterExpression>> context)
+    {
+        String labelName = extractLabelName(captures, LABEL_NAME);
+        String labelValue = extractVarchar(captures.get(LABEL_VALUE));
+
+        return Optional.of(ImmutableList.of(new LabelFilterExpression(
+                labelName,
+                labelValue,
+                false,
+                call.getFunctionName().equals(NOT_EQUAL_OPERATOR_FUNCTION_NAME))));
+    }
+}

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/expression/RewriteHelpers.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/expression/RewriteHelpers.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.prometheus.expression;
+
+import io.airlift.slice.Slice;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.expression.Variable;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import static com.google.common.base.Verify.verify;
+
+public final class RewriteHelpers
+{
+    private RewriteHelpers() {}
+
+    public static final Predicate<Call> LABEL_MAP_CHECK_CORRECT_TYPE = connectorExpression -> {
+        List<ConnectorExpression> arguments = connectorExpression.getArguments();
+
+        if (arguments.isEmpty() || !(arguments.getFirst() instanceof Variable)) {
+            return false;
+        }
+
+        String variableName = ((Variable) arguments.getFirst()).getName();
+        if (!variableName.equals("labels")) {
+            return false;
+        }
+        return isCharOrStringType(connectorExpression.getType());
+    };
+
+    public static String extractLabelName(Captures captures, Capture<Call> captureKey)
+    {
+        // Extract the label name from the call expression, which is actually the key of the labels map.
+        List<ConnectorExpression> arguments = captures.get(captureKey).getArguments();
+
+        if (arguments.isEmpty() || !(arguments.getLast() instanceof Constant constant)) {
+            throw new IllegalArgumentException("Expected the last argument to be a constant representing the label name");
+        }
+
+        Object labelNameObject = constant.getValue();
+        if (!(labelNameObject instanceof Slice slice)) {
+            throw new IllegalArgumentException("Expected label name to be a Slice, but got: " + (labelNameObject == null ? "null" : labelNameObject.getClass().getSimpleName()));
+        }
+        return slice.toStringUtf8();
+    }
+
+    public static boolean isCharOrStringType(Type type)
+    {
+        return type instanceof CharType || type instanceof VarcharType;
+    }
+
+    public static String extractVarchar(ConnectorExpression expression)
+    {
+        verify(isCharOrStringType(expression.getType()), "Unexpected type of argument: '%s' (expected VARCHAR)", expression.getType());
+
+        if (!(expression instanceof Constant constant)) {
+            throw new IllegalArgumentException("Expected a Constant expression, but got: " + expression.getClass().getSimpleName());
+        }
+        Object value = constant.getValue();
+        if (!(value instanceof Slice slice)) {
+            throw new IllegalArgumentException("Expected value to be a Slice, but got: " + (value == null ? "null" : value.getClass().getSimpleName()));
+        }
+        return slice.toStringUtf8();
+    }
+}

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/expression/RewriteIn.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/expression/RewriteIn.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.prometheus.expression;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argument;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argumentCount;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.arguments;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.prometheus.expression.RewriteHelpers.LABEL_MAP_CHECK_CORRECT_TYPE;
+import static io.trino.plugin.prometheus.expression.RewriteHelpers.extractLabelName;
+import static io.trino.spi.expression.StandardFunctions.ARRAY_CONSTRUCTOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.IN_PREDICATE_FUNCTION_NAME;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+
+public class RewriteIn
+        implements ConnectorExpressionRule<Call, List<LabelFilterExpression>>
+{
+    private static final Capture<Call> LABEL_NAME = newCapture();
+    private static final Capture<List<ConnectorExpression>> LABEL_VALUES = newCapture();
+
+    private static final Pattern<Call> PATTERN = call()
+            .with(functionName().equalTo(IN_PREDICATE_FUNCTION_NAME))
+            .with(type().equalTo(BOOLEAN))
+            .with(argumentCount().equalTo(2))
+            .with(argument(0).matching(call()
+                    .matching(LABEL_MAP_CHECK_CORRECT_TYPE)
+                    .capturedAs(LABEL_NAME)))
+            .with(argument(1).matching(call()
+                    .with(functionName().equalTo(ARRAY_CONSTRUCTOR_FUNCTION_NAME))
+                    .matching(call -> call.getArguments().stream().map(ConnectorExpression::getType).allMatch(RewriteHelpers::isCharOrStringType))
+                    .with(arguments().capturedAs(LABEL_VALUES))));
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<List<LabelFilterExpression>> rewrite(Call call, Captures captures, RewriteContext<List<LabelFilterExpression>> context)
+    {
+        String labelName = extractLabelName(captures, LABEL_NAME);
+        List<ConnectorExpression> expressions = captures.get(LABEL_VALUES);
+
+        return Optional.of(ImmutableList.of(new LabelFilterExpression(
+                labelName,
+                expressions.stream()
+                        .map(RewriteHelpers::extractVarchar)
+                        .distinct()
+                        .collect(Collectors.joining("|", "(", ")")),
+                true,
+                false)));
+    }
+}

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/expression/RewriteLikeEscapeWithCaseSensitivity.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/expression/RewriteLikeEscapeWithCaseSensitivity.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.prometheus.expression;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.Constant;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argument;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argumentCount;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.constant;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.prometheus.expression.RewriteHelpers.LABEL_MAP_CHECK_CORRECT_TYPE;
+import static io.trino.plugin.prometheus.expression.RewriteHelpers.extractLabelName;
+import static io.trino.plugin.prometheus.expression.RewriteHelpers.extractVarchar;
+import static io.trino.spi.expression.StandardFunctions.LIKE_FUNCTION_NAME;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+
+public class RewriteLikeEscapeWithCaseSensitivity
+        implements ConnectorExpressionRule<Call, List<LabelFilterExpression>>
+{
+    private static final Capture<Call> LABEL_NAME = newCapture();
+    private static final Capture<Constant> LABEL_VALUE_LIKE_PATTERN = newCapture();
+    private static final Capture<Constant> ESCAPE_PATTERN = newCapture();
+
+    private static final Pattern<Call> PATTERN = call()
+            .with(functionName().equalTo(LIKE_FUNCTION_NAME))
+            .with(type().equalTo(BOOLEAN))
+            .with(argumentCount().equalTo(3))
+            .with(argument(0).matching(call()
+                    .matching(LABEL_MAP_CHECK_CORRECT_TYPE)
+                    .capturedAs(LABEL_NAME)))
+            .with(argument(1).matching(constant()
+                    .with(type().matching(RewriteHelpers::isCharOrStringType))
+                    .capturedAs(LABEL_VALUE_LIKE_PATTERN)))
+            .with(argument(2).matching(constant()
+                    .with(type().matching(RewriteHelpers::isCharOrStringType))
+                    .capturedAs(ESCAPE_PATTERN)));
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<List<LabelFilterExpression>> rewrite(Call expression, Captures captures, RewriteContext<List<LabelFilterExpression>> context)
+    {
+        String labelName = extractLabelName(captures, LABEL_NAME);
+        String labelValue = extractVarchar(captures.get(LABEL_VALUE_LIKE_PATTERN));
+        String escapePattern = extractVarchar(captures.get(ESCAPE_PATTERN));
+
+        return Optional.of(ImmutableList.of(new LabelFilterExpression(
+                labelName,
+                // Only replace LIKE matching characters ('%' and '_') in case they're not escaped.
+                // I didn't manage to get negative lookaheads to work, so we use this dummy workaround.
+                labelValue
+                        .replaceAll(Matcher.quoteReplacement(escapePattern) + "%", "<LiteralLikePercentage>")
+                        .replaceAll(Matcher.quoteReplacement(escapePattern) + "_", "<LiteralLikeUnderscore>")
+                        .replaceAll("%", ".*")
+                        .replaceAll("_", ".")
+                        .replaceAll("<LiteralLikePercentage>", "%")
+                        .replaceAll("<LiteralLikeUnderscore>", "_"),
+                true,
+                false)));
+    }
+}

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/expression/RewriteLikeWithCaseSensitivity.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/expression/RewriteLikeWithCaseSensitivity.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.prometheus.expression;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.Constant;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argument;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argumentCount;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.constant;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.prometheus.expression.RewriteHelpers.LABEL_MAP_CHECK_CORRECT_TYPE;
+import static io.trino.plugin.prometheus.expression.RewriteHelpers.extractLabelName;
+import static io.trino.plugin.prometheus.expression.RewriteHelpers.extractVarchar;
+import static io.trino.spi.expression.StandardFunctions.LIKE_FUNCTION_NAME;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+
+public class RewriteLikeWithCaseSensitivity
+        implements ConnectorExpressionRule<Call, List<LabelFilterExpression>>
+{
+    private static final Capture<Call> LABEL_NAME = newCapture();
+    private static final Capture<Constant> LABEL_VALUE_LIKE_PATTERN = newCapture();
+
+    private static final Pattern<Call> PATTERN = call()
+            .with(functionName().equalTo(LIKE_FUNCTION_NAME))
+            .with(type().equalTo(BOOLEAN))
+            .with(argumentCount().equalTo(2))
+            .with(argument(0).matching(call()
+                    .matching(LABEL_MAP_CHECK_CORRECT_TYPE)
+                    .capturedAs(LABEL_NAME)))
+            .with(argument(1).matching(constant()
+                    .with(type().matching(RewriteHelpers::isCharOrStringType))
+                    .capturedAs(LABEL_VALUE_LIKE_PATTERN)));
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<List<LabelFilterExpression>> rewrite(Call expression, Captures captures, RewriteContext<List<LabelFilterExpression>> context)
+    {
+        String labelName = extractLabelName(captures, LABEL_NAME);
+        String labelValue = extractVarchar(captures.get(LABEL_VALUE_LIKE_PATTERN));
+
+        return Optional.of(ImmutableList.of(new LabelFilterExpression(
+                labelName,
+                labelValue.replaceAll("%", ".*").replaceAll("_", "."),
+                true,
+                false)));
+    }
+}

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/LoggedRequest.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/LoggedRequest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.prometheus;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+import static java.lang.String.format;
+
+public class LoggedRequest
+{
+    @JsonProperty("request_method")
+    public String method;
+
+    @JsonProperty("request_uri")
+    public String uri;
+
+    @JsonProperty("status")
+    public int status;
+
+    private String extractGetParameter(String parameterName)
+    {
+        int paramIndex = uri.indexOf(parameterName + "=");
+        if (paramIndex < 0) {
+            return null;
+        }
+        int endIndex = uri.indexOf('&', paramIndex);
+        if (endIndex < 0) {
+            endIndex = uri.length();
+        }
+        return URLDecoder.decode(
+                uri.substring(paramIndex + parameterName.length() + 1, endIndex),
+                StandardCharsets.UTF_8);
+    }
+
+    public String extractPromQL()
+    {
+        return extractGetParameter("query");
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("[%s] %s -> %s", method, uri, status);
+    }
+}

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/PrometheusQueryRunner.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/PrometheusQueryRunner.java
@@ -33,6 +33,11 @@ public final class PrometheusQueryRunner
 {
     private PrometheusQueryRunner() {}
 
+    public static final Integer QUERY_CHUNK_SIZE_DURATION_DAYS = 1;
+    public static final Integer MAX_QUERY_RANGE_DURATION_DAYS = 21;
+
+    public static final Integer DEFAULT_NUMBER_OF_REQUESTS_WITHOUT_TIME_FILTER = MAX_QUERY_RANGE_DURATION_DAYS / QUERY_CHUNK_SIZE_DURATION_DAYS;
+
     public static Builder builder(PrometheusServer prometheusServer)
     {
         return new Builder()
@@ -80,8 +85,8 @@ public final class PrometheusQueryRunner
     {
         PrometheusConnectorConfig config = new PrometheusConnectorConfig();
         config.setPrometheusURI(server.getUri());
-        config.setQueryChunkSizeDuration(new Duration(1, DAYS));
-        config.setMaxQueryRangeDuration(new Duration(21, DAYS));
+        config.setQueryChunkSizeDuration(new Duration(QUERY_CHUNK_SIZE_DURATION_DAYS, DAYS));
+        config.setMaxQueryRangeDuration(new Duration(MAX_QUERY_RANGE_DURATION_DAYS, DAYS));
         config.setCacheDuration(new Duration(30, SECONDS));
         config.setReadTimeout(new Duration(10, SECONDS));
         return new PrometheusClient(config, METRIC_CODEC, TESTING_TYPE_MANAGER);

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/PrometheusServer.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/PrometheusServer.java
@@ -13,58 +13,132 @@
  */
 package io.trino.plugin.prometheus;
 
+import com.google.common.io.Closer;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.MountableFile;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import static org.testcontainers.utility.MountableFile.forClasspathResource;
 
 public class PrometheusServer
         implements Closeable
 {
+    private static final int PROXY_PORT = 8080;
+    private static final String DEFAULT_NGINX_PROXY_VERSION = "1.28.0-alpine";
+
     private static final int PROMETHEUS_PORT = 9090;
-    private static final String DEFAULT_VERSION = "v2.15.1";
-    public static final String LATEST_VERSION = "v2.35.0";
+    public static final String DEFAULT_PROMETHEUS_VERSION = "v2.15.1";
+    public static final String LATEST_PROMETHEUS_VERSION = "v2.35.0";
 
     public static final String USER = "admin";
     public static final String PASSWORD = "password";
     public static final String PROMETHEUS_QUERY_API = "/api/v1/query?query=up[1d]";
 
-    private final GenericContainer<?> dockerContainer;
+    private final boolean enableLoggingProxy;
+    private final Network network;
+    private final GenericContainer<?> prometheusContainer;
+    private final GenericContainer<?> proxyContainer;
+    private final Set<Consumer<OutputFrame>> requestConsumers = ConcurrentHashMap.newKeySet();
+    private final Closer closer = Closer.create();
 
     public PrometheusServer()
     {
-        this(DEFAULT_VERSION, false);
+        this(DEFAULT_PROMETHEUS_VERSION, false, false);
     }
 
-    public PrometheusServer(String version, boolean enableBasicAuth)
+    @SuppressWarnings("resource")
+    public PrometheusServer(String prometheusVersion, boolean enableBasicAuth, boolean enableLoggingProxy)
     {
-        this.dockerContainer = new GenericContainer<>("prom/prometheus:" + version)
+        this.enableLoggingProxy = enableLoggingProxy;
+        this.network = Network.newNetwork();
+        closer.register(network::close);
+
+        this.prometheusContainer = new GenericContainer<>("prom/prometheus:" + prometheusVersion)
+                .withNetwork(network)
+                .withNetworkAliases("prometheus")
                 .withExposedPorts(PROMETHEUS_PORT)
                 .waitingFor(Wait.forHttp(PROMETHEUS_QUERY_API).forResponsePredicate(response -> response.contains("\"values\"")))
                 .withStartupTimeout(Duration.ofMinutes(6));
         // Basic authentication was introduced in v2.24.0
         if (enableBasicAuth) {
-            this.dockerContainer
+            this.prometheusContainer
+                    .withNetwork(network)
                     .withCommand("--config.file=/etc/prometheus/prometheus.yml", "--web.config.file=/etc/prometheus/web.yml")
                     .withCopyFileToContainer(forClasspathResource("web.yml"), "/etc/prometheus/web.yml")
                     .waitingFor(Wait.forHttp(PROMETHEUS_QUERY_API).forResponsePredicate(response -> response.contains("\"values\"")).withBasicCredentials(USER, PASSWORD))
                     .withStartupTimeout(Duration.ofMinutes(6));
         }
-        this.dockerContainer.start();
+        this.prometheusContainer.start();
+        closer.register(prometheusContainer::close);
+
+        if (enableLoggingProxy) {
+            // Nginx-based HTTP logging proxy
+            this.proxyContainer = new GenericContainer<>("nginx:" + DEFAULT_NGINX_PROXY_VERSION)
+                    .withNetwork(network)
+                    .withNetworkAliases("proxy")
+                    .withExposedPorts(PROXY_PORT)
+                    .withCopyFileToContainer(
+                            MountableFile.forClasspathResource("nginx.conf"),
+                            "/etc/nginx/nginx.conf")
+                    .dependsOn(prometheusContainer)
+                    .withLogConsumer(frame ->
+                            requestConsumers.forEach(consumer -> consumer.accept(frame)));
+
+            this.proxyContainer.start();
+            closer.register(proxyContainer::close);
+        }
+        else {
+            this.proxyContainer = null;
+        }
     }
 
     public URI getUri()
     {
-        return URI.create("http://" + dockerContainer.getHost() + ":" + dockerContainer.getMappedPort(PROMETHEUS_PORT) + "/");
+        if (enableLoggingProxy) {
+            return URI.create("http://" + proxyContainer.getHost() + ":" + proxyContainer.getMappedPort(PROXY_PORT) + "/");
+        }
+        return URI.create("http://" + prometheusContainer.getHost() + ":" + prometheusContainer.getMappedPort(PROMETHEUS_PORT) + "/");
+    }
+
+    /**
+     * Records all incoming HTTP requests during the operation and returns its result.
+     */
+    public <T> T recordRequestsFor(RequestsRecorder recorder, Supplier<T> operation)
+    {
+        startTracingRequests(recorder);
+        try {
+            return operation.get();
+        }
+        finally {
+            stopTracingRequests(recorder);
+        }
+    }
+
+    private void startTracingRequests(Consumer<OutputFrame> consumer)
+    {
+        requestConsumers.add(consumer);
+    }
+
+    private void stopTracingRequests(Consumer<OutputFrame> consumer)
+    {
+        requestConsumers.remove(consumer);
     }
 
     @Override
     public void close()
+            throws IOException
     {
-        dockerContainer.close();
+        closer.close();
     }
 }

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/RequestsRecorder.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/RequestsRecorder.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.prometheus;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.airlift.json.ObjectMapperProvider;
+import org.testcontainers.containers.output.OutputFrame;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+
+public class RequestsRecorder
+        implements Consumer<OutputFrame>
+{
+    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+    public final List<LoggedRequest> requests = new CopyOnWriteArrayList<>();
+
+    private List<LoggedRequest> requestsWithoutDiscovery;
+
+    public List<LoggedRequest> getRequestsWithoutDiscovery()
+    {
+        if (requestsWithoutDiscovery != null) {
+            return requestsWithoutDiscovery;
+        }
+        requestsWithoutDiscovery = requests.stream()
+                .filter(request -> !request.uri.equals("/api/v1/label/__name__/values"))
+                .toList();
+        return requestsWithoutDiscovery;
+    }
+
+    @Override
+    public void accept(OutputFrame outputFrame)
+    {
+        String text = outputFrame.getUtf8String().trim();
+        try {
+            LoggedRequest req = objectMapper.readValue(text, LoggedRequest.class);
+            requests.add(req);
+        }
+        catch (IOException e) {
+            // ignore non-JSON lines
+        }
+    }
+}

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusBasicAuth.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusBasicAuth.java
@@ -19,7 +19,7 @@ import io.trino.testing.QueryRunner;
 import org.junit.jupiter.api.Test;
 
 import static io.trino.plugin.prometheus.MetadataUtil.METRIC_CODEC;
-import static io.trino.plugin.prometheus.PrometheusServer.LATEST_VERSION;
+import static io.trino.plugin.prometheus.PrometheusServer.LATEST_PROMETHEUS_VERSION;
 import static io.trino.plugin.prometheus.PrometheusServer.PASSWORD;
 import static io.trino.plugin.prometheus.PrometheusServer.USER;
 import static io.trino.testing.assertions.Assert.assertEventually;
@@ -37,7 +37,7 @@ public class TestPrometheusBasicAuth
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        server = closeAfterClass(new PrometheusServer(LATEST_VERSION, true));
+        server = closeAfterClass(new PrometheusServer(LATEST_PROMETHEUS_VERSION, true, false));
         return PrometheusQueryRunner.builder(server)
                 .addConnectorProperty("prometheus.auth.user", USER)
                 .addConnectorProperty("prometheus.auth.password", PASSWORD)

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusTableHandle.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusTableHandle.java
@@ -13,11 +13,15 @@
  */
 package io.trino.plugin.prometheus;
 
+import com.google.common.collect.ImmutableList;
 import io.airlift.json.JsonCodec;
 import io.airlift.testing.EquivalenceTester;
+import io.trino.plugin.prometheus.expression.LabelFilterExpression;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.predicate.TupleDomain;
 import org.junit.jupiter.api.Test;
 
-import java.util.Optional;
+import java.util.List;
 
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,6 +51,11 @@ public class TestPrometheusTableHandle
 
     public static PrometheusTableHandle newTableHandle(String schemaName, String tableName)
     {
-        return new PrometheusTableHandle(schemaName, tableName, Optional.empty());
+        return newTableHandle(schemaName, tableName, TupleDomain.all(), ImmutableList.of());
+    }
+
+    public static PrometheusTableHandle newTableHandle(String schemaName, String tableName, TupleDomain<ColumnHandle> predicate, List<LabelFilterExpression> expressions)
+    {
+        return new PrometheusTableHandle(schemaName, tableName, predicate, expressions);
     }
 }

--- a/plugin/trino-prometheus/src/test/resources/nginx.conf
+++ b/plugin/trino-prometheus/src/test/resources/nginx.conf
@@ -1,0 +1,18 @@
+events {}
+http {
+    log_format json escape=json '{'
+        '"request_method":"$request_method",'
+        '"request_uri":"$request_uri",'
+        '"status":"$status"'
+    '}';
+    access_log /dev/stdout json;
+    sendfile on;
+
+    upstream prometheus { server prometheus:9090; }
+    server {
+        listen 8080;
+        location / {
+            proxy_pass http://prometheus;
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Implements pushdown for Prometheus predicates, as requested in #8742.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Prometheus Connector
* Support predicate pushdown for equality, non-equality, LIKE & IN operators. (#8742)
```
