### PR TITLE
Skip updating partition stats when adding empty stats partitions to Glue

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -1106,6 +1106,7 @@ public class GlueHiveMetastore
 
         // statistics are created after partitions because it is not clear if ordering matters in Glue
         var createStatisticsTasks = partitionsWithStatistics.stream()
+                .filter(partitionWithStatistics -> partitionWithStatistics.getStatistics() != PartitionStatistics.empty())
                 .map(partitionWithStatistics -> createUpdatePartitionStatisticsTasks(
                         StatisticsUpdateMode.OVERWRITE_ALL,
                         partitionWithStatistics.getPartition(),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastoreAccessOperations.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastoreAccessOperations.java
@@ -162,7 +162,6 @@ public class TestHiveGlueMetastoreAccessOperations
                     ImmutableMultiset.<GlueMetastoreMethod>builder()
                             .add(GET_TABLE)
                             .add(CREATE_PARTITIONS)
-                            .add(DELETE_COLUMN_STATISTICS_FOR_PARTITION)
                             .addCopies(GET_PARTITION_NAMES, 5)
                             .build());
 


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
