### PR TITLE
Remove HTTP server event listener plugin from binaries

### DIFF
--- a/core/trino-server/src/main/provisio/trino.xml
+++ b/core/trino-server/src/main/provisio/trino.xml
@@ -106,12 +106,6 @@
         </artifact>
     </artifactSet>
 
-    <artifactSet to="plugin/http-server-event-listener">
-        <artifact id="${project.groupId}:trino-http-server-event-listener:zip:${project.version}">
-            <unpack />
-        </artifact>
-    </artifactSet>
-
     <artifactSet to="plugin/hudi">
         <artifact id="${project.groupId}:trino-hudi:zip:${project.version}">
             <unpack />

--- a/plugin/trino-http-server-event-listener/README.md
+++ b/plugin/trino-http-server-event-listener/README.md
@@ -1,0 +1,9 @@
+# Trino HTTP server event listener plugin
+
+The HTTP server event listener plugin is optional and and therefore not included
+in the default tarball and the default Docker image.
+
+Follow the [plugin installation instructions](https://trino.io/docs/current/installation/plugins.html)
+and optionally use the [trino-packages project](https://github.com/trinodb/trino-packages)
+or manually [download the plugin archive](https://central.sonatype.com/artifact/io.trino/trino-http-server-event-listener)
+for your installation and version.


### PR DESCRIPTION
## Description

Remove the undocumented and seemingly unused plugin at least from the binaries. 


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

* Follow up to https://github.com/trinodb/trino/pull/25124
* Part of https://github.com/trinodb/trino/issues/22597
* Related to https://github.com/trinodb/trino/pull/25128

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## General

* Remove the HTTP server event listener plugin from the tar.gz archive and the Docker container.  ({issue}`25967`)

```
