### PR TITLE
Hudi sessin property: parquet_max_read_block_row_count

### DIFF
--- a/docs/src/main/sphinx/admin/properties-writer-scaling.md
+++ b/docs/src/main/sphinx/admin/properties-writer-scaling.md
@@ -37,7 +37,7 @@ and query is bottlenecked on writing.
 ## `writer-scaling-min-data-processed`
 
 - **Type:** {ref}`prop-type-data-size`
-- **Default value:** `100MB`
+- **Default value:** `120MB`
 - **Session property:** `writer_scaling_min_data_processed`
 
 The minimum amount of uncompressed data that must be processed by a writer

--- a/docs/src/main/sphinx/object-storage/file-formats.md
+++ b/docs/src/main/sphinx/object-storage/file-formats.md
@@ -89,7 +89,7 @@ with Parquet files performed by supported object storage connectors:
 * - `parquet.max-read-block-row-count`
   - Sets the maximum number of rows read in a batch. The equivalent catalog
     session property is named `parquet_max_read_block_row_count` and supported
-    by the Delta Lake, Hive, and Iceberg connectors.
+    by the Delta Lake, Hive, Iceberg and Hudi connectors.
   - `8192`
 * - `parquet.small-file-threshold`
   - [Data size](prop-type-data-size) below which a Parquet file is read

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiPageSourceProvider.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiPageSourceProvider.java
@@ -92,6 +92,7 @@ import static io.trino.plugin.hudi.HudiErrorCode.HUDI_CANNOT_OPEN_SPLIT;
 import static io.trino.plugin.hudi.HudiErrorCode.HUDI_CURSOR_ERROR;
 import static io.trino.plugin.hudi.HudiErrorCode.HUDI_INVALID_PARTITION_VALUE;
 import static io.trino.plugin.hudi.HudiErrorCode.HUDI_UNSUPPORTED_FILE_FORMAT;
+import static io.trino.plugin.hudi.HudiSessionProperties.getParquetMaxReadBlockRowCount;
 import static io.trino.plugin.hudi.HudiSessionProperties.getParquetSmallFileThreshold;
 import static io.trino.plugin.hudi.HudiSessionProperties.isParquetVectorizedDecodingEnabled;
 import static io.trino.plugin.hudi.HudiSessionProperties.shouldUseParquetColumnNames;
@@ -178,6 +179,7 @@ public class HudiPageSourceProvider
                 ParquetReaderOptions.builder(options)
                         .withSmallFileThreshold(getParquetSmallFileThreshold(session))
                         .withVectorizedDecodingEnabled(isParquetVectorizedDecodingEnabled(session))
+                        .withMaxReadBlockRowCount(getParquetMaxReadBlockRowCount(session))
                         .build(),
                 timeZone);
 

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSessionProperties.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSessionProperties.java
@@ -43,6 +43,7 @@ public class HudiSessionProperties
 {
     private static final String COLUMNS_TO_HIDE = "columns_to_hide";
     private static final String USE_PARQUET_COLUMN_NAMES = "use_parquet_column_names";
+    private static final String PARQUET_MAX_READ_BLOCK_ROW_COUNT = "parquet_max_read_block_row_count";
     private static final String PARQUET_SMALL_FILE_THRESHOLD = "parquet_small_file_threshold";
     private static final String PARQUET_VECTORIZED_DECODING_ENABLED = "parquet_vectorized_decoding_enabled";
     private static final String SIZE_BASED_SPLIT_WEIGHTS_ENABLED = "size_based_split_weights_enabled";
@@ -75,6 +76,18 @@ public class HudiSessionProperties
                         USE_PARQUET_COLUMN_NAMES,
                         "Access parquet columns using names from the file. If disabled, then columns are accessed using index.",
                         hudiConfig.getUseParquetColumnNames(),
+                        false),
+                integerProperty(
+                        PARQUET_MAX_READ_BLOCK_ROW_COUNT,
+                        "Parquet: Maximum number of rows read in a batch",
+                        parquetReaderConfig.getMaxReadBlockRowCount(),
+                        value -> {
+                            if (value < 128 || value > 65536) {
+                                throw new TrinoException(
+                                        INVALID_SESSION_PROPERTY,
+                                        format("%s must be between 128 and 65536: %s", PARQUET_MAX_READ_BLOCK_ROW_COUNT, value));
+                            }
+                        },
                         false),
                 dataSizeProperty(
                         PARQUET_SMALL_FILE_THRESHOLD,
@@ -149,6 +162,11 @@ public class HudiSessionProperties
     public static boolean shouldUseParquetColumnNames(ConnectorSession session)
     {
         return session.getProperty(USE_PARQUET_COLUMN_NAMES, Boolean.class);
+    }
+
+    public static int getParquetMaxReadBlockRowCount(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_MAX_READ_BLOCK_ROW_COUNT, Integer.class);
     }
 
     public static DataSize getParquetSmallFileThreshold(ConnectorSession session)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

- Update document of writer_scaling_min_data_processed
- Add session property parquet_max_read_block_row_count to Hudi connector


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

- The default value of writer_scaling_min_data_processed is [120MB](https://github.com/trinodb/trino/blob/master/core/trino-main/src/main/java/io/trino/FeaturesConfig.java#L90).
- This session property `parquet_max_read_block_row_count` is intended to limit the maximum number of rows read in a batch for Hudi connector.


## Release notes

```markdown
## Hudi
* Add support for `parquet_max_read_block_row_count` session property.
```
