### PR TITLE
Remove Teradata functions plugin from binaries

### DIFF
--- a/core/trino-server/src/main/provisio/trino.xml
+++ b/core/trino-server/src/main/provisio/trino.xml
@@ -250,7 +250,6 @@
         </artifact>
     </artifactSet>
 
-
     <artifactSet to="plugin/redis">
         <artifact id="${project.groupId}:trino-redis:zip:${project.version}">
             <unpack />
@@ -277,12 +276,6 @@
 
     <artifactSet to="plugin/sqlserver">
         <artifact id="${project.groupId}:trino-sqlserver:zip:${project.version}">
-            <unpack />
-        </artifact>
-    </artifactSet>
-
-    <artifactSet to="plugin/teradata-functions">
-        <artifact id="${project.groupId}:trino-teradata-functions:zip:${project.version}">
             <unpack />
         </artifact>
     </artifactSet>

--- a/docs/src/main/sphinx/functions/teradata.md
+++ b/docs/src/main/sphinx/functions/teradata.md
@@ -2,6 +2,18 @@
 
 These functions provide compatibility with Teradata SQL.
 
+## Installation
+
+The Teradata functions plugin is optional and therefore not included in the
+default [tarball](/installation/deployment) and the default [Docker
+image](/installation/containers).
+
+Follow the [plugin installation instructions](plugins-installation) and
+optionally use the [trino-packages
+project](https://github.com/trinodb/trino-packages) or manually download the
+plugin archive {maven_download}`teradata-functions`.
+
+
 ## String functions
 
 :::{function} char2hexint(string) -> varchar


### PR DESCRIPTION
## Description

Remove the Teradata functions plugin from the binaries. Trino doesnt even have a Teradata connector and at this stage users migrating from Teradata are probably VERY rare. One using the functions are even rarer so we dont need to pull the plugin into the binaries for all other users. 

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

* Follow up to https://github.com/trinodb/trino/pull/25124
* Part of https://github.com/trinodb/trino/issues/22597
* Related to https://github.com/trinodb/trino/pull/25128

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## General

* Remove the Teradata functions plugin from the tar.gz archive and the Docker container.  ({issue}`25968`)
```
