### PR TITLE
Avoid reading unusually large parquet footers

### DIFF
--- a/docs/src/main/sphinx/object-storage/file-formats.md
+++ b/docs/src/main/sphinx/object-storage/file-formats.md
@@ -101,6 +101,12 @@ with Parquet files performed by supported object storage connectors:
     The equivalent catalog session property is
     `parquet_vectorized_decoding_enabled`.
   - `true`
+* - `parquet.max-footer-read-size`
+  - Sets the maximum allowed read size for Parquet file footers. Attempting to
+    read a file with a footer larger than this value will result in an error.
+    This prevents workers from going into full GC or crashing due to poorly
+    configured Parquet writers.
+  - `15MB`
 :::
 
 [](file-compression) is automatically performed and some details can be

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetReaderOptions.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetReaderOptions.java
@@ -26,6 +26,7 @@ public class ParquetReaderOptions
     private static final DataSize DEFAULT_MAX_MERGE_DISTANCE = DataSize.of(1, MEGABYTE);
     private static final DataSize DEFAULT_MAX_BUFFER_SIZE = DataSize.of(8, MEGABYTE);
     private static final DataSize DEFAULT_SMALL_FILE_THRESHOLD = DataSize.of(3, MEGABYTE);
+    private static final DataSize DEFAULT_MAX_FOOTER_READ_SIZE = DataSize.of(15, MEGABYTE);
 
     private final boolean ignoreStatistics;
     private final DataSize maxReadBlockSize;
@@ -36,6 +37,7 @@ public class ParquetReaderOptions
     private final boolean useBloomFilter;
     private final DataSize smallFileThreshold;
     private final boolean vectorizedDecodingEnabled;
+    private final DataSize maxFooterReadSize;
 
     private ParquetReaderOptions()
     {
@@ -48,6 +50,7 @@ public class ParquetReaderOptions
         useBloomFilter = true;
         smallFileThreshold = DEFAULT_SMALL_FILE_THRESHOLD;
         vectorizedDecodingEnabled = true;
+        maxFooterReadSize = DEFAULT_MAX_FOOTER_READ_SIZE;
     }
 
     private ParquetReaderOptions(
@@ -59,7 +62,8 @@ public class ParquetReaderOptions
             boolean useColumnIndex,
             boolean useBloomFilter,
             DataSize smallFileThreshold,
-            boolean vectorizedDecodingEnabled)
+            boolean vectorizedDecodingEnabled,
+            DataSize maxFooterReadSize)
     {
         this.ignoreStatistics = ignoreStatistics;
         this.maxReadBlockSize = requireNonNull(maxReadBlockSize, "maxReadBlockSize is null");
@@ -71,6 +75,7 @@ public class ParquetReaderOptions
         this.useBloomFilter = useBloomFilter;
         this.smallFileThreshold = requireNonNull(smallFileThreshold, "smallFileThreshold is null");
         this.vectorizedDecodingEnabled = vectorizedDecodingEnabled;
+        this.maxFooterReadSize = requireNonNull(maxFooterReadSize, "maxFooterReadSize is null");
     }
 
     public static Builder builder()
@@ -133,6 +138,11 @@ public class ParquetReaderOptions
         return smallFileThreshold;
     }
 
+    public DataSize getMaxFooterReadSize()
+    {
+        return maxFooterReadSize;
+    }
+
     public static class Builder
     {
         private boolean ignoreStatistics;
@@ -144,6 +154,7 @@ public class ParquetReaderOptions
         private boolean useBloomFilter;
         private DataSize smallFileThreshold;
         private boolean vectorizedDecodingEnabled;
+        private DataSize maxFooterReadSize;
 
         private Builder(ParquetReaderOptions parquetReaderOptions)
         {
@@ -157,6 +168,7 @@ public class ParquetReaderOptions
             this.useBloomFilter = parquetReaderOptions.useBloomFilter;
             this.smallFileThreshold = parquetReaderOptions.smallFileThreshold;
             this.vectorizedDecodingEnabled = parquetReaderOptions.vectorizedDecodingEnabled;
+            this.maxFooterReadSize = parquetReaderOptions.maxFooterReadSize;
         }
 
         public Builder withIgnoreStatistics(boolean ignoreStatistics)
@@ -213,6 +225,12 @@ public class ParquetReaderOptions
             return this;
         }
 
+        public Builder withMaxFooterReadSize(DataSize maxFooterReadSize)
+        {
+            this.maxFooterReadSize = requireNonNull(maxFooterReadSize, "maxFooterReadSize is null");
+            return this;
+        }
+
         public ParquetReaderOptions build()
         {
             return new ParquetReaderOptions(
@@ -224,7 +242,8 @@ public class ParquetReaderOptions
                     useColumnIndex,
                     useBloomFilter,
                     smallFileThreshold,
-                    vectorizedDecodingEnabled);
+                    vectorizedDecodingEnabled,
+                    maxFooterReadSize);
         }
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
@@ -237,7 +237,7 @@ public class ParquetWriter
         checkState(validationBuilder.isPresent(), "validation is not enabled");
         ParquetWriteValidation writeValidation = validationBuilder.get().build();
         try {
-            ParquetMetadata parquetMetadata = MetadataReader.readFooter(input, Optional.of(writeValidation));
+            ParquetMetadata parquetMetadata = MetadataReader.readFooter(input, Optional.empty(), Optional.of(writeValidation));
             try (ParquetReader parquetReader = createParquetReader(input, parquetMetadata, writeValidation)) {
                 for (SourcePage page = parquetReader.nextPage(); page != null; page = parquetReader.nextPage()) {
                     // fully load the page

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/BenchmarkColumnarFilterParquetData.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/BenchmarkColumnarFilterParquetData.java
@@ -226,7 +226,7 @@ public class BenchmarkColumnarFilterParquetData
                         testData.getColumnNames(),
                         testData.getPages()),
                 ParquetReaderOptions.defaultOptions());
-        parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+        parquetMetadata = MetadataReader.readFooter(dataSource);
         columnNames = columns.stream()
                 .map(TpchColumn::getColumnName)
                 .collect(toImmutableList());

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestByteStreamSplitEncoding.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestByteStreamSplitEncoding.java
@@ -28,7 +28,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.IntStream;
 
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
@@ -49,7 +48,7 @@ public class TestByteStreamSplitEncoding
         ParquetDataSource dataSource = new FileParquetDataSource(
                 new File(Resources.getResource("byte_stream_split_float_and_double.parquet").toURI()),
                 ParquetReaderOptions.defaultOptions());
-        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource);
         ParquetReader reader = createParquetReader(dataSource, parquetMetadata, newSimpleAggregatedMemoryContext(), types, columnNames);
 
         readAndCompare(reader, getExpectedValues());

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestInt96Timestamp.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestInt96Timestamp.java
@@ -112,7 +112,7 @@ public class TestInt96Timestamp
         ParquetDataSource dataSource = new FileParquetDataSource(
                 new File(Resources.getResource("int96_timestamps_nanos_outside_day_range.parquet").toURI()),
                 ParquetReaderOptions.defaultOptions());
-        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource);
         ParquetReader reader = createParquetReader(dataSource, parquetMetadata, newSimpleAggregatedMemoryContext(), types, columnNames);
 
         SourcePage page = reader.nextPage();

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestTimeMillis.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestTimeMillis.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.List;
-import java.util.Optional;
 
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.parquet.ParquetTestUtils.createParquetReader;
@@ -59,7 +58,7 @@ public class TestTimeMillis
         ParquetDataSource dataSource = new FileParquetDataSource(
                 new File(Resources.getResource("time_millis_int32.snappy.parquet").toURI()),
                 ParquetReaderOptions.defaultOptions());
-        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource);
         ParquetReader reader = createParquetReader(dataSource, parquetMetadata, newSimpleAggregatedMemoryContext(), types, columnNames);
 
         SourcePage page = reader.nextPage();

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriter.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriter.java
@@ -130,7 +130,7 @@ public class TestParquetWriter
                         columnNames,
                         generateInputPages(types, 100, 1000)),
                 ParquetReaderOptions.defaultOptions());
-        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource);
         assertThat(parquetMetadata.getBlocks()).hasSize(1);
         assertThat(parquetMetadata.getBlocks().get(0).rowCount()).isEqualTo(100 * 1000);
 
@@ -179,7 +179,7 @@ public class TestParquetWriter
                         columnNames,
                         generateInputPages(types, 100, 1000)),
                 ParquetReaderOptions.defaultOptions());
-        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource);
         assertThat(parquetMetadata.getBlocks()).hasSize(1);
         assertThat(parquetMetadata.getBlocks().get(0).rowCount()).isEqualTo(100 * 1000);
 
@@ -260,7 +260,7 @@ public class TestParquetWriter
                         ImmutableList.of(new Page(2, blockA, blockB))),
                 ParquetReaderOptions.defaultOptions());
 
-        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource);
         BlockMetadata blockMetaData = getOnlyElement(parquetMetadata.getBlocks());
 
         ColumnChunkMetadata chunkMetaData = blockMetaData.columns().get(0);
@@ -293,7 +293,7 @@ public class TestParquetWriter
                         generateInputPages(types, 100, 100)),
                 ParquetReaderOptions.defaultOptions());
 
-        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource);
         assertThat(parquetMetadata.getBlocks().size()).isGreaterThanOrEqualTo(10);
         for (BlockMetadata blockMetaData : parquetMetadata.getBlocks()) {
             // Verify that the columns are stored in the same order as the metadata
@@ -350,7 +350,7 @@ public class TestParquetWriter
                         generateInputPages(types, 100, 100)),
                 ParquetReaderOptions.defaultOptions());
 
-        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource);
         assertThat(parquetMetadata.getBlocks().size()).isGreaterThanOrEqualTo(1);
         for (BlockMetadata blockMetaData : parquetMetadata.getBlocks()) {
             ColumnChunkMetadata chunkMetaData = getOnlyElement(blockMetaData.columns());
@@ -399,7 +399,7 @@ public class TestParquetWriter
                         generateInputPages(types, 100, 10)),
                 ParquetReaderOptions.defaultOptions());
 
-        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource);
         List<BlockMetadata> blocks = parquetMetadata.getBlocks();
         assertThat(blocks.size()).isGreaterThan(1);
 
@@ -434,7 +434,7 @@ public class TestParquetWriter
                         generateInputPages(types, 100, data)),
                 ParquetReaderOptions.defaultOptions());
 
-        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource);
         // Check that bloom filters are right after each other
         int bloomFilterSize = Integer.highestOneBit(BlockSplitBloomFilter.optimalNumOfBits(BLOOM_FILTER_EXPECTED_ENTRIES, DEFAULT_BLOOM_FILTER_FPP) / 8) << 1;
         for (BlockMetadata block : parquetMetadata.getBlocks()) {
@@ -499,7 +499,7 @@ public class TestParquetWriter
                                 .build()),
                 ParquetReaderOptions.defaultOptions());
 
-        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource);
         BlockMetadata blockMetaData = getOnlyElement(parquetMetadata.getBlocks());
         ColumnChunkMetadata chunkMetaData = getOnlyElement(blockMetaData.columns());
         assertThat(chunkMetaData.getEncodingStats().hasDictionaryPages()).isTrue();

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
@@ -386,7 +386,7 @@ public class DeltaLakeMergeSink
         }
         TrinoInputFile inputFile = fileSystem.newInputFile(Location.of(path.toStringUtf8()));
         try (ParquetDataSource dataSource = new TrinoParquetDataSource(inputFile, parquetReaderOptions, fileFormatDataSourceStats)) {
-            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource);
             long rowCount = parquetMetadata.getBlocks().stream().map(BlockMetadata::rowCount).mapToLong(Long::longValue).sum();
             RoaringBitmapArray rowsRetained = new RoaringBitmapArray();
             rowsRetained.addRange(0, rowCount - 1);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSourceProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSourceProvider.java
@@ -363,7 +363,7 @@ public class DeltaLakePageSourceProvider
     private Map<Integer, String> loadParquetIdAndNameMapping(TrinoInputFile inputFile, ParquetReaderOptions options)
     {
         try (ParquetDataSource dataSource = new TrinoParquetDataSource(inputFile, options, fileFormatDataSourceStats)) {
-            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, options.getMaxFooterReadSize());
             FileMetadata fileMetaData = parquetMetadata.getFileMetaData();
             MessageType fileSchema = fileMetaData.getSchema();
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
@@ -399,7 +399,7 @@ public class TestDeltaLakeBasic
             assertThat(partitionValuesParsedType.getFields().stream().collect(onlyElement()).getName().orElseThrow()).isEqualTo(physicalColumnName);
 
             TrinoParquetDataSource dataSource = new TrinoParquetDataSource(new LocalInputFile(checkpoint.toFile()), ParquetReaderOptions.defaultOptions(), new FileFormatDataSourceStats());
-            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource);
             try (ParquetReader reader = createParquetReader(dataSource, parquetMetadata, ImmutableList.of(addEntryType), List.of("add"))) {
                 List<Object> actual = new ArrayList<>();
                 SourcePage page = reader.nextPage();
@@ -477,8 +477,7 @@ public class TestDeltaLakeBasic
         // Verify optimized parquet file contains the expected physical id and name
         TrinoInputFile inputFile = new LocalInputFile(tableLocation.resolve(addFileEntry.getPath()).toFile());
         ParquetMetadata parquetMetadata = MetadataReader.readFooter(
-                new TrinoParquetDataSource(inputFile, ParquetReaderOptions.defaultOptions(), new FileFormatDataSourceStats()),
-                Optional.empty());
+                new TrinoParquetDataSource(inputFile, ParquetReaderOptions.defaultOptions(), new FileFormatDataSourceStats()));
         FileMetadata fileMetaData = parquetMetadata.getFileMetaData();
         PrimitiveType physicalType = getOnlyElement(fileMetaData.getSchema().getColumns().iterator()).getPrimitiveType();
         assertThat(physicalType.getName()).isEqualTo(physicalName);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
@@ -230,7 +230,7 @@ public class ParquetPageSourceFactory
             AggregatedMemoryContext memoryContext = newSimpleAggregatedMemoryContext();
             dataSource = createDataSource(inputFile, estimatedFileSize, options, memoryContext, stats);
 
-            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, parquetWriteValidation);
+            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.of(options.getMaxFooterReadSize()), parquetWriteValidation);
             FileMetadata fileMetaData = parquetMetadata.getFileMetaData();
             fileSchema = fileMetaData.getSchema();
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetReaderConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetReaderConfig.java
@@ -175,6 +175,22 @@ public class ParquetReaderConfig
         return options.isVectorizedDecodingEnabled();
     }
 
+    @Config("parquet.max-footer-read-size")
+    @ConfigDescription("Maximum allowed size of the parquet footer. Files with footers larger than this will generate an exception on read")
+    public ParquetReaderConfig setMaxFooterReadSize(DataSize maxFooterReadSize)
+    {
+        options = ParquetReaderOptions.builder(options)
+                .withMaxFooterReadSize(maxFooterReadSize)
+                .build();
+        return this;
+    }
+
+    @NotNull
+    public DataSize getMaxFooterReadSize()
+    {
+        return options.getMaxFooterReadSize();
+    }
+
     public ParquetReaderOptions toParquetReaderOptions()
     {
         return options;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetReaderConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetReaderConfig.java
@@ -16,7 +16,6 @@ package io.trino.plugin.hive.parquet;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.DefunctConfig;
-import io.airlift.configuration.LegacyConfig;
 import io.airlift.units.DataSize;
 import io.airlift.units.MaxDataSize;
 import io.airlift.units.MinDataSize;
@@ -29,7 +28,8 @@ import jakarta.validation.constraints.NotNull;
         "hive.parquet.fail-on-corrupted-statistics",
         "parquet.fail-on-corrupted-statistics",
         "parquet.optimized-reader.enabled",
-        "parquet.optimized-nested-reader.enabled"
+        "parquet.optimized-nested-reader.enabled",
+        "hive.parquet.max-read-block-size",
 })
 public class ParquetReaderConfig
 {
@@ -59,7 +59,6 @@ public class ParquetReaderConfig
     }
 
     @Config("parquet.max-read-block-size")
-    @LegacyConfig("hive.parquet.max-read-block-size")
     public ParquetReaderConfig setMaxReadBlockSize(DataSize maxReadBlockSize)
     {
         options = ParquetReaderOptions.builder(options)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestBloomFilterStore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestBloomFilterStore.java
@@ -308,7 +308,7 @@ public class TestBloomFilterStore
         TrinoInputFile inputFile = new LocalInputFile(tempFile.getFile());
         TrinoParquetDataSource dataSource = new TrinoParquetDataSource(inputFile, ParquetReaderOptions.defaultOptions(), new FileFormatDataSourceStats());
 
-        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource);
         ColumnChunkMetadata columnChunkMetaData = getOnlyElement(getOnlyElement(parquetMetadata.getBlocks()).columns());
 
         return new BloomFilterStore(dataSource, getOnlyElement(parquetMetadata.getBlocks()), Set.of(columnChunkMetaData.getPath()));

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetReaderConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetReaderConfig.java
@@ -39,7 +39,8 @@ public class TestParquetReaderConfig
                 .setUseColumnIndex(true)
                 .setUseBloomFilter(true)
                 .setSmallFileThreshold(DataSize.of(3, MEGABYTE))
-                .setVectorizedDecodingEnabled(true));
+                .setVectorizedDecodingEnabled(true)
+                .setMaxFooterReadSize(DataSize.of(15, MEGABYTE)));
     }
 
     @Test
@@ -55,6 +56,7 @@ public class TestParquetReaderConfig
                 .put("parquet.use-bloom-filter", "false")
                 .put("parquet.small-file-threshold", "1kB")
                 .put("parquet.experimental.vectorized-decoding.enabled", "false")
+                .put("parquet.max-footer-read-size", "25MB")
                 .buildOrThrow();
 
         ParquetReaderConfig expected = new ParquetReaderConfig()
@@ -66,7 +68,8 @@ public class TestParquetReaderConfig
                 .setUseColumnIndex(false)
                 .setUseBloomFilter(false)
                 .setSmallFileThreshold(DataSize.of(1, KILOBYTE))
-                .setVectorizedDecodingEnabled(false);
+                .setVectorizedDecodingEnabled(false)
+                .setMaxFooterReadSize(DataSize.of(25, MEGABYTE));
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiPageSourceProvider.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiPageSourceProvider.java
@@ -228,7 +228,7 @@ public class HudiPageSourceProvider
         try {
             AggregatedMemoryContext memoryContext = newSimpleAggregatedMemoryContext();
             dataSource = createDataSource(inputFile, OptionalLong.of(hudiSplit.fileSize()), options, memoryContext, dataSourceStats);
-            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, options.getMaxFooterReadSize());
             FileMetadata fileMetaData = parquetMetadata.getFileMetaData();
             MessageType fileSchema = fileMetaData.getSchema();
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -900,7 +900,7 @@ public class IcebergPageSourceProvider
         ParquetDataSource dataSource = null;
         try {
             dataSource = createDataSource(inputFile, OptionalLong.of(fileSize), options, memoryContext, fileFormatDataSourceStats);
-            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, options.getMaxFooterReadSize());
             FileMetadata fileMetaData = parquetMetadata.getFileMetaData();
             MessageType fileSchema = fileMetaData.getSchema();
             if (nameMapping.isPresent() && !ParquetSchemaUtil.hasIds(fileSchema)) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrationUtils.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrationUtils.java
@@ -151,8 +151,9 @@ public final class MigrationUtils
 
     private static Metrics parquetMetrics(TrinoInputFile file, MetricsConfig metricsConfig, NameMapping nameMapping)
     {
+        ParquetReaderOptions options = ParquetReaderOptions.defaultOptions();
         try (ParquetDataSource dataSource = new TrinoParquetDataSource(file, ParquetReaderOptions.defaultOptions(), new FileFormatDataSourceStats())) {
-            ParquetMetadata metadata = MetadataReader.readFooter(dataSource, Optional.empty());
+            ParquetMetadata metadata = MetadataReader.readFooter(dataSource, options.getMaxFooterReadSize());
             return ParquetUtil.footerMetrics(metadata, Stream.empty(), metricsConfig, nameMapping);
         }
         catch (IOException e) {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergTestUtils.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergTestUtils.java
@@ -254,8 +254,7 @@ public final class IcebergTestUtils
     {
         try {
             return MetadataReader.readFooter(
-                    new TrinoParquetDataSource(inputFile, ParquetReaderOptions.defaultOptions(), new FileFormatDataSourceStats()),
-                    Optional.empty());
+                    new TrinoParquetDataSource(inputFile, ParquetReaderOptions.defaultOptions(), new FileFormatDataSourceStats()));
         }
         catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftPageSourceProvider.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftPageSourceProvider.java
@@ -104,7 +104,7 @@ public class RedshiftPageSourceProvider
     {
         ParquetReaderOptions options = ParquetReaderOptions.defaultOptions();
         TrinoParquetDataSource dataSource = new TrinoParquetDataSource(inputFile, options, fileFormatDataSourceStats);
-        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, options.getMaxFooterReadSize());
         MessageType fileSchema = parquetMetadata.getFileMetaData().getSchema();
         MessageColumnIO messageColumn = getColumnIO(fileSchema, fileSchema);
         Map<List<String>, ColumnDescriptor> descriptorsByPath = getDescriptors(fileSchema, fileSchema);


### PR DESCRIPTION
## Description

Reading unusually large parquet footers can lead to workers
going into full GC and crashing when decoding the footer in
org.apache.parquet.format.Util#readFileMetaData
This is usually caused by misconfigured parquet writers producing
too many row groups per file. This change adds a guard rail to
fail reads of such files gracefully.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Hive, Delta Lake, Iceberg, Hudi
* Prevent workers from going into full GC or crashing when decoding unusually large parquet footers. ({issue}`25973`)
```
