### PR TITLE
Support PostGIS extension on non-public schemas in PostgreSQL

### DIFF
--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -592,9 +592,14 @@ public class PostgreSqlClient
             case "geometry":
                 return Optional.of(geometryColumnMapping());
         }
+
+        // Handling of schema-qualified types
+        // TODO: Find more reliable way to detect these types. The type name can be eg. "schema-name"."vector"
         if (jdbcTypeName.endsWith("\"vector\"")) {
-            // TODO: Find more reliable way to detect vector type. The type name can be "schema-name"."vector"
             return Optional.of(vectorColumnMapping());
+        }
+        if (jdbcTypeName.endsWith("\"geometry\"")) {
+            return Optional.of(geometryColumnMapping());
         }
 
         switch (typeHandle.jdbcType()) {


### PR DESCRIPTION
Fixes #25972

## Description

This allows supporting of PostgreSQL PostGIS geometry types when the extension is installed on a schema other than public. 

## Additional context and related issues

Currently if PostGIS is installed on a schema other than public, the `Geometry` type column will not be recognized or will appear as a `varchar` if `CONVERT_TO_VARCHAR` is set.  This fixes this bug and will allow use of `Geometry` types when this extension is installed on another schema.

### Before change
![Screenshot 2025-06-10 at 9 29 54 PM](https://github.com/user-attachments/assets/73bc5613-92b7-41ff-b99f-f3c99ddc9434)

### After change
![Screenshot 2025-06-10 at 9 30 05 PM](https://github.com/user-attachments/assets/3565af47-b380-416b-aaf4-f3fb0f8f4cf9)

## Release notes

```markdown
## PostgreSQL
* Add support for `geometry` types installed in schemas other than `public`. ({issue}`25972`)
```
